### PR TITLE
nvme-cli: Fix small mem leak.

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3694,7 +3694,7 @@ static int passthru(int argc, char **argv, int ioctl_cmd, const char *desc, stru
 		} else if (data && cfg.read)
 			d_raw((unsigned char *)data, cfg.data_len);
 	}
-	return err;
+
 free_and_return:
 	free(data);
 	free(metadata);


### PR DESCRIPTION
Internally some people are building with asan which complains
that we're leaking that memory. So we'll fix it for them.

Signed-off-by: Scott Bauer <scott.bauer@intel.com>