### PR TITLE
Fixed malformed json output from sanitize-log.

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3672,6 +3672,7 @@ void nvme_show_sanitize_log(struct nvme_sanitize_log_page *sanitize,
 		d_raw((unsigned char *)sanitize, sizeof(*sanitize));
 	else if (flags & JSON)
 		json_sanitize_log(sanitize, devname);
+        return;
 
 	printf("Sanitize Progress                      (SPROG) :  %u",
 	       le16_to_cpu(sanitize->progress));

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3672,7 +3672,7 @@ void nvme_show_sanitize_log(struct nvme_sanitize_log_page *sanitize,
 		d_raw((unsigned char *)sanitize, sizeof(*sanitize));
 	else if (flags & JSON)
 		json_sanitize_log(sanitize, devname);
-        return;
+		return;
 
 	printf("Sanitize Progress                      (SPROG) :  %u",
 	       le16_to_cpu(sanitize->progress));

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3670,9 +3670,10 @@ void nvme_show_sanitize_log(struct nvme_sanitize_log_page *sanitize,
 
 	if (flags & BINARY)
 		d_raw((unsigned char *)sanitize, sizeof(*sanitize));
-	else if (flags & JSON)
+	else if (flags & JSON) {
 		json_sanitize_log(sanitize, devname);
 		return;
+    }
 
 	printf("Sanitize Progress                      (SPROG) :  %u",
 	       le16_to_cpu(sanitize->progress));


### PR DESCRIPTION
Fixes #679

```
[root@FM21V304-DEV09 ~]# git clone https://github.com/gcoakes/nvme-cli
Cloning into 'nvme-cli'...
remote: Enumerating objects: 41, done.
remote: Counting objects: 100% (41/41), done.
remote: Compressing objects: 100% (32/32), done.
remote: Total 8992 (delta 19), reused 18 (delta 9), pack-reused 8951
Receiving objects: 100% (8992/8992), 4.19 MiB | 5.81 MiB/s, done.
Resolving deltas: 100% (6804/6804), done.
[root@FM21V304-DEV09 ~]# cd nvme-cli
[root@FM21V304-DEV09 nvme-cli]# git branch
* master
[root@FM21V304-DEV09 nvme-cli]# git checkout sanitize-log-json-fix
Branch sanitize-log-json-fix set up to track remote branch sanitize-log-json-fix from origin.
Switched to a new branch 'sanitize-log-json-fix'
[root@FM21V304-DEV09 nvme-cli]# make
NVME_VERSION = 1.10.1.33.gf30e
    CC nvme-print.o
    CC nvme-ioctl.o
    CC nvme-lightnvm.o
    CC fabrics.o
    CC nvme-models.o
    CC plugin.o
    CC nvme-status.o
    CC nvme-filters.o
    CC nvme-topology.o
    CC plugins/intel/intel-nvme.o
    CC plugins/lnvm/lnvm-nvme.o
    CC plugins/memblaze/memblaze-nvme.o
    CC plugins/wdc/wdc-nvme.o
    CC plugins/wdc/wdc-utils.o
    CC plugins/huawei/huawei-nvme.o
    CC plugins/netapp/netapp-nvme.o
    CC plugins/toshiba/toshiba-nvme.o
    CC plugins/micron/micron-nvme.o
    CC plugins/seagate/seagate-nvme.o
    CC plugins/virtium/virtium-nvme.o
    CC plugins/shannon/shannon-nvme.o
    CC plugins/dera/dera-nvme.o
    CC util/argconfig.o
    CC util/suffix.o
    CC util/json.o
    CC util/parser.o
    CC nvme
[root@FM21V304-DEV09 nvme-cli]# ./nvme sanitize-log -o json /dev/nvme0n1
{
  "nvme0n1" : {
    "sprog" : 65535,
    "sstat" : {
      "global_erased" : 1,
      "no_cmplted_passes" : 0,
      "status" : "(1) Most Recent Sanitize Command Completed Successfully."
    },
    "cdw10_info" : 4,
    "time_over_write" : 4294967295,
    "time_block_erase" : 174,
    "time_crypto_erase" : 34,
    "time_over_write_no_dealloc" : 0,
    "time_block_erase_no_dealloc" : 0,
    "time_crypto_erase_no_dealloc" : 0
  }
}
```