### PR TITLE
nvme-list: Add PCI B:D.f to list output

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2166,21 +2166,22 @@ static void show_list_item(struct list_item list_item)
 		nsze, s_suffix);
 	sprintf(format,"%3.0f %2sB + %2d B", (double)lba, l_suffix,
 		le16_to_cpu(list_item.ns.lbaf[(list_item.ns.flbas & 0x0f)].ms));
-	printf("%-16s %-*.*s %-*.*s %-9d %-26s %-16s %-.*s\n", list_item.node,
+	printf("%-16s %-*.*s %-*.*s %-9d %-26s %-16s %12s %-.*s\n", list_item.node,
             (int)sizeof(list_item.ctrl.sn), (int)sizeof(list_item.ctrl.sn), list_item.ctrl.sn,
             (int)sizeof(list_item.ctrl.mn), (int)sizeof(list_item.ctrl.mn), list_item.ctrl.mn,
-            list_item.nsid, usage, format, (int)sizeof(list_item.ctrl.fr), list_item.ctrl.fr);
+            list_item.nsid, usage, format, list_item.pci_bdf,
+	    (int)sizeof(list_item.ctrl.fr), list_item.ctrl.fr);
 }
 
 void show_list_items(struct list_item *list_items, unsigned len)
 {
 	unsigned i;
 
-	printf("%-16s %-20s %-40s %-9s %-26s %-16s %-8s\n",
-	    "Node", "SN", "Model", "Namespace", "Usage", "Format", "FW Rev");
-	printf("%-16s %-20s %-40s %-9s %-26s %-16s %-8s\n",
+	printf("%-16s %-20s %-40s %-9s %-26s %-16s %-12s %-8s\n",
+	    "Node", "SN", "Model", "Namespace", "Usage", "Format", "PCI Address", "FW Rev");
+	printf("%-16s %-20s %-40s %-9s %-26s %-16s %-12s %-8s\n",
             "----------------", "--------------------", "----------------------------------------",
-            "---------", "--------------------------", "----------------", "--------");
+            "---------", "--------------------------", "----------------", "------------", "--------");
 	for (i = 0 ; i < len ; i++)
 		show_list_item(list_items[i]);
 

--- a/nvme.c
+++ b/nvme.c
@@ -1842,6 +1842,10 @@ static char *path_trim_last(char *path, char needle)
 {
 	int i;
 	i = strlen(path);
+	if (i>0 && path[i-1] == needle) {	// remove trailing slash
+		path[i-1] = 0;
+		i--;
+	}
 	for (; i>0; i--)
 		if (path[i] == needle) {
 			path[i] = 0;

--- a/nvme.h
+++ b/nvme.h
@@ -152,6 +152,7 @@ struct list_item {
 	int                 nsid;
 	struct nvme_id_ns   ns;
 	unsigned            block;
+	char                pci_bdf[16];
 };
 
 struct ctrl_list_item {


### PR DESCRIPTION
The PCI address helps to distinguish between local and fabrics devices, and facilitates driver bind/unbind using sysfs.