### PR TITLE
nvme: add support for Namespace Granularity

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -306,6 +306,7 @@ enum {
 	NVME_CTRL_CTRATT_READ_RECV_LVLS		= 1 << 3,
 	NVME_CTRL_CTRATT_ENDURANCE_GROUPS	= 1 << 4,
 	NVME_CTRL_CTRATT_PREDICTABLE_LAT	= 1 << 5,
+	NVME_CTRL_CTRATT_NAMESPACE_GRANULARITY	= 1 << 7,
 };
 
 struct nvme_lbaf {
@@ -365,6 +366,7 @@ enum {
 	NVME_ID_CNS_CTRL_NS_LIST	= 0x12,
 	NVME_ID_CNS_CTRL_LIST		= 0x13,
 	NVME_ID_CNS_SCNDRY_CTRL_LIST	= 0x15,
+	NVME_ID_CNS_NS_GRANULARITY	= 0x16,
 };
 
 enum {
@@ -433,6 +435,18 @@ struct nvme_id_nvmset {
 	__u8				nid;
 	__u8				rsvd1[127];
 	struct nvme_nvmset_attr_entry	ent[NVME_MAX_NVMSET];
+};
+
+struct nvme_id_ns_granularity_list_entry {
+	__le64			namespace_size_granularity;
+	__le64			namespace_capacity_granularity;
+};
+
+struct nvme_id_ns_granularity_list {
+	__le32			attributes;
+	__u8			num_descriptors;
+	__u8			rsvd[27];
+	struct nvme_id_ns_granularity_list_entry entry[16];
 };
 
 /**

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -11,6 +11,7 @@ COMMAND_LIST(
 	ENTRY("list-subsys", "List nvme subsystems", list_subsys)
 	ENTRY("id-ctrl", "Send NVMe Identify Controller", id_ctrl)
 	ENTRY("id-ns", "Send NVMe Identify Namespace, display structure", id_ns)
+	ENTRY("id-ns-granularity", "Send NVMe Identify Namespace Granularity List, display structure", id_ns_granularity)
 	ENTRY("list-ns", "Send NVMe Identify List, display structure", list_ns)
 	ENTRY("list-ctrl", "Send NVMe Identify Controller List, display structure", list_ctrl)
 	ENTRY("list-secondary", "List Secondary Controllers associated with a Primary Controller", list_secondary_ctrl)

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -403,6 +403,11 @@ int nvme_identify_nvmset(int fd, __u16 nvmset_id, void *data)
 	return nvme_identify13(fd, 0, NVME_ID_CNS_NVMSET_LIST, nvmset_id, data);
 }
 
+int nvme_identify_ns_granularity(int fd, void *data)
+{
+	return nvme_identify13(fd, 0, NVME_ID_CNS_NS_GRANULARITY, 0, data);
+}
+
 int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
                  __u16 lsi, bool rae, __u32 data_len, void *data)
 {

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -79,11 +79,11 @@ int nvme_identify_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
 int nvme_identify_ns_descs(int fd, __u32 nsid, void *data);
 int nvme_identify_nvmset(int fd, __u16 nvmset_id, void *data);
 int nvme_identify_secondary_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
+int nvme_identify_ns_granularity(int fd, void *data);
 int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
 		   __u16 group_id, bool rae, __u32 data_len, void *data);
 int nvme_get_log(int fd, __u32 nsid, __u8 log_id, bool rae,
 		 __u32 data_len, void *data);
-
 
 int nvme_get_telemetry_log(int fd, void *lp, int generate_report,
 			   int ctrl_gen, size_t log_page_size, __u64 offset);

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -40,6 +40,7 @@ void show_list_items(struct list_item *list_items, unsigned len);
 void show_nvme_subsystem_list(struct subsys_list_item *slist, int n);
 void show_nvme_id_nvmset(struct nvme_id_nvmset *nvmset);
 void show_nvme_list_secondary_ctrl(const struct nvme_secondary_controllers_list *sc_list, __u32 count);
+void show_nvme_id_ns_granularity_list(const struct nvme_id_ns_granularity_list *granularity, unsigned int flags);
 
 void nvme_feature_show_fields(__u32 fid, unsigned int result, unsigned char *buf);
 void nvme_directive_show_fields(__u8 dtype, __u8 doper, unsigned int result, unsigned char *buf);
@@ -68,5 +69,5 @@ void json_self_test_log(struct nvme_self_test_log *self_test, const char *devnam
 void json_nvme_id_nvmset(struct nvme_id_nvmset *nvmset, const char *devname);
 void json_ctrl_registers(void *bar);
 void json_nvme_list_secondary_ctrl(const struct nvme_secondary_controllers_list *sc_list, __u32 count);
-
+void json_nvme_id_ns_granularity_list(const struct nvme_id_ns_granularity_list *granularity, unsigned int flags);
 #endif


### PR DESCRIPTION
* Add 'id-ns-granularity' (Identify command CNS 16h)
* Show Namespace Granularity Support (ctratt) for Identify Controller

Signed-off-by: Kenneth Heitke <kenneth.heitke@intel.com>