### PR TITLE
nvme-cli: add print for command specific info field of error log page

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -947,6 +947,7 @@ void show_error_log(struct nvme_error_log_page *err_log, int entries, const char
 		printf("lba          : %#"PRIx64"\n",(uint64_t)le64_to_cpu(err_log[i].lba));
 		printf("nsid         : %#x\n", err_log[i].nsid);
 		printf("vs           : %d\n", err_log[i].vs);
+		printf("cs           : %#"PRIx64"\n", (uint64_t) err_log[i].cs);
 		printf(".................\n");
 	}
 }

--- a/nvme.h
+++ b/nvme.h
@@ -48,7 +48,9 @@ struct nvme_error_log_page {
 	__u64	lba;
 	__u32	nsid;
 	__u8	vs;
-	__u8	resv[35];
+	__u8	resv[3];
+	__u64	cs;
+	__u8	resv2[24];
 };
 
 struct nvme_firmware_log_page {


### PR DESCRIPTION
Add print line for Command Specific Information[39:32] in Error
Information Log Entry.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>