### PR TITLE
make: install-hostparams depends on install-etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ install-zsh-completion:
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/zsh/site-functions
 	$(INSTALL) -m 644 -T ./completions/_nvme $(DESTDIR)$(PREFIX)/share/zsh/site-functions/_nvme
 
-install-hostparams:
+install-hostparams: install-etc
 	if [ ! -s $(DESTDIR)$(SYSCONFDIR)/nvme/hostnqn ]; then \
 		echo `$(DESTDIR)$(SBINDIR)/nvme gen-hostnqn` > $(DESTDIR)$(SYSCONFDIR)/nvme/hostnqn; \
 	fi


### PR DESCRIPTION
It's possible for the install target to fail if the install-hostparams
target executes before the install-etc target:
```
/bin/sh: line 1: $(DESTDIR)$(SYSCONFDIR)/nvme/hostnqn: No such file or directory
make: *** [Makefile:113: install-hostparams] Error 1
```
Signed-off-by: Zac Medico <zmedico@gentoo.org>