### PR TITLE
Makefile: fix bash completion install path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ install-bin: default
 	$(INSTALL) -m 755 nvme $(DESTDIR)$(SBINDIR)
 
 install-bash-completion:
-	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/bash_completion.d
-	$(INSTALL) -m 644 -T ./completions/bash-nvme-completion.sh $(DESTDIR)$(PREFIX)/share/bash_completion.d/nvme
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/bash-completion/completions
+	$(INSTALL) -m 644 -T ./completions/bash-nvme-completion.sh $(DESTDIR)$(PREFIX)/share/bash-completion/completions/nvme
 
 install: install-bin install-man install-bash-completion
 


### PR DESCRIPTION
Change path to bash-completion upstream recommendation used by most
distributions.

Signed-off-by: Stefan Wiehler <stefan.wiehler@missinglinkelectronics.com>