### PR TITLE
add support for issuing simple copy commands

### DIFF
--- a/Documentation/nvme-copy.1
+++ b/Documentation/nvme-copy.1
@@ -1,0 +1,141 @@
+'\" t
+.\"     Title: nvme-copy
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 05/06/2020
+.\"    Manual: NVMe Manual
+.\"    Source: NVMe
+.\"  Language: English
+.\"
+.TH "NVME\-COPY" "1" "05/06/2020" "NVMe" "NVMe Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+nvme-copy \- Send an NVMe Simple Copy command, provide results
+.SH "SYNOPSIS"
+.sp
+.nf
+\fInvme\-copy\fR <device> [\-\-sdlba=<sdlba> | \-d <sdlba>]
+                        [\-\-blocks=<nlb\-list,> | \-b <nlb\-list,>]
+                        [\-\-slbs=<slbas,> | \-s <slbas,>]
+                        [\-\-limited\-retry | \-l]
+                        [\-\-force\-unit\-access | \-f]
+                        [\-\-prinfow=<prinfow> | \-p <prinfow>]
+                        [\-\-prinfor=<prinfor> | \-P <prinfor>]
+                        [\-\-ref\-tag=<reftag> | \-r <reftag>]
+                        [\-\-expected\-ref\-tags=<reftag,> | \-R <reftag,>]
+                        [\-\-app\-tag=<apptag> | \-a <apptag>]
+                        [\-\-expected\-app\-tags=<apptag,> | \-A <apptag,>]
+                        [\-\-app\-mask=<appmask> | \-m <appmask>]
+                        [\-\-expected\-app\-masks=<appmask,> | \-M <appmask,>]
+                        [\-\-dir\-type=<type> | \-T <type>]
+                        [\-\-dir\-spec=<spec> | \-S <spec>]
+                        [\-\-format=<entry\-format> | \-F <entry\-format>]
+.fi
+.SH "DESCRIPTION"
+.sp
+The Copy command is used by the host to copy data from one or more source logical block ranges to a single consecutive destination logical block range\&.
+.SH "OPTIONS"
+.PP
+\-\-sdlba=<sdlba>, \-d <sdlba>
+.RS 4
+64\-bit addr of first destination logical block
+.RE
+.PP
+\-\-blocks=<nlb\-list,>, \-b <nlb\-list,>
+.RS 4
+Comma separated list of the number of blocks in each range
+.RE
+.PP
+\-\-slbs=<slbas,>, \-s <slbas,>
+.RS 4
+Comma separated list of the starting blocks in each range
+.RE
+.PP
+\-\-limited\-retry, \-l
+.RS 4
+Sets the limited retry flag\&.
+.RE
+.PP
+\-\-force\-unit\-access, \-f
+.RS 4
+Set the force\-unit access flag\&.
+.RE
+.PP
+\-\-prinfow=<prinfow>, \-p <prinfow>
+.RS 4
+Protection Information field write definition\&.
+.RE
+.PP
+\-\-prinfor=<prinfor>, \-P <prinfor>
+.RS 4
+Protection Information field read definition\&.
+.RE
+.PP
+\-\-ref\-tag=<reftag>, \-r <reftag>
+.RS 4
+initial lba reference tag\&.
+.RE
+.PP
+\-\-expected\-ref\-tags=<reftag,>, \-R <reftag,>
+.RS 4
+expected lba reference tags (comma\-separated list)\&.
+.RE
+.PP
+\-\-app\-tag=<apptag>, \-a <apptag>
+.RS 4
+lba app tag
+.RE
+.PP
+\-\-expected\-app\-tags=<apptag,>, \-A <apptag,>
+.RS 4
+expected lba app tags (comma\-separated list)
+.RE
+.PP
+\-\-app\-mask=<appmask>, \-m <appmask>
+.RS 4
+lba tag mask
+.RE
+.PP
+\-\-expected\-app\-masks=<appmask,>, \-M <appmask,>
+.RS 4
+expected lba tag masks (comma\-separated list)
+.RE
+.PP
+\-\-dir\-type=<type>, \-T <type>
+.RS 4
+Optional directive type\&. The nvme\-cli only enforces the value be in the defined range for the directive type, though the NVMe specifcation (1\&.3a) defines only one directive, 01h, for write stream idenfiers\&.
+.RE
+.PP
+\-\-dir\-spec=<spec>, \-S <spec>
+.RS 4
+Optional field for directive specifics\&. When used with write streams, this value is defined to be the write stream identifier\&. The nvme\-cli will not validate the stream requested is within the controller\(cqs capabilities\&.
+.RE
+.PP
+\-\-format=<entry\-format>, \-F <entry\-format>
+.RS 4
+source range entry format
+.RE
+.SH "EXAMPLES"
+.sp
+No examples yet\&.
+.SH "NVME"
+.sp
+Part of the nvme\-user suite

--- a/Documentation/nvme-copy.html
+++ b/Documentation/nvme-copy.html
@@ -1,0 +1,989 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
+<title>nvme-copy(1)</title>
+<style type="text/css">
+/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+
+/* Default font. */
+body {
+  font-family: Georgia,serif;
+}
+
+/* Title font. */
+h1, h2, h3, h4, h5, h6,
+div.title, caption.title,
+thead, p.table.header,
+#toctitle,
+#author, #revnumber, #revdate, #revremark,
+#footer {
+  font-family: Arial,Helvetica,sans-serif;
+}
+
+body {
+  margin: 1em 5% 1em 5%;
+}
+
+a {
+  color: blue;
+  text-decoration: underline;
+}
+a:visited {
+  color: fuchsia;
+}
+
+em {
+  font-style: italic;
+  color: navy;
+}
+
+strong {
+  font-weight: bold;
+  color: #083194;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #527bbd;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+h1, h2, h3 {
+  border-bottom: 2px solid silver;
+}
+h2 {
+  padding-top: 0.5em;
+}
+h3 {
+  float: left;
+}
+h3 + * {
+  clear: left;
+}
+h5 {
+  font-size: 1.0em;
+}
+
+div.sectionbody {
+  margin-left: 0;
+}
+
+hr {
+  border: 1px solid silver;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+ul, ol, li > p {
+  margin-top: 0;
+}
+ul > li     { color: #aaa; }
+ul > li > * { color: black; }
+
+.monospaced, code, pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: inherit;
+  color: navy;
+  padding: 0;
+  margin: 0;
+}
+pre {
+  white-space: pre-wrap;
+}
+
+#author {
+  color: #527bbd;
+  font-weight: bold;
+  font-size: 1.1em;
+}
+#email {
+}
+#revnumber, #revdate, #revremark {
+}
+
+#footer {
+  font-size: small;
+  border-top: 2px solid silver;
+  padding-top: 0.5em;
+  margin-top: 4.0em;
+}
+#footer-text {
+  float: left;
+  padding-bottom: 0.5em;
+}
+#footer-badges {
+  float: right;
+  padding-bottom: 0.5em;
+}
+
+#preamble {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+div.imageblock, div.exampleblock, div.verseblock,
+div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
+div.admonitionblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.admonitionblock {
+  margin-top: 2.0em;
+  margin-bottom: 2.0em;
+  margin-right: 10%;
+  color: #606060;
+}
+
+div.content { /* Block element content. */
+  padding: 0;
+}
+
+/* Block element titles. */
+div.title, caption.title {
+  color: #527bbd;
+  font-weight: bold;
+  text-align: left;
+  margin-top: 1.0em;
+  margin-bottom: 0.5em;
+}
+div.title + * {
+  margin-top: 0;
+}
+
+td div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content + div.title {
+  margin-top: 0.0em;
+}
+
+div.sidebarblock > div.content {
+  background: #ffffee;
+  border: 1px solid #dddddd;
+  border-left: 4px solid #f0f0f0;
+  padding: 0.5em;
+}
+
+div.listingblock > div.content {
+  border: 1px solid #dddddd;
+  border-left: 5px solid #f0f0f0;
+  background: #f8f8f8;
+  padding: 0.5em;
+}
+
+div.quoteblock, div.verseblock {
+  padding-left: 1.0em;
+  margin-left: 1.0em;
+  margin-right: 10%;
+  border-left: 5px solid #f0f0f0;
+  color: #888;
+}
+
+div.quoteblock > div.attribution {
+  padding-top: 0.5em;
+  text-align: right;
+}
+
+div.verseblock > pre.content {
+  font-family: inherit;
+  font-size: inherit;
+}
+div.verseblock > div.attribution {
+  padding-top: 0.75em;
+  text-align: left;
+}
+/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
+div.verseblock + div.attribution {
+  text-align: left;
+}
+
+div.admonitionblock .icon {
+  vertical-align: top;
+  font-size: 1.1em;
+  font-weight: bold;
+  text-decoration: underline;
+  color: #527bbd;
+  padding-right: 0.5em;
+}
+div.admonitionblock td.content {
+  padding-left: 0.5em;
+  border-left: 3px solid #dddddd;
+}
+
+div.exampleblock > div.content {
+  border-left: 3px solid #dddddd;
+  padding-left: 0.5em;
+}
+
+div.imageblock div.content { padding-left: 0; }
+span.image img { border-style: none; vertical-align: text-bottom; }
+a.image:visited { color: white; }
+
+dl {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+dt {
+  margin-top: 0.5em;
+  margin-bottom: 0;
+  font-style: normal;
+  color: navy;
+}
+dd > *:first-child {
+  margin-top: 0.1em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+ol.arabic {
+  list-style-type: decimal;
+}
+ol.loweralpha {
+  list-style-type: lower-alpha;
+}
+ol.upperalpha {
+  list-style-type: upper-alpha;
+}
+ol.lowerroman {
+  list-style-type: lower-roman;
+}
+ol.upperroman {
+  list-style-type: upper-roman;
+}
+
+div.compact ul, div.compact ol,
+div.compact p, div.compact p,
+div.compact div, div.compact div {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+tfoot {
+  font-weight: bold;
+}
+td > div.verse {
+  white-space: pre;
+}
+
+div.hdlist {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+div.hdlist tr {
+  padding-bottom: 15px;
+}
+dt.hdlist1.strong, td.hdlist1.strong {
+  font-weight: bold;
+}
+td.hdlist1 {
+  vertical-align: top;
+  font-style: normal;
+  padding-right: 0.8em;
+  color: navy;
+}
+td.hdlist2 {
+  vertical-align: top;
+}
+div.hdlist.compact tr {
+  margin: 0;
+  padding-bottom: 0;
+}
+
+.comment {
+  background: yellow;
+}
+
+.footnote, .footnoteref {
+  font-size: 0.8em;
+}
+
+span.footnote, span.footnoteref {
+  vertical-align: super;
+}
+
+#footnotes {
+  margin: 20px 0 20px 0;
+  padding: 7px 0 0 0;
+}
+
+#footnotes div.footnote {
+  margin: 0 0 5px 0;
+}
+
+#footnotes hr {
+  border: none;
+  border-top: 1px solid silver;
+  height: 1px;
+  text-align: left;
+  margin-left: 0;
+  width: 20%;
+  min-width: 100px;
+}
+
+div.colist td {
+  padding-right: 0.5em;
+  padding-bottom: 0.3em;
+  vertical-align: top;
+}
+div.colist td img {
+  margin-top: 0.3em;
+}
+
+@media print {
+  #footer-badges { display: none; }
+}
+
+#toc {
+  margin-bottom: 2.5em;
+}
+
+#toctitle {
+  color: #527bbd;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 1.0em;
+  margin-bottom: 0.1em;
+}
+
+div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.toclevel2 {
+  margin-left: 2em;
+  font-size: 0.9em;
+}
+div.toclevel3 {
+  margin-left: 4em;
+  font-size: 0.9em;
+}
+div.toclevel4 {
+  margin-left: 6em;
+  font-size: 0.9em;
+}
+
+span.aqua { color: aqua; }
+span.black { color: black; }
+span.blue { color: blue; }
+span.fuchsia { color: fuchsia; }
+span.gray { color: gray; }
+span.green { color: green; }
+span.lime { color: lime; }
+span.maroon { color: maroon; }
+span.navy { color: navy; }
+span.olive { color: olive; }
+span.purple { color: purple; }
+span.red { color: red; }
+span.silver { color: silver; }
+span.teal { color: teal; }
+span.white { color: white; }
+span.yellow { color: yellow; }
+
+span.aqua-background { background: aqua; }
+span.black-background { background: black; }
+span.blue-background { background: blue; }
+span.fuchsia-background { background: fuchsia; }
+span.gray-background { background: gray; }
+span.green-background { background: green; }
+span.lime-background { background: lime; }
+span.maroon-background { background: maroon; }
+span.navy-background { background: navy; }
+span.olive-background { background: olive; }
+span.purple-background { background: purple; }
+span.red-background { background: red; }
+span.silver-background { background: silver; }
+span.teal-background { background: teal; }
+span.white-background { background: white; }
+span.yellow-background { background: yellow; }
+
+span.big { font-size: 2em; }
+span.small { font-size: 0.6em; }
+
+span.underline { text-decoration: underline; }
+span.overline { text-decoration: overline; }
+span.line-through { text-decoration: line-through; }
+
+div.unbreakable { page-break-inside: avoid; }
+
+
+/*
+ * xhtml11 specific
+ *
+ * */
+
+div.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.tableblock > table {
+  border: 3px solid #527bbd;
+}
+thead, p.table.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.table {
+  margin-top: 0;
+}
+/* Because the table frame attribute is overriden by CSS in most browsers. */
+div.tableblock > table[frame="void"] {
+  border-style: none;
+}
+div.tableblock > table[frame="hsides"] {
+  border-left-style: none;
+  border-right-style: none;
+}
+div.tableblock > table[frame="vsides"] {
+  border-top-style: none;
+  border-bottom-style: none;
+}
+
+
+/*
+ * html5 specific
+ *
+ * */
+
+table.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+thead, p.tableblock.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.tableblock {
+  margin-top: 0;
+}
+table.tableblock {
+  border-width: 3px;
+  border-spacing: 0px;
+  border-style: solid;
+  border-color: #527bbd;
+  border-collapse: collapse;
+}
+th.tableblock, td.tableblock {
+  border-width: 1px;
+  padding: 4px;
+  border-style: solid;
+  border-color: #527bbd;
+}
+
+table.tableblock.frame-topbot {
+  border-left-style: hidden;
+  border-right-style: hidden;
+}
+table.tableblock.frame-sides {
+  border-top-style: hidden;
+  border-bottom-style: hidden;
+}
+table.tableblock.frame-none {
+  border-style: hidden;
+}
+
+th.tableblock.halign-left, td.tableblock.halign-left {
+  text-align: left;
+}
+th.tableblock.halign-center, td.tableblock.halign-center {
+  text-align: center;
+}
+th.tableblock.halign-right, td.tableblock.halign-right {
+  text-align: right;
+}
+
+th.tableblock.valign-top, td.tableblock.valign-top {
+  vertical-align: top;
+}
+th.tableblock.valign-middle, td.tableblock.valign-middle {
+  vertical-align: middle;
+}
+th.tableblock.valign-bottom, td.tableblock.valign-bottom {
+  vertical-align: bottom;
+}
+
+
+/*
+ * manpage specific
+ *
+ * */
+
+body.manpage h1 {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  border-top: 2px solid silver;
+  border-bottom: 2px solid silver;
+}
+body.manpage h2 {
+  border-style: none;
+}
+body.manpage div.sectionbody {
+  margin-left: 3em;
+}
+
+@media print {
+  body.manpage div#toc { display: none; }
+}
+
+
+</style>
+<script type="text/javascript">
+/*<![CDATA[*/
+var asciidoc = {  // Namespace.
+
+/////////////////////////////////////////////////////////////////////
+// Table Of Contents generator
+/////////////////////////////////////////////////////////////////////
+
+/* Author: Mihai Bazon, September 2002
+ * http://students.infoiasi.ro/~mishoo
+ *
+ * Table Of Content generator
+ * Version: 0.4
+ *
+ * Feel free to use this script under the terms of the GNU General Public
+ * License, as long as you do not remove or alter this notice.
+ */
+
+ /* modified by Troy D. Hanson, September 2006. License: GPL */
+ /* modified by Stuart Rackham, 2006, 2009. License: GPL */
+
+// toclevels = 1..4.
+toc: function (toclevels) {
+
+  function getText(el) {
+    var text = "";
+    for (var i = el.firstChild; i != null; i = i.nextSibling) {
+      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
+        text += i.data;
+      else if (i.firstChild != null)
+        text += getText(i);
+    }
+    return text;
+  }
+
+  function TocEntry(el, text, toclevel) {
+    this.element = el;
+    this.text = text;
+    this.toclevel = toclevel;
+  }
+
+  function tocEntries(el, toclevels) {
+    var result = new Array;
+    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
+    // Function that scans the DOM tree for header elements (the DOM2
+    // nodeIterator API would be a better technique but not supported by all
+    // browsers).
+    var iterate = function (el) {
+      for (var i = el.firstChild; i != null; i = i.nextSibling) {
+        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
+          var mo = re.exec(i.tagName);
+          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
+            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
+          }
+          iterate(i);
+        }
+      }
+    }
+    iterate(el);
+    return result;
+  }
+
+  var toc = document.getElementById("toc");
+  if (!toc) {
+    return;
+  }
+
+  // Delete existing TOC entries in case we're reloading the TOC.
+  var tocEntriesToRemove = [];
+  var i;
+  for (i = 0; i < toc.childNodes.length; i++) {
+    var entry = toc.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div'
+     && entry.getAttribute("class")
+     && entry.getAttribute("class").match(/^toclevel/))
+      tocEntriesToRemove.push(entry);
+  }
+  for (i = 0; i < tocEntriesToRemove.length; i++) {
+    toc.removeChild(tocEntriesToRemove[i]);
+  }
+
+  // Rebuild TOC entries.
+  var entries = tocEntries(document.getElementById("content"), toclevels);
+  for (var i = 0; i < entries.length; ++i) {
+    var entry = entries[i];
+    if (entry.element.id == "")
+      entry.element.id = "_toc_" + i;
+    var a = document.createElement("a");
+    a.href = "#" + entry.element.id;
+    a.appendChild(document.createTextNode(entry.text));
+    var div = document.createElement("div");
+    div.appendChild(a);
+    div.className = "toclevel" + entry.toclevel;
+    toc.appendChild(div);
+  }
+  if (entries.length == 0)
+    toc.parentNode.removeChild(toc);
+},
+
+
+/////////////////////////////////////////////////////////////////////
+// Footnotes generator
+/////////////////////////////////////////////////////////////////////
+
+/* Based on footnote generation code from:
+ * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
+ */
+
+footnotes: function () {
+  // Delete existing footnote entries in case we're reloading the footnodes.
+  var i;
+  var noteholder = document.getElementById("footnotes");
+  if (!noteholder) {
+    return;
+  }
+  var entriesToRemove = [];
+  for (i = 0; i < noteholder.childNodes.length; i++) {
+    var entry = noteholder.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
+      entriesToRemove.push(entry);
+  }
+  for (i = 0; i < entriesToRemove.length; i++) {
+    noteholder.removeChild(entriesToRemove[i]);
+  }
+
+  // Rebuild footnote entries.
+  var cont = document.getElementById("content");
+  var spans = cont.getElementsByTagName("span");
+  var refs = {};
+  var n = 0;
+  for (i=0; i<spans.length; i++) {
+    if (spans[i].className == "footnote") {
+      n++;
+      var note = spans[i].getAttribute("data-note");
+      if (!note) {
+        // Use [\s\S] in place of . so multi-line matches work.
+        // Because JavaScript has no s (dotall) regex flag.
+        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
+        spans[i].innerHTML =
+          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+        spans[i].setAttribute("data-note", note);
+      }
+      noteholder.innerHTML +=
+        "<div class='footnote' id='_footnote_" + n + "'>" +
+        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
+        n + "</a>. " + note + "</div>";
+      var id =spans[i].getAttribute("id");
+      if (id != null) refs["#"+id] = n;
+    }
+  }
+  if (n == 0)
+    noteholder.parentNode.removeChild(noteholder);
+  else {
+    // Process footnoterefs.
+    for (i=0; i<spans.length; i++) {
+      if (spans[i].className == "footnoteref") {
+        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
+        href = href.match(/#.*/)[0];  // Because IE return full URL.
+        n = refs[href];
+        spans[i].innerHTML =
+          "[<a href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+      }
+    }
+  }
+},
+
+install: function(toclevels) {
+  var timerId;
+
+  function reinstall() {
+    asciidoc.footnotes();
+    if (toclevels) {
+      asciidoc.toc(toclevels);
+    }
+  }
+
+  function reinstallAndRemoveTimer() {
+    clearInterval(timerId);
+    reinstall();
+  }
+
+  timerId = setInterval(reinstall, 500);
+  if (document.addEventListener)
+    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
+  else
+    window.onload = reinstallAndRemoveTimer;
+}
+
+}
+asciidoc.install();
+/*]]>*/
+</script>
+</head>
+<body class="manpage">
+<div id="header">
+<h1>
+nvme-copy(1) Manual Page
+</h1>
+<h2>NAME</h2>
+<div class="sectionbody">
+<p>nvme-copy -
+   Send an NVMe Simple Copy command, provide results
+</p>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_synopsis">SYNOPSIS</h2>
+<div class="sectionbody">
+<div class="verseblock">
+<pre class="content"><em>nvme-copy</em> &lt;device&gt; [--sdlba=&lt;sdlba&gt; | -d &lt;sdlba&gt;]
+                        [--blocks=&lt;nlb-list,&gt; | -b &lt;nlb-list,&gt;]
+                        [--slbs=&lt;slbas,&gt; | -s &lt;slbas,&gt;]
+                        [--limited-retry | -l]
+                        [--force-unit-access | -f]
+                        [--prinfow=&lt;prinfow&gt; | -p &lt;prinfow&gt;]
+                        [--prinfor=&lt;prinfor&gt; | -P &lt;prinfor&gt;]
+                        [--ref-tag=&lt;reftag&gt; | -r &lt;reftag&gt;]
+                        [--expected-ref-tags=&lt;reftag,&gt; | -R &lt;reftag,&gt;]
+                        [--app-tag=&lt;apptag&gt; | -a &lt;apptag&gt;]
+                        [--expected-app-tags=&lt;apptag,&gt; | -A &lt;apptag,&gt;]
+                        [--app-mask=&lt;appmask&gt; | -m &lt;appmask&gt;]
+                        [--expected-app-masks=&lt;appmask,&gt; | -M &lt;appmask,&gt;]
+                        [--dir-type=&lt;type&gt; | -T &lt;type&gt;]
+                        [--dir-spec=&lt;spec&gt; | -S &lt;spec&gt;]
+                        [--format=&lt;entry-format&gt; | -F &lt;entry-format&gt;]</pre>
+<div class="attribution">
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_description">DESCRIPTION</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>The Copy command is used by the host to copy data from one or more source
+logical block ranges to a single consecutive destination logical block range.</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_options">OPTIONS</h2>
+<div class="sectionbody">
+<div class="dlist"><dl>
+<dt class="hdlist1">
+--sdlba=&lt;sdlba&gt;
+</dt>
+<dt class="hdlist1">
+-d &lt;sdlba&gt;
+</dt>
+<dd>
+<p>
+        64-bit addr of first destination logical block
+</p>
+</dd>
+<dt class="hdlist1">
+--blocks=&lt;nlb-list,&gt;
+</dt>
+<dt class="hdlist1">
+-b &lt;nlb-list,&gt;
+</dt>
+<dd>
+<p>
+        Comma separated list of the number of blocks in each range
+</p>
+</dd>
+<dt class="hdlist1">
+--slbs=&lt;slbas,&gt;
+</dt>
+<dt class="hdlist1">
+-s &lt;slbas,&gt;
+</dt>
+<dd>
+<p>
+        Comma separated list of the starting blocks in each range
+</p>
+</dd>
+<dt class="hdlist1">
+--limited-retry
+</dt>
+<dt class="hdlist1">
+-l
+</dt>
+<dd>
+<p>
+        Sets the limited retry flag.
+</p>
+</dd>
+<dt class="hdlist1">
+--force-unit-access
+</dt>
+<dt class="hdlist1">
+-f
+</dt>
+<dd>
+<p>
+        Set the force-unit access flag.
+</p>
+</dd>
+<dt class="hdlist1">
+--prinfow=&lt;prinfow&gt;
+</dt>
+<dt class="hdlist1">
+-p &lt;prinfow&gt;
+</dt>
+<dd>
+<p>
+        Protection Information field write definition.
+</p>
+</dd>
+<dt class="hdlist1">
+--prinfor=&lt;prinfor&gt;
+</dt>
+<dt class="hdlist1">
+-P &lt;prinfor&gt;
+</dt>
+<dd>
+<p>
+        Protection Information field read definition.
+</p>
+</dd>
+<dt class="hdlist1">
+--ref-tag=&lt;reftag&gt;
+</dt>
+<dt class="hdlist1">
+-r &lt;reftag&gt;
+</dt>
+<dd>
+<p>
+        initial lba reference tag.
+</p>
+</dd>
+<dt class="hdlist1">
+--expected-ref-tags=&lt;reftag,&gt;
+</dt>
+<dt class="hdlist1">
+-R &lt;reftag,&gt;
+</dt>
+<dd>
+<p>
+        expected lba reference tags (comma-separated list).
+</p>
+</dd>
+<dt class="hdlist1">
+--app-tag=&lt;apptag&gt;
+</dt>
+<dt class="hdlist1">
+-a &lt;apptag&gt;
+</dt>
+<dd>
+<p>
+        lba app tag
+</p>
+</dd>
+<dt class="hdlist1">
+--expected-app-tags=&lt;apptag,&gt;
+</dt>
+<dt class="hdlist1">
+-A &lt;apptag,&gt;
+</dt>
+<dd>
+<p>
+        expected lba app tags (comma-separated list)
+</p>
+</dd>
+<dt class="hdlist1">
+--app-mask=&lt;appmask&gt;
+</dt>
+<dt class="hdlist1">
+-m &lt;appmask&gt;
+</dt>
+<dd>
+<p>
+        lba tag mask
+</p>
+</dd>
+<dt class="hdlist1">
+--expected-app-masks=&lt;appmask,&gt;
+</dt>
+<dt class="hdlist1">
+-M &lt;appmask,&gt;
+</dt>
+<dd>
+<p>
+        expected lba tag masks (comma-separated list)
+</p>
+</dd>
+<dt class="hdlist1">
+--dir-type=&lt;type&gt;
+</dt>
+<dt class="hdlist1">
+-T &lt;type&gt;
+</dt>
+<dd>
+<p>
+        Optional directive type. The nvme-cli only enforces the value
+        be in the defined range for the directive type, though the NVMe
+        specifcation (1.3a) defines only one directive, 01h, for write
+        stream idenfiers.
+</p>
+</dd>
+<dt class="hdlist1">
+--dir-spec=&lt;spec&gt;
+</dt>
+<dt class="hdlist1">
+-S &lt;spec&gt;
+</dt>
+<dd>
+<p>
+        Optional field for directive specifics. When used with
+        write streams, this value is defined to be the write stream
+        identifier. The nvme-cli will not validate the stream requested
+        is within the controller&#8217;s capabilities.
+</p>
+</dd>
+<dt class="hdlist1">
+--format=&lt;entry-format&gt;
+</dt>
+<dt class="hdlist1">
+-F &lt;entry-format&gt;
+</dt>
+<dd>
+<p>
+        source range entry format
+</p>
+</dd>
+</dl></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_examples">EXAMPLES</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>No examples yet.</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_nvme">NVME</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>Part of the nvme-user suite</p></div>
+</div>
+</div>
+</div>
+<div id="footnotes"><hr /></div>
+<div id="footer">
+<div id="footer-text">
+Last updated
+ 2020-05-06 10:35:20 CEST
+</div>
+</div>
+</body>
+</html>

--- a/Documentation/nvme-copy.txt
+++ b/Documentation/nvme-copy.txt
@@ -1,0 +1,111 @@
+nvme-copy(1)
+============
+
+NAME
+----
+nvme-copy - Send an NVMe Simple Copy command, provide results
+
+SYNOPSIS
+--------
+[verse]
+'nvme-copy' <device> [--sdlba=<sdlba> | -d <sdlba>]
+			[--blocks=<nlb-list,> | -b <nlb-list,>]
+			[--slbs=<slbas,> | -s <slbas,>]
+			[--limited-retry | -l]
+			[--force-unit-access | -f]
+			[--prinfow=<prinfow> | -p <prinfow>]
+			[--prinfor=<prinfor> | -P <prinfor>]
+			[--ref-tag=<reftag> | -r <reftag>]
+			[--expected-ref-tags=<reftag,> | -R <reftag,>]
+			[--app-tag=<apptag> | -a <apptag>]
+			[--expected-app-tags=<apptag,> | -A <apptag,>]
+			[--app-mask=<appmask> | -m <appmask>]
+			[--expected-app-masks=<appmask,> | -M <appmask,>]
+			[--dir-type=<type> | -T <type>]
+			[--dir-spec=<spec> | -S <spec>]
+			[--format=<entry-format> | -F <entry-format>]
+
+DESCRIPTION
+-----------
+The Copy command is used by the host to copy data from one or more source
+logical block ranges to a single consecutive destination logical block range.
+
+OPTIONS
+-------
+--sdlba=<sdlba>::
+-d <sdlba>::
+	64-bit addr of first destination logical block
+
+--blocks=<nlb-list,>::
+-b <nlb-list,>::
+	Comma separated list of the number of blocks in each range
+
+--slbs=<slbas,>::
+-s <slbas,>::
+	Comma separated list of the starting blocks in each range
+
+--limited-retry::
+-l::
+	Sets the limited retry flag.
+
+--force-unit-access::
+-f::
+	Set the force-unit access flag.
+
+--prinfow=<prinfow>::
+-p <prinfow>::
+	Protection Information field write definition.
+
+--prinfor=<prinfor>::
+-P <prinfor>::
+	Protection Information field read definition.
+
+--ref-tag=<reftag>::
+-r <reftag>::
+	initial lba reference tag.
+
+--expected-ref-tags=<reftag,>::
+-R <reftag,>::
+	expected lba reference tags (comma-separated list).
+
+--app-tag=<apptag>::
+-a <apptag>::
+	lba app tag
+
+--expected-app-tags=<apptag,>::
+-A <apptag,>::
+	expected lba app tags (comma-separated list)
+
+--app-mask=<appmask>::
+-m <appmask>::
+	lba tag mask
+
+--expected-app-masks=<appmask,>::
+-M <appmask,>::
+	expected lba tag masks (comma-separated list)
+
+--dir-type=<type>::
+-T <type>::
+	Optional directive type. The nvme-cli only enforces the value
+	be in the defined range for the directive type, though the NVMe
+	specifcation (1.3a) defines only one directive, 01h, for write
+	stream idenfiers.
+
+--dir-spec=<spec>::
+-S <spec>::
+	Optional field for directive specifics. When used with
+	write streams, this value is defined to be the write stream
+	identifier. The nvme-cli will not validate the stream requested
+	is within the controller's capabilities.
+
+--format=<entry-format>::
+-F <entry-format>::
+	source range entry format
+
+EXAMPLES
+--------
+No examples yet.
+
+NVME
+----
+Part of the nvme-user suite

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -35,6 +35,7 @@ _nvme () {
 	'resv-register:register reservation on a namespace'
 	'resv-release:release reservation on a namespace'
 	'resv-report:report reservation on a namespace'
+	'copy:submit a simple copy command'
 	'flush:submit a flush'
 	'compare:compare data on device to data elsewhere'
 	'read:submit a read command'
@@ -530,6 +531,46 @@ _nvme () {
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme resv-register options" _reg
 			;;
+		(copy)
+			local _copy
+			_copy=(
+			/dev/nvme':supply a device to use (required)'
+			--sdlba=':64-bit addr of first destination logical block'
+			-d':alias of --sdlba'
+			--slbs=':64-bit addr of first block per range (comma-separated list)'
+			-s':alias of --slbs'
+			--blocks=':number of blocks per range (comma-separated list, zeroes-based values)'
+			-b':alias of --blocks'
+			--limited-retry':if included, controller should try less hard to retrieve data from media (if not included, all available data recovery means used)'
+			-l':alias of --limited-retry'
+			--force-unit-access':if included, the data shall be read from non-volatile media'
+			-f':alias of --force-unit access'
+			--prinfow=':protection information and check field (write part)'
+			-p':alias of --prinfow'
+			--prinfor=':protection information and check field (read part)'
+			-P':alias of --prinfor'
+			--ref-tag=':initial lba reference tag (write part)'
+			-r':alias of --ref-tag'
+			--expected-ref-tags=':expected lba reference tags (read part, comma-separated list)'
+			-R':alias of --expected-ref-tags'
+			--app-tag=':lba application tag (write part)'
+			-a':alias of --app-tag'
+			--expected-app-tags=':expected lba application tags (read part, comma-separated list)'
+			-A':alias of --expected-app-tags'
+			--app-tag-mask=':lba application tag mask (write part)'
+			-m':alias of --app-tag-mask'
+			--expected-app-tag-masks=':expected lba application tag masks (read part, comma-separated list)'
+			-M':alias of --expected-app-tag-masks'
+			--dir-type':directive type (write part)'
+			-T':alias of --dir-type'
+			--dir-spec':directive specific (write part)'
+			-S':alias of --dir-spec'
+			--format':source range entry format'
+			-F':alias of --format'
+			)
+			_arguments '*:: :->subcmds'
+                       _describe -t commands "nvme copy options" _copy
+		       ;;
 		(flush)
 			local _flush
 			_flush=(
@@ -658,7 +699,7 @@ _nvme () {
 			     list-ctrl get-ns-id get-log fw-log smart-log error-log get-feature
 			     set-feature format fw-activate fw-download admin-passthru io-passthru
 			     security-send security-recv resv-acquire resv-register resv-release
-			     resv-report flush compare read write show-regs
+			     resv-report flush compare read write copy show-regs
 			   )
 			_arguments '*:: :->subcmds'
 			_describe -t commands "help: infos on a specific nvme command, or provide no option to see a synopsis of all nvme commands" _h

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -9,7 +9,7 @@ _cmds="list id-ctrl id-ns list-ns id-iocs create-ns delete-ns \
 	fw-download admin-passthru io-passthru security-send \
 	security-recv resv-acquire resv-register resv-release \
 	resv-report dsm flush compare read write write-zeroes \
-	write-uncor reset subsystem-reset show-regs discover \
+	write-uncor copy reset subsystem-reset show-regs discover \
 	connect-all connect disconnect version help \
 	intel lnvm memblaze list-subsys"
 
@@ -147,6 +147,15 @@ nvme_list_opts () {
 		"dsm")
 		opts+=" --namespace-id= -n --ctx-attrs= -a --blocks= -b\
 			-slbs= -s --ad -d --idw -w --idr -r --cdw11= -c"
+			;;
+		"copy")
+		opts+=" --sdlba= -d --blocks= -b --slbs= -s \
+			--limited-retry -l --force-unit-access -f \
+			--prinfow= -p --prinfor= -P \
+			--ref-tag= -r --expected-ref-tag= -R \
+			--app-tag= -a --expected-app-tag= -A \
+			--app-tag-mask= -m --expected-app-tag-mask= -M \
+			--dir-type= -T --dir-spec= -S --format= -F"
 			;;
 		"flush")
 		opts+=" --namespace-id= -n"

--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -335,7 +335,7 @@ struct nvme_id_ctrl {
 	__u8			icsvscc;
 	__u8			nwpc;
 	__le16			acwu;
-	__u8			rsvd534[2];
+	__le16			ocfs;
 	__le32			sgls;
 	__le32			mnan;
 	__u8			rsvd544[224];
@@ -405,7 +405,10 @@ struct nvme_id_ns {
 	__le16			npdg;
 	__le16			npda;
 	__le16			nows;
-	__u8			rsvd74[18];
+	__le16			mssrl;
+	__le32			mcl;
+	__u8			msrc;
+	__u8			rsvd81[11];
 	__le32			anagrpid;
 	__u8			rsvd96[3];
 	__u8			nsattr;
@@ -833,6 +836,7 @@ enum nvme_opcode {
 	nvme_cmd_resv_report	= 0x0e,
 	nvme_cmd_resv_acquire	= 0x11,
 	nvme_cmd_resv_release	= 0x15,
+	nvme_cmd_copy		= 0x19,
 	nvme_zns_cmd_mgmt_send	= 0x79,
 	nvme_zns_cmd_mgmt_recv	= 0x7a,
 	nvme_zns_cmd_append	= 0x7d,
@@ -960,6 +964,16 @@ struct nvme_dsm_range {
 	__le32			cattr;
 	__le32			nlb;
 	__le64			slba;
+};
+
+struct nvme_copy_range {
+	__u8			rsvd0[8];
+	__le64			slba;
+	__le16			nlb;
+	__u8			rsvd18[6];
+	__le32			eilbrt;
+	__le16			elbatm;
+	__le16			elbat;
 };
 
 /* Features */
@@ -1403,7 +1417,7 @@ enum {
 	NVME_SC_BAD_ATTRIBUTES		= 0x180,
 	NVME_SC_INVALID_PI		= 0x181,
 	NVME_SC_READ_ONLY		= 0x182,
-	NVME_SC_ONCS_NOT_SUPPORTED	= 0x183,
+	NVME_SC_CMD_SIZE_LIMIT_EXCEEDED = 0x183,
 
 	/*
 	 * I/O Command Set Specific - Fabrics commands:

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -52,6 +52,7 @@ COMMAND_LIST(
 	ENTRY("resv-release", "Submit a Reservation Release, return results", resv_release)
 	ENTRY("resv-report", "Submit a Reservation Report, return results", resv_report)
 	ENTRY("dsm", "Submit a Data Set Management command, return results", dsm)
+	ENTRY("copy", "Submit a Simple Copy command, return results", copy)
 	ENTRY("flush", "Submit a Flush command, return results", flush)
 	ENTRY("compare", "Submit a Compare command, return results", compare)
 	ENTRY("read", "Submit a read command, return results", read_cmd)

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -65,6 +65,13 @@ struct nvme_dsm_range *nvme_setup_dsm_range(__u32 *ctx_attrs,
 					    __u32 *llbas, __u64 *slbas,
 					    __u16 nr_ranges);
 
+int nvme_copy(int fd, __u32 nsid, struct nvme_copy_range *copy, __u64 sdlba,
+		__u16 nr, __u8 prinfor, __u8 prinfow, __u8 dtype, __u16 dspec,
+		__u8 format, int lr, int fua, __u32 ilbrt, __u16 lbatm,
+		__u16 lbat);
+struct nvme_copy_range *nvme_setup_copy_range(__u16 *nlbs, __u64 *slbas,
+		__u32 *eilbrts, __u16 *elbatms, __u16 *elbats, __u16 nr);
+
 int nvme_resv_acquire(int fd, __u32 nsid, __u8 rtype, __u8 racqa,
 		      bool iekey, __u64 crkey, __u64 nrkey);
 int nvme_resv_register(int fd, __u32 nsid, __u8 rrega, __u8 cptpl,

--- a/nvme-status.c
+++ b/nvme-status.c
@@ -97,7 +97,6 @@ static inline __u8 nvme_cmd_specific_status_to_errno(__u16 status)
 	case NVME_SC_NS_ALREADY_ATTACHED:
 		return EALREADY;
 	case NVME_SC_THIN_PROV_NOT_SUPP:
-	case NVME_SC_ONCS_NOT_SUPPORTED:
 		return EOPNOTSUPP;
 	case NVME_SC_DEVICE_SELF_TEST_IN_PROGRESS:
 		return EINPROGRESS;


### PR DESCRIPTION
Add support for NVMe TP 4065a ("Simple Copy Command"), v2020.05.04
("Ratified").

Signed-off-by: Klaus Jensen <k.jensen@samsung.com>
Co-authored-by: Steven Seungcheol Lee <sc108.lee@samsung.com>

**Note** For testing, there is an implementation of TP 4065a [available](https://irrelevant.dk/g/pci-nvme.git/commit/?h=scc) for the QEMU emulated NVMe device.