### PR TITLE
README: update Arch Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For example:
 
 Install from AUR, e.g.:
 ```
-$ yaourt -S nvme-cli-git
+$ yay -S nvme-cli-git
 ```
 
 ### Nix(OS)


### PR DESCRIPTION
Really small change, but as `yaourt` is now [discontinued](https://wiki.archlinux.org/index.php/AUR_helpers), I think we should encourage installation through the new recommended AUR helper: `yay`.

P.S Great tool :)