### PR TITLE
nvme-cli: fix memory leak in nvme.c

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1791,6 +1791,9 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	}
 	if (!err)
 		printf("Firmware download success\n");
+
+	free(fw_buf);
+
 	return err;
 }
 

--- a/nvme.c
+++ b/nvme.c
@@ -587,6 +587,9 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 			nvme_status_to_string(err), err, cfg.cntid);
 	else
 		perror("id controller list");
+
+	free(cntlist);
+
 	return err;
 }
 

--- a/nvme.c
+++ b/nvme.c
@@ -2541,12 +2541,14 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
                         ffd = open(cfg.file, O_RDONLY);
                         if (ffd <= 0) {
                                 fprintf(stderr, "no firmware file provided\n");
-                                return -EINVAL;
+				err = EINVAL;
+				goto free;
                         }
                 }
                 if (read(ffd, (void *)buf, cfg.data_len) < 0) {
                         fprintf(stderr, "failed to read data buffer from input file\n");
-                        return EINVAL;
+			err = EINVAL;
+			goto free;
                 }
         }
 
@@ -2554,7 +2556,7 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
                                 cfg.data_len, dw12, buf, &result);
         if (err < 0) {
                 perror("dir-send");
-                return errno;
+		goto free;
         }
         if (!err) {
                 printf("dir-send: type %#x, operation %#x, spec_val %#x, nsid %#x, result %#x \n",
@@ -2569,6 +2571,8 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
         else if (err > 0)
                 fprintf(stderr, "NVMe Status:%s(%x)\n",
                                 nvme_status_to_string(err), err);
+
+free:
         if (buf)
                 free(buf);
         return err;

--- a/nvme.c
+++ b/nvme.c
@@ -3536,7 +3536,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
                         cfg.data_len, dw12, buf, &result);
         if (err < 0) {
                 perror("dir-receive");
-                return errno;
+		goto free;
         }
 
         if (!err) {
@@ -3556,6 +3556,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
         else if (err > 0)
                 fprintf(stderr, "NVMe Status:%s(%x)\n",
                                 nvme_status_to_string(err), err);
+free:
         if (buf)
                 free(buf);
         return err;

--- a/nvme.c
+++ b/nvme.c
@@ -2420,7 +2420,8 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	if (read(sec_fd, sec_buf, sec_size) < 0) {
 		fprintf(stderr, "Failed to read data from security file with %s\n",
 			strerror(errno));
-		return EINVAL;
+		err = EINVAL;
+		goto free;
 	}
 
 	err = nvme_sec_send(fd, cfg.namespace_id, cfg.nssf, cfg.spsp, cfg.secp,
@@ -2431,6 +2432,9 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		fprintf(stderr, "NVME Security Send Command Error:%d\n", err);
 	else
 		printf("NVME Security Send Command Success:%d\n", result);
+
+free:
+	free(sec_buf);
 	return err;
 }
 

--- a/nvme.c
+++ b/nvme.c
@@ -3679,6 +3679,8 @@ static int passthru(int argc, char **argv, int ioctl_cmd, const char *desc, stru
 		metadata = malloc(cfg.metadata_len);
 	if (cfg.data_len) {
 		if (posix_memalign(&data, getpagesize(), cfg.data_len)) {
+			if (metadata)
+				free(metadata);
 			fprintf(stderr, "can not allocate data payload\n");
 			return ENOMEM;
 		}

--- a/nvme.c
+++ b/nvme.c
@@ -2314,12 +2314,14 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 			ffd = open(cfg.file, O_RDONLY);
 			if (ffd <= 0) {
 				fprintf(stderr, "no firmware file provided\n");
-				return -EINVAL;
+				err = EINVAL;
+				goto free;
 			}
 		}
 		if (read(ffd, (void *)buf, cfg.data_len) < 0) {
 			fprintf(stderr, "failed to read data buffer from input file\n");
-			return EINVAL;
+			err = EINVAL;
+			goto free;
 		}
 	}
 
@@ -2327,7 +2329,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 				cfg.data_len, buf, &result);
 	if (err < 0) {
 		perror("set-feature");
-		return errno;
+		goto free;
 	} else if (!err) {
 		printf("set-feature:%02x (%s), value:%#08x\n", cfg.feature_id,
 			nvme_feature_to_string(cfg.feature_id), cfg.value);
@@ -2341,6 +2343,8 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	} else if (err > 0)
 		fprintf(stderr, "NVMe Status:%s(%x)\n",
 				nvme_status_to_string(err), err);
+
+free:
 	if (buf)
 		free(buf);
 	return err;

--- a/nvme.c
+++ b/nvme.c
@@ -3431,6 +3431,9 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 		} else if (cfg.size)
 			d_raw((unsigned char *)sec_buf, cfg.size);
 	}
+
+	free(sec_buf);
+
 	return err;
 }
 


### PR DESCRIPTION
Fix memory leak from posix_memalign() without any free.

Minwoo Im (9):
  nvme-cli: fix memory leak in list_ctrl()
  nvme-cli: fix memory leak in ns_descs()
  nvme-cli: fix memory leak in fw_download()
  nvme-cli: fix memory leak in set_feature()
  nvme-cli: fix memory leak in sec_send()
  nvme-cli: fix memory leak in dir_send()
  nvme-cli: fix memory leak in sec_recv()
  nvme-cli: fix memory leak in dir_receive()
  nvme-cli: fix memory leak in passthru()

 nvme.c | 63 +++++++++++++++++++++++++++++++++++++++++++++------------------
 1 file changed, 45 insertions(+), 18 deletions(-)