### PR TITLE
nvme-print: Unify nsid format to decimal

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4689,7 +4689,7 @@ static void nvme_show_details_ns(struct nvme_namespace *n, bool ctrl)
 	sprintf(format,"%3.0f %2sB + %2d B", (double)lba, l_suffix,
 		le16_to_cpu(n->ns.lbaf[(n->ns.flbas & 0x0f)].ms));
 
-	printf("%-12s %-8x %-26s %-16s ", n->name, n->nsid, usage, format);
+	printf("%-12s %-8d %-26s %-16s ", n->name, n->nsid, usage, format);
 
 	if (ctrl)
 		printf("%s", n->ctrl->name);


### PR DESCRIPTION
Hi,

From the "nvme list" command, NSID format is not the same between verbose
and non-verbose mode.

I prefer nsid as a decimal format so I posted this patch converting the hex format
to the decimal for the verbose-mode, but If it's should be in hex format, I can re-post
another patch to convert non-verbose mode printing format.

Thanks,

---
When printing the ns list with "nvme list -v", the nsid is not matched
with the nsid from the non-verbose mode which prints in decimal format.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>