### PR TITLE
Allow for firmware activation that needs a reset

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2172,8 +2172,12 @@ static int fw_activate(int argc, char **argv)
 	if (err < 0)
 		perror("ioctl");
 	else if (err != 0)
-		fprintf(stderr, "NVME Admin command error:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		if (err == NVME_SC_FIRMWARE_NEEDS_RESET)
+			printf("Success activating firmware action:%d slot:%d, but a conventional reset is required\n",
+			       cfg.action, cfg.slot);
+		else
+			fprintf(stderr, "NVME Admin command error:%s(%x)\n",
+						nvme_status_to_string(err), err);
 	else
 		printf("Success activating firmware action:%d slot:%d\n",
 		       cfg.action, cfg.slot);


### PR DESCRIPTION
On a firmware activate, some drives require a reset before the new
firmware can be used. Such drives return a status 0x10b to the activate
request.
Rather than treat this as an error, tell this user the activation was
successful, but a reset is required.