### PR TITLE
Fix passing CFLAGS on the make command line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CFLAGS ?= -O2 -g -Wall -Werror
-CFLAGS += -std=gnu99 -I.
-CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
+override CFLAGS += -std=gnu99 -I.
+override CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
 LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
 NVME = nvme
 INSTALL ?= install


### PR DESCRIPTION
Commit 254bcd6b2343 ("Fix CFLAGS parameter") only fixed the problem
if the variable came from the environment, not if it came from the
command line.  Fix it using 'override'.  See the GNU Make manual,
section 6.7 ("Overriding variables") for details.

Signed-off-by: Andy Lutomirski <luto@kernel.org>