### PR TITLE
ioctl: Free memory if get_property for fabrics failed

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -626,6 +626,8 @@ int nvme_get_properties(int fd, void **pbar)
 		err = get_property_helper(fd, offset, *pbar + offset, &advance);
 		if (!err)
 			ret = 0;
+		else
+			free(*pbar);
 	}
 
 	return ret;


### PR DESCRIPTION
```
The given *pbar is allocated inside this function without freeing it
will be freed from the caller in case of show-regs subcommand for NVMe-oF
controller.

If Get Property is failed because it has PCIe transport, then it needs
to be freed here instead of caller.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>
```