### PR TITLE
Documentation: allow parent PREFIX to override

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -91,7 +91,7 @@ NO_SUBDIR = :
 endif
 
 DESTDIR =
-PREFIX := /usr/local
+PREFIX ?= /usr/local
 
 all: man html
 


### PR DESCRIPTION
The current Documentation/Makefile always sets PREFIX to /usr/local.
If the parent Makefile sets it to something else, then it still gets
clobbered.  Change the Makefile to look like the parent and allow the
cascading logic to work.

Signed-off-by: Mike Frysinger <vapier@gentoo.org>