### PR TITLE
fix build error due to asprintf()

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3961,11 +3961,13 @@ void show_relatives(const char *name)
 	ret = sscanf(name, "nvme%dn%d", &id, &nsid);
 	switch (ret) {
 	case 1:
-		asprintf(&path, "/sys/class/nvme/%s", name);
+		if (asprintf(&path, "/sys/class/nvme/%s", name) < 0)
+			path = NULL;
 		block = false;
 		break;
 	case 2:
-		asprintf(&path, "/sys/block/%s/device", name);
+		if (asprintf(&path, "/sys/block/%s/device", name) < 0)
+			path = NULL;
 		break;
 	default:
 		return;

--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -637,7 +637,8 @@ char *nvme_char_from_block(char *dev)
 		return strdup(dev);
 		break;
 	case 2:
-		asprintf(&path, "/sys/block/%s/device", dev);
+		if (asprintf(&path, "/sys/block/%s/device", dev) < 0)
+			path = NULL;
 		break;
 	default:
 		fprintf(stderr, "%s is not an nvme device\n", dev);


### PR DESCRIPTION
Fixes a3b3e93286a3 ("nvme-cli: Code reorg")

$ gcc -v
minwoo@minwoo-desktop:~/work/nvme-cli.git$ (fix-build-error-for-asprintf) gcc -v
...
gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)

nvme-print.c: In function ‘show_relatives’:
nvme-print.c:3964:3: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
   asprintf(&path, "/sys/class/nvme/%s", name);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nvme-print.c:3968:3: error: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Werror=unused-result]
   asprintf(&path, "/sys/block/%s/device", name);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Minwoo Im <minwoo.im@samsung.com>