### PR TITLE
nvme.spec: rpmbuild error fix (missing file)

### DIFF
--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -41,6 +41,7 @@ make install-spec DESTDIR=%{buildroot} PREFIX=/usr
 %{_libdir}/systemd/system/nvmf-connect@.service
 %{_libdir}/systemd/system/nvmefc-boot-connections.service
 %{_libdir}/systemd/system/nvmf-connect.target
+%{_libdir}/systemd/system/nvmf-autoconnect.service
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>