### PR TITLE
Update Makefile to remove old destination folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ HAVE_SYSTEMD = $(shell pkg-config --exists libsystemd  --atleast-version=232; ec
 NVME = nvme
 INSTALL ?= install
 DESTDIR =
+DESTDIROLD = /usr/local/sbin
 PREFIX ?= /usr
 SYSCONFDIR = /etc
 SBINDIR = $(PREFIX)/sbin
@@ -114,6 +115,7 @@ install-man:
 	$(MAKE) -C Documentation install-no-build
 
 install-bin: default
+	$(RM) $(DESTDIROLD)/nvme
 	$(INSTALL) -d $(DESTDIR)$(SBINDIR)
 	$(INSTALL) -m 755 nvme $(DESTDIR)$(SBINDIR)
 


### PR DESCRIPTION
The install path has been changed recently.  This change removes the old install folder if it exists.