### PR TITLE
Few fix related to 'nvme list-subsys'

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1217,18 +1217,24 @@ int get_nvme_subsystem_info(char *name, char *path,
 	int n, i, ret = 1;
 
 	item->subsysnqn = get_nvme_subsnqn(path);
-	if (!item->subsysnqn)
+	if (!item->subsysnqn) {
+		fprintf(stderr, "failed to get subsystem nqn.\n");
 		return ret;
+	}
 
 	item->name = strdup(name);
 
 	n = scandir(path, &ctrls, scan_ctrls_filter, alphasort);
-	if (n < 0)
+	if (n < 0) {
+		fprintf(stderr, "failed to scan controller(s).\n");
 		return ret;
+	}
 
 	item->ctrls = calloc(n, sizeof(struct ctrl_list_item));
-	if (!item->ctrls)
+	if (!item->ctrls) {
+		fprintf(stderr, "failed to allocate subsystem controller(s)\n");
 		goto free_ctrls;
+	}
 
 	item->nctrls = n;
 
@@ -1239,12 +1245,16 @@ int get_nvme_subsystem_info(char *name, char *path,
 			 item->ctrls[i].name);
 
 		item->ctrls[i].address = get_nvme_ctrl_address(ctrl_path);
-		if (!item->ctrls[i].address)
+		if (!item->ctrls[i].address) {
+			fprintf(stderr, "failed to get controller[%d] address.\n", i);
 			goto free_ctrls;
+		}
 
 		item->ctrls[i].transport = get_nvme_ctrl_transport(ctrl_path);
-		if (!item->ctrls[i].transport)
+		if (!item->ctrls[i].transport) {
+			fprintf(stderr, "failed to get controller[%d] transport.\n", i);
 			goto free_ctrls;
+		}
 	}
 
 	ret = 0;


### PR DESCRIPTION
Sending these changes for review:

1) Fix double free in list_subsys

    get_nvme_subsystem_info() deallocates subsys_list_item in case of error.
    This hits double free when list_subsys() as well attempts to free it.
    Removed deallocation of subsys_list_item from get_nvme_subsystem_info().

2) Log error incase of failure in get_nvme_subsystem_info()

    Currently get_nvme_subsystem_info() silently fails in case
    of error. This patch logs relevant error message incase of
    failure in get_nvme_subsystem_info().
    
Signed-off-by: Vijay Kumar <vijay.ac.kumar@oracle.com>