### PR TITLE
remove LIBUUID things from nvme.h

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -24,14 +24,6 @@
 
 #define unlikely(x) x
 
-#ifdef LIBUUID
-#include <uuid/uuid.h>
-#else
-typedef struct {
-	uint8_t b[16];
-} uuid_t;
-#endif
-
 #include "linux/nvme.h"
 
 struct nvme_effects_log_page {


### PR DESCRIPTION
We have this structure in linux/nvme.h already.

cc -D_GNU_SOURCE -D__CHECK_ENDIAN__ -O2 -g -Wall -Werror -std=gnu99 -I. -DNVME_VERSION='"1.9.22.g6936.dirty"' -Iutil -o nvme-print.o -c nvme-print.c
In file included from nvme.h:35:0,
                 from nvme-print.h:4,
                 from nvme-print.c:7:
linux/nvme.h:24:3: error: conflicting types for ‘uuid_t’
 } uuid_t;
   ^~~~~~
In file included from nvme-print.h:4:0,
                 from nvme-print.c:7:
nvme.h:32:3: note: previous declaration of ‘uuid_t’ was here
 } uuid_t;
   ^~~~~~
Makefile:70: recipe for target 'nvme-print.o' failed

Signed-off-by: Minwoo Im <minwoo.im@samsung.com>