### PR TITLE
Fix potential device string truncation

### DIFF
--- a/huawei-nvme.c
+++ b/huawei-nvme.c
@@ -71,7 +71,7 @@ static const char *dev = "/dev/";
 /* Assume every block device starting with /dev/nvme is an nvme namespace */
 static int huawei_scan_dev_filter(const struct dirent *d)
 {
-	char path[256];
+	char path[264];
 	struct stat bd;
 	int ctrl, ns, part;
 
@@ -318,7 +318,7 @@ static void huawei_print_list_items(struct huawei_list_item *list_items, unsigne
 static int huawei_list(int argc, char **argv, struct command *command,
 		struct plugin *plugin)
 {
-	char path[256];
+	char path[264];
 	struct dirent **devices;
 	struct huawei_list_item *list_items;
 	unsigned int i, n, fd, ret;

--- a/nvme.c
+++ b/nvme.c
@@ -786,7 +786,7 @@ static const char *dev = "/dev/";
 /* Assume every block device starting with /dev/nvme is an nvme namespace */
 static int scan_dev_filter(const struct dirent *d)
 {
-	char path[256];
+	char path[264];
 	struct stat bd;
 	int ctrl, ns, part;
 
@@ -808,7 +808,7 @@ static int scan_dev_filter(const struct dirent *d)
 
 static int list(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	char path[256];
+	char path[264];
 	struct dirent **devices;
 	struct list_item *list_items;
 	unsigned int i, n, fd, ret;


### PR DESCRIPTION
While compiling using gcc 7.1.1 I ran into compile errors, eg.

``` C
nvme.c: In function ‘scan_dev_filter.part.5’:
nvme.c:797:35: error: ‘%s’ directive output may be truncated writing " \
   "up to 255 bytes into a region of size 251 [-Werror=format-truncation=]
   snprintf(path, sizeof(path), "%s%s", dev, d->d_name);
``` 
This is caused because the buffer on the stack is only 256 bytes and the
dirent.d_name is 256 and the constant string is "/dev/", so  256 + 5,
but I've rounded up to nearest 4/8 byte alignment of 264.

Signed-off-by: Tony Asleson <tasleson@redhat.com>