### PR TITLE
attach-ns : fix segfault for ctrl list wrong input

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1072,7 +1072,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	__u16 ctrlist[2048];
 
 	const char *namespace_id = "namespace to attach";
-	const char *cont = "optional comma-sep controllers list";
+	const char *cont = "optional comma-sep controller id list";
 
 	struct config {
 		char  *cntlist;
@@ -1102,6 +1102,14 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 
 	num = argconfig_parse_comma_sep_array(cfg.cntlist,
 					list, 2047);
+
+    if (num == -1) {
+		fprintf(stderr, "%s: controller id list is required\n",
+						cmd->name);
+		err = EINVAL;
+		goto close_fd;
+    }
+
 	for (i = 0; i < num; i++)
 		ctrlist[i] = (uint16_t)list[i];
 


### PR DESCRIPTION
Original
```
# nvme attach-ns /dev/nvme0 -n 1 -c /dev/nvme1
Segmentation fault (core dumped)
```

After fix:
```
# ./nvme attach-ns /dev/nvme0 -n 1 -c /dev/nvme1
attach-ns: controller id list is required
```