### PR TITLE
nvme list : fix nvme list output if identify failed on device

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -74,7 +74,7 @@ int nvme_get_nsid(int fd)
 	int err = fstat(fd, &nvme_stat);
 
 	if (err < 0)
-		return err;
+		return -errno;
 
 	if (!S_ISBLK(nvme_stat.st_mode)) {
 		fprintf(stderr,

--- a/nvme.c
+++ b/nvme.c
@@ -1652,37 +1652,50 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	list_items = calloc(n, sizeof(*list_items));
 	if (!list_items) {
 		fprintf(stderr, "can not allocate controller list payload\n");
-		return ENOMEM;
+		ret = -ENOMEM;
+		goto cleanup_devices;
 	}
 
 	for (i = 0; i < n; i++) {
 		snprintf(path, sizeof(path), "%s%s", dev, devices[i]->d_name);
 		fd = open(path, O_RDONLY);
 		if (fd < 0) {
-			fprintf(stderr, "can not open %s: %s\n", path,
+			fprintf(stderr, "cannot open %s: %s\n", path,
 					strerror(errno));
-			return errno;
+			ret = -errno;
+			goto cleanup_list_items;
 		}
 		ret = get_nvme_info(fd, &list_items[list_cnt], path);
 		close(fd);
-		if (ret)
-			fprintf(stderr, "%s: failed to obtain nvme info: %s\n",
-				path, strerror(errno));
-		else
+		if (ret == 0) {
 			list_cnt++;
+		}
+		else if (ret > 0) {
+			fprintf(stderr, "%s: failed to obtain nvme info: %s\n",
+					path, nvme_status_to_string(ret));
+		}
+		else {
+			fprintf(stderr, "%s: failed to obtain nvme info: %s\n",
+					path, strerror(-ret));
+		}
 	}
 
-	if (fmt == JSON)
-		json_print_list_items(list_items, list_cnt);
-	else
-		show_list_items(list_items, list_cnt);
+	if (list_cnt) {
+		if (fmt == JSON)
+			json_print_list_items(list_items, list_cnt);
+		else
+			show_list_items(list_items, list_cnt);
+	}
 
+ cleanup_list_items:
+	free(list_items);
+
+ cleanup_devices:
 	for (i = 0; i < n; i++)
 		free(devices[i]);
 	free(devices);
-	free(list_items);
 
-	return 0;
+	return ret;
 }
 
 int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin, void (*vs)(__u8 *vs, struct json_object *root))


### PR DESCRIPTION
changed files:
nvme.c        function list()
nvme-ioctl.c  function nvme_get_nsid() : return -errno if fstat fails

**Before fix:**
Note that "Success" print is because strerror (errno) is called after successful close (errno == 0)
```
# ./nvme-upstream list
/dev/nvme0n2: failed to obtain nvme info: Success    <<<< ERROR
/dev/nvme0n3: failed to obtain nvme info: Success
/dev/nvme0n4: failed to obtain nvme info: Success
/dev/nvme4n1: failed to obtain nvme info: Success
/dev/nvme4n2: failed to obtain nvme info: Success
/dev/nvme4n3: failed to obtain nvme info: Success
/dev/nvme4n4: failed to obtain nvme info: Success
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev  
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------

# echo $?
0        <<<<<<<<<<<< ERROR
```

**After Fix**
```
# ./nvme list
/dev/nvme0n2: failed to obtain nvme info: ABORT_REQ: The command was aborted due to a Command Abort request
/dev/nvme0n3: failed to obtain nvme info: ABORT_REQ: The command was aborted due to a Command Abort request
/dev/nvme0n4: failed to obtain nvme info: ABORT_REQ: The command was aborted due to a Command Abort request
/dev/nvme4n1: failed to obtain nvme info: ABORT_REQ: The command was aborted due to a Command Abort request
/dev/nvme4n2: failed to obtain nvme info: ABORT_REQ: The command was aborted due to a Command Abort request
/dev/nvme4n3: failed to obtain nvme info: ABORT_REQ: The command was aborted due to a Command Abort request
/dev/nvme4n4: failed to obtain nvme info: ABORT_REQ: The command was aborted due to a Command Abort request

# echo $?
7
```
