### PR TITLE
nvme-print: streamline show-regs output

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -946,7 +946,7 @@ static void nvme_show_registers_cap(struct nvme_bar_cap *cap)
 			"Not Supported");
 	printf("\tPersistent Memory Region Supported (PMRS): The Persistent Memory Region is %s\n",
 		(cap->rsvd_cmbs_pmrs & 0x01) ? "Supported" : "Not Supported");
-	printf("\tMemory Page Size Maximum	   (MPSMAX): %u bytes\n",
+	printf("\tMemory Page Size Maximum         (MPSMAX): %u bytes\n",
 		1 <<  (12 + ((cap->mpsmax_mpsmin & 0xf0) >> 4)));
 	printf("\tMemory Page Size Minimum         (MPSMIN): %u bytes\n",
 		1 <<  (12 + (cap->mpsmax_mpsmin & 0x0f)));
@@ -964,7 +964,7 @@ static void nvme_show_registers_cap(struct nvme_bar_cap *cap)
 		cap->to * 500);
 	printf("\tArbitration Mechanism Supported     (AMS): Weighted Round Robin with Urgent Priority Class is %s\n",
 		(cap->ams_cqr & 0x02) ? "supported":"not supported");
-	printf("\tContiguous Queues Required	      (CQR): %s\n",
+	printf("\tContiguous Queues Required          (CQR): %s\n",
 		(cap->ams_cqr & 0x01) ? "Yes":"No");
 	printf("\tMaximum Queue Entries Supported    (MQES): %u\n\n",
 		cap->mqes + 1);
@@ -1203,11 +1203,11 @@ static void nvme_show_registers_bpmbl(uint64_t bpmbl)
 
 static void nvme_show_registers_cmbmsc(uint64_t cmbmsc)
 {
-	printf("\tController Base Address (CBA)	     : %" PRIx64 "\n",
+	printf("\tController Base Address         (CBA): %" PRIx64 "\n",
 			(cmbmsc & 0xfffffffffffff000) >> 12);
 	printf("\tController Memory Space Enable (CMSE): %" PRIx64 "\n",
 			(cmbmsc & 0x0000000000000002) >> 1);
-	printf("\tCapabilities Registers Enabled (CRE) : CMBLOC and "\
+	printf("\tCapabilities Registers Enabled  (CRE): CMBLOC and "\
 	       "CMBSZ registers are%senabled\n\n",
 		(cmbmsc & 0x0000000000000001) ? " " : " NOT ");
 }
@@ -1220,20 +1220,20 @@ static void nvme_show_registers_cmbsts(__u32 cmbsts)
 
 static void nvme_show_registers_pmrcap(__u32 pmrcap)
 {
-	printf("\tController Memory Space Supported (CMSS)		   : "\
+	printf("\tController Memory Space Supported                   (CMSS): "\
 	       "Referencing PMR with host supplied addresses is %s\n",
 	       ((pmrcap & 0x01000000) >> 24) ? "Supported" : "Not Supported");
-	printf("\tPersistent Memory Region Timeout		    (PMRTO): %x\n",
+	printf("\tPersistent Memory Region Timeout                   (PMRTO): %x\n",
 		(pmrcap & 0x00ff0000) >> 16);
-	printf("\tPersistent Memory Region Write Barrier Mechanisms(PMRWBM): %x\n",
+	printf("\tPersistent Memory Region Write Barrier Mechanisms (PMRWBM): %x\n",
 		(pmrcap & 0x00003c00) >> 10);
-	printf("\tPersistent Memory Region Time Units		    (PMRTU): PMR time unit is %s\n",
+	printf("\tPersistent Memory Region Time Units                (PMRTU): PMR time unit is %s\n",
 		(pmrcap & 0x00000300) >> 8 ? "minutes":"500 milliseconds");
-	printf("\tBase Indicator Register			      (BIR): %x\n",
+	printf("\tBase Indicator Register                              (BIR): %x\n",
 		(pmrcap & 0x000000e0) >> 5);
-	printf("\tWrite Data Support				      (WDS): Write data to the PMR is %s\n",
+	printf("\tWrite Data Support                                   (WDS): Write data to the PMR is %s\n",
 		(pmrcap & 0x00000010) ? "supported":"not supported");
-	printf("\tRead Data Support				      (RDS): Read data from the PMR is %s\n",
+	printf("\tRead Data Support                                    (RDS): Read data from the PMR is %s\n",
 		(pmrcap & 0x00000008) ? "supported":"not supported");
 }
 
@@ -1258,14 +1258,14 @@ static void nvme_show_registers_pmrsts(__u32 pmrsts, __u32 pmrctl)
 {
 	printf("\tController Base Address Invalid (CBAI): %x\n",
 		(pmrsts & 0x00001000) >> 12);
-	printf("\tHealth Status			  (HSTS): %s\n",
+	printf("\tHealth Status                   (HSTS): %s\n",
 		nvme_register_pmr_hsts_to_string((pmrsts & 0x00000e00) >> 9));
-	printf("\tNot Ready			  (NRDY): "\
+	printf("\tNot Ready                       (NRDY): "\
 		"The Persistent Memory Region is %s to process "\
 		"PCI Express memory read and write requests\n",
 			(pmrsts & 0x00000100) == 0 && (pmrctl & 0x00000001) ?
 				"READY":"Not Ready");
-	printf("\tError				  (ERR) : %x\n", (pmrsts & 0x000000ff));
+	printf("\tError                            (ERR): %x\n", (pmrsts & 0x000000ff));
 }
 
 static const char *nvme_register_pmr_pmrszu_to_string(__u8 pmrszu)
@@ -1282,7 +1282,7 @@ static const char *nvme_register_pmr_pmrszu_to_string(__u8 pmrszu)
 static void nvme_show_registers_pmrebs(__u32 pmrebs)
 {
 	printf("\tPMR Elasticity Buffer Size Base  (PMRWBZ): %x\n", (pmrebs & 0xffffff00) >> 8);
-	printf("\tRead Bypass Behavior			   : memory reads not conflicting with memory writes "\
+	printf("\tRead Bypass Behavior                     : memory reads not conflicting with memory writes "\
 	       "in the PMR Elasticity Buffer %s bypass those memory writes\n",
 	       (pmrebs & 0x00000010) ? "SHALL":"MAY");
 	printf("\tPMR Elasticity Buffer Size Units (PMRSZU): %s\n",
@@ -1299,9 +1299,9 @@ static void nvme_show_registers_pmrswtp(__u32 pmrswtp)
 
 static void nvme_show_registers_pmrmsc(uint64_t pmrmsc)
 {
-	printf("\tController Base Address (CBA)		: %" PRIx64 "\n",
+	printf("\tController Base Address         (CBA): %" PRIx64 "\n",
 		(pmrmsc & 0xfffffffffffff000) >> 12);
-	printf("\tController Memory Space Enable (CMSE)	: %" PRIx64 "\n\n",
+	printf("\tController Memory Space Enable (CMSE): %" PRIx64 "\n\n",
 		(pmrmsc & 0x0000000000000002) >> 1);
 }
 


### PR DESCRIPTION
Fix mixed tabs/spaces use in show-regs pretty print and align tabulated
output.

Signed-off-by: Klaus Jensen <k.jensen@samsung.com>