### PR TITLE
nvme-cli: change 'r' to 'c' for connect flag

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -759,7 +759,7 @@ int connect(const char *desc, int argc, char **argv)
 		 "number of io queues to use (default is core count)" },
 		{"keep-alive-tmo", 'k', "LIST", CFG_STRING, &cfg.keep_alive_tmo, required_argument,
 			"keep alive timeout period in seconds" },
-		{"reconnect-delay", 'r', "LIST", CFG_STRING, &cfg.reconnect_delay, required_argument,
+		{"reconnect-delay", 'c', "LIST", CFG_STRING, &cfg.reconnect_delay, required_argument,
 			"reconnect timeout period in seconds" },
 		{NULL},
 	};


### PR DESCRIPTION
To make things a tad easier for human usage understanding,
refine the single letter short option of 'r' to 'c' for the
'connect' command as 'r' is already used by 'discover'.

Signed-off-by: Jay Freyensee <james_p_freyensee@linux.intel.com>
Signed-off-by: Christoph Hellwig <hch@lst.de>
Signed-off-by: Sagi Grimberg <sagi@grimberg.me>