### PR TITLE
MAINT: compile warning error on 32 bit system

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2392,7 +2392,7 @@ void show_lba_status(struct nvme_lba_status *list)
 {
 	int idx;
 
-	printf("Number of LBA Status Descriptors(NLSD): %lu\n",
+	printf("Number of LBA Status Descriptors(NLSD): %" PRIu64 "\n",
 			le64_to_cpu(list->nlsd));
 	printf("Completion Condition(CMPC): %u\n", list->cmpc);
 	switch (list->cmpc) {

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1310,7 +1310,7 @@ static int wdc_do_cap_dui(int fd, char *file, __u32 xfer_size, int data_area, in
 	__u32 cap_dui_length;
 	__u64 cap_dui_length_v2;
 	__u8 *dump_data = NULL;
-	__u64 buffer_addr;
+	__u8 *buffer_addr;
 	__s64 total_size = 0;
 	int i;
 	int j;
@@ -1397,7 +1397,7 @@ static int wdc_do_cap_dui(int fd, char *file, __u32 xfer_size, int data_area, in
 			log_size -= WDC_NVME_CAP_DUI_HEADER_SIZE;
 			curr_data_offset = WDC_NVME_CAP_DUI_HEADER_SIZE;
 			i = 0;
-			buffer_addr = (__u64)(uintptr_t)dump_data;
+			buffer_addr = dump_data;
 
 			for(; log_size > 0; log_size -= xfer_size_long) {
 				xfer_size_long = min(xfer_size_long, log_size);
@@ -1405,7 +1405,7 @@ static int wdc_do_cap_dui(int fd, char *file, __u32 xfer_size, int data_area, in
 				if (log_size <= xfer_size_long)
 					last_xfer = true;
 
-				ret = wdc_dump_dui_data_v2(fd, (__u32)xfer_size_long, curr_data_offset, (__u8 *)buffer_addr, last_xfer);
+				ret = wdc_dump_dui_data_v2(fd, (__u32)xfer_size_long, curr_data_offset, buffer_addr, last_xfer);
 				if (ret != 0) {
 					fprintf(stderr, "%s: ERROR : WDC : Get chunk %d, size = 0x%lx, offset = 0x%lx, addr = 0x%lx\n",
 							__func__, i, (long unsigned int)total_size, (long unsigned int)curr_data_offset, (long unsigned int)buffer_addr);
@@ -1486,7 +1486,7 @@ static int wdc_do_cap_dui(int fd, char *file, __u32 xfer_size, int data_area, in
 			log_size -= WDC_NVME_CAP_DUI_HEADER_SIZE;
 			curr_data_offset = WDC_NVME_CAP_DUI_HEADER_SIZE;
 			i = 0;
-			buffer_addr = (__u64)(uintptr_t)dump_data;
+			buffer_addr = dump_data;
 
 			for(; log_size > 0; log_size -= xfer_size) {
 				xfer_size = min(xfer_size, log_size);
@@ -1494,10 +1494,10 @@ static int wdc_do_cap_dui(int fd, char *file, __u32 xfer_size, int data_area, in
 				if (log_size <= xfer_size)
 					last_xfer = true;
 
-				ret = wdc_dump_dui_data(fd, xfer_size, curr_data_offset, (__u8 *)buffer_addr, last_xfer);
+				ret = wdc_dump_dui_data(fd, xfer_size, curr_data_offset, buffer_addr, last_xfer);
 				if (ret != 0) {
-					fprintf(stderr, "%s: ERROR : WDC : Get chunk %d, size = 0x%lx, offset = 0x%x, addr = 0x%lx\n",
-							__func__, i, (long unsigned int)log_size, curr_data_offset, (long unsigned int)buffer_addr);
+					fprintf(stderr, "%s: ERROR : WDC : Get chunk %d, size = 0x%lx, offset = 0x%x, addr = %p\n",
+							__func__, i, (long unsigned int)log_size, curr_data_offset, buffer_addr);
 					fprintf(stderr, "%s: ERROR : WDC : NVMe Status:%s(%x)\n", __func__, nvme_status_to_string(ret), ret);
 					break;
 				}
@@ -3899,7 +3899,7 @@ static int wdc_drive_resize(int argc, char **argv,
 	}
 
 	if (!ret)
-		printf("New size: %lu GB\n", cfg.size);
+		printf("New size: %" PRIu64 " GB\n", cfg.size);
 
 	fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
 	return ret;


### PR DESCRIPTION
Since some pointer handlings are depended on 64 bit system.
So fix them as generic.

Signed-off-by: Tokunori Ikegami <ikegami.t@gmail.com>