### PR TITLE
list-subsys: show PCIe device addresses of local devices, even when running on legacy kernels

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1212,7 +1212,7 @@ static int discover_from_conf_file(const char *desc, char *argstr,
 
 		err = argconfig_parse(argc, argv, desc, opts);
 		if (err)
-			continue;
+			goto free_and_continue;
 
 		if (cfg.persistent && !cfg.keep_alive_tmo)
 			cfg.keep_alive_tmo = NVMF_DEF_DISC_TMO;
@@ -1220,15 +1220,14 @@ static int discover_from_conf_file(const char *desc, char *argstr,
 		err = build_options(argstr, BUF_SIZE, true);
 		if (err) {
 			ret = err;
-			continue;
+			goto free_and_continue;
 		}
 
 		err = do_discover(argstr, connect);
-		if (err) {
+		if (err)
 			ret = err;
-			continue;
-		}
 
+free_and_continue:
 		free(args);
 		free(argv);
 	}

--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -92,6 +92,56 @@ err_free_path:
 	return NULL;
 }
 
+static char *path_trim_last(char *path, char needle)
+{
+	int i;
+	i = strlen(path);
+	if (i>0 && path[i-1] == needle)		// remove trailing slash
+		path[--i] = 0;
+	for (; i>0; i--)
+		if (path[i] == needle) {
+			path[i] = 0;
+			return path+i+1;
+	}
+	return NULL;
+}
+
+static void legacy_get_pci_bdf(char *node, char *bdf)
+{
+	int ret;
+	char path[264], nodetmp[264];
+	struct stat st;
+	char *p;
+
+	bdf[0] = 0;
+	strcpy(nodetmp, node);
+	p = path_trim_last(nodetmp, '/');
+	sprintf(path, "/sys/block/%s/device", p);
+	ret = readlink(path, nodetmp, sizeof(nodetmp));
+	if (ret <= 0)
+		return;
+	nodetmp[ret] = 0;
+	// The link value is either "device -> ../../../0000:86:00.0" or "device -> ../../nvme0"
+	(void) path_trim_last(path, '/');
+	sprintf(path+strlen(path), "/%s/device", nodetmp);
+	ret = stat(path, &st);
+	if (ret < 0)
+		return;
+	if ((st.st_mode & S_IFLNK) == 0) {
+		// follow the second link to get the PCI address
+		ret = readlink(path, path, sizeof(path));
+		if (ret <= 0)
+			return;
+		path[ret] = 0;
+	}
+	else
+		(void) path_trim_last(path, '/');
+
+	p = path_trim_last(path, '/');
+	if (p && strlen(p) == 12)
+		strcpy(bdf, p);
+}
+
 static int scan_namespace(struct nvme_namespace *n)
 {
 	int ret, fd;
@@ -303,6 +353,15 @@ static int verify_legacy_ns(struct nvme_namespace *n)
 	ret = asprintf(&path, "%s%s", dev, n->name);
 	if (ret < 0)
 		return ret;
+
+	if (!n->ctrl->transport && !n->ctrl->address) {
+		char tmp_address[64] = "";
+		legacy_get_pci_bdf(path, tmp_address);
+		if (tmp_address[0]) {
+			asprintf(&n->ctrl->transport, "pcie");
+			asprintf(&n->ctrl->address, tmp_address);
+		}
+	}
 
 	fd = open(path, O_RDONLY);
 	free (path);

--- a/util/json.c
+++ b/util/json.c
@@ -119,7 +119,7 @@ static struct json_value *json_create_value_string(const char *str)
 
 	if (value) {
 		value->type = JSON_TYPE_STRING;
-		value->string = strdup_escape(str);
+		value->string = strdup_escape(str ? str : "(null)");
 		if (!value->string) {
 			free(value);
 			value = NULL;


### PR DESCRIPTION
See issue https://github.com/linux-nvme/nvme-cli/issues/388
