### PR TITLE
nvme-cli: fix typo in json_print_list_items

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2009,7 +2009,7 @@ void json_print_list_items(struct list_item *list_items, unsigned len)
 					  "UsedBytes",
 					  nuse);
 		json_object_add_value_uint(device_attrs,
-					  "MaximiumLBA",
+					  "MaximumLBA",
 					  le64_to_cpu(list_items[i].ns.nsze));
 		json_object_add_value_uint(device_attrs,
 					  "PhysicalSize",


### PR DESCRIPTION
Fix the typo like below:
	MaximiumLBA -> MaximumLBA

Issue: #396: Typo in nvme list command
Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>