### PR TITLE
nvme-cli: Implement list command that doesn't rely on libudev

### DIFF
--- a/Documentation/nvme-list.1
+++ b/Documentation/nvme-list.1
@@ -38,7 +38,6 @@ nvme-list \- List all recognized NVMe devices
 .sp
 Scan the sysfs tree for NVM Express devices and return the /dev node for those devices as well as some pertinent information about them\&.
 .sp
-This command requires udev\&.
 .SH "OPTIONS"
 .sp
 No options yet\&.

--- a/Documentation/nvme-list.html
+++ b/Documentation/nvme-list.html
@@ -762,7 +762,6 @@ nvme-list(1) Manual Page
 <div class="sectionbody">
 <div class="paragraph"><p>Scan the sysfs tree for NVM Express devices and return the /dev node
 for those devices as well as some pertinent information about them.</p></div>
-<div class="paragraph"><p>This command requires udev.</p></div>
 </div>
 </div>
 <div class="sect1">

--- a/Documentation/nvme-list.txt
+++ b/Documentation/nvme-list.txt
@@ -15,8 +15,6 @@ DESCRIPTION
 Scan the sysfs tree for NVM Express devices and return the /dev node
 for those devices as well as some pertinent information about them.
 
-This command requires udev.
-
 OPTIONS
 -------
 No options yet.

--- a/README.md
+++ b/README.md
@@ -62,13 +62,7 @@ steps:
 nvme-cli is tested on AlpineLinux 3.3.  Install it using:
 
     # akp update && apk add nvme-cli nvme-cli-doc
-    
-    the "list" command will not work unless you installed udev for some reason.
-    ```
-    # nvme list
-    nvme-list: libudev not detected, install and rebuild.
-    ```
-    
+
     if you just use the device you're after, it will work flawless.
     ```
     # nvme smart-log /dev/nvme0


### PR DESCRIPTION
The previous list command required libudev. We can accomplish the same
thing with standard functions, and in the future remove the libudev
dependency

Signed-off-by: Scott Bauer <scott.bauer@intel.com>