### PR TITLE
nvme-cli: add error message for nvme list.

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -836,8 +836,10 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 		return -EINVAL;
 
 	n = scandir(dev, &devices, scan_dev_filter, alphasort);
-	if (n < 0)
+	if (n < 0) {
+		fprintf(stderr, "no NVMe device(s) detected.\n");
 		return n;
+	}
 
 	list_items = calloc(n, sizeof(*list_items));
 	if (!list_items) {


### PR DESCRIPTION
Print error message for "nvme list" command when NVMe device(s)
is not present.