### PR TITLE
Intel: Add feature enable lat-stats-tracking

### DIFF
--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -819,7 +819,6 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	int err, fd;
 	const char *desc = (
 			"Enable/Disable Intel Latency Statistics Tracking.\n"
-			"1 = Enable, 0 = Disable\n"
 			"No argument prints current status.");
 	const char *enable_desc = "Enable LST";
 	const char *disable_desc = "Disable LST";

--- a/plugins/intel/intel-nvme.h
+++ b/plugins/intel/intel-nvme.h
@@ -9,11 +9,12 @@
 PLUGIN(NAME("intel", "Intel vendor specific extensions"),
 	COMMAND_LIST(
 		ENTRY("id-ctrl", "Send NVMe Identify Controller", id_ctrl)
-		ENTRY("smart-log-add", "Retrieve Intel SMART Log, show it", get_additional_smart_log)
-		ENTRY("market-name", "Retrieve Intel Marketing Name log, show it", get_market_log)
-		ENTRY("temp-stats", "Retrieve Intel Temperature Statistics log, show it", get_temp_stats_log)
-		ENTRY("lat-stats", "Retrieve Intel IO Latency Statistics log, show it", get_lat_stats_log)
 		ENTRY("internal-log", "Retrieve Intel internal firmware log, save it", get_internal_log)
+		ENTRY("lat-stats", "Retrieve Intel IO Latency Statistics log, show it", get_lat_stats_log)
+		ENTRY("lat-stats-tracking", "Enable and disable Latency Statistics logging.", enable_lat_stats_tracking)
+		ENTRY("market-name", "Retrieve Intel Marketing Name log, show it", get_market_log)
+		ENTRY("smart-log-add", "Retrieve Intel SMART Log, show it", get_additional_smart_log)
+		ENTRY("temp-stats", "Retrieve Intel Temperature Statistics log, show it", get_temp_stats_log)
 	)
 );
 


### PR DESCRIPTION
Adds the lat-stats-tracking feature to the Intel plugin for nvme log pages.