### PR TITLE
Unbreak RPM build after bash completion files were moved in 7e4c7596

### DIFF
--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -28,7 +28,7 @@ make install DESTDIR=%{buildroot} PREFIX=/usr
 %doc Documentation/nvme*.1
 %{_sbindir}/nvme
 %{_mandir}/man1/nvme*.1*
-%{_sysconfdir}/bash_completion.d/nvme
+%{_datadir}/bash_completion.d/nvme
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
The build would otherwise fail with:
```
Processing files: nvme-1.2-1.el7.centos.x86_64
error: File not found: /root/rpmbuild/BUILDROOT/nvme-1.2-1.el7.centos.x86_64/etc/bash_completion.d/nvme
```