### PR TITLE
nvme-cli: Add namespace-id option to self-test-log

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -523,9 +523,9 @@ int nvme_ana_log(int fd, void *ana_log, size_t ana_log_len, int rgo)
 			true, ana_log_len, ana_log);
 }
 
-int nvme_self_test_log(int fd, struct nvme_self_test_log *self_test_log)
+int nvme_self_test_log(int fd, __u32 nsid, struct nvme_self_test_log *self_test_log)
 {
-	return nvme_get_log(fd, NVME_NSID_ALL, NVME_LOG_DEVICE_SELF_TEST, false,
+	return nvme_get_log(fd, nsid, NVME_LOG_DEVICE_SELF_TEST, false,
 		sizeof(*self_test_log), self_test_log);
 }
 

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -153,6 +153,6 @@ int nvme_get_property(int fd, int offset, uint64_t *value);
 int nvme_sanitize(int fd, __u8 sanact, __u8 ause, __u8 owpass, __u8 oipbp,
 		  __u8 no_dealloc, __u32 ovrpat);
 int nvme_self_test_start(int fd, __u32 nsid, __u32 cdw10);
-int nvme_self_test_log(int fd, struct nvme_self_test_log *self_test_log);
+int nvme_self_test_log(int fd, __u32 nsid, struct nvme_self_test_log *self_test_log);
 int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result);
 #endif				/* _NVME_LIB_H */

--- a/nvme.c
+++ b/nvme.c
@@ -2152,17 +2152,22 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 	const char *desc = "Retrieve the self-test log for the given device and given test "\
 			"(or optionally a namespace) in either decoded format "\
 			"(default) or binary.";
+	const char *namespace_id = "Indicate the namespace from which the self-test "\
+				    "log has to be obtained";
 	int err, fmt, fd;
 
 	struct config {
+		__u32 namespace_id;
 		char *output_format;
 	};
 
 	struct config cfg = {
+		.namespace_id = NVME_NSID_ALL,
 		.output_format = "normal",
 	};
 
 	OPT_ARGS(opts) = {
+		OPT_UINT("namespace-id", 'n', &cfg.namespace_id,  namespace_id),
 		OPT_FMT("output-format", 'o', &cfg.output_format, output_format),
 		OPT_END()
 	};
@@ -2179,7 +2184,7 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 		goto close_fd;
 	}
 
-	err = nvme_self_test_log(fd, &self_test_log);
+	err = nvme_self_test_log(fd, cfg.namespace_id, &self_test_log);
 	if (!err) {
 		if (self_test_log.crnt_dev_selftest_oprn == 0) {
 			if (fmt == BINARY)


### PR DESCRIPTION
Instead of scanning all the namespaces for logs, the user can specify
the namespace from which he wants to retrieve the self-test log from.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>