### PR TITLE
ioctl: Remove duplicated header files

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -1,11 +1,8 @@
 #include <assert.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
-#include <string.h>
 #include <errno.h>
-#include <unistd.h>
 
-#include <errno.h>
 #include <getopt.h>
 #include <fcntl.h>
 #include <inttypes.h>


### PR DESCRIPTION
Remove duplicated included header files in a file (nvme-ioctl.c)

Signed-off-by: Minwoo Im <minwoo.im@samsung.com>