### PR TITLE
nvmf-autoconnect.service

### DIFF
--- a/nvmf-autoconnect/systemd/nvmf-autoconnect.service
+++ b/nvmf-autoconnect/systemd/nvmf-autoconnect.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Connect NVMe-oF subsystems automatically during boot
+ConditionPathExists=/etc/nvme/discovery.conf
+After=network.target
+Before=remote-fs-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/nvme connect-all
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Add a systemd service to automatically start 'nvme connect-all'
upon booting if an /etc/nvme/discovery.conf file exists.
The 'nvme-tcp' or 'nvme-rdma' modules need to be loaded earlier
by eg the modules-load service.

Signed-off-by: Hannes Reinecke <hare@suse.com>