### PR TITLE
Fixes to make version 0.8 available in Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ install-bin: default
 	$(INSTALL) -m 755 nvme $(DESTDIR)$(SBINDIR)
 
 install-bash-completion:
-	$(INSTALL) -d $(DESTDIR)$(SYSCONFDIR)/bash_completion.d
-	$(INSTALL) -m 644 -T ./completions/bash-nvme-completion.sh $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/nvme
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/bash-completion/completions
+	$(INSTALL) -m 644 -T ./completions/bash-nvme-completion.sh $(DESTDIR)$(PREFIX)/share/bash-completion/completions/nvme
 
 install: install-bin install-man install-bash-completion
 

--- a/fabrics.c
+++ b/fabrics.c
@@ -27,6 +27,8 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <asm/byteorder.h>
+#include <inttypes.h>
 #ifdef LIBUDEV_EXISTS
 #include <libudev.h>
 #endif
@@ -266,8 +268,8 @@ static void print_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 {
 	int i;
 
-	printf("Discovery Log Number of Records %d, Generation counter %lld\n",
-		numrec, log->genctr);
+	printf("Discovery Log Number of Records %d, Generation counter %"PRIu64"\n",
+		numrec, __le64_to_cpu(log->genctr));
 
 	for (i = 0; i < numrec; i++) {
 		struct nvmf_disc_rsp_page_entry *e = &log->entries[i];

--- a/intel-nvme.c
+++ b/intel-nvme.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <linux/fs.h>
+#include <inttypes.h>
+#include <asm/byteorder.h>
 
 #include "linux/nvme_ioctl.h"
 
@@ -127,14 +129,14 @@ static void show_temp_stats(struct intel_temp_stats *stats)
 {
 	printf("  Intel Temperature Statistics\n");
 	printf("--------------------------------\n");
-	printf("Current temperature         : %llu\n", stats->curr);
-	printf("Last critical overtemp flag : %llu\n", stats->last_overtemp);
-	printf("Life critical overtemp flag : %llu\n", stats->life_overtemp);
-	printf("Highest temperature         : %llu\n", stats->highest_temp);
-	printf("Lowest temperature          : %llu\n", stats->lowest_temp);
-	printf("Max operating temperature   : %llu\n", stats->max_operating_temp);
-	printf("Min operating temperature   : %llu\n", stats->min_operating_temp);
-	printf("Estimated offset            : %llu\n", stats->est_offset);
+	printf("Current temperature         : %"PRIu64"\n", __le64_to_cpu(stats->curr));
+	printf("Last critical overtemp flag : %"PRIu64"\n", __le64_to_cpu(stats->last_overtemp));
+	printf("Life critical overtemp flag : %"PRIu64"\n", __le64_to_cpu(stats->life_overtemp));
+	printf("Highest temperature         : %"PRIu64"\n", __le64_to_cpu(stats->highest_temp));
+	printf("Lowest temperature          : %"PRIu64"\n", __le64_to_cpu(stats->lowest_temp));
+	printf("Max operating temperature   : %"PRIu64"\n", __le64_to_cpu(stats->max_operating_temp));
+	printf("Min operating temperature   : %"PRIu64"\n", __le64_to_cpu(stats->min_operating_temp));
+	printf("Estimated offset            : %"PRIu64"\n", __le64_to_cpu(stats->est_offset));
 }
 
 static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)

--- a/intel-nvme.c
+++ b/intel-nvme.c
@@ -309,7 +309,7 @@ static int get_internal_log(int argc, char **argv, struct command *command, stru
 	cmd.cdw10 = 0x400;
 	cmd.cdw12 = cfg.log;
 	cmd.data_len = 0x1000;
-	cmd.addr = (__u64)(void *)buf;
+	cmd.addr = (unsigned long)(void *)buf;
 
 	memset(buf, 0, sizeof(buf));
 	err = nvme_submit_passthru(fd, NVME_IOCTL_ADMIN_CMD, &cmd);


### PR DESCRIPTION
There are current 2 issues on version 0.8 that blocks it to be integrated in Debian.
 1) The package is not compiling in all architectures anymore
 2) The package is using the legacy directory for bash completion

Both of them are fixed in this pull request.