### PR TITLE
Add a single get-property command for NVMeOF.

### DIFF
--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -33,6 +33,7 @@ COMMAND_LIST(
 	ENTRY("self-test-log", "Retrieve the SELF-TEST Log, show it", self_test_log)
 	ENTRY("set-feature", "Set a feature and show the resulting value", set_feature)
 	ENTRY("set-property", "Set a property and show the resulting value", set_property)
+	ENTRY("get-property", "Get a property and show the resulting value", get_property)
 	ENTRY("format", "Format namespace with new block format", format)
 	ENTRY("fw-commit", "Verify and commit firmware to a specific slot (fw-activate in old version < 1.2)", fw_commit, "fw-activate")
 	ENTRY("fw-download", "Download new firmware", fw_download)

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -136,6 +136,7 @@ int nvme_dir_recv(int fd, __u32 nsid, __u16 dspec, __u8 dtype, __u8 doper,
 		  __u32 data_len, __u32 dw12, void *data, __u32 *result);
 int nvme_get_properties(int fd, void **pbar);
 int nvme_set_property(int fd, int offset, int value);
+int nvme_get_property(int fd, int offset, uint64_t *value);
 int nvme_sanitize(int fd, __u8 sanact, __u8 ause, __u8 owpass, __u8 oipbp,
 		  __u8 no_dealloc, __u32 ovrpat);
 int nvme_self_test_start(int fd, __u32 nsid, __u32 cdw10);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2921,3 +2921,48 @@ void show_ctrl_registers(void *bar, unsigned int mode, bool fabrics)
 		}
 	}
 }
+
+void show_single_property(int offset, uint64_t value64, int human)
+{
+	uint32_t value32;
+
+	if (!human) {
+		printf("property: 0x%02x (%s), value: %"PRIx64"\n", offset,
+			   nvme_register_to_string(offset), value64);
+		return;
+	}
+
+	value32 = (uint32_t) value64;
+
+	switch (offset) {
+	case NVME_REG_CAP:
+		printf("cap : %"PRIx64"\n", value64);
+		show_registers_cap((struct nvme_bar_cap *)&value64);
+		break;
+
+	case NVME_REG_VS:
+		printf("version : %x\n", value32);
+		show_registers_version(value32);
+		break;
+
+	case NVME_REG_CC:
+		printf("cc : %x\n", value32);
+		show_registers_cc(value32);
+		break;
+
+	case NVME_REG_CSTS:
+		printf("csts : %x\n", value32);
+		show_registers_csts(value32);
+		break;
+
+	case NVME_REG_NSSR:
+		printf("nssr : %x\n", value32);
+		printf("\tNVM Subsystem Reset Control (NSSRC): %u\n\n", value32);
+		break;
+
+	default:
+		printf("unknown property: 0x%02x (%s), value: %"PRIx64"\n", offset,
+			   nvme_register_to_string(offset), value64);
+		break;
+	}
+}

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -32,6 +32,7 @@ void show_endurance_log(struct nvme_endurance_group_log *endurance_group,
 			__u16 group_id, const char *devname);
 void show_sanitize_log(struct nvme_sanitize_log_page *sanitize, unsigned int mode, const char *devname);
 void show_ctrl_registers(void *bar, unsigned int mode, bool fabrics);
+void show_single_property(int offset, uint64_t prop, int human);
 void show_nvme_id_ns_descs(void *data);
 void show_list_items(struct list_item *list_items, unsigned len);
 void show_nvme_subsystem_list(struct subsys_list_item *slist, int n);

--- a/nvme.c
+++ b/nvme.c
@@ -1026,7 +1026,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	for (i = 0; i < num; i++)
 		ctrlist[i] = (uint16_t)list[i];
 
-	if (attach)	
+	if (attach)
 		err = nvme_ns_attach_ctrls(fd, cfg.namespace_id, num, ctrlist);
 	else
 		err = nvme_ns_detach_ctrls(fd, cfg.namespace_id, num, ctrlist);
@@ -2582,6 +2582,59 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 	return err;
 }
 
+static int get_property(int argc, char **argv, struct command *cmd, struct plugin *plugin)
+{
+	const char *desc = "Reads and shows the defined NVMe controller property "\
+			   "for NVMe over Fabric. Property offset must be one of:\n"
+			   "CAP=0x0, VS=0x8, CC=0x14, CSTS=0x1c, NSSR=0x20";
+	const char *offset = "offset of the requested property";
+	const char *human_readable = "show infos in readable format";
+
+	int fd, err;
+	uint64_t value;
+
+	struct config {
+		int offset;
+		int human_readable;
+	};
+
+	struct config cfg = {
+		.offset = -1,
+		.human_readable = 0,
+	};
+
+	const struct argconfig_commandline_options command_line_options[] = {
+		{"offset", 'o', "NUM", CFG_POSITIVE, &cfg.offset, required_argument, offset},
+		{"human-readable", 'H', "", CFG_NONE, &cfg.human_readable, no_argument, human_readable},
+		{NULL}
+	};
+
+	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	if (fd < 0)
+		return fd;
+
+	if (cfg.offset == -1) {
+		fprintf(stderr, "offset required param");
+		err = EINVAL;
+		goto close_fd;
+	}
+
+	err = nvme_get_property(fd, cfg.offset, &value);
+	if (err < 0) {
+		perror("get-property");
+	} else if (!err) {
+		show_single_property(cfg.offset, value, cfg.human_readable);
+	} else if (err > 0) {
+		fprintf(stderr, "NVMe Status: %s(%x)\n",
+				nvme_status_to_string(err), err);
+	}
+
+ close_fd:
+	close(fd);
+
+	return err;
+}
+
 static int set_property(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Writes and shows the defined NVMe controller property "\
@@ -3844,7 +3897,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		control |= cfg.dtype << 4;
 		dsmgmt |= ((__u32)cfg.dspec) << 16;
 	}
-	
+
 	if (strlen(cfg.data)){
 		dfd = open(cfg.data, flags, mode);
 		if (dfd < 0) {


### PR DESCRIPTION
We can get all properties with show regs but getting a single property (instead of block of registers) looks more suitable for NVMeOF. When using nvme-cli for QA tests for devices, show regs might not be appropriate in some cases.

Missing doc (txt, man, html) for this command.
