### PR TITLE
fix bad memory management in argconfig, add nvme help strings to subopt help menu, add tab completions for zsh and bash

### DIFF
--- a/completions/README
+++ b/completions/README
@@ -1,0 +1,60 @@
+Kelly Kaoudis, kelly.n.kaoudis at intel.com, June 2015
+
+Setting Up NVMe Tab Autocompletion for bash or zsh
+==================================================
+
+If your working shell is bash...
+--------------------------------
+the following gets bash autocompletion to behave properly
+#echo "bind 'set show-all-if-ambiguous on'" >> ~/.bashrc
+#echo "bind 'set show-all-if-unmodified on'" >> ~/.bashrc
+#echo "bind 'set completion-ignore-case on'" >> ~/.bashrc
+#echo "bind 'set completion-map-case on'" >> ~/.bashrc
+
+add NVMe autocompletion script to your autocompletes directory
+#cp `pwd`/bash-nvme-completion.sh /etc/bash_completion.d/nvme
+
+make sure this bash knows where everything is
+#source /etc/bash_completion.d/nvme && source ~/.bashrc
+
+you should be able to autocomplete with the nvme utility now
+(double TABs still apply)! If autocompleting has disappeared,
+just re-source nvme and .bashrc.
+
+You may also need to uncomment the "enable bash completion in interactive
+shells" part of /etc/bash.bashrc, that is:
+
+if [ -f /usr/share/bash-completion/bash_completion ]; then
+	. /usr/share/bash-completion/bash_completion
+elif [ -f /etc/bash_completion ]; then
+	. /etc/bash_completion
+fi
+
+(don't bother with the shopt part, your Bash version might not support shopt).
+
+if your working shell is zsh...
+-------------------------------
+create the zsh completions directory if you don't have it
+#if [ ! -e "~/.zsh" ]; then
+#	mkdir ~/.zsh
+#	mkdir ~/.zsh/completion
+#fi
+
+#cp `pwd`/_nvme ~/.zsh/completion/_nvme
+
+add compinit if you don't have it in your .zshrc already (compinit is zsh's
+autocompletion engine)
+#echo "autoload -Uz compinit && compinit" >> ~/.zshrc
+
+add nvme autocompletions to your .zshrc
+#echo "# source for tab autocompletions" >> ~/.zshrc
+#echo "fpath=(~/.zsh/completion $fpath)" >> ~/.zshrc
+#echo "source ~/.zsh/completion/_nvme" >> ~/.zshrc
+
+make sure this zsh knows where everything is
+#source ~/.zsh/completion/_nvme && source ~/.zshrc
+
+You should be able to autocomplete with the nvme utility now (single TAB press
+should get you a completion with descriptions -- sadly, bash doesn't support
+descriptions within completions). If autocompletes disappear, just re-source
+_nvme and .zshrc.

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -1,0 +1,632 @@
+#compdef _nvme nvme
+
+# zsh completions for the nvme command-line interface,
+# very loosely based on git and adb command completion
+# Kelly Kaoudis kelly.n.kaoudis at intel.com, June 2015
+
+_nvme () {
+	local -a _cmds
+	_cmds=(
+	'id-ctrl:display information about the controller'
+	'id-ns:display information about the namespace'
+	'list-ns:identify all namespace(s) attached'
+	'create-ns:create a new namespace before attachment'
+	'delete-ns:delete a detached namespace'
+	'attach-ns:attach namespace to controller'
+	'detach-ns:detach namespace from controller'
+	'list-ctrl:identify all controller(s) attached'
+	'get-ns-id:get namespace id of opened block device'
+	'get-log:retrieve any log in raw format'
+	'fw-log:retrieve fw log'
+	'smart-log:retrieve SMART log'
+	'error-log:retrieve error log'
+	'get-feature:display a controller feature'
+	'set-feature:set a controller feature and show results'
+	'format:apply new block format to namespace'
+	'fw-activate:activate a firmware on the device'
+	'fw-download:download a firmware to the device'
+	'admin-passthru:submit a passthrough IOCTL'
+	'io-passthru:submit a passthrough IOCTL'
+	'security-send:send security/secure data to controller'
+	'security-recv:ask for security/secure data from controller'
+	'resv-acquire:acquire reservation on a namespace'
+	'resv-register:register reservation on a namespace'
+	'resv-release:release reservation on a namespace'
+	'resv-report:report reservation on a namespace'
+	'flush:submit a flush'
+	'compare:compare data on device to data elsewhere'
+	'read:submit a read command'
+	'write:submit a write command'
+	'show-regs:shows the controller registers; requires admin character device'
+	'help:print brief descriptions of all nvme commands'
+	)
+
+	local expl
+
+	_arguments '*:: :->subcmds' && return 0
+
+	if (( CURRENT == 1 )); then
+		_describe -t commands "nvme subcommands" _cmds
+		return
+	else
+		case ${words[CURRENT-1]} in
+		(id-ctrl)
+			local _idctrl
+			_idctrl=(
+			/dev/nvme':supply a device to use (required)'
+			--raw-binary':dump infos in binary format'
+			-b':alias of --raw-binary'
+			--human-readable':show infos in readable format'
+			-H':alias of --human-readable'
+			--vendor-specific':also dump binary vendor infos'
+			-v':alias of --vendor-specific'
+			)
+
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme id-ctrl options" _idctrl
+			;;
+		(id-ns)
+			local _idns
+			_idns=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':show infos for namespace <nsid>'
+			-n':alias of --namespace-id'
+			--raw-binary':dump infos in binary format'
+			-b':alias of --raw-binary'
+			--human-readable':show infos in readable format'
+			-H':alias of --human-readable'
+			--vendor-specific':also dump binary vendor infos'
+			-v':alias of --vendor-specific'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme id-ns options" _idns
+			;;
+		(list-ns)
+			local _listns
+			_listns=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':start namespace infos listing with this nsid'
+			-n':alias of --namespace-id'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme list-ns options" _listns
+			;;
+		(create-ns)
+			local _createns
+			_createns=(
+			/dev/nvme':supply a device to use (required)'
+			--nsze=':namespace size to create'
+			-s':alias of --nsze'
+			--ncap=':namespace capacity'
+			-c':alias of --ncap'
+			--flbas=':FLBA size'
+			-f':alias of --flbas'
+			--dps=':data protection?'
+			-d':alias of --dps'
+			--nmic=':multipath and sharing'
+			-n':alias of --nmic'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme create-ns options" _createns
+			;;
+		(delete-ns)
+			local _deletens
+			_deletens=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':namespace to delete'
+			-n':alias of --namespace-id'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme delete-ns options" _deletens
+			;;
+		(attach-ns)
+			local _attachns
+			_attachns=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':namespace to attach to the controller'
+			-n':alias of --namespace-id'
+			--controllers=':if a device is not provided, supply a comma-sep list of controllers'
+			-c':alias of --controllers'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme attach-ns options" _attachns
+			;;
+		(detach-ns)
+			local _detachns
+			_detachns=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':namespace to detach from controller'
+			-n':alias of --namespace-id'
+			--controllers=':if a device is not provided, supply a comma-sep list of controllers'
+			-c':alias of --controllers'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme detach-ns options" _detachns
+			;;
+		(list-ctrl)
+			local _listctrl
+			_listctrl=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':show controllers attached to this namespace'
+			-n':alias of --namespace-id'
+			--cntid=':start the list with this controller'
+			-c':alias of --cntid'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme list-ctrl options" _listctrl
+			;;
+		(get-ns-id)
+			local _getnsid
+			_getnsid=(
+			/dev/nvme':supply a device to use (required)'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme get-ns-id options" _getnsid
+			;;
+		(get-log)
+			local _getlog
+			_getlog=(
+			/dev/nvme':supply a device to use (required)'
+			--log-id=':requested log number'
+			-i':alias of --log-id'
+			--log-len=':number of bytes to show for requested log'
+			-l':alias of --log-len'
+			--namespace-id=':get log specific to <nsid> if namespace logs are supported'
+			-n':alias of --namespace-id'
+			--raw-binary':dump infos in binary format'
+			-b':alias of --raw-binary'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme get-log options" _getlog
+			;;
+		(fw-log)
+			local _fwlog
+			_fwlog=(
+			/dev/nvme':supply a device to use (required)'
+			--raw-binary':dump infos in binary format'
+			-b':alias of --raw-binary'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme fw-log options" _fwlog
+			;;
+		(smart-log)
+			local _smartlog
+			_smartlog=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':get SMART log specific to <nsid> if namespace logs are supported'
+			-n':alias to --namespace-id'
+			--raw-binary':dump infos in binary format'
+			-b':alias to --raw-binary'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme smart-log options" _smartlog
+			;;
+		(error-log)
+			local _errlog
+			_errlog=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':get log specific to <nsid> if namespace logs are supported'
+			-n':alias to --namespace-id'
+			--raw-binary':dump infos in binary format'
+			-b':alias to --raw-binary'
+			--log-entries=':request n >= 1 log entries'
+			-e':alias to --log-entries'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme error-log options" _errlog
+			;;
+		(get-feature)
+			local _getf
+			_getf=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':get feature specific to <nsid>'
+			-n':alias to --namespace-id'
+			--feature-id=':hexadecimal name of feature to examine (required)'
+			-f':alias to --feature-id'
+			--sel=':select from 0 - current, 1 - default, 2 - saved, 3 - supported'
+			-s':alias to --sel'
+			--data-len=':buffer len for returned LBA Type Range or host identifier data'
+			-l':alias for --data-len'
+			--cdw11=':dword 11 value, used for interrupt vector configuration only'
+			--raw-binary':dump infos in binary format'
+			-b':alias to --raw-binary'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme get-feature options" _getf
+			;;
+		(set-feature)
+			local _setf
+			_setf=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':feature is specific to <nsid>'
+			-n':alias to --namespace-id'
+			--feature-id=':hexadecimal name of feature to set (required)'
+			-f':alias to --feature-id'
+			--data-len=':buffer length, only used for LBA Type Range or host identifier data'
+			-l':alias for --data-len'
+			--data=':data file for LBA Type Range or host identifier buffer (defaults to stdin)'
+			-d':alias to --data'
+			--value=':new value of feature (required)'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme set-feature options" _setf
+			;;
+		(format)
+			local _format
+			_format=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':<nsid> of namespace to format (required)'
+			-n':alias of --namespace-id'
+			--lbaf=':LBA format to apply to namespace (required)'
+			-l':alias of --lbaf'
+			--ses=':secure erase? 0 - no-op (default), 1 - user-data erase, 2 - cryptographic erase'
+			-s':alias of --ses'
+			--pil=':location of protection information? 0 - end, 1 - start'
+			-p':alias of --pil'
+			--pi=':protection information? 0 - off, 1 - Type 1 on, 2 - Type 2 on, 3 - Type 3 on'
+			-i':alias of --pi'
+			--ms=':extended format? 0 - off (metadata in separate buffer), 1 - on (extended LBA used)'
+			-m':alias of --ms'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme format options" _format
+			;;
+		(fw-activate)
+			local _fwact
+			_fwact=(
+			/dev/nvme':supply a device to use (required)'
+			--action=':activation action (required)? 0 - replace fw without activating, 1 - replace with activation, 2 - replace with activation at next reset'
+			-a':alias of --action'
+			--slot=':firmware slot to activate'
+			-s':alias of --slot'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme fw-activate options" _fwact
+			;;
+		(fw-download)
+			local _fwd
+			_fwd=(
+			/dev/nvme':supply a device to use (required)'
+			--fw=':firmware file to download (required)'
+			-f':alias of --fw'
+			--xfer=':limit on chunk-size of transfer (if device has download size limit)'
+			-x':alias of --xfer'
+			--offset=':starting offset, in dwords (defaults to 0, only useful if download is split across multiple files)'
+			-o':alias of --offset'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme fw-download options" _fwd
+			;;
+		(admin-passthru)
+			local _admin
+			_admin=(
+			/dev/nvme':supply a device to use (required)'
+			--opcode=':hexadecimal opcode to send (required)'
+			-o':alias of --opcode'
+			--flags=':command flags'
+			-f':alias of --flags'
+			--rsvd=':value for reserved field'
+			-R':alias of --rsvd'
+			--namespace-id=':value for nsid'
+			-n':alias of --namespace-id'
+			--data-len=':length for data buffer'
+			-l':alias of --data-len'
+			--metadata-len=':length for metadata buffer'
+			-m':alias of --metadata-len'
+			--timeout=':value for timeout'
+			-t':alias of --timeout'
+			--cdw2=':value for command dword 2'
+			-2':alias for --cdw2'
+			--cdw3=':value for command dword 3'
+			-3':alias for --cdw3'
+			--cdw10=':value for command dword 10'
+			-4':alias for --cdw10'
+			--cdw11=':value for command dword 11'
+			-5':alias for --cdw11'
+			--cdw12=':value for command dword 12'
+			-6':alias for --cdw12'
+			--cdw13=':value for command dword 13'
+			-7':alias for --cdw13'
+			--cdw14=':value for command dword 14'
+			-8':alias for command dword 14'
+			--cdw15=':value for command dword 15'
+			-9':alias for command dword 15'
+			--input-file=':defaults to stdin; input for write (send direction)'
+			-i':alias for --input-file'
+			--raw-binary':dump output in binary format'
+			-b':alias for --raw-binary'
+			--show-command':simply print command instead of sending it to <device>'
+			-s':alias for --show-command'
+			--dry-run':alias for --show-command'
+			-d':alias for --show-command'
+			--read':set dataflow direction to receive'
+			-r':alias for --read'
+			--write':set dataflow direction to send'
+			-w':alias for --write'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme admin-passthru options" _admin
+			;;
+		(io-passthru)
+			local _io
+			_io=(
+			/dev/nvme':supply a device to use (required)'
+			--opcode=':hexadecimal opcode to send (required)'
+			-o':alias of --opcode'
+			--flags=':command flags'
+			-f':alias of --flags'
+			--rsvd=':value for reserved field'
+			-R':alias of --rsvd'
+			--namespace-id=':value for nsid'
+			-n':alias of --namespace-id'
+			--data-len=':length for data buffer'
+			-l':alias of --data-len'
+			--metadata-len=':length for metadata buffer'
+			-m':alias of --metadata-len'
+			--timeout=':value for timeout'
+			-t':alias of --timeout'
+			--cdw2=':value for command dword 2'
+			-2':alias for --cdw2'
+			--cdw3=':value for command dword 3'
+			-3':alias for --cdw3'
+			--cdw10=':value for command dword 10'
+			-4':alias for --cdw10'
+			--cdw11=':value for command dword 11'
+			-5':alias for --cdw11'
+			--cdw12=':value for command dword 12'
+			-6':alias for --cdw12'
+			--cdw13=':value for command dword 13'
+			-7':alias for --cdw13'
+			--cdw14=':value for command dword 14'
+			-8':alias for command dword 14'
+			--cdw15=':value for command dword 15'
+			-9':alias for command dword 15'
+			--input-file=':defaults to stdin; input for write (send direction)'
+			-i':alias for --input-file'
+			--raw-binary':dump output in binary format'
+			-b':alias for --raw-binary'
+			--show-command':simply print command instead of sending it to <device>'
+			-s':alias for --show-command'
+			--dry-run':alias for --show-command'
+			-d':alias for --show-command'
+			--read':set dataflow direction to receive'
+			-r':alias for --read'
+			--write':set dataflow direction to send'
+			-w':alias for --write'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme io-passthru options" _io
+			;;
+		(security-send)
+			local _ssend
+			_ssend=(
+			/dev/nvme':supply a device to use (required)'
+			--file=':payload'
+			-f':alias for --file'
+			--secp=':security protocol as defined in SPC-4'
+			-p':alias for --secp'
+			--spsp=':send security-protocol-specific data as defined in SPC-4'
+			-s':alias for --spsp'
+			--tl=':transfer length as defined in SPC-4'
+			-t':alias for --tl'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme security-send options" _ssend
+			;;
+		(security-recv)
+			local _srecv
+			_srecv=(
+			/dev/nvme':supply a device to use (required)'
+			--secp=':security protocol as defined in SPC-4'
+			-p':alias for --secp'
+			--spsp=':send security-protocol-specific data as defined in SPC-4'
+			-s':alias for --spsp'
+			--size=':size of buffer (prints to stdout on successful recv)'
+			-x':alias for --size'
+			--al=':allocation length as defined in SPC-4'
+			-a':alias for --al'
+			--raw-binary':dump output in binary format'
+			-b':alias for --raw-binary'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme security-recv options" _srecv
+			;;
+		(resv-acquire)
+			local _acq
+			_acq=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':<nsid> of namespace to try to reserve (required)'
+			-n':alias for --namespace-id'
+			--prkey=':pre-empt reservation key'
+			-p':alias for --prkey'
+			--rtype=':hexadecimal reservation type'
+			-t':alias for --rtype'
+			--racqa=':reservation acquiry action'
+			-a':alias for --racqa'
+			--iekey=':ignore existing reservation key'
+			-i':alias for --iekey'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme resv-acquire options" _acq
+			;;
+		(resv-release)
+			local _rel
+			_rel=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':nsid'
+			-n':alias of --namespace-id'
+			--rtype=':hexadecimal reservation type'
+			-t':alias of --rtype'
+			--rrela=':reservation release action'
+			-a':alias of --rrela'
+			--iekey':ignore existing reservation key'
+			-i':alias of --iekey'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme resv-release options" _rel
+			;;
+		(resv-report)
+			local _rep
+			_rep=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':nsid'
+			-n':alias of --namespace-id'
+			--numd=':number of dwords of reservation status to xfer'
+			-d':alias of --numd'
+			--raw-binary':dump output in bnary format'
+			-b':alias of --raw-binary'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme resv-report options" _rep
+			;;
+		(resv-register)
+			local _reg
+			_reg=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':nsid'
+			-n':alias of --namespace-id'
+			--crkey=':current reservation key'
+			-c'alias of --crkey'
+			--nrkey=':new reservation key'
+			-k':alias of --nrkey'
+			--cptpl=':change persistence through power loss setting'
+			-p':alias for --cptpl'
+			--rrega=':reservation registration action to perform'
+			-a':alias for --rrega'
+			--iekey':ignore existing reservation key'
+			-i':alias for --iekey'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme resv-register options" _reg
+			;;
+		(flush)
+			local _flush
+			_flush=(
+			/dev/nvme':supply a device to use (required)'
+			--namespace-id=':nsid'
+			-n':alias of --namespace-id'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme flush options" _flush
+			;;
+		(compare)
+			local _comp
+			_comp=(
+			/dev/nvme':supply a device to use (required)'
+			--start-block=':begin compare at this 64-bit LBA on device'
+			-s':alias of --start-block'
+			--block-count=':number of logical blocks on device to compare to local data'
+			-c':alias of --block-count'
+			--metadata-size=':number of bytes of metadata to compare'
+			-y':alias of --metadata-size'
+			--data-size=':size of local data buffer in bytes'
+			-z':alias of --data-size'
+			--data=':local data file to compare to blocks on device'
+			-d':alias of --data'
+			--prinfo=':protection information action and check field'
+			-p':alias of --prinfo'
+			--app-tag-mask=':no description available yet'
+			-m':alias of --app-tag-mask'
+			--app-tag=':no description available yet'
+			-a':alias of --app-tag'
+			--limited-retry':if included, controller should try less hard to retrieve data from media (if not included, all available data recovery means used)'
+			-l':alias of --limited-retry'
+			--force-unit-access':if included, the data shall be read from non-volatile media'
+			-f':alias of --force-unit access'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme compare options" _comp
+			;;
+		(read)
+			local _read
+			_read=(
+			/dev/nvme':supply a device to use (required)'
+			--start-block=':64-bit address of the first logical block to be read'
+			-s':alias of --start-block'
+			--block-count=':number of logical blocks on device to read'
+			-c':alias of --block-count'
+			--data-size=':size of data to be read'
+			-z':alias of --data-size'
+			--metadata-size=':size of metadata to be read'
+			-y':alias of --metadata-size'
+			--ref-tag=':no description available yet'
+			-r':alias of --ref-tag'
+			--data=':file into which data should be read (defaults to stdout)'
+			-d':alias of --data'
+			--prinfo=':protection information and check field'
+			-p':alias of --prinfo'
+			--app-tag-mask=':no description available yet'
+			-m':alias of --app-tag-mask'
+			--app-tag=':no description available yet'
+			-a':alias of --app-tag'
+			--limited-retry=':if included, controller should try less hard to retrieve data from media (if not included, all available data-recovery means used)'
+			-l':alias of --limited-retry'
+			--latency':latency statistics will be output following read'
+			-t':alias of --latency'
+			--force-unit-access':data read shall be returned from nonvolatile media before command completion is indicated'
+			-f':alias of --force-unit-access'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme read options" _read
+			;;
+		(write)
+			local _wr
+			_wr=(
+			/dev/nvme':supply a device to use (required)'
+			--start-block=':64-bit address of the first logical block to be written'
+			-s':alias of --start-block'
+			--block-count=':number of logical blocks on device to write'
+			-c':alias of --block-count'
+			--data-size=':size of data to be written'
+			-z':alias of --data-size'
+			--metadata-size=':size of metadata to be written'
+			-y':alias of --metadata-size'
+			--ref-tag=':no description available yet'
+			-r':alias of --ref-tag'
+			--data=':file from which data should be written to device (defaults to stdin)'
+			-d':alias of --data'
+			--prinfo=':protection information and check field'
+			-p':alias of --prinfo'
+			--app-tag-mask=':no description available yet'
+			-m':alias of --app-tag-mask'
+			--app-tag=':no description available yet'
+			-a':alias of --app-tag'
+			--limited-retry=':if included, controller should try less hard to send data to media (if not included, all available data-recovery means used)'
+			-l':alias of --limited-retry'
+			--latency':latency statistics will be output following write'
+			-t':alias of --latency'
+			--force-unit-access':data shall be written to nonvolatile media before command completion is indicated'
+			-f':alias of --force-unit-access'
+
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme write options" _wr
+			;;
+		(show-regs)
+			local _shor
+			_shor=(
+			/dev/nvme':supply a device to use (required)'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme show-regs options" _shor
+			;;
+		(help)
+			local _h
+			_h=( id-ctrl id-ns list-ns create-ns delete-ns attach-ns detach-ns
+			     list-ctrl get-ns-id get-log fw-log smart-log error-log get-feature
+			     set-feature format fw-activate fw-download admin-passthru io-passthru
+			     security-send security-recv resv-acquire resv-register resv-release
+			     resv-report flush compare read write show-regs
+			   )
+			_arguments '*:: :->subcmds'
+			_describe -t commands "help: infos on a specific nvme command, or provide no option to see a synopsis of all nvme commands" _h
+			;;
+		(*)
+			_files
+			;;
+		esac
+		return
+	fi
+
+	_files
+}

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# bash tab completion for the nvme command line utility
+# (unfortunately, bash won't let me add descriptions to cmds)
+# Kelly Kaoudis kelly.n.kaoudis at intel.com, June 2015
+
+_cmds="admin-passthru attach-ns compare create-ns delete-ns detach-ns error-log flush format fw-activate fw-download fw-log get-feature get-log get-ns-id help id-ctrl id-ns io-passthru list-ctrl list-ns read resv-acquire resv-register resv-release resv-report security-resv security-send set-feature show-regs smart-log write"
+
+_nvme_list_opts () {
+	local opts="/dev/nvme*"
+
+	case "$1" in
+		"admin-passthru")
+		opts+=" --opcode= -o --flags= -f --rsvd= -R --namespace-id= -n --data-len= -l --metadata-len= -m --timeout= -t --cdw2= -2 --cdw3= -3 --cdw10= -4 --cdw11= -5 --cdw12= -6 --cdw13= -7 --cdw14= -8 --cdw15= -9 --input-file= -i --raw-binary= -b --show-command -s --dry-run -d --read -r --write -w"
+			;;
+		"attach-ns")
+		opts+=" --namespace-id= -n --controllers= -c"
+			;;
+		"compare")
+		opts+=" --start-block= -s --block-count= -c --metadata-size= -y --data-size= -z --data= -d --prinfo= -p --app-tag-mask= -m --app-tag= -a --limited-retry -l --force-unit-access -f"
+			;;
+		"create-ns")
+		opts+=" --nsze= -s --ncap= -c --flbas= -f --dps= -d --nmic= -n"
+			;;
+		"delete-ns")
+		opts+=" -namespace-id= -n"
+			;;
+		"detach-ns")
+		opts+=" --namespace-id= -n --controllers= -c"
+			;;
+		"error-log")
+		opts+=" --namespace-id= -n --raw-binary -b --log-entries= -e"
+			;;
+		"flush")
+		opts+=" --namespace-id= -n"
+			;;
+		"format")
+		opts+=" --namespace-id= -n --lbaf= -l --ses= -s --pil= -p --pi= -i --ms= -m"
+			;;
+		"fw-activate")
+		opts+=" --action= -a --slot= -s"
+			;;
+		"fw-download")
+		opts+=" --fw= -f --xfer= -x --offset= -o"
+			;;
+		"fw-log")
+		opts+=" --raw-binary -b"
+			;;
+		"get-feature")
+		opts+=" --namespace-id= -n --feature-id= -f --sel= -s --data-len= -l --cdw11= --raw-binary -b"
+			;;
+		"get-log")
+		opts+=" --log-id= -i --log-len= -l --namespace-id= -n --raw-binary= -b"
+			;;
+		"get-ns-id")
+			;;
+		"help")
+		opts=$_cmds
+			;;
+		"id-ctrl")
+		opts+=" --raw-binary -b --human-readable -H --vendor-specific -v"
+			;;
+		"id-ns")
+		opts+=" --namespace-id= -n --raw-binary -b --human-readable -H --vendor-specific -v"
+			;;
+		"list-ctrl")
+		opts+=" --namespace-id= -n --cntid= -c"
+			;;
+		"list-ns")
+		opts+=" --namespace-id= -n"
+			;;
+		"read")
+		opts+=" --start-block= -s --block-count= -c --data-size= -z --metadata-size= -y --ref-tag= -r --data= -d --prinfo= -p --app-tag-mask= -m --app-tag= -a --limited-retry -l --latency -t --force-unit-access -f"
+			;;
+		"resv-acquire")
+		opts+=" --namespace-id= -n --prkey= -p --rtype= -t --racqa= -a --iekey= -i"
+			;;
+		"resv-register")
+		opts+=" --namespace-id= -n --crkey= -c --nrkey= -k --cptpl= -p --rrega= -a --iekey -i"
+			;;
+		"resv-release")
+		opts+=" --namespace-id= -n --rtype= -t --rrela= -a --iekey -i"
+			;;
+		"resv-report")
+		opts+=" --namespace-id= -n --numd= -d --raw-binary= -b"
+			;;
+		"security-recv")
+		opts+=" --secp= -p --spsp= -s --size= -x --al= -a --raw-binary -b"
+			;;
+		"security-send")
+		opts+=" --file= -f --secp= -p --spsp= -s --tl= -t"
+			;;
+		"set-feature")
+		opts+=" --namespace-id= -n --feature-id= -f --data-len= -l --data= -d --value="
+			;;
+		"show-regs")
+			;;
+		"smart-log")
+		opts+=" --namespace-id= -n --raw-binary -b"
+			;;
+		"write")
+		opts+=" --start-block= -s --block-count= -c --data-size= -z --metadata-size= -y --ref-tag= -r --data= -d --prinfo= -p --app-tag-mask= -m --app-tag= -a --limited-retry -l --latency -t --force-unit-access -f"
+			;;
+	esac
+
+	COMPREPLY+=( $( compgen -W "$opts" -- $cur ) )
+	return 0
+}
+
+_nvme_subcmds () {
+	local prev cur
+
+	prev=${COMP_WORDS[COMP_CWORD - 1]}
+
+	if [[ "$prev" != "nvme" ]]; then
+		if [[ "$_cmds" =~ "$prev" ]]; then
+			_nvme_list_opts $prev
+		else
+			_nvme_list_opts ${COMP_WORDS[1]}
+		fi
+	else
+		COMPREPLY+=( $( compgen -W "$_cmds" -- $cur ) )
+	fi
+
+	return 0
+}
+
+complete -F _nvme_subcmds nvme

