### PR TITLE
nvme.c: format help modification(clear explaination)

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2663,7 +2663,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		"Can also be used to change LBAF to change the namespaces reported physical block format.";
 	const char *namespace_id = "identifier of desired namespace";
 	const char *lbaf = "LBA format to apply (required)";
-	const char *ses = "[0-2]: secure erase";
+	const char *ses = "[0-3]: secure erase";
 	const char *pil = "[0-1]: protection info location last/first 8 bytes of metadata";
 	const char *pi = "[0-3]: protection info off/Type 1/Type 2/Type 3";
 	const char *ms = "[0-1]: extended format off/on";


### PR DESCRIPTION
former commit was unclear (bit rule was worng for ses[0-3])
so reordering with bit order, show bit numbers for each options

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>