### PR TITLE
according to chapter 5.10.1.3 of the nvme v 1.2 the size of the frs fiel...

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -32,7 +32,7 @@ struct nvme_error_log_page {
 struct nvme_firmware_log_page {
 	__u8	afi;
 	__u8	resv[7];
-	__u64	frs[8];
+	__u64	frs[7];
 	__u8	resv2[448];
 };
 


### PR DESCRIPTION
Hi 
according to chapter 5.10.1.3 of the nvme v 1.2 the size of the frs field of the struct nvme_firmware_log_page has to be 7
Please pull, 
Thanks
D