### PR TITLE
fabrics: Fix disconnect_by_device from disconnecting instance 0 on error

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -31,6 +31,7 @@
 #include <asm/byteorder.h>
 #include <inttypes.h>
 #include <linux/types.h>
+#include <libgen.h>
 
 #include "parser.h"
 #include "nvme-ioctl.h"
@@ -899,9 +900,12 @@ static int disconnect_by_device(char *device)
 	int instance;
 	int ret;
 
+	device = basename(device);
 	ret = sscanf(device, "nvme%d", &instance);
 	if (ret < 0)
 		return ret;
+	if (!ret)
+		return -1;
 
 	return remove_ctrl(instance);
 }


### PR DESCRIPTION
I was a bit surprised that running:

nvme disconnect -d /dev/nvme1

actually disconnected nvme0 and I could never disconnect nvme1. Turns
out the code was not expecting a full path and silently used instance
zero if it failed to parse any arguments.

This patch fixes it so that it ignores any path component and fails if
sscanf doesn't match any items.