### PR TITLE
 Fix leak of mbuffer on error exit path

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2174,8 +2174,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 
 	if ((opcode & 1) && read(dfd, (void *)buffer, cfg.data_size) < 0) {
 		fprintf(stderr, "failed to read data buffer from input file\n");
-		free(buffer);
-		return EINVAL;
+		err = EINVAL;
+		goto free_and_return;
 	}
 
 	if ((opcode & 1) && cfg.metadata_size &&
@@ -2230,7 +2230,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	free(buffer);
 	if (cfg.metadata_size)
 		free(mbuffer);
-    return err;
+	return err;
 }
 
 static int compare(int argc, char **argv)


### PR DESCRIPTION
building with clang scan-build picked up a memory leak:
nvme.c:2176:3: warning: Potential leak of memory pointed to by 'mbuffer'
   fprintf(stderr, "failed to read data buffer from input file\n");
   ^~~~~~~

instead of returning, jump to free_and_return which performs the
correct cleanup.  Also fix the indentation of the return at the end of
the function.

Signed-off-by: Colin Ian King <colin.king@canonical.com>