### PR TITLE
nvme-cli: add initial value to namespace of list-ctrl

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -674,6 +674,7 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 
 	struct config cfg = {
 		.cntid = 0,
+		.namespace_id = 0,
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {


### PR DESCRIPTION
cfg.namespace_id has been used without any initialization if not given.
nvme_identify_ctrl_list() function checks given namespace_id value.

Add initial value for this namespace id.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>