### PR TITLE
nvme-print: Few code clean-ups here

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -78,6 +78,12 @@ void d_raw(unsigned char *buf, unsigned len)
 		putchar(*(buf+i));
 }
 
+void show_nvme_status(__u16 status)
+{
+	fprintf(stderr, "NVMe status: %s(%#x)\n",
+			nvme_status_to_string(status), status);
+}
+
 static void format(char *formatter, size_t fmt_sz, char *tofmt, size_t tofmtsz)
 {
 

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1221,7 +1221,7 @@ void show_nvme_resv_report(struct nvme_reservation_status *status, int bytes, __
 	printf("\n");
 }
 
-static char *fw_to_string(__u64 fw)
+static const char *fw_to_string(__u64 fw)
 {
 	static char ret[9];
 	char *c = (char *)&fw;
@@ -1283,7 +1283,7 @@ static void show_effects_log_human(__u32 effect)
 		printf("  Reserved CSE\n");
 }
 
-static char *nvme_cmd_to_string(int admin, __u8 opcode)
+static const char *nvme_cmd_to_string(int admin, __u8 opcode)
 {
 	if (admin) {
 		switch (opcode) {
@@ -1625,7 +1625,7 @@ void show_sanitize_log(struct nvme_sanitize_log_page *sanitize, unsigned int mod
 	printf("Estimated Time For Crypto Erase               :  %u\n", le32_to_cpu(sanitize->est_crypto_erase_time));
 }
 
-char *nvme_feature_to_string(int feature)
+const char *nvme_feature_to_string(int feature)
 {
 	switch (feature) {
 	case NVME_FEAT_ARBITRATION:	return "Arbitration";
@@ -1657,7 +1657,7 @@ char *nvme_feature_to_string(int feature)
 	}
 }
 
-char *nvme_register_to_string(int reg)
+const char *nvme_register_to_string(int reg)
 {
 	switch (reg) {
 	case NVME_REG_CAP:	return "Controller Capabilities";
@@ -1676,7 +1676,7 @@ char *nvme_register_to_string(int reg)
 	}
 }
 
-char* nvme_select_to_string(int sel)
+const char *nvme_select_to_string(int sel)
 {
 	switch (sel) {
 	case 0:  return "Current";
@@ -1697,7 +1697,7 @@ void nvme_show_select_result(__u32 result)
 		printf("  Feature is changeable\n");
 }
 
-char *nvme_status_to_string(__u32 status)
+const char *nvme_status_to_string(__u32 status)
 {
 	switch (status & 0x3ff) {
 	case NVME_SC_SUCCESS:			return "SUCCESS: The command completed successfully";
@@ -1765,7 +1765,7 @@ char *nvme_status_to_string(__u32 status)
 	}
 }
 
-static char* nvme_feature_lba_type_to_string(__u8 type)
+static const char *nvme_feature_lba_type_to_string(__u8 type)
 {
 	switch (type) {
 	case 0:	return "Reserved";
@@ -1799,7 +1799,7 @@ void show_lba_range(struct nvme_lba_range_type *lbrt, int nr_ranges)
 }
 
 
-static char *nvme_feature_wl_hints_to_string(__u8 wh)
+static const char *nvme_feature_wl_hints_to_string(__u8 wh)
 {
 	switch (wh) {
 	case 0:	return "No Workload";
@@ -1809,7 +1809,7 @@ static char *nvme_feature_wl_hints_to_string(__u8 wh)
 	}
 }
 
-static char *nvme_feature_temp_type_to_string(__u8 type)
+static const char *nvme_feature_temp_type_to_string(__u8 type)
 {
 	switch (type) {
 	case 0:	return "Over Temperature Threshold";
@@ -1818,7 +1818,7 @@ static char *nvme_feature_temp_type_to_string(__u8 type)
 	}
 }
 
-static char *nvme_feature_temp_sel_to_string(__u8 sel)
+static const char *nvme_feature_temp_sel_to_string(__u8 sel)
 {
 	switch (sel)
 	{
@@ -1927,7 +1927,7 @@ void nvme_directive_show_fields(__u8 dtype, __u8 doper, unsigned int result, uns
         return;
 }
 
-static char *nvme_plm_window(__u32 plm)
+static const char *nvme_plm_window(__u32 plm)
 {
 	switch (plm & 0x7) {
 	case 1:
@@ -2977,7 +2977,7 @@ static void show_registers_cmbloc(__u32 cmbloc, __u32 cmbsz)
 	}
 }
 
-static char *nvme_register_szu_to_string(__u8 szu)
+static const char *nvme_register_szu_to_string(__u8 szu)
 {
 	switch (szu) {
 	case 0:	return "4 KB";

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -14,6 +14,7 @@ enum {
 
 void d(unsigned char *buf, int len, int width, int group);
 void d_raw(unsigned char *buf, unsigned len);
+void show_nvme_status(__u16 status);
 
 uint64_t int48_to_long(__u8 *data);
 

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -42,10 +42,10 @@ void show_nvme_id_nvmset(struct nvme_id_nvmset *nvmset);
 
 void nvme_feature_show_fields(__u32 fid, unsigned int result, unsigned char *buf);
 void nvme_directive_show_fields(__u8 dtype, __u8 doper, unsigned int result, unsigned char *buf);
-char *nvme_status_to_string(__u32 status);
-char *nvme_select_to_string(int sel);
-char *nvme_feature_to_string(int feature);
-char *nvme_register_to_string(int reg);
+const char *nvme_status_to_string(__u32 status);
+const char *nvme_select_to_string(int sel);
+const char *nvme_feature_to_string(int feature);
+const char *nvme_register_to_string(int reg);
 void nvme_show_select_result(__u32 result);
 
 void json_nvme_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode, void (*vendor_show)(__u8 *vs, struct json_object *root));

--- a/nvme.c
+++ b/nvme.c
@@ -214,8 +214,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 			show_smart_log(&smart_log, cfg.namespace_id, devicename);
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("smart log");
 
@@ -288,7 +287,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 		else
 			show_ana_log(ana_log, devicename);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("ana-log");
 	free(ana_log);
@@ -362,8 +361,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 
 	err = nvme_get_telemetry_log(fd, hdr, cfg.host_gen, cfg.ctrl_init, bs, 0);
 	if (err) {
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-			nvme_status_to_string(err), err);
+		show_nvme_status(err);
 		fprintf(stderr, "Failed to acquire telemetry header %d!\n", err);
 		goto close_output;
 	}
@@ -398,8 +396,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 		err = nvme_get_telemetry_log(fd, page_log, 0, cfg.ctrl_init, bs, offset);
 		if (err) {
 			fprintf(stderr, "Failed to acquire full telemetry log!\n");
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+			show_nvme_status(err);
 			break;
 		}
 
@@ -466,8 +463,7 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 		else
 			show_endurance_log(&endurance_log, cfg.group_id, devicename);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("endurance log");
 
@@ -529,8 +525,7 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 			show_effects_log(&effects, flags);
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("effects log page");
 
@@ -612,8 +607,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 				show_error_log(err_log, cfg.log_entries, devicename);
 		}
 		else if (err > 0)
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-						nvme_status_to_string(err), err);
+			show_nvme_status(err);
 		else
 			perror("error log");
 		free(err_log);
@@ -669,8 +663,7 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 			show_fw_log(&fw_log, devicename);
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("fw log");
 
@@ -725,7 +718,7 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 		else
 			show_changed_ns_list_log(&changed_ns_list_log, devicename);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("changed ns list log");
 
@@ -823,8 +816,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 			} else
 				d_raw((unsigned char *)log, cfg.log_len);
 		} else if (err > 0)
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-						nvme_status_to_string(err), err);
+			show_nvme_status(err);
 		else
 			perror("log page");
 		free(log);
@@ -888,7 +880,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 			show_sanitize_log(&sanitize_log, flags, devicename);
 	}
 	else if (ret > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
+		show_nvme_status(ret);
 	else
 		perror("sanitize status log");
 
@@ -939,8 +931,7 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 			printf("[%4u]:%#x\n", i, le16_to_cpu(cntlist->identifier[i]));
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x) cntid:%d\n",
-			nvme_status_to_string(err), err, cfg.cntid);
+		show_nvme_status(err);
 	else
 		perror("id controller list");
 
@@ -986,8 +977,7 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 				printf("[%4u]:%#x\n", i, le32_to_cpu(ns_list[i]));
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x) NSID:%d\n",
-			nvme_status_to_string(err), err, cfg.namespace_id);
+		show_nvme_status(err);
 	else
 		perror("id namespace list");
 
