### PR TITLE
lightnvm: allow to init target on factory mode

### DIFF
--- a/linux/lightnvm.h
+++ b/linux/lightnvm.h
@@ -85,6 +85,10 @@ struct nvm_ioctl_create_conf {
 	};
 };
 
+enum {
+	NVM_TARGET_FACTORY = 1 << 0,	/* Init target in factory mode */
+};
+
 struct nvm_ioctl_create {
 	char dev[DISK_NAME_LEN];		/* open-channel SSD device */
 	char tgttype[NVM_TTYPE_NAME_MAX];	/* target type name */

--- a/lnvm-nvme.c
+++ b/lnvm-nvme.c
@@ -127,6 +127,8 @@ static int lnvm_create_tgt(int argc, char **argv, struct command *cmd, struct pl
 	const char *tgttype = "identifier of target type. e.g. pblk.";
 	const char *lun_begin = "Define begin of luns to use for target.";
 	const char *lun_end = "Define set of luns to use for target.";
+	const char *flag_factory = "Create target in factory mode";
+	int flags;
 
 	struct config
 	{
@@ -135,6 +137,8 @@ static int lnvm_create_tgt(int argc, char **argv, struct command *cmd, struct pl
 		char *tgttype;
 		__u32 lun_begin;
 		__u32 lun_end;
+		/* flags */
+		__u32 factory;
 	};
 
 	struct config cfg = {
@@ -143,6 +147,7 @@ static int lnvm_create_tgt(int argc, char **argv, struct command *cmd, struct pl
 		.tgttype = "",
 		.lun_begin = -1,
 		.lun_end = -1,
+		.factory = 0,
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {
@@ -151,6 +156,7 @@ static int lnvm_create_tgt(int argc, char **argv, struct command *cmd, struct pl
 		{"target-type",   't', "TARGETTYPE",  CFG_STRING,    &cfg.tgttype,   required_argument, tgttype},
 		{"lun-begin",     'b', "NUM",    CFG_POSITIVE,  &cfg.lun_begin,      required_argument,       lun_begin},
 		{"lun-end",       'e', "NUM",    CFG_POSITIVE,  &cfg.lun_end,   required_argument,       lun_end},
+		{"factory",      'f', "FLAG",   CFG_NONE,  &cfg.factory,   no_argument,  flag_factory},
 		{NULL}
 	};
 
@@ -169,7 +175,11 @@ static int lnvm_create_tgt(int argc, char **argv, struct command *cmd, struct pl
 		return -EINVAL;
 	}
 
-	return lnvm_do_create_tgt(cfg.devname, cfg.tgtname, cfg.tgttype, cfg.lun_begin, cfg.lun_end);
+	flags = 0;
+	if (cfg.factory)
+		flags |= NVM_TARGET_FACTORY;
+
+	return lnvm_do_create_tgt(cfg.devname, cfg.tgtname, cfg.tgttype, cfg.lun_begin, cfg.lun_end, flags);
 }
 
 static int lnvm_remove_tgt(int argc, char **argv, struct command *cmd, struct plugin *plugin)

--- a/nvme-lightnvm.c
+++ b/nvme-lightnvm.c
@@ -147,7 +147,7 @@ int lnvm_do_info(void)
 }
 
 int lnvm_do_create_tgt(char *devname, char *tgtname, char *tgttype,
-						int lun_begin, int lun_end)
+					int lun_begin, int lun_end, int flags)
 {
 	struct nvm_ioctl_create c;
 	int fd, ret;
@@ -163,6 +163,7 @@ int lnvm_do_create_tgt(char *devname, char *tgtname, char *tgttype,
 	c.conf.type = 0;
 	c.conf.s.lun_begin = lun_begin;
 	c.conf.s.lun_end = lun_end;
+	c.flags = flags;
 
 	ret = ioctl(fd, NVM_DEV_CREATE, &c);
 	if (ret)

--- a/nvme-lightnvm.h
+++ b/nvme-lightnvm.h
@@ -220,7 +220,7 @@ static inline struct ppa_addr generic_to_dev_addr(
 int lnvm_do_init(char *, char *);
 int lnvm_do_list_devices(void);
 int lnvm_do_info(void);
-int lnvm_do_create_tgt(char *, char *, char *, int, int);
+int lnvm_do_create_tgt(char *, char *, char *, int, int, int);
 int lnvm_do_remove_tgt(char *);
 int lnvm_do_factory_init(char *, int, int, int);
 int lnvm_do_id_ns(int, int, unsigned int);


### PR DESCRIPTION
Allow to drop the target recovery mechanism when creating a target in
order to start in factory mode. This facilitates development and makes
it possible to evaluate an OCSSD in different states.

Signed-off-by: Javier González <javier@cnexlabs.com>