### PR TITLE
fix false error in nvme_get_property

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -601,7 +601,7 @@ int nvme_get_property(int fd, int offset, uint64_t *value)
 int nvme_get_properties(int fd, void **pbar)
 {
 	int offset;
-	int err;
+	int err, ret = EINVAL;
 	int size = getpagesize();
 
 	*pbar = malloc(size);
@@ -613,15 +613,17 @@ int nvme_get_properties(int fd, void **pbar)
 	memset(*pbar, 0xff, size);
 	for (offset = NVME_REG_CAP; offset <= NVME_REG_CMBSZ;) {
 		err = nvme_get_property(fd, offset, *pbar + offset);
-		if (err) {
-			free(*pbar);
-			break;
+		if (!err) {
+			ret=0;
 		}
 
 		offset += is_64bit_reg(offset) ? 8 : 4;
 	}
 
-	return err;
+	if(*pbar)
+		free(*pbar);
+
+	return ret;
 }
 
 int nvme_set_property(int fd, int offset, int value)

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -601,7 +601,7 @@ int nvme_get_property(int fd, int offset, uint64_t *value)
 int nvme_get_properties(int fd, void **pbar)
 {
 	int offset;
-	int err, ret = EINVAL;
+	int err, ret = -EINVAL;
 	int size = getpagesize();
 
 	*pbar = malloc(size);
@@ -620,7 +620,7 @@ int nvme_get_properties(int fd, void **pbar)
 		offset += is_64bit_reg(offset) ? 8 : 4;
 	}
 
-	if(*pbar)
+	if(ret)
 		free(*pbar);
 
 	return ret;


### PR DESCRIPTION
 When the target is NVMe Over fabrics device, the return value is possibly FAIL even though the device's status is normal. The reason is that get property CMD reponds with FAIL if the user tries to get reserved property such as INTMS, INTMC, and etc.

(NVMeOF's Property table is not the same as NVMe controller register table.)

Therefore, even if the return value is not successful, the loop must go on.