### PR TITLE
nvme-cli: add support of RAE

### DIFF
--- a/Documentation/nvme-get-log.1
+++ b/Documentation/nvme-get-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-get-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/05/2018
+.\"      Date: 06/28/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-LOG" "1" "06/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-LOG" "1" "06/28/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -39,6 +39,7 @@ nvme-get-log \- Retrieves a log page from an NVMe device
                       [\-\-raw\-binary | \-b]
                       [\-\-lpo=<offset> | \-o <offset>]
                       [\-\-lsp=<field> | \-s <field>]
+                      [\-\-rae | \-r]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -82,6 +83,11 @@ The log page offset specifies the location within a log page to start returning 
 \-s <field>, \-\-lsp=<field>
 .RS 4
 The log specified field of LID\&.
+.RE
+.PP
+\-r, \-\-rae
+.RS 4
+Retain an Asynchronous Event\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-get-log.html
+++ b/Documentation/nvme-get-log.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-get-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -752,7 +755,8 @@ nvme-get-log(1) Manual Page
                       [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
                       [--raw-binary | -b]
                       [--lpo=&lt;offset&gt; | -o &lt;offset&gt;]
-                      [--lsp=&lt;field&gt; | -s &lt;field&gt;]</pre>
+                      [--lsp=&lt;field&gt; | -s &lt;field&gt;]
+                      [--rae | -r]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -859,6 +863,17 @@ program to parse.</p></div>
         The log specified field of LID.
 </p>
 </dd>
+<dt class="hdlist1">
+-r
+</dt>
+<dt class="hdlist1">
+--rae
+</dt>
+<dd>
+<p>
+        Retain an Asynchronous Event.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -902,7 +917,8 @@ Have the program return the raw log page in binary:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-02-07 09:54:27 MST
+Last updated
+ 2018-06-28 16:56:55 UTC
 </div>
 </div>
 </body>

--- a/Documentation/nvme-get-log.txt
+++ b/Documentation/nvme-get-log.txt
@@ -15,6 +15,7 @@ SYNOPSIS
 		      [--raw-binary | -b]
 		      [--lpo=<offset> | -o <offset>]
 		      [--lsp=<field> | -s <field>]
+		      [--rae | -r]
 
 DESCRIPTION
 -----------
@@ -66,6 +67,10 @@ OPTIONS
 -s <field>::
 --lsp=<field>::
 	The log specified field of LID.
+
+-r::
+--rae::
+	Retain an Asynchronous Event.
 
 EXAMPLES
 --------

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -81,7 +81,7 @@ int nvme_identify_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
 int nvme_identify_ns_descs(int fd, __u32 nsid, void *data);
 int nvme_identify_nvmset(int fd, __u16 nvmset_id, void *data);
 int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
-		   __u16 group_id, __u32 data_len, void *data);
+		   __u16 group_id, bool rae, __u32 data_len, void *data);
 int nvme_get_log(int fd, __u32 nsid, __u8 log_id, __u32 data_len, void *data);
 
 

--- a/nvme.c
+++ b/nvme.c
@@ -673,6 +673,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *aen = "result of the aen, use to override log id";
 	const char *lsp = "log specific field";
 	const char *lpo = "log page offset specifies the location within a log page from where to start returning data";
+	const char *rae = "retain an asynchronous event";
 	const char *raw_binary = "output in raw format";
 	int err, fd;
 
@@ -683,6 +684,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		__u32 aen;
 		__u64 lpo;
 		__u8  lsp;
+		int   rae;
 		int   raw_binary;
 	};
 
@@ -692,6 +694,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		.log_len      = 0,
 		.lpo          = NVME_NO_LOG_LPO,
 		.lsp          = NVME_NO_LOG_LSP,
+		.rae          = 0,
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {
@@ -702,6 +705,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		{"raw-binary",   'b', "",    CFG_NONE,     &cfg.raw_binary,   no_argument,       raw_binary},
 		{"lpo",          'o', "NUM", CFG_LONG,     &cfg.lpo,          required_argument, lpo},
 		{"lsp",          's', "NUM", CFG_BYTE,     &cfg.lsp,          required_argument, lsp},
+		{"rae",          'r', "",    CFG_NONE,     &cfg.rae,          no_argument,       rae},
 		{NULL}
 	};
 
@@ -734,7 +738,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		}
 
 		err = nvme_get_log13(fd, cfg.namespace_id, cfg.log_id,
-				     cfg.lsp, cfg.lpo, 0,
+				     cfg.lsp, cfg.lpo, 0, cfg.rae,
 				     cfg.log_len, log);
 		if (!err) {
 			if (!cfg.raw_binary) {
@@ -2811,7 +2815,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 		{"cdw12",        'c', "NUM",  CFG_POSITIVE, &cfg.cdw12,        required_argument, cdw12},
 		{"data-len",     'l', "NUM",  CFG_POSITIVE, &cfg.data_len,     required_argument, data_len},
 		{"data",         'd', "FILE", CFG_STRING,   &cfg.file,         required_argument, data},
-		{"save",         's', "",     CFG_NONE,     &cfg.save,         no_argument, save},
+		{"save",         's', "",     CFG_NONE,     &cfg.save,         no_argument,       save},
 		{NULL}
 	};
 


### PR DESCRIPTION
Currently telemetry-log cannot retain content of corresponding log page as RAE is not set.
This patch adds RAE bit support into routines to retrieve log pages.

Signed-off-by: Alexey Timofeyev <alexey.timofeyev@sk.com>