### PR TITLE
lightnvm: default to -1 on lun begin and end

### DIFF
--- a/lnvm-nvme.c
+++ b/lnvm-nvme.c
@@ -141,8 +141,8 @@ static int lnvm_create_tgt(int argc, char **argv, struct command *cmd, struct pl
 		.devname = "",
 		.tgtname = "",
 		.tgttype = "",
-		.lun_begin = 0,
-		.lun_end = 0,
+		.lun_begin = -1,
+		.lun_end = -1,
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {


### PR DESCRIPTION
The default behavior when initializing a target without lun end and
begin is to use only the first lun of the OCSSD. Going forward, the
user shall either explicit specific the begin and end, or if not defined
for kernel 4.11 and newer, the full SSD is initialized.

Signed-off-by: Matias Bjørling <matias@cnexlabs.com>