### PR TITLE
Fix spelling errors

### DIFF
--- a/Documentation/nvme-discover.1
+++ b/Documentation/nvme-discover.1
@@ -51,7 +51,7 @@ Otherwise, a specific Discovery Controller should be specified using the \-\-tra
 .sp
 The NVMe\-over\-Fabrics specification defines the concept of a Discovery Controller that an NVMe Host can query on a fabric network to discover NVMe subsystems contained in NVMe Targets which it can connect to on the network\&. The Discovery Controller will return Discovery Log Pages that provide the NVMe Host with specific information (such as network address and unique subsystem NQN) the NVMe Host can use to issue an NVMe connect command to connect itself to a storage resource contained in that NVMe subsystem on the NVMe Target\&.
 .sp
-Note that the base NVMe specfication defines the NQN (NVMe Qualified Name) format which an NVMe endpoint (device, subsystem, etc) must follow to guarantee a unique name under the NVMe standard\&. In particular, the Host NQN uniquely identifies the NVMe Host, and may be used by the the Discovery Controller to control what NVMe Target resources are allocated to the NVMe Host for a connection\&.
+Note that the base NVMe specification defines the NQN (NVMe Qualified Name) format which an NVMe endpoint (device, subsystem, etc) must follow to guarantee a unique name under the NVMe standard\&. In particular, the Host NQN uniquely identifies the NVMe Host, and may be used by the the Discovery Controller to control what NVMe Target resources are allocated to the NVMe Host for a connection\&.
 .sp
 A Discovery Controller has it\(cqs own NQN defined in the NVMe\-over\-Fabrics specification, \fBnqn\&.2014\-08\&.org\&.nvmexpress\&.discovery\fR\&. All Discovery Controllers must use this NQN name\&. This NQN is used by default by nvme\-cli for the \fIdiscover\fR command\&.
 .SH "OPTIONS"

--- a/Documentation/nvme-gen-hostnqn.1
+++ b/Documentation/nvme-gen-hostnqn.1
@@ -36,7 +36,10 @@ nvme-gen-hostnqn \- Generate a host NVMe Qualified Name
 .fi
 .SH "DESCRIPTION"
 .sp
-Generate a random host NQN in the form: nqn\&.2014\-08\&.org\&.nvmexpress:NVMf:uuid:1b4e28ba\-2fa1\-11d2\-883f\-0016d3cca427 and prints it to stdout\&.
+Generate a random host NQN in the form: \
+        nqn\&.2014\-08\&.org\&.nvmexpress: \
+        NVMf:uuid:1b4e28ba\-2fa1\-11d2\-883f\-0016d3cca427 \
+        and prints it to stdout\&.
 .SH "OPTIONS"
 .sp
 No options needed

--- a/Documentation/nvme-id-ns.1
+++ b/Documentation/nvme-id-ns.1
@@ -52,7 +52,7 @@ Retrieve the identify namespace structure for the given nsid\&. This is required
 .PP
 \-f, \-\-force
 .RS 4
-Request controller return the indentify namespace structure even if the namespace is not attached to the controller\&. This is valid only for controllers at or newer than revision 1\&.2\&. Controllers at revision lower than this may interpret the command incorrectly\&.
+Request controller return the identify namespace structure even if the namespace is not attached to the controller\&. This is valid only for controllers at or newer than revision 1\&.2\&. Controllers at revision lower than this may interpret the command incorrectly\&.
 .RE
 .PP
 \-b, \-\-raw\-binary

--- a/wdc-nvme.c
+++ b/wdc-nvme.c
@@ -795,7 +795,7 @@ static void wdc_print_log_json(struct wdc_ssd_perf_stats *perf)
 			(uint64_t)le64_to_cpu(perf->nw_blks));
 	json_object_add_value_int(root, "Average NAND Write Size",
 			safe_div_fp((le64_to_cpu(perf->nw_blks)), (le64_to_cpu(perf->nw_cmds))));
-	json_object_add_value_int(root, "NAND Read Before Writen",
+	json_object_add_value_int(root, "NAND Read Before Written",
 			(uint64_t)le64_to_cpu(perf->nrbw));
 	json_print_object(root, NULL);
 	printf("\n");


### PR DESCRIPTION
Spelling errors were corrected in some documentation files. They were
showing up when trying to run the Lintian tool.

Signed-off-by: Rodrigo R. Galvão <rodrigorosattig@gmail.com>