### PR TITLE
Update for the main nvme documentation

### DIFF
--- a/Documentation/nvme.1
+++ b/Documentation/nvme.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme
 .\"    Author: [see the "Authors" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 04/04/2019
+.\"      Date: 07/24/2019
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME" "1" "04/04/2019" "NVMe" "NVMe Manual"
+.TH "NVME" "1" "07/24/2019" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-nvme \- the dumb pci\-e storage utility
+nvme \- the NVMe storage command line interface utility (nvme\-cli)
 .SH "SYNOPSIS"
 .sp
 .nf
@@ -36,7 +36,7 @@ nvme \- the dumb pci\-e storage utility
 .fi
 .SH "DESCRIPTION"
 .sp
-NVM\-Express is a fast, scalable host controller interface designed to address the needs for PCI Express based solid state drives\&.
+NVM\-Express is a fast, scalable host controller interface designed to address the needs for not only PCI Express based solid state drives, but also NVMe\-oF(over fabrics)\&.
 .sp
 This \fInvme\fR program is a user space utility to provide standards compliant tooling for NVM\-Express drives\&. It was made specifically for Linux as it relies on the IOCTLs defined by the mainline kernel driver\&.
 .SH "NVME COMMANDS"

--- a/Documentation/nvme.1
+++ b/Documentation/nvme.1
@@ -31,8 +31,16 @@
 nvme \- the NVMe storage command line interface utility (nvme\-cli)
 .SH "SYNOPSIS"
 .sp
+bulit\-in plugin:
+.sp
 .nf
 \fInvme\fR <command> <device> [<args>]
+.fi
+.sp
+extension plugins:
+.sp
+.nf
+\fInvme\fR <plugin> <command> <device> [<args>]
 .fi
 .SH "DESCRIPTION"
 .sp

--- a/Documentation/nvme.html
+++ b/Documentation/nvme.html
@@ -740,7 +740,7 @@ nvme(1) Manual Page
 <h2>NAME</h2>
 <div class="sectionbody">
 <p>nvme -
-   the dumb pci-e storage utility
+   the NVMe storage command line interface utility (nvme-cli)
 </p>
 </div>
 </div>
@@ -758,7 +758,8 @@ nvme(1) Manual Page
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
 <div class="paragraph"><p>NVM-Express is a fast, scalable host controller interface designed to
-address the needs for PCI Express based solid state drives.</p></div>
+address the needs for not only PCI Express based solid state drives, but
+also NVMe-oF(over fabrics).</p></div>
 <div class="paragraph"><p>This <em>nvme</em> program is a user space utility to provide standards compliant
 tooling for NVM-Express drives. It was made specifically for Linux as
 it relies on the IOCTLs defined by the mainline kernel driver.</p></div>
@@ -1183,7 +1184,7 @@ NVM-Express Site</a>.</p></div>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-09-04 00:00:12 KST
+ 2019-07-24 00:35:34 KST
 </div>
 </div>
 </body>

--- a/Documentation/nvme.html
+++ b/Documentation/nvme.html
@@ -748,8 +748,14 @@ nvme(1) Manual Page
 <div class="sect1">
 <h2 id="_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
+<div class="paragraph"><p>bulit-in plugin:</p></div>
 <div class="verseblock">
 <pre class="content"><em>nvme</em> &lt;command&gt; &lt;device&gt; [&lt;args&gt;]</pre>
+<div class="attribution">
+</div></div>
+<div class="paragraph"><p>extension plugins:</p></div>
+<div class="verseblock">
+<pre class="content"><em>nvme</em> &lt;plugin&gt; &lt;command&gt; &lt;device&gt; [&lt;args&gt;]</pre>
 <div class="attribution">
 </div></div>
 </div>

--- a/Documentation/nvme.txt
+++ b/Documentation/nvme.txt
@@ -7,8 +7,13 @@ nvme - the NVMe storage command line interface utility (nvme-cli)
 
 SYNOPSIS
 --------
+bulit-in plugin:
 [verse]
-'nvme' <command> <device> [<args>] 
+'nvme' <command> <device> [<args>]
+
+extension plugins:
+[verse]
+'nvme' <plugin> <command> <device> [<args>]
 
 DESCRIPTION
 -----------

--- a/Documentation/nvme.txt
+++ b/Documentation/nvme.txt
@@ -3,7 +3,7 @@ nvme(1)
 
 NAME
 ----
-nvme - the dumb pci-e storage utility
+nvme - the NVMe storage command line interface utility (nvme-cli)
 
 SYNOPSIS
 --------
@@ -13,7 +13,8 @@ SYNOPSIS
 DESCRIPTION
 -----------
 NVM-Express is a fast, scalable host controller interface designed to
-address the needs for PCI Express based solid state drives.
+address the needs for not only PCI Express based solid state drives, but
+also NVMe-oF(over fabrics).
 
 This 'nvme' program is a user space utility to provide standards compliant
 tooling for NVM-Express drives. It was made specifically for Linux as


### PR DESCRIPTION
Hi @keithbusch ,

This series is just a update for the nvme main page of the doc.
It updates the main description to indicates not only just for PCIe,
but also fabrics.  Also the extensions plugin format has been updated.

```
Minwoo Im (2):
  doc: make description not only for PCIe
  doc: add extension plugins' command format

 Documentation/nvme.1    | 16 ++++++++++++----
 Documentation/nvme.html | 13 ++++++++++---
 Documentation/nvme.txt  | 12 +++++++++---
 3 files changed, 31 insertions(+), 10 deletions(-)
```