### PR TITLE
Intel: Added json format output to temp-stats.

### DIFF
--- a/Documentation/nvme-intel-temp-stats.1
+++ b/Documentation/nvme-intel-temp-stats.1
@@ -28,7 +28,7 @@
 .\" * MAIN CONTENT STARTS HERE *
 .\" -----------------------------------------------------------------
 .SH "NAME"
-nvme-intel-temp-stats \- Send NVMe SMART log page request, returns result and log
+nvme-intel-temp-stats \- Send NVMe temperature stats log page request, returns result and log
 .SH "SYNOPSIS"
 .sp
 .nf
@@ -36,16 +36,21 @@ nvme-intel-temp-stats \- Send NVMe SMART log page request, returns result and lo
 .fi
 .SH "DESCRIPTION"
 .sp
-Retrieves the NVMe Intel Additional SMART log page from the device and provides the returned structure\&.
+Retrieves the NVMe Intel temperature stats log from the device and provides the returned structure\&.
 .sp
 The <device> parameter is mandatory and may be either the NVMe character device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1)\&.
 .sp
-On success, the returned smart log structure may be returned in one of several ways depending on the option flags; the structure may parsed by the program and printed in a readable format or the raw buffer may be printed to stdout for another program to parse\&.
+On success, the returned temperature stats structure may be returned in one of several ways depending on the option flags; the structure may parsed bythe program and printed in a readable format, the raw buffer may beprinted to stdout for another program to parse, or the structure may be formattedas JSON and printed\&.
 .SH "OPTIONS"
 .PP
 \-b, \-\-raw\-binary
 .RS 4
 Print the raw temperature stats log buffer to stdout\&.
+.RE
+.PP
+\-j, \-\-json
+.RS 4
+Print the temperature stats log buffer to stdout in json format\&.
 .RE
 .SH "EXAMPLES"
 .sp
@@ -78,7 +83,7 @@ Print the temperature stats log page in a human readable format:
 .sp -1
 .IP \(bu 2.3
 .\}
-Print the raw SMART log to a file:
+Write the raw temperature stats log to a file:
 .sp
 .if n \{\
 .RS 4

--- a/Documentation/nvme-intel-temp-stats.html
+++ b/Documentation/nvme-intel-temp-stats.html
@@ -737,7 +737,7 @@ nvme-intel-temp-stats(1) Manual Page
 <h2>NAME</h2>
 <div class="sectionbody">
 <p>nvme-intel-temp-stats -
-   Send NVMe SMART log page request, returns result and log
+   Send NVMe temperature stats log page request, returns result and log
 </p>
 </div>
 </div>
@@ -746,7 +746,7 @@ nvme-intel-temp-stats(1) Manual Page
 <h2 id="_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="verseblock">
-<pre class="content"><em>nvme intel temp-stats</em> &lt;device&gt; [--raw-binary | -b]</pre>
+<pre class="content"><em>nvme intel temp-stats</em> &lt;device&gt; [--raw-binary | -b] [--json | -j]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -754,14 +754,15 @@ nvme-intel-temp-stats(1) Manual Page
 <div class="sect1">
 <h2 id="_description">DESCRIPTION</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Retrieves the NVMe Intel Additional SMART log page from the device and
+<div class="paragraph"><p>Retrieves the NVMe Intel temperature stats log from the device and
 provides the returned structure.</p></div>
 <div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).</p></div>
-<div class="paragraph"><p>On success, the returned smart log structure may be returned in one of
+<div class="paragraph"><p>On success, the returned temperature stats structure may be returned in one of
 several ways depending on the option flags; the structure may parsed by
-the program and printed in a readable format or the raw buffer may be
-printed to stdout for another program to parse.</p></div>
+the program and printed in a readable format, the raw buffer may be
+printed to stdout for another program to parse, or the structure may be formatted
+as JSON and printed.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -777,6 +778,17 @@ printed to stdout for another program to parse.</p></div>
 <dd>
 <p>
         Print the raw temperature stats log buffer to stdout.
+</p>
+</dd>
+<dt class="hdlist1">
+-j
+</dt>
+<dt class="hdlist1">
+--json
+</dt>
+<dd>
+<p>
+              Dump output in json format.
 </p>
 </dd>
 </dl></div>
