### PR TITLE
nvme-print: Fix evaluation of ctratt on pretty print

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -132,12 +132,12 @@ static void show_nvme_id_ctrl_ctratt(__le32 ctrl_ctratt)
 {
 	__u32 ctratt = le32_to_cpu(ctrl_ctratt);
 	__u32 rsvd0 = ctratt >> 6;
-	__u32 hostid128 = ctratt & NVME_CTRL_CTRATT_128_ID >> 0;
-	__u32 psp = ctratt & NVME_CTRL_CTRATT_NON_OP_PSP >> 1;
-	__u32 sets = ctratt & NVME_CTRL_CTRATT_NVM_SETS >> 2;
-	__u32 rrl = ctratt & NVME_CTRL_CTRATT_READ_RECV_LVLS >> 3;
-	__u32 eg = ctratt & NVME_CTRL_CTRATT_ENDURANCE_GROUPS >> 4;
-	__u32 iod = ctratt & NVME_CTRL_CTRATT_PREDICTABLE_LAT >> 5;
+	__u32 hostid128 = (ctratt & NVME_CTRL_CTRATT_128_ID) >> 0;
+	__u32 psp = (ctratt & NVME_CTRL_CTRATT_NON_OP_PSP) >> 1;
+	__u32 sets = (ctratt & NVME_CTRL_CTRATT_NVM_SETS) >> 2;
+	__u32 rrl = (ctratt & NVME_CTRL_CTRATT_READ_RECV_LVLS) >> 3;
+	__u32 eg = (ctratt & NVME_CTRL_CTRATT_ENDURANCE_GROUPS) >> 4;
+	__u32 iod = (ctratt & NVME_CTRL_CTRATT_PREDICTABLE_LAT) >> 5;
 
 	if (rsvd0)
 		printf(" [31:6] : %#x\tReserved\n", rsvd0);


### PR DESCRIPTION
We accidantly evaluated SHIFT operation before AND
operation which caused wrong values to be printed
using Human Readable output (-H).

Signed-off-by: Roy Shterman <roys@lightbitslabs.com>