### PR TITLE
Fixed problem with security-recv binary output not working correctly

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2498,7 +2498,7 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 							result);
 			d(sec_buf, cfg.size, 16, 1);
 		} else if (cfg.size)
-			d_raw((unsigned char *)&sec_buf, cfg.size);
+			d_raw((unsigned char *)sec_buf, cfg.size);
 	}
 	return err;
 }


### PR DESCRIPTION
Security Receive sent the wrong pointer, specifically a pointer to a
stack location. When using the Dump raw command we would dump stack
contents, not the buffer received from the controller.

Signed-off-by: Thomas Bowen <thomas.r.bowen@intel.com>
Signed-off-by: Scott Bauer <Scott.Bauer@intel.com>