@@ -797,7 +809,7 @@ Print the temperature stats log page in a human readable format:
 </li>
 <li>
 <p>
-Print the raw SMART log to a file:
+Write the raw temperature stats log to a file:
 </p>
 <div class="listingblock">
 <div class="content">
@@ -818,7 +830,7 @@ Print the raw SMART log to a file:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-27 10:11:58 EST
+Last updated 2019-08-08 21:00:00 PST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-intel-temp-stats.txt
+++ b/Documentation/nvme-intel-temp-stats.txt
@@ -3,31 +3,36 @@ nvme-intel-temp-stats(1)
 
 NAME
 ----
-nvme-intel-temp-stats - Send NVMe SMART log page request, returns result and log
+nvme-intel-temp-stats - Send NVMe temperature stats log page request, returns result and log
 
 SYNOPSIS
 --------
 [verse]
-'nvme intel temp-stats' <device> [--raw-binary | -b]
+'nvme intel temp-stats' <device> [--raw-binary | -b] [--json | -j]
 
 DESCRIPTION
 -----------
-Retrieves the NVMe Intel Additional SMART log page from the device and
+Retrieves the NVMe Intel temperature stats log page from the device and
 provides the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
 
-On success, the returned smart log structure may be returned in one of
-several ways depending on the option flags; the structure may parsed by
-the program and printed in a readable format or the raw buffer may be
-printed to stdout for another program to parse.
+On success, the returned temperature stats structure may be returned in
+one of several ways depending on the option flags; the structure may
+parsed by the program and printed in a readable format, the raw buffer
+may be printed to stdout for another program to parse, or the structure
+may be formatted as JSON and printed.
 
 OPTIONS
 -------
 -b::
 --raw-binary::
 	Print the raw temperature stats log buffer to stdout.
+ 
+-j::
+--json::
+              Dump output in json format.
 
 EXAMPLES
 --------
@@ -38,7 +43,7 @@ EXAMPLES
 ------------
 +
 
-* Print the raw SMART log to a file:
+* Write the raw temperature stats log to a file:
 +
 ------------
 # nvme intel temp-stats /dev/nvme0 --raw-binary > temp_stats_log.raw

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -65,7 +65,7 @@ static const char *json_desc = "DEPRECATED: Dump output in json format.";
 static void intel_id_ctrl(__u8 *vs, struct json_object *root)
 {
 	char bl[9];
-        char health[21];
+	char health[21];
 
 	memcpy(bl, &vs[28], sizeof(bl));
 	memcpy(health, &vs[4], sizeof(health));
@@ -398,14 +398,14 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 	if (fd < 0) {
 		err = fd;
 		goto ret;
-    }
+	}
 
