### PR TITLE
nvme: add Persistent Memory Region(PMR) Write Elasticity Status Regis…

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -127,6 +127,8 @@ enum {
 	NVME_REG_PMRCAP = 0x0e00,	/* Persistent Memory Capabilities */
 	NVME_REG_PMRCTL = 0x0e04,	/* Persistent Memory Region Control */
 	NVME_REG_PMRSTS = 0x0e08,	/* Persistent Memory Region Status */
+	NVME_REG_PMREBS = 0x0e0c,	/* Persistent Memory Region Elasticity Buffer Size */
+	NVME_REG_PMRSWTP= 0x0e10,	/* Persistent Memory Region Sustained Write Throughput */
 	NVME_REG_DBS	= 0x1000,	/* SQ 0 Tail Doorbell */
 };
 


### PR DESCRIPTION
…ters

    *update 'show-regs' to display the new PMR Write Elasticity Status
     registers (PMREBS, PMRSWTP)

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>