### PR TITLE
nvme-cli: Check for sysfs interface before NVMe discovery

### DIFF
--- a/nvmf-autoconnect/systemd/nvmefc-boot-connections.service
+++ b/nvmf-autoconnect/systemd/nvmefc-boot-connections.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Auto-connect to subsystems on FC-NVME devices found during boot
+ConditionPathExists=/sys/class/fc/fc_udev_device/nvme_discovery
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This prevents an unnecessary error message in the case that the nvme-fc
kernel module is not loaded and the
  `/sys/class/fc/fc_udev_device/nvme_discovery`
handle is not available.

Apparently somebody sent my unit-files upstream, but didn't choose the up-to-date version :)