### PR TITLE
Fix typo of flbas in nvme_create_max_ns_test

### DIFF
--- a/tests/nvme_create_max_ns_test.py
+++ b/tests/nvme_create_max_ns_test.py
@@ -39,7 +39,7 @@ class TestNVMeCreateMaxNS(TestNVMe):
 
         - Attributes:
               - dps : data protection information.
-              - flabs : LBA format information.
+              - flbas : LBA format information.
               - nsze : namespace size.
               - ncap : namespace capacity.
               - ctrl_id : controller id.


### PR DESCRIPTION
Fix typo of flbas in nvme_create_max_ns_test

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>