### PR TITLE
change default CFLAGS settings into the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CFLAGS += -std=gnu99 -O2 -g -Wall -Werror
+CFLAGS ?= -O2 -g -Wall -Werror
+CFLAGS += -std=gnu99
 CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
 NVME = nvme
 INSTALL ?= install


### PR DESCRIPTION
The way compiler settings are appended to CFLAGS breaks custom flags
that people are using to build.  So if someone does:
	$ export CFLAGS='-O0 -ggdb'
	$ make
The build will force -O2 instead.

Shift these defaults into a default setting rather than always appending.

Signed-off-by: Mike Frysinger <vapier@gentoo.org>