### PR TITLE
Intel plugin: Adding fields to id-ctrl VU region

### DIFF
--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -58,7 +58,6 @@ struct nvme_additional_smart_log {
 	struct nvme_additional_smart_log_item	host_bytes_written;
 };
 
-#pragma pack(push,1)
 struct nvme_vu_id_ctrl_field { //CDR MR5
 	__u8			rsvd1[3];
 	__u8			ss;
@@ -73,7 +72,6 @@ struct nvme_vu_id_ctrl_field { //CDR MR5
 	__u8			mic_bl[4];
 	__u8			mic_fw[4];
 };
-#pragma pack(pop)
 
 static void intel_id_ctrl(__u8 *vs, struct json_object *root)
 {


### PR DESCRIPTION
Updating fields in 'nvme intel id-ctrl' to parse/print data already provided by the drive.

Signed-off-by: Ben Reese <5884008+benreese0@users.noreply.github.com>