### PR TITLE
nvme-cli: make return negative value in nvme_get_nsid() when not blkdev

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -79,7 +79,7 @@ int nvme_get_nsid(int fd)
 	if (!S_ISBLK(nvme_stat.st_mode)) {
 		fprintf(stderr,
 			"Error: requesting namespace-id from non-block device\n");
-		return ENOTBLK;
+		return -ENOTBLK;
 	}
 	return ioctl(fd, NVME_IOCTL_ID);
 }


### PR DESCRIPTION
If caller invokes get_nsid() with character device without checking
whether a given device is block device or not, ENOTBLK is returned from
nvme_get_nsid() which is a positive value, so that caller may treat this
value as a valid nsid.

Make it return a negative vaelue with -ENOTBLK and add error checking to
callers.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>