### PR TITLE
getting discovery fields up-to-par with standard

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -269,7 +269,7 @@ static int nvmf_get_log_page_discovery(const char *dev_path,
 		struct nvmf_disc_rsp_page_hdr **logp, int *numrec)
 {
 	struct nvmf_disc_rsp_page_hdr *log;
-	unsigned log_size = 0;
+	unsigned int log_size = 0;
 	unsigned long genctr;
 	int error, fd;
 
@@ -358,7 +358,8 @@ static void print_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 {
 	int i;
 
-	printf("Discovery Log Number of Records %d, Generation counter %"PRIu64"\n",
+	printf("\nDiscovery Log Number of Records %d, "
+	       "Generation counter %"PRIu64"\n",
 		numrec, (uint64_t)__le64_to_cpu(log->genctr));
 
 	for (i = 0; i < numrec; i++) {
@@ -376,10 +377,14 @@ static void print_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 
 		switch (e->trtype) {
 		case NVMF_TRTYPE_RDMA:
-			printf("rdma_prtype: %s\n", prtype_str(e->tsas.rdma.prtype));
-			printf("rdma_qptype: %s\n", qptype_str(e->tsas.rdma.qptype));
-			printf("rdma_cms:    %s\n", cms_str(e->tsas.rdma.cms));
-			printf("rdma_pkey: 0x%04x\n", e->tsas.rdma.pkey);
+			printf("rdma_prtype: %s\n",
+				prtype_str(e->tsas.rdma.prtype));
+			printf("rdma_qptype: %s\n",
+				qptype_str(e->tsas.rdma.qptype));
+			printf("rdma_cms:    %s\n",
+				cms_str(e->tsas.rdma.cms));
+			printf("rdma_pkey: 0x%04x\n",
+				e->tsas.rdma.pkey);
 			break;
 		}
 	}
@@ -392,7 +397,8 @@ static void save_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 
 	fd = open(cfg.raw, O_CREAT|O_RDWR|O_TRUNC, S_IRUSR|S_IWUSR);
 	if (fd < 0) {
-		fprintf(stderr, "failed to open %s: %s\n", cfg.raw, strerror(errno));
+		fprintf(stderr, "failed to open %s: %s\n",
+			cfg.raw, strerror(errno));
 		return;
 	}
 
@@ -400,7 +406,8 @@ static void save_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 			numrec * sizeof(struct nvmf_disc_rsp_page_entry);
 	ret = write(fd, log, len);
 	if (ret < 0)
-		fprintf(stderr, "failed to write to %s: %s\n", cfg.raw, strerror(errno));
+		fprintf(stderr, "failed to write to %s: %s\n",
+			cfg.raw, strerror(errno));
 	else
 		printf("Discovery log is saved to %s\n", cfg.raw);
 
@@ -483,7 +490,8 @@ static int build_options(char *argstr, int max_len)
 	}
 
 	if (cfg.nr_io_queues) {
-		len = snprintf(argstr, max_len, ",nr_io_queues=%s", cfg.nr_io_queues);
+		len = snprintf(argstr, max_len, ",nr_io_queues=%s",
+				cfg.nr_io_queues);
 		if (len < 0)
 			return -EINVAL;
 		argstr += len;
@@ -594,7 +602,8 @@ static int do_discover(char *argstr, bool connect)
 			print_discovery_log(log, numrec);
 		break;
 	case DISC_GET_NUMRECS:
-		fprintf(stderr, "Get number of discovery log entries failed.\n");
+		fprintf(stderr,
+			"Get number of discovery log entries failed.\n");
 		break;
 	case DISC_GET_LOG:
 		fprintf(stderr, "Get discovery log entries failed.\n");
@@ -603,7 +612,8 @@ static int do_discover(char *argstr, bool connect)
 		fprintf(stderr, "No discovery log entries to fetch.\n");
 		break;
 	case DISC_NOT_EQUAL:
-		fprintf(stderr, "Numrec values of last two get dicovery log page not equal\n");
+		fprintf(stderr,
+		"Numrec values of last two get dicovery log page not equal\n");
 		break;
 	default:
 		fprintf(stderr, "Get dicovery log page failed: %d\n", ret);
@@ -622,7 +632,8 @@ static int discover_from_conf_file(const char *desc, char *argstr,
 
 	f = fopen(PATH_NVMF_DISC, "r");
 	if (f == NULL) {
-		fprintf(stderr, "No discover params given and no %s conf\n", PATH_NVMF_DISC);
+		fprintf(stderr, "No discover params given and no %s conf\n",
+			PATH_NVMF_DISC);
 		return -EINVAL;
 	}
 
@@ -678,20 +689,22 @@ int discover(const char *desc, int argc, char **argv, bool connect)
 	char argstr[BUF_SIZE];
 	int ret;
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"transport", 't', "LIST", CFG_STRING, &cfg.transport, required_argument,
-			"transport type" },
-		{"traddr", 'a', "LIST", CFG_STRING, &cfg.traddr, required_argument,
-			"transport address" },
-		{"trsvcid", 's', "LIST", CFG_STRING, &cfg.trsvcid, required_argument,
-			"transport service id (e.g. IP port)" },
-		{"hostnqn", 'q', "LIST", CFG_STRING, &cfg.hostnqn, required_argument,
-			"user-defined hostnqn (if default not used)" },
+		{"transport", 't', "LIST", CFG_STRING, &cfg.transport,
+		 required_argument, "transport type" },
+		{"traddr", 'a', "LIST", CFG_STRING, &cfg.traddr,
+		 required_argument, "transport address" },
+		{"trsvcid", 's', "LIST", CFG_STRING, &cfg.trsvcid,
+		 required_argument, "transport service id (e.g. IP port)" },
+		{"hostnqn", 'q', "LIST", CFG_STRING, &cfg.hostnqn,
+		 required_argument,
+		 "user-defined hostnqn (if default not used)" },
 		{"raw", 'r', "LIST", CFG_STRING, &cfg.raw, required_argument,
-			"raw output file" },
+		 "raw output file" },
 		{0},
 	};
 
-	argconfig_parse(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	argconfig_parse(argc, argv, desc, command_line_options, &cfg,
+			sizeof(cfg));
 
 	cfg.nqn = NVME_DISC_SUBSYS_NAME;
 
@@ -712,22 +725,25 @@ int connect(const char *desc, int argc, char **argv)
 	char argstr[BUF_SIZE];
 	int instance, ret;
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"transport", 't', "LIST", CFG_STRING, &cfg.transport, required_argument,
-			"transport type" },
+		{"transport", 't', "LIST", CFG_STRING, &cfg.transport,
+		 required_argument,
+		 "transport type" },
 		{"nqn", 'n', "LIST", CFG_STRING, &cfg.nqn, required_argument,
 			"nqn name" },
-		{"traddr", 'a', "LIST", CFG_STRING, &cfg.traddr, required_argument,
-			"transport address" },
-		{"trsvcid", 's', "LIST", CFG_STRING, &cfg.trsvcid, required_argument,
-			"transport service id (e.g. IP port)" },
-		{"hostnqn", 'q', "LIST", CFG_STRING, &cfg.hostnqn, required_argument,
-			"user-defined hostnqn" },
-		{"nr-io-queues", 'i', "LIST", CFG_STRING, &cfg.nr_io_queues, required_argument,
-			"number of io queues to use (default is core count)" },
+		{"traddr", 'a', "LIST", CFG_STRING, &cfg.traddr,
+		 required_argument, "transport address" },
+		{"trsvcid", 's', "LIST", CFG_STRING, &cfg.trsvcid,
+		 required_argument, "transport service id (e.g. IP port)" },
+		{"hostnqn", 'q', "LIST", CFG_STRING, &cfg.hostnqn,
+		 required_argument, "user-defined hostnqn" },
+		{"nr-io-queues", 'i', "LIST", CFG_STRING, &cfg.nr_io_queues,
+		 required_argument,
+		 "number of io queues to use (default is core count)" },
 		{0},
 	};
 
