### PR TITLE
Portability fixes

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -29,7 +29,6 @@
 #include <dirent.h>
 #include <sys/ioctl.h>
 #include <inttypes.h>
-#include <linux/types.h>
 #include <libgen.h>
 #include <sys/stat.h>
 #include <stddef.h>

--- a/fabrics.c
+++ b/fabrics.c
@@ -28,7 +28,6 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <sys/ioctl.h>
-#include <asm/byteorder.h>
 #include <inttypes.h>
 #include <linux/types.h>
 #include <libgen.h>

--- a/intel-nvme.c
+++ b/intel-nvme.c
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <inttypes.h>
-#include <asm/byteorder.h>
 
 #include "linux/nvme_ioctl.h"
 

--- a/intel-nvme.c
+++ b/intel-nvme.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <linux/fs.h>
 #include <inttypes.h>
 #include <asm/byteorder.h>
 

--- a/linux/nvme_ioctl.h
+++ b/linux/nvme_ioctl.h
@@ -16,6 +16,7 @@
 #define _UAPI_LINUX_NVME_IOCTL_H
 
 #include <linux/types.h>
+#include <sys/ioctl.h>
 
 struct nvme_user_io {
 	__u8	opcode;

--- a/memblaze-nvme.c
+++ b/memblaze-nvme.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <linux/fs.h>
 
 #include "linux/nvme_ioctl.h"
 

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -81,7 +81,8 @@ int nvme_get_nsid(int fd)
 	return ioctl(fd, NVME_IOCTL_ID);
 }
 
-int nvme_submit_passthru(int fd, int ioctl_cmd, struct nvme_passthru_cmd *cmd)
+int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
+			 struct nvme_passthru_cmd *cmd)
 {
 	return ioctl(fd, ioctl_cmd, cmd);
 }
@@ -96,7 +97,8 @@ static int nvme_submit_io_passthru(int fd, struct nvme_passthru_cmd *cmd)
 	return ioctl(fd, NVME_IOCTL_IO_CMD, cmd);
 }
 
