### PR TITLE
plugin: Return EINVAL instead of ENOTTY

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4962,7 +4962,7 @@ int main(int argc, char **argv)
 	setlocale(LC_ALL, "");
 
 	ret = handle_plugin(argc - 1, &argv[1], nvme.extensions);
-	if (ret == -ENOTTY)
+	if (ret == -EINVAL)
 		general_help(&builtin);
 
 	return ret;

--- a/plugin.c
+++ b/plugin.c
@@ -161,7 +161,7 @@ int handle_plugin(int argc, char **argv, struct plugin *plugin)
 	/* Check extensions only if this is running the built-in plugin */
 	if (plugin->name) { 
 		printf("ERROR: Invalid sub-command '%s' for plugin %s\n", str, plugin->name);
-		return -ENOTTY;
+		return -EINVAL;
         }
 
 	extension = plugin->next;
@@ -184,5 +184,5 @@ int handle_plugin(int argc, char **argv, struct plugin *plugin)
 		extension = extension->next;
 	}
 	printf("ERROR: Invalid sub-command '%s'\n", str);
-	return -ENOTTY;
+	return -EINVAL;
 }


### PR DESCRIPTION
```
When a given string for a subcommand is not valid, we can return EINVAL which
means invalid arguments.  ENOTTY is used to indicate that an invalid IOCTL
number was specified.

Signed-off-by: Minwoo Im <minwoo.im@samsung.com>
```