### PR TITLE
add Documentation contents that should not be propagated in repo cloning to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 nvme
 *.xml
+*.xsl
+Documentation/*.xml
+Documentation/*.xsl


### PR DESCRIPTION
Add a gitignore to Documentation/ so that contents of the folder stay constant regardless of make [clobber/doc] status. 