### PR TITLE
nvme.spec.in: fix rpm build error

### DIFF
--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -35,7 +35,7 @@ make install-spec DESTDIR=%{buildroot} PREFIX=/usr
 %{_sysconfdir}/nvme/hostnqn
 %{_sysconfdir}/nvme/hostid
 %{_sysconfdir}/nvme/discovery.conf
-%{_libdir}/udev/rules.d/70-nvmf-autoconnect.rules
+%{_sysconfdir}/udev/rules.d/70-nvmf-autoconnect.rules
 %{_libdir}/dracut/dracut.conf.d/70-nvmf-autoconnect.conf
 %{_libdir}/systemd/system/nvmf-connect@.service
 %{_libdir}/systemd/system/nvmefc-boot-connections.service


### PR DESCRIPTION
error caused by 70-nvmf-autoconnect.rules location different with Makefile.

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>