### PR TITLE
fix data_size and metadata_size types

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2042,8 +2042,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 	struct config {
 		__u64 start_block;
 		__u16 block_count;
-		__u32 data_size;
-		__u32 metadata_size;
+		__u64 data_size;
+		__u64 metadata_size;
 		__u32 ref_tag;
 		char  *data;
 		char  *metadata;


### PR DESCRIPTION
The data_size and metadata_size fields in the config struct are declared as
__u32, but should actually be __u64. The current types cause issues in the
argument parsing functions depending on machine architecture and endianness. In
ppc64, using __u32 causes "data size not provided" errors due to the way writes
are being done by argconfig_parse() at src/argconfig.c. Changing the types to
__u64 should fix this behaviour and is in accordance to the CFG_LONG_SUFFIX
flag.

Signed-off-by: Heitor Ricardo Alves de Siqueira <halves@linux.vnet.ibm.com>