### PR TITLE
Decode power states more readably

### DIFF
--- a/common.c
+++ b/common.c
@@ -579,9 +579,17 @@ void show_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode)
 		show_nvme_id_ctrl_sgls(ctrl->sgls);
 
 	for (i = 0; i <= ctrl->npss; i++) {
-		printf("ps %4d : mp:%d flags:%x enlat:%d exlat:%d rrt:%d rrl:%d\n"
+		printf("ps %4d : mp:", i);
+
+		if (ctrl->psd[i].flags & NVME_PS_FLAGS_MAX_POWER_SCALE)
+			printf("%01u.%04uW ", ctrl->psd[i].max_power / 10000, ctrl->psd[i].max_power % 10000);
+		else
+			printf("%01u.%02uW ", ctrl->psd[i].max_power / 100, ctrl->psd[i].max_power % 100);
+
+		if (ctrl->psd[i].flags & NVME_PS_FLAGS_NON_OP_STATE)
+			printf("non-");
+		printf("operational enlat:%d exlat:%d rrt:%d rrl:%d\n"
 			"          rwt:%d rwl:%d idlp:%d ips:%x actp:%x ap flags:%x\n",
-			i, ctrl->psd[i].max_power, ctrl->psd[i].flags,
 			ctrl->psd[i].entry_lat, ctrl->psd[i].exit_lat,
 			ctrl->psd[i].read_tput, ctrl->psd[i].read_lat,
 			ctrl->psd[i].write_tput, ctrl->psd[i].write_lat,


### PR DESCRIPTION
This improve the output of id-ctrl on my Samsung 950 to:

    ps    0 : mp:6.50W operational enlat:5 exlat:5 rrt:0 rrl:0
              rwt:0 rwl:0 idle_power:- active_power:-
    ps    1 : mp:5.80W operational enlat:30 exlat:30 rrt:1 rrl:1
              rwt:1 rwl:1 idle_power:- active_power:-
    ps    2 : mp:3.60W operational enlat:100 exlat:100 rrt:2 rrl:2
              rwt:2 rwl:2 idle_power:- active_power:-
    ps    3 : mp:0.0700W non-operational enlat:500 exlat:5000 rrt:3 rrl:3
              rwt:3 rwl:3 idle_power:- active_power:-
    ps    4 : mp:0.0050W non-operational enlat:2000 exlat:22000 rrt:4 rrl:4
              rwt:4 rwl:4 idle_power:- active_power:-

This will increase my inspiration level to teach Linux about power saving.