-	argconfig_parse(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	argconfig_parse(argc, argv, desc, command_line_options, &cfg,
+			sizeof(cfg));
 
 	ret = build_options(argstr, BUF_SIZE);
 	if (ret)
@@ -752,16 +768,20 @@ static int disconnect_subsys(struct udev_enumerate *enumerate, char *nqn)
 	char *sysfs_path;
 	int ret = 1;
 
-	udev_list_entry_foreach(list_entry, udev_enumerate_get_list_entry(enumerate)) {
+	udev_list_entry_foreach(list_entry,
+				udev_enumerate_get_list_entry(enumerate)) {
 		struct udev_device *device;
 
-		device = udev_device_new_from_syspath(udev_enumerate_get_udev(enumerate),
-						udev_list_entry_get_name(list_entry));
+		device = udev_device_new_from_syspath(
+				udev_enumerate_get_udev(enumerate),
+				udev_list_entry_get_name(list_entry));
 		if (device != NULL) {
-			subsysnqn = udev_device_get_sysattr_value(device, "subsysnqn");
+			subsysnqn = udev_device_get_sysattr_value(
+					device, "subsysnqn");
 			if (subsysnqn && !strcmp(subsysnqn, nqn)) {
-				if (asprintf(&sysfs_path, "%s/delete_controller",
-						udev_device_get_syspath(device)) < 0) {
+				if (asprintf(&sysfs_path,
+					"%s/delete_controller",
+					udev_device_get_syspath(device)) < 0) {
 					ret = errno;
 					udev_device_unref(device);
 					break;
@@ -815,7 +835,7 @@ exit:
 #else
 static int disconnect_by_nqn(char *nqn)
 {
-	fprintf(stderr,"libudev not detected, install and rebuild.\n");
+	fprintf(stderr, "libudev not detected, install and rebuild.\n");
 	return -1;
 }
 #endif
@@ -839,12 +859,15 @@ int disconnect(const char *desc, int argc, char **argv)
 	int ret = 0;
 
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"nqn", 'n', "LIST", CFG_STRING, &cfg.nqn, required_argument, nqn},
-		{"device", 'd', "LIST", CFG_STRING, &cfg.device, required_argument, device},
+		{"nqn", 'n', "LIST", CFG_STRING, &cfg.nqn,
+		 required_argument, nqn},
+		{"device", 'd', "LIST", CFG_STRING, &cfg.device,
+		 required_argument, device},
 		{0},
 	};
 
-	argconfig_parse(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	argconfig_parse(argc, argv, desc, command_line_options, &cfg,
+			sizeof(cfg));
 	if (!cfg.nqn && !cfg.device) {
 		fprintf(stderr, "need a -n or -d argument\n");
 		return -EINVAL;
@@ -853,13 +876,16 @@ int disconnect(const char *desc, int argc, char **argv)
 	if (cfg.nqn) {
 		ret = disconnect_by_nqn(cfg.nqn);
 		if (ret)
-			fprintf(stderr, "Failed to disconnect by NQN: %s\n", cfg.nqn);
+			fprintf(stderr, "Failed to disconnect by NQN: %s\n",
+				cfg.nqn);
 	}
 
 	if (cfg.device) {
 		ret = disconnect_by_device(cfg.device);
 		if (ret)
-			fprintf(stderr, "Failed to disconnect by device name: %s\n", cfg.device);
+			fprintf(stderr,
+				"Failed to disconnect by device name: %s\n",
+				cfg.device);
 	}
 
 	return ret;

--- a/fabrics.c
+++ b/fabrics.c
@@ -116,7 +116,7 @@ static inline const char *nqntype_str(__u8 nqntype)
 }
 
 static const char * const treqs[] = {
-	[NVMF_TREQ_NOT_SPECIFIED]	= "unspecified transport requirements",
+	[NVMF_TREQ_NOT_SPECIFIED]	= "not specified",
 	[NVMF_TREQ_REQUIRED]		= "required",
 	[NVMF_TREQ_NOT_REQUIRED]	= "not required",
 };

--- a/fabrics.c
+++ b/fabrics.c
@@ -105,14 +105,14 @@ static inline const char *adrfam_str(__u8 adrfam)
 	return arg_str(adrfams, ARRAY_SIZE(adrfams), adrfam);
 }
 
-static const char * const nqntypes[] = {
+static const char * const subtypes[] = {
 	[NVME_NQN_DISC]		= "discovery subsystem",
 	[NVME_NQN_NVME]		= "nvme subsystem",
 };
 
-static inline const char *nqntype_str(__u8 nqntype)
+static inline const char *subtype_str(__u8 subtype)
 {
-	return arg_str(nqntypes, ARRAY_SIZE(nqntypes), nqntype);
+	return arg_str(subtypes, ARRAY_SIZE(subtypes), subtype);
 }
 
 static const char * const treqs[] = {
@@ -367,7 +367,7 @@ static void print_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 		printf("=====Discovery Log Entry %d======\n", i);
 		printf("trtype:  %s\n", trtype_str(e->trtype));
 		printf("adrfam:  %s\n", adrfam_str(e->adrfam));
-		printf("nqntype: %s\n", nqntype_str(e->nqntype));
+		printf("subtype: %s\n", subtype_str(e->subtype));
 		printf("treq:    %s\n", treq_str(e->treq));
 		printf("portid:  %d\n", e->portid);
 		printf("trsvcid: %s\n", e->trsvcid);
@@ -499,14 +499,14 @@ static int connect_ctrl(struct nvmf_disc_rsp_page_entry *e)
 	bool discover = false;
 	int len;
 
-	switch (e->nqntype) {
+	switch (e->subtype) {
 	case NVME_NQN_DISC:
 		discover = true;
 	case NVME_NQN_NVME:
 		break;
 	default:
-		fprintf(stderr, "skipping unsupported NQNtype %d\n",
-			 e->nqntype);
+		fprintf(stderr, "skipping unsupported subtype %d\n",
+			 e->subtype);
 		return -EINVAL;
 	}
 

--- a/nvme.h
+++ b/nvme.h
@@ -566,7 +566,7 @@ struct nvme_bar_cap {
 struct nvmf_disc_rsp_page_entry {
 	__u8	trtype;
 	__u8	adrfam;
-	__u8	nqntype;
+	__u8	subtype;
 	__u8	treq;
 	__le16	portid;
 	__le16	cntlid;


### PR DESCRIPTION
There are a couple fields defined in the tool not-in-sync with the NVMe-over-Fabrics standard, so getting that up to par.

I also style-cleaned up the entire fabrics.c file based on checkpatch.pl tool.