### PR TITLE
Fix a host of typos in utils, tests and docs

### DIFF
--- a/Documentation/nvme-admin-passthru.1
+++ b/Documentation/nvme-admin-passthru.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-admin-passthru
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ADMIN\-PASSTHR" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ADMIN\-PASSTHR" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -110,7 +110,7 @@ Print out the command to be sent\&.
 .RS 4
 Do not actually send the command\&. If want to use \-\-dry\-run option, \-\-show\-cmd option
 \fImust\fR
-be set\&. Otherwise \-\-dry\-run optionn will be
+be set\&. Otherwise \-\-dry\-run option will be
 \fIignored\fR\&.
 .RE
 .PP

--- a/Documentation/nvme-admin-passthru.html
+++ b/Documentation/nvme-admin-passthru.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.9" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-admin-passthru(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -912,7 +913,7 @@ printed to stdout for another program to parse.</p></div>
 <dd>
 <p>
         Do not actually send the command. If want to use --dry-run option,
-        --show-cmd option <em>must</em> be set. Otherwise --dry-run optionn will be
+        --show-cmd option <em>must</em> be set. Otherwise --dry-run option will be
         <em>ignored</em>.
 </p>
 </dd>
@@ -985,7 +986,7 @@ Or if you want to save that structure to a file:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-01-30 19:28:39 KST
+ 2018-11-29 13:30:44 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-admin-passthru.txt
+++ b/Documentation/nvme-admin-passthru.txt
@@ -89,7 +89,7 @@ OPTIONS
 -d::
 --dry-run::
 	Do not actually send the command. If want to use --dry-run option,
-	--show-cmd option _must_ be set. Otherwise --dry-run optionn will be
+	--show-cmd option _must_ be set. Otherwise --dry-run option will be
 	_ignored_.
 
 -b::

--- a/Documentation/nvme-ana-log.1
+++ b/Documentation/nvme-ana-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-ana-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ANA\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ANA\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-ana-log.html
+++ b/Documentation/nvme-ana-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-attach-ns.1
+++ b/Documentation/nvme-attach-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-attach-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ATTACH\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ATTACH\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-attach-ns.html
+++ b/Documentation/nvme-attach-ns.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-changed-ns-list-log.1
+++ b/Documentation/nvme-changed-ns-list-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-changed-ns-list-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-CHANGED\-NS\-L" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-CHANGED\-NS\-L" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -37,7 +37,7 @@ nvme-changed-ns-list-log \- Send NVMe Changed Namespace List log page request, r
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe Changed Namespace List log page from an NVMe device and provides the retuned structure\&.
+Retrieves the NVMe Changed Namespace List log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and must be a NVMe character device (ex: /dev/nvme0)\&.
 .sp

