### PR TITLE
Add toshiba plugin to makefile rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ NVME_DPKG_VERSION=1~`lsb_release -sc`
 OBJS := argconfig.o suffix.o parser.o nvme-print.o nvme-ioctl.o \
 	nvme-lightnvm.o fabrics.o json.o plugin.o intel-nvme.o \
 	lnvm-nvme.o memblaze-nvme.o wdc-nvme.o wdc-utils.o nvme-models.o \
-	huawei-nvme.o netapp-nvme.o
+	huawei-nvme.o netapp-nvme.o  toshiba-nvme.o
 
 nvme: nvme.c nvme.h $(OBJS) NVME-VERSION-FILE
 	$(CC) $(CPPFLAGS) $(CFLAGS) nvme.c -o $(NVME) $(OBJS) $(LDFLAGS)


### PR DESCRIPTION
Hello again nvme-cli team,
I'm sending you another pull request, following on from #326. This change causes the toshiba plugin to be included in the makefile rules. Many apologies - it was accidentally missed from the previous pull request.
Thanks and regards,
Andrew Meir