### PR TITLE
Change default value for log_id

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -621,7 +621,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	struct config cfg = {
 		.namespace_id = NVME_NSID_ALL,
-		.log_id       = 0,
+		.log_id       = 1,
 		.log_len      = 0,
 		.lpo          = NVME_NO_LOG_LPO,
 		.lsp          = NVME_NO_LOG_LSP,


### PR DESCRIPTION
Currently the log_id is being set as 0 for default, if no value is
passed with the '-i' parameter. In this situation, we get the error:
NVMe Status:INVALID_LOG_PAGE(2109). It happens because 00h is Reserved
according to the NVM Express Spec 1.3.

Signed-off-by: Rodrigo R. Galvao <rosattig@linux.vnet.ibm.com>