### PR TITLE
Allow LIBUUID to be set by the caller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CFLAGS ?= -O2 -g -Wall -Werror
 CFLAGS += -std=gnu99
 CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
-LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
+LIBUUID ?= $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =


### PR DESCRIPTION
Allow the user to compile with uud with make LIBUUID=0

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>