### PR TITLE
nvme: add Persistent Memory Region (PMR) registers

### DIFF
--- a/Documentation/nvme-sanitize-log.1
+++ b/Documentation/nvme-sanitize-log.1
@@ -90,7 +90,7 @@ T{
 0x0100
 T}:T{
 .sp
-Global Data Erased bit If set to 1 then non\-volatile storage in the NVM subsystem has not been written to: a) since being manufactured and the NVM subsystem has never been sanitized; or b) since the most recent successful sanitize operation\&. If cleared to 0, then non\-volatile storage in the NVM subsystem has been written to: a) since being manufactured and the NVM subsystem has never been sanitized; or b) since the most recent successful sanitize operation of the NVM subsystem\&.
+Global Data Erased bit If set to 1 then no namespace logical block in the NVM subsystem has been written to and no Persistent Memory Region in the NVM subsystem has been enabled: a) since being manufactured and the NVM subsystem has never been sanitized; or b) since the most recent successful sanitize operation\&. If cleared to 0, then a namespace logical block in the NVM subsystem has been written to or a Persistent Memory Region in the NVM subsystem has been enabled: a) since being manufactured and the NVM subsystem has never been sanitized; or b) since the most recent successful sanitize operation of the NVM subsystem\&.
 T}
 .TE
 .sp 1

--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -124,6 +124,9 @@ enum {
 	NVME_REG_BPINFO	= 0x0040,	/* Boot Partition Information */
 	NVME_REG_BPRSEL	= 0x0044,	/* Boot Partition Read Select */
 	NVME_REG_BPMBL	= 0x0048,	/* Boot Partition Memory Buffer Location */
+	NVME_REG_PMRCAP = 0x0e00,	/* Persistent Memory Capabilities */
+	NVME_REG_PMRCTL = 0x0e04,	/* Persistent Memory Region Control */
+	NVME_REG_PMRSTS = 0x0e08,	/* Persistent Memory Region Status */
 	NVME_REG_DBS	= 0x1000,	/* SQ 0 Tail Doorbell */
 };
 
@@ -1441,6 +1444,7 @@ enum {
 	NVME_SC_THIN_PROV_NOT_SUPP	= 0x11b,
 	NVME_SC_CTRL_LIST_INVALID	= 0x11c,
 	NVME_SC_BP_WRITE_PROHIBITED	= 0x11e,
+	NVME_SC_PMR_SAN_PROHIBITED	= 0x123,
 
 	/*
 	 * I/O Command Set Specific - NVM commands:

--- a/nvme-status.c
+++ b/nvme-status.c
@@ -80,6 +80,7 @@ static inline __u8 nvme_cmd_specific_status_to_errno(__u16 status)
 	case NVME_SC_NS_IS_PRIVATE:
 	case NVME_SC_BP_WRITE_PROHIBITED:
 	case NVME_SC_READ_ONLY:
+	case NVME_SC_PMR_SAN_PROHIBITED:
 		return EPERM;
 	case NVME_SC_OVERLAPPING_RANGE:
 	case NVME_SC_NS_NOT_ATTACHED:

--- a/nvme.h
+++ b/nvme.h
@@ -110,7 +110,7 @@ struct nvme_bar_cap {
 	__u8	to;
 	__u16	bps_css_nssrs_dstrd;
 	__u8	mpsmax_mpsmin;
-	__u8	reserved;
+	__u8	rsvd_pmrs;
 };
 
 #ifdef __CHECKER__


### PR DESCRIPTION
*update 'show-regs' to display the new PMR registers (PMRCAP, PMRCTL, PMRSTS)
*update 'show-regs' to display the PMRS bit of the Controller Capabilities Register
*add support for error status NVME_SC_SANITIZE_PROHIBITED_PMR

Change-Id: Iec44c4c6cb6518dd6aacd870bd339668892d2525
Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>