### PR TITLE
nvme-cli: tests: remove nsid parameter in a testcase of error-log

### DIFF
--- a/tests/nvme_error_log_test.py
+++ b/tests/nvme_error_log_test.py
@@ -21,7 +21,6 @@
 NVMe Smart Log Verification Testcase:-
 
     1. Execute error-log on controller.
-    2. Execute error-log on each available namespace.
 
 """
 
@@ -57,30 +56,8 @@ class TestNVMeErrorLogCmd(TestNVMe):
             - Returns:
                 - 0 on success, error code on failure.
         """
-        return self.get_error_log("0xFFFFFFFF")
-
-    def get_error_log_ns(self, nsid):
-        """ Wrapper for executing error-log on a namespace.
-            - Args:
-                - nsid: namespace id to be used in error-log command.
-            - Returns:
-                - 0 on success, error code on failure.
-        """
-        return self.get_error_log(nsid)
-
-    def get_error_log_all_ns(self):
-        """ Wrapper for executing error-log on all the namespaces.
-            - Args:
-                - None:
-            - Returns:
-                - 0 on success, error code on failure.
-        """
-        ns_list = self.get_ns_list()
-        for nsid in range(0, len(ns_list)):
-            self.get_error_log_ns(ns_list[nsid])
-        return 0
+        return self.get_error_log()
 
     def test_get_error_log(self):
         """ Testcase main """
         assert_equal(self.get_error_log_ctrl(), 0)
-        assert_equal(self.get_error_log_all_ns(), 0)

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -349,15 +349,15 @@ class TestNVMe(object):
         print "host_write_commands " + host_write_commands
         return err
 
-    def get_error_log(self, nsid):
+    def get_error_log(self):
         """ Wrapper for nvme error-log command.
             - Args:
-                - nsid : namespace id to get error log from.
+                - None
             - Returns:
                 - 0 on success, error code on failure.
         """
         pattern = re.compile("^ Entry\[[ ]*[0-9]+\]")
-        error_log_cmd = "nvme error-log " + self.ctrl + " -n " + str(nsid)
+        error_log_cmd = "nvme error-log " + self.ctrl
         proc = subprocess.Popen(error_log_cmd,
                                 shell=True,
                                 stdout=subprocess.PIPE)


### PR DESCRIPTION
Remove nsid parameter in a testcase of error-log subcommand.

This parameter has been removed by a commit 98ffd4b on the master branch
of linux-nvme/nvme-cli.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>