@@ -1058,8 +1048,7 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		printf("%s: Success, deleted nsid:%d\n", cmd->name,
 								cfg.namespace_id);
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("delete namespace");
 
@@ -1124,8 +1113,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	if (!err)
 		printf("%s: Success, nsid:%d\n", cmd->name, cfg.namespace_id);
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror(attach ? "attach namespace" : "detach namespace");
 
@@ -1220,10 +1208,10 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		if (err) {
 			if (err < 0)
 				perror("identify-namespace");
-			else
-				fprintf(stderr,
-					"NVME Admin command error:%s(%x)\n",
-					nvme_status_to_string(err), err);
+			else {
+				fprintf(stderr, "identify failed\n");
+				show_nvme_status(err);
+			}
 			return err;
 		}
 		for (i = 0; i < 16; ++i) {
@@ -1249,8 +1237,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	if (!err)
 		printf("%s: Success, created nsid:%d\n", cmd->name, nsid);
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("create namespace");
 
@@ -1846,8 +1833,8 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 			list_cnt++;
 		}
 		else if (ret > 0) {
-			fprintf(stderr, "%s: failed to obtain nvme info: %s\n",
-					path, nvme_status_to_string(ret));
+			fprintf(stderr, "identify failed\n");
+			show_nvme_status(ret);
 		}
 		else {
 			fprintf(stderr, "%s: failed to obtain nvme info: %s\n",
@@ -1937,8 +1924,7 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 		}
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		perror("identify controller");
 
@@ -2017,8 +2003,7 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 		}
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x) NSID:%d\n",
-			nvme_status_to_string(err), err, cfg.namespace_id);
+		show_nvme_status(err);
 	else
 		perror("identify namespace");
 
