### PR TITLE
Fix f28 (gcc 8.1) compilation

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1245,7 +1245,7 @@ static const char *subsys_dir = "/sys/class/nvme-subsystem/";
 
 static char *get_nvme_subsnqn(char *path)
 {
-	char sspath[319];
+	char sspath[FILENAME_MAX];
 	char *subsysnqn;
 	int fd;
 	int ret;


### PR DESCRIPTION
Original:
```
nvme.c:1253:48: error: ‘snprintf’ output may be truncated before the last format character [-Werror=format-truncation=]
  snprintf(sspath, sizeof(sspath), "%s/subsysnqn", path);
                                                ^
```
