### PR TITLE
JSON format fixes

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -63,14 +63,15 @@ void d_raw(unsigned char *buf, unsigned len)
 static void format(char *formatter, size_t fmt_sz, char *tofmt, size_t tofmtsz)
 {
 
-	snprintf(formatter,fmt_sz, "%-*.*s",
+	fmt_sz = snprintf(formatter,fmt_sz, "%-*.*s",
 		 (int)tofmtsz, (int)tofmtsz, tofmt);
 	/* trim() the obnoxious trailing white lines */
-	while (--fmt_sz) {
+	while (fmt_sz) {
 		if (formatter[fmt_sz - 1] != ' ' && formatter[fmt_sz - 1] != '\0') {
 			formatter[fmt_sz] = '\0';
 			break;
 		}
+		fmt_sz--;
 	}
 }
 

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1139,12 +1139,14 @@ void nvme_feature_show_fields(__u32 fid, unsigned int result, unsigned char *buf
 void json_print_list_items(struct list_item *list_items, unsigned len)
 {
 	struct json_object *root;
+	struct json_array *devices;
 	struct json_object *device_attrs;
 	char formatter[41] = { 0 };
 	int index, i = 0;
 	char *product;
 
 	root = json_create_object();
+	devices = json_create_array();
 	for (i = 0; i < len; i++) {
 		device_attrs = json_create_object();
 
@@ -1175,6 +1177,10 @@ void json_print_list_items(struct list_item *list_items, unsigned len)
 
 		product = nvme_product_name(index);
 
+		json_object_add_value_string(device_attrs,
+					     "ProductName",
+					     product);
+
 		format(formatter, sizeof(formatter),
 		       list_items[i].ctrl.sn,
 		       sizeof(list_items[i].ctrl.sn));
@@ -1183,9 +1189,10 @@ void json_print_list_items(struct list_item *list_items, unsigned len)
 					     "SerialNumber",
 					     formatter);
 
-		json_object_add_value_object(root, product, device_attrs);
+		json_array_add_value_object(devices, device_attrs);
 		free((void*)product);
 	}
+	json_object_add_value_array(root, "Devices", devices);
 	json_print_object(root, NULL);
 }
 

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1151,9 +1151,14 @@ void json_print_list_items(struct list_item *list_items, unsigned len)
 		json_object_add_value_string(device_attrs,
 					     "DevicePath",
 					     list_items[i].node);
+
+		format(formatter, sizeof(formatter),
+			   list_items[i].ctrl.fr,
+			   sizeof(list_items[i].ctrl.fr));
+
 		json_object_add_value_string(device_attrs,
 					     "Firmware",
-					     list_items[i].ctrl.fr);
+					     formatter);
 
 		if (sscanf(list_items[i].node, "/dev/nvme%d", &index) == 1)
 			json_object_add_value_int(device_attrs,


### PR DESCRIPTION
Some fixes for issues prevented the list output's JSON format being parseable in some cases:

* Fix the 'Firmware' field in the JSON output mode possibly reading past the end of the `.fr` field in the `nvme_id_ctrl` struct.
* Print the list as a JSON array of objects (as the "Devices" key of a root JSON object) rather than an object with the product name as the key, to avoid the issue of duplicate keys when two cards have the same product name
* Fix some issues right-trimming field whitespace