-int nvme_passthru(int fd, int ioctl_cmd, __u8 opcode, __u8 flags, __u16 rsvd,
+int nvme_passthru(int fd, unsigned long ioctl_cmd, __u8 opcode,
+		  __u8 flags, __u16 rsvd,
 		  __u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10, __u32 cdw11,
 		  __u32 cdw12, __u32 cdw13, __u32 cdw14, __u32 cdw15,
 		  __u32 data_len, void *data, __u32 metadata_len,

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -15,8 +15,6 @@
 #include <unistd.h>
 #include <math.h>
 
-#include <linux/types.h>
-
 #include "nvme-ioctl.h"
 
 static int nvme_verify_chr(int fd)

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -1,11 +1,9 @@
-#include <endian.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
 
-#include <endian.h>
 #include <errno.h>
 #include <getopt.h>
 #include <fcntl.h>

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -9,9 +9,10 @@
 int nvme_get_nsid(int fd);
 
 /* Generic passthrough */
-int nvme_submit_passthru(int fd, int ioctl_cmd, struct nvme_passthru_cmd *cmd);
+int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
+			 struct nvme_passthru_cmd *cmd);
 
-int nvme_passthru(int fd, int ioctl_cmd, __u8 opcode, __u8 flags,
+int nvme_passthru(int fd, unsigned long ioctl_cmd, __u8 opcode, __u8 flags,
 		  __u16 rsvd, __u32 nsid, __u32 cdw2, __u32 cdw3,
 		  __u32 cdw10, __u32 cdw11, __u32 cdw12,
 		  __u32 cdw13, __u32 cdw14, __u32 cdw15,

--- a/nvme-models.c
+++ b/nvme-models.c
@@ -279,7 +279,7 @@ static FILE *open_pci_ids(void)
 
 char *nvme_product_name(int id)
 {
-	char *line;
+	char *line = NULL;
 	ssize_t amnt;
 	char vendor[7] = { 0 };
 	char device[7] = { 0 };

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1,4 +1,3 @@
-#include <endian.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/nvme.c
+++ b/nvme.c
@@ -24,7 +24,6 @@
  * This program uses NVMe IOCTLs to run native nvme commands to a device.
  */
 
-#include <endian.h>
 #include <errno.h>
 #include <getopt.h>
 #include <fcntl.h>

--- a/nvme.c
+++ b/nvme.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <math.h>
 #include <dirent.h>
+#include <libgen.h>
 
 #include <linux/fs.h>
 
@@ -92,7 +93,7 @@ static unsigned long long elapsed_utime(struct timeval start_time,
 	return ret;
 }
 
-static int open_dev(const char *dev)
+static int open_dev(char *dev)
 {
 	int err, fd;
 
@@ -133,7 +134,7 @@ static int get_dev(int argc, char **argv)
 	if (ret)
 		return ret;
 
-	return open_dev((const char *)argv[optind]);
+	return open_dev(argv[optind]);
 }
 
 int parse_and_open(int argc, char **argv, const char *desc,

--- a/nvme.h
+++ b/nvme.h
@@ -16,8 +16,8 @@
 #define _NVME_H
 
 #include <stdbool.h>
-#include <endian.h>
 #include <stdint.h>
+#include <endian.h>
 #include "plugin.h"
 #include "json.h"
 

--- a/seagate-nvme.c
+++ b/seagate-nvme.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <ctype.h>
 #include "linux/nvme_ioctl.h"
 #include "nvme.h"

--- a/seagate-nvme.c
+++ b/seagate-nvme.c
@@ -24,7 +24,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <linux/fs.h>
 #include <inttypes.h>
 #include <asm/byteorder.h>
 #include <sys/ioctl.h>

--- a/seagate-nvme.c
+++ b/seagate-nvme.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <inttypes.h>
-#include <asm/byteorder.h>
 #include <sys/ioctl.h>
 #include <ctype.h>
 #include "linux/nvme_ioctl.h"

--- a/toshiba-nvme.c
+++ b/toshiba-nvme.c
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <linux/fs.h>
 #include <stddef.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/wdc-utils.c
+++ b/wdc-utils.c
@@ -65,22 +65,20 @@ int wdc_UtilsGetTime(PUtilsTimeInfo timeInfo)
 	time_t currTime;
 	struct tm currTimeInfo;
 
+	tzset();
 	time(&currTime);
 	localtime_r(&currTime, &currTimeInfo);
 
 	timeInfo->year			=  currTimeInfo.tm_year + 1900;
 	timeInfo->month			=  currTimeInfo.tm_mon + 1;
 	timeInfo->dayOfWeek		=  currTimeInfo.tm_wday;
-	timeInfo->dayOfMonth	=  currTimeInfo.tm_mday;
+	timeInfo->dayOfMonth		=  currTimeInfo.tm_mday;
 	timeInfo->hour			=  currTimeInfo.tm_hour;
 	timeInfo->minute		=  currTimeInfo.tm_min;
 	timeInfo->second		=  currTimeInfo.tm_sec;
 	timeInfo->msecs			=  0;
 	timeInfo->isDST			=  currTimeInfo.tm_isdst;
-
-	tzset();
-
-	timeInfo->zone = -1 *  (timezone / SECONDS_IN_MIN);
+	timeInfo->zone			= -currTimeInfo.tm_gmtoff / 60;
 
 	return WDC_STATUS_SUCCESS;
 }

--- a/wdc-utils.h
+++ b/wdc-utils.h
@@ -75,7 +75,3 @@ int wdc_UtilsStrCompare(char *pcSrc, char *pcDst);
 int wdc_UtilsCreateDir(char *path);
 int wdc_WriteToFile(char *fileName, char *buffer, unsigned int bufferLen);
 
-extern char *tzname[2];
-extern long timezone;
-extern int daylight;
-


### PR DESCRIPTION
There's a series of commits that fix many Linux-specific idioms where more portable constructs work just as well. It's part of a larger series that ports things to FreeBSD, but the rest of the series aren't ready yet as to complete that port some structural changes will be needed and I've not settled on the proper way to do them. These are needed regardless of any future work, however, and should be generally uncontroversial. It only makes three real code changes: uses the proper unsigned long for the command argument to ioctl where it's passed from function to function, removes a needless const on a char * argument, and gets timezone offsets from standard interfaces rather than glibc specific exported globals. Other than that, I'm just removing needless includes and preferring POSIX include files to Linux specific ones.
This is my first pull request to nvme-cli, so if there's some guidelines I've missed that I don't yet conform to, a simple pointer is all that would be needed.