### PR TITLE
For 1.9/fix double free in a loop

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -626,8 +626,10 @@ int nvme_get_properties(int fd, void **pbar)
 		err = get_property_helper(fd, offset, *pbar + offset, &advance);
 		if (!err)
 			ret = 0;
-		else
+		else {
 			free(*pbar);
+			break;
+		}
 	}
 
 	return ret;

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -612,7 +612,7 @@ int nvme_get_property(int fd, int offset, uint64_t *value)
 int nvme_get_properties(int fd, void **pbar)
 {
 	int offset, advance;
-	int err, ret = -EINVAL;
+	int err;
 	int size = getpagesize();
 
 	*pbar = malloc(size);
@@ -624,15 +624,13 @@ int nvme_get_properties(int fd, void **pbar)
 	memset(*pbar, 0xff, size);
 	for (offset = NVME_REG_CAP; offset <= NVME_REG_CMBSZ; offset += advance) {
 		err = get_property_helper(fd, offset, *pbar + offset, &advance);
-		if (!err)
-			ret = 0;
-		else {
+		if (err) {
 			free(*pbar);
 			break;
 		}
 	}
 
-	return ret;
+	return err;
 }
 
 int nvme_set_property(int fd, int offset, int value)


### PR DESCRIPTION
Hi Keith,
The first one needs to be merged to fix what Ken has reported. Also,
the second one will fix the return value of this function in case
get_property_helper() fails after the first time.

Reported from https://github.com/linux-nvme/nvme-cli/pull/471

```
Minwoo Im (2):
  ioctl: Fix double-free in a loop of get_property
  ioctl: Fix wrong return case of get_property

 nvme-ioctl.c | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
```

Thanks,