### PR TITLE
Mask out invalid options during discovery.

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -98,7 +98,9 @@ OPTIONS
 
 -k <#>::
 --keep-alive-tmo=<#>::
-	Overrides the default keep alive timeout (in seconds).
+	Overrides the default keep alive timeout (in seconds). This
+	option will be ignored for discovery, but will be passed on to
+	the subsequent connect call.
 
 -c <#>::
 --reconnect-delay=<#>::
@@ -120,6 +122,8 @@ OPTIONS
 -i <#>::
 --nr-io-queues=<#>::
 	Overrides the default number of I/O queues create by the driver.
+	This option will be ignored for discovery, but will be passed on
+	to the subsequent connect call.
 
 -W <#>::
 --nr-write-queues=<#>::
@@ -132,7 +136,9 @@ OPTIONS
 -Q <#>::
 --queue-size=<#>::
 	Overrides the default number of elements in the I/O queues created
-	by the driver.
+	by the driver. This option will be ignored for discovery, but will be
+	passed on to the subsequent connect call.
+
 
 EXAMPLES
 --------

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -117,6 +117,8 @@ OPTIONS
 -k <#>::
 --keep-alive-tmo=<#>::
 	Overrides the default dealy (in seconds) for keep alive.
+	This option will be ignored for the discovery, and it is only
+	implemented for completeness.
 
 -c <#>::
 --reconnect-delay=<#>::
@@ -138,6 +140,8 @@ OPTIONS
 -i <#>::
 --nr-io-queues=<#>::
 	Overrides the default number of I/O queues create by the driver.
+	This option will be ignored for the discovery, and it is only
+	implemented for completeness.
 
 -W <#>::
 --nr-write-queues=<#>::
@@ -151,6 +155,8 @@ OPTIONS
 --queue-size=<#>::
 	Overrides the default number of elements in the I/O queues created
 	by the driver which can be found at drivers/nvme/host/fabrics.h.
+	This option will be ignored for the discovery, and it is only
+	implemented for completeness.
 
 EXAMPLES
 --------

--- a/fabrics.c
+++ b/fabrics.c
@@ -685,14 +685,14 @@ retry:
 		p += len;
 	}
 
-	if (cfg.queue_size) {
+	if (cfg.queue_size && !discover) {
 		len = sprintf(p, ",queue_size=%d", cfg.queue_size);
 		if (len < 0)
 			return -EINVAL;
 		p += len;
 	}
 
-	if (cfg.nr_io_queues) {
+	if (cfg.nr_io_queues && !discover) {
 		len = sprintf(p, ",nr_io_queues=%d", cfg.nr_io_queues);
 		if (len < 0)
 			return -EINVAL;

--- a/fabrics.c
+++ b/fabrics.c
@@ -589,7 +589,7 @@ add_argument(char **argstr, int *max_len, char *arg_str, char *arg)
 	return 0;
 }
 
-static int build_options(char *argstr, int max_len)
+static int build_options(char *argstr, int max_len, bool discover)
 {
 	int len;
 
@@ -620,15 +620,19 @@ static int build_options(char *argstr, int max_len)
 		    add_argument(&argstr, &max_len, "hostnqn", cfg.hostnqn)) ||
 	    ((cfg.hostid || nvmf_hostid_file()) &&
 		    add_argument(&argstr, &max_len, "hostid", cfg.hostid)) ||
-	    add_int_argument(&argstr, &max_len, "nr_io_queues",
-				cfg.nr_io_queues) ||
+	    (!discover &&
+	      add_int_argument(&argstr, &max_len, "nr_io_queues",
+				cfg.nr_io_queues)) ||
 	    add_int_argument(&argstr, &max_len, "nr_write_queues",
 				cfg.nr_write_queues) ||
 	    add_int_argument(&argstr, &max_len, "nr_poll_queues",
 				cfg.nr_poll_queues) ||
-	    add_int_argument(&argstr, &max_len, "queue_size", cfg.queue_size) ||
-	    add_int_argument(&argstr, &max_len, "keep_alive_tmo",
-				cfg.keep_alive_tmo) ||
+	    (!discover &&
+	      add_int_argument(&argstr, &max_len, "queue_size",
+				cfg.queue_size)) ||
+	    (!discover &&
+	      add_int_argument(&argstr, &max_len, "keep_alive_tmo",
+				cfg.keep_alive_tmo)) ||
 	    add_int_argument(&argstr, &max_len, "reconnect_delay",
 				cfg.reconnect_delay) ||
 	    add_int_argument(&argstr, &max_len, "ctrl_loss_tmo",
@@ -957,7 +961,7 @@ static int discover_from_conf_file(const char *desc, char *argstr,
 		if (err)
 			continue;
 
-		err = build_options(argstr, BUF_SIZE);
+		err = build_options(argstr, BUF_SIZE, true);
 		if (err) {
 			ret = err;
 			continue;
@@ -1013,7 +1017,7 @@ int discover(const char *desc, int argc, char **argv, bool connect)
 		ret = discover_from_conf_file(desc, argstr,
 				command_line_options, connect);
 	} else {
-		ret = build_options(argstr, BUF_SIZE);
+		ret = build_options(argstr, BUF_SIZE, true);
 		if (ret)
 			goto out;
 
@@ -1055,7 +1059,7 @@ int connect(const char *desc, int argc, char **argv)
 	if (ret)
 		goto out;
 
-	ret = build_options(argstr, BUF_SIZE);
+	ret = build_options(argstr, BUF_SIZE, false);
 	if (ret)
 		goto out;
 


### PR DESCRIPTION
These are old patches by Hannes we forgot to send upstream. I had to fiddle a bit to make them apply again so I will ask Hannes to review them too.

A few things:
* I am not sure how to properly indent in the `build_options` function, because of the inconsistent use of whitespace.
* There are some new options, which weren't there when Hannes made the patches initially, which may need to be masked out as well.
* I think I also found the original discussion regarding these patches, as a bit of background:
http://lists.infradead.org/pipermail/linux-nvme/2019-February/022249.html