### PR TITLE
fix json print for list-subsys command

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2875,7 +2875,6 @@ void json_print_nvme_subsystem_list(struct subsys_list_item *slist, int n)
 	struct json_object *subsystem_attrs;
 	struct json_array *paths;
 	struct json_object *path_attrs;
-	struct json_object *path_object;
 	int i, j;
 
 	root = json_create_object();
@@ -2892,7 +2891,6 @@ void json_print_nvme_subsystem_list(struct subsys_list_item *slist, int n)
 		json_array_add_value_object(subsystems, subsystem_attrs);
 
 		paths = json_create_array();
-		path_object = json_create_object();
 
 		for (j = 0; j < slist[i].nctrls; j++) {
 			path_attrs = json_create_object();
@@ -2911,9 +2909,7 @@ void json_print_nvme_subsystem_list(struct subsys_list_item *slist, int n)
 			json_array_add_value_object(paths, path_attrs);
 		}
 		if (j) {
-			json_object_add_value_array(path_object, "Paths",
-					paths);
-			json_array_add_value_object(subsystems, path_object);
+			json_object_add_value_array(subsystem_attrs, "Paths", paths);
 		}
 
 	}


### PR DESCRIPTION
The bug was the instead of adding paths to to the subsystem object it
was added as a new subsystem