### PR TITLE
nvme-cli: wdc: Removed superfluous output in WDC plugin

### DIFF
--- a/plugin.c
+++ b/plugin.c
@@ -61,7 +61,8 @@ void general_help(struct plugin *plugin)
 	struct program *prog = plugin->parent;
 	struct plugin *extension;
 	unsigned i = 0;
-
+	unsigned padding = 15;
+	unsigned curr_length = 0;
 	printf("%s-%s\n", prog->name, prog->version);
 
 	usage(plugin);
@@ -78,12 +79,19 @@ void general_help(struct plugin *plugin)
 
 	printf("\nThe following are all implemented sub-commands:\n");
 
+	/* iterate through all commands to get maximum length */
+	/* Still need to handle the case of ultra long strings, help messages, etc */
 	for (; plugin->commands[i]; i++)
-		printf("  %-*s %s\n", 15, plugin->commands[i]->name,
+		if (padding < (curr_length = 2 + strlen(plugin->commands[i]->name)))
+			padding = curr_length;
+
+	i = 0;
+	for (; plugin->commands[i]; i++)
+		printf("  %-*s %s\n", padding, plugin->commands[i]->name,
 					plugin->commands[i]->help);
 
-	printf("  %-*s %s\n", 15, "version", "Shows the program version");
-	printf("  %-*s %s\n", 15, "help", "Display this help");
+	printf("  %-*s %s\n", padding, "version", "Shows the program version");
+	printf("  %-*s %s\n", padding, "help", "Display this help");
 	printf("\n");
 
 	if (plugin->name)

--- a/wdc-nvme.c
+++ b/wdc-nvme.c
@@ -1110,8 +1110,6 @@ static void wdc_print_log_normal(struct wdc_ssd_perf_stats *perf)
 		(uint64_t)le64_to_cpu(perf->nr_blks));
 	printf("  Average NAND Read Size                         %20f\n",
 		safe_div_fp((le64_to_cpu(perf->nr_blks)), (le64_to_cpu((perf->nr_cmds)))));
-	printf("  Host Write Odd Start Commands                  %20"PRIu64"\n",
-			(uint64_t)le64_to_cpu(perf->hw_os_cmds));
 	printf("  Nand Write Commands                            %20"PRIu64"\n",
 			(uint64_t)le64_to_cpu(perf->nw_cmds));
 	printf("  NAND Write Blocks                              %20"PRIu64"\n",
@@ -1167,8 +1165,6 @@ static void wdc_print_log_json(struct wdc_ssd_perf_stats *perf)
 		(uint64_t)le64_to_cpu(perf->nr_blks));
 	json_object_add_value_int(root, "Average NAND Read Size",
 		safe_div_fp((le64_to_cpu(perf->nr_blks)), (le64_to_cpu((perf->nr_cmds)))));
-	json_object_add_value_int(root, "Host Write Odd Start Commands",
-			(uint64_t)le64_to_cpu(perf->hw_os_cmds));
 	json_object_add_value_int(root, "Nand Write Commands",
 			(uint64_t)le64_to_cpu(perf->nw_cmds));
 	json_object_add_value_int(root, "NAND Write Blocks",


### PR DESCRIPTION
Signed-off-by: Oleksii Timofieiev <tim.oleksii@gmail.com>