### PR TITLE
nvme-cli: Added support for virtualization-management command

### DIFF
--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -67,6 +67,7 @@ COMMAND_LIST(
 	ENTRY("gen-hostnqn", "Generate NVMeoF host NQN", gen_hostnqn_cmd)
 	ENTRY("dir-receive", "Submit a Directive Receive command, return results", dir_receive)
 	ENTRY("dir-send", "Submit a Directive Send command, return results", dir_send)
+	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller ", virtual_mgmt)
 );
 
 #endif

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -867,3 +867,19 @@ int nvme_self_test_start(int fd, __u32 nsid, __u32 cdw10)
 
 	return nvme_submit_admin_passthru(fd, &cmd);
 }
+
+int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result)
+{
+	struct nvme_admin_cmd cmd = {
+		.opcode = nvme_admin_virtual_mgmt,
+		.cdw10  = cdw10,
+		.cdw11  = cdw11,
+	};
+	int err;
+
+	err = nvme_submit_admin_passthru(fd, &cmd);
+	if (!err && result)
+		*result = cmd.result;
+
+	return err;
+}

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -136,4 +136,5 @@ int nvme_sanitize(int fd, __u8 sanact, __u8 ause, __u8 owpass, __u8 oipbp,
 		  __u8 no_dealloc, __u32 ovrpat);
 int nvme_self_test_start(int fd, __u32 nsid, __u32 cdw10);
 int nvme_self_test_log(int fd, struct nvme_self_test_log *self_test_log);
+int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result);
 #endif				/* _NVME_LIB_H */


### PR DESCRIPTION
Previous feedback, **(http://lists.infradead.org/pipermail/linux-nvme/2018-June/018724.html)**, on the implementation of NVMe 1.3's virtualization feature for nvme-cli requested that the change be tested against a device actually supporting the feature.  This has now been completed internally at Intel, and this pull request merges the previous patch into the latest nvme-cli sources.