### PR TITLE
nvme-cli: tests: fix interrupt vector number in get_features_test

### DIFF
--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -54,8 +54,8 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
         self.setup_log_dir(self.__class__.__name__)
         self.feature_id_list = ["0x01", "0x02", "0x04", "0x05", "0x07",
                                 "0x08", "0x09", "0x0A", "0x0B"]
-        get_vector_list_cmd = "cat /proc/interrupts | grep nvme |" \
-                              " cut -d : -f 1 | tr -d ' ' | tr '\n' ' '"
+        get_vector_list_cmd = "cat /proc/interrupts | grep -o 'nvme[0-9]*q[0-9]*'" \
+                              " | sed 's/nvme[0-9]*q//g' | tr '\n' ' '"
         proc = subprocess.Popen(get_vector_list_cmd,
                                 shell=True,
                                 stdout=subprocess.PIPE)
@@ -78,9 +78,12 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
         """
         if str(feature_id) == "0x09":
             for vector in self.vector_list:
+                if int(vector) != 0:
+                    vector = str(int(vector)-1)
+
                 get_feat_cmd = "nvme get-feature " + self.ctrl + \
                                " --feature-id=" + str(feature_id) + \
-                               " --cdw11=" + str(vector)
+                               " --cdw11=" + vector
                 proc = subprocess.Popen(get_feat_cmd,
                                         shell=True,
                                         stdout=subprocess.PIPE)


### PR DESCRIPTION
Interrupt Vector(IV) is given when "Create I/O CQ" command is submitted by
driver with value (qid-1).
Set Feature with FID 9h (Interrupt Vector Configuration) needs interrupt
vector specified in cdw11.

Fix this specified interrupt vector number to (qid-1) instead of from
/proc/interrupts which may not be same with (qid-1).

cdw11 (as-is):
    121 125 126 127 128 129 130 131
cdw11 (to-be):
    0 1 2 3 4 5 6 7 8

Test Results with Samsung 960EVO.
  `#` nose2 --verbose nvme_get_features_test

/sys/devices/pci0000:00/0000:00:1d.0/0000:02:00.0/nvme/nvme0
get-feature:0x1 (Arbitration), Current value:0x000002

get-feature:0x2 (Power Management), Current value:0x000004

get-feature:0x4 (Temperature Threshold), Current value:0x00015e

get-feature:0x5 (Error Recovery), Current value:00000000

get-feature:0x7 (Number of Queues), Current value:0x070007

get-feature:0x8 (Interrupt Coalescing), Current value:00000000

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x010000

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x010000

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x000001

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x000002

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x000003

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x000004

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x000005

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x000006

get-feature:0x9 (Interrupt Vector Configuration), Current value:0x000007

get-feature:0xa (Write Atomicity Normal), Current value:00000000

get-feature:0xb (Async Event Configuration), Current value:0x000200


Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>