### PR TITLE
nvme: Clean-up duplicated macros

### DIFF
--- a/common.h
+++ b/common.h
@@ -6,4 +6,7 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+#define min(x, y) ((x) > (y) ? (y) : (x))
+#define max(x, y) ((x) > (y) ? (x) : (y))
+
 #endif

--- a/nvme.c
+++ b/nvme.c
@@ -55,9 +55,6 @@
 
 #include "fabrics.h"
 
-#define min(x, y) ((x) > (y) ? (y) : (x))
-#define max(x, y) ((x) > (y) ? (x) : (y))
-
 static struct stat nvme_stat;
 const char *devicename;
 

--- a/nvme.c
+++ b/nvme.c
@@ -45,6 +45,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 
+#include "common.h"
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
 #include "nvme-lightnvm.h"
@@ -54,7 +55,6 @@
 
 #include "fabrics.h"
 
-#define array_len(x) ((size_t)(sizeof(x) / sizeof(x[0])))
 #define min(x, y) ((x) > (y) ? (y) : (x))
 #define max(x, y) ((x) > (y) ? (x) : (y))
 
@@ -3767,9 +3767,9 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	if (fd < 0)
 		return fd;
 
-	nc = argconfig_parse_comma_sep_array(cfg.ctx_attrs, ctx_attrs, array_len(ctx_attrs));
-	nb = argconfig_parse_comma_sep_array(cfg.blocks, nlbs, array_len(nlbs));
-	ns = argconfig_parse_comma_sep_array_long(cfg.slbas, slbas, array_len(slbas));
+	nc = argconfig_parse_comma_sep_array(cfg.ctx_attrs, ctx_attrs, ARRAY_SIZE(ctx_attrs));
+	nb = argconfig_parse_comma_sep_array(cfg.blocks, nlbs, ARRAY_SIZE(nlbs));
+	ns = argconfig_parse_comma_sep_array_long(cfg.slbas, slbas, ARRAY_SIZE(slbas));
 	nr = max(nc, max(nb, ns));
 	if (!nr || nr > 256) {
 		fprintf(stderr, "No range definition provided\n");

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -7,6 +7,7 @@
 
 #include "linux/nvme_ioctl.h"
 
+#include "common.h"
 #include "nvme.h"
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
@@ -503,9 +504,6 @@ struct intel_cd_log {
 	__u32 entireDword;
     }u;
 };
-
-#define max(x,y) (x) > (y) ? (x) : (y)
-#define min(x,y) (x) > (y) ? (y) : (x)
 
 static void print_intel_nlog(struct intel_vu_nlog *intel_nlog)
 {

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -12,9 +12,8 @@
 #include <sys/ioctl.h>
 
 #define CREATE_CMD
+#include "common.h"
 #include "micron-nvme.h"
-#define min(x, y) ((x) > (y) ? (y) : (x))
-
 
 static int micron_fw_commit(int fd, int select)
 {

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -31,6 +31,7 @@
 
 #include "linux/nvme_ioctl.h"
 
+#include "common.h"
 #include "nvme.h"
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
@@ -260,8 +261,6 @@
 #define WDC_DE_EVENT_LOG_FILE_NAME			"event_log"
 #define WDC_DE_DESTN_SPI				1
 #define WDC_DE_DUMPTRACE_DESTINATION			6
-
-#define min(x, y) ((x) > (y) ? (y) : (x))
 
 typedef enum _NVME_FEATURES_SELECT
 {


### PR DESCRIPTION
Hi,
This patchset cleans-up code quality by removing duplicated macros.

```
Minwoo Im (2):
  nvme: Use ARRAY_SIZE() macro in common.h
  nvme: Unify min(), max() macro as a common one

 common.h                     |  3 +++
 nvme.c                       | 11 ++++-------
 plugins/intel/intel-nvme.c   |  4 +---
 plugins/micron/micron-nvme.c |  3 +--
 plugins/wdc/wdc-nvme.c       |  3 +--
 5 files changed, 10 insertions(+), 14 deletions(-)
```