### PR TITLE
fabrics: Return negative errno to check failure in discovery

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -852,7 +852,7 @@ static int do_discover(char *argstr, bool connect)
 		return instance;
 
 	if (asprintf(&dev_name, "/dev/nvme%d", instance) < 0)
-		return errno;
+		return -errno;
 	ret = nvmf_get_log_page_discovery(dev_name, &log, &numrec);
 	free(dev_name);
 	remove_ctrl(instance);

--- a/fabrics.c
+++ b/fabrics.c
@@ -251,14 +251,14 @@ static int remove_ctrl_by_path(char *sysfs_path)
 
 	fd = open(sysfs_path, O_WRONLY);
 	if (fd < 0) {
-		ret = errno;
+		ret = -errno;
 		fprintf(stderr, "Failed to open %s: %s\n", sysfs_path,
 				strerror(errno));
 		goto out;
 	}
 
 	if (write(fd, "1", 1) != 1) {
-		ret = errno;
+		ret = -errno;
 		goto out_close;
 	}
 
@@ -276,7 +276,7 @@ static int remove_ctrl(int instance)
 
 	if (asprintf(&sysfs_path, "/sys/class/nvme/nvme%d/delete_controller",
 			instance) < 0) {
-		ret = errno;
+		ret = -errno;
 		goto out;
 	}
 
@@ -845,7 +845,7 @@ static int do_discover(char *argstr, bool connect)
 {
 	struct nvmf_disc_rsp_page_hdr *log = NULL;
 	char *dev_name;
-	int instance, numrec = 0, ret;
+	int instance, numrec = 0, ret, err;
 
 	instance = add_ctrl(argstr);
 	if (instance < 0)
@@ -855,7 +855,9 @@ static int do_discover(char *argstr, bool connect)
 		return -errno;
 	ret = nvmf_get_log_page_discovery(dev_name, &log, &numrec);
 	free(dev_name);
-	remove_ctrl(instance);
+	err = remove_ctrl(instance);
+	if (err)
+		return err;
 
 	switch (ret) {
 	case DISC_OK:


### PR DESCRIPTION
Hi,
I'd like to add a very few features to check failure in the middle of the
discovery process.

```
Minwoo Im (2):
  fabrics: Return negative errno when asprintf() fails
  fabrics: Return negative errno to check remove_ctrl() is failed

 fabrics.c | 14 ++++++++------
 1 file changed, 8 insertions(+), 6 deletions(-)
```