### PR TITLE
nvme: Do not return directly without freeing fd

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -925,7 +925,8 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 
 	if (posix_memalign((void *)&cntlist, getpagesize(), 0x1000)) {
 		fprintf(stderr, "can not allocate controller list payload\n");
-		return ENOMEM;
+		err = -ENOMEM;
+		goto close_fd;
 	}
 
 	err = nvme_identify_ctrl_list(fd, cfg.namespace_id, cfg.cntid, cntlist);
@@ -942,6 +943,7 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 
 	free(cntlist);
 
+close_fd:
 	close(fd);
 
 	return err;


### PR DESCRIPTION
Hi @keithbusch ,

This patchsets fix fd-leak in caes of error.  This branch might be
conflicted if prefious PR is merged first.  Then I'll rebase it after
all.

```
Minwoo Im (3):
  format: Do not return directly without freeing fd
  create-ns: Do not return directly without freeing fd
  list-ctrl: Do not return directly without freeing fd

 nvme.c | 28 +++++++++++++++++++---------
 1 file changed, 19 insertions(+), 9 deletions(-)
```