### PR TITLE
Fix Memory leak on fail case of mbuffer

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2212,8 +2212,10 @@ static int submit_io(int opcode, char *command, const char *desc,
 
 	if (cfg.metadata_size) {
 		mbuffer = malloc(cfg.metadata_size);
-		if (!mbuffer)
+		if (!mbuffer) {
+ 			free(buffer);
 			return ENOMEM;
+		}
 	}
 
 	if ((opcode & 1) && read(dfd, (void *)buffer, cfg.data_size) < 0) {


### PR DESCRIPTION
Fix to release the allocated "buffer" memory on the failure of "mbuffer" allocation before returning  