### PR TITLE
Restrict 'nvme list' to disks, i.e. exclude partitions

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1192,8 +1192,8 @@ static int list(int argc, char **argv)
 	}
 
 	enumerate = udev_enumerate_new(udev);
-	udev_enumerate_add_match_subsystem(enumerate, "char");
 	udev_enumerate_add_match_subsystem(enumerate, "block");
+	udev_enumerate_add_match_property(enumerate, "DEVTYPE", "disk");
 	udev_enumerate_scan_devices(enumerate);
 	devices = udev_enumerate_get_list_entry(enumerate);
 	udev_list_entry_foreach(dev_list_entry, devices) {


### PR DESCRIPTION
I used to see:

    Node             Model                Version  Namepace Usage                      Format           FW Rev  
    ---------------- -------------------- -------- -------- -------------------------- ---------------- --------
    /dev/nvme0n1     Samsung SSD 950 PRO  1.1      1         73.12  GB / 512.11  GB    512   B +  0 B   1B0QBXX7
    /dev/nvme0n1p1   Samsung SSD 950 PRO  1.1      1         73.12  GB / 512.11  GB    512   B +  0 B   1B0QBXX7
    /dev/nvme0n1p2   Samsung SSD 950 PRO  1.1      1         73.12  GB / 512.11  GB    512   B +  0 B   1B0QBXX7
    /dev/nvme0n1p3   Samsung SSD 950 PRO  1.1      1         73.12  GB / 512.11  GB    512   B +  0 B   1B0QBXX7


Now I see:

    Node             Model                Version  Namepace Usage                      Format           FW Rev  
    ---------------- -------------------- -------- -------- -------------------------- ---------------- --------
    /dev/nvme0n1     Samsung SSD 950 PRO  1.1      1         73.12  GB / 512.11  GB    512   B +  0 B   1B0QBXX7

I think it would be even better to enumerate all nvme admin devices and then list the namespaces for each device, but this is probably a decent start toward improving 'nvme list'.