### PR TITLE
nvme-cli: make it return 0 in case of non-fabric for show-regs

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2298,6 +2298,8 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 	if (err) {
 		bar = get_registers();
 		fabrics = false;
+		if (bar)
+			err = 0;
 	}
 	if (!bar) {
 		err = ENODEV;


### PR DESCRIPTION
Currently, non-fabrics show-regs subcommand is *not* returning 0 even if it has
successfully read from the bar.  Make it return 0 when successfully done.

Link: #338

Signed-off-by: Minwoo Im \<minwoo.im.dev@gmail.com>