### PR TITLE
Always use 0x prefix for hexdecimal values of id-ctrl output

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -970,10 +970,10 @@ void __show_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode, void (*ve
 	if (human)
 		show_nvme_id_ctrl_cmic(ctrl->cmic);
 	printf("mdts      : %d\n", ctrl->mdts);
-	printf("cntlid    : %x\n", le16_to_cpu(ctrl->cntlid));
-	printf("ver       : %x\n", le32_to_cpu(ctrl->ver));
-	printf("rtd3r     : %x\n", le32_to_cpu(ctrl->rtd3r));
-	printf("rtd3e     : %x\n", le32_to_cpu(ctrl->rtd3e));
+	printf("cntlid    : %#x\n", le16_to_cpu(ctrl->cntlid));
+	printf("ver       : %#x\n", le32_to_cpu(ctrl->ver));
+	printf("rtd3r     : %#x\n", le32_to_cpu(ctrl->rtd3r));
+	printf("rtd3e     : %#x\n", le32_to_cpu(ctrl->rtd3e));
 	printf("oaes      : %#x\n", le32_to_cpu(ctrl->oaes));
 	if (human)
 		show_nvme_id_ctrl_oaes(ctrl->oaes);
@@ -1060,7 +1060,7 @@ void __show_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode, void (*ve
 	if (human)
 		show_nvme_id_ctrl_nwpc(ctrl->nwpc);
 	printf("acwu      : %d\n", le16_to_cpu(ctrl->acwu));
-	printf("sgls      : %x\n", le32_to_cpu(ctrl->sgls));
+	printf("sgls      : %#x\n", le32_to_cpu(ctrl->sgls));
 	if (human)
 		show_nvme_id_ctrl_sgls(ctrl->sgls);
 	printf("mnan      : %d\n", le32_to_cpu(ctrl->mnan));
@@ -1068,7 +1068,7 @@ void __show_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode, void (*ve
 	printf("ioccsz    : %d\n", le32_to_cpu(ctrl->ioccsz));
 	printf("iorcsz    : %d\n", le32_to_cpu(ctrl->iorcsz));
 	printf("icdoff    : %d\n", le16_to_cpu(ctrl->icdoff));
-	printf("ctrattr   : %x\n", ctrl->ctrattr);
+	printf("ctrattr   : %#x\n", ctrl->ctrattr);
 	if (human)
 		show_nvme_id_ctrl_ctrattr(ctrl->ctrattr);
 	printf("msdbd     : %d\n", ctrl->msdbd);


### PR DESCRIPTION
Sometimes human-readable id-ctrl output could be confusing, e.g.
```
$ nvme id-ctrl /dev/nvme0
NVME Identify Controller:
vid       : 0x144d
ssvid     : 0x144d
sn        : S3HDNX0K601842
mn        : SAMSUNG MZWLL1T6HEHP-00003
fr        : GPNA5B3Q
rab       : 8
ieee      : 002538
cmic      : 0x3
mdts      : 5
cntlid    : 21
...
```
Here cntlid value is hexdecimal and equals 33, but nothing shows that.
In the same time some other values have 0x prefix. Let's use the prefix
for all hexdecimal values of the output.

Signed-off-by: Alexander Larin <znahar@yandex-team.ru>