### PR TITLE
bash completion: Remove shebang line

### DIFF
--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # bash tab completion for the nvme command line utility
 # (unfortunately, bash won't let me add descriptions to cmds)
 # Kelly Kaoudis kelly.n.kaoudis at intel.com, Aug. 2015


### PR DESCRIPTION
Remove shebang line from bash completion file as rpmlint on openSUSE/SLE
complains about a script ment to be sourced not executed containing a shebang
line.

[   38s] nvme-cli.x86_64: W: sourced-script-with-shebang /etc/bash_completion.d/nvme /usr/bin/env
[   38s] This text file contains a shebang, but is meant to be sourced, not executed.

Signed-off-by: Johannes Thumshirn <jthumshirn@suse.de>