### PR TITLE
nvme-cli:nvme:fix fd leak when an error occurs in open_dev()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -148,10 +148,13 @@ static int open_dev(char *dev)
 	fd = err;
 
 	err = fstat(fd, &nvme_stat);
-	if (err < 0)
+	if (err < 0) {
+		close(fd);
 		goto perror;
+	}
 	if (!S_ISCHR(nvme_stat.st_mode) && !S_ISBLK(nvme_stat.st_mode)) {
 		fprintf(stderr, "%s is not a block or character device\n", dev);
+		close(fd);
 		return -ENODEV;
 	}
 	return fd;


### PR DESCRIPTION
fix fd leak when an error occurs in open_dev()

Signed-off-by: Wu Bo <wubo40@huawei.com>
