### PR TITLE
In json output, if there is zero length string in command return data, it occur allocation failure & abort (cannot display empty value)

### DIFF
--- a/json.c
+++ b/json.c
@@ -123,6 +123,7 @@ static struct json_value *json_create_value_string(const char *str)
 		if (!value->string) {
 			free(value);
 			value = NULL;
+			return value;
 		}
 	}
 	if (!value)


### PR DESCRIPTION
I think zero length string is no error. nvmecli have to just display data from ssd.