### PR TITLE
nvme-cli: Update err to 0 in get_telemetry_log

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -444,6 +444,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 			fprintf(stderr, "Failed to flush all data to file!");
 			break;
 		}
+		err = 0;
 		offset += bs;
 	}
 


### PR DESCRIPTION
Err needs to be updated to 0 else err contains bs(no. of bytes written).
This gets passd onto nvme_status_to_errno, thus returning irrelevant errno.

Signed-off-by: Revanth Rajashekar <revanth.rajashekar@intel.com>