### PR TITLE
For 1.9/fit print property size

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -577,7 +577,7 @@ static int nvme_property(int fd, __u8 fctype, __le32 off, __le64 *value, __u8 at
 	return err;
 }
 
-static int get_property_helper(int fd, int offset, void *value)
+int nvme_get_property(int fd, int offset, uint64_t *value)
 {
 	__le64 value64;
 	int err = -EINVAL;
@@ -598,11 +598,6 @@ static int get_property_helper(int fd, int offset, void *value)
 	return err;
 }
 
-int nvme_get_property(int fd, int offset, uint64_t *value)
-{
-	return get_property_helper(fd, offset, value);
-}
-
 int nvme_get_properties(int fd, void **pbar)
 {
 	int offset;
@@ -617,7 +612,7 @@ int nvme_get_properties(int fd, void **pbar)
 
 	memset(*pbar, 0xff, size);
 	for (offset = NVME_REG_CAP; offset <= NVME_REG_CMBSZ;) {
-		err = get_property_helper(fd, offset, *pbar + offset);
+		err = nvme_get_property(fd, offset, *pbar + offset);
 		if (err) {
 			free(*pbar);
 			break;

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3296,8 +3296,14 @@ void show_single_property(int offset, uint64_t value64, int human)
 	uint32_t value32;
 
 	if (!human) {
-		printf("property: 0x%02x (%s), value: %"PRIx64"\n", offset,
-			   nvme_register_to_string(offset), value64);
+		if (is_64bit_reg(offset))
+			printf("property: 0x%02x (%s), value: %"PRIx64"\n", offset,
+				   nvme_register_to_string(offset), value64);
+		else
+			printf("property: 0x%02x (%s), value: %x\n", offset,
+				   nvme_register_to_string(offset),
+				   (uint32_t) value64);
+
 		return;
 	}
 

--- a/nvme.h
+++ b/nvme.h
@@ -177,4 +177,28 @@ int	validate_output_format(char *format);
 struct subsys_list_item *get_subsys_list(int *subcnt, char *subsysnqn, __u32 nsid);
 void free_subsys_list(struct subsys_list_item *slist, int n);
 char *nvme_char_from_block(char *block);
+
+/*
+ * is_64bit_reg - It checks whether given offset of the controller register is
+ *                64bit or not.
+ * @offset: offset of controller register field in bytes
+ *
+ * It gives true if given offset is 64bit register, otherwise it returns false.
+ *
+ * Notes:  This function does not care about transport so that the offset is
+ * not going to be checked inside of this function for the unsupported fields
+ * in a specific transport.  For example, BPMBL(Boot Partition Memory Buffer
+ * Location) register is not supported by fabrics, but it can be chcked here.
+ */
+static inline bool is_64bit_reg(__u32 offset)
+{
+	if (offset == NVME_REG_CAP ||
+			offset == NVME_REG_ASQ ||
+			offset == NVME_REG_ACQ ||
+			offset == NVME_REG_BPMBL)
+		return true;
+
+	return false;
+}
+
 #endif /* _NVME_H */


### PR DESCRIPTION
Hi,

If you follow the commands below, you can see an over-printed
result of the get-property command in fabrics env.
```bash
# nvme get-property /dev/nvme0 -o 0x14
property: 0x14 (Controller Configuration), value: 7f7800460001
```
But, If you have an option with `-H`, then the value would be printed
out in 32bit size which is intended.  So this patchset fixes the case
whose human option is not given to print out proper size of it.

```
Minwoo Im (3):
  property: Introduce inline function to check 64bit reg
  property: Remove unnecessary wrapper function
  property: Fit print size for a property

 nvme-ioctl.c | 30 ++++++++----------------------
 nvme-print.c | 10 ++++++++--
 nvme.h       | 24 ++++++++++++++++++++++++
 3 files changed, 40 insertions(+), 24 deletions(-)
```