### PR TITLE
README: Add Nix(OS) install instructions and fix some minor Markdown mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ many architectures. For a complete list try running:
   ```
   rmadison nvme-cli
    nvme-cli | 0.3-1 | xenial/universe | source, amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
-  ```  
+  ```
 A Debian based package for nvme-cli is currently maintained as a
 Ubuntu PPA. Right now there is support for Trusty, Vivid and Wiley. To
 install nvme-cli using this approach please perform the following
@@ -56,22 +56,22 @@ steps:
    ```
    otherwise you will see information about each NVMe device installed
    in the system.
-   
-### AlpineLinux
 
-nvme-cli is tested on AlpineLinux 3.3.  Install it using:
+### Alpine Linux
+
+nvme-cli is tested on Alpine Linux 3.3.  Install it using:
 
     # akp update && apk add nvme-cli nvme-cli-doc
 
-    if you just use the device you're after, it will work flawless.
-    ```
-    # nvme smart-log /dev/nvme0
+if you just use the device you're after, it will work flawless.
+```
+# nvme smart-log /dev/nvme0
 Smart Log for NVME device:/dev/nvme0 namespace-id:ffffffff
 critical_warning                    : 0
 temperature                         : 49 C
 available_spare                     : 100%
-    ```
-   
+```
+
 ### openSUSE Tumbleweed
 
 nvme-cli is available in openSUSE Tumbleweed. You can install it using zypper.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Install from AUR, e.g.:
 $ yaourt -S nvme-cli-git
 ```
 
+### Nix(OS)
+
+The attribute is named `nvme-cli` and can e.g. be installed with:
+```
+$ nix-env -f '<nixpkgs>' -iA nvme-cli
+```
+
 ### Other Distros
 
 TBD


### PR DESCRIPTION
Just updated the Nix package to 1.4 and noticed this list. This'll add install instructions for Nix(OS) if you want. I also noticed that the Alpine Linux install instructions [weren't rendered correctly](https://github.com/linux-nvme/nvme-cli/tree/9c1c0c7f7900642ca64985f1e0609da05c3709a9#alpinelinux) ([new version](https://github.com/primeos/nvme-cli/blob/300104d3be129af7cac1a6f3384c40dd727ee0c0/README.md#alpine-linux)). Feel free to squash the two commits if you prefer only one commit.