### PR TITLE
nvme: Support raw_binary and json format for show-regs

### DIFF
--- a/Documentation/nvme-show-regs.1
+++ b/Documentation/nvme-show-regs.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-id-ns
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 01/08/2019
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 04/07/2019
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NS" "1" "01/08/2019" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NS" "1" "04/07/2019" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -32,7 +32,8 @@ nvme-show-regs \- Reads and shows the defined NVMe controller registers for NVMe
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme show\-regs\fR <device> [\-\-human\-readable | \-H]
+\fInvme show\-regs\fR <device>       [\-\-human\-readable | \-H]
+                                [\-\-output\-format=<FMT> | \-o <FMT>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -44,6 +45,14 @@ The <device> parameter is mandatory and must be the nvme admin character device 
 \-H, \-\-human\-readable
 .RS 4
 Display registers or supported properties in human readable format\&.
+.RE
+.PP
+\-o <format>, \-\-output\-format=<format>
+.RS 4
+Set the reporting format to
+\fInormal\fR,
+\fIjson\fR, or
+\fIbinary\fR\&. Only one output format can be used at a time\&.
 .RE
 .SH "EXAMPLES"
 .sp
@@ -61,7 +70,7 @@ Show the NVMe over PCIe controller registers or the NVMe over Fabric controller 
 .RS 4
 .\}
 .nf
