### PR TITLE
nvme-cli: fix endurance_log subcommand

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -362,6 +362,7 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 	const struct argconfig_commandline_options command_line_options[] = {
 		{"output-format", 'o', "FMT", CFG_STRING, &cfg.output_format, required_argument, output_format},
 		{"group-id",      'g', "NUM", CFG_SHORT,  &cfg.group_id,      required_argument, group_id},
+		{NULL}
 	};
 
 	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));

--- a/nvme.c
+++ b/nvme.c
@@ -370,8 +370,10 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 		return fd;
 
 	fmt = validate_output_format(cfg.output_format);
-	if (fmt < 0)
-		return fmt;
+	if (fmt < 0) {
+		err = fmt;
+		goto close_fd;
+	}
 
 	err = nvme_endurance_log(fd, cfg.group_id, &endurance_log);
 	if (!err) {
@@ -387,6 +389,7 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 	else
 		perror("endurance log");
 
+ close_fd:
 	close(fd);
 	return err;
 }


### PR DESCRIPTION
From f9fa2b9001f1abfb0d2fcb96d3aa8c3de83a7313 Mon Sep 17 00:00:00 2001
From: Minwoo Im <minwoo.im.dev@gmail.com>
Date: Tue, 10 Apr 2018 02:29:47 +0900
Subject: [PATCH 0/2] nvme-cli: fix endurance_log subcommand

This patch set is to fix segmentation fault and the leak of file descriptor in endurance_log subcommand.

Minwoo Im (2):
  nvme-cli: fix seg_fault by cmd options in endurance_log
  nvme-cli: fix leak in endurance_log command

 nvme.c | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)

-- 
2.7.4
