### PR TITLE
Added handling for temperature threshold values below 0C(273K)

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1342,7 +1342,7 @@ void nvme_feature_show_fields(__u32 fid, unsigned int result, unsigned char *buf
 		printf("\tThreshold Type Select         (THSEL): %u - %s\n", field, nvme_feature_temp_type_to_string(field));
 		field = (result & 0x000f0000) >> 16;
 		printf("\tThreshold Temperature Select (TMPSEL): %u - %s\n", field, nvme_feature_temp_sel_to_string(field));
-		printf("\tTemperature Threshold         (TMPTH): %u C\n", (result & 0x0000ffff) - 273);
+		printf("\tTemperature Threshold         (TMPTH): %d C\n", (result & 0x0000ffff) - 273);
 		break;
 	case NVME_FEAT_ERR_RECOVERY:
 		printf("\tDeallocated or Unwritten Logical Block Error Enable (DULBE): %s\n", ((result & 0x00010000) >> 16) ? "Enabled":"Disabled");

--- a/nvme.c
+++ b/nvme.c
@@ -1281,9 +1281,9 @@ static int get_feature(int argc, char **argv, struct command *cmd, struct plugin
 			printf("get-feature:%#02x (%s), %s value:%#08x\n", cfg.feature_id,
 				nvme_feature_to_string(cfg.feature_id),
 				nvme_select_to_string(cfg.sel), result);
-			if (cfg.human_readable && buf)
-				nvme_feature_show_fields(cfg.feature_id, result, buf);
-			else if (buf)
+			if (cfg.human_readable)
+				nvme_feature_show_fields(cfg.feature_id, (cfg.cdw11 & 0x3f0000) | result, buf);
+			if (buf)
 				d(buf, cfg.data_len, 16, 1);
 		} else if (buf)
 			d_raw(buf, cfg.data_len);

--- a/nvme.c
+++ b/nvme.c
@@ -1282,7 +1282,7 @@ static int get_feature(int argc, char **argv, struct command *cmd, struct plugin
 				nvme_feature_to_string(cfg.feature_id),
 				nvme_select_to_string(cfg.sel), result);
 			if (cfg.human_readable)
-				nvme_feature_show_fields(cfg.feature_id, (cfg.cdw11 & 0x3f0000) | result, buf);
+				nvme_feature_show_fields(cfg.feature_id, result, buf);
 			if (buf)
 				d(buf, cfg.data_len, 16, 1);
 		} else if (buf)


### PR DESCRIPTION
Added handling for temperature threshold values below 0C(273K) in human readable option and removed buffer check for human readable output as Temperature threshold feature does not use Memory Buffer for Attributes

 Changes to be committed:
	modified:   nvme-print.c
	modified:   nvme.c