### PR TITLE
fix nvme disconnect by device failure

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -269,7 +269,7 @@ static int ctrl_instance(char *device)
 	if (ret <= 0)
 		return -EINVAL;
 	if (snprintf(d, sizeof(d), "nvme%d", instance) <= 0 ||
-	    strcmp(device, d))
+	    strncmp(device, d, strlen(d)))
 		return -EINVAL;
 	return instance;
 }


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

When nvme disconnect with device path is issued, it fails as below.

```
root:github.com/linux-nvme/nvme-cli# ./nvme disconnect -d /dev/nvme0n1
Failed to disconnect by device name: /dev/nvme0n1
```

Looking  at the  code and debugging, I find there is an added suffix to device name and the match only happens for nvme0 and not nvme0n1.
In fabrics.c:ctrl_instance() method:
nvme ctrl_instance passed device /dev/nvme0n1, basename nvme0n1, instance 0, tmp 'd' nvme0
