### PR TITLE
nvme/id-ns: do not try to get namespace id from non-block device.

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1178,8 +1178,11 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		flags |= VS;
 	if (cfg.human_readable)
 		flags |= HUMAN;
-	if (!cfg.namespace_id)
+	if (!cfg.namespace_id && S_ISBLK(nvme_stat.st_mode))
 		cfg.namespace_id = get_nsid(fd);
+	else if(!cfg.namespace_id)
+		fprintf(stderr,
+			"Error: requesting namespace-id from non-block device\n");`
 
 	err = nvme_identify_ns(fd, cfg.namespace_id, cfg.force, &ns);
 	if (!err) {


### PR DESCRIPTION
namespace id's default value is 0 and changed to 15 by get_nsid()
when device is not a block device.

With this change:
`# ./nvme id-ns /dev/nvme0 -n 0`
Error: requesting namespace-id from non-block device
NVMe Status:INVALID_NS(b) **NSID:0**

Without this change:
Missleading output when user passed 0 or 15 as namespace id.
`# nvme id-ns /dev/nvme0`
Error: requesting namespace-id from non-block device
NVMe Status:INVALID_NS(b) **NSID:15**
`# nvme id-ns /dev/nvme0 -n 0`
Error: requesting namespace-id from non-block device
NVMe Status:INVALID_NS(b) **NSID:15**
`# nvme id-ns /dev/nvme0 -n 15`
NVMe Status:INVALID_NS(b) **NSID:15**

Signed-off-by: Xiao Liang <xiliang@redhat.com>