### PR TITLE
Add an example for attach-ns

### DIFF
--- a/Documentation/nvme-attach-ns.txt
+++ b/Documentation/nvme-attach-ns.txt
@@ -30,7 +30,12 @@ OPTIONS
 
 EXAMPLES
 --------
-No examples yet.
+	Attach namspace to the controller:
+
+		# nvme attach-ns /dev/nvme1  -n 0x2 -c 0x21
+        
+		Note: Namespace identifier and controller identifier(s) should be in hexadecimal.
+
 
 NVME
 ----

--- a/updated.patch1
+++ b/updated.patch1
@@ -1,0 +1,14 @@
+diff --git a/Documentation/nvme-attach-ns.txt b/Documentation/nvme-attach-ns.txt
+index 8467335..79bb525 100644
+--- a/Documentation/nvme-attach-ns.txt
++++ b/Documentation/nvme-attach-ns.txt
+@@ -34,9 +34,6 @@ EXAMPLES
+ 
+ 		# nvme attach-ns /dev/nvme1  -n 0x2 -c 0x21
+         
+-		Note: Namespace identifier and controller identifier(s) should be in hexadecimal.
+-
+-
+ NVME
+ ----
+ Part of the nvme-user suite


### PR DESCRIPTION
Add an example to man page of attach-ns command showing syntax and information to use hexadecimal value for Namespace identifier and controller identifier.