### PR TITLE
Makefile cleanup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-CFLAGS := -I $(SRC) $(CFLAGS) -m64 -std=gnu99 -O2 -g -pthread -D_GNU_SOURCE -D_REENTRANT -Wall -Werror
-LDFLAGS := $(LDFLAGS) -lm
+CFLAGS += -std=gnu99 -O2 -g -Wall -Werror
+CPPFLAGS += -I $(SRC) -D_GNU_SOURCE
 NVME = nvme
 INSTALL ?= install
 SRC = ./src
 DESTDIR =
-PREFIX := /usr/local
+PREFIX ?= /usr/local
 SBINDIR = $(PREFIX)/sbin
 LIBUDEV:=$(shell ld -ludev > /dev/null 2>&1 ; echo $$?)
 LIB_DEPENDS =
@@ -27,13 +27,13 @@ NVME-VERSION-FILE: FORCE
 override CFLAGS += -DNVME_VERSION='"$(NVME_VERSION)"'
 
 nvme: nvme.c ./linux/nvme.h argconfig.o suffix.o common.o NVME-VERSION-FILE
-	$(CC) $(CFLAGS) nvme.c $(LDFLAGS) -o $(NVME) argconfig.o suffix.o common.o
+	$(CC) $(CPPFLAGS) $(CFLAGS) nvme.c $(LDFLAGS) -o $(NVME) argconfig.o suffix.o common.o
 
 argconfig.o: $(SRC)/argconfig.c $(SRC)/argconfig.h $(SRC)/suffix.h
-	$(CC) -c $(CFLAGS) $(SRC)/argconfig.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $(SRC)/argconfig.c
 
 suffix.o: $(SRC)/suffix.c $(SRC)/suffix.h
-	$(CC) -c $(CFLAGS) $(SRC)/suffix.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $(SRC)/suffix.c
 
 common.o: common.c
 


### PR DESCRIPTION
Don't link with unused libs: -lm, -lpthread
Don't hardcode in 64 bit compile, this will break cross compilation
Put preprocessor flags in CPPFLAGS
Add to existing variables instead of var = $var pattern

Signed-off-by: Patrick McCormick <patrick.m.mccormick@intel.com>