### PR TITLE
MAINT: nvme-cli: Add LF code into error messages

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -412,7 +412,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 
 	err = write(output, (void *) hdr, bs);
 	if (err != bs) {
-		fprintf(stderr, "Failed to flush all data to file!");
+		fprintf(stderr, "Failed to flush all data to file!\n");
 		goto close_output;
 	}
 
@@ -427,7 +427,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 		full_size = (le16_to_cpu(hdr->dalb3) * bs) + offset;
 		break;
 	default:
-		fprintf(stderr, "Invalid data area requested");
+		fprintf(stderr, "Invalid data area requested\n");
 		err = -EINVAL;
 		goto close_output;
 	}
@@ -449,7 +449,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 
 		err = write(output, (void *) page_log, bs);
 		if (err != bs) {
-			fprintf(stderr, "Failed to flush all data to file!");
+			fprintf(stderr, "Failed to flush all data to file!\n");
 			break;
 		}
 		err = 0;
@@ -1580,7 +1580,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 			err = -ENOTBLK;
 			goto close_fd;
 		}
-	} 
+	}
 
 	err = nvme_identify_ns(fd, cfg.namespace_id, cfg.force, &ns);
 	if (!err)
@@ -2603,7 +2603,7 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 		goto ret;
 
 	if (cfg.offset == -1) {
-		fprintf(stderr, "offset required param");
+		fprintf(stderr, "offset required param\n");
 		err = -EINVAL;
 		goto close_fd;
 	}
@@ -2652,12 +2652,12 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 		goto ret;
 
 	if (cfg.offset == -1) {
-		fprintf(stderr, "offset required param");
+		fprintf(stderr, "offset required param\n");
 		err = -EINVAL;
 		goto close_fd;
 	}
 	if (cfg.value == -1) {
-		fprintf(stderr, "value required param");
+		fprintf(stderr, "value required param\n");
 		err = -EINVAL;
 		goto close_fd;
 	}

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1289,7 +1289,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 				"Latency Statistics Tracking (FID 0x%X) is currently (%i).\n",
 				fid, result);
 		} else {
-			printf("Could not read feature id 0xE2.");
+			printf("Could not read feature id 0xE2.\n");
 			return err;
 		}
 		break;
@@ -1302,14 +1302,14 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 					nvme_status_to_string(err), err);
 		} else if (err < 0) {
 			perror("Enable latency tracking");
-			fprintf(stderr, "Command failed while parsing.");
+			fprintf(stderr, "Command failed while parsing.\n");
 		} else {
 			printf("Successfully set enable bit for FID (0x%X) to %i.\n",
 				fid, option);
 		}
 		break;
 	default:
-		printf("%d not supported.", option);
+		printf("%d not supported.\n", option);
 		return EINVAL;
 	}
 	return fd;


### PR DESCRIPTION
Some error mesages are output without LF code so add it.

Signed-off-by: Tokunori Ikegami <ikegami.t@gmail.com>