### PR TITLE
Moving the bash completion files to the standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ install-bin: default
 	$(INSTALL) -m 755 nvme $(DESTDIR)$(SBINDIR)
 
 install-bash-completion:
-	$(INSTALL) -d $(DESTDIR)$(SYSCONFDIR)/bash_completion.d
-	$(INSTALL) -m 644 -T ./completions/bash-nvme-completion.sh $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/nvme
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/bash_completion.d
+	$(INSTALL) -m 644 -T ./completions/bash-nvme-completion.sh $(DESTDIR)$(PREFIX)/share/bash_completion.d/nvme
 
 install: install-bin install-man install-bash-completion
 


### PR DESCRIPTION
Currently it is not recommend to put the bash completion files inside
/etc, but on the new /usr/share/bash-completion, as stated in :

https://lintian.debian.org/tags/package-installs-into-obsolete-dir.html
https://bugs.debian.org/776954

Signed-off-by: Breno Leitao <breno.leitao@gmail.com>