### PR TITLE
nvme-cli: make it have bpid in cdw10 for fw-commit

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -689,7 +689,7 @@ int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid)
 {
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_activate_fw,
-		.cdw10		= (action << 3) | slot,
+		.cdw10		= (bpid << 31) | (action << 3) | slot,
 	};
 
 	return nvme_submit_admin_passthru(fd, &cmd);


### PR DESCRIPTION
_bpid_ was added as a parameter in commit d52c9988 without any being
used.
Make it have inside of cdw10 before submitting a command.

Fixes: d52c9988 ("nvme-cli: update Firmware Commit with boot partition
feature")
Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>