### PR TITLE
Improve debian package build process.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libudev0 | libudev1
 Description: User space tooling to control NVMe drives.
  NVMe is a fast, scalable, direct attached storage interface, accessing
- solid state drivers through PCIe.
+ solid state drives through PCIe.
  .
  The nvme CLI contains core management tools with minimal dependencies.

--- a/debian/rules
+++ b/debian/rules
@@ -3,18 +3,5 @@
 %:
 	dh $@
 
-override_dh_auto_build:
-	# Remove "-lm" from LDFLAGS, because dpkg-shlibdeps says it's
-	# a useless dependency. Add hardening flags to both CFLAGS
-	# (with CPPFLAGS) and LDFLAGS.
-	$(MAKE) DESTDIR=$$(pwd)/debian/nvme-cli \
-	  CFLAGS="-I./src $(shell dpkg-buildflags --get CFLAGS) \
-	          -m64 -std=gnu99 -O2 -g -pthread \
-	          $(shell dpkg-buildflags --get CPPFLAGS) \
-	          -DLIBUDEV_EXISTS -D_GNU_SOURCE -D_REENTRANT -Wall -Werror" \
-	  LDFLAGS="$(shell dpkg-buildflags --get LDFLAGS) -ludev" \
-	  nvme
-
 override_dh_auto_install:
-	# Fix that it installs to /usr instead of /usr/local.
-	$(MAKE) DESTDIR=$$(pwd)/debian/nvme-cli PREFIX=/usr install
+	dh_auto_install -- PREFIX=/usr


### PR DESCRIPTION
* The changes from 3686759 make the debian/rules a lot simpler.
* Fix so ld doesn't leave a.out turds.
* Add dist-orig make target that creates a reproducible orig.tar.gz.
  A reproducible source archive is a first step towards reproducible
  builds.
* Fix typo in debian package description.
* Add dist and pkg to the PHONY targets.