### PR TITLE
Use a systemd app-specific machine ID for hostnqn

### DIFF
--- a/Documentation/nvme-show-hostnqn.txt
+++ b/Documentation/nvme-show-hostnqn.txt
@@ -1,0 +1,29 @@
+nvme-show-hostnqn(1)
+===================
+
+NAME
+----
+nvme-show-hostnqn - Generate a host NVMe Qualified Name
+
+SYNOPSIS
+--------
+[verse]
+'nvme show-hostnqn'
+
+DESCRIPTION
+-----------
+Show the host NQN configured for the system.  If /etc/nvme/hostnqn is
+not present and systemd application-specific machine IDs are available,
+this will show the systemd-generated host NQN for the system.
+
+OPTIONS
+-------
+No options needed
+
+EXAMPLES
+--------
+nvme show-hostnqn
+
+NVME
+----
+Part of the nvme-user suite

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CFLAGS ?= -O2 -g -Wall -Werror
 override CFLAGS += -std=gnu99 -I.
 override CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
 LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
+HAVE_SYSTEMD = $(shell pkg-config --exists systemd  --atleast-version=232; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =
@@ -21,6 +22,11 @@ ifeq ($(LIBUUID),0)
 endif
 
 INC=-Iutil
+
+ifeq ($(HAVE_SYSTEMD),0)
+	override LDFLAGS += -lsystemd
+	override CFLAGS += -DHAVE_SYSTEMD
+endif
 
 RPMBUILD = rpmbuild
 TAR = tar

--- a/fabrics.h
+++ b/fabrics.h
@@ -3,6 +3,8 @@
 
 #define NVMF_DEF_DISC_TMO	30
 
+extern char *hostnqn_read(void);
+
 extern int discover(const char *desc, int argc, char **argv, bool connect);
 extern int connect(const char *desc, int argc, char **argv);
 extern int disconnect(const char *desc, int argc, char **argv);

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -70,6 +70,7 @@ COMMAND_LIST(
 	ENTRY("disconnect", "Disconnect from NVMeoF subsystem", disconnect_cmd)
 	ENTRY("disconnect-all", "Disconnect from all connected NVMeoF subsystems", disconnect_all_cmd)
 	ENTRY("gen-hostnqn", "Generate NVMeoF host NQN", gen_hostnqn_cmd)
+	ENTRY("show-hostnqn", "Show NVMeoF host NQN", show_hostnqn_cmd)
 	ENTRY("dir-receive", "Submit a Directive Receive command, return results", dir_receive)
 	ENTRY("dir-send", "Submit a Directive Send command, return results", dir_send)
 	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller ", virtual_mgmt)

--- a/nvme.c
+++ b/nvme.c
@@ -5026,6 +5026,21 @@ static int gen_hostnqn_cmd(int argc, char **argv, struct command *command, struc
 }
 #endif
 
+static int show_hostnqn_cmd(int argc, char **argv, struct command *command, struct plugin *plugin)
+{
+	char *hostnqn;
+
+	hostnqn = hostnqn_read();
+	if (hostnqn) {
+		fputs(hostnqn, stdout);
+		free(hostnqn);
+		return 0;
+	} else {
+		fprintf(stderr, "hostnqn is not available -- use nvme gen-hostnqn\n");
+		return -ENOENT;
+	}
+}
+
 static int discover_cmd(int argc, char **argv, struct command *command, struct plugin *plugin)
 {
 	const char *desc = "Send Get Log Page request to Discovery Controller.";


### PR DESCRIPTION
If /etc/nvme/hostnqn is not present, the fabric commands will ask
systemd for an app-specific machine ID as a fallback.  This should
improve functionality if /etc/nvme/hostnqn is not present and should
allow packagers to avoid creating /etc/nvme/hostnqn.

Heavily based on an earlier patch from Tomasz Torcz.

See also #415.

If you like this, similar treatment may be needed for hostid.