### PR TITLE
Fix the bug of Model Number and display the info of Serial Number

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -579,7 +579,7 @@ void show_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode)
 	printf("vid     : %#x\n", le16toh(ctrl->vid));
 	printf("ssvid   : %#x\n", le16toh(ctrl->ssvid));
 	printf("sn      : %-20.20s\n", ctrl->sn);
-	printf("mn      : %-20.20s\n", ctrl->mn);
+	printf("mn      : %-40.40s\n", ctrl->mn);
 	printf("fr      : %-.8s\n", ctrl->fr);
 	printf("rab     : %d\n", ctrl->rab);
 	printf("ieee    : %02x%02x%02x\n",

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -578,9 +578,9 @@ void show_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode)
 
 	printf("vid     : %#x\n", le16toh(ctrl->vid));
 	printf("ssvid   : %#x\n", le16toh(ctrl->ssvid));
-	printf("sn      : %-20.20s\n", ctrl->sn);
-	printf("mn      : %-40.40s\n", ctrl->mn);
-	printf("fr      : %-.8s\n", ctrl->fr);
+	printf("sn      : %-.*s\n", (int)sizeof(ctrl->sn), ctrl->sn);
+	printf("mn      : %-.*s\n", (int)sizeof(ctrl->mn), ctrl->mn);
+	printf("fr      : %-.*s\n", (int)sizeof(ctrl->fr), ctrl->fr);
 	printf("rab     : %d\n", ctrl->rab);
 	printf("ieee    : %02x%02x%02x\n",
 		ctrl->ieee[2], ctrl->ieee[1], ctrl->ieee[0]);

--- a/nvme.c
+++ b/nvme.c
@@ -758,19 +758,21 @@ static void print_list_item(struct list_item list_item)
 	sprintf(version,"%d.%d", (list_item.ver >> 16),
 		(list_item.ver >> 8) & 0xff);
 
-	printf("%-16s %-20.20s %-40.40s %-8s %-8d %-26s %-16s %-.8s\n", list_item.node,
-	    list_item.ctrl.sn, list_item.ctrl.mn, version, list_item.nsid, usage, format, list_item.ctrl.fr);
+	printf("%-16s %-*.*s %-*.*s %-8s %-9d %-26s %-16s %-.*s\n", list_item.node,
+            (int)sizeof(list_item.ctrl.sn), (int)sizeof(list_item.ctrl.sn), list_item.ctrl.sn,
+            (int)sizeof(list_item.ctrl.mn), (int)sizeof(list_item.ctrl.mn), list_item.ctrl.mn,
+            version, list_item.nsid, usage, format, (int)sizeof(list_item.ctrl.fr), list_item.ctrl.fr);
 }
 
 static void print_list_items(struct list_item *list_items, unsigned len)
 {
 	unsigned i;
 
-	printf("%-16s %-20s %-40s %-8s %-8s %-26s %-16s %-8s\n",
-	    "Node", "SN", "Model", "Version", "Namepace", "Usage", "Format", "FW Rev");
-	printf("%-16s %-20s %-40s %-8s %-8s %-26s %-16s %-8s\n",
+	printf("%-16s %-20s %-40s %-8s %-9s %-26s %-16s %-8s\n",
+	    "Node", "SN", "Model", "Version", "Namespace", "Usage", "Format", "FW Rev");
+	printf("%-16s %-20s %-40s %-8s %-9s %-26s %-16s %-8s\n",
             "----------------", "--------------------", "----------------------------------------",
-            "--------", "--------", "--------------------------", "----------------", "--------");
+            "--------", "---------", "--------------------------", "----------------", "--------");
 	for (i = 0 ; i < len ; i++)
 		print_list_item(list_items[i]);
 

--- a/nvme.c
+++ b/nvme.c
@@ -758,19 +758,19 @@ static void print_list_item(struct list_item list_item)
 	sprintf(version,"%d.%d", (list_item.ver >> 16),
 		(list_item.ver >> 8) & 0xff);
 
-	printf("%-16s %-20.20s %-8s %-8d %-26s %-16s %-.8s\n", list_item.node,
-		list_item.ctrl.mn, version, list_item.nsid, usage, format, list_item.ctrl.fr);
+	printf("%-16s %-20.20s %-40.40s %-8s %-8d %-26s %-16s %-.8s\n", list_item.node,
+	    list_item.ctrl.sn, list_item.ctrl.mn, version, list_item.nsid, usage, format, list_item.ctrl.fr);
 }
 
 static void print_list_items(struct list_item *list_items, unsigned len)
 {
 	unsigned i;
 
-	printf("%-16s %-20s %-8s %-8s %-26s %-16s %-8s\n",
-		"Node","Model","Version","Namepace", "Usage", "Format", "FW Rev");
-	printf("%-16s %-20s %-8s %-8s %-26s %-16s %-8s\n",
-            "----------------","--------------------","--------","--------",
-            "--------------------------","----------------","--------");
+	printf("%-16s %-20s %-40s %-8s %-8s %-26s %-16s %-8s\n",
+	    "Node", "SN", "Model", "Version", "Namepace", "Usage", "Format", "FW Rev");
+	printf("%-16s %-20s %-40s %-8s %-8s %-26s %-16s %-8s\n",
+            "----------------", "--------------------", "----------------------------------------",
+            "--------", "--------", "--------------------------", "----------------", "--------");
 	for (i = 0 ; i < len ; i++)
 		print_list_item(list_items[i]);
 


### PR DESCRIPTION
According to the NVMe Specification, there is an error when display Model Number.
In addition, currently it does not display the info of Serial Number, so add it.