-    fmt = validate_output_format(cfg.output_format);
-    if (fmt < 0) {
+	fmt = validate_output_format(cfg.output_format);
+	if (fmt < 0) {
 		err = fmt;
 		goto close_fd;
-    }
-    if (cfg.raw_binary)
+	}
+	if (cfg.raw_binary)
 		fmt = BINARY;
 
 	err = nvme_get_log(fd, NVME_NSID_ALL, 0xc5, false,
@@ -498,11 +498,11 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 }
 
 struct intel_assert_dump {
-    __u32 coreoffset;
-    __u32 assertsize;
-    __u8  assertdumptype;
-    __u8  assertvalid;
-    __u8  reserved[2];
+	__u32 coreoffset;
+	__u32 assertsize;
+	__u8  assertdumptype;
+	__u8  assertvalid;
+	__u8  reserved[2];
 };
 
 struct intel_event_dump {
@@ -524,11 +524,11 @@ struct intel_event_header {
 };
 
 struct intel_vu_log {
-    struct intel_vu_version ver;
-    __u32    header;
-    __u32    size;
-    __u32    numcores;
-    __u8     reserved[4080];
+	struct intel_vu_version ver;
+	__u32    header;
+	__u32    size;
+	__u32    numcores;
+	__u8     reserved[4080];
 };
 
 struct intel_vu_nlog {
@@ -552,7 +552,7 @@ struct intel_vu_nlog {
 };
 
 struct intel_cd_log {
-    union {
+	union {
 	struct {
 		__u32 selectLog  : 3;
 		__u32 selectCore : 2;
@@ -562,7 +562,7 @@ struct intel_cd_log {
 		__u32 reserved2  : 16;
 	}fields;
 	__u32 entireDword;
-    }u;
+	}u;
 };
 
 static void print_intel_nlog(struct intel_vu_nlog *intel_nlog)
@@ -623,7 +623,7 @@ static int read_entire_cmd(struct nvme_passthru_cmd *cmd, int total_size,
 		cmd->data_len = (min(max_tfer, total_size)) * 4;
 	}
 
- out:
+out:
 	return err;
 }
 
@@ -695,7 +695,7 @@ static int get_internal_log_old(__u8 *buf, int output, int fd,
 		goto out;
 
 	err = 0;
- out:
+out:
 	return err;
 }
 
@@ -859,7 +859,7 @@ static int get_internal_log(int argc, char **argv, struct command *command, stru
 		}
 	}
 	err = 0;
- out:
+out:
 	if (err > 0) {
 		fprintf(stderr, "NVMe Status:%s(%x)\n",
 				nvme_status_to_string(err), err);

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -480,39 +480,58 @@ static void show_lat_stats(struct intel_lat_stats *stats, int write)
 static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	struct intel_lat_stats stats;
-	int err, fd;
+	int err, fmt, fd;
 
 	const char *desc = "Get Intel Latency Statistics log and show it.";
-	const char *raw = "dump output in binary format";
 	const char *write = "Get write statistics (read default)";
 	struct config {
 		int  raw_binary;
 		int  write;
+		char *output_format;
 	};
 
 	struct config cfg = {
+		.output_format = "normal",
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"write",      'w', "", CFG_NONE, &cfg.write,      no_argument, write},
-		{"raw-binary", 'b', "", CFG_NONE, &cfg.raw_binary, no_argument, raw},
+		// long option  | short | metavar | type      | destination       | action           | description
+		{"write",         'w',    "",       CFG_NONE,   &cfg.write,         no_argument,       write},
+		{"raw-binary",    'b',    "",       CFG_NONE,   &cfg.raw_binary,    no_argument,       raw_desc},
+		{"output-format", 'o',    "FMT",    CFG_STRING, &cfg.output_format, required_argument, output_format_desc },
 		{NULL}
 	};
 
 	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
-	if (fd < 0)
-		return fd;
+	if (fd < 0) {
+		err = fd;
+		goto ret;
+	}
+
+	fmt = validate_output_format(cfg.output_format);
+	if (fmt < 0) {
+		err = fmt;
+		goto close_fd;
+	}
+	if (cfg.raw_binary)
+		fmt = BINARY;
 
 	err = nvme_get_log(fd, NVME_NSID_ALL, cfg.write ? 0xc2 : 0xc1,
 			   false, sizeof(stats), &stats);
 	if (!err) {
-		if (!cfg.raw_binary)
-			show_lat_stats(&stats, cfg.write);
-		else
+		if (fmt == BINARY)
 			d_raw((unsigned char *)&stats, sizeof(stats));
+		// TODO: Implement JSON output.
+		else
+			show_lat_stats(&stats, cfg.write);
 	} else if (err > 0)
 		fprintf(stderr, "NVMe Status:%s(%x)\n",
 					nvme_status_to_string(err), err);
+
+close_fd:
+	close(fd);
+
+ret:
 	return err;
 }
 

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -268,6 +268,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	}
 	if (cfg.raw_binary)
 		fmt = BINARY;
+	else if (cfg.json)
+		fmt = JSON;
 
 	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false,
 			   sizeof(smart_log), &smart_log);


### PR DESCRIPTION
It seemed odd that temp-stats was the only command from the Intel plugin which does not have a json output format. I added it. Also, it seemed as if several of the documentation pages were simply copies of the SMART log documentation, and there were some references to it that were never updated to refer to temp stats.

@keithbusch I've been told you are the primary maintainer from Intel for nvme-cli. Is there anything else that might be desired in the output? 