### PR TITLE
nvme-cli: intel: fix smart-log-add documentation

### DIFF
--- a/Documentation/nvme-intel-smart-log-add.1
+++ b/Documentation/nvme-intel-smart-log-add.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-smart-log-add
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 01/11/2018
+.\"      Date: 01/12/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-SMART\-" "1" "01/11/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-SMART\-" "1" "01/12/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -34,7 +34,7 @@ nvme-intel-smart-log-add \- Send NVMe Intel Additional SMART log page request, r
 .nf
 \fInvme intel smart\-log\-add\fR <device> [\-\-namespace\-id=<nsid> | \-n <nsid>]
                         [\-\-raw\-binary | \-b]
-                        [\-\-output\-format=<fmt> | \-o <fmt>]
+                        [\-\-json | \-j]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -55,12 +55,9 @@ Retrieve the Additional SMART log for the given nsid\&. This is optional and its
 Print the raw Intel Additional SMART log buffer to stdout\&.
 .RE
 .PP
-\-o <format>, \-\-output\-format=<format>
+\-j, \-\-json
 .RS 4
-Set the reporting format to
-\fInormal\fR,
-\fIjson\fR, or
-\fIbinary\fR\&. Only one output format can be used at a time\&.
+Dump output in json format\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-intel-smart-log-add.html
+++ b/Documentation/nvme-intel-smart-log-add.html
@@ -750,7 +750,7 @@ nvme-intel-smart-log-add(1) Manual Page
 <div class="verseblock">
 <pre class="content"><em>nvme intel smart-log-add</em> &lt;device&gt; [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
                         [--raw-binary | -b]
-                        [--output-format=&lt;fmt&gt; | -o &lt;fmt&gt;]</pre>
+                        [--json | -j]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -799,15 +799,14 @@ printed to stdout for another program to parse.</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
--o &lt;format&gt;
+-j
 </dt>
 <dt class="hdlist1">
---output-format=&lt;format&gt;
+--json
 </dt>
 <dd>
 <p>
-              Set the reporting format to <em>normal</em>, <em>json</em>, or
-              <em>binary</em>. Only one output format can be used at a time.
+              Dump output in <em>json</em> format.
 </p>
 </dd>
 </dl></div>

--- a/Documentation/nvme-intel-smart-log-add.txt
+++ b/Documentation/nvme-intel-smart-log-add.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 [verse]
 'nvme intel smart-log-add' <device> [--namespace-id=<nsid> | -n <nsid>]
 			[--raw-binary | -b]
-			[--output-format=<fmt> | -o <fmt>]
+			[--json | -j]
 
 DESCRIPTION
 -----------
@@ -39,10 +39,9 @@ OPTIONS
 --raw-binary::
 	Print the raw Intel Additional SMART log buffer to stdout.
 
--o <format>::
---output-format=<format>::
-              Set the reporting format to 'normal', 'json', or
-              'binary'. Only one output format can be used at a time.
+-j::
+--json::
+              Dump output in json format.
 
 EXAMPLES
 --------


### PR DESCRIPTION
tim-oleksii has reported that intel smart-log-add help differs from man
page in #260 .

Update man, html, and txt documentation to follow output of below
command.
    ./nvme intel smart-log-add

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>