### PR TITLE
nvme-cli: fix perror when blkdev not given when get-ns-id

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -79,7 +79,8 @@ int nvme_get_nsid(int fd)
 	if (!S_ISBLK(nvme_stat.st_mode)) {
 		fprintf(stderr,
 			"Error: requesting namespace-id from non-block device\n");
-		return -ENOTBLK;
+		errno = ENOTBLK;
+		return -errno;
 	}
 	return ioctl(fd, NVME_IOCTL_ID);
 }


### PR DESCRIPTION
nvme-cli currently is printing out the error code via perror when nsid
from the nvme_get_nsid(fd) <= 0.  Once user gives a chrdev node instead of
blkdev node, following "Success" message is being printed-out even it's
a failure case.

  Error: requesting namespace-id from non-block device
  nvme0: Success

errno will *not* be set in case that blkdev is not given.  So set the
proper errno for this case.  The following message will be nicer than
previous one.

  Error: requesting namespace-id from non-block device
  nvme0: Block device required

This patch will also fix the return value of this subcommand.  0 will
*not* be given when the subcommand fails.

Signed-off-by: Minwoo Im \<minwoo.im.dev@gmail.com>