### PR TITLE
nvme-cli: replace input val to returned one when printing result

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2586,7 +2586,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 		perror("set-feature");
 	} else if (!err) {
 		printf("set-feature:%02x (%s), value:%#08x\n", cfg.feature_id,
-			nvme_feature_to_string(cfg.feature_id), cfg.value);
+			nvme_feature_to_string(cfg.feature_id), result);
 		if (buf) {
 			if (cfg.feature_id == NVME_FEAT_LBA_RANGE)
 				show_lba_range((struct nvme_lba_range_type *)buf,


### PR DESCRIPTION
Make it print out the returned value from the Set Feature command   
instead of the value from the user so that user can see the result  
in CDW0 directly just like get_feature().  

Signed-off-by: Minwoo Im \<minwoo.im.dev@gmail.com>