### PR TITLE
nvme-cli/write: add checking for data file while doing write/compare operation

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2566,6 +2566,11 @@ static int submit_io(int opcode, char *command, const char *desc,
 		return EINVAL;
 	}
 
+	if (!dfd)       {
+		fprintf(stderr, "data file not provided\n");
+		return EINVAL;
+	}
+
 	if (ioctl(fd, BLKPBSZGET, &phys_sector_size) < 0)
 		return errno;
 


### PR DESCRIPTION

If don't provide --data= or -d when do write/compare operation, read function
will wait for user inputting without any prompt. Now add checking before reading.

Signed-off-by: Xiao Liang <xiliang@redhat.com>