### PR TITLE
nvme-cli: make gen-hostnqn output stable, host specific IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CFLAGS ?= -O2 -g -Wall -Werror
 CFLAGS += -std=gnu99
 CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
 LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
+HAVE_SYSTEMD = $(shell pkg-config --exists systemd  --atleast-version=232; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =
@@ -14,6 +15,11 @@ ifeq ($(LIBUUID),0)
 	override LDFLAGS += -luuid
 	override CFLAGS += -DLIBUUID
 	override LIB_DEPENDS += uuid
+endif
+
+ifeq ($(HAVE_SYSTEMD),0)
+	override LDFLAGS += -lsystemd
+	override CFLAGS += -DHAVE_SYSTEMD
 endif
 
 RPMBUILD = rpmbuild


### PR DESCRIPTION
  This changes generation of hostnqn to depend on `/etc/machine-id`. Each invocation of gen-hostnqn on the same host will generate the same ID. Different hosts still get different ids.
  This makes gen-hostnqn idempotent.

  `NVME_APPLICATION_ID` was randomly generated.