### PR TITLE
Makefile: generate Dracut config according to UDEVDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test:
 all: doc
 
 clean:
-	$(RM) $(NVME) $(OBJS) $(PLUGIN_OBJS) $(UTIL_OBJS) *~ a.out NVME-VERSION-FILE *.tar* nvme.spec version control nvme-*.deb
+	$(RM) $(NVME) $(OBJS) $(PLUGIN_OBJS) $(UTIL_OBJS) *~ a.out NVME-VERSION-FILE *.tar* nvme.spec version control nvme-*.deb 70-nvmf-autoconnect.conf
 	$(MAKE) -C Documentation clean
 	$(RM) tests/*.pyc
 	$(RM) verify-no-dep
@@ -128,9 +128,9 @@ install-udev:
 	$(INSTALL) -d $(DESTDIR)$(UDEVDIR)/rules.d
 	$(INSTALL) -m 644 ./nvmf-autoconnect/udev-rules/* $(DESTDIR)$(UDEVDIR)/rules.d
 
-install-dracut:
+install-dracut: 70-nvmf-autoconnect.conf
 	$(INSTALL) -d $(DESTDIR)$(DRACUTDIR)/dracut.conf.d
-	$(INSTALL) -m 644 ./nvmf-autoconnect/dracut-conf/* $(DESTDIR)$(DRACUTDIR)/dracut.conf.d
+	$(INSTALL) -m 644 $< $(DESTDIR)$(DRACUTDIR)/dracut.conf.d
 
 install-zsh-completion:
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/share/zsh/site-functions
@@ -157,6 +157,10 @@ install: install-spec install-hostparams
 
 nvme.spec: nvme.spec.in NVME-VERSION-FILE
 	sed -e 's/@@VERSION@@/$(NVME_VERSION)/g' < $< > $@+
+	mv $@+ $@
+
+70-nvmf-autoconnect.conf: nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
+	sed -e 's#@@UDEVDIR@@#$(UDEVDIR)#g' < $< > $@+
 	mv $@+ $@
 
 dist: nvme.spec

--- a/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf
+++ b/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf
@@ -1,1 +1,0 @@
-install_items+="/usr/lib/udev/rules.d/70-nvmf-autoconnect.rules"

--- a/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
+++ b/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
@@ -1,0 +1,1 @@
+install_items+="@@UDEVDIR@@/rules.d/70-nvmf-autoconnect.rules"


### PR DESCRIPTION
Currently, UDEVDIR defaults to `/etc/udev` while the dracut config file hardcodes `/usr/lib/udev`. This makes dracut complain that it cannot find the specified file.