### PR TITLE
Fix non-qword-aligned PMRMSC read

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -170,7 +170,8 @@ enum {
 	NVME_REG_PMRSTS = 0x0e08,	/* Persistent Memory Region Status */
 	NVME_REG_PMREBS = 0x0e0c,	/* Persistent Memory Region Elasticity Buffer Size */
 	NVME_REG_PMRSWTP= 0x0e10,	/* Persistent Memory Region Sustained Write Throughput */
-	NVME_REG_PMRMSC = 0x0e14,	/* Persistent Memory Region Controller Memory Space Control */
+	NVME_REG_PMRMSCL= 0x0e14,	/* Persistent Memory Region Controller Memory Space Control Low */
+	NVME_REG_PMRMSCH= 0x0e18,	/* Persistent Memory Region Controller Memory Space Control High */
 	NVME_REG_DBS	= 0x1000,	/* SQ 0 Tail Doorbell */
 };
 

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1297,8 +1297,8 @@ static void nvme_show_registers_pmrmsc(uint64_t pmrmsc)
 {
 	printf("\tController Base Address (CBA)		: %" PRIx64 "\n",
 		(pmrmsc & 0xfffffffffffff000) >> 12);
-	printf("\tController Memory Space Enable (CMSE	: %" PRIx64 "\n\n",
-		(pmrmsc & 0x0000000000000001) >> 1);
+	printf("\tController Memory Space Enable (CMSE)	: %" PRIx64 "\n\n",
+		(pmrmsc & 0x0000000000000002) >> 1);
 }
 
 static inline uint32_t mmio_read32(void *addr)
@@ -1320,7 +1320,8 @@ static void json_ctrl_registers(void *bar)
 {
 	uint64_t cap, asq, acq, bpmbl, cmbmsc, pmrmsc;
 	uint32_t vs, intms, intmc, cc, csts, nssr, aqa, cmbsz, cmbloc,
-		bpinfo, bprsel, cmbsts, pmrcap, pmrctl, pmrsts, pmrebs, pmrswtp;
+		bpinfo, bprsel, cmbsts, pmrcap, pmrctl, pmrsts, pmrebs, pmrswtp,
+		pmrmscl, pmrmsch;
 	struct json_object *root;
 
 	cap = mmio_read64(bar + NVME_REG_CAP);
@@ -1345,7 +1346,9 @@ static void json_ctrl_registers(void *bar)
 	pmrsts = mmio_read32(bar + NVME_REG_PMRSTS);
 	pmrebs = mmio_read32(bar + NVME_REG_PMREBS);
 	pmrswtp = mmio_read32(bar + NVME_REG_PMRSWTP);
-	pmrmsc = mmio_read64(bar + NVME_REG_PMRMSC);
+	pmrmscl = mmio_read32(bar + NVME_REG_PMRMSCL);
+	pmrmsch = mmio_read32(bar + NVME_REG_PMRMSCH);
+	pmrmsc = ((uint64_t) pmrmsch << 32) | pmrmscl;
 
 	root = json_create_object();
 	json_object_add_value_uint(root, "cap", cap);
@@ -1381,7 +1384,8 @@ void nvme_show_ctrl_registers(void *bar, bool fabrics, enum nvme_print_flags fla
 	const unsigned int reg_size = 0x50;  /* 00h to 4Fh */
 	uint64_t cap, asq, acq, bpmbl, cmbmsc, pmrmsc;
 	uint32_t vs, intms, intmc, cc, csts, nssr, aqa, cmbsz, cmbloc, bpinfo,
-		 bprsel, cmbsts, pmrcap, pmrctl, pmrsts, pmrebs, pmrswtp;
+		 bprsel, cmbsts, pmrcap, pmrctl, pmrsts, pmrebs, pmrswtp, pmrmscl,
+		 pmrmsch;
 	int human = flags & VERBOSE;
 
 	if (flags & BINARY)
@@ -1411,7 +1415,9 @@ void nvme_show_ctrl_registers(void *bar, bool fabrics, enum nvme_print_flags fla
 	pmrsts = mmio_read32(bar + NVME_REG_PMRSTS);
 	pmrebs = mmio_read32(bar + NVME_REG_PMREBS);
 	pmrswtp = mmio_read32(bar + NVME_REG_PMRSWTP);
-	pmrmsc = mmio_read64(bar + NVME_REG_PMRMSC);
+	pmrmscl = mmio_read32(bar + NVME_REG_PMRMSCL);
+	pmrmsch = mmio_read32(bar + NVME_REG_PMRMSCH);
+	pmrmsc = ((uint64_t) pmrmsch << 32) | pmrmscl;
 
 	if (human) {
 		if (cap != 0xffffffff) {


### PR DESCRIPTION
PMRMSC is defined at a non-qword-aligned offset, so depending on the architecture used, accessing this register can cause some controllers to crash. I also noticed the CMSE bitmask in nvme_show_registers_pmrmsc was off by one and corrected it.