### PR TITLE
doc: add 'tcp' as transport type option

### DIFF
--- a/Documentation/nvme-connect-all.1
+++ b/Documentation/nvme-connect-all.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-connect-all
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/16/2020
+.\"      Date: 07/14/2020
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-CONNECT\-ALL" "1" "06/16/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-CONNECT\-ALL" "1" "07/14/2020" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -72,6 +72,7 @@ allbox tab(:);
 lt lt
 lt lt
 lt lt
+lt lt
 lt lt.
 T{
 Value
@@ -88,6 +89,11 @@ fc
 T}:T{
 \fBWIP\fR
 The network fabric is a Fibre Channel network\&.
+T}
+T{
+tcp
+T}:T{
+The network fabric is a TCP/IP network\&.
 T}
 T{
 loop

--- a/Documentation/nvme-connect-all.html
+++ b/Documentation/nvme-connect-all.html
@@ -825,6 +825,10 @@ cellspacing="0" cellpadding="4">
 <td align="left" valign="top"><p class="table"><strong>WIP</strong> The network fabric is a Fibre Channel network.</p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table">tcp</p></td>
+<td align="left" valign="top"><p class="table">The network fabric is a TCP/IP network.</p></td>
+</tr>
+<tr>
 <td align="left" valign="top"><p class="table">loop</p></td>
 <td align="left" valign="top"><p class="table">Connect to a NVMe over Fabrics target on the local host</p></td>
 </tr>

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -58,6 +58,7 @@ OPTIONS
 |Value|Definition
 |rdma|The network fabric is an rdma network (RoCE, iWARP, Infiniband, basic rdma, etc)
 |fc  |*WIP* The network fabric is a Fibre Channel network.
+|tcp |The network fabric is a TCP/IP network.
 |loop|Connect to a NVMe over Fabrics target on the local host
 |=================
 

--- a/Documentation/nvme-connect.1
+++ b/Documentation/nvme-connect.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-connect
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/16/2020
+.\"      Date: 07/14/2020
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-CONNECT" "1" "06/16/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-CONNECT" "1" "07/14/2020" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -65,6 +65,7 @@ allbox tab(:);
 lt lt
 lt lt
 lt lt
+lt lt
 lt lt.
 T{
 Value
@@ -81,6 +82,11 @@ fc
 T}:T{
 \fBWIP\fR
 The network fabric is a Fibre Channel network\&.
+T}
+T{
+tcp
+T}:T{
+The network fabric is a TCP/IP network\&.
 T}
 T{
 loop

--- a/Documentation/nvme-connect.html
+++ b/Documentation/nvme-connect.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-connect(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -816,6 +816,10 @@ cellspacing="0" cellpadding="4">
 <td align="left" valign="top"><p class="table"><strong>WIP</strong> The network fabric is a Fibre Channel network.</p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table">tcp</p></td>
+<td align="left" valign="top"><p class="table">The network fabric is a TCP/IP network.</p></td>
+</tr>
+<tr>
 <td align="left" valign="top"><p class="table">loop</p></td>
 <td align="left" valign="top"><p class="table">Connect to a NVMe over Fabrics target on the local host</p></td>
 </tr>
@@ -1070,7 +1074,7 @@ and <a href="mailto:hch@lst.de">Christoph Hellwig</a></p></div>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2020-06-08 08:31:26 PDT
+ 2020-07-14 17:50:40 -03
 </div>
 </div>
 </body>

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -46,6 +46,7 @@ OPTIONS
 |Value|Definition
 |rdma|The network fabric is an rdma network (RoCE, iWARP, Infiniband, basic rdma, etc)
 |fc  |*WIP* The network fabric is a Fibre Channel network.
+|tcp |The network fabric is a TCP/IP network.
 |loop|Connect to a NVMe over Fabrics target on the local host
 |=================
 

--- a/Documentation/nvme-discover.1
+++ b/Documentation/nvme-discover.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-discover
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/16/2020
+.\"      Date: 07/14/2020
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-DISCOVER" "1" "06/16/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-DISCOVER" "1" "07/14/2020" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -76,6 +76,7 @@ allbox tab(:);
 lt lt
 lt lt
 lt lt
+lt lt
 lt lt.
 T{
 Value
@@ -92,6 +93,11 @@ fc
 T}:T{
 \fBWIP\fR
 The network fabric is a Fibre Channel network\&.
+T}
+T{
+tcp
+T}:T{
+The network fabric is a TCP/IP network\&.
 T}
 T{
 loop

--- a/Documentation/nvme-discover.html
+++ b/Documentation/nvme-discover.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-discover(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -846,6 +846,10 @@ cellspacing="0" cellpadding="4">
 <td align="left" valign="top"><p class="table"><strong>WIP</strong> The network fabric is a Fibre Channel network.</p></td>
 </tr>
 <tr>
+<td align="left" valign="top"><p class="table">tcp</p></td>
+<td align="left" valign="top"><p class="table">The network fabric is a TCP/IP network.</p></td>
+</tr>
+<tr>
 <td align="left" valign="top"><p class="table">loop</p></td>
 <td align="left" valign="top"><p class="table">Connect to a NVMe over Fabrics target on the local host</p></td>
 </tr>
@@ -1122,7 +1126,7 @@ nvme-connect-all(1)</p></div>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2019-11-08 08:22:36 JST
+ 2020-07-14 17:46:53 -03
 </div>
 </div>
 </body>

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -78,6 +78,7 @@ OPTIONS
 |Value|Definition
 |rdma|The network fabric is an rdma network (RoCE, iWARP, Infiniband, basic rdma, etc)
 |fc  |*WIP* The network fabric is a Fibre Channel network.
+|tcp |The network fabric is a TCP/IP network.
 |loop|Connect to a NVMe over Fabrics target on the local host
 |=================
 


### PR DESCRIPTION
Commit d48164ad3a5 ("nvme: Add TCP transport ") added 'tcp' as a
transport type option, but didn't document it.

Add it for:
nvme-connect-all
nvme-connect
nvme-discover