### PR TITLE
Makefile: use UDEVRULESDIR instead of UDEVDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SBINDIR = $(PREFIX)/sbin
 LIBDIR ?= $(PREFIX)/lib
 SYSTEMDDIR ?= $(LIBDIR)/systemd
 UDEVDIR ?= $(SYSCONFDIR)/udev
+UDEVRULESDIR ?= $(UDEVDIR)/rules.d
 DRACUTDIR ?= $(LIBDIR)/dracut
 LIB_DEPENDS =
 
@@ -125,8 +126,8 @@ install-systemd:
 	$(INSTALL) -m 644 ./nvmf-autoconnect/systemd/* $(DESTDIR)$(SYSTEMDDIR)/system
 
 install-udev:
-	$(INSTALL) -d $(DESTDIR)$(UDEVDIR)/rules.d
-	$(INSTALL) -m 644 ./nvmf-autoconnect/udev-rules/* $(DESTDIR)$(UDEVDIR)/rules.d
+	$(INSTALL) -d $(DESTDIR)$(UDEVRULESDIR)
+	$(INSTALL) -m 644 ./nvmf-autoconnect/udev-rules/* $(DESTDIR)$(UDEVRULESDIR)
 
 install-dracut: 70-nvmf-autoconnect.conf
 	$(INSTALL) -d $(DESTDIR)$(DRACUTDIR)/dracut.conf.d
@@ -160,7 +161,7 @@ nvme.spec: nvme.spec.in NVME-VERSION-FILE
 	mv $@+ $@
 
 70-nvmf-autoconnect.conf: nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
-	sed -e 's#@@UDEVDIR@@#$(UDEVDIR)#g' < $< > $@+
+	sed -e 's#@@UDEVRULESDIR@@#$(UDEVRULESDIR)#g' < $< > $@+
 	mv $@+ $@
 
 dist: nvme.spec

--- a/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
+++ b/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
@@ -1,1 +1,1 @@
-install_items+="@@UDEVDIR@@/rules.d/70-nvmf-autoconnect.rules"
+install_items+="@@UDEVRULESDIR@@/70-nvmf-autoconnect.rules"


### PR DESCRIPTION
The SUSE rpm macros only have UDEVRULESDIR, not UDEVDIR.
So introduce a UDEVRULESDIR variable which is preset to
UDEVDIR/rules.d

Signed-off-by: Hannes Reinecke <hare@suse.de>