### PR TITLE
nvme-ioctl.c : nvme_get_properties(): fix 64bit offset advance

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -578,8 +578,10 @@ int nvme_get_properties(int fd, void **pbar)
 			continue;
 		}
 		ret = 0;
-		if (is64bit)
+		if (is64bit) {
 			*(uint64_t *)(*pbar + off) = le64_to_cpu(value64);
+			off += 4;
+		}
 		else
 			*(uint32_t *)(*pbar + off) = le32_to_cpu(value64);
 	}


### PR DESCRIPTION
In the case of 64 bit property, the offset loop variable is advanced correctly only on error. When the call to nvme_property is successful (and thus err == 0) the offset variable is advanced by 4 bytes only.