### PR TITLE
Need to reset varialbe len in function show_nvme_id_ns_descs()

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -864,6 +864,7 @@ void show_nvme_id_ns_descs(void *data)
 
 	for (pos = 0; pos < NVME_IDENTIFY_DATA_SIZE; pos += len) {
 		struct nvme_ns_id_desc *cur = data + pos;
+		len = 0;
 
 		if (cur->nidl == 0)
 			break;


### PR DESCRIPTION
When print the NSID descriptor list, the for loop did not reset len at each loop, cause the third item cannot be displayed.