--- a/Documentation/nvme-changed-ns-list-log.html
+++ b/Documentation/nvme-changed-ns-list-log.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-changed-ns-list-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -756,7 +759,7 @@ nvme-changed-ns-list-log(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves the NVMe Changed Namespace List log page from an NVMe device and
-provides the retuned structure.</p></div>
+provides the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and must be a NVMe character device
 (ex: /dev/nvme0).</p></div>
 <div class="paragraph"><p>On success, the returned Changed Namespace List log structure may be
@@ -831,7 +834,8 @@ Print the raw Changed Namespace List log to a file:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-06-08 22:10:18 EDT
+Last updated
+ 2018-11-29 13:32:28 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-changed-ns-list-log.txt
+++ b/Documentation/nvme-changed-ns-list-log.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves the NVMe Changed Namespace List log page from an NVMe device and
-provides the retuned structure.
+provides the returned structure.
 
 The <device> parameter is mandatory and must be a NVMe character device
 (ex: /dev/nvme0).

--- a/Documentation/nvme-compare.1
+++ b/Documentation/nvme-compare.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-compare
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-COMPARE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-COMPARE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -194,7 +194,7 @@ Print out the command to be sent\&.
 .RS 4
 Do not actually send the command\&. If want to use \-\-dry\-run option, \-\-show\-cmd option
 \fImust\fR
-be set\&. Otherwise \-\-dry\-run optionn will be
+be set\&. Otherwise \-\-dry\-run option will be
 \fIignored\fR\&.
 .RE
 .PP

--- a/Documentation/nvme-compare.html
+++ b/Documentation/nvme-compare.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -1024,7 +1024,7 @@ metadata is passes.</p></td>
 <dd>
 <p>
         Do not actually send the command. If want to use --dry-run option,
-        --show-cmd option <em>must</em> be set. Otherwise --dry-run optionn will be
+        --show-cmd option <em>must</em> be set. Otherwise --dry-run option will be
         <em>ignored</em>.
 </p>
 </dd>

--- a/Documentation/nvme-compare.txt
+++ b/Documentation/nvme-compare.txt
@@ -132,7 +132,7 @@ metadata is passes.
 -w::
 --dry-run::
 	Do not actually send the command. If want to use --dry-run option,
-	--show-cmd option _must_ be set. Otherwise --dry-run optionn will be
+	--show-cmd option _must_ be set. Otherwise --dry-run option will be
 	_ignored_.
 
 -t::

--- a/Documentation/nvme-connect-all.1
+++ b/Documentation/nvme-connect-all.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-connect-all
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-CONNECT\-ALL" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-CONNECT\-ALL" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-connect-all.html
+++ b/Documentation/nvme-connect-all.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-connect.1
+++ b/Documentation/nvme-connect.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-connect
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-CONNECT" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-CONNECT" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-connect.html
+++ b/Documentation/nvme-connect.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-create-ns.1
+++ b/Documentation/nvme-create-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-create-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-CREATE\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-CREATE\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-create-ns.html
+++ b/Documentation/nvme-create-ns.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-delete-ns.1
+++ b/Documentation/nvme-delete-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-delete-ns.html
+++ b/Documentation/nvme-delete-ns.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-detach-ns.1
+++ b/Documentation/nvme-detach-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-detach-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DETACH\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DETACH\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-detach-ns.html
+++ b/Documentation/nvme-detach-ns.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-device-self-test.1
+++ b/Documentation/nvme-device-self-test.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-device-self-test
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DEVICE\-SELF\-" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DEVICE\-SELF\-" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-device-self-test.html
+++ b/Documentation/nvme-device-self-test.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-dir-receive.1
+++ b/Documentation/nvme-dir-receive.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-dir-receive
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DIR\-RECEIVE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DIR\-RECEIVE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-dir-receive.html
+++ b/Documentation/nvme-dir-receive.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-dir-send.1
+++ b/Documentation/nvme-dir-send.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-dir-send
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DIR\-SEND" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DIR\-SEND" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-dir-send.html
+++ b/Documentation/nvme-dir-send.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-disconnect-all.1
+++ b/Documentation/nvme-disconnect-all.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-disconnect-all
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DISCONNECT\-AL" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DISCONNECT\-AL" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-disconnect-all.html
+++ b/Documentation/nvme-disconnect-all.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-disconnect.1
+++ b/Documentation/nvme-disconnect.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-disconnect
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DISCONNECT" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DISCONNECT" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-nvme-disconnect \- Disonnect one or more Fabrics controller(s)\&.
+nvme-disconnect \- Disconnect one or more Fabrics controller(s)\&.
 .SH "SYNOPSIS"
 .sp
 .nf

--- a/Documentation/nvme-disconnect.html
+++ b/Documentation/nvme-disconnect.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -737,7 +737,7 @@ nvme-disconnect(1) Manual Page
 <h2>NAME</h2>
 <div class="sectionbody">
 <p>nvme-disconnect -
-   Disonnect one or more Fabrics controller(s).
+   Disconnect one or more Fabrics controller(s).
 </p>
 </div>
 </div>

--- a/Documentation/nvme-disconnect.txt
+++ b/Documentation/nvme-disconnect.txt
@@ -3,7 +3,7 @@ nvme-disconnect(1)
 
 NAME
 ----
-nvme-disconnect - Disonnect one or more Fabrics controller(s).
+nvme-disconnect - Disconnect one or more Fabrics controller(s).
 
 SYNOPSIS
 --------

--- a/Documentation/nvme-discover.1
+++ b/Documentation/nvme-discover.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-discover
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DISCOVER" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DISCOVER" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -53,7 +53,7 @@ Otherwise, a specific Discovery Controller should be specified using the \-\-tra
 .sp
 The NVMe\-over\-Fabrics specification defines the concept of a Discovery Controller that an NVMe Host can query on a fabric network to discover NVMe subsystems contained in NVMe Targets which it can connect to on the network\&. The Discovery Controller will return Discovery Log Pages that provide the NVMe Host with specific information (such as network address and unique subsystem NQN) the NVMe Host can use to issue an NVMe connect command to connect itself to a storage resource contained in that NVMe subsystem on the NVMe Target\&.
 .sp
-Note that the base NVMe specfication defines the NQN (NVMe Qualified Name) format which an NVMe endpoint (device, subsystem, etc) must follow to guarantee a unique name under the NVMe standard\&. In particular, the Host NQN uniquely identifies the NVMe Host, and may be used by the the Discovery Controller to control what NVMe Target resources are allocated to the NVMe Host for a connection\&.
+Note that the base NVMe specification defines the NQN (NVMe Qualified Name) format which an NVMe endpoint (device, subsystem, etc) must follow to guarantee a unique name under the NVMe standard\&. In particular, the Host NQN uniquely identifies the NVMe Host, and may be used by the the Discovery Controller to control what NVMe Target resources are allocated to the NVMe Host for a connection\&.
 .sp
 A Discovery Controller has it\(cqs own NQN defined in the NVMe\-over\-Fabrics specification, \fBnqn\&.2014\-08\&.org\&.nvmexpress\&.discovery\fR\&. All Discovery Controllers must use this NQN name\&. This NQN is used by default by nvme\-cli for the \fIdiscover\fR command\&.
 .SH "OPTIONS"

--- a/Documentation/nvme-discover.html
+++ b/Documentation/nvme-discover.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -785,7 +785,7 @@ with specific information (such as network address and unique
 subsystem NQN) the NVMe Host can use to issue an
 NVMe connect command to connect itself to a storage resource
 contained in that NVMe subsystem on the NVMe Target.</p></div>
-<div class="paragraph"><p>Note that the base NVMe specfication defines the NQN (NVMe Qualified
+<div class="paragraph"><p>Note that the base NVMe specification defines the NQN (NVMe Qualified
 Name) format which an NVMe endpoint (device, subsystem, etc) must
 follow to guarantee a unique name under the NVMe standard.
 In particular, the Host NQN uniquely identifies the NVMe Host, and

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -44,7 +44,7 @@ subsystem NQN) the NVMe Host can use to issue an
 NVMe connect command to connect itself to a storage resource
 contained in that NVMe subsystem on the NVMe Target.
 
-Note that the base NVMe specfication defines the NQN (NVMe Qualified
+Note that the base NVMe specification defines the NQN (NVMe Qualified
 Name) format which an NVMe endpoint (device, subsystem, etc) must
 follow to guarantee a unique name under the NVMe standard.
 In particular, the Host NQN uniquely identifies the NVMe Host, and

--- a/Documentation/nvme-dsm.1
+++ b/Documentation/nvme-dsm.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-dsm
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DSM" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-DSM" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-dsm.html
+++ b/Documentation/nvme-dsm.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-effects-log.1
+++ b/Documentation/nvme-effects-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-effects-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-EFFECTS\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-EFFECTS\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -38,7 +38,7 @@ nvme-effects-log \- Send NVMe Command Effects log page request, returns result a
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe Command Effects log page from an NVMe device and provides the retuned structure\&.
+Retrieves the NVMe Command Effects log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and should be the NVMe character device (ex: /dev/nvme0)\&.
 .sp

--- a/Documentation/nvme-effects-log.html
+++ b/Documentation/nvme-effects-log.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.9" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-effects-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -759,7 +760,7 @@ nvme-effects-log(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves the NVMe Command Effects log page from an NVMe device and provides
-the retuned structure.</p></div>
+the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and should be the NVMe character
 device (ex: /dev/nvme0).</p></div>
 <div class="paragraph"><p>On success, the returned command effects log structure will be printed
@@ -846,7 +847,7 @@ Have the program return the raw structure in binary:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-01-13 21:15:43 KST
+ 2018-11-29 13:32:28 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-effects-log.txt
+++ b/Documentation/nvme-effects-log.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves the NVMe Command Effects log page from an NVMe device and provides
-the retuned structure.
+the returned structure.
 
 The <device> parameter is mandatory and should be the NVMe character
 device (ex: /dev/nvme0).

--- a/Documentation/nvme-endurance-log.1
+++ b/Documentation/nvme-endurance-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-endurance-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ENDURANCE\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ENDURANCE\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -37,7 +37,7 @@ nvme-endurance-log \- Send NVMe Endurance log page request, returns result and l
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe Endurance log page from an NVMe device and provides the retuned structure\&.
+Retrieves the NVMe Endurance log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-endurance-log.html
+++ b/Documentation/nvme-endurance-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -755,7 +755,7 @@ nvme-endurance-log(1) Manual Page
 <div class="sect1">
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Retrieves the NVMe Endurance log page from an NVMe device and provides the retuned structure.</p></div>
+<div class="paragraph"><p>Retrieves the NVMe Endurance log page from an NVMe device and provides the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned endurance log structure may be returned in one of

--- a/Documentation/nvme-endurance-log.txt
+++ b/Documentation/nvme-endurance-log.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Retrieves the NVMe Endurance log page from an NVMe device and provides the retuned structure.
+Retrieves the NVMe Endurance log page from an NVMe device and provides the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-error-log.1
+++ b/Documentation/nvme-error-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-error-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ERROR\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ERROR\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -38,7 +38,7 @@ nvme-error-log \- Send NVME Error log page request, return result and log
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves NVMe Error log page from an NVMe device and provides the retuned structure\&.
+Retrieves NVMe Error log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-error-log.html
+++ b/Documentation/nvme-error-log.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-error-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -757,7 +760,7 @@ nvme-error-log(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves NVMe Error log page from an NVMe device and provides the
-retuned structure.</p></div>
+returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned error log structure may be returned in one of
@@ -845,7 +848,8 @@ Print the raw output to a file:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-27 10:11:57 EST
+Last updated
+ 2018-11-29 13:35:56 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-error-log.txt
+++ b/Documentation/nvme-error-log.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves NVMe Error log page from an NVMe device and provides the
-retuned structure.
+returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-flush.1
+++ b/Documentation/nvme-flush.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-flush
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FLUSH" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-FLUSH" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-flush.html
+++ b/Documentation/nvme-flush.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-format.1
+++ b/Documentation/nvme-format.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-format
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FORMAT" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-FORMAT" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-format.html
+++ b/Documentation/nvme-format.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-fw-commit.1
+++ b/Documentation/nvme-fw-commit.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-fw-commit
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FW\-COMMIT" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-FW\-COMMIT" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-fw-commit.html
+++ b/Documentation/nvme-fw-commit.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-fw-download.1
+++ b/Documentation/nvme-fw-download.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-fw-download
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FW\-DOWNLOAD" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-FW\-DOWNLOAD" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-fw-download.html
+++ b/Documentation/nvme-fw-download.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-fw-log.1
+++ b/Documentation/nvme-fw-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-fw-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FW\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-FW\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -37,7 +37,7 @@ nvme-fw-log \- Send NVMe Firmware log page request, returns result and log
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe Firmware log page from an NVMe device and provides the retuned structure\&.
+Retrieves the NVMe Firmware log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-fw-log.html
+++ b/Documentation/nvme-fw-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -756,7 +756,7 @@ nvme-fw-log(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves the NVMe Firmware log page from an NVMe device and provides
-the retuned structure.</p></div>
+the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned f/w log structure may be returned in one of

--- a/Documentation/nvme-fw-log.txt
+++ b/Documentation/nvme-fw-log.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves the NVMe Firmware log page from an NVMe device and provides
-the retuned structure.
+the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-gen-hostnqn.1
+++ b/Documentation/nvme-gen-hostnqn.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-gen-hostnqn
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GEN\-HOSTNQN" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-GEN\-HOSTNQN" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-gen-hostnqn.html
+++ b/Documentation/nvme-gen-hostnqn.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-get-feature.1
+++ b/Documentation/nvme-get-feature.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-get-feature
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-FEATURE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-FEATURE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-get-feature.html
+++ b/Documentation/nvme-get-feature.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-get-log.1
+++ b/Documentation/nvme-get-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-get-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -43,7 +43,7 @@ nvme-get-log \- Retrieves a log page from an NVMe device
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves an arbitrary NVMe log page from an NVMe device and provides the retuned structure\&.
+Retrieves an arbitrary NVMe log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-get-log.html
+++ b/Documentation/nvme-get-log.html
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -765,7 +765,7 @@ nvme-get-log(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves an arbitrary NVMe log page from an NVMe device and provides
-the retuned structure.</p></div>
+the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned log structure may be returned in one of several

--- a/Documentation/nvme-get-log.txt
+++ b/Documentation/nvme-get-log.txt
@@ -20,7 +20,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves an arbitrary NVMe log page from an NVMe device and provides
-the retuned structure.
+the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-get-ns-id.1
+++ b/Documentation/nvme-get-ns-id.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-get-ns-id
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-NS\-ID" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-NS\-ID" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-get-ns-id.html
+++ b/Documentation/nvme-get-ns-id.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-get-property.1
+++ b/Documentation/nvme-get-property.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-get-property
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-PROPERTY" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-PROPERTY" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -47,7 +47,7 @@ The offset of the property\&. One of CAP=0x0, VS=0x8, CC=0x14, CSTS=0x1c, NSSR=0
 .PP
 \-H
 .RS 4
-\-\-human\-readable: Show the fields packed in the propery
+\-\-human\-readable: Show the fields packed in the property
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-get-property.html
+++ b/Documentation/nvme-get-property.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -779,7 +779,7 @@ nvme-get-property(1) Manual Page
 <dd>
 <p>
 --human-readable:
-        Show the fields packed in the propery
+        Show the fields packed in the property
 </p>
 </dd>
 </dl></div>

--- a/Documentation/nvme-get-property.txt
+++ b/Documentation/nvme-get-property.txt
@@ -26,7 +26,7 @@ OPTIONS
 
 -H::
 --human-readable:
-	Show the fields packed in the propery
+	Show the fields packed in the property
 
 
 EXAMPLES

--- a/Documentation/nvme-help.1
+++ b/Documentation/nvme-help.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-help
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-HELP" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-HELP" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-help.html
+++ b/Documentation/nvme-help.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-huawei-id-ctrl.1
+++ b/Documentation/nvme-huawei-id-ctrl.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-huawei-id-ctrl
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-HUAWEI\-ID\-CT" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-HUAWEI\-ID\-CT" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-huawei-id-ctrl.html
+++ b/Documentation/nvme-huawei-id-ctrl.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-huawei-list.1
+++ b/Documentation/nvme-huawei-list.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-list
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LIST" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LIST" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-huawei-list.html
+++ b/Documentation/nvme-huawei-list.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-id-ctrl.1
+++ b/Documentation/nvme-id-ctrl.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-ctrl
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-CTRL" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-CTRL" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-id-ctrl.html
+++ b/Documentation/nvme-id-ctrl.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-id-ns.1
+++ b/Documentation/nvme-id-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -53,7 +53,7 @@ Retrieve the identify namespace structure for the given nsid\&. This is required
 .PP
 \-f, \-\-force
 .RS 4
-Request controller return the indentify namespace structure even if the namespace is not attached to the controller\&. This is valid only for controllers at or newer than revision 1\&.2\&. Controllers at revision lower than this may interpret the command incorrectly\&.
+Request controller return the identify namespace structure even if the namespace is not attached to the controller\&. This is valid only for controllers at or newer than revision 1\&.2\&. Controllers at revision lower than this may interpret the command incorrectly\&.
 .RE
 .PP
 \-b, \-\-raw\-binary

--- a/Documentation/nvme-id-ns.html
+++ b/Documentation/nvme-id-ns.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.9" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-id-ns(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -797,7 +798,7 @@ raw buffer may be printed to stdout.</p></div>
 </dt>
 <dd>
 <p>
-        Request controller return the indentify namespace structure even
+        Request controller return the identify namespace structure even
         if the namespace is not attached to the controller. This is valid
         only for controllers at or newer than revision 1.2. Controllers
         at revision lower than this may interpret the command incorrectly.
@@ -954,7 +955,7 @@ int main(int argc, char **argv)
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-01-30 19:28:39 KST
+ 2018-11-29 13:36:39 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-id-ns.txt
+++ b/Documentation/nvme-id-ns.txt
@@ -39,7 +39,7 @@ OPTIONS
 
 -f::
 --force::
-	Request controller return the indentify namespace structure even
+	Request controller return the identify namespace structure even
 	if the namespace is not attached to the controller. This is valid
 	only for controllers at or newer than revision 1.2. Controllers
 	at revision lower than this may interpret the command incorrectly.

--- a/Documentation/nvme-id-nvmset.1
+++ b/Documentation/nvme-id-nvmset.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-nvmset
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NVMSET" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NVMSET" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-id-nvmset.html
+++ b/Documentation/nvme-id-nvmset.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-intel-id-ctrl.1
+++ b/Documentation/nvme-intel-id-ctrl.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-id-ctrl
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-ID\-CTR" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-ID\-CTR" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-intel-id-ctrl.html
+++ b/Documentation/nvme-intel-id-ctrl.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-intel-internal-log.1
+++ b/Documentation/nvme-intel-internal-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-internal-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-INTERNA" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-INTERNA" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-intel-internal-log.html
+++ b/Documentation/nvme-intel-internal-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-intel-lat-stats.1
+++ b/Documentation/nvme-intel-lat-stats.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-lat-stats
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-LAT\-ST" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-LAT\-ST" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-intel-lat-stats.html
+++ b/Documentation/nvme-intel-lat-stats.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-intel-market-name.1
+++ b/Documentation/nvme-intel-market-name.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-market-name
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-MARKET\" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-MARKET\" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-intel-market-name.html
+++ b/Documentation/nvme-intel-market-name.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-intel-smart-log-add.1
+++ b/Documentation/nvme-intel-smart-log-add.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-smart-log-add
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-SMART\-" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-SMART\-" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -38,7 +38,7 @@ nvme-intel-smart-log-add \- Send NVMe Intel Additional SMART log page request, r
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe Intel Additional SMART log page from the device and provides the retuned structure\&.
+Retrieves the NVMe Intel Additional SMART log page from the device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-intel-smart-log-add.html
+++ b/Documentation/nvme-intel-smart-log-add.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.9" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-intel-smart-log-add(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -759,7 +760,7 @@ nvme-intel-smart-log-add(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves the NVMe Intel Additional SMART log page from the device and
-provides the retuned structure.</p></div>
+provides the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned smart log structure may be returned in one of
@@ -806,7 +807,7 @@ printed to stdout for another program to parse.</p></div>
 </dt>
 <dd>
 <p>
-              Dump output in <em>json</em> format.
+              Dump output in json format.
 </p>
 </dd>
 </dl></div>
@@ -849,7 +850,7 @@ Print the raw Intel Additional SMART log to a file:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-01-11 01:34:36 KST
+ 2018-11-29 13:32:28 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-intel-smart-log-add.txt
+++ b/Documentation/nvme-intel-smart-log-add.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves the NVMe Intel Additional SMART log page from the device and
-provides the retuned structure.
+provides the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-intel-temp-stats.1
+++ b/Documentation/nvme-intel-temp-stats.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-intel-temp-stats
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-INTEL\-TEMP\-S" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-INTEL\-TEMP\-S" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -36,7 +36,7 @@ nvme-intel-temp-stats \- Send NVMe SMART log page request, returns result and lo
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe Intel Additional SMART log page from the device and provides the retuned structure\&.
+Retrieves the NVMe Intel Additional SMART log page from the device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-intel-temp-stats.html
+++ b/Documentation/nvme-intel-temp-stats.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -755,7 +755,7 @@ nvme-intel-temp-stats(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves the NVMe Intel Additional SMART log page from the device and
-provides the retuned structure.</p></div>
+provides the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned smart log structure may be returned in one of

--- a/Documentation/nvme-intel-temp-stats.txt
+++ b/Documentation/nvme-intel-temp-stats.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves the NVMe Intel Additional SMART log page from the device and
-provides the retuned structure.
+provides the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-io-passthru.1
+++ b/Documentation/nvme-io-passthru.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-io-passthru
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-IO\-PASSTHRU" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-IO\-PASSTHRU" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -112,7 +112,7 @@ Print out the command to be sent\&.
 .RS 4
 Do not actually send the command\&. If want to use \-\-dry\-run option, \-\-show\-cmd option
 \fImust\fR
-be set\&. Otherwise \-\-dry\-run optionn will be
+be set\&. Otherwise \-\-dry\-run option will be
 \fIignored\fR\&.
 .RE
 .PP

--- a/Documentation/nvme-io-passthru.html
+++ b/Documentation/nvme-io-passthru.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -913,7 +913,7 @@ printed to stdout for another program to parse.</p></div>
 <dd>
 <p>
         Do not actually send the command. If want to use --dry-run option,
-        --show-cmd option <em>must</em> be set. Otherwise --dry-run optionn will be
+        --show-cmd option <em>must</em> be set. Otherwise --dry-run option will be
         <em>ignored</em>.
 </p>
 </dd>

--- a/Documentation/nvme-io-passthru.txt
+++ b/Documentation/nvme-io-passthru.txt
@@ -90,7 +90,7 @@ OPTIONS
 -d::
 --dry-run::
 	Do not actually send the command. If want to use --dry-run option,
-	--show-cmd option _must_ be set. Otherwise --dry-run optionn will be
+	--show-cmd option _must_ be set. Otherwise --dry-run option will be
 	_ignored_.
 
 -b::

--- a/Documentation/nvme-list-ctrl.1
+++ b/Documentation/nvme-list-ctrl.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-list-ctrl.html
+++ b/Documentation/nvme-list-ctrl.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-list-ns.1
+++ b/Documentation/nvme-list-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-list-ns.html
+++ b/Documentation/nvme-list-ns.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-list-subsys.1
+++ b/Documentation/nvme-list-subsys.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-list-subsys
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 11/16/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LIST\-SUBSYS" "1" "11/16/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LIST\-SUBSYS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-list-subsys.html
+++ b/Documentation/nvme-list-subsys.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-list.1
+++ b/Documentation/nvme-list.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-list
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LIST" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LIST" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-list.html
+++ b/Documentation/nvme-list.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-create.1
+++ b/Documentation/nvme-lnvm-create.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-create
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-CREATE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-CREATE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-create.html
+++ b/Documentation/nvme-lnvm-create.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-diag-bbtbl.1
+++ b/Documentation/nvme-lnvm-diag-bbtbl.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-diag-bbtbl
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-DIAG\-BB" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-DIAG\-BB" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-diag-bbtbl.html
+++ b/Documentation/nvme-lnvm-diag-bbtbl.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-diag-set-bbtbl.1
+++ b/Documentation/nvme-lnvm-diag-set-bbtbl.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-diag-set-bbtbl
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-DIAG\-SE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-DIAG\-SE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-diag-set-bbtbl.html
+++ b/Documentation/nvme-lnvm-diag-set-bbtbl.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-factory.1
+++ b/Documentation/nvme-lnvm-factory.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-factory
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-FACTORY" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-FACTORY" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-factory.html
+++ b/Documentation/nvme-lnvm-factory.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-id-ns.1
+++ b/Documentation/nvme-lnvm-id-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-ID\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-ID\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-id-ns.html
+++ b/Documentation/nvme-lnvm-id-ns.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-info.1
+++ b/Documentation/nvme-lnvm-info.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-info
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-INFO" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-INFO" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-info.html
+++ b/Documentation/nvme-lnvm-info.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-init.1
+++ b/Documentation/nvme-lnvm-init.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-init
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-INIT" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-INIT" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-init.html
+++ b/Documentation/nvme-lnvm-init.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-list.1
+++ b/Documentation/nvme-lnvm-list.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-list
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-LIST" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-LIST" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-list.html
+++ b/Documentation/nvme-lnvm-list.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-lnvm-remove.1
+++ b/Documentation/nvme-lnvm-remove.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-remove
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-REMOVE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-REMOVE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-lnvm-remove.html
+++ b/Documentation/nvme-lnvm-remove.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-netapp-smdevices.1
+++ b/Documentation/nvme-netapp-smdevices.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-netapp-smdevices
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-NETAPP\-SMDEVI" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-NETAPP\-SMDEVI" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -36,7 +36,7 @@ nvme-netapp-smdevices \- Display information for each NVMe path to an E\-Series 
 .fi
 .SH "DESCRIPTION"
 .sp
-Display vendor\-specific information for each NVMe path to an E\-Series namespace currently connnected to the host\&. The E\-Series paths are identified from the NVMe nodes in /dev by sending an Identify Controller\&.
+Display vendor\-specific information for each NVMe path to an E\-Series namespace currently connected to the host\&. The E\-Series paths are identified from the NVMe nodes in /dev by sending an Identify Controller\&.
 .SH "OPTIONS"
 .PP
 \-o <fmt>, \-\-output\-format=<fmt>

--- a/Documentation/nvme-netapp-smdevices.html
+++ b/Documentation/nvme-netapp-smdevices.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-netapp-smdevices(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -758,7 +758,7 @@ nvme-netapp-smdevices(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Display vendor-specific information for each NVMe path to an E-Series namespace
-currently connnected to the host.  The E-Series paths are identified from the
+currently connected to the host.  The E-Series paths are identified from the
 NVMe nodes in /dev by sending an Identify Controller.</p></div>
 </div>
 </div>
@@ -809,7 +809,7 @@ namespace.
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-02-07 15:49:54 CST
+ 2018-11-29 13:36:56 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-netapp-smdevices.txt
+++ b/Documentation/nvme-netapp-smdevices.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Display vendor-specific information for each NVMe path to an E-Series namespace
-currently connnected to the host.  The E-Series paths are identified from the
+currently connected to the host.  The E-Series paths are identified from the
 NVMe nodes in /dev by sending an Identify Controller.
 
 OPTIONS

--- a/Documentation/nvme-ns-descs.1
+++ b/Documentation/nvme-ns-descs.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-ns-descs
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-NS\-DESCS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-NS\-DESCS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-ns-descs.html
+++ b/Documentation/nvme-ns-descs.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-ns-rescan.1
+++ b/Documentation/nvme-ns-rescan.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-ns-rescan
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-NS\-RESCAN" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-NS\-RESCAN" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-ns-rescan.html
+++ b/Documentation/nvme-ns-rescan.html
@@ -268,7 +268,7 @@ td > div.verse {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-read.1
+++ b/Documentation/nvme-read.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-read
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-READ" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-READ" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -88,7 +88,7 @@ Metadata file, if necessary\&.
 .PP
 \-\-prinfo=<prinfo>, \-p <prinfo>
 .RS 4
-Protection Information field defintion\&.
+Protection Information field definition\&.
 .TS
 allbox tab(:);
 lt lt
@@ -170,7 +170,7 @@ Print out the command to be sent\&.
 .RS 4
 Do not actually send the command\&. If want to use \-\-dry\-run option, \-\-show\-cmd option
 \fImust\fR
-be set\&. Otherwise \-\-dry\-run optionn will be
+be set\&. Otherwise \-\-dry\-run option will be
 \fIignored\fR\&.
 .RE
 .PP

--- a/Documentation/nvme-read.html
+++ b/Documentation/nvme-read.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -856,7 +856,7 @@ by default if you don&#8217;t provide a file.</p></div>
 </dt>
 <dd>
 <p>
-        Protection Information field defintion.
+        Protection Information field definition.
 </p>
 <div class="tableblock">
 <table rules="all"
@@ -995,7 +995,7 @@ metadata is passes.</p></td>
 <dd>
 <p>
         Do not actually send the command. If want to use --dry-run option,
-        --show-cmd option <em>must</em> be set. Otherwise --dry-run optionn will be
+        --show-cmd option <em>must</em> be set. Otherwise --dry-run option will be
         <em>ignored</em>.
 </p>
 </dd>

--- a/Documentation/nvme-read.txt
+++ b/Documentation/nvme-read.txt
@@ -63,7 +63,7 @@ OPTIONS
 
 --prinfo=<prinfo>::
 -p <prinfo>::
-	Protection Information field defintion.
+	Protection Information field definition.
 +
 []
 |=================
@@ -121,7 +121,7 @@ metadata is passes.
 -w::
 --dry-run::
 	Do not actually send the command. If want to use --dry-run option,
-	--show-cmd option _must_ be set. Otherwise --dry-run optionn will be
+	--show-cmd option _must_ be set. Otherwise --dry-run option will be
 	_ignored_.
 
 -t::

--- a/Documentation/nvme-reset.1
+++ b/Documentation/nvme-reset.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-reset
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-RESET" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-RESET" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-reset.html
+++ b/Documentation/nvme-reset.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-resv-acquire.1
+++ b/Documentation/nvme-resv-acquire.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-resv-acquire
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-RESV\-ACQUIRE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-RESV\-ACQUIRE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-resv-acquire.html
+++ b/Documentation/nvme-resv-acquire.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-resv-register.1
+++ b/Documentation/nvme-resv-register.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-resv-register
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-RESV\-REGISTER" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-RESV\-REGISTER" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-resv-register.html
+++ b/Documentation/nvme-resv-register.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-resv-release.1
+++ b/Documentation/nvme-resv-release.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-resv-release
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-RESV\-RELEASE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-RESV\-RELEASE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-resv-release.html
+++ b/Documentation/nvme-resv-release.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-resv-report.1
+++ b/Documentation/nvme-resv-report.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-resv-report
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-RESV\-REPORT" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-RESV\-REPORT" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-resv-report.html
+++ b/Documentation/nvme-resv-report.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-sanitize-log.1
+++ b/Documentation/nvme-sanitize-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-sanitize-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SANITIZE\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SANITIZE\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-sanitize-log.html
+++ b/Documentation/nvme-sanitize-log.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-sanitize.1
+++ b/Documentation/nvme-sanitize.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-sanitize
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SANITIZE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SANITIZE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-sanitize.html
+++ b/Documentation/nvme-sanitize.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-security-recv.1
+++ b/Documentation/nvme-security-recv.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-security-recv
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SECURITY\-RECV" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SECURITY\-RECV" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-security-recv.html
+++ b/Documentation/nvme-security-recv.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-security-send.1
+++ b/Documentation/nvme-security-send.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-security-send
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SECURITY\-SEND" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SECURITY\-SEND" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-security-send.html
+++ b/Documentation/nvme-security-send.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-self-test-log.1
+++ b/Documentation/nvme-self-test-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-self-test-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SELF\-TEST\-LO" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SELF\-TEST\-LO" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -36,7 +36,7 @@ nvme-self-test-log \- Retrieve the log information initited by device\-self\-tes
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the log pages from an NVMe device corresponding to the requested self\-test by the user and provides 20\-most recent result retuned strutcure\&.
+Retrieves the log pages from an NVMe device corresponding to the requested self\-test by the user and provides 20\-most recent result returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-self-test-log.html
+++ b/Documentation/nvme-self-test-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -756,7 +756,7 @@ nvme-self-test-log(1) Manual Page
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves the log pages from an NVMe device corresponding to the
 requested self-test by the user and provides 20-most recent result
-retuned strutcure.</p></div>
+returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned log structure may be returned in one of

--- a/Documentation/nvme-self-test-log.txt
+++ b/Documentation/nvme-self-test-log.txt
@@ -14,7 +14,7 @@ DESCRIPTION
 -----------
 Retrieves the log pages from an NVMe device corresponding to the 
 requested self-test by the user and provides 20-most recent result 
-retuned strutcure.
+returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-set-feature.1
+++ b/Documentation/nvme-set-feature.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-set-feature
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SET\-FEATURE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SET\-FEATURE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-set-feature.html
+++ b/Documentation/nvme-set-feature.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-set-property.1
+++ b/Documentation/nvme-set-property.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-set-property
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SET\-PROPERTY" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SET\-PROPERTY" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-set-property.html
+++ b/Documentation/nvme-set-property.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-show-regs.1
+++ b/Documentation/nvme-show-regs.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-show-regs.html
+++ b/Documentation/nvme-show-regs.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-smart-log.1
+++ b/Documentation/nvme-smart-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-smart-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SMART\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SMART\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -38,7 +38,7 @@ nvme-smart-log \- Send NVMe SMART log page request, returns result and log
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe SMART log page from an NVMe device and provides the retuned structure\&.
+Retrieves the NVMe SMART log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-smart-log.html
+++ b/Documentation/nvme-smart-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -756,7 +756,7 @@ nvme-smart-log(1) Manual Page
 <div class="sect1">
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Retrieves the NVMe SMART log page from an NVMe device and provides the retuned structure.</p></div>
+<div class="paragraph"><p>Retrieves the NVMe SMART log page from an NVMe device and provides the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned smart log structure may be returned in one of

--- a/Documentation/nvme-smart-log.txt
+++ b/Documentation/nvme-smart-log.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Retrieves the NVMe SMART log page from an NVMe device and provides the retuned structure.
+Retrieves the NVMe SMART log page from an NVMe device and provides the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-subsystem-reset.1
+++ b/Documentation/nvme-subsystem-reset.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-subsystem-reset
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SUBSYSTEM\-RES" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-SUBSYSTEM\-RES" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-subsystem-reset.html
+++ b/Documentation/nvme-subsystem-reset.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-telemetry-log.1
+++ b/Documentation/nvme-telemetry-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-telemetry-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-TELEMETRY\-LOG" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-TELEMETRY\-LOG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -37,7 +37,7 @@ nvme-telemetry-log \- Retrieves a Telemetry Host\-Initiated log page from an NVM
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves an Telemetry Host\-Initiated log page from an NVMe device and provides the retuned structure\&.
+Retrieves an Telemetry Host\-Initiated log page from an NVMe device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp

--- a/Documentation/nvme-telemetry-log.html
+++ b/Documentation/nvme-telemetry-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -756,7 +756,7 @@ nvme-telemetry-log(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>Retrieves an Telemetry Host-Initiated log page from an NVMe device and provides
-the retuned structure.</p></div>
+the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
 <div class="paragraph"><p>On success, the returned log structure will be in raw binary format <em>only</em> with

--- a/Documentation/nvme-telemetry-log.txt
+++ b/Documentation/nvme-telemetry-log.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves an Telemetry Host-Initiated log page from an NVMe device and provides
-the retuned structure.
+the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-toshiba-clear-pcie-correctable-errors.1
+++ b/Documentation/nvme-toshiba-clear-pcie-correctable-errors.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-toshiba-clear-pcie-correctable-errors
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-TOSHIBA\-CLEAR" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-TOSHIBA\-CLEAR" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-toshiba-clear-pcie-correctable-errors.html
+++ b/Documentation/nvme-toshiba-clear-pcie-correctable-errors.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-toshiba-vs-internal-log.1
+++ b/Documentation/nvme-toshiba-vs-internal-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-toshiba-vs-internal-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-TOSHIBA\-VS\-I" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-TOSHIBA\-VS\-I" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-toshiba-vs-internal-log.html
+++ b/Documentation/nvme-toshiba-vs-internal-log.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-toshiba-vs-smart-add-log.1
+++ b/Documentation/nvme-toshiba-vs-smart-add-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-toshiba-vs-smart-add-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-TOSHIBA\-VS\-S" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-TOSHIBA\-VS\-S" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-toshiba-vs-smart-add-log.html
+++ b/Documentation/nvme-toshiba-vs-smart-add-log.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-cap-diag.1
+++ b/Documentation/nvme-wdc-cap-diag.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-cap-diag
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/12/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-CAP\-DIAG" "1" "10/12/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-CAP\-DIAG" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-cap-diag.html
+++ b/Documentation/nvme-wdc-cap-diag.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-clear-pcie-corr.1
+++ b/Documentation/nvme-wdc-clear-pcie-corr.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-clear-pcie-corr
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-CLEAR\-PC" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-CLEAR\-PC" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-clear-pcie-corr.html
+++ b/Documentation/nvme-wdc-clear-pcie-corr.html
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-drive-essentials.1
+++ b/Documentation/nvme-wdc-drive-essentials.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-drive-essentials
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-DRIVE\-ES" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-DRIVE\-ES" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-drive-essentials.html
+++ b/Documentation/nvme-wdc-drive-essentials.html
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-drive-log.1
+++ b/Documentation/nvme-wdc-drive-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-drive-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-DRIVE\-LO" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-DRIVE\-LO" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-drive-log.html
+++ b/Documentation/nvme-wdc-drive-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-get-crash-dump.1
+++ b/Documentation/nvme-wdc-get-crash-dump.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-get-crash-dump
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-GET\-CRAS" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-GET\-CRAS" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-get-crash-dump.html
+++ b/Documentation/nvme-wdc-get-crash-dump.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-get-pfail-dump.1
+++ b/Documentation/nvme-wdc-get-pfail-dump.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-get-pfail-dump
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/19/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-GET\-PFAI" "1" "10/19/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-GET\-PFAI" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-get-pfail-dump.html
+++ b/Documentation/nvme-wdc-get-pfail-dump.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-id-ctrl.1
+++ b/Documentation/nvme-wdc-id-ctrl.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-id-ctrl
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-ID\-CTRL" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-ID\-CTRL" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-id-ctrl.html
+++ b/Documentation/nvme-wdc-id-ctrl.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-purge-monitor.1
+++ b/Documentation/nvme-wdc-purge-monitor.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-purge-monitor
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-PURGE\-MO" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-PURGE\-MO" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-purge-monitor.html
+++ b/Documentation/nvme-wdc-purge-monitor.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-purge.1
+++ b/Documentation/nvme-wdc-purge.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-purge
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-PURGE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-PURGE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-purge.html
+++ b/Documentation/nvme-wdc-purge.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-smart-add-log.1
+++ b/Documentation/nvme-wdc-smart-add-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-smart-add-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-SMART\-AD" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-SMART\-AD" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-smart-add-log.html
+++ b/Documentation/nvme-wdc-smart-add-log.html
@@ -435,7 +435,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-wdc-vs-internal-log.1
+++ b/Documentation/nvme-wdc-vs-internal-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-wdc-vs-internal-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/12/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WDC\-VS\-INTER" "1" "10/12/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WDC\-VS\-INTER" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-wdc-vs-internal-log.html
+++ b/Documentation/nvme-wdc-vs-internal-log.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-write-uncor.1
+++ b/Documentation/nvme-write-uncor.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-uncor
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-UNCOR" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-UNCOR" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme-write-uncor.html
+++ b/Documentation/nvme-write-uncor.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/Documentation/nvme-write-zeroes.1
+++ b/Documentation/nvme-write-zeroes.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-zeroes
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ZEROES" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-ZEROES" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -60,7 +60,7 @@ Number of logical blocks to write zeroes\&.
 .PP
 \-\-prinfo=<prinfo>, \-p <prinfo>
 .RS 4
-Protection Information field defintion\&.
+Protection Information field definition\&.
 .TS
 allbox tab(:);
 lt lt

--- a/Documentation/nvme-write-zeroes.html
+++ b/Documentation/nvme-write-zeroes.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-zeroes(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -800,7 +803,7 @@ nvme-zeroes(1) Manual Page
 </dt>
 <dd>
 <p>
-        Protection Information field defintion.
+        Protection Information field definition.
 </p>
 <div class="tableblock">
 <table rules="all"
@@ -933,7 +936,8 @@ NVME</code></pre>
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-11-27 08:57:30 MST
+Last updated
+ 2018-11-29 13:31:13 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-write-zeroes.txt
+++ b/Documentation/nvme-write-zeroes.txt
@@ -35,7 +35,7 @@ OPTIONS
 
 --prinfo=<prinfo>::
 -p <prinfo>::
-	Protection Information field defintion.
+	Protection Information field definition.
 +
 []
 |=================

--- a/Documentation/nvme-write.1
+++ b/Documentation/nvme-write.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-write
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WRITE" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME\-WRITE" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -88,7 +88,7 @@ Metadata file, if necessary\&.
 .PP
 \-\-prinfo=<prinfo>, \-p <prinfo>
 .RS 4
-Protection Information field defintion\&.
+Protection Information field definition\&.
 .TS
 allbox tab(:);
 lt lt
@@ -180,7 +180,7 @@ Print out the command to be sent\&.
 .RS 4
 Do not actually send the command\&. If want to use \-\-dry\-run option, \-\-show\-cmd option
 \fImust\fR
-be set\&. Otherwise \-\-dry\-run optionn will be
+be set\&. Otherwise \-\-dry\-run option will be
 \fIignored\fR\&.
 .RE
 .PP

--- a/Documentation/nvme-write.html
+++ b/Documentation/nvme-write.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.9" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-write(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -858,7 +859,7 @@ if you don&#8217;t provide a file.</p></div>
 </dt>
 <dd>
 <p>
-        Protection Information field defintion.
+        Protection Information field definition.
 </p>
 <div class="tableblock">
 <table rules="all"
@@ -1019,7 +1020,7 @@ metadata is passes.</p></td>
 <dd>
 <p>
         Do not actually send the command. If want to use --dry-run option,
-        --show-cmd option <em>must</em> be set. Otherwise --dry-run optionn will be
+        --show-cmd option <em>must</em> be set. Otherwise --dry-run option will be
         <em>ignored</em>.
 </p>
 </dd>
@@ -1054,7 +1055,7 @@ metadata is passes.</p></td>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-01-30 19:28:39 KST
+ 2018-11-29 13:31:13 GMT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-write.txt
+++ b/Documentation/nvme-write.txt
@@ -63,7 +63,7 @@ OPTIONS
 
 --prinfo=<prinfo>::
 -p <prinfo>::
-	Protection Information field defintion.
+	Protection Information field definition.
 +
 []
 |=================
@@ -129,7 +129,7 @@ metadata is passes.
 -w::
 --dry-run::
 	Do not actually send the command. If want to use --dry-run option,
-	--show-cmd option _must_ be set. Otherwise --dry-run optionn will be
+	--show-cmd option _must_ be set. Otherwise --dry-run option will be
 	_ignored_.
 
 -t::

--- a/Documentation/nvme.1
+++ b/Documentation/nvme.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme
 .\"    Author: [see the "Authors" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09/05/2018
+.\"      Date: 11/29/2018
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME" "1" "09/05/2018" "NVMe" "NVMe Manual"
+.TH "NVME" "1" "11/29/2018" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/Documentation/nvme.html
+++ b/Documentation/nvme.html
@@ -433,7 +433,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/completions/README
+++ b/completions/README
@@ -23,7 +23,7 @@ just re-source nvme and .bashrc. To see a full list of auto-completable
 NVMe commands, type "nvme help " and hit TAB.
 
 You may also need to uncomment the "enable bash completion in interactive
-shells" part of /etc/bash.bashrc, which hopefully looks somehting like:
+shells" part of /etc/bash.bashrc, which hopefully looks something like:
 
 if [ -f /usr/share/bash-completion/bash_completion ]; then
 	. /usr/share/bash-completion/bash_completion

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -713,7 +713,7 @@ void show_nvme_id_ns(struct nvme_id_ns *ns, unsigned int mode)
 	printf("nvmcap  : %.0Lf\n", int128_to_double(ns->nvmcap));
 	printf("nsattr	: %u\n", ns->nsattr);
 	printf("nvmsetid: %d\n", le16_to_cpu(ns->nvmsetid));
-	printf("anagrpid: %d\n", le32_to_cpu(ns->anagrpid));
+	printf("anagrpid: %u\n", le32_to_cpu(ns->anagrpid));
 	printf("endgid  : %d\n", le16_to_cpu(ns->endgid));
 
 	printf("nguid   : ");

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -657,7 +657,7 @@ static void show_nvme_id_ns_dlfeat(__u8 dlfeat)
 		printf("  [7:5] : %#x\tReserved\n", rsvd);
 	printf("  [4:4] : %#x\tGuard Field of Deallocated Logical Blocks is set to %s\n",
 		guard, guard ? "CRC of The Value Read" : "0xFFFF");
-	printf("  [3:3] : %#x\tDeallocate Bit in the Write Zeroes Commmand is %sSupported\n",
+	printf("  [3:3] : %#x\tDeallocate Bit in the Write Zeroes Command is %sSupported\n",
 		dwz, dwz ? "" : "Not ");
 	printf("  [2:0] : %#x\tBytes Read From a Deallocated Logical Block and its Metadata are %s\n", val,
 		val == 2 ? "0xFF" :
@@ -3002,7 +3002,7 @@ static void show_registers_bpinfo_brs(__u8 brs)
 		printf("No Boot Partition read operation requested\n");
 		break;
 	case 1:
-		printf("Boot Partition read in progres\n");
+		printf("Boot Partition read in progress\n");
 		break;
 	case 2:
 		printf("Boot Partition read completed successfully\n");

--- a/nvme.c
+++ b/nvme.c
@@ -367,7 +367,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	if (err) {
 		fprintf(stderr, "NVMe Status:%s(%x)\n",
 			nvme_status_to_string(err), err);
-		fprintf(stderr, "Failed to aquire telemetry header %d!\n", err);
+		fprintf(stderr, "Failed to acquire telemetry header %d!\n", err);
 		close(output);
 		goto free_mem;
 	}
@@ -401,7 +401,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	while (offset != full_size) {
 		err = nvme_get_telemetry_log(fd, page_log, 0, cfg.ctrl_init, bs, offset);
 		if (err) {
-			fprintf(stderr, "Failed to aquire full telemetry log!\n");
+			fprintf(stderr, "Failed to acquire full telemetry log!\n");
 			fprintf(stderr, "NVMe Status:%s(%x)\n",
 				nvme_status_to_string(err), err);
 			break;
@@ -1903,7 +1903,7 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
 static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Send Namespace Identification Descriptors command to the "\
-			    "given device, returns the namespace identifcation descriptors "\
+			    "given device, returns the namespace identification descriptors "\
 			    "of the specific namespace in either human-readable or binary format.";
 	const char *raw_binary = "show infos in binary format";
 	const char *namespace_id = "identifier of desired namespace";

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -62,7 +62,7 @@ struct huawei_list_element_len {
 	unsigned int ns_name;
 	unsigned int nguid;
 	unsigned int ns_id;
-	unsigned int useage;
+	unsigned int usage;
 	unsigned int array_name;
 };
 
@@ -223,13 +223,13 @@ static void huawei_print_list_head(struct huawei_list_element_len element_len)
 		element_len.ns_name, element_len.ns_name, "NS Name",
 		element_len.nguid, element_len.nguid, "Nguid",
 		element_len.ns_id, element_len.ns_id, "NS ID",
-		element_len.useage, element_len.useage, "Usage",
+		element_len.usage, element_len.usage, "Usage",
 		element_len.array_name, element_len.array_name, "Array Name");
 
 	printf("%-.*s %-.*s %-.*s %-.*s %-.*s %-.*s\n",
 		element_len.node, dash, element_len.ns_name, dash,
 		element_len.nguid, dash, element_len.ns_id, dash,
-		element_len.useage, dash, element_len.array_name, dash);
+		element_len.usage, dash, element_len.array_name, dash);
 }
 
 static void huawei_print_list_item(struct huawei_list_item list_item,
@@ -259,7 +259,7 @@ static void huawei_print_list_item(struct huawei_list_item list_item,
 		element_len.ns_name, element_len.ns_name, list_item.ns_name,
 		element_len.nguid, element_len.nguid, nguid_buf,
 		element_len.ns_id, list_item.nsid,
-		element_len.useage, element_len.useage, usage,
+		element_len.usage, element_len.usage, usage,
 		element_len.array_name, element_len.array_name, list_item.array_name);
 
 }
@@ -306,7 +306,7 @@ static void huawei_print_list_items(struct huawei_list_item *list_items, unsigne
 	element_len.node = 16;
 	element_len.nguid = 2 * sizeof(list_items->ns.nguid) + 1;
 	element_len.ns_id = 9;
-	element_len.useage = 26;
+	element_len.usage = 26;
 	element_len.ns_name = huawei_get_ns_len(list_items, len, MIN_NS_NAME_LEN);
 	element_len.array_name = huawei_get_array_len(list_items, len, MIN_ARRAY_NAME_LEN);
 

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -168,7 +168,7 @@ static int netapp_smdevices_get_info(int fd, struct smdevice_info *item,
 
 	err = nvme_identify_ctrl(fd, &item->ctrl);
 	if (err) {
-		fprintf(stderr, "Identify Controler failed to %s (%s)\n", dev,
+		fprintf(stderr, "Identify Controller failed to %s (%s)\n", dev,
 			strerror(err));
 		return 0;
 	}

--- a/tests/nvme_compare_test.py
+++ b/tests/nvme_compare_test.py
@@ -40,7 +40,7 @@ class TestNVMeCompareCmd(TestNVMeIO):
         - Attributes:
               - data_size : data size to perform IO.
               - start_block : starting block of to perform IO.
-              - compare_file : data file to use in nvme comapre commmand.
+              - compare_file : data file to use in nvme compare command.
               - test_log_dir : directory for logs, temp files.
     """
 

--- a/tests/nvme_read_write_test.py
+++ b/tests/nvme_read_write_test.py
@@ -38,7 +38,7 @@ class TestNVMeReadWriteTest(TestNVMeIO):
 
         - Attributes:
               - start_block : starting block of to perform IO.
-              - compare_file : data file to use in nvme comapre commmand.
+              - compare_file : data file to use in nvme compare command.
               - test_log_dir : directory for logs, temp files.
     """
     def __init__(self):

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -310,7 +310,7 @@ class TestNVMe(object):
     def attach_ns(self, ctrl_id, ns_id):
         """ Wrapper for attaching the namespace.
             - Args:
-                - ctrl_id : controller id to which namespace to be attched.
+                - ctrl_id : controller id to which namespace to be attached.
                 - nsid : new namespace id.
             - Returns:
                 - 0 on success, error code on failure.
@@ -334,7 +334,7 @@ class TestNVMe(object):
     def detach_ns(self, ctrl_id, nsid):
         """ Wrapper for detaching the namespace.
             - Args:
-                - ctrl_id : controller id to which namespace to be attched.
+                - ctrl_id : controller id to which namespace to be attached.
                 - nsid : new namespace id.
             - Returns:
                 - 0 on success, error code on failure.


### PR DESCRIPTION
I have regenerated the docs using asciidoc 8.6.10 on Fedora after fixing the typos.

Docs changes are in a different commit to the utils changes as there are a lot of changes in docs (due to html/txt versions etc).