### PR TITLE
Include limits.h for PATH_MAX and NAME_MAX on musl

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -13,6 +13,7 @@
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
 #include <sys/ioctl.h>
+#include <limits.h>
 
 #define CREATE_CMD
 #include "micron-nvme.h"


### PR DESCRIPTION
nvme-cli fails to build on musl with errors:
`error: 'PATH_MAX' undeclared` and `error: 'NAME_MAX' undeclared`
https://travis-ci.org/void-linux/void-packages/builds/650527256

Including the limits header fixes this: https://travis-ci.org/void-linux/void-packages/builds/650567795