### PR TITLE
Update systemd required version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ override CFLAGS += -std=gnu99 -I.
 override CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
 LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
 LIBHUGETLBFS = $(shell $(LD) -o /dev/null -lhugetlbfs >/dev/null 2>&1; echo $$?)
-HAVE_SYSTEMD = $(shell pkg-config --exists libsystemd  --atleast-version=232; echo $$?)
+HAVE_SYSTEMD = $(shell pkg-config --exists libsystemd  --atleast-version=242; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =


### PR DESCRIPTION
A change to fabrics.c - commit 48c10dbf requires systemd version 242 or later.

Signed-off-by: Randy Bates <randall.bates@wdc.com>