### PR TITLE
nvme-cli: wdc: update wdc plugin

### DIFF
--- a/Documentation/nvme-wdc-smart-add-log.1
+++ b/Documentation/nvme-wdc-smart-add-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-smart-add-log
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 12/10/2017
+.\"      Date: 01/17/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-SMART\-AD" "1" "12/10/2017" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-SMART\-AD" "1" "01/17/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -53,8 +53,8 @@ Return the statistics from specific interval, defaults to 14
 \-o <format>, \-\-output\-format=<format>
 .RS 4
 Set the reporting format to
-\fIhuman\fR, or
-\fIjson\fR\&. Only one output format can be used at a time\&. Default is human\&.
+\fInormal\fR, or
+\fIjson\fR\&. Only one output format can be used at a time\&. Default is normal\&.
 .RE
 .sp
 Valid Interval values and description :\-

--- a/Documentation/nvme-wdc-smart-add-log.html
+++ b/Documentation/nvme-wdc-smart-add-log.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.9" />
 <title>nvme-wdc-smart-add-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +94,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +225,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -787,9 +789,9 @@ Results for any other device are undefined.</p></div>
 </dt>
 <dd>
 <p>
-        Set the reporting format to <em>human</em>, or
+        Set the reporting format to <em>normal</em>, or
         <em>json</em>. Only one output format can be used at a time.
-        Default is human.
+        Default is normal.
 </p>
 </dd>
 </dl></div>
@@ -1129,7 +1131,8 @@ Has the program issue WDC smart-add-log Vendor Unique Command with default inter
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-11-28 08:42:45 MST
+Last updated
+ 2018-01-17 20:47:00 KST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-wdc-smart-add-log.txt
+++ b/Documentation/nvme-wdc-smart-add-log.txt
@@ -32,9 +32,9 @@ OPTIONS
 
 -o <format>::
 --output-format=<format>::
-	Set the reporting format to 'human', or
+	Set the reporting format to 'normal', or
 	'json'. Only one output format can be used at a time.
-	Default is human.
+	Default is normal.
 
 Valid Interval values and description :-
 

--- a/wdc-nvme.c
+++ b/wdc-nvme.c
@@ -550,8 +550,8 @@ static int wdc_do_cap_diag(int fd, char *file)
 static int wdc_cap_diag(int argc, char **argv, struct command *command,
 		struct plugin *plugin)
 {
-	char *desc = "Capture Diagnostics Log.";
-	char *file = "Output file pathname.";
+	const char *desc = "Capture Diagnostics Log.";
+	const char *file = "Output file pathname.";
 	char f[PATH_MAX] = {0};
 	int fd;
 
@@ -671,8 +671,8 @@ static int wdc_do_drive_log(int fd, char *file)
 static int wdc_drive_log(int argc, char **argv, struct command *command,
 		struct plugin *plugin)
 {
-	char *desc = "Capture Drive Log.";
-	char *file = "Output file pathname.";
+	const char *desc = "Capture Drive Log.";
+	const char *file = "Output file pathname.";
 	char f[PATH_MAX] = {0};
 	int fd;
 	struct config {
@@ -707,8 +707,8 @@ static int wdc_drive_log(int argc, char **argv, struct command *command,
 static int wdc_get_crash_dump(int argc, char **argv, struct command *command,
 		struct plugin *plugin)
 {
-	char *desc = "Get Crash Dump.";
-	char *file = "Output file pathname.";
+	const char *desc = "Get Crash Dump.";
+	const char *file = "Output file pathname.";
 	int fd;
 	int ret;
 	struct config {
@@ -788,7 +788,7 @@ static const char* wdc_purge_mon_status_to_string(__u32 status)
 static int wdc_purge(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	char *desc = "Send a Purge command.";
+	const char *desc = "Send a Purge command.";
 	char *err_str;
 	int fd;
 	int ret;
@@ -829,7 +829,7 @@ static int wdc_purge(int argc, char **argv,
 static int wdc_purge_monitor(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	char *desc = "Send a Purge Monitor command.";
+	const char *desc = "Send a Purge Monitor command.";
 	int fd;
 	int ret;
 	__u8 output[WDC_NVME_PURGE_MONITOR_DATA_LEN];
@@ -1219,8 +1219,8 @@ static int wdc_get_c1_log_page(int fd, char *format, uint8_t interval)
 static int wdc_smart_add_log(int argc, char **argv, struct command *command,
 		struct plugin *plugin)
 {
-	char *desc = "Retrieve additional performance statistics.";
-	char *interval = "Interval to read the statistics from [1, 15].";
+	const char *desc = "Retrieve additional performance statistics.";
+	const char *interval = "Interval to read the statistics from [1, 15].";
 	int fd;
 	int ret;
 


### PR DESCRIPTION
Clean up wdc-nvme.c by making few descriptions (const char *).
Also, update document of wdc-smart-add-log.

Minwoo Im (2):
  nvme-cli: wdc: add const to descriptions
  nvme-cli: wdc: fix mismatch in document for smart-add-log

 Documentation/nvme-wdc-smart-add-log.1    |  8 ++++----
 Documentation/nvme-wdc-smart-add-log.html | 15 +++++++++------
 Documentation/nvme-wdc-smart-add-log.txt  |  4 ++--
 wdc-nvme.c                                | 20 ++++++++++----------
 4 files changed, 25 insertions(+), 22 deletions(-)