### PR TITLE
nvme-cli: New Command Implemented: Format Progress Indicator

### DIFF
--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -74,6 +74,7 @@ COMMAND_LIST(
 	ENTRY("dir-receive", "Submit a Directive Receive command, return results", dir_receive)
 	ENTRY("dir-send", "Submit a Directive Send command, return results", dir_send)
 	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller ", virtual_mgmt)
+	ENTRY("format-pi", "Indicate the percentage of the namespace that remains to be formatted", format_pi)
 );
 
 #endif

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1706,6 +1706,26 @@ static void format(char *formatter, size_t fmt_sz, char *tofmt, size_t tofmtsz)
 	}
 }
 
+void nvme_show_format_pi(struct nvme_id_ns *ns, unsigned int nsid)
+{
+	__u8 fpi_sup, fpi_percent;
+
+	fpi_sup = (ns->fpi & 0x80) >> 7;
+	if (!fpi_sup) {
+		printf("The namespace: %d does NOT support the Format Progress "\
+			"Indicator(FPI)\n", nsid);
+		return;
+	}
+
+	fpi_percent = ns->fpi & 0x7f;
+	if (!fpi_percent)
+		printf("Namespace fromatted as specified by the FLBAS and DPS. "\
+			"There is NO Format NVM command in progress\n");
+	else
+		printf("%d%% of the Format NVM command has been completed and %d%% "\
+			"remains to be completed\n", (100 - fpi_percent), fpi_percent);
+}
+
 static const char *nvme_uuid_to_string(uuid_t uuid)
 {
 	/* large enough to hold uuid str (37) + null-termination byte */

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -58,6 +58,7 @@ void nvme_feature_show_fields(__u32 fid, unsigned int result, unsigned char *buf
 void nvme_directive_show(__u8 type, __u8 oper, __u16 spec, __u32 nsid, __u32 result,
 	void *buf, __u32 len, enum nvme_print_flags flags);
 void nvme_show_select_result(__u32 result);
+void nvme_show_format_pi(struct nvme_id_ns *ns, unsigned int nsid);
 
 const char *nvme_status_to_string(__u32 status);
 const char *nvme_select_to_string(int sel);


### PR DESCRIPTION
If a format operation is in progress, this feature indicates
the percentage of the namespace that remains to be formatted.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>