### PR TITLE
Making gcc compiler (5.4.0 among others) happy

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1279,7 +1279,7 @@ void show_self_test_log(struct nvme_self_test_log *self_test, const char *devnam
 		temp = self_test->result[i].valid_diagnostic_info;
 		printf("  Valid Diagnostic Information : %#x\n", temp);
 		printf("  Power on hours (POH)         : %#"PRIx64"\n",
-			le64_to_cpu(self_test->result[i].power_on_hours));
+			(uint64_t)le64_to_cpu(self_test->result[i].power_on_hours));
 
 		if (temp & NVME_SELF_TEST_VALID_NSID)
 			printf("  Namespace Identifier         : %#x\n",


### PR DESCRIPTION
I was getting this on gcc 5.4.0
nvme-print.c:1340:10: error: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘long long unsigned int’ [-Werror=format=]
   printf("  Power on hours (POH)         : %#"PRIx64"\n",
          ^
