### PR TITLE
Fixing macro definitions to avoid issues when these are used in expression

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -56,8 +56,8 @@
 #include "fabrics.h"
 
 #define array_len(x) ((size_t)(sizeof(x) / sizeof(x[0])))
-#define min(x, y) (x) > (y) ? (y) : (x)
-#define max(x, y) (x) > (y) ? (x) : (y)
+#define min(x, y) ((x) > (y) ? (y) : (x))
+#define max(x, y) ((x) > (y) ? (x) : (y))
 
 static struct stat nvme_stat;
 const char *devicename;


### PR DESCRIPTION
C operator precedence puts ternary operator below many arithmetic operators
http://en.cppreference.com/w/c/language/operator_precedence

Without these changes following expression will return 2 instead of expected answer 5
printf("Sum = %d", min(2,3)+max(2,3));

