### PR TITLE
nvme-cli: add command specific field to json output of error-log

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1841,6 +1841,7 @@ void json_error_log(struct nvme_error_log_page *err_log, int entries, const char
 		json_object_add_value_int(error, "lba", err_log[i].lba);
 		json_object_add_value_int(error, "nsid", err_log[i].nsid);
 		json_object_add_value_int(error, "vs", err_log[i].vs);
+		json_object_add_value_uint(error, "cs", err_log[i].cs);
 
 		json_array_add_value_object(errors, error);
 	}


### PR DESCRIPTION
Add command specific field to json output of error-log command.
This field was added in commit 662c1618 without considering json output
format.

Fixes: 662c1618("nvme-cli: add print for command specific info field of
error log page")
Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>