### PR TITLE
nvme.spec.in: Add a build/install requirement on systemd

### DIFF
--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -7,6 +7,8 @@ Group: 		Development/Tools
 URL: 		https://github.com/linux-nvme/nvme-cli/
 Source: 	nvme-@@VERSION@@.tar.gz
 Provides:	nvme
+BuildRequires:  systemd-devel
+Requires:       systemd
 BuildRoot:	%{_tmppath}/%{name}-%{version}-root
 
 %description


### PR DESCRIPTION
systemd and systemd-dev include libudev on RHEL7 based
distributions. I'm not sure about SLES12, if SLES12 should
have different dependencies, we would need to add a distribution
detection and different requirements for RHEL and SLES.