--- a/nvme.c
+++ b/nvme.c
@@ -977,6 +977,11 @@ static void show_nvme_id_ns(struct nvme_id_ns *ns, int id, int vs, int human)
 static int get_smart_log(int argc, char **argv)
 {
 	struct nvme_smart_log smart_log;
+	const char *desc = "smart-log: retrieve SMART log for the given "\
+		"device (or optionally, namespace) in either hex-dump "\
+		"(default) or binary format.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --raw-binary | -b ]";
 	int err;
 
 	struct config {
@@ -996,11 +1001,9 @@ static int get_smart_log(int argc, char **argv)
 		{"b",            "",    CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "get_smart_log", command_line_options, 4,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 4, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1021,6 +1024,11 @@ static int get_smart_log(int argc, char **argv)
 
 static int get_error_log(int argc, char **argv)
 {
+	const char *desc = "error-log: retrieve specified number of "\
+		"error log entries from a given device (or "\
+		"namespace) in either hex-dump (default) or binary format.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --log-entries=NUM | -e NUM ][ --raw-binary | -b ]";
 	int err;
 
 	struct config {
@@ -1044,16 +1052,14 @@ static int get_error_log(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "get_error_log", command_line_options, 6,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 6, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
 	if (!cfg.log_entries) {
-		fprintf(stderr, "non-zero log-entires is required param\n");
+		fprintf(stderr, "non-zero log-entries is required param\n");
 		return EINVAL;
 	}
 	struct nvme_error_log_page err_log[cfg.log_entries];
@@ -1075,6 +1081,10 @@ static int get_error_log(int argc, char **argv)
 
 static int get_fw_log(int argc, char **argv)
 {
+	const char *desc = "fw-log: retrieve the firmware log for the "\
+		"specified device in either hex-dump (default) or binary "\
+		"format.";
+	const char *options_list = "/dev/nvmeX [ --raw-binary | -b ]";
 	int err;
 	struct nvme_firmware_log_page fw_log;
 
@@ -1091,11 +1101,9 @@ static int get_fw_log(int argc, char **argv)
 		{"b",          "",   CFG_NONE, &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "get_fw_log", command_line_options, 2,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 2, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1118,6 +1126,12 @@ static int get_fw_log(int argc, char **argv)
 
 static int get_log(int argc, char **argv)
 {
+	const char *desc = "get-log: retrieve desired number of bytes "\
+		"from a given log on a specified device in either "\
+		"hex-dump (default) or binary format";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --log-id=NUM | -i NUM ][ --log-len=NUM | -l NUM ]"\
+		"[ --raw-binary | -b ]";
 	int err;
 
 	struct config {
@@ -1145,11 +1159,9 @@ static int get_log(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "get_log", command_line_options, 8,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 8, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1178,6 +1190,10 @@ static int get_log(int argc, char **argv)
 
 static int list_ctrl(int argc, char **argv)
 {
+	const char *desc = "list-ctrl: show controller information for the "\
+		"given device (and optionally, namespace)";
+	const char *options_list = "/dev/nvmeX [ --cntid=NUM | -c NUM ]"\
+		"[ --namespace-id=NUM | -n NUM ]";
 	int err, i;
 	struct nvme_controller_list *cntlist;
 
@@ -1199,11 +1215,8 @@ static int list_ctrl(int argc, char **argv)
 		{0}
 	};
 
-	err = argconfig_parse(argc, argv, "list_ctrl", command_line_options, 4,
-			&defaults, &cfg, sizeof(cfg));
-
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 4, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1224,6 +1237,10 @@ static int list_ctrl(int argc, char **argv)
 
 static int list_ns(int argc, char **argv)
 {
+	const char *desc = "list-ns: for the specified device, show the "\
+		"namespace list (optionally starting with a given namespace)";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ]";
 	int err, i;
 	__u32 ns_list[1024];
 
@@ -1241,11 +1258,9 @@ static int list_ns(int argc, char **argv)
 		{"n",            "NUM",  CFG_POSITIVE, &defaults.namespace_id, required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "list_ns", command_line_options, 2,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 2, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1264,6 +1279,14 @@ static int list_ns(int argc, char **argv)
 static int delete_ns(int argc, char **argv)
 {
 	struct nvme_admin_cmd cmd;
+	const char *desc = "delete-ns: delete the given namespace by "\
+		"sending a namespace management command to "\
+		"the given device. All controllers should be detached from "\
+		"the namespace prior to namespace deletion. A namespace ID "\
+		"becomes inactive when that namespace is detached (or, if "\
+		"the namespace is not already inactive, once deleted).";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+			"M ]";
 	int err;
 
 	struct config {
@@ -1280,11 +1303,8 @@ static int delete_ns(int argc, char **argv)
 		{"n",               "NUM",  CFG_POSITIVE, &defaults.namespace_id,    required_argument, NULL},
 	};
 
-	err = argconfig_parse(argc, argv, "delete_ns", command_line_options, 2,
-			&defaults, &cfg, sizeof(cfg));
-
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 2, &defaults, &cfg, sizeof(cfg));
 
 	if (!cfg.namespace_id) {
 		fprintf(stderr, "%s: namespace-id parameter required\n",
@@ -1307,11 +1327,15 @@ static int delete_ns(int argc, char **argv)
 	return err;
 }
 
-static int nvme_attach_ns(int argc, char **argv, int attach)
+static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc)
 {
 	struct nvme_controller_list *cntlist;
 	struct nvme_admin_cmd cmd;
 	char *name = commands[attach ? ATTACH_NS : DETACH_NS].name;
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --controllers=/dev/nvmeX,...,/dev/nvmeY | "\
+		"--controllers=/dev/nvmeX | -c /dev/nvmeX | "\
+		"-c /dev/nvmeX,...,/dev/nvmeY ]";
 	int err;
 
 	struct config {
@@ -1335,11 +1359,8 @@ static int nvme_attach_ns(int argc, char **argv, int attach)
 		return ENOMEM;
 	memset(cntlist, 0, sizeof(*cntlist));
 
-	err = argconfig_parse(argc, argv, name, command_line_options, 4,
-			&defaults, &cfg, sizeof(cfg));
-
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 4, &defaults, &cfg, sizeof(cfg));
 
 	if (!cfg.namespace_id) {
 		fprintf(stderr, "%s: namespace-id parameter required\n",
@@ -1369,18 +1390,35 @@ static int nvme_attach_ns(int argc, char **argv, int attach)
 
 static int attach_ns(int argc, char **argv)
 {
-	return nvme_attach_ns(argc, argv, 1);
+	const char *desc = "attach-ns: attach the given namespace to the "\
+		"given controller or comma-sep list of controllers. ID of the "\
+		"given namespace becomes active upon attachment to a "\
+		"controller. A namespace must be attached to a controller "\
+		"before IO commands may be directed to that namespace.";
+	return nvme_attach_ns(argc, argv, 1, desc);
 }
 
 static int detach_ns(int argc, char **argv)
 {
-	return nvme_attach_ns(argc, argv, 0);
+	const char *desc = "detach-ns: detach the given namespace from the "\
+		"given controller; de-activates the given namespace's ID. A "\
+		"namespace must be attached to a controller before IO "\
+		"commands may be directed to that namespace.";
+	return nvme_attach_ns(argc, argv, 0, desc);
 }
 
 static int create_ns(int argc, char **argv)
 {
 	struct nvme_admin_cmd cmd;
 	struct nvme_id_ns *ns;
+	const char *desc = "create-ns: send a namespace management command "\
+		"to the specified device to create a namespace with the given "\
+		"parameters. The next available namespace ID is used for the "\
+		"create operation. Note that create-ns does not attach the "\
+		"namespace to a controller, the attach-ns command is needed.";
+	const char *options_list = "/dev/nvmeX [ --nsze=NUM | -s NUM ]"\
+		"[ --ncap=NUM | -c NUM ][ --flbas=NUM | -f NUM]"\
+		"[ --dps=NUM | -d NUM ][ --nmic NUM | -n NUM ]";
 	int err = 0;
 
 	struct config {
@@ -1409,11 +1447,8 @@ static int create_ns(int argc, char **argv)
 		{0}
 	};
 
-	err = argconfig_parse(argc, argv, "create_ns", command_line_options, 10,
-			&defaults, &cfg, sizeof(cfg));
-
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 10, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1463,7 +1498,7 @@ static void get_registers(struct nvme_bar **bar, unsigned char_only)
 	void *membase;
 
 	if (char_only && !S_ISCHR(nvme_stat.st_mode)) {
-		fprintf(stderr, "%s is not character device\n", devicename);
+		fprintf(stderr, "%s is not a character device\n", devicename);
 		exit(ENODEV);
 	}
 
@@ -1617,6 +1652,13 @@ static int list(int argc, char **argv)
 
 static int id_ctrl(int argc, char **argv)
 {
+	const char *desc = "id-ctrl: send an Identify Controller command to "\
+		"the given device and report information about the specified "\
+		"controller in human-readable or "\
+		"binary format. Can also return binary vendor-specific "\
+		"controller attributes.";
+	const char *options_list = "/dev/nvmeX [ --raw-binary | -b ][ -H"\
+		" | --human-readable ][ --vendor-specific | -v ]";
 	int err;
 	struct nvme_id_ctrl ctrl;
 
@@ -1639,11 +1681,9 @@ static int id_ctrl(int argc, char **argv)
 		{"H",               "", CFG_NONE, &defaults.human_readable,  no_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "id_ctrl", command_line_options, 6,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 6, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1663,6 +1703,13 @@ static int id_ctrl(int argc, char **argv)
 
 static int id_ns(int argc, char **argv)
 {
+	const char *desc = "id-ns: send an Identify Namespace command to the "\
+		"given device, returns properties of the specified namespace "\
+		"in either human-readable or binary format. Can also return "\
+		"binary vendor-specific namespace attributes.";
+	const char *options_list = "   /dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --vendor-specific | -v ][ --raw-binary | -b ]"\
+		"[ --human-readable | -H ]";
 	struct nvme_id_ns ns;
 	int err;
 
@@ -1689,11 +1736,9 @@ static int id_ns(int argc, char **argv)
 		{"H",               "",    CFG_NONE,     &defaults.human_readable,  no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "id_ns", command_line_options, 8,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 8, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1764,6 +1809,18 @@ static int nvme_feature(int opcode, void *buf, int data_len, __u32 fid,
 
 static int get_feature(int argc, char **argv)
 {
+	const char *desc = "get-feature: read operating parameters of the "\
+		"specified controller. Operating parameters are grouped "\
+		"and identified by Feature Identifiers; each Feature "\
+		"Identifier contains one or more attributes that may affect "\
+		"behaviour of the feature. Each Feature has three possible "\
+		"settings: default, saveable, and current. If a Feature is "\
+		"saveable, it may be modified by set-feature. Default values "\
+		"are vendor-specific and not changeable. Use set-feature to "\
+		"change saveable Features.";
+	const char *options_list = "   /dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --feature-id=NUM | -f NUM ][ --sel=NUM | -s NUM ]"\
+		"[ --data-len=NUM | -l NUM ][ --raw-binary | -b ] --cdw11=NUM ";
 	int err;
 	unsigned int result, cdw10 = 0;
 	void *buf = NULL;
@@ -1800,11 +1857,9 @@ static int get_feature(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "get_feature", command_line_options, 11,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 11, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1849,6 +1904,16 @@ static int get_feature(int argc, char **argv)
 
 static int fw_download(int argc, char **argv)
 {
+	const char *desc = "fw-download: copy all or part of a firmware to "\
+		"a controller for future update. Optionally, specify how "\
+		"many KiB of the firmware to transfer at once (offset will "\
+		"start at 0 and automatically adjust based on xfer size "\
+		"unless fw is split across multiple files). May be submitted "\
+		"while outstanding commands exist on the Admin and IO "\
+		"Submission Queues. Activate downloaded firmware with "\
+		"fw-activate and reset the device to apply the downloaded firmware.";
+	const char *options_list = "/dev/nvmeX [ --fw=FILE | -f FILE ][ "\
+		"--xfer=NUM | -x NUM ][ --offset=NUM | -o NUM ]";
 	int err, fw_fd = -1;
 	unsigned int fw_size;
 	struct stat sb;
@@ -1877,11 +1942,9 @@ static int fw_download(int argc, char **argv)
 		{"o",      "NUM",  CFG_POSITIVE, &defaults.offset, required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "fw_download", command_line_options, 6,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 6, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -1941,6 +2004,13 @@ static int fw_download(int argc, char **argv)
 
 static int fw_activate(int argc, char **argv)
 {
+	const char *desc = "fw-activate: verify downloaded firmware image and "\
+		"commit to specific firmware slot. Device is not automatically "\
+		"reset following firmware activation. A reset may be issued "\
+		"with an 'echo 1 > /sys/class/misc/nvmeX/device/reset'. "\
+		"Ensure nvmeX is the device you just activated before reset.";
+	const char *options_list = "/dev/nvmeX [ --slot=NUM | -s NUM ][ "\
+		"--action=NUM | -a NUM ]";
 	int err;
 	struct nvme_admin_cmd cmd;
 
@@ -1962,11 +2032,9 @@ static int fw_activate(int argc, char **argv)
 		{"a",      "NUM", CFG_BYTE, &defaults.action, required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "fw_activate", command_line_options, 4,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 4, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2024,6 +2092,15 @@ static int show_registers(int argc, char **argv)
 
 static int format(int argc, char **argv)
 {
+	const char *desc = "format: re-format a specified namespace on the "\
+		"given device. Can erase all data in namespace (user "\
+		"data erase) or delete data encryption key if specified. "\
+		"Can also be used to change LBAF such that device may "\
+		"disappear from all lists since capacity superficially "\
+		"appears to be 0.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --lbaf=NUM |  -l NUM ][ --ses=NUM | -s NUM ][ --pi=NU"\
+		"M | -i NUM ][ --pil=NUM | -p NUM ][ --ms=NUM | -m NUM ]";
 	int err;
 	struct nvme_admin_cmd cmd;
 
@@ -2059,11 +2136,9 @@ static int format(int argc, char **argv)
 		{"m",            "NUM",  CFG_BYTE,     &defaults.ms,           required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "format", command_line_options, 12,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 12, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2109,6 +2184,18 @@ static int format(int argc, char **argv)
 
 static int set_feature(int argc, char **argv)
 {
+	const char *desc = "set-feature: modify the saveable/changeable "\
+		"current operating parameters of the controller. Operating "\
+		"parameters are grouped and identified by Feature "\
+		"Identifiers. Feature settings can be applied to the entire "\
+		"controller and all associated namespaces, or to only a few "\
+		"namespace(s) associated with the controller. Default values "\
+		"for each Feature are vendor-specific and may not be modified."\
+		"Use get-feature to determine which Features are supported by "\
+		"the controller and are saveable/changeable.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --feature-id=NUM | -f NUM ][ --value=NUM | -v NUM ]"\
+		"[ --data-len=NUM | -l NUM ][ --data=FILE | -d FILE ]";
 	int err;
 	unsigned int result;
 	void *buf = NULL;
@@ -2144,11 +2231,9 @@ static int set_feature(int argc, char **argv)
 		{"d",            "FILE", CFG_STRING,   &defaults.file,         required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "set_feature", command_line_options, 10,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 10, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2203,6 +2288,14 @@ static int sec_send(int argc, char **argv)
 {
 	struct stat sb;
 	struct nvme_admin_cmd cmd;
+	const char *desc = "security-send: transfer security protocol data to "\
+		"a controller. Security Receives for the same protocol should be "\
+		"performed after Security Sends. The security protocol field "\
+		"associates Security Sends (security-send) and Security Receives "\
+		"(security-recv).";
+	const char *options_list = "/dev/nvmeX [ --file=FILE | -f FILE ][ "\
+		"--secp=NUM | -p NUM ][ --spsp=NUM | -s NUM ][ --tl=NUM | "\
+		"-t NUM ]";
 	int err, sec_fd = -1;
 	void *sec_buf;
 	unsigned int sec_size;
@@ -2233,11 +2326,9 @@ static int sec_send(int argc, char **argv)
 		{"t",          "NUM",   CFG_POSITIVE, &defaults.tl,         required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "sec_send", command_line_options, 8,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 8, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2277,6 +2368,12 @@ static int sec_send(int argc, char **argv)
 static int flush(int argc, char **argv)
 {
 	struct nvme_passthru_cmd cmd;
+	const char *desc = "flush: commit data and metadata associated with "\
+	"given namespaces to nonvolatile media. Applies to all commands "\
+	"finished before the flush was submitted. Additional data may also be "\
+	"flushed by the controller, from any namespace, depending on controller and "\
+	"associated namespace status.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NUM ]";
 	int err;
 
 	struct config {
@@ -2293,11 +2390,9 @@ static int flush(int argc, char **argv)
 		{"n",            "NUM",  CFG_POSITIVE,    &defaults.namespace_id, required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "flush", command_line_options, 2,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 2, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2319,6 +2414,15 @@ static int flush(int argc, char **argv)
 static int resv_acquire(int argc, char **argv)
 {
 	struct nvme_passthru_cmd cmd;
+	const char *desc = "resv-acquire: obtain a reservation on a given "\
+		"namespace. Only one reservation is allowed at a time on a "\
+		"given namespace, though multiple controllers may register "\
+		"with that namespace. Namespace reservation will abort with "\
+		"status Reservation Conflict if the given namespace is "\
+		"already reserved.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --crkey=NUM | -c NUM ][ --prkey=NUM | -p NUM ][ --rty"\
+		"pe=NUM | -t NUM ][ --racqa=NUM | -a NUM ][ --iekey | -i ]";
 	int err;
 	__u64 payload[2];
 
@@ -2355,11 +2459,9 @@ static int resv_acquire(int argc, char **argv)
 		{"i",            "",     CFG_NONE,        &defaults.iekey,        no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "resv_acquire", command_line_options, 12,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 12, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2406,6 +2508,12 @@ static int resv_acquire(int argc, char **argv)
 static int resv_register(int argc, char **argv)
 {
 	struct nvme_passthru_cmd cmd;
+	const char *desc = "resv-register: register, de-register, or "\
+		"replace a controller's reservation on a given namespace. "\
+		"Only one reservation at a time is allowed on any namespace.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --crkey=NUM | -c NUM ][ --nrkey=NUM | -k NUM ][ --rre"\
+		"ga=NUM | -r NUM ][ --cptpl=NUM | -p NUM ][ --iekey | -i ]";
 	int err;
 	__u64 payload[2];
 
@@ -2442,11 +2550,9 @@ static int resv_register(int argc, char **argv)
 		{"i",            "",     CFG_NONE,        &defaults.iekey,        no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "resv_register", command_line_options, 12,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 12, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2493,6 +2599,17 @@ static int resv_register(int argc, char **argv)
 static int resv_release(int argc, char **argv)
 {
 	struct nvme_passthru_cmd cmd;
+	const char *desc = "resv-release: releases reservation held on a "\
+		"namespace by the given controller. If rtype != current reser"\
+		"vation type, release fails. If the given controller holds no "\
+		"reservation on the namespace/is not the namespace's current "\
+		"reservation holder, the release command completes with no "\
+		"effect. If the reservation type is not Write Exclusive or "\
+		"Exclusive Access, all registrants on the namespace except "\
+		"the issuing controller are notified.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --crkey=NUM | -c NUM ][ --rtype=NUM | -t NUM ][ --rre"\
+		"la=NUM | -a NUM ][ --iekey=NUM | -i NUM ]";
 	int err;
 
 	struct config {
@@ -2525,11 +2642,9 @@ static int resv_release(int argc, char **argv)
 		{"i",            "NUM",  CFG_BYTE,        &defaults.iekey,        required_argument, NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "resv_release", command_line_options, 10,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 10, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2577,6 +2692,13 @@ static int resv_release(int argc, char **argv)
 static int resv_report(int argc, char **argv)
 {
 	struct nvme_passthru_cmd cmd;
+	const char *desc = "resv-report: returns Reservation Status data "\
+		"structure describing any existing reservations on and the "\
+		"status of a given namespace. Namespace Reservation Status "\
+		"depends on the number of controllers registered for that "\
+		"namespace.";
+	const char *options_list = "/dev/nvmeX [ --namespace-id=NUM | -n NU"\
+		"M ][ --numd=NUM | -d NUM ][ --raw-binary | -b ]";
 	int err;
 	struct nvme_reservation_status *status;
 
@@ -2601,11 +2723,9 @@ static int resv_report(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "resv_report", command_line_options, 6,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 6, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2654,8 +2774,16 @@ static int resv_report(int argc, char **argv)
 	return 0;
 }
 
-static int submit_io(int opcode, char *command, int argc, char **argv)
+static int submit_io(int opcode, char *command, const char *desc,
+		     int argc, char **argv)
 {
+	const char *options_list = "/dev/nvmeX [ --start-block=NUM | -s N"\
+		"UM ][ --block-count=NUM | -c NUM ][ --data-size=NUM | -z"\
+		"NUM ][ --metadata-size=NUM | -y NUM ][ --ref-tag=NUM | -"\
+		"r NUM ][ --data=FILE | -d FILE ][ --prinfo=NUM | -p NUM ]"\
+		"[ --app-tag-mask=NUM | -m NUM ][ --app-tag=NUM | -a NUM ][ "\
+		"--limited-retry | -l ][ --latency | -t ][ --force-unit-a"\
+		"ccess | -f ]";
 	struct nvme_user_io io;
 	struct timeval start_time, end_time;
 	void *buffer, *mbuffer = NULL;
@@ -2723,11 +2851,8 @@ static int submit_io(int opcode, char *command, int argc, char **argv)
 		{0}
 	};
 
-	err = argconfig_parse(argc, argv, command, command_line_options, 30,
-			&defaults, &cfg, sizeof(cfg));
-
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 30, &defaults, &cfg, sizeof(cfg));
 
 	memset(&io, 0, sizeof(io));
 
@@ -2819,23 +2944,40 @@ static int submit_io(int opcode, char *command, int argc, char **argv)
 
 static int compare(int argc, char **argv)
 {
-	return submit_io(nvme_cmd_compare, "compare", argc, argv);
+	const char *desc = "compare: diff specified logical blocks on "\
+		"device with specified data buffer; return failure if buffer "\
+		"and block(s) are dissimilar";
+	return submit_io(nvme_cmd_compare, "compare", desc, argc, argv);
 }
 
 static int read_cmd(int argc, char **argv)
 {
-	return submit_io(nvme_cmd_read, "read", argc, argv);
+	const char *desc = "read: copy specified logical blocks on the given "\
+		"device to specified data buffer (default buffer is stdout).";
+	return submit_io(nvme_cmd_read, "read", desc, argc, argv);
 }
 
 static int write_cmd(int argc, char **argv)
 {
-	return submit_io(nvme_cmd_write, "write", argc, argv);
+	const char *desc = "write: copy from provided data buffer (default "\
+		"buffer is stdin) to specified logical blocks on the given "\
+		"device.";
+	return submit_io(nvme_cmd_write, "write", desc, argc, argv);
 }
 
 static int sec_recv(int argc, char **argv)
 {
-	struct nvme_admin_cmd cmd;
+	const char *desc = "security-recv: obtain results of one or more "\
+		"previously submitted security-sends. Results, and association "\
+		"between Security Send and Receive, depend on the security "\
+		"protocol field as they are defined by the security protocol "\
+		"used. A Security Receive must follow a Security Send made with "\
+		"the same security protocol.";
+	const char *options_list = "   /dev/nvmeX [ --size=NUM | -x NUM ][ "\
+		"--secp=NUM | -p NUM ][ --spsp=NUM | -s NUM ][ --al=NUM | -t N"\
+		"UM ][ --raw-binary | -b ]";
 	int err;
+	struct nvme_admin_cmd cmd;
 	void *sec_buf = NULL;
 
 	struct config {
@@ -2867,11 +3009,9 @@ static int sec_recv(int argc, char **argv)
 		{"b",          "",     CFG_NONE,     &defaults.raw_binary, no_argument,       NULL},
 		{0}
 	};
-	err = argconfig_parse(argc, argv, "sec_recv", command_line_options, 10,
-			&defaults, &cfg, sizeof(cfg));
 
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 10, &defaults, &cfg, sizeof(cfg));
 
 	get_dev(1, argc, argv);
 
@@ -2893,11 +3033,11 @@ static int sec_recv(int argc, char **argv)
 	if (err < 0)
 		return errno;
 	else if (err != 0)
-		fprintf(stderr, "NVME Security Receivce Command Error:%d\n",
+		fprintf(stderr, "NVME Security Receive Command Error:%d\n",
 									err);
 	else {
 		if (!cfg.raw_binary) {
-			printf("NVME Security Receivce Command Success:%d\n",
+			printf("NVME Security Receive Command Success:%d\n",
 							cmd.result);
 			d(sec_buf, cfg.size, 16, 1);
 		} else if (cfg.size)
@@ -2909,6 +3049,19 @@ static int sec_recv(int argc, char **argv)
 static int nvme_passthru(int argc, char **argv, int ioctl_cmd)
 {
 	int err, wfd = STDIN_FILENO;
+	const char *desc = "[io/admin]-passthru: send a user-specified IO or "\
+		"admin command to the specified device via IOCTL passthrough, "\
+		"return results";
+	const char *options_list = "/dev/nvmeX [ --opcode=NUM | -o NUM ]"\
+		"[ --flags=NUM | -f NUM ][ --rsvd=NUM | -R NUM ][ --namesp"\
+		"ace-id=NUM | -n NUM ][ --data-len=NUM | -l NUM ][ --metadata"\
+		"-len=NUM | -m NUM ][ --timeout=NUM | -t NUM ][ --cdw2=NUM"\
+		"|-2 NUM ][ --cdw3=NUM | -3 NUM ][ --cdw10=NUM | -4 NUM ]["\
+		" --cdw11=NUM | -5 NUM ][ --cdw12=NUM | -6 NUM ][ --cdw13 | -"\
+		"7 NUM ][ --cdw14=NUM | -8 NUM ][ --cdw15=NUM | -9 NUM ][ "\
+		"--input-file=FILE | -i FILE ][ --raw-binary | -b ][ --sho"\
+		"w-command | -s ][ --dry-run | -d ][ --read | -r ][ --writ"\
+		"e | -w ]";
 	struct nvme_passthru_cmd cmd;
 
 	struct config {
@@ -3002,11 +3155,8 @@ static int nvme_passthru(int argc, char **argv, int ioctl_cmd)
 	};
 
 	memset(&cmd, 0, sizeof(cmd));
-	err = argconfig_parse(argc, argv, "nvme_passthru", command_line_options, 42,
-			&defaults, &cfg, sizeof(cfg));
-
-	if (err == -1)
-		return err;
+	argconfig_parse(argc, argv, desc, options_list,
+		command_line_options, 42, &defaults, &cfg, sizeof(cfg));
 
 	cmd.cdw2         = cfg.cdw2;
 	cmd.cdw3         = cfg.cdw3;
@@ -3121,8 +3271,9 @@ static void general_help()
 
 	usage("nvme");
 	printf("\n");
-	printf("The '<device>' may be either an NVMe character device (ex: /dev/nvme0)\n"
-	       "or an nvme block device (ex: /dev/nvme0n1)\n\n");
+	printf("'<device>' / '/dev/nvmeX' may be either an NVMe character "\
+	       "device (ex: /dev/nvme0)\n or an nvme block device (ex: /d"\
+	       "ev/nvme0n1)\n\n");
 	printf("The following are all implemented sub-commands:\n");
 	for (i = 0; i < NUM_COMMANDS; i++)
 		printf("  %-*s %s\n", 15, commands[i].name, commands[i].help);

--- a/nvme.c
+++ b/nvme.c
@@ -996,8 +996,12 @@ static int get_smart_log(int argc, char **argv)
 		{"b",            "",    CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "get_smart_log", command_line_options,
+	err = argconfig_parse(argc, argv, "get_smart_log", command_line_options, 4,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	err = nvme_get_log(&smart_log,
@@ -1040,8 +1044,12 @@ static int get_error_log(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "get_error_log", command_line_options,
+	err = argconfig_parse(argc, argv, "get_error_log", command_line_options, 6,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (!cfg.log_entries) {
@@ -1083,8 +1091,12 @@ static int get_fw_log(int argc, char **argv)
 		{"b",          "",   CFG_NONE, &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "get_fw_log", command_line_options,
+	err = argconfig_parse(argc, argv, "get_fw_log", command_line_options, 2,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	err = nvme_get_log(&fw_log,
@@ -1133,8 +1145,12 @@ static int get_log(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "get_log", command_line_options,
+	err = argconfig_parse(argc, argv, "get_log", command_line_options, 8,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (!cfg.log_len) {
@@ -1182,8 +1198,13 @@ static int list_ctrl(int argc, char **argv)
 		{"n",            "NUM", CFG_POSITIVE, &defaults.namespace_id, required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "list_ctrl", command_line_options,
+
+	err = argconfig_parse(argc, argv, "list_ctrl", command_line_options, 4,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (posix_memalign((void *)&cntlist, getpagesize(), 0x1000))
@@ -1220,8 +1241,12 @@ static int list_ns(int argc, char **argv)
 		{"n",            "NUM",  CFG_POSITIVE, &defaults.namespace_id, required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "list_ns", command_line_options,
+	err = argconfig_parse(argc, argv, "list_ns", command_line_options, 2,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	err = identify(cfg.namespace_id, ns_list, 2);
@@ -1254,8 +1279,12 @@ static int delete_ns(int argc, char **argv)
 		{"namespace-id",    "NUM",  CFG_POSITIVE, &defaults.namespace_id,    required_argument, NULL},
 		{"n",               "NUM",  CFG_POSITIVE, &defaults.namespace_id,    required_argument, NULL},
 	};
-	argconfig_parse(argc, argv, "delete_ns", command_line_options,
+
+	err = argconfig_parse(argc, argv, "delete_ns", command_line_options, 2,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
 
 	if (!cfg.namespace_id) {
 		fprintf(stderr, "%s: namespace-id parameter required\n",
@@ -1306,8 +1335,12 @@ static int nvme_attach_ns(int argc, char **argv, int attach)
 		return ENOMEM;
 	memset(cntlist, 0, sizeof(*cntlist));
 
-	argconfig_parse(argc, argv, name, command_line_options,
+	err = argconfig_parse(argc, argv, name, command_line_options, 4,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	if (!cfg.namespace_id) {
 		fprintf(stderr, "%s: namespace-id parameter required\n",
 						name);
@@ -1315,6 +1348,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach)
 	}
 	cntlist->num = argconfig_parse_comma_sep_array(cfg.cntlist,
 					(int *)cntlist->identifier, 2047);
+
 	get_dev(1, argc, argv);
 
 	memset(&cmd, 0, sizeof(cmd));
@@ -1374,8 +1408,13 @@ static int create_ns(int argc, char **argv)
 		{"m",               "NUM", CFG_BYTE,        &defaults.nmic,  required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "create_ns", command_line_options,
+
+	err = argconfig_parse(argc, argv, "create_ns", command_line_options, 10,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (posix_memalign((void *)&ns, getpagesize(), 4096))
@@ -1600,8 +1639,12 @@ static int id_ctrl(int argc, char **argv)
 		{"H",               "", CFG_NONE, &defaults.human_readable,  no_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "id_ctrl", command_line_options,
+	err = argconfig_parse(argc, argv, "id_ctrl", command_line_options, 6,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	err = identify(0, &ctrl, 1);
@@ -1646,8 +1689,12 @@ static int id_ns(int argc, char **argv)
 		{"H",               "",    CFG_NONE,     &defaults.human_readable,  no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "id_ns", command_line_options,
+	err = argconfig_parse(argc, argv, "id_ns", command_line_options, 8,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (!cfg.namespace_id) {
@@ -1753,8 +1800,12 @@ static int get_feature(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "get_feature", command_line_options,
+	err = argconfig_parse(argc, argv, "get_feature", command_line_options, 11,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (cfg.sel > 7) {
@@ -1826,8 +1877,12 @@ static int fw_download(int argc, char **argv)
 		{"o",      "NUM",  CFG_POSITIVE, &defaults.offset, required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "fw_download", command_line_options,
+	err = argconfig_parse(argc, argv, "fw_download", command_line_options, 6,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	fw_fd = open(cfg.fw, O_RDONLY);
@@ -1907,8 +1962,12 @@ static int fw_activate(int argc, char **argv)
 		{"a",      "NUM", CFG_BYTE, &defaults.action, required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "fw_activate", command_line_options,
+	err = argconfig_parse(argc, argv, "fw_activate", command_line_options, 4,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (cfg.slot > 7) {
@@ -2000,8 +2059,12 @@ static int format(int argc, char **argv)
 		{"m",            "NUM",  CFG_BYTE,     &defaults.ms,           required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "format", command_line_options,
+	err = argconfig_parse(argc, argv, "format", command_line_options, 12,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (cfg.ses > 7) {
@@ -2081,8 +2144,12 @@ static int set_feature(int argc, char **argv)
 		{"d",            "FILE", CFG_STRING,   &defaults.file,         required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "set_feature", command_line_options,
+	err = argconfig_parse(argc, argv, "set_feature", command_line_options, 10,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (cfg.value == -1) {
@@ -2166,8 +2233,12 @@ static int sec_send(int argc, char **argv)
 		{"t",          "NUM",   CFG_POSITIVE, &defaults.tl,         required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "sec_send", command_line_options,
+	err = argconfig_parse(argc, argv, "sec_send", command_line_options, 8,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	sec_fd = open(cfg.file, O_RDONLY);
@@ -2222,8 +2293,12 @@ static int flush(int argc, char **argv)
 		{"n",            "NUM",  CFG_POSITIVE,    &defaults.namespace_id, required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "flush", command_line_options,
+	err = argconfig_parse(argc, argv, "flush", command_line_options, 2,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	memset(&cmd, 0, sizeof(cmd));
@@ -2280,8 +2355,12 @@ static int resv_acquire(int argc, char **argv)
 		{"i",            "",     CFG_NONE,        &defaults.iekey,        no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "resv_acquire", command_line_options,
+	err = argconfig_parse(argc, argv, "resv_acquire", command_line_options, 12,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (!cfg.namespace_id) {
@@ -2363,8 +2442,12 @@ static int resv_register(int argc, char **argv)
 		{"i",            "",     CFG_NONE,        &defaults.iekey,        no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "resv_register", command_line_options,
+	err = argconfig_parse(argc, argv, "resv_register", command_line_options, 12,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (!cfg.namespace_id) {
@@ -2442,8 +2525,12 @@ static int resv_release(int argc, char **argv)
 		{"i",            "NUM",  CFG_BYTE,        &defaults.iekey,        required_argument, NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "resv_release", command_line_options,
+	err = argconfig_parse(argc, argv, "resv_release", command_line_options, 10,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (!cfg.namespace_id) {
@@ -2514,8 +2601,12 @@ static int resv_report(int argc, char **argv)
 		{"b",            "",     CFG_NONE,     &defaults.raw_binary,   no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "resv_report", command_line_options,
+	err = argconfig_parse(argc, argv, "resv_report", command_line_options, 6,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (!cfg.namespace_id) {
@@ -2632,8 +2723,12 @@ static int submit_io(int opcode, char *command, int argc, char **argv)
 		{0}
 	};
 
-	argconfig_parse(argc, argv, command, command_line_options,
+	err = argconfig_parse(argc, argv, command, command_line_options, 30,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	memset(&io, 0, sizeof(io));
 
 	io.slba    = cfg.start_block;
@@ -2772,8 +2867,12 @@ static int sec_recv(int argc, char **argv)
 		{"b",          "",     CFG_NONE,     &defaults.raw_binary, no_argument,       NULL},
 		{0}
 	};
-	argconfig_parse(argc, argv, "sec_recv", command_line_options,
+	err = argconfig_parse(argc, argv, "sec_recv", command_line_options, 10,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
+
 	get_dev(1, argc, argv);
 
 	if (cfg.size) {
@@ -2903,8 +3002,11 @@ static int nvme_passthru(int argc, char **argv, int ioctl_cmd)
 	};
 
 	memset(&cmd, 0, sizeof(cmd));
-	argconfig_parse(argc, argv, "nvme_passthru", command_line_options,
+	err = argconfig_parse(argc, argv, "nvme_passthru", command_line_options, 42,
 			&defaults, &cfg, sizeof(cfg));
+
+	if (err == -1)
+		return err;
 
 	cmd.cdw2         = cfg.cdw2;
 	cmd.cdw3         = cfg.cdw3;

--- a/src/argconfig.c
+++ b/src/argconfig.c
@@ -34,7 +34,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <stdarg.h>
-#include <inttypes.h>
 
 #define MAX_HELP_FUNC 20
 static argconfig_help_func *help_funcs[MAX_HELP_FUNC] = {NULL};
@@ -79,98 +78,27 @@ void argconfig_append_usage(const char *str)
 }
 
 void argconfig_print_help(char *command, const char *program_desc,
-                          const struct argconfig_commandline_options * options)
+                          const char *options_list)
 {
-    const struct argconfig_commandline_options *s;
-    const int bufsize = 0x1000;
-    char buf[bufsize];
-    int  last_line, nodefault;
+	printf("\033[1mUsage: %s [OPTIONS] %s\n\n\033[0m", command, append_usage_str);
+	print_word_wrapped(program_desc, 0, 0);
 
-    printf("Usage: %s [OPTIONS] %s\n\n", command, append_usage_str);
-    print_word_wrapped(program_desc, 0, 0);
-    printf("\n\nOptions:\n");
-
-    buf[0] = ' ';
-    buf[1] = ' ';
-    buf[2] = 0;
-
-    for (s = options; s->option != 0; s++) {
-        if (s->option[0] == '=') {
-            const char *c = s->option;
-            while (*c == '=') c++;
-            printf("\n%s\n", c);
-            continue;
-        }
-
-        strcat(buf, "-");
-
-        strcat(buf, s->option);
-        strcat(buf, " ");
-        strcat(buf, s->meta);
-
-        if (s->help == NULL) {
-            strcat(buf, ", ");
-            continue;
-        }
-
-        printf("%-30s", buf);
-        if (strlen(buf) > 29)
-            printf("%-31s", "\n");
-
-        last_line = print_word_wrapped(s->help, 30, 30);
-
-        nodefault = 0;
-        if (s->config_type == CFG_STRING) {
-            if (*((char **) s->default_value)) {
-                sprintf(&buf[3], " - default: '%s'", *((char **) s->default_value));
-                nodefault = strlen(*((char **) s->default_value)) == 0;
-            } else {
-                nodefault = 1;
-            }
-        } else if (s->config_type == CFG_INT || s->config_type == CFG_POSITIVE){
-            sprintf(&buf[3], " - default: %d", *((int *) s->default_value));
-        } else if (s->config_type == CFG_LONG){
-            sprintf(&buf[3], " - default: %ld", *((long *) s->default_value));
-        } else if (s->config_type == CFG_LONG_SUFFIX){
-            long long val = *((long *) s->default_value);
-            const char *s = suffix_binary_get(&val);
-            sprintf(&buf[3], " - default: %lld%s", val, s);
-        } else if (s->config_type == CFG_SIZE){
-            sprintf(&buf[3], " - default: %zd", *((size_t *) s->default_value));
-        } else if (s->config_type == CFG_DOUBLE){
-            sprintf(&buf[3], " - default: %.2f", *((double *) s->default_value));
-        } else {
-            sprintf(&buf[3], " ");
-        }
-
-
-        if (!nodefault && s->config_type != CFG_NONE)
-            print_word_wrapped(&buf[3], 30, last_line);
-
-        putchar('\n');
-
-        buf[2] = 0;
-    }
-
-    for (int i = 0; i < MAX_HELP_FUNC; i++) {
-        if (help_funcs[i] == NULL) break;
-        putchar('\n');
-        help_funcs[i]();
-    }
-
-    putchar('\n');
+	printf("\n\n\033[1mOptions:\n\033[0m");
+	printf("\t%s\n", options_list);
 }
 
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
+		    const char *options_list,
                     const struct argconfig_commandline_options *options,
+		    const unsigned int opt_arr_len,
                     const void *config_default, void *config_out,
                     size_t config_size)
 {
     int c;
     int option_index = 0, short_index = 0;
-    int options_count = 0;
     struct option *long_opts;
-    char * short_opts, *endptr;
+    char *short_opts;
+    char *endptr;
     const struct argconfig_commandline_options *s;
     void *value_addr;
 
@@ -178,19 +106,11 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 
     memcpy(config_out, config_default, config_size);
 
-    for (s = options; s->option != 0; s++)
-        options_count++;
-
-    long_opts = malloc(sizeof(struct option)* (options_count + 1));
-    short_opts = malloc(sizeof(*short_opts) * (options_count*2 + 2));
+    long_opts = malloc(sizeof(struct option)* (opt_arr_len + 1));
+    short_opts = malloc(sizeof(*short_opts) * (opt_arr_len*2 + 2));
     short_opts[short_index++] = '-';
 
-    if (long_opts == NULL) {
-        fprintf(stderr,  "Unable to allocate memory!\n");
-        exit(1);
-    }
-
-    for (s = options; s->option != 0; s++) {
+    for (s = options; option_index < opt_arr_len; s++) {
         if (strlen(s->option) == 1) {
             short_opts[short_index++] = s->option[0];
             if (s->argument_type == required_argument) {
@@ -200,6 +120,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 
         long_opts[option_index].name    = s->option;
         long_opts[option_index].has_arg = s->argument_type;
+
         if (s->argument_type == no_argument &&
             s->default_value != NULL)
         {
@@ -212,8 +133,10 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
             long_opts[option_index].flag    = NULL;
             long_opts[option_index].val     = 0;
         }
+
         option_index++;
     }
+
     long_opts[option_index].name = NULL;
     long_opts[option_index].flag = NULL;
     long_opts[option_index].val  = 0;
@@ -230,8 +153,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
               !strcmp(long_opts[option_index].name, "help") ||
               !strcmp(long_opts[option_index].name, "-help"))))
         {
-            argconfig_print_help(argv[0], program_desc, options);
-            exit(1);
+            goto err;
         } else if (c == 1) {
             argv[1+non_opt_args] = optarg;
             non_opt_args++;
@@ -239,12 +161,15 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
         } else if (c){
             for (option_index = 0; options[option_index].option[0] != c ||
                  options[option_index].option[1] != 0; option_index++);
+
             if (long_opts[option_index].flag != NULL)
                 *long_opts[option_index].flag = 1;
         }
 
         s = &options[option_index];
+
         while(s->default_value == NULL) s++;
+
         value_addr = (void *) ((char *) s->default_value -
                                (char *) config_default +
                                (char *) config_out);
@@ -310,9 +235,10 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
         } else if (s->config_type == CFG_LONG_SUFFIX) {
             *((long *) value_addr) = suffix_binary_parse(optarg);
             if (errno) {
-                fprintf(stderr, "Expected long suffixed integer argument for '%s' but got '%s'!\n",
-                        long_opts[option_index].name, optarg);
-                exit(1);
+                fprintf(stderr,
+		"Expected long suffixed int argument for '%s' but got '%s'!\n",
+                long_opts[option_index].name, optarg);
+                goto err;
             }
         } else if (s->config_type == CFG_DOUBLE) {
             *((double *) value_addr) = strtod(optarg, &endptr);
@@ -341,10 +267,10 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
             int r = argconfig_parse_subopt_string(optarg, opts, remaining_space);
             if (r == 2) {
                 fprintf(stderr, "Error Parsing Sub-Options: Too many options!\n");
-                exit(1);
+                goto err;
             } else if (r) {
                 fprintf(stderr, "Error Parsing Sub-Options\n");
-                exit(1);
+                goto err;
             }
         } else if (s->config_type == CFG_FILE_A ||
                    s->config_type == CFG_FILE_R ||
@@ -371,7 +297,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
             if (f == NULL) {
                 fprintf(stderr, "Unable to open %s file: %s\n", s->option,
                         optarg);
-                exit(1);
+                goto err;
             }
 
             *((FILE **) value_addr) = f;
@@ -382,15 +308,22 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
     free(long_opts);
 
     for (int i = optind; i < argc; i++) {
-        argv[1+non_opt_args] = argv[i];
+        argv[non_opt_args + 1] = argv[i];
         non_opt_args++;
     }
 
     return non_opt_args;
+
+err:
+    free(short_opts);
+    free(long_opts);
+
+    argconfig_print_help(argv[0], program_desc, options_list);
+
+    return -1;
 }
 
-
-int argconfig_parse_subopt_string (char *string, char **options,
+int argconfig_parse_subopt_string(char *string, char **options,
                                    size_t max_options)
 {
     char **o = options;
@@ -403,15 +336,14 @@ int argconfig_parse_subopt_string (char *string, char **options,
     }
 
     tmp = calloc(strlen(string)+2, 1);
-    if (tmp == NULL) {
-        fprintf(stderr,  "Unable to allocate memory!\n");
-        exit(1);
-    }
     strcpy(tmp, string);
 
     size_t toklen;
     toklen = strcspn(tmp, "=");
-    if (!toklen) return 1;
+
+    if (!toklen)
+	    return 1;
+
     *(o++) = tmp;
     tmp[toklen] = 0;
     tmp += toklen + 1;
@@ -424,7 +356,9 @@ int argconfig_parse_subopt_string (char *string, char **options,
             tmp++;
             toklen = strcspn(tmp, "\"'])}");
 
-            if (!toklen) return 1;
+            if (!toklen)
+		    return 1;
+
             *(o++) = tmp;
             tmp[toklen] = 0;
             tmp += toklen + 1;
@@ -434,7 +368,10 @@ int argconfig_parse_subopt_string (char *string, char **options,
             tmp += toklen + 1;
         } else {
             toklen = strcspn(tmp, ";:,");
-            if (!toklen) return 1;
+
+            if (!toklen)
+		    return 1;
+
             *(o++) = tmp;
             tmp[toklen] = 0;
             tmp += toklen + 1;
@@ -442,7 +379,10 @@ int argconfig_parse_subopt_string (char *string, char **options,
 
 
         toklen = strcspn(tmp, "=");
-        if (!toklen) break;
+
+        if (!toklen)
+		break;
+
         *(o++) = tmp;
         tmp[toklen] = 0;
         tmp += toklen + 1;
@@ -454,84 +394,55 @@ int argconfig_parse_subopt_string (char *string, char **options,
     *(o++) = NULL;
     *(o++) = NULL;
 
-    return 0;
+	return 0;
 }
 
-unsigned argconfig_parse_comma_sep_array(char *string,int *val,unsigned max_length)
+
+unsigned argconfig_parse_comma_sep_array(char *string, int *val,
+		unsigned max_length)
 {
   unsigned ret = 0;
   char *tmp;
   char *p;
 
   if (!strlen(string) || string == NULL)
-    return -1;
+	  return -1;
 
-  tmp = malloc(strlen(string)+1);
-  if (tmp==NULL) {
-    fprintf(stderr,  "Unable to allocate memory!\n");
-    exit(1);}
+  tmp = malloc(strlen(string) + 1);
+  tmp = strtok(string, ",");
 
-  tmp = strtok(string,",");
   if (tmp==NULL)
-    return -1;
+	  return -1;
 
-  val[ret] = strtol(tmp,&p,0);
-  if (*p!=0)
-    return -1;
+  val[ret] = strtol(tmp, &p, 0);
+
+  if (*p != 0)
+	  return -1;
+
   ret++;
 
   while(1) {
-    tmp = strtok(NULL,",");
-    if (tmp==NULL)
-      return ret;
-    if (ret>=max_length)
-      return -1;
-    val[ret] = strtol(tmp,&p,0);
-    if (*p!=0)
-      return -1;
-    ret++;
+	  tmp = strtok(NULL, ",");
+
+	  if (tmp == NULL)
+		return ret;
+
+
+	  if (ret >= max_length)
+		  return -1;
+
+
+	  val[ret] = strtol(tmp, &p, 0);
+
+	  if (*p != 0)
+		  return -1;
+
+	  ret++;
     }
 
 }
 
-unsigned argconfig_parse_comma_sep_arrayd(char *string,double *val,unsigned max_length)
-{
-  unsigned ret = 0;
-  char *tmp;
-  char *p;
-
-  if (!strlen(string) || string == NULL)
-    return -1;
-
-  tmp = malloc(strlen(string)+1);
-  if (tmp==NULL) {
-    fprintf(stderr,  "Unable to allocate memory!\n");
-    exit(1);}
-
-  tmp = strtok(string,",");
-  if (tmp==NULL)
-    return -1;
-
-  val[ret] = strtod(tmp,&p);
-  if (*p!=0)
-    return -1;
-  ret++;
-
-  while(1) {
-    tmp = strtok(NULL,",");
-    if (tmp==NULL)
-      return ret;
-    if (ret>=max_length)
-      return -1;
-    val[ret] = strtod(tmp,&p);
-    if (*p!=0)
-      return -1;
-    ret++;
-    }
-
-}
-
-void argconfig_register_help_func(argconfig_help_func * f) {
+void argconfig_register_help_func(argconfig_help_func *f) {
     for (int i = 0; i < MAX_HELP_FUNC; i++) {
         if (help_funcs[i] == NULL) {
             help_funcs[i] = f;
@@ -541,81 +452,18 @@ void argconfig_register_help_func(argconfig_help_func * f) {
     }
 }
 
-void argconfig_print_subopt_help(const struct argconfig_sub_options * options,
-                                 int indent)
-{
-    const struct argconfig_sub_options *s;
-    const int bufsize = 120;
-    char buf[bufsize];
-    int  last_line, nodefault;
-
-    buf[0] = ' ';
-    buf[1] = ' ';
-    buf[2] = 0;
-
-    for (s = options; s->option != 0; s++) {
-        if (s->option[0] == '=') {
-            const char *c = s->option;
-            while (*c == '=') c++;
-            printf("\n%*s%s", indent, "", c);
-            continue;
-        }
-
-        strcat(buf, s->option);
-        strcat(buf, "=");
-        strcat(buf, s->meta);
-
-        if (s->help == NULL) {
-            strcat(buf, ", ");
-            continue;
-        }
-
-        printf("%*s%-*s", indent, "", 30-indent, buf);
-        if (strlen(buf) > 29-indent)
-            printf("%-31s", "\n");
-
-        last_line = print_word_wrapped(s->help, 30-indent, 30-indent);
-
-        nodefault = 0;
-        if (s->config_type == CFG_STRING) {
-            sprintf(&buf[3], " - default: '%s'", *((char **) s->default_value));
-            nodefault = strlen(*((char **) s->default_value)) == 0;
-        } else if (s->config_type == CFG_INT || s->config_type == CFG_BOOL){
-            sprintf(&buf[3], " - default: %d", *((int *) s->default_value));
-        } else if (s->config_type == CFG_LONG){
-            sprintf(&buf[3], " - default: %ld", *((long *) s->default_value));
-        } else if (s->config_type == CFG_LONG_SUFFIX){
-            long long val = *((long *) s->default_value);
-            const char *s = suffix_binary_get(&val);
-            sprintf(&buf[3], " - default: %lld%s", val, s);
-        } else if (s->config_type == CFG_SIZE){
-            sprintf(&buf[3], " - default: %zd", *((size_t *) s->default_value));
-        } else if (s->config_type == CFG_DOUBLE){
-            sprintf(&buf[3], " - default: %.2f", *((double *) s->default_value));
-        } else {
-            sprintf(&buf[3], " ");
-        }
-
-
-        if (!nodefault && s->config_type != CFG_NONE)
-            print_word_wrapped(&buf[3], 30, last_line);
-
-        putchar('\n');
-
-        buf[2] = 0;
-    }
-}
-
-void argconfig_parse_subopt(char * const opts[], const char *module,
+int argconfig_parse_subopt(char * const opts[], const char *module,
+			    const char *program_desc, const char *options_list,
                             const struct argconfig_sub_options *options,
                             const void *config_default, void *config_out,
                             size_t config_size)
 {
-    memcpy(config_out, config_default, config_size);
     int enddefault = 0;
-
+    int tmp;
     const struct argconfig_sub_options *s;
+
     errno = 0;
+    memcpy(config_out, config_default, config_size);
 
     for (char * const *o = opts; o != NULL && *o != NULL; o += 2) {
         if (*o == END_DEFAULT) {
@@ -629,6 +477,7 @@ void argconfig_parse_subopt(char * const opts[], const char *module,
 
         if (s->option == NULL && enddefault) {
             fprintf(stderr, "%s: Invalid option '%s'.\n", module, o[0]);
+	    goto err;
         } else if (s->option == NULL) {
             continue;
         }
@@ -650,12 +499,18 @@ void argconfig_parse_subopt(char * const opts[], const char *module,
         } else if (s->config_type == CFG_DOUBLE) {
             *((double *) value_addr) = strtod(o[1], NULL);
         } else if (s->config_type == CFG_BOOL) {
-            int tmp = strtol(o[1], NULL, 0);
-            if (tmp < 0 || tmp > 1) errno = 1;
+            tmp = strtol(o[1], NULL, 0);
+
+            if (tmp < 0 || tmp > 1)
+		    errno = 1;
+
             *((int *) value_addr) = (int) tmp;
         } else if (s->config_type == CFG_POSITIVE) {
-            int tmp = strtol(o[1], NULL, 0);
-            if (tmp < 0) errno = 1;
+            tmp = strtol(o[1], NULL, 0);
+
+            if (tmp < 0)
+		    errno = 1;
+
             *((int *) value_addr) = (int) tmp;
         } else if (s->config_type == CFG_FILE_A ||
                    s->config_type == CFG_FILE_R ||
@@ -679,10 +534,11 @@ void argconfig_parse_subopt(char * const opts[], const char *module,
                 fopts = "w+";
 
             FILE *f = fopen(o[1], fopts);
+
             if (f == NULL) {
                 fprintf(stderr, "Unable to open %s file: %s\n", s->option,
                         o[1]);
-                exit(1);
+                goto err;
             }
 
             *((FILE **) value_addr) = f;
@@ -692,10 +548,15 @@ void argconfig_parse_subopt(char * const opts[], const char *module,
         if (errno) {
             fprintf(stderr, "%s: Invalid value '%s' for option '%s'.\n", module,
                     o[1], o[0]);
-            exit(1);
+	    goto err;
         }
     }
 
+    return 0;
+
+err:
+    argconfig_print_help(opts[0], program_desc, options_list);
+    return -1;
 }
 
 int argconfig_set_subopt(const char *opt,

--- a/src/argconfig.c
+++ b/src/argconfig.c
@@ -84,7 +84,9 @@ void argconfig_print_help(char *command, const char *program_desc,
 	print_word_wrapped(program_desc, 0, 0);
 
 	printf("\n\n\033[1mOptions:\n\033[0m");
-	printf("\t%s\n", options_list);
+	printf("\t");
+	print_word_wrapped(options_list, 0, 0);
+	printf("\n");
 }
 
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
@@ -111,12 +113,13 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
     short_opts[short_index++] = '-';
 
     for (s = options; option_index < opt_arr_len; s++) {
-        if (strlen(s->option) == 1) {
+        if ((strlen(s->option) == 1) && (options != NULL)){
             short_opts[short_index++] = s->option[0];
             if (s->argument_type == required_argument) {
                 short_opts[short_index++] = ':';
             }
-        }
+        } else
+		goto err;
 
         long_opts[option_index].name    = s->option;
         long_opts[option_index].has_arg = s->argument_type;
@@ -320,7 +323,7 @@ err:
 
     argconfig_print_help(argv[0], program_desc, options_list);
 
-    return -1;
+    exit(1);
 }
 
 int argconfig_parse_subopt_string(char *string, char **options,
@@ -406,18 +409,18 @@ unsigned argconfig_parse_comma_sep_array(char *string, int *val,
   char *p;
 
   if (!strlen(string) || string == NULL)
-	  return -1;
+	  exit(1);
 
   tmp = malloc(strlen(string) + 1);
   tmp = strtok(string, ",");
 
   if (tmp==NULL)
-	  return -1;
+	  exit(1);
 
   val[ret] = strtol(tmp, &p, 0);
 
   if (*p != 0)
-	  return -1;
+	  exit(1);
 
   ret++;
 
@@ -429,13 +432,13 @@ unsigned argconfig_parse_comma_sep_array(char *string, int *val,
 
 
 	  if (ret >= max_length)
-		  return -1;
+		  exit(1);
 
 
 	  val[ret] = strtol(tmp, &p, 0);
 
 	  if (*p != 0)
-		  return -1;
+		  exit(1);
 
 	  ret++;
     }
@@ -556,7 +559,7 @@ int argconfig_parse_subopt(char * const opts[], const char *module,
 
 err:
     argconfig_print_help(opts[0], program_desc, options_list);
-    return -1;
+    exit(1);
 }
 
 int argconfig_set_subopt(const char *opt,

--- a/src/argconfig.h
+++ b/src/argconfig.h
@@ -91,9 +91,9 @@ extern "C" {
 typedef void argconfig_help_func();
 void argconfig_append_usage(const char *str);
 void argconfig_print_help(char *command, const char *program_desc,
-                       const struct argconfig_commandline_options * options,
-		       const unsigned int opt_arr_len);
+			  const char *options_list);
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
+		    const char *options_list,
                     const struct argconfig_commandline_options *options,
 		    const unsigned int opt_arr_len, const void *config_default,
 		    void *config_out, size_t config_size);
@@ -101,17 +101,16 @@ int argconfig_parse_subopt_string (char *string, char **options,
                                 size_t max_options);
 unsigned argconfig_parse_comma_sep_array(char *string,int *ret,
 				      unsigned max_length);
-unsigned argconfig_parse_comma_sep_arrayd(char *string,double *ret,
-				      unsigned max_length);
 void argconfig_register_help_func(argconfig_help_func * f);
 
 void argconfig_print_subopt_help(const struct argconfig_sub_options * options,
                               int indent);
 
-void argconfig_parse_subopt(char * const opts[], const char *module,
-                            const struct argconfig_sub_options *options,
-                            const void *config_default, void *config_out,
-                            size_t config_size);
+int argconfig_parse_subopt(char * const opts[], const char *module,
+			   const char *program_desc, const char *options_list,
+                           const struct argconfig_sub_options *options,
+                           const void *config_default, void *config_out,
+                           size_t config_size);
 
 int argconfig_set_subopt(const char *opt,
                          const struct argconfig_sub_options *options,

--- a/src/argconfig.h
+++ b/src/argconfig.h
@@ -91,12 +91,12 @@ extern "C" {
 typedef void argconfig_help_func();
 void argconfig_append_usage(const char *str);
 void argconfig_print_help(char *command, const char *program_desc,
-                       const struct argconfig_commandline_options * options);
-
+                       const struct argconfig_commandline_options * options,
+		       const unsigned int opt_arr_len);
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
                     const struct argconfig_commandline_options *options,
-                    const void *config_default, void *config_out,
-                    size_t config_size);
+		    const unsigned int opt_arr_len, const void *config_default,
+		    void *config_out, size_t config_size);
 int argconfig_parse_subopt_string (char *string, char **options,
                                 size_t max_options);
 unsigned argconfig_parse_comma_sep_array(char *string,int *ret,

--- a/src/argconfig.h
+++ b/src/argconfig.h
@@ -33,7 +33,8 @@
 #include <getopt.h>
 #include <stdarg.h>
 
-enum argconfig_types {CFG_NONE,
+enum argconfig_types {
+	CFG_NONE,
         CFG_STRING,
         CFG_INT,
         CFG_SIZE,
@@ -71,8 +72,7 @@ struct argconfig_commandline_options {
 };
 
 #define CFG_MAX_SUBOPTS 500
-
-
+#define MAX_HELP_FUNC 20
 
 struct argconfig_sub_options {
     const char *option;


### PR DESCRIPTION
Commit 1 
--------------

In the case of a bad option parse or the user providing an unsupported option to any NVMe sub-command (e.g., read), argument parsing and argconfig's help-menu printing segfaulted due to multiple cases of improper memory management. 

- Add an argument *const unsigned int opt_arr_len* to option and suboption parsing as well as argconfig_parse's subcommand help menu function. Since we already know how many (max) possible arguments could be used in the NVMe sub-command functions where parsing is called, there's no reason to look through an indeterminate amount of memory to figure out what the options are and how many there are, esp since this can cause segmentation faults when argconfig wanders into memory it does not own.

- Replace *strcat ()* (which by definition appends strings to the end of a buffer, doesn't copy into a buffer as the original author may have intended) with printf straight to stdout. Also, remove extraneous string buffers. Previous behaviour: append (strcat) help strings to end of buffer, extending into unallocated memory. Note that *nothing* is ever stored in the buffer in the original version of this code; the NVMe sub-command help string is printed by a different function called by the help menu function, then an attempt is made to populate the buffer with options (which results in text being appended to instead of put into the buffer, because strcat concatenates).

The above items eliminate many (hopefully all?) of the memory management issues with argconfig.

- Finally, get rid of some weird spacing issues in argconfig.c that made the code harder to look over in vim (lines > 80 characters are now split up). 

Things that would fail before adding this patch:

*nvme read --e-*

*nvme attach-ns --namespace-id=1 -?*

*nvme help ?*

*nvme attach-ns*

Commit 2 
---------------

 - Add NVMe sub-option function descriptions to sub-command help messages. This makes sub-command help messages actually helpful. 

- Prettify option output in help messages; group options by what they do, instead of listing long options and short options randomly.

- In argconfig.c, clean up help menu printing function since we really don't need it to re-parse the full list of options for the given nvme sub-command (now, we just print the char * option string constructed in nvme.c to console).

Try out the improved subcommand help menus by doing something like *nvme read --e-*.

Commit 3
--------------
add completions/*, where _nvme is our zsh tab completions and bash-nvme-completions.sh is our bash completions. Also add completions/readme, since this is a little non-intuitive to set up. Adding tab completions ought not to be done automatically, since it requires editing the ~/.+rc file for the shell in question. 

Try out both sets if you like! The zsh set provides a description for each option since it's supported by compinit, but the bash set does not. 

In zsh, hit TAB once after typing nvme to see a list of subcommands and brief descriptions, and once a subcommand has been chosen (e.g., your current line looks something like nvme read) hit TAB again to see all the options to read and brief descriptions of each.

In bash, TAB twice after typing nvme to see a list of subcommands, and once a subcommand has been chosen (e.g., your current line looks something like nvme read) you can keep hitting TAB TAB after entering each option and value to see the full options list for that command again.