### PR TITLE
Memory leak fix at argconfig_parse_subopt_string of argconfig

### DIFF
--- a/src/argconfig.c
+++ b/src/argconfig.c
@@ -426,8 +426,10 @@ int argconfig_parse_subopt_string(char *string, char **options,
     size_t toklen;
     toklen = strcspn(tmp, "=");
 
-    if (!toklen)
-	    return 1;
+    if (!toklen) {
+    	free(tmp);
+	return 1;
+    }
 
     *(o++) = tmp;
     tmp[toklen] = 0;


### PR DESCRIPTION
This patch helps to avoid memory leak in the function argconfig_parse_subopt_string of argconfig.c
file