### PR TITLE
Add  vs-error-reason-identifier WDC plugin command

### DIFF
--- a/Documentation/nvme-wdc-clear-fw-activate-history.txt
+++ b/Documentation/nvme-wdc-clear-fw-activate-history.txt
@@ -15,9 +15,7 @@ DESCRIPTION
 For the NVMe device given, sends the wdc vendor unique clear fw activate
 history command.
 
-The <device> parameter is mandatory and may be either the NVMe
-character device (ex: /dev/nvme0), or a namespace block device (ex:
-/dev/nvme0n1).
+The <device> parameter is mandatory and must be the NVMe character device (ex: /dev/nvme0).
 
 This will only work on WDC devices supporting this feature.
 Results for any other device are undefined.

--- a/Documentation/nvme-wdc-vs-error-reason-identifier.txt
+++ b/Documentation/nvme-wdc-vs-error-reason-identifier.txt
@@ -1,0 +1,56 @@
+nvme-wdc-vs-error-reason-identifier(1)
+======================================
+
+NAME
+----
+nvme-wdc-vs-error-reason-identifier - Retrieve WDC device's telemetry log error reason identifier field
+
+SYNOPSIS
+--------
+[verse]
+'nvme wdc vs-error-reason-identifier' <device> [--log-id=<NUM>, -i <NUM>] [--file=<FILE>, -o <FILE>]
+
+DESCRIPTION
+-----------
+For the NVMe device given, retrieve the telemetry log error reason id field for either the host generated or 
+controller initiated log.  The controller initiated telemetry log page option must be enabled to retrieve the
+error reason id for that log page id.  
+
+The <device> parameter is mandatory and must be the NVMe character device (ex: /dev/nvme0).
+
+This will only work on WDC devices supporting this feature.
+Results for any other device are undefined.
+
+On success it returns 0, error code otherwise.
+
+OPTIONS
+-------
+-i <id>::
+--log-id=<id>::
+	Specifies the telemetry log id of the error reason identifier to retrieve.  
+	Use id 7 for the host generated log page.
+	Use id 8 for the controller initiated log page. 
+	The default is 7/host generated
+
+-o <FILE>::
+--output-file=<FILE>::
+	Output file; defaults to "<device serial number>_error_reason_identifier_host_<date>_<time>.bin" for 
+	the host generated log or "<device serial number>_error_reason_identifier_ctlr_<date>_<time>.bin" for 
+	the controller initiated log. 
+
+EXAMPLES
+--------
+* Retrieves the host generated error reason identifier field and save it in file host_gen_error_reason_id.bin. 
++
+--------
+# nvme wdc vs-error-reason-identifier /dev/nvme0 -i 7 -o host_gen_error_reason_id.bin
+--------
+* Retrieves the controller initiated error reason identifier field and save it in file ctlr_init_error_reason_id.bin. 
++
+--------
+# nvme wdc vs-error-reason-identifier /dev/nvme0 -i 8 -o ctlr_init_error_reason_id.bin
+--------
+
+NVME
+----
+Part of the nvme-user suite.

--- a/Documentation/nvme-wdc-vs-fw-activate-history.txt
+++ b/Documentation/nvme-wdc-vs-fw-activate-history.txt
@@ -3,7 +3,7 @@ nvme-wdc-vs-fw-activate-history(1)
 
 NAME
 ----
-nvme-wdc-vs-fw-activate-history - Rend NVMe WDC vs-fw-acivate-history Vendor Unique Command, return result
+nvme-wdc-vs-fw-activate-history - Execute NVMe WDC vs-fw-activate-history Vendor Unique Command, return result
 
 SYNOPSIS
 --------
@@ -15,8 +15,7 @@ DESCRIPTION
 For the NVMe device given, read a Vendor Unique WDC log page that returns the firmware actiation
 history. 
 
-The <device> parameter is mandatory and may be either the NVMe character
-device (ex: /dev/nvme0).
+The <device> parameter is mandatory and must be the NVMe character device (ex: /dev/nvme0).
 
 This will only work on WDC devices supporting this feature.
 Results for any other device are undefined.

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -26,6 +26,8 @@ PLUGIN(NAME("wdc", "Western Digital vendor specific extensions"),
 		ENTRY("vs-fw-activate-history", "WDC Get FW Activate History", wdc_vs_fw_activate_history)
 		ENTRY("clear-fw-activate-history", "WDC Clear FW Activate History", wdc_clear_fw_activate_history)
 		ENTRY("vs-telemetry-controller-option", "WDC Enable/Disable Controller Initiated Telemetry Log", wdc_vs_telemetry_controller_option)
+		ENTRY("vs-error-reason-identifier", "WDC Telemetry Reason Identifier", wdc_reason_identifier)
+
 	)
 );
 


### PR DESCRIPTION
This commit contains the following changes:
Add support for WDC plugin command - vs-error-reason-identifier
Reverse enable/disable bit on the vs-telemetry-controller-option WDC plugin command
Add documentation file for vs-error-reason-identifier WDC plugin command
Minor corrections to the documentation files for vs-fw-activate-history and clear-fw-activate-history WDC plugin commands

