### PR TITLE
nvme-connect-all: add -m /  -matching option

### DIFF
--- a/Documentation/nvme-connect-all.1
+++ b/Documentation/nvme-connect-all.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-connect-all
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 04/24/2020
+.\"      Date: 04/29/2020
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-CONNECT\-ALL" "1" "04/24/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-CONNECT\-ALL" "1" "04/29/2020" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -49,6 +49,9 @@ nvme-connect-all \- Discover and Connect to Fabrics controllers\&.
                 [\-\-nr\-write\-queues=<#>    | \-W <#>]
                 [\-\-nr\-poll\-queues=<#>     | \-P <#>]
                 [\-\-queue\-size=<#>         | \-Q <#>]
+                [\-\-matching               | \-m]
+                [\-\-persistent             | \-p]
+                [\-\-quiet                  | \-q]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -172,6 +175,21 @@ Adds additional queues that will be used for polling latency sensitive I/O\&.
 \-Q <#>, \-\-queue\-size=<#>
 .RS 4
 Overrides the default number of elements in the I/O queues created by the driver\&. This option will be ignored for discovery, but will be passed on to the subsequent connect call\&.
+.RE
+.PP
+\-m, \-\-matching
+.RS 4
+If a traddr was specified on the command line or in the configuration file, only create controllers for discovery records that match the given traddr, rather than for all entries in the discovery log page\&.
+.RE
+.PP
+\-p, \-\-persistent
+.RS 4
+Don\(cqt remove the discovery controller after retrieving the discovery log page\&.
+.RE
+.PP
+\-q, \-\-quiet
+.RS 4
+Suppress error messages\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-connect-all.html
+++ b/Documentation/nvme-connect-all.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-connect-all(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -433,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -762,7 +765,10 @@ nvme-connect-all(1) Manual Page
                 [--nr-io-queues=&lt;#&gt;       | -i &lt;#&gt;]
                 [--nr-write-queues=&lt;#&gt;    | -W &lt;#&gt;]
                 [--nr-poll-queues=&lt;#&gt;     | -P &lt;#&gt;]
-                [--queue-size=&lt;#&gt;         | -Q &lt;#&gt;]</pre>
+                [--queue-size=&lt;#&gt;         | -Q &lt;#&gt;]
+                [--matching               | -m]
+                [--persistent             | -p]
+                [--quiet                  | -q]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -1012,6 +1018,42 @@ cellspacing="0" cellpadding="4">
         passed on to the subsequent connect call.
 </p>
 </dd>
+<dt class="hdlist1">
+-m
+</dt>
+<dt class="hdlist1">
+--matching
+</dt>
+<dd>
+<p>
+        If a traddr was specified on the command line or in the configuration
+        file, only create controllers for discovery records that match the
+        given traddr, rather than for all entries in the discovery log page.
+</p>
+</dd>
+<dt class="hdlist1">
+-p
+</dt>
+<dt class="hdlist1">
+--persistent
+</dt>
+<dd>
+<p>
+        Don&#8217;t remove the discovery controller after retrieving the discovery
+        log page.
+</p>
+</dd>
+<dt class="hdlist1">
+-q
+</dt>
+<dt class="hdlist1">
+--quiet
+</dt>
+<dd>
+<p>
+        Suppress error messages.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -1068,7 +1110,8 @@ nvme-connect(1)</p></div>
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-08-29 18:41:45 MDT
+Last updated
+ 2020-04-29 22:28:00 CEST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -27,6 +27,7 @@ SYNOPSIS
 		[--queue-size=<#>         | -Q <#>]
 		[--matching               | -m]
 		[--persistent             | -p]
+		[--quiet                  | -q]
 
 DESCRIPTION
 -----------
@@ -151,6 +152,10 @@ OPTIONS
 --persistent::
 	Don't remove the discovery controller after retrieving the discovery
 	log page.
+
+-q::
+--quiet::
+	Suppress error messages.
 
 
 EXAMPLES

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -25,6 +25,7 @@ SYNOPSIS
 		[--nr-write-queues=<#>    | -W <#>]
 		[--nr-poll-queues=<#>     | -P <#>]
 		[--queue-size=<#>         | -Q <#>]
+		[--matching               | -m]
 
 DESCRIPTION
 -----------
@@ -138,6 +139,12 @@ OPTIONS
 	Overrides the default number of elements in the I/O queues created
 	by the driver. This option will be ignored for discovery, but will be
 	passed on to the subsequent connect call.
+
+-m::
+--matching::
+	If a traddr was specified on the command line or in the configuration
+	file, only create controllers for discovery records that match the
+	given traddr, rather than for all entries in the discovery log page.
 
 
 EXAMPLES

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -26,6 +26,7 @@ SYNOPSIS
 		[--nr-poll-queues=<#>     | -P <#>]
 		[--queue-size=<#>         | -Q <#>]
 		[--matching               | -m]
+		[--persistent             | -p]
 
 DESCRIPTION
 -----------
@@ -145,6 +146,11 @@ OPTIONS
 	If a traddr was specified on the command line or in the configuration
 	file, only create controllers for discovery records that match the
 	given traddr, rather than for all entries in the discovery log page.
+
+-p::
+--persistent::
+	Don't remove the discovery controller after retrieving the discovery
+	log page.
 
 
 EXAMPLES

--- a/fabrics.c
+++ b/fabrics.c
@@ -84,6 +84,7 @@ static struct config {
 	int  data_digest;
 	bool persistent;
 	bool quiet;
+	bool matching_only;
 } cfg = { NULL };
 
 struct connect_args {
@@ -1103,6 +1104,17 @@ retry:
 	return ret;
 }
 
+static bool should_connect(struct nvmf_disc_rsp_page_entry *entry)
+{
+	int len;
+
+	if (!cfg.matching_only || !cfg.traddr)
+		return true;
+
+	len = space_strip_len(NVMF_TRADDR_SIZE, entry->traddr);
+	return !strncmp(cfg.traddr, entry->traddr, len);
+}
+
 static int connect_ctrls(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 {
 	int i;
@@ -1110,6 +1122,9 @@ static int connect_ctrls(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 	int ret = 0;
 
 	for (i = 0; i < numrec; i++) {
+		if (!should_connect(&log->entries[i]))
+			continue;
+
 		instance = connect_ctrl(&log->entries[i]);
 
 		/* clean success */
@@ -1343,6 +1358,7 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 		OPT_INT("queue-size",      'Q', &cfg.queue_size,      "number of io queue elements to use (default 128)"),
 		OPT_FLAG("persistent",     'p', &cfg.persistent,      "persistent discovery connection"),
 		OPT_FLAG("quiet",          'S', &cfg.quiet,           "suppress already connected errors"),
+		OPT_FLAG("matching",       'm', &cfg.matching_only,   "connect only records matching the traddr"),
 		OPT_END()
 	};
 

--- a/nvmf-autoconnect/systemd/nvmf-connect@.service
+++ b/nvmf-autoconnect/systemd/nvmf-connect@.service
@@ -11,4 +11,4 @@ Requires=nvmf-connect.target
 [Service]
 Type=simple
 Environment="CONNECT_ARGS=%i"
-ExecStart=/bin/sh -c "nvme connect-all --quiet `/bin/echo -e '${CONNECT_ARGS}'`"
+ExecStart=/bin/sh -c "nvme connect-all --matching --quiet `/bin/echo -e '${CONNECT_ARGS}'`"


### PR DESCRIPTION
Optionally have `connect-all` connect only to such controllers that have a matching `traddr` field. 

This avoids confusing error messages and failed connect attempts for NVMeoFC autoconnect. See https://github.com/linux-nvme/nvme-cli/commit/f989634e0595b1f184a0acb125c4460b1b31960a commit message for a detailed rationale.