### PR TITLE
Fixed option checking for format to match NVMe spec limits.

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1388,7 +1388,8 @@ static int format(int argc, char **argv)
 
 	get_dev(1, argc, argv);
 
-	if (cfg.ses > 2) {
+	/* ses & pi checks set to 7 for forward-compatibility */
+	if (cfg.ses > 7) {
 		fprintf(stderr, "invalid secure erase settings:%d\n", cfg.ses);
 		return EINVAL;
 	}
@@ -1396,7 +1397,7 @@ static int format(int argc, char **argv)
 		fprintf(stderr, "invalid lbaf:%d\n", cfg.lbaf);
 		return EINVAL;
 	}
-	if (cfg.pi > 3) {
+	if (cfg.pi > 7) {
 		fprintf(stderr, "invalid pi:%d\n", cfg.pi);
 		return EINVAL;
 	}

--- a/nvme.c
+++ b/nvme.c
@@ -1339,8 +1339,8 @@ static int format(int argc, char **argv)
 	const char *namespace_id = "name of desired namespace";
 	const char *lbaf = "LBA format to apply (req'd)";
 	const char *ses = "[0-2]: secure erase";
-	const char *pil = "[0-3]: protection info location";
-	const char *pi = "[0-1]: protection info off/on";
+	const char *pil = "[0-1]: protection info location last/first 8 bytes of metadata";
+	const char *pi = "[0-3]: protection info off/Type 1/Type 2/Type 3";
 	const char *ms = "[0-1]: extended format off/on";
 	const char *timeout = "timeout value";
 	int err;
@@ -1388,7 +1388,7 @@ static int format(int argc, char **argv)
 
 	get_dev(1, argc, argv);
 
-	if (cfg.ses > 7) {
+	if (cfg.ses > 2) {
 		fprintf(stderr, "invalid secure erase settings:%d\n", cfg.ses);
 		return EINVAL;
 	}
@@ -1396,8 +1396,16 @@ static int format(int argc, char **argv)
 		fprintf(stderr, "invalid lbaf:%d\n", cfg.lbaf);
 		return EINVAL;
 	}
-	if (cfg.pi > 7) {
+	if (cfg.pi > 3) {
 		fprintf(stderr, "invalid pi:%d\n", cfg.pi);
+		return EINVAL;
+	}
+	if (cfg.pil > 1) {
+		fprintf(stderr, "invalid pil:%d\n", cfg.pil);
+		return EINVAL;
+	}
+	if (cfg.ms > 1) {
+		fprintf(stderr, "invalid ms:%d\n", cfg.ms);
 		return EINVAL;
 	}
 	if (S_ISBLK(nvme_stat.st_mode)) {


### PR DESCRIPTION
I noticed the format command help text text was a little off from the spec and the range checking was also not respecting the spec defined values.  Updated the help text and option range checking.  Please let me know if these changes are out of line.