### PR TITLE
Enlarge local char[] so snprintf(3) can't truncate path.

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1247,7 +1247,7 @@ static const char *subsys_dir = "/sys/class/nvme-subsystem/";
 
 static char *get_nvme_subsnqn(char *path)
 {
-	char sspath[319];
+	char sspath[320];
 	char *subsysnqn;
 	int fd;
 	int ret;


### PR DESCRIPTION
The path is in a char[310], contributing at most 309 chars for the ‘%s’.
‘/subsysnqn’ is a further 10.  Plus one for the NUL.
309 + 10 + 1 = 320 so sspath[319] is too short.