### PR TITLE
micron-nvme: Replace direct use of ioctl

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -23,7 +23,7 @@ static int micron_fw_commit(int fd, int select)
 		.cdw10		= 8,
         .cdw12      = select,
 	};
-    return ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+    return nvme_submit_passthru(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
 
 }
 


### PR DESCRIPTION
Where possible it is best to use the redirections, so that any future usb bridges etc (where the nvme command will have to do translation) will work.