### PR TITLE
nvme-cli: intel: add check for fd after open to intel commands

### DIFF
--- a/intel-nvme.c
+++ b/intel-nvme.c
@@ -252,6 +252,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	};
 
 	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	if (fd < 0)
+		return fd;
 
 	err = nvme_get_log(fd, cfg.namespace_id, 0xca, sizeof(smart_log),
 			&smart_log);
@@ -289,6 +291,8 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 	};
 
 	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	if (fd < 0)
+		return fd;
 
 	err = nvme_get_log(fd, NVME_NSID_ALL, 0xdd, sizeof(log), log);
 	if (!err) {
@@ -349,6 +353,8 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 	};
 
 	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	if (fd < 0)
+		return fd;
 
 	err = nvme_get_log(fd, NVME_NSID_ALL, 0xc5, sizeof(stats), &stats);
 	if (!err) {
@@ -415,6 +421,8 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	if (fd < 0)
+		return fd;
 
 	err = nvme_get_log(fd, NVME_NSID_ALL, cfg.write ? 0xc2 : 0xc1, sizeof(stats), &stats);
 	if (!err) {


### PR DESCRIPTION
Make it return negative error value when file open is failed to intel
commands.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>