### PR TITLE
Add a "friendly" error message on create_ns()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1016,10 +1016,13 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	err = nvme_ns_create(fd, cfg.nsze, cfg.ncap, cfg.flbas, cfg.dps, cfg.nmic, &nsid);
 	if (!err)
 		printf("%s: Success, created nsid:%d\n", cmd->name, nsid);
-	else if (err > 0)
+	else if (err > 0) {
 		fprintf(stderr, "NVMe Status:%s(%x)\n",
 					nvme_status_to_string(err), err);
-	else
+        if (err == NVME_SC_NS_ID_UNAVAILABLE) 
+            fprintf(stderr, "The number of namespaces supported h
+                    as been exceeded!\n");
+    } else
 		perror("create namespace");
 
 	close(fd);


### PR DESCRIPTION
If you try to create a namespace when you already have reached the
maximum number of namespaces, we're throwing the following error: NVMe Status:NS_ID_UNAVAILABLE(116).
The idea of this commit is just to add a more friendly error message
together with the current message:

NVMe Status:NS_ID_UNAVAILABLE(116)
The number of namespaces supported has been exceeded!

Signed-off-by: Rodrigo R. Galvao <rosattig@linux.vnet.ibm.com>