### PR TITLE
DOC: Move to DocBook 5 when using asciidoctor

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -28,7 +28,7 @@ ASCIIDOC_COMMON = $(ASCIIDOC) $(ASCIIDOC_EXTRA)
 TXT_TO_XML = $(ASCIIDOC_COMMON) -b $(ASCIIDOC_DOCBOOK)
 MANPAGE_XSL = manpage-normal.xsl
 XMLTO = xmlto
-XMLTO_EXTRA =
+XMLTO_EXTRA = --skip-validation
 INSTALL ?= install
 RM ?= rm -f
 MAN_REPO = ../../nvme-manpages
@@ -40,7 +40,7 @@ ifdef USE_ASCIIDOCTOR
 ASCIIDOC = asciidoctor
 ASCIIDOC_CONF =
 ASCIIDOC_HTML = xhtml5
-ASCIIDOC_DOCBOOK = docbook45
+ASCIIDOC_DOCBOOK = docbook5
 ASCIIDOC_EXTRA += -acompat-mode
 ASCIIDOC_EXTRA += -I. -rasciidoctor-extensions
 ASCIIDOC_EXTRA += -alitdd='&\#x2d;&\#x2d;'


### PR DESCRIPTION
DocBook 5 has been released about a decade ago. Newer versions of
asciidoctor (since version 2.x) no longer support the previously
used DocBook 4.x format, so it is about time for us to switch too.

Fixes #495