### PR TITLE
nvme-cli: memblaze: update memblaze plugin

### DIFF
--- a/memblaze-nvme.c
+++ b/memblaze-nvme.c
@@ -411,12 +411,14 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 			ffd = open(cfg.file, O_RDONLY);
 			if (ffd <= 0) {
 				fprintf(stderr, "no firmware file provided\n");
-				return -EINVAL;
+				err = EINVAL;
+				goto free;
 			}
 		}
 		if (read(ffd, (void *)buf, cfg.data_len) < 0) {
 			fprintf(stderr, "failed to read data buffer from input file\n");
-			return EINVAL;
+			err = EINVAL;
+			goto free;
 		}
 	}
 
@@ -424,7 +426,7 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 				cfg.data_len, buf, &result);
 	if (err < 0) {
 		perror("set-feature");
-		return errno;
+		goto free;
 	}
 	if (!err) {
 		printf("set-feature:%02x (%s), value:%#08x\n", cfg.feature_id,
@@ -434,6 +436,8 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 	} else if (err > 0)
 		fprintf(stderr, "NVMe Status:%s(%x)\n",
 				nvme_status_to_string(err), err);
+
+free:
 	if (buf)
 		free(buf);
 	return err;


### PR DESCRIPTION
Update memblaze plugin with error returning and fix for memory leak

Minwoo Im (2):
  nvme-cli: memblaze: fix memory leak in memblaze-nvme.c
  nvme-cli: memblaze: add error return after parse_and_open()

 memblaze-nvme.c | 6 ++++++
 1 file changed, 6 insertions(+)