### PR TITLE
nvme-cli: make it use NVME_IDENTIFY_DATA_SIZE

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -342,7 +342,7 @@ int nvme_identify(int fd, __u32 nsid, __u32 cdw10, void *data)
 		.opcode		= nvme_admin_identify,
 		.nsid		= nsid,
 		.addr		= (__u64)(uintptr_t) data,
-		.data_len	= 0x1000,
+		.data_len	= NVME_IDENTIFY_DATA_SIZE,
 		.cdw10		= cdw10,
 	};
 


### PR DESCRIPTION
Update 0x1000 hard coding magic value to NVME_IDENTIFY_DATA_SIZE which
was added in linux-nvme driver commit 0add5e8e588c.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>