### PR TITLE
remove block device checking for namespace

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -70,12 +70,6 @@ int nvme_get_nsid(int fd)
 	if (err < 0)
 		return -errno;
 
-	if (!S_ISBLK(nvme_stat.st_mode)) {
-		fprintf(stderr,
-			"Error: requesting namespace-id from non-block device\n");
-		errno = ENOTBLK;
-		return -errno;
-	}
 	return ioctl(fd, NVME_IOCTL_ID);
 }
 

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -472,8 +472,6 @@ static int netapp_nvme_filter(const struct dirent *d)
 		snprintf(path, sizeof(path), "%s%s", dev_path, d->d_name);
 		if (stat(path, &bd))
 			return 0;
-		if (!S_ISBLK(bd.st_mode))
-			return 0;
 		if (sscanf(d->d_name, "nvme%dn%d", &ctrl, &ns) != 2)
 			return 0;
 		if (sscanf(d->d_name, "nvme%dn%dp%d", &ctrl, &ns, &partition) == 3)


### PR DESCRIPTION
In SPDK project (see spdk.io) we have implemented the ability
to set up devices via CUSE device exposing controller and
namespaces as character devices.

Namespace devices are also exposed as character devices, so
nvme-cli tools will not recognize them as valid devices.

To allow to use nvme-cli tool with SPDK NVMe CUSE devices
we can't assume that namespaces are block devices.

Change-Id: I52aa79d24002b8dec10e6fdd0cb9a71bb6750358
Signed-off-by: Tomasz Kulasek <tomaszx.kulasek@intel.com>