### PR TITLE
Fix compilation errors

### DIFF
--- a/argconfig.c
+++ b/argconfig.c
@@ -244,28 +244,28 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 			}
 			*((int *)value_addr) = tmp;
 		} else if (s->config_type == CFG_BYTE) {
-			uint8_t tmp = strtoul(optarg, &endptr, 0);
-			if (errno || tmp < 0 || optarg == endptr) {
+			unsigned long tmp = strtoul(optarg, &endptr, 0);
+			if (errno || tmp >= (1 << 8)  || optarg == endptr) {
 				fprintf(stderr,
-					"Expected positive argument for '%s' but got '%s'!\n",
+					"Expected byte argument for '%s' but got '%s'!\n",
 					long_opts[option_index].name, optarg);
 				goto exit;
 			}
 			*((uint8_t *) value_addr) = tmp;
 		} else if (s->config_type == CFG_SHORT) {
-			uint16_t tmp = strtoul(optarg, &endptr, 0);
-			if (errno || tmp < 0 || optarg == endptr) {
+			unsigned long tmp = strtoul(optarg, &endptr, 0);
+			if (errno || tmp >= (1 << 16) || optarg == endptr) {
 				fprintf(stderr,
-					"Expected positive argument for '%s' but got '%s'!\n",
+					"Expected short argument for '%s' but got '%s'!\n",
 					long_opts[option_index].name, optarg);
 				goto exit;
 			}
 			*((uint16_t *) value_addr) = tmp;
 		} else if (s->config_type == CFG_POSITIVE) {
 			uint32_t tmp = strtoul(optarg, &endptr, 0);
-			if (errno || tmp < 0 || optarg == endptr) {
+			if (errno || optarg == endptr) {
 				fprintf(stderr,
-					"Expected positive argument for '%s' but got '%s'!\n",
+					"Expected word argument for '%s' but got '%s'!\n",
 					long_opts[option_index].name, optarg);
 				goto exit;
 			}
@@ -273,7 +273,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		} else if (s->config_type == CFG_INCREMENT) {
 			(*((int *)value_addr))++;
 		} else if (s->config_type == CFG_LONG) {
-			*((long *)value_addr) = strtoul(optarg, &endptr, 0);
+			*((unsigned long *)value_addr) = strtoul(optarg, &endptr, 0);
 			if (errno || optarg == endptr) {
 				fprintf(stderr,
 					"Expected long integer argument for '%s' but got '%s'!\n",

--- a/fabrics.c
+++ b/fabrics.c
@@ -166,8 +166,7 @@ static int add_ctrl(const char *argstr)
 {
 	substring_t args[MAX_OPT_ARGS];
 	char buf[BUF_SIZE], *options, *p;
-	size_t len = strlen(argstr);
-	int token, ret, fd;
+	int token, ret, fd, len = strlen(argstr);
 
 	fd = open(PATH_NVME_FABRICS, O_RDWR);
 	if (fd < 0) {

--- a/suffix.c
+++ b/suffix.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
+#include <math.h>
 
 static struct si_suffix {
 	double magnitude;
@@ -99,7 +100,7 @@ const char *suffix_dbinary_get(double *value)
 	struct binary_suffix *s;
 
 	for (s = binary_suffixes; s->shift != 0; s++) {
-		if (llabs(*value) >= (1LL << s->shift)) {
+		if (fabs(*value) >= (1LL << s->shift)) {
 			*value = *value / (1 << s->shift);
 			return s->suffix;
 		}


### PR DESCRIPTION
While compiling nvme-cli for ChromeOS, the compiler founds minor issues
in the code:
- unsigned and sizet_t can never be negative.
- use fabs instead of llabs when argument is a double.

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>