### PR TITLE
Fix stack-based overflow in id-ctrl json output.

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1192,9 +1192,9 @@ void json_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode)
 
 	int i;
 
-	sprintf(sn, "%-.*s\n", (int)sizeof(ctrl->sn), ctrl->sn);
-	sprintf(mn, "%-.*s\n", (int)sizeof(ctrl->mn), ctrl->mn);
-	sprintf(fr, "%-.*s\n", (int)sizeof(ctrl->fr), ctrl->fr);
+	snprintf(sn, sizeof(sn), "%-.*s\n", (int)sizeof(ctrl->sn), ctrl->sn);
+	snprintf(mn, sizeof(mn),  "%-.*s\n", (int)sizeof(ctrl->mn), ctrl->mn);
+	snprintf(fr, sizeof(fr), "%-.*s\n", (int)sizeof(ctrl->fr), ctrl->fr);
 
 	root = json_create_object();
 


### PR DESCRIPTION
Fixes:

==15224==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffffffcf55 at pc 0x7ffff6ecb9f5 bp 0x7fffffffcd80 sp 0x7fffffffc510
WRITE of size 22 at 0x7fffffffcf55 thread T0
    #0 0x7ffff6ecb9f4 in __interceptor_vsprintf (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x619f4)
    #1 0x7ffff6ecbcc9 in __interceptor_sprintf (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x61cc9)
    #2 0x420357 in json_nvme_id_ctrl /home/sbauer/nvme_code/nvme-cli/nvme-print.c:1266
    #3 0x4072f1 in __id_ctrl /home/sbauer/nvme_code/nvme-cli/nvme.c:935
    #4 0x40742f in id_ctrl /home/sbauer/nvme_code/nvme-cli/nvme.c:950
    #5 0x42fa63 in handle_plugin /home/sbauer/nvme_code/nvme-cli/plugin.c:140
    #6 0x410c46 in main /home/sbauer/nvme_code/nvme-cli/nvme.c:2729
    #7 0x7ffff6ac182f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #8 0x402268 in _start (/home/sbauer/nvme_code/nvme-cli/nvme+0x402268)

Address 0x7fffffffcf55 is located in stack of thread T0 at offset 117 in frame
    #0 0x42011f in json_nvme_id_ctrl /home/sbauer/nvme_code/nvme-cli/nvme-print.c:1254

  This frame has 3 object(s):
    [32, 41) 'fr'
    [96, 117) 'sn' <== Memory access at offset 117 overflows this variable
    [160, 201) 'mn'

Signed-off-by: Scott Bauer <scott.bauer@intel.com>