### PR TITLE
fix use-after-free in pci.ids parsing

### DIFF
--- a/nvme-models.c
+++ b/nvme-models.c
@@ -32,11 +32,17 @@ static char *class_final;
 static void free_all(void)
 {
 	free(device_top);
+	device_top = NULL;
 	free(device_mid);
+	device_mid = NULL;
 	free(device_final);
+	device_final = NULL;
 	free(class_top);
+	class_top = NULL;
 	free(class_mid);
+	class_mid = NULL;
 	free(class_final);
+	class_final = NULL;
 }
 
 static char *find_data(char *data)


### PR DESCRIPTION
If a device that is _not_ in pci.ids has its name looked up after a device
that _was_ present in pci.ids, these pointers are still set even though
they've been free'd, and then get passed to snprintf resulting in a
use-after-free.