### PR TITLE
nvme-cli: intel: update smart-log-add command documentation

### DIFF
--- a/Documentation/nvme-intel-smart-log-add.1
+++ b/Documentation/nvme-intel-smart-log-add.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-smart-log-add
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 12/10/2017
+.\"      Date: 01/11/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-SMART\-" "1" "12/10/2017" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-SMART\-" "1" "01/11/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -34,6 +34,7 @@ nvme-intel-smart-log-add \- Send NVMe Intel Additional SMART log page request, r
 .nf
 \fInvme intel smart\-log\-add\fR <device> [\-\-namespace\-id=<nsid> | \-n <nsid>]
                         [\-\-raw\-binary | \-b]
+                        [\-\-output\-format=<fmt> | \-o <fmt>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -52,6 +53,14 @@ Retrieve the Additional SMART log for the given nsid\&. This is optional and its
 \-b, \-\-raw\-binary
 .RS 4
 Print the raw Intel Additional SMART log buffer to stdout\&.
+.RE
+.PP
+\-o <format>, \-\-output\-format=<format>
+.RS 4
+Set the reporting format to
+\fInormal\fR,
+\fIjson\fR, or
+\fIbinary\fR\&. Only one output format can be used at a time\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-intel-smart-log-add.html
+++ b/Documentation/nvme-intel-smart-log-add.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.9" />
 <title>nvme-intel-smart-log-add(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +94,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +225,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -747,7 +749,8 @@ nvme-intel-smart-log-add(1) Manual Page
 <div class="sectionbody">
 <div class="verseblock">
 <pre class="content"><em>nvme intel smart-log-add</em> &lt;device&gt; [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
-                        [--raw-binary | -b]</pre>
+                        [--raw-binary | -b]
+                        [--output-format=&lt;fmt&gt; | -o &lt;fmt&gt;]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -795,6 +798,18 @@ printed to stdout for another program to parse.</p></div>
         Print the raw Intel Additional SMART log buffer to stdout.
 </p>
 </dd>
+<dt class="hdlist1">
+-o &lt;format&gt;
+</dt>
+<dt class="hdlist1">
+--output-format=&lt;format&gt;
+</dt>
+<dd>
+<p>
+              Set the reporting format to <em>normal</em>, <em>json</em>, or
+              <em>binary</em>. Only one output format can be used at a time.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -834,7 +849,8 @@ Print the raw Intel Additional SMART log to a file:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-27 10:11:58 EST
+Last updated
+ 2018-01-11 01:34:36 KST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-intel-smart-log-add.txt
+++ b/Documentation/nvme-intel-smart-log-add.txt
@@ -10,6 +10,7 @@ SYNOPSIS
 [verse]
 'nvme intel smart-log-add' <device> [--namespace-id=<nsid> | -n <nsid>]
 			[--raw-binary | -b]
+			[--output-format=<fmt> | -o <fmt>]
 
 DESCRIPTION
 -----------
@@ -37,6 +38,11 @@ OPTIONS
 -b::
 --raw-binary::
 	Print the raw Intel Additional SMART log buffer to stdout.
+
+-o <format>::
+--output-format=<format>::
+              Set the reporting format to 'normal', 'json', or
+              'binary'. Only one output format can be used at a time.
 
 EXAMPLES
 --------


### PR DESCRIPTION
Update smart-log-add command documentation in intel plugin with
output-format parameter description.

In github issue #175, tim-oleksii reported that descriptions of
output-format whose implementation was added in Pull request #178 was
not added in documentation.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>