### PR TITLE
nvme-format: reject format to char device without an explicit NSID

### DIFF
--- a/Documentation/nvme-format.1
+++ b/Documentation/nvme-format.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-format
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 05/16/2019
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 07/28/2019
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FORMAT" "1" "05/16/2019" "NVMe" "NVMe Manual"
+.TH "NVME\-FORMAT" "1" "07/28/2019" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -46,7 +46,7 @@ nvme-format \- Format an NVMe device
 .sp
 For the NVMe device given, send an nvme Format Namespace admin command and provides the results\&.
 .sp
-The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&. If the character device is given, the namespace identifier will default to 0xffffffff to send the format to all namespace, but can be overridden to any namespace with the \fInamespace\-id\fR option\&. If the block device is given, the namespace identifier will default to the namespace id of the block device given, but can be overridden with the same option\&.
+The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&. If the character device is given, and the controller does not support formatting of particular namespaces (ID_CTRL\&.FNA bit 0 enabled), then all namespaces will be formatted\&. If FNA is disabled, then the namespace identifier must be specified with the \fInamespace\-id\fR option; specify a value of 0xffffffff to send the format to all namespaces\&. If the block device is given, the namespace identifier will default to the namespace ID of the block device given, but can be overridden with the same option\&.
 .sp
 Note, the numeric suffix on the character device, for example the \fI0\fR in /dev/nvme0, does NOT indicate this device handle is the parent controller of any namespaces with the same suffix\&. The namespace handle\(cqs numeral may be coming from the subsystem identifier, which is independent of the controller\(cqs identifier\&. Do not assume any particular device relationship based on their names\&. If you do, you may irrevocably erase data on an unintended device\&.
 .sp
@@ -55,7 +55,7 @@ On success, the program will automatically issue BLKRRPART ioctl to force rescan
 .PP
 \-n <nsid>, \-\-namespace\-id=<nsid>
 .RS 4
-Send the format command for the specified nsid\&. This can be used to override the default value for either character device (0xffffffff) or the block device (result from NVME_IOCTL_ID)\&.
+Send the format command for the specified nsid\&. This can be used to override the default value for either character device (unspecified) or the block device (result from NVME_IOCTL_ID)\&.
 .RE
 .PP
 \-l <lbaf>, \-\-lbaf=<lbaf>

--- a/Documentation/nvme-format.html
+++ b/Documentation/nvme-format.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-format(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -766,11 +769,13 @@ nvme-format(1) Manual Page
 and provides the results.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
-If the character device is given, the namespace identifier will default
-to 0xffffffff to send the format to all namespace, but can be overridden
-to any namespace with the <em>namespace-id</em> option. If the block device
-is given, the namespace identifier will default to the namespace id of
-the block device given, but can be overridden with the same option.</p></div>
+If the character device is given, and the controller does not support
+formatting of particular namespaces (ID_CTRL.FNA bit 0 enabled), then all
+namespaces will be formatted. If FNA is disabled, then the namespace
+identifier must be specified with the <em>namespace-id</em> option; specify a
+value of 0xffffffff to send the format to all namespaces. If the block
+device is given, the namespace identifier will default to the namespace
+ID of the block device given, but can be overridden with the same option.</p></div>
 <div class="paragraph"><p>Note, the numeric suffix on the character device, for example the <em>0</em> in
 /dev/nvme0, does NOT indicate this device handle is the parent controller
 of any namespaces with the same suffix. The namespace handle&#8217;s numeral
@@ -799,7 +804,7 @@ new block size to be visible, if the size was changed with this command.</p></di
 <p>
         Send the format command for the specified nsid. This can be
         used to override the default value for either character device
-        (0xffffffff) or the block device (result from NVME_IOCTL_ID).
+        (unspecified) or the block device (result from NVME_IOCTL_ID).
 </p>
 </dd>
 <dt class="hdlist1">
@@ -1020,7 +1025,8 @@ information:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-05-16 09:47:03 MDT
+Last updated
+ 2019-07-28 09:33:55 IDT
 </div>
 </div>
 </body>

--- a/Documentation/nvme-format.txt
+++ b/Documentation/nvme-format.txt
@@ -25,11 +25,13 @@ and provides the results.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
-If the character device is given, the namespace identifier will default
-to 0xffffffff to send the format to all namespace, but can be overridden
-to any namespace with the 'namespace-id' option. If the block device
-is given, the namespace identifier will default to the namespace id of
-the block device given, but can be overridden with the same option.
+If the character device is given, and the controller does not support
+formatting of particular namespaces (ID_CTRL.FNA bit 0 enabled), then all
+namespaces will be formatted. If FNA is disabled, then the namespace
+identifier must be specified with the 'namespace-id' option; specify a
+value of 0xffffffff to send the format to all namespaces. If the block
+device is given, the namespace identifier will default to the namespace
+ID of the block device given, but can be overridden with the same option.
 
 Note, the numeric suffix on the character device, for example the '0' in
 /dev/nvme0, does NOT indicate this device handle is the parent controller
@@ -51,7 +53,7 @@ OPTIONS
 --namespace-id=<nsid>::
 	Send the format command for the specified nsid. This can be
 	used to override the default value for either character device
-	(0xffffffff) or the block device (result from NVME_IOCTL_ID).
+	(unspecified) or the block device (result from NVME_IOCTL_ID).
 
 -l <lbaf>::
 --lbaf=<lbaf>::

--- a/nvme.c
+++ b/nvme.c
@@ -3241,7 +3241,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	};
 
 	struct config cfg = {
-		.namespace_id = NVME_NSID_ALL,
+		.namespace_id = 0,
 		.timeout      = 600000,
 		.lbaf         = 0xff,
 		.ses          = 0,
@@ -3287,6 +3287,26 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	if (S_ISBLK(nvme_stat.st_mode)) {
 		cfg.namespace_id = get_nsid(fd);
 		if (cfg.namespace_id == 0) {
+			err = -EINVAL;
+			goto close_fd;
+		}
+	}
+	else if (cfg.namespace_id == 0) {
+		struct nvme_id_ctrl ctrl;
+		memset(&ctrl, 0, sizeof (struct nvme_id_ctrl));
+		err = nvme_identify_ctrl(fd, &ctrl);
+		if (err) {
+			perror("identify-ctrl");
+			goto close_fd;
+		}
+		if ((ctrl.fna & 1) == 1) {
+			// FNA bit 0 set to 1: all namespaces ... shall be configured with the same
+			// attributes and a format (excluding secure erase) of any namespace results in a
+			// format of all namespaces.
+			cfg.namespace_id = NVME_NSID_ALL;
+		}
+		else {
+			fprintf(stderr, "Invalid namespace ID, specify a namespace to format or use '-n 0xffffffff' to format all namespaces on this controller.\n");
 			err = -EINVAL;
 			goto close_fd;
 		}


### PR DESCRIPTION
When formatting a char device and NSID is not specified, check ID_CTRL.FNA bit 0.
If FNA is enabled, then default to NSID_ALL; otherwise, reject the command.
See issue #510 
