### PR TITLE
tests: Update print to print() for python3

### DIFF
--- a/tests/nvme_create_max_ns_test.py
+++ b/tests/nvme_create_max_ns_test.py
@@ -77,21 +77,21 @@ class TestNVMeCreateMaxNS(TestNVMe):
     def test_attach_detach_ns(self):
         """ Testcase main """
         for nsid in range(1, self.max_ns):
-            print "##### Creating " + str(nsid)
+            print("##### Creating " + str(nsid))
             err = self.create_and_validate_ns(nsid,
                                               self.nsze,
                                               self.ncap,
                                               self.flbas,
                                               self.dps)
             assert_equal(err, 0)
-            print "##### Attaching " + str(nsid)
+            print("##### Attaching " + str(nsid))
             assert_equal(self.attach_ns(self.ctrl_id, nsid), 0)
-            print "##### Running IOs in " + str(nsid)
+            print("##### Running IOs in " + str(nsid))
             self.run_ns_io(nsid, 0)
 
         for nsid in range(1, self.max_ns):
-            print "##### Detaching " + str(nsid)
+            print("##### Detaching " + str(nsid))
             assert_equal(self.detach_ns(self.ctrl_id, nsid), 0)
-            print "#### Deleting " + str(nsid)
+            print("#### Deleting " + str(nsid))
             assert_equal(self.delete_and_validate_ns(nsid), 0)
         self.nvme_reset_ctrl()

--- a/tests/nvme_flush_test.py
+++ b/tests/nvme_flush_test.py
@@ -53,7 +53,7 @@ class TestNVMeFlushCmd(TestNVMe):
                - None
         """
         flush_cmd = "nvme flush " + self.ctrl + " -n " + str(self.default_nsid)
-        print flush_cmd
+        print(flush_cmd)
         return self.exec_cmd(flush_cmd)
 
     def test_nvme_flush(self):

--- a/tests/nvme_format_test.py
+++ b/tests/nvme_format_test.py
@@ -127,9 +127,9 @@ class TestNVMeFormatCmd(TestNVMe):
 
         # iterate through all supported format
         for i in range(0, len(self.lba_format_list)):
-            print "\nlba format " + str(self.lba_format_list[i]) + \
+            print("\nlba format " + str(self.lba_format_list[i]) + \
                   " lbad       " + str(self.lbads_list[i]) + \
-                  " ms         " + str(self.ms_list[i])
+                  " ms         " + str(self.ms_list[i]))
             metadata_size = 1 if self.ms_list[i] == '8' else 0
             err = self.create_and_validate_ns(self.default_nsid,
                                               self.nsze,

--- a/tests/nvme_fw_log_test.py
+++ b/tests/nvme_fw_log_test.py
@@ -61,7 +61,7 @@ class TestNVMeFwLogCmd(TestNVMe):
                                 shell=True,
                                 stdout=subprocess.PIPE)
         fw_log_output = proc.communicate()[0]
-        print fw_log_output + "\n"
+        print(fw_log_output + "\n")
         err = proc.wait()
         return err
 

--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -85,7 +85,7 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
                                         shell=True,
                                         stdout=subprocess.PIPE)
                 feature_output = proc.communicate()[0]
-                print feature_output
+                print(feature_output)
                 assert_equal(proc.wait(), 0)
         else:
             get_feat_cmd = "nvme get-feature " + self.ctrl + \
@@ -94,7 +94,7 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
                                     shell=True,
                                     stdout=subprocess.PIPE)
             feature_output = proc.communicate()[0]
-            print feature_output
+            print(feature_output)
             assert_equal(proc.wait(), 0)
 
     def test_get_mandatory_features(self):

--- a/tests/nvme_id_ns_test.py
+++ b/tests/nvme_id_ns_test.py
@@ -64,7 +64,7 @@ class TestNVMeIdentifyNamespace(TestNVMe):
                                 shell=True,
                                 stdout=subprocess.PIPE)
         id_ns_output = proc.communicate()[0]
-        print id_ns_output + "\n"
+        print(id_ns_output + "\n")
         err = proc.wait()
         return err
 

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -202,7 +202,7 @@ class TestNVMe(object):
             if pattern.match(line):
                 max_ns = line.split(":")[1].strip()
                 break
-        print max_ns
+        print(max_ns)
         return int(max_ns)
 
     @tools.nottest
@@ -226,7 +226,7 @@ class TestNVMe(object):
             if pattern.match(line):
                 ncap = line.split(":")[1].strip()
                 break
-        print ncap
+        print(ncap)
         return int(ncap)
 
     @tools.nottest
@@ -249,7 +249,7 @@ class TestNVMe(object):
         for line in proc.stdout:
             if "in use" in line:
                 nvm_format = 2 ** int(line.split(":")[3].split()[0])
-        print nvm_format
+        print(nvm_format)
         return int(nvm_format)
 
     @tools.nottest
@@ -370,7 +370,7 @@ class TestNVMe(object):
                 - 0 on success, error code on failure.
         """
         smart_log_cmd = "nvme smart-log " + self.ctrl + " -n " + str(nsid)
