### PR TITLE
nvme-cli: controller list argument is required in attach-ns/detach-ns commands

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1058,7 +1058,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	__u16 ctrlist[2048];
 
 	const char *namespace_id = "namespace to attach";
-	const char *cont = "optional comma-sep controller id list";
+	const char *cont = "comma-sep controller id list";
 
 	struct config {
 		char  *cntlist;
@@ -1088,7 +1088,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	}
 
 	num = argconfig_parse_comma_sep_array(cfg.cntlist, list, 2047);
-	if (num == -1) {
+	if (num < 1) {
 		fprintf(stderr, "%s: controller id list is required\n",
 						cmd->name);
 		err = -EINVAL;

--- a/nvme.c
+++ b/nvme.c
@@ -1093,7 +1093,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	}
 
 	if (num == -1) {
-		fprintf(stderr, "%s: controller id list is required\n",
+		fprintf(stderr, "%s: controller id list is malformed\n",
 						cmd->name);
 		err = -EINVAL;
 		goto close_fd;

--- a/nvme.c
+++ b/nvme.c
@@ -1058,7 +1058,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	__u16 ctrlist[2048];
 
 	const char *namespace_id = "namespace to attach";
-	const char *cont = "comma-sep controller id list";
+	const char *cont = "optional comma-sep controller id list";
 
 	struct config {
 		char  *cntlist;
@@ -1088,7 +1088,11 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	}
 
 	num = argconfig_parse_comma_sep_array(cfg.cntlist, list, 2047);
-	if (num < 1) {
+	if (!num) {
+		fprintf(stderr, "warning: empty controller-id list will result in no actual change in namespace attachment\n");
+	}
+
+	if (num == -1) {
 		fprintf(stderr, "%s: controller id list is required\n",
 						cmd->name);
 		err = -EINVAL;


### PR DESCRIPTION
Empty controller-id list in the ioctl call for attach/detach of namespace results effectively in no operation, yet the nvme cli reports falsely success. The controller id list must be specified with at least 1 controller in the list.