-# nvme show\-regs /dev/nvme0
+# nvme show\-regs /dev/nvme0 \-o binary
 .fi
 .if n \{\
 .RE
@@ -83,6 +92,27 @@ Show the NVMe over PCIe controller registers or the NVMe over Fabric controller 
 .\}
 .nf
 # nvme show\-regs /dev/nvme0 \-H
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Show the NVMe over PCIe controller registers or NVMe\-oF controller properties in a json format:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# nvme show\-regs /dev/nvme0 \-o json
 .fi
 .if n \{\
 .RE

--- a/Documentation/nvme-show-regs.html
+++ b/Documentation/nvme-show-regs.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-id-ns(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -433,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overridden by CSS in most browsers. */
+/* Because the table frame attribute is overriden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -746,7 +749,8 @@ nvme-id-ns(1) Manual Page
 <h2 id="_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="verseblock">
-<pre class="content"><em>nvme show-regs</em> &lt;device&gt; [--human-readable | -H]</pre>
+<pre class="content"><em>nvme show-regs</em> &lt;device&gt;       [--human-readable | -H]
+                                [--output-format=&lt;FMT&gt; | -o &lt;FMT&gt;]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -781,6 +785,18 @@ Only the supported properties are displayed.</p></div>
        Display registers or supported properties in human readable format.
 </p>
 </dd>
+<dt class="hdlist1">
+-o &lt;format&gt;
+</dt>
+<dt class="hdlist1">
+--output-format=&lt;format&gt;
+</dt>
+<dd>
+<p>
+              Set the reporting format to <em>normal</em>, <em>json</em>, or
+              <em>binary</em>. Only one output format can be used at a time.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -795,7 +811,7 @@ properties in a binary format:
 </p>
 <div class="listingblock">
 <div class="content">
-<pre><code># nvme show-regs /dev/nvme0</code></pre>
+<pre><code># nvme show-regs /dev/nvme0 -o binary</code></pre>
 </div></div>
 </li>
 <li>
@@ -806,6 +822,16 @@ properties in a human readable format:
 <div class="listingblock">
 <div class="content">
 <pre><code># nvme show-regs /dev/nvme0 -H</code></pre>
+</div></div>
+</li>
+<li>
+<p>
+Show the NVMe over PCIe controller registers or NVMe-oF controller properties
+in a json format:
+</p>
+<div class="listingblock">
+<div class="content">
+<pre><code># nvme show-regs /dev/nvme0 -o json</code></pre>
 </div></div>
 </li>
 </ul></div>
@@ -821,7 +847,8 @@ properties in a human readable format:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-12-13 08:26:02 MST
+Last updated
+ 2019-04-07 06:12:04 KST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-show-regs.txt
+++ b/Documentation/nvme-show-regs.txt
@@ -9,7 +9,8 @@ NVMe over PCIe or the controller properties for NVMe over Fabrics.
 SYNOPSIS
 --------
 [verse]
-'nvme show-regs' <device> [--human-readable | -H]
+'nvme show-regs' <device>	[--human-readable | -H]
+				[--output-format=<FMT> | -o <FMT>]
 
 DESCRIPTION
 -----------
@@ -31,6 +32,10 @@ OPTIONS
 --human-readable::
        Display registers or supported properties in human readable format.
 
+-o <format>::
+--output-format=<format>::
+              Set the reporting format to 'normal', 'json', or
+              'binary'. Only one output format can be used at a time.
 
 EXAMPLES
 --------
@@ -38,13 +43,19 @@ EXAMPLES
 properties in a binary format:
 +
 ------------
-# nvme show-regs /dev/nvme0
+# nvme show-regs /dev/nvme0 -o binary
 ------------
 * Show the NVMe over PCIe controller registers or the NVMe over Fabric controller
 properties in a human readable format:
 +
 ------------
 # nvme show-regs /dev/nvme0 -H
+------------
+* Show the NVMe over PCIe controller registers or NVMe-oF controller properties
+in a json format:
++
+------------
+# nvme show-regs /dev/nvme0 -o json
 ------------
 
 NVME

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3075,6 +3075,48 @@ static inline __u64 mmio_read64(void *addr)
 	return le32_to_cpu(*p) | ((uint64_t)le32_to_cpu(*(p + 1)) << 32);
 }
 
+void json_ctrl_registers(void *bar)
+{
+	uint64_t cap, asq, acq, bpmbl;
+	uint32_t vs, intms, intmc, cc, csts, nssr, aqa, cmbsz, cmbloc,
+			bpinfo, bprsel;
+	struct json_object *root;
+
+	cap = mmio_read64(bar + NVME_REG_CAP);
+	vs = mmio_read32(bar + NVME_REG_VS);
+	intms = mmio_read32(bar + NVME_REG_INTMS);
+	intmc = mmio_read32(bar + NVME_REG_INTMC);
+	cc = mmio_read32(bar + NVME_REG_CC);
+	csts = mmio_read32(bar + NVME_REG_CSTS);
+	nssr = mmio_read32(bar + NVME_REG_NSSR);
+	aqa = mmio_read32(bar + NVME_REG_AQA);
+	asq = mmio_read64(bar + NVME_REG_ASQ);
+	acq = mmio_read64(bar + NVME_REG_ACQ);
+	cmbloc = mmio_read32(bar + NVME_REG_CMBLOC);
+	cmbsz = mmio_read32(bar + NVME_REG_CMBSZ);
+	bpinfo = mmio_read32(bar + NVME_REG_BPINFO);
+	bprsel = mmio_read32(bar + NVME_REG_BPRSEL);
+	bpmbl = mmio_read64(bar + NVME_REG_BPMBL);
+
+	root = json_create_object();
+	json_object_add_value_uint(root, "cap", cap);
+	json_object_add_value_int(root, "vs", vs);
+	json_object_add_value_int(root, "intms", intms);
+	json_object_add_value_int(root, "intmc", intmc);
+	json_object_add_value_int(root, "cc", cc);
+	json_object_add_value_int(root, "csts", csts);
+	json_object_add_value_int(root, "nssr", nssr);
+	json_object_add_value_int(root, "aqa", aqa);
+	json_object_add_value_uint(root, "asq", asq);
+	json_object_add_value_uint(root, "acq", acq);
+	json_object_add_value_int(root, "cmbloc", cmbloc);
+	json_object_add_value_int(root, "cmbsz", cmbsz);
+	json_object_add_value_int(root, "bpinfo", bpinfo);
+	json_object_add_value_int(root, "bprsel", bprsel);
+	json_object_add_value_uint(root, "bpmbl", bpmbl);
+	json_print_object(root, NULL);
+}
+
 void show_ctrl_registers(void *bar, unsigned int mode, bool fabrics)
 {
 	uint64_t cap, asq, acq, bpmbl;

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -64,6 +64,7 @@ void json_nvme_id_ns_descs(void *data);
 void json_print_nvme_subsystem_list(struct subsys_list_item *slist, int n);
 void json_self_test_log(struct nvme_self_test_log *self_test, const char *devname);
 void json_nvme_id_nvmset(struct nvme_id_nvmset *nvmset, const char *devname);
+void json_ctrl_registers(void *bar);
 
 
 #endif


### PR DESCRIPTION
This patchset introduces --output-format support for show-regs subcommand.
Document will also be upated if merged.

```
Minwoo Im (2):
  nvme: Support raw_binary and json format for show-regs
  doc: Update show-regs document with output-format

 Documentation/nvme-show-regs.1    | 42 ++++++++++++++++++++++++++-----
 Documentation/nvme-show-regs.html | 41 ++++++++++++++++++++++++------
 Documentation/nvme-show-regs.txt  | 15 +++++++++--
 nvme-print.c                      | 42 +++++++++++++++++++++++++++++++
 nvme-print.h                      |  1 +
 nvme.c                            | 31 ++++++++++++++++++++---
 6 files changed, 154 insertions(+), 18 deletions(-)
```