### PR TITLE
nvme-cli: add support for json output format of sanitize-log command

### DIFF
--- a/nvme-print.h
+++ b/nvme-print.h
@@ -42,6 +42,7 @@ void json_nvme_id_ns(struct nvme_id_ns *ns, unsigned int flags);
 void json_nvme_resv_report(struct nvme_reservation_status *status, int bytes, __u32 cdw11);
 void json_error_log(struct nvme_error_log_page *err_log, int entries, const char *devname);
 void json_smart_log(struct nvme_smart_log *smart, unsigned int nsid, const char *devname);
+void json_sanitize_log(struct nvme_sanitize_log_page *sanitize_log, const char *devname);
 void json_fw_log(struct nvme_firmware_log_page *fw_log, const char *devname);
 void json_print_list_items(struct list_item *items, unsigned amnt);
 void json_nvme_id_ns_descs(void *data);

--- a/nvme.c
+++ b/nvme.c
@@ -508,7 +508,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 		if (fmt == BINARY)
 			d_raw((unsigned char *)&sanitize_log, sizeof(sanitize_log));
 		else if (fmt == JSON)
-			return -EINVAL;
+			json_sanitize_log(&sanitize_log, devicename);
 		else
 			show_sanitize_log(&sanitize_log, flags, devicename);
 	}


### PR DESCRIPTION
Add support for json output format of sanitize-log command.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>