### PR TITLE
nvme.c: remove side effects from older commit

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2874,7 +2874,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		nvme_show_status(err);
 	else {
 		printf("Success formatting namespace:%x\n", cfg.namespace_id);
-		if (ioctl(fd, BLKRRPART) < 0) {
+		if (cfg.lbaf != prev_lbaf && ioctl(fd, BLKRRPART) < 0) {
 			fprintf(stderr, "failed to re-read partition table\n");
 			err = -errno;
 			goto close_fd;


### PR DESCRIPTION
If there is given nsid by user, no need to set using nvme_get_nsid.
(e770466615096a6d41f038a28819b00bc3078e1d)

Format for All namespace not using prev_lbaf.
(62ae3bea42cb3a81cc77492568747a330f783100)

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>