### PR TITLE
Fix to determine initial value for lba in print_list_item

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1259,7 +1259,7 @@ static void print_list_item(struct list_item list_item)
 
 	double nsze       = list_item.ns.nsze;
 	double nuse       = list_item.ns.nuse;
-	long long int lba = list_item.ns.lbaf[list_item.ns.flbas].ds;
+	long long int lba = list_item.ns.lbaf[(list_item.ns.flbas & 0x0f)].ds;
 
 	lba  = (1 << lba);
 	nsze *= lba;


### PR DESCRIPTION
The index used to determine lba value takes into account the entire FLBAS field.  Bit 4 determines whether an extended or separate buffer is used to send metadata and if set to 1'b, throws off the index value.  Masked out the top 4 bits to only take into account Bits 3:0 which indicate the LBA format type used.

Without this change any device with bit 4 set will not show usage/capacity correctly in the list output.