### PR TITLE
Include endian.h for byte/host order functions

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -16,6 +16,7 @@
 #define _NVME_H
 
 #include <stdbool.h>
+#include <endian.h>
 #include "plugin.h"
 
 #define unlikely(x) x


### PR DESCRIPTION
Fix the following error when building with musl libc:

nvme.h:136:2: error: implicit declaration of function 'le16toh'
[-Werror=implicit-function-declaration]
  le16toh((__force __u16)(x))
  ^

Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>