### PR TITLE
nvme-cli: add error handling for a failure of malloc

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3650,8 +3650,13 @@ static int passthru(int argc, char **argv, int ioctl_cmd, const char *desc, stru
 		}
 	}
 
-	if (cfg.metadata_len)
+	if (cfg.metadata_len) {
 		metadata = malloc(cfg.metadata_len);
+		if (!metadata) {
+			fprintf(stderr, "can not allocate metadata payload\n");
+			return ENOMEM;
+		}
+	}
 	if (cfg.data_len) {
 		if (posix_memalign(&data, getpagesize(), cfg.data_len)) {
 			fprintf(stderr, "can not allocate data payload\n");


### PR DESCRIPTION
Make it return ENOMEM when malloc of metadat is failed with some error
message.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>