@@ -2107,8 +2092,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		}
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x) NSID:%d\n",
-			nvme_status_to_string(err), err, cfg.namespace_id);
+		show_nvme_status(err);
 	else
 		perror("identify namespace");
 
@@ -2166,8 +2150,7 @@ static int id_nvmset(int argc, char **argv, struct command *cmd, struct plugin *
 		}
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x) NVMSETID:%d\n",
-			nvme_status_to_string(err), err, cfg.nvmset_id);
+		show_nvme_status(err);
 	else
 		perror("identify nvm set list");
 
@@ -2258,8 +2241,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 		printf("success, Number of Resources allocated:%#x\n", result);
 	}
 	else if (err > 0) {
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	} else
 		perror("virt-mgmt");
 
@@ -2308,8 +2290,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 		else
 			printf("Device self-test started\n");
 	} else if (err > 0) {
-		fprintf(stderr, "NVMe Status:%s(%x) NSID:%d\n",
-			nvme_status_to_string(err), err, cfg.namespace_id);
+		show_nvme_status(err);
 	} else
 		perror("Device self-test");
 
@@ -2362,8 +2343,7 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 				self_test_log.crnt_dev_selftest_compln);
 		}
 	} else if (err > 0) {
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	} else {
 		perror("self_test_log");
 	}
@@ -2492,8 +2472,7 @@ static int get_feature(int argc, char **argv, struct command *cmd, struct plugin
 		} else if (buf)
 			d_raw(buf, cfg.data_len);
 	} else if (err > 0) {
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	} else
 		perror("get-feature");
 
@@ -2591,8 +2570,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 			perror("fw-download");
 			break;
 		} else if (err != 0) {
-			fprintf(stderr, "NVME Admin command error:%s(%x)\n",
-					nvme_status_to_string(err), err);
+			show_nvme_status(err);
 			break;
 		}
 		fw_buf     += cfg.xfer;
@@ -2688,8 +2666,7 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 			printf(", but firmware requires %s reset\n", nvme_fw_status_reset_type(err));
 			break;
 		default:
-			fprintf(stderr, "NVME Admin command error:%s(%x)\n",
-						nvme_status_to_string(err), err);
+			show_nvme_status(err);
 			break;
 		}
 	else {
@@ -2864,8 +2841,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	ret = nvme_sanitize(fd, cfg.sanact, cfg.ause, cfg.owpass, cfg.oipbp,
 			    cfg.no_dealloc, cfg.ovrpat);
 	if (ret)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(ret), ret);
+		show_nvme_status(ret);
 
  close_fd:
 	close(fd);
