### PR TITLE
Adding a Format Helper to create-ns

### DIFF
--- a/Documentation/nvme-create-ns.txt
+++ b/Documentation/nvme-create-ns.txt
@@ -13,6 +13,7 @@ SYNOPSIS
 			[--flbas=<flbas> | -f <flbas>]
 			[--dps=<dps> | -d <dps>]
 			[--nmic=<nmic> | -m <nmic>]
+			[--block-size=<block-size> | -b <block-size>]
 
 DESCRIPTION
 -----------
@@ -36,6 +37,7 @@ OPTIONS
 -f::
 --flbas::
 	The namespace formatted logical block size setting.
+	Conflicts with --block-size argument.
 
 -d::
 --dps::
@@ -44,6 +46,12 @@ OPTIONS
 -m::
 --nmic::
 	Namespace multipath and sharing capabilities.
+
+-b::
+--block-size::
+	Target block size the new namespace should be formatted as. Potential FLBAS
+  values will be values will be scanned and the lowest numbered will be
+  selected for the create-ns operation. Conflicts with --flbas argument.
 
 
 EXAMPLES

--- a/Documentation/nvme-format.txt
+++ b/Documentation/nvme-format.txt
@@ -10,6 +10,7 @@ SYNOPSIS
 [verse]
 'nvme format' <device> [--namespace-id=<nsid> | -n <nsid>]
 		    [--lbaf=<lbaf> | -l <lbaf>]
+		    [--block-size=<block size | -b <block size>]
 		    [--ses=<ses> | -s <ses>]
 		    [--pil=<pil> | -p <pil>]
 		    [--pi=<pi> | -i <pi>]
@@ -48,7 +49,15 @@ OPTIONS
 --lbaf=<lbaf>::
 	LBA Format: This field specifies the LBA format to apply to the NVM
 	media. This corresponds to the LBA formats indicated in the
-	Identify Namespace command. Defaults to 0.
+	Identify Namespace command. Conflicts with --block-size argument.
+	Defaults to 0.
+
+-b <block size>::
+--block-size=<block size>::
+	Block Size: This field is used to specify the target block size to
+	format to. Potential lbaf values will be scanned and the lowest 
+	numbered will be selected for the format operation. Conflicts with
+	--lbaf argument.
 
 -s <ses>::
 --ses=<ses>::


### PR DESCRIPTION
Similar to #445 however adds the helper to create-ns command instead of format. Allows user to select target block size in a create-ns command instead of requiring FLBAS to be specified directly.