### PR TITLE
nvme-cli: Update err value to 0 in get_ns_id func.

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1758,6 +1758,7 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 		err = errno;
 		goto close_fd;
 	}
+	err = 0;
 	printf("%s: namespace-id:%d\n", devicename, nsid);
 
 close_fd:


### PR DESCRIPTION
Err value should be updated to 0 on success of nvme_get_nsid,
else the File Descriptor is passed on to nvme_status_to_errno
which returns an irrelevant errno.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>