### PR TITLE
nvme-cli: Remove nsid param in error-log

### DIFF
--- a/Documentation/nvme-error-log.1
+++ b/Documentation/nvme-error-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-error-log
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 12/10/2017
+.\"      Date: 01/11/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ERROR\-LOG" "1" "12/10/2017" "NVMe" "NVMe Manual"
+.TH "NVME\-ERROR\-LOG" "1" "01/11/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -32,8 +32,7 @@ nvme-error-log \- Send NVME Error log page request, return result and log
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme error\-log\fR <device>  [\-\-namespace\-id=<nsid> | \-n <nsid>]
-                         [\-\-log\-entries=<entries> | \-e <entries>]
+\fInvme error\-log\fR <device>  [\-\-log\-entries=<entries> | \-e <entries>]
                          [\-\-raw\-binary | \-b]
                          [\-\-output\-format=<fmt> | \-o <fmt>]
 .fi
@@ -45,11 +44,6 @@ The <device> parameter is mandatory and may be either the NVMe character device 
 .sp
 On success, the returned error log structure may be returned in one of several ways depending on the option flags; the structure may parsed by the program and printed in a readable format or the raw buffer may be printed to stdout for another program to parse\&.
 .SH "OPTIONS"
-.PP
-\-n <nsid>, \-\-namespace\-id=<nsid>
-.RS 4
-Retrieve the Error Log for the given nsid\&. This is optional and its success may depend on the device\(cqs capabilities to provide this log on a per\-namespace basis (see the NVMe Identify Controller for this capability)\&. The default nsid to use is 0xffffffff for the device global error log\&.
-.RE
 .PP
 \-e <entries>, \-\-log\-entries=<entries>
 .RS 4

--- a/Documentation/nvme-error-log.html
+++ b/Documentation/nvme-error-log.html
@@ -746,8 +746,7 @@ nvme-error-log(1) Manual Page
 <h2 id="_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="verseblock">
-<pre class="content"><em>nvme error-log</em> &lt;device&gt;  [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
-                         [--log-entries=&lt;entries&gt; | -e &lt;entries&gt;]
+<pre class="content"><em>nvme error-log</em> &lt;device&gt;  [--log-entries=&lt;entries&gt; | -e &lt;entries&gt;]
                          [--raw-binary | -b]
                          [--output-format=&lt;fmt&gt; | -o &lt;fmt&gt;]</pre>
 <div class="attribution">
@@ -771,21 +770,6 @@ printed to stdout for another program to parse.</p></div>
 <h2 id="_options">OPTIONS</h2>
 <div class="sectionbody">
 <div class="dlist"><dl>
-<dt class="hdlist1">
--n &lt;nsid&gt;
-</dt>
-<dt class="hdlist1">
---namespace-id=&lt;nsid&gt;
-</dt>
-<dd>
-<p>
-        Retrieve the Error Log for the given nsid. This is optional
-        and its success may depend on the device&#8217;s capabilities to
-        provide this log on a per-namespace basis (see the NVMe Identify
-        Controller for this capability). The default nsid to use is
-        0xffffffff for the device global error log.
-</p>
-</dd>
 <dt class="hdlist1">
 -e &lt;entries&gt;
 </dt>

--- a/Documentation/nvme-error-log.txt
+++ b/Documentation/nvme-error-log.txt
@@ -8,8 +8,7 @@ nvme-error-log - Send NVME Error log page request, return result and log
 SYNOPSIS
 --------
 [verse]
-'nvme error-log' <device>  [--namespace-id=<nsid> | -n <nsid>]
-			 [--log-entries=<entries> | -e <entries>]
+'nvme error-log' <device>  [--log-entries=<entries> | -e <entries>]
 			 [--raw-binary | -b]
 			 [--output-format=<fmt> | -o <fmt>]
 
@@ -28,14 +27,6 @@ printed to stdout for another program to parse.
 
 OPTIONS
 -------
--n <nsid>::
---namespace-id=<nsid>::
-	Retrieve the Error Log for the given nsid. This is optional
-	and its success may depend on the device's capabilities to
-	provide this log on a per-namespace basis (see the NVMe Identify
-	Controller for this capability). The default nsid to use is
-	0xffffffff for the device global error log.
-
 -e <entries>::
 --log-entries=<entries>::
 	Specifies how many log entries the program should request from

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -403,10 +403,9 @@ int nvme_fw_log(int fd, struct nvme_firmware_log_page *fw_log)
 	return nvme_get_log(fd, NVME_NSID_ALL, NVME_LOG_FW_SLOT, sizeof(*fw_log), fw_log);
 }
 
-int nvme_error_log(int fd, __u32 nsid, int entries,
-		   struct nvme_error_log_page *err_log)
+int nvme_error_log(int fd, int entries, struct nvme_error_log_page *err_log)
 {
-	return nvme_get_log(fd, nsid, NVME_LOG_ERROR, entries * sizeof(*err_log), err_log);
+	return nvme_get_log(fd, 0, NVME_LOG_ERROR, entries * sizeof(*err_log), err_log);
 }
 
 int nvme_smart_log(int fd, __u32 nsid, struct nvme_smart_log *smart_log)

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -81,8 +81,7 @@ int nvme_identify_ns_descs(int fd, __u32 nsid, void *data);
 
 int nvme_get_log(int fd, __u32 nsid, __u8 log_id, __u32 data_len, void *data);
 int nvme_fw_log(int fd, struct nvme_firmware_log_page *fw_log);
-int nvme_error_log(int fd, __u32 nsid, int entries,
-		   struct nvme_error_log_page *err_log);
+int nvme_error_log(int fd, int entries, struct nvme_error_log_page *err_log);
 int nvme_smart_log(int fd, __u32 nsid, struct nvme_smart_log *smart_log);
 int nvme_discovery_log(int fd, struct nvmf_disc_rsp_page_hdr *log, __u32 size);
 

--- a/nvme.c
+++ b/nvme.c
@@ -258,29 +258,25 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 static int get_error_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Retrieve specified number of "\
-		"error log entries from a given device (or "\
-		"namespace) in either decoded format (default) or binary.";
-	const char *namespace_id = "desired namespace";
+		"error log entries from a given device "\
+		"in either decoded format (default) or binary.";
 	const char *log_entries = "number of entries to retrieve";
 	const char *raw_binary = "dump in binary format";
 	struct nvme_id_ctrl ctrl;
 	int err, fmt, fd;
 
 	struct config {
-		__u32 namespace_id;
 		__u32 log_entries;
 		int   raw_binary;
 		char *output_format;
 	};
 
 	struct config cfg = {
-		.namespace_id = NVME_NSID_ALL,
 		.log_entries  = 64,
 		.output_format = "normal",
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"namespace-id",  'n', "NUM", CFG_POSITIVE, &cfg.namespace_id,  required_argument, namespace_id},
 		{"log-entries",   'e', "NUM", CFG_POSITIVE, &cfg.log_entries,   required_argument, log_entries},
 		{"raw-binary",    'b', "",    CFG_NONE,     &cfg.raw_binary,    no_argument,       raw_binary},
 		{"output-format", 'o', "FMT", CFG_STRING,   &cfg.output_format, required_argument, output_format },
@@ -318,7 +314,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 			return ENOMEM;
 		}
 
-		err = nvme_error_log(fd, cfg.namespace_id, cfg.log_entries, err_log);
+		err = nvme_error_log(fd, cfg.log_entries, err_log);
 		if (!err) {
 			if (fmt == BINARY)
 				d_raw((unsigned char *)err_log, sizeof(err_log));


### PR DESCRIPTION
nvme-cli: Remove nsid param in error-log

Namespace Identifier is not needed for error information in get log page command.
Update nvme-error-log.txt documentation also.