### PR TITLE
Use tnvmcap register for creating namespace

### DIFF
--- a/tests/nvme_create_max_ns_test.py
+++ b/tests/nvme_create_max_ns_test.py
@@ -50,8 +50,8 @@ class TestNVMeCreateMaxNS(TestNVMe):
         TestNVMe.__init__(self)
         self.dps = 0
         self.flbas = 0
-        self.nsze = 0x1400000
-        self.ncap = 0x1400000
+        self.nsze = self.get_ncap() / self.get_format() / self.get_max_ns()
+        self.ncap = self.nsze
         self.setup_log_dir(self.__class__.__name__)
         self.max_ns = self.get_max_ns()
         self.ctrl_id = self.get_ctrl_id()

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -205,6 +205,53 @@ class TestNVMe(object):
         return int(max_ns)
 
     @tools.nottest
+    def get_ncap(self):
+        """ Wrapper for extracting capacity.
+            - Args:
+                - None
+            - Returns:
+                - maximum number of namespaces supported.
+        """
+        pattern = re.compile("^tnvmcap[ ]+: [0-9]", re.IGNORECASE)
+        ncap = -1
+        ncap_cmd = "nvme id-ctrl " + self.ctrl
+        proc = subprocess.Popen(ncap_cmd,
+                                shell=True,
+                                stdout=subprocess.PIPE)
+        err = proc.wait()
+        assert_equal(err, 0, "ERROR : reading nvm capacity failed")
+
+        for line in proc.stdout:
+            if pattern.match(line):
+                ncap = line.split(":")[1].strip()
+                break
+        print ncap
+        return int(ncap)
+
+    @tools.nottest
+    def get_format(self):
+        """ Wrapper for extracting format.
+            - Args:
+                - None
+            - Returns:
+                - maximum format of namespace.
+        """
+        # defaulting to 4K
+        nvm_format = 4096
+        nvm_format_cmd = "nvme id-ns " + self.ctrl + " -n1"
+        proc = subprocess.Popen(nvm_format_cmd,
+                                shell=True,
+                                stdout=subprocess.PIPE)
+        err = proc.wait()
+        assert_equal(err, 0, "ERROR : reading nvm capacity failed")
+
+        for line in proc.stdout:
+            if "in use" in line:
+                nvm_format = 2 ** int(line.split(":")[3].split()[0])
+        print nvm_format
+        return int(nvm_format)
+
+    @tools.nottest
     def delete_all_ns(self):
         """ Wrapper for deleting all the namespaces.
             - Args:


### PR DESCRIPTION
Creating max ns by getting the total nvm capacity, and format.
Thus, the whole capacity is used in nvme_create_max_ns_test

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>