### PR TITLE
nvme-cli: intel: add const to descriptions of subcommand option

### DIFF
--- a/intel-nvme.c
+++ b/intel-nvme.c
@@ -229,7 +229,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 {
 	struct nvme_additional_smart_log smart_log;
 	int err, fd;
-	char *desc = "Get Intel vendor specific additional smart log (optionally, "\
+	const char *desc = "Get Intel vendor specific additional smart log (optionally, "\
 		      "for the specified namespace), and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
@@ -274,7 +274,7 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 	char log[512];
 	int err, fd;
 
-	char *desc = "Get Intel Marketing Name log and show it.";
+	const char *desc = "Get Intel Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
 	struct config {
 		int  raw_binary;
@@ -334,7 +334,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 	struct intel_temp_stats stats;
 	int err, fd;
 
-	char *desc = "Get Intel Marketing Name log and show it.";
+	const char *desc = "Get Intel Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
 	struct config {
 		int  raw_binary;
@@ -397,7 +397,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	struct intel_lat_stats stats;
 	int err, fd;
 
-	char *desc = "Get Intel Latency Statistics log and show it.";
+	const char *desc = "Get Intel Latency Statistics log and show it.";
 	const char *raw = "dump output in binary format";
 	const char *write = "Get write statistics (read default)";
 	struct config {
@@ -645,12 +645,12 @@ static int get_internal_log(int argc, char **argv, struct command *command, stru
 	struct intel_assert_dump *ad = (struct intel_assert_dump *) intel->reserved;
 	struct intel_event_header *ehdr = (struct intel_event_header *)intel->reserved;
 
-	char *desc = "Get Intel Firmware Log and save it.";
-	char *log = "Log type: 0, 1, or 2 for nlog, event log, and assert log, respectively.";
-	char *core = "Select which region log should come from. -1 for all";
-	char *nlognum = "Select which nlog to read. -1 for all nlogs";
-	char *file = "Output file; defaults to device name provided";
-	char *verbose = "To print out verbose nlog info";
+	const char *desc = "Get Intel Firmware Log and save it.";
+	const char *log = "Log type: 0, 1, or 2 for nlog, event log, and assert log, respectively.";
+	const char *core = "Select which region log should come from. -1 for all";
+	const char *nlognum = "Select which nlog to read. -1 for all nlogs";
+	const char *file = "Output file; defaults to device name provided";
+	const char *verbose = "To print out verbose nlog info";
 	const char *namespace_id = "Namespace to get logs from";
 
 	struct config {


### PR DESCRIPTION
Add const to descriptions of subcommand option.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>