### PR TITLE
nvme-cli: tests: fix typo in get_feature_test

### DIFF
--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -20,8 +20,8 @@
 """
 Get Features Testcase:-
 
-Test the Mandetory features with get features command:-
-    1. 01h rbitration.
+Test the Mandatory features with get features command:-
+    1. 01h M Arbitration.
     2. 02h M Power Management.
     3. 04h M Temperature Threshold.
     4. 05h M Error Recovery.
@@ -37,19 +37,19 @@ from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
-class TestNVMeGetMandetoryFeatures(TestNVMe):
+class TestNVMeGetMandatoryFeatures(TestNVMe):
 
     """
     Represents Get Features testcase.
 
         - Attributes:
-              - feature_id_list : list of the mandetory features.
+              - feature_id_list : list of the mandatory features.
               - get_vector_list_cmd : vector list collection for 09h.
               - vector_list : vector list to hold the interrupt vectors.
     """
 
     def __init__(self):
-        """ Pre Section for TestNVMeGetMandetoryFeatures """
+        """ Pre Section for TestNVMeGetMandatoryFeatures """
         TestNVMe.__init__(self)
         self.setup_log_dir(self.__class__.__name__)
         self.feature_id_list = ["0x01", "0x02", "0x04", "0x05", "0x07",
@@ -63,13 +63,13 @@ class TestNVMeGetMandetoryFeatures(TestNVMe):
         self.vector_list = proc.stdout.read().strip().split(" ")
 
     def __del__(self):
-        """ Post Section for TestNVMeGetMandetoryFeatures
+        """ Post Section for TestNVMeGetMandatoryFeatures
 
             Call super class's destructor.
         """
         TestNVMe.__del__(self)
 
-    def get_mandetory_features(self, feature_id):
+    def get_mandatory_features(self, feature_id):
         """ Wrapper for NVMe get features command
             - Args:
                 - feature_id : feature id to be used with get feature command.
@@ -97,7 +97,7 @@ class TestNVMeGetMandetoryFeatures(TestNVMe):
             print feature_output
             assert_equal(proc.wait(), 0)
 
-    def test_get_mandetory_features(self):
+    def test_get_mandatory_features(self):
         """ Testcase main """
         for feature_id in self.feature_id_list:
-            self.get_mandetory_features(feature_id)
+            self.get_mandatory_features(feature_id)


### PR DESCRIPTION
Comment and function name typo will directly reflect document which
will be generated by Makefile.

Fix typos like below.
    1. Typo in feature lists in the global comment.
    2. Mandetory -> Mandatory

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>