@@ -2989,8 +2965,7 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 	} else if (!err) {
 		show_single_property(cfg.offset, value, cfg.human_readable);
 	} else if (err > 0) {
-		fprintf(stderr, "NVMe Status: %s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	}
 
  close_fd:
@@ -3045,8 +3020,7 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 		printf("set-property: %02x (%s), value: %#08x\n", cfg.offset,
 				nvme_register_to_string(cfg.offset), cfg.value);
 	} else if (err > 0) {
-		fprintf(stderr, "NVMe Status: %s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	}
 
  close_fd:
@@ -3139,10 +3113,10 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		if (err) {
 			if (err < 0)
 				perror("identify-namespace");
-			else
-				fprintf(stderr,
-					"NVME Admin command error:%s(%x)\n",
-					nvme_status_to_string(err), err);
+			else {
+				fprintf(stderr, "identify failed\n");
+				show_nvme_status(err);
+			}
 			return err;
 		}
 		prev_lbaf = ns.flbas & 0xf;
@@ -3199,8 +3173,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	if (err < 0)
 		perror("format");
 	else if (err != 0)
-		fprintf(stderr, "NVME Admin command error:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else {
 		printf("Success formatting namespace:%x\n", cfg.namespace_id);
 		ioctl(fd, BLKRRPART);
@@ -3321,8 +3294,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 				d(buf, cfg.data_len, 16, 1);
 		}
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 
  close_ffd:
 	close(ffd);
@@ -3569,8 +3541,7 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		}
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 
 close_ffd:
 	close(ffd);
@@ -3627,8 +3598,7 @@ static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin
 	if (err < 0)
 		perror("write uncorrectable");
 	else if (err != 0)
-		fprintf(stderr, "NVME IO command error:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		printf("NVME Write Uncorrectable Success\n");
 
@@ -3720,8 +3690,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	if (err < 0)
 		perror("write-zeroes");
 	else if (err != 0)
-		fprintf(stderr, "NVME IO command error:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		printf("NVME Write Zeroes Success\n");
 
@@ -3821,8 +3790,7 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	if (err < 0)
 		perror("data-set management");
 	else if (err != 0)
-		fprintf(stderr, "NVME IO command error:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		printf("NVMe DSM: success\n");
 
@@ -3870,8 +3838,7 @@ static int flush(int argc, char **argv, struct command *cmd, struct plugin *plug
 	if (err < 0)
 		perror("flush");
 	else if (err != 0)
-		fprintf(stderr, "NVME IO command error:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		printf("NVMe Flush: success\n");
 close_fd:
@@ -3944,7 +3911,7 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	if (err < 0)
 		perror("reservation acquire");
 	else if (err != 0)
-		fprintf(stderr, "NVME IO command error:%s(%x)\n", nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		printf("NVME Reservation Acquire success\n");
 
@@ -4021,7 +3988,7 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 	if (err < 0)
 		perror("reservation register");
 	else if (err != 0)
-		fprintf(stderr, "NVME IO command error:%s(%x)\n", nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		printf("NVME Reservation  success\n");
 
@@ -4094,7 +4061,7 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 	if (err < 0)
 		perror("reservation release");
 	else if (err != 0)
-		fprintf(stderr, "NVME IO command error:%s(%x)\n", nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else
 		printf("NVME Reservation Release success\n");
 
@@ -4412,7 +4379,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	if (err < 0)
 		perror("submit-io");
 	else if (err)
-		fprintf(stderr, "%s:%s(%04x)\n", command, nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else {
 		if (!(opcode & 1) && write(dfd, (void *)buffer, cfg.data_size) < 0) {
 			fprintf(stderr, "write: %s: failed to write buffer to output file\n",
@@ -4669,8 +4636,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 		}
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 free:
 	if (cfg.data_len)
 		free(buf);
@@ -4854,8 +4820,7 @@ static int passthru(int argc, char **argv, int ioctl_cmd, const char *desc, stru
 	if (err < 0)
 		perror("passthru");
 	else if (err)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		show_nvme_status(err);
 	else  {
 		if (!cfg.raw_binary) {
 			fprintf(stderr, "NVMe command result:%08x\n", result);

--- a/nvme.c
+++ b/nvme.c
@@ -360,7 +360,9 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	}
 
 	err = nvme_get_telemetry_log(fd, hdr, cfg.host_gen, cfg.ctrl_init, bs, 0);
-	if (err) {
+	if (err < 0)
+		perror("get-telemetry-log");
+	else if (err > 0) {
 		show_nvme_status(err);
 		fprintf(stderr, "Failed to acquire telemetry header %d!\n", err);
 		goto close_output;
@@ -394,7 +396,10 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	 */
 	while (offset != full_size) {
 		err = nvme_get_telemetry_log(fd, page_log, 0, cfg.ctrl_init, bs, offset);
-		if (err) {
+		if (err < 0) {
+			perror("get-telemetry-log");
+			break;
+		} else if (err > 0) {
 			fprintf(stderr, "Failed to acquire full telemetry log!\n");
 			show_nvme_status(err);
 			break;

--- a/nvme.c
+++ b/nvme.c
@@ -2845,7 +2845,9 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	ret = nvme_sanitize(fd, cfg.sanact, cfg.ause, cfg.owpass, cfg.oipbp,
 			    cfg.no_dealloc, cfg.ovrpat);
-	if (ret)
+	if (ret < 0)
+		perror("sanitize");
+	else if (ret > 0)
 		show_nvme_status(ret);
 
  close_fd:


### PR DESCRIPTION
Hi @keithbusch ,

Minor patches are here without any functional changes.  The first one
introduces a common API to print out nvme status in case of error.  The second
makes function which returns string type to have const with it. The third and
fourth make printing nvme status to be in case of return value is positive.

```
Minwoo Im (4):
  print: Introduce show_nvme_status to print nvme status
  print: Add const to return type of string
  get-telemtry-log: Print nvme status in case err > 0
  sanitize: Print nvme status in case ret > 0

 nvme-print.c |  30 ++++++----
 nvme-print.h |   9 +--
 nvme.c       | 152 +++++++++++++++++++++------------------------------
 3 files changed, 85 insertions(+), 106 deletions(-)
```