### PR TITLE
Rename nvme_log() to nvme_get_log()

### DIFF
--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -76,8 +76,7 @@ int nvme_identify_ns(int fd, __u32 nsid, bool present, void *data);
 int nvme_identify_ns_list(int fd, __u32 nsid, bool all, void *data);
 int nvme_identify_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
 
-int nvme_get_log(int fd, __u32 nsid, __u32 cdw10, __u32 data_len, void *data);
-int nvme_log(int fd, __u32 nsid, __u8 log_id, __u32 data_len, void *data);
+int nvme_get_log(int fd, __u32 nsid, __u8 log_id, __u32 data_len, void *data);
 int nvme_fw_log(int fd, struct nvme_firmware_log_page *fw_log);
 int nvme_error_log(int fd, __u32 nsid, int entries,
 		   struct nvme_error_log_page *err_log);

--- a/nvme.c
+++ b/nvme.c
@@ -395,7 +395,7 @@ static int get_log(int argc, char **argv)
 	} else {
 		unsigned char log[cfg.log_len];
 
-		err = nvme_log(fd, cfg.namespace_id, cfg.log_id, cfg.log_len, log);
+		err = nvme_get_log(fd, cfg.namespace_id, cfg.log_id, cfg.log_len, log);
 		if (!err) {
 			if (!cfg.raw_binary) {
 				printf("Device:%s log-id:%d namespace-id:%#x\n",


### PR DESCRIPTION
This kills off the old nvme_get_log() and rename
nvme_log() to nvme_get_log().

Signed-off-by: Ming Lin <ming.l@ssi.samsung.com>