### PR TITLE
Correct self-test-log output

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2178,7 +2178,7 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 
 	err = nvme_self_test_log(fd, &self_test_log);
 	if (!err) {
-		if (self_test_log.crnt_dev_selftest_compln == 100) {
+		if (self_test_log.crnt_dev_selftest_oprn == 0) {
 			if (fmt == BINARY)
 				d_raw((unsigned char *)&self_test_log, sizeof(self_test_log));
 			else if (fmt == JSON)


### PR DESCRIPTION
Changes determination of Device Self-Test in progress to be based on the
Current Device Self-Test Operation field as opposed to the Current
Device Self-Test Completion field.

Current implementation assumes that the Current Device Self-Test
Completion field will be 100% when no Device Self-Test operation is in
progress. This is an unsafe assumption as the NVMe Specification
explicitly specifies that the Current Device Self-Test Completion field
is invalid when no Device Self-Test operation in progress as indicated
by a value of 0 in the Current Device Self-Test Operation field.

A safe assumption is to use the Current Device Self-Test Operation field
which will be 0 when no Device Self-Test operation is in progress.

Current output when no Device Self-Test in progress:
```
$ nvme self-test-log /dev/nvme0
Test is 0% complete and is still in progress.
```
The above output is so because the Current Device Self-Test Completion is not 100%

New output examples:
```
$ nvme self-test-log /dev/nvme0
Device Self Test Log for NVME device:nvme0
Current operation : 0
Current Completion : 0%

$ nvme device-self-test /dev/nvme0 -n 0 -s 1 && nvme self-test-log /dev/nvme0
Device self-test started
Test is 0% complete and is still in progress.

$ nvme self-test-log /dev/nvme0
Device Self Test Log for NVME device:nvme0
Current operation : 0
Current Completion : 0%
Result[0]:
  Test Result                  : 0 Operation completed without error
  Test Code                    : 0x1 Short device self-test operation
  Valid Diagnostic Information : 0
  Power on hours (POH)         : 0x37
  Vendor Specific                      : 0 0
Result[1]:
  Test Result                  : 0 Operation completed without error
  Test Code                    : 0x1 Short device self-test operation
  Valid Diagnostic Information : 0
  Power on hours (POH)         : 0x37
  Vendor Specific                      : 0 0
Result[2]:
  Test Result                  : 0 Operation completed without error
  Test Code                    : 0x1 Short device self-test operation
  Valid Diagnostic Information : 0
  Power on hours (POH)         : 0x37
  Vendor Specific                      : 0 0
Result[3]:
  Test Result                  : 0 Operation completed without error
  Test Code                    : 0x1 Short device self-test operation
  Valid Diagnostic Information : 0
  Power on hours (POH)         : 0x37
  Vendor Specific                      : 0 0
```