### PR TITLE
nvme-print: update self-test log to include 'aborted due to sanitize'

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1549,7 +1549,7 @@ void show_self_test_log(struct nvme_self_test_log *self_test, const char *devnam
 {
 	int i, temp;
 	const char *test_code_res;
-	const char *test_res[10] = {
+	static const char *const test_res[] = {
 		"Operation completed without error",
 		"Operation was aborted by a Device Self-test command",
 		"Operation was aborted by a Controller Level Reset",
@@ -1561,6 +1561,7 @@ void show_self_test_log(struct nvme_self_test_log *self_test, const char *devnam
 		"Operation completed with one or more failed segments and the first segment that failed "\
 		"is indicated in the SegmentNumber field",
 		"Operation was aborted for unknown reason",
+		"Operation was aborted due to a sanitize operation",
 		"Reserved"
 	};
 
@@ -1574,7 +1575,7 @@ void show_self_test_log(struct nvme_self_test_log *self_test, const char *devnam
 
 		printf("Result[%d]:\n", i);
 		printf("  Test Result                  : %#x %s\n", temp,
-			test_res[temp > 9 ? 9 : temp]);
+			test_res[temp > 10 ? 10 : temp]);
 
 		temp = self_test->result[i].device_self_test_status >> 4;
 		switch (temp) {


### PR DESCRIPTION
TP 4022 states that when a sanitize operation is started, self-test
operations in progress shall be aborted. The device-self test log page
includes a new result code that indicates if a self-test was aborted due
to a sanitize operation.

Signed-off-by: Kenneth Heitke <kenneth.heitke@intel.com>