### PR TITLE
Makefile: allow linker override for cross uuid test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CFLAGS ?= -O2 -g -Wall -Werror
 CFLAGS += -std=gnu99
 CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
-LIBUUID = $(shell ld -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
+LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =


### PR DESCRIPTION
The test to determine whether libuuid is installed uses the host 'ld' utility.
This breaks when cross compiling, since target libraries are often different
than host libraries.

Use $(LD) instead. This allows to easily use the cross compiler linker.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>