### PR TITLE
nvme-cli: Add support for nvme abort admin command

### DIFF
--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -74,6 +74,7 @@ COMMAND_LIST(
 	ENTRY("dir-receive", "Submit a Directive Receive command, return results", dir_receive)
 	ENTRY("dir-send", "Submit a Directive Send command, return results", dir_send)
 	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller ", virtual_mgmt)
+	ENTRY("abort", "Submit a Abort admin command ", abort_cmd)
 );
 
 #endif

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -926,3 +926,13 @@ int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result)
 
 	return err;
 }
+
+int nvme_abort(int fd, __u16 sqid, __u16 cid)
+{
+	struct nvme_admin_cmd cmd = {
+		.opcode		= nvme_admin_abort_cmd,
+		.cdw10		= cid << 16 | sqid,
+	};
+
+	return nvme_submit_admin_passthru(fd, &cmd);
+}

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -155,4 +155,5 @@ int nvme_sanitize(int fd, __u8 sanact, __u8 ause, __u8 owpass, __u8 oipbp,
 int nvme_self_test_start(int fd, __u32 nsid, __u32 cdw10);
 int nvme_self_test_log(int fd, __u32 nsid, struct nvme_self_test_log *self_test_log);
 int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result);
+int nvme_abort(int fd, __u16 sqid, __u16 cid);
 #endif				/* _NVME_LIB_H */


### PR DESCRIPTION
Currently the abort command can be submitted by using nvme admin-passthru.
But it is better to be supported by the nvme abort command directly so add it.

Signed-off-by: Tokunori Ikegami <ikegami.t@gmail.com>