### PR TITLE
add path to nvme list

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1699,7 +1699,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 		for (j = 0; j < s->nr_ctrls; j++) {
 			struct nvme_ctrl *c = &s->ctrls[j];
 
-			if (!strcmp(c->transport, "pcie"))
+			if (!c->transport || !strcmp(c->transport, "pcie"))
 				continue;
 			err = disconnect_by_device(c->name);
 			if (err)

--- a/fabrics.c
+++ b/fabrics.c
@@ -1687,7 +1687,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 	if (err)
 		goto out;
 
-	err = scan_subsystems(&t, NULL, 0);
+	err = scan_subsystems(&t, NULL, 0, NULL);
 	if (err) {
 		fprintf(stderr, "Failed to scan namespaces\n");
 		goto out;

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1629,7 +1629,7 @@ void nvme_show_relatives(const char *name)
 			free(path);
 			return;
 		}
-		err = scan_subsystems(&t, subsysnqn, 0);
+		err = scan_subsystems(&t, subsysnqn, 0, NULL);
 		if (err || t.nr_subsystems != 1) {
 			free(subsysnqn);
 			free(path);
@@ -4699,7 +4699,7 @@ static void nvme_show_list_item(struct nvme_namespace *n)
 	struct stat st;
 	int ret;
 
-	sprintf(path, "/dev/%s", n->name);
+	sprintf(path, "%s%s", n->ctrl->path, n->name);
 	ret = stat(path, &st);
 	if (ret < 0)
 		return;
@@ -4708,7 +4708,7 @@ static void nvme_show_list_item(struct nvme_namespace *n)
 		nsze, s_suffix);
 	sprintf(format,"%3.0f %2sB + %2d B", (double)lba, l_suffix,
 		le16_to_cpu(n->ns.lbaf[(n->ns.flbas & 0x0f)].ms));
-	printf("/dev/%-11s %-*.*s %-*.*s %-9d %-26s %-16s %-.*s\n", n->name,
+	printf("%-21s %-*.*s %-*.*s %-9d %-26s %-16s %-.*s\n", path,
 		(int)sizeof(n->ctrl->id.sn), (int)sizeof(n->ctrl->id.sn), n->ctrl->id.sn,
 		(int)sizeof(n->ctrl->id.mn), (int)sizeof(n->ctrl->id.mn), n->ctrl->id.mn,
 		n->nsid, usage, format, (int)sizeof(n->ctrl->id.fr), n->ctrl->id.fr);
@@ -4718,9 +4718,9 @@ static void nvme_show_simple_list(struct nvme_topology *t)
 {
 	int i, j, k;
 
-	printf("%-16s %-20s %-40s %-9s %-26s %-16s %-8s\n",
+	printf("%-21s %-20s %-40s %-9s %-26s %-16s %-8s\n",
 	    "Node", "SN", "Model", "Namespace", "Usage", "Format", "FW Rev");
-	printf("%-.16s %-.20s %-.40s %-.9s %-.26s %-.16s %-.8s\n", dash, dash,
+	printf("%-.21s %-.20s %-.40s %-.9s %-.26s %-.16s %-.8s\n", dash, dash,
 		dash, dash, dash, dash, dash);
 
 	for (i = 0; i < t->nr_subsystems; i++) {
@@ -4972,7 +4972,7 @@ static void json_simple_ns(struct nvme_namespace *n, struct json_array *devices)
 	long long lba;
 	char *devnode;
 
-	if (asprintf(&devnode, "/dev/%s", n->name) < 0)
+	if (asprintf(&devnode, "%s%s", n->ctrl->path, n->name) < 0)
 		return;
 
 	device_attrs = json_create_object();

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -875,9 +875,9 @@ static void nvme_show_subsystem(struct nvme_subsystem *s)
 
 	for (i = 0; i < s->nr_ctrls; i++) {
 		printf(" +- %s %s %s %s %s\n", s->ctrls[i].name,
-				s->ctrls[i].transport,
-				s->ctrls[i].address,
-				s->ctrls[i].state,
+				s->ctrls[i].transport ? : "",
+				s->ctrls[i].address ? : "",
+				s->ctrls[i].state ? : "",
 				s->ctrls[i].ana_state ? : "");
 	}
 }
@@ -910,12 +910,15 @@ static void json_print_nvme_subsystem_list(struct nvme_topology *t)
 			path_attrs = json_create_object();
 			json_object_add_value_string(path_attrs, "Name",
 					c->name);
-			json_object_add_value_string(path_attrs, "Transport",
-					c->transport);
-			json_object_add_value_string(path_attrs, "Address",
-					c->address);
-			json_object_add_value_string(path_attrs, "State",
-					c->state);
+			if (c->transport)
+				json_object_add_value_string(path_attrs,
+						"Transport", c->transport);
+			if (c->address)
+				json_object_add_value_string(path_attrs,
+						"Address", c->address);
+			if (c->state)
+				json_object_add_value_string(path_attrs,
+						"State", c->state);
 			if (c->ana_state)
 				json_object_add_value_string(path_attrs,
 						"ANAState", c->ana_state);
@@ -4819,7 +4822,7 @@ static void nvme_show_detailed_list(struct nvme_topology *t)
 
 			printf("%-8s %-.20s %-.40s %-.8s %-6s %-14s %-12s ",
 				c->name, c->id.sn, c->id.mn, c->id.fr,
-				c->transport, c->address, s->name);
+				c->transport ? : "", c->address ? : "", s->name);
 
 			for (k = 0; k < c->nr_namespaces; k++) {
 				struct nvme_namespace *n = &c->namespaces[k];
@@ -4907,9 +4910,12 @@ static void json_detail_list(struct nvme_topology *t)
 			struct json_array *namespaces;
 
 			json_object_add_value_string(ctrl_attrs, "Controller", c->name);
-			json_object_add_value_string(ctrl_attrs, "Transport", c->transport);
-			json_object_add_value_string(ctrl_attrs, "Address", c->address);
-			json_object_add_value_string(ctrl_attrs, "State", c->state);
+			if (c->transport)
+				json_object_add_value_string(ctrl_attrs, "Transport", c->transport);
+			if (c->address)
+				json_object_add_value_string(ctrl_attrs, "Address", c->address);
+			if (c->state)
+				json_object_add_value_string(ctrl_attrs, "State", c->state);
 			if (c->hostnqn)
 				json_object_add_value_string(ctrl_attrs, "HostNQN", c->hostnqn);
 			if (c->hostid)
@@ -4996,7 +5002,7 @@ static void json_simple_ns(struct nvme_namespace *n, struct json_array *devices)
 
 	json_object_add_value_string(device_attrs, "ModelNumber", formatter);
 
-	if (index >= 0 && !strcmp(n->ctrl->transport, "pcie")) {
+	if (index >= 0 && n->ctrl->transport && !strcmp(n->ctrl->transport, "pcie")) {
 		char *product = nvme_product_name(index);
 
 		json_object_add_value_string(device_attrs, "ProductName", product);

--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -431,9 +431,9 @@ static int legacy_list(struct nvme_topology *t, char *dev_dir)
 	char *path;
 
 	t->nr_subsystems = scandir(dev_dir, &devices, scan_ctrls_filter, alphasort);
-	if (t->nr_subsystems < 0) {
-		fprintf(stderr, "no NVMe device(s) detected.\n");
-		return t->nr_subsystems;
+	if (t->nr_subsystems == -1) {
+		fprintf(stderr, "Failed to open %s: %s\n", dev_dir, strerror(errno));
+		return errno;
 	}
 
 	t->subsystems = calloc(t->nr_subsystems, sizeof(*s));

--- a/nvme.c
+++ b/nvme.c
@@ -1337,7 +1337,7 @@ ret:
 static int list(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Retrieve basic information for all NVMe namespaces";
-	const char *device_dir = "Directory to search for devices";
+	const char *device_dir = "Additional directory to search for devices";
 	const char *verbose = "Increase output verbosity";
 	struct nvme_topology t = { };
 	enum nvme_print_flags flags;

--- a/nvme.c
+++ b/nvme.c
@@ -1320,7 +1320,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
-	err = scan_subsystems(&t, subsysnqn, ns_instance);
+	err = scan_subsystems(&t, subsysnqn, ns_instance, NULL);
 	if (err) {
 		fprintf(stderr, "Failed to scan namespaces\n");
 		goto free;
@@ -1337,22 +1337,26 @@ ret:
 static int list(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Retrieve basic information for all NVMe namespaces";
+	const char *device_dir = "Directory to search for devices";
 	const char *verbose = "Increase output verbosity";
 	struct nvme_topology t = { };
 	enum nvme_print_flags flags;
 	int err = 0;
 
 	struct config {
+		char *device_dir;
 		char *output_format;
 		int verbose;
 	};
 
 	struct config cfg = {
+		.device_dir = NULL,
 		.output_format = "normal",
 		.verbose = 0,
 	};
 
 	OPT_ARGS(opts) = {
+		OPT_STRING("directory",  'd', "DIR",             &cfg.device_dir, device_dir),
 		OPT_FMT("output-format", 'o', &cfg.output_format, output_format_no_binary),
 		OPT_FLAG("verbose",      'v', &cfg.verbose,       verbose),
 		OPT_END()
@@ -1372,7 +1376,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
-	err = scan_subsystems(&t, NULL, 0);
+	err = scan_subsystems(&t, NULL, 0, cfg.device_dir);
 	if (err) {
 		fprintf(stderr, "Failed to scan namespaces\n");
 		return err;

--- a/nvme.h
+++ b/nvme.h
@@ -47,6 +47,7 @@ struct nvme_namespace {
 
 struct nvme_ctrl {
 	char *name;
+	char *path;
 	struct nvme_subsystem *subsys;
 
 	char *address;
@@ -105,7 +106,7 @@ int scan_subsys_filter(const struct dirent *d);
 int scan_dev_filter(const struct dirent *d);
 
 int scan_subsystems(struct nvme_topology *t, const char *subsysnqn,
-		    __u32 ns_instance);
+		    __u32 ns_instance, char *dev_dir);
 void free_topology(struct nvme_topology *t);
 char *get_nvme_subsnqn(char *path);
 char *nvme_get_ctrl_attr(char *path, const char *attr);


### PR DESCRIPTION
In SPDK project (spdk.io) it is possible to represent
devices using CUSE as character devices in "/dev/spdk/" directory.
No sysfs entries are generated for those devices.

nvme-cli default behavior is to scan the sysfs for entries on
newer kernels. Previously legacy_list() was used to determine
the topology, but that worked only on "/dev/" path.

To enable listing SPDK devices following changes were made:
- pass path parameter to list command
- before checking sysfs, check the path using legacy_list()
- expand arguments of scan_subsystems and related functions to accept the path

Example:
nvme list -d /dev/spdk/

Signed-off-by: Tomasz Zawadzki <tomasz.zawadzki@intel.com>