### PR TITLE
Minor fixes to printed output of set/get feature

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1039,7 +1039,11 @@ void nvme_feature_show_fields(__u32 fid, unsigned int result, unsigned char *buf
 		printf("\tHigh Priority Weight   (HPW): %u\n", ((result & 0xff000000) >> 24) + 1);
 		printf("\tMedium Priority Weight (MPW): %u\n", ((result & 0x00ff0000) >> 16) + 1);
 		printf("\tLow Priority Weight    (LPW): %u\n", ((result & 0x0000ff00) >> 8) + 1);
-		printf("\tArbitration Burst       (AB): %u\n",  1 << (result & 0x00000007));
+		printf("\tArbitration Burst       (AB): ");
+		if ((result & 0x00000007) == 7)
+			printf("No limit\n");
+		else
+			printf("%u\n",  1 << (result & 0x00000007));
 		break;
 	case NVME_FEAT_POWER_MGMT:
 		field = (result & 0x000000E0) >> 5;

--- a/nvme.c
+++ b/nvme.c
@@ -1504,7 +1504,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	}
 	if (!err) {
 		printf("set-feature:%02x (%s), value:%#08x\n", cfg.feature_id,
-			nvme_feature_to_string(cfg.feature_id), result);
+			nvme_feature_to_string(cfg.feature_id), cfg.value);
 		if (buf) {
 			if (cfg.feature_id == NVME_FEAT_LBA_RANGE)
 				show_lba_range((struct nvme_lba_range_type *)buf,


### PR DESCRIPTION
- In nvme_feature_show_fields:  Correct printed output of Arbitration Burst.  Per spec, if value is 7, print "No limit"
- In set_feature print actual value used for set-feature command instead of result