### PR TITLE
nvme: UUIDs for Vendor-Specific Information

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -310,6 +310,7 @@ enum {
 	NVME_CTRL_CTRATT_ENDURANCE_GROUPS	= 1 << 4,
 	NVME_CTRL_CTRATT_PREDICTABLE_LAT	= 1 << 5,
 	NVME_CTRL_CTRATT_NAMESPACE_GRANULARITY	= 1 << 7,
+	NVME_CTRL_CTRATT_UUID_LIST		= 1 << 9,
 };
 
 struct nvme_lbaf {
@@ -370,6 +371,7 @@ enum {
 	NVME_ID_CNS_CTRL_LIST		= 0x13,
 	NVME_ID_CNS_SCNDRY_CTRL_LIST	= 0x15,
 	NVME_ID_CNS_NS_GRANULARITY	= 0x16,
+	NVME_ID_CNS_UUID_LIST		= 0x17,
 };
 
 enum {
@@ -450,6 +452,17 @@ struct nvme_id_ns_granularity_list {
 	__u8			num_descriptors;
 	__u8			rsvd[27];
 	struct nvme_id_ns_granularity_list_entry entry[16];
+};
+
+#define NVME_MAX_UUID_ENTRIES	128
+struct nvme_id_uuid_list_entry {
+	__u8			header;
+	__u8			rsvd1[15];
+	__u8			uuid[16];
+};
+
+struct nvme_id_uuid_list {
+	struct nvme_id_uuid_list_entry	entry[NVME_MAX_UUID_ENTRIES];
 };
 
 /**
@@ -583,6 +596,7 @@ enum {
 	NVME_CMD_EFFECTS_NIC		= 1 << 3,
 	NVME_CMD_EFFECTS_CCC		= 1 << 4,
 	NVME_CMD_EFFECTS_CSE_MASK	= 3 << 16,
+	NVME_CMD_EFFECTS_UUID_SEL	= 1 << 19,
 };
 
 struct nvme_effects_log {

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -17,6 +17,7 @@ COMMAND_LIST(
 	ENTRY("list-secondary", "List Secondary Controllers associated with a Primary Controller", list_secondary_ctrl)
 	ENTRY("ns-descs", "Send NVMe Namespace Descriptor List, display structure", ns_descs)
 	ENTRY("id-nvmset", "Send NVMe Identify NVM Set List, display structure", id_nvmset)
+	ENTRY("id-uuid", "Send NVMe Identify UUID List, display structure", id_uuid)
 	ENTRY("create-ns", "Creates a namespace with the provided parameters", create_ns)
 	ENTRY("delete-ns", "Deletes a namespace from the controller", delete_ns)
 	ENTRY("attach-ns", "Attaches a namespace to requested controller(s)", attach_ns)

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -408,8 +408,13 @@ int nvme_identify_ns_granularity(int fd, void *data)
 	return nvme_identify13(fd, 0, NVME_ID_CNS_NS_GRANULARITY, 0, data);
 }
 
-int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
-                 __u16 lsi, bool rae, __u32 data_len, void *data)
+int nvme_identify_uuid(int fd, void *data)
+{
+	return nvme_identify(fd, 0, NVME_ID_CNS_UUID_LIST, data);
+}
+
+int nvme_get_log14(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
+                 __u16 lsi, bool rae, __u8 uuid_ix, __u32 data_len, void *data)
 {
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_get_log_page,
@@ -427,6 +432,7 @@ int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
 	cmd.cdw11 = numdu | (lsi << 16);
 	cmd.cdw12 = lpo;
 	cmd.cdw13 = (lpo >> 32);
+	cmd.cdw14 = uuid_ix;
 
 	return nvme_submit_admin_passthru(fd, &cmd);
 

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -78,12 +78,22 @@ int nvme_identify_ns_list(int fd, __u32 nsid, bool all, void *data);
 int nvme_identify_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
 int nvme_identify_ns_descs(int fd, __u32 nsid, void *data);
 int nvme_identify_nvmset(int fd, __u16 nvmset_id, void *data);
+int nvme_identify_uuid(int fd, void *data);
 int nvme_identify_secondary_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
 int nvme_identify_ns_granularity(int fd, void *data);
-int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
-		   __u16 group_id, bool rae, __u32 data_len, void *data);
 int nvme_get_log(int fd, __u32 nsid, __u8 log_id, bool rae,
 		 __u32 data_len, void *data);
+int nvme_get_log14(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
+		   __u16 group_id, bool rae, __u8 uuid_ix,
+		   __u32 data_len, void *data);
+
+static inline int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp,
+				 __u64 lpo, __u16 lsi, bool rae, __u32 data_len,
+				 void *data)
+{
+	return nvme_get_log14(fd, nsid, log_id, lsp, lpo, lsi, rae, 0,
+			      data_len, data);
+}
 
 int nvme_get_telemetry_log(int fd, void *lp, int generate_report,
 			   int ctrl_gen, size_t log_page_size, __u64 offset);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -10,6 +10,14 @@
 #include "suffix.h"
 #include "common.h"
 
+static const uint8_t zero_uuid[16] = {
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+static const uint8_t invalid_uuid[16] = {
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+
 static const char *nvme_ana_state_to_string(enum nvme_ana_state state)
 {
 	switch (state) {
@@ -102,6 +110,27 @@ static void format(char *formatter, size_t fmt_sz, char *tofmt, size_t tofmtsz)
 	}
 }
 
+static const char *nvme_uuid_to_string(uuid_t uuid)
+{
+	/* large enough to hold uuid str (37) + null-termination byte */
+	static char uuid_str[40];
+#ifdef LIBUUID
+	uuid_unparse_lower(uuid, uuid_str);
+#else
+	static const char *hex_digits = "0123456789abcdef";
+	char *p = &uuid_str[0];
+	int i;
+	for (i = 0; i < 16; i++) {
+		*p++ = hex_digits[(uuid.b[i] & 0xf0) >> 4];
+		*p++ = hex_digits[uuid.b[i] & 0x0f];
+		if (i == 3 || i == 5 || i == 7 || i == 9)
+			*p++ = '-';
+	}
+	*p = '\0';
+#endif
+	return uuid_str;
+}
+
 static void show_nvme_id_ctrl_cmic(__u8 cmic)
 {
 	__u8 rsvd = (cmic & 0xF0) >> 4;
@@ -155,7 +184,7 @@ static void show_nvme_id_ctrl_oaes(__le32 ctrl_oaes)
 static void show_nvme_id_ctrl_ctratt(__le32 ctrl_ctratt)
 {
 	__u32 ctratt = le32_to_cpu(ctrl_ctratt);
-	__u32 rsvd0 = ctratt >> 8;
+	__u32 rsvd = ctratt >> 10;
 	__u32 hostid128 = (ctratt & NVME_CTRL_CTRATT_128_ID) >> 0;
 	__u32 psp = (ctratt & NVME_CTRL_CTRATT_NON_OP_PSP) >> 1;
 	__u32 sets = (ctratt & NVME_CTRL_CTRATT_NVM_SETS) >> 2;
@@ -163,11 +192,21 @@ static void show_nvme_id_ctrl_ctratt(__le32 ctrl_ctratt)
 	__u32 eg = (ctratt & NVME_CTRL_CTRATT_ENDURANCE_GROUPS) >> 4;
 	__u32 iod = (ctratt & NVME_CTRL_CTRATT_PREDICTABLE_LAT) >> 5;
 	__u32 ng = (ctratt & NVME_CTRL_CTRATT_NAMESPACE_GRANULARITY) >> 7;
+	__u32 uuidlist = (ctratt & NVME_CTRL_CTRATT_UUID_LIST) >> 9;
+	__u32 rsvd6 = (ctratt & 0x00000040) >> 6;
+	__u32 rsvd8 = (ctratt & 0x00000100) >> 8;
 
-	if (rsvd0)
-		printf(" [31:8] : %#x\tReserved\n", rsvd0);
+	if (rsvd)
+		printf(" [31:10] : %#x\tReserved\n", rsvd);
+
+	printf("  [9:9] : %#x\tUUID List %sSupported\n",
+		uuidlist, uuidlist ? "" : "Not ");
+	if (rsvd8)
+		printf(" [8:8] : %#x\tReserved\n", rsvd8);
 	printf("  [7:7] : %#x\tNamespace Granularity %sSupported\n",
 		ng, ng ? "" : "Not ");
+	if (rsvd6)
+		printf(" [6:6] : %#x\tReserved\n", rsvd6);
 	printf("  [5:5] : %#x\tPredictable Latency Mode %sSupported\n",
 		iod, iod ? "" : "Not ");
 	printf("  [4:4] : %#x\tEndurance Groups %sSupported\n",
@@ -1316,6 +1355,69 @@ void json_nvme_id_ns_granularity_list(const struct nvme_id_ns_granularity_list *
 	json_free_object(root);
 }
 
+void show_nvme_id_uuid_list(const struct nvme_id_uuid_list *uuid_list, unsigned int flags)
+{
+	int i, human = flags & HUMAN;
+	/* The 0th entry is reserved */
+	for (i = 1; i < NVME_MAX_UUID_ENTRIES; i++) {
+		uuid_t uuid;
+		char *association = "";
+		uint8_t identifier_association = uuid_list->entry[i].header & 0x3;
+		/* The list is terminated by a zero UUID value */
+		if (memcmp(uuid_list->entry[i].uuid, zero_uuid, sizeof(zero_uuid)) == 0)
+			break;
+		memcpy(&uuid, uuid_list->entry[i].uuid, sizeof(uuid));
+		if (human) {
+			switch (identifier_association) {
+			case 0x0:
+				association = "No association reported";
+				break;
+			case 0x1:
+				association = "associated with PCI Vendor ID";
+				break;
+			case 0x2:
+				association = "associated with PCI Subsystem Vendor ID";
+				break;
+			default:
+				association = "Reserved";
+				break;
+			}
+		}
+		printf(" Entry[%3d]\n", i);
+		printf(".................\n");
+		printf("association  : 0x%x %s\n", identifier_association, association);
+		printf("UUID         : %s", nvme_uuid_to_string(uuid));
+		if (memcmp(uuid_list->entry[i].uuid, invalid_uuid, sizeof(zero_uuid)) == 0)
+			printf(" (Invalid UUID)");
+		printf("\n.................\n");
+	}
+}
+
+void json_nvme_id_uuid_list(struct nvme_id_uuid_list *uuid_list)
+{
+	struct json_object *root;
+	struct json_array *entries;
+	int i;
+	root = json_create_object();
+	entries = json_create_array();
+	/* The 0th entry is reserved */
+	for (i = 1; i < NVME_MAX_UUID_ENTRIES; i++) {
+		uuid_t uuid;
+		struct json_object *entry = json_create_object();
+		/* The list is terminated by a zero UUID value */
+		if (memcmp(uuid_list->entry[i].uuid, zero_uuid, sizeof(zero_uuid)) == 0)
+			break;
+		memcpy(&uuid, uuid_list->entry[i].uuid, sizeof(uuid));
+		json_object_add_value_int(entry, "association", uuid_list->entry[i].header & 0x3);
+		json_object_add_value_string(entry, "uuid", nvme_uuid_to_string(uuid));
+		json_array_add_value_object(entries, entry);
+	}
+	json_object_add_value_array(root, "UUID-list", entries);
+	json_print_object(root, NULL);
+	printf("\n");
+	json_free_object(root);
+}
+
 void show_error_log(struct nvme_error_log_page *err_log, int entries, const char *devname)
 {
 	int i;
@@ -1439,6 +1541,7 @@ static void show_effects_log_human(__u32 effect)
 	printf("  NCC%s", (effect & NVME_CMD_EFFECTS_NCC) ? set : clr);
 	printf("  NIC%s", (effect & NVME_CMD_EFFECTS_NIC) ? set : clr);
 	printf("  CCC%s", (effect & NVME_CMD_EFFECTS_CCC) ? set : clr);
+	printf("  USS%s", (effect & NVME_CMD_EFFECTS_UUID_SEL) ? set : clr);
 
 	if ((effect & NVME_CMD_EFFECTS_CSE_MASK) >> 16 == 0)
 		printf("  No command restriction\n");

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -42,6 +42,7 @@ void show_nvme_subsystem_list(struct subsys_list_item *slist, int n);
 void show_nvme_id_nvmset(struct nvme_id_nvmset *nvmset);
 void show_nvme_list_secondary_ctrl(const struct nvme_secondary_controllers_list *sc_list, __u32 count);
 void show_nvme_id_ns_granularity_list(const struct nvme_id_ns_granularity_list *granularity, unsigned int flags);
+void show_nvme_id_uuid_list(const struct nvme_id_uuid_list *uuid_list, unsigned int flags);
 
 void nvme_feature_show_fields(__u32 fid, unsigned int result, unsigned char *buf);
 void nvme_directive_show_fields(__u8 dtype, __u8 doper, unsigned int result, unsigned char *buf);
@@ -71,4 +72,6 @@ void json_nvme_id_nvmset(struct nvme_id_nvmset *nvmset, const char *devname);
 void json_ctrl_registers(void *bar);
 void json_nvme_list_secondary_ctrl(const struct nvme_secondary_controllers_list *sc_list, __u32 count);
 void json_nvme_id_ns_granularity_list(const struct nvme_id_ns_granularity_list *granularity, unsigned int flags);
+void json_nvme_id_uuid_list(struct nvme_id_uuid_list *uuid_list);
+
 #endif


### PR DESCRIPTION
1. Add 'id-uuid' command to show the available UUID list
2. Update the get-log, get-feature, and set-feature commands
   to include a uuid-index parameter
	a. If set, the index will be passed as part of DW14 to
	   the controller
3. Update show_nvme_id_ctrl_ctratt() to show bit 9 of the CTRATT
   (UUID List Supported)
4. Update show_effects_log_human() to show the UUID selection bit
   of the effects log

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>