-        print smart_log_cmd
+        print(smart_log_cmd)
         proc = subprocess.Popen(smart_log_cmd,
                                 shell=True,
                                 stdout=subprocess.PIPE)
@@ -391,10 +391,10 @@ class TestNVMe(object):
                 host_write_commands = \
                     string.replace(line.split(":")[1].strip(), ",", "")
 
-        print "data_units_read " + data_units_read
-        print "data_units_written " + data_units_written
-        print "host_read_commands " + host_read_commands
-        print "host_write_commands " + host_write_commands
+        print("data_units_read " + data_units_read)
+        print("data_units_written " + data_units_written)
+        print("host_read_commands " + host_read_commands)
+        print("host_write_commands " + host_write_commands)
         return err
 
     def get_id_ctrl(self, vendor=False):
@@ -408,7 +408,7 @@ class TestNVMe(object):
             id_ctrl_cmd = "nvme id-ctrl " + self.ctrl
         else:
             id_ctrl_cmd = "nvme id-ctrl -v " + self.ctrl
-        print id_ctrl_cmd
+        print(id_ctrl_cmd)
         proc = subprocess.Popen(id_ctrl_cmd,
                                 shell=True,
                                 stdout=subprocess.PIPE)
@@ -450,13 +450,13 @@ class TestNVMe(object):
         ns_path = self.ctrl + "n" + str(nsid)
         io_cmd = "dd if=" + ns_path + " of=/dev/null" + " bs=" + \
                  str(block_size) + " count=10 > /dev/null 2>&1"
-        print io_cmd
+        print(io_cmd)
         run_io = subprocess.Popen(io_cmd, shell=True, stdout=subprocess.PIPE)
         run_io_result = run_io.communicate()[1]
         assert_equal(run_io_result, None)
         io_cmd = "dd if=/dev/zero of=" + ns_path + " bs=" + \
                  str(block_size) + " count=10 > /dev/null 2>&1"
-        print io_cmd
+        print(io_cmd)
         run_io = subprocess.Popen(io_cmd, shell=True, stdout=subprocess.PIPE)
         run_io_result = run_io.communicate()[1]
         assert_equal(run_io_result, None)

--- a/tests/nvme_test_io.py
+++ b/tests/nvme_test_io.py
@@ -95,5 +95,5 @@ class TestNVMeIO(TestNVMe):
                    str(self.start_block) + " --block-count=" + \
                    str(self.block_count) + " --data-size=" + \
                    str(self.data_size) + " --data=" + self.read_file
-        print read_cmd
+        print(read_cmd)
         return self.exec_cmd(read_cmd)


### PR DESCRIPTION
```
The following issue has been reported that README in "tests" seems not
correct because it will not be able to be invoked in case python3
because print() has to be taken instead of print which had been used for
python2.

Issue !429:
  https://github.com/linux-nvme/nvme-cli/issues/429

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>
```