### PR TITLE
Add support for Replay Protection Memory Block (RPMB) commands

### DIFF
--- a/Documentation/nvme-rpmb.1
+++ b/Documentation/nvme-rpmb.1
@@ -1,0 +1,326 @@
+'\" t
+.\"     Title: nvme-rpmb
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 08/04/2020
+.\"    Manual: NVMe Manual
+.\"    Source: NVMe
+.\"  Language: English
+.\"
+.TH "NVME\-RPMB" "1" "08/04/2020" "NVMe" "NVMe Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+nvme-rpmb \- Send RPMB commands to an NVMe device
+.SH "SYNOPSIS"
+.sp
+.nf
+\fInvme rpmb\fR <device> [\-\-cmd=<command> | \-c <command>]
+                    [\-\-msgfile=<data\-file> | \-f <data\-file>]
+                    [\-\-keyfile=<key\-file> | \-g <key\-file>]
+                    [\-\-key=<key> | \-k <key>]
+                    [\-\-msg=<data> | \-d <data>]
+                    [\-\-address=<offset> | \-o <offset>]
+                    [\-\-blocks=<512 byte sectors> | \-b <sectors> ]
+                    [\-\-target=<target\-id> | \-t <id> ]
+.fi
+.SH "DESCRIPTION"
+.sp
+For the NVMe device given, send an nvme rpmb command and provide the results\&.
+.sp
+The <device> parameter is mandatory and NVMe character device (ex: /dev/nvme0) must be specified\&. If the given device supports RPMB targets, command given with \-\-cmd or \-c option shall be sent to the controller\&. If given NVMe device doesn\(cqt support RPMB targets, a message indicating the same shall be printed along with controller register values related RPMB\&.
+.SH "OPTIONS"
+.PP
+\-c <command>, \-\-cmd=<command>
+.RS 4
+RPMB command to be sent to the device\&. It can be one of the following
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+info          \- print information regarding supported RPMB targets and
+                access and total sizes\&. No further arguments are required
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+program\-key   \- program \*(Aqkey\*(Aq specified with \-k option or key read from
+                file specified with \-\-keyfile option to the specified
+                RPMB target given with \-\-target or \-t options\&. As per
+                spec, this is one time action which can\*(Aqt be undone\&.
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+read\-couter   \- Read \*(Aqwrite counter\*(Aq of specified RPMB target\&. The
+                counter value read is printed onto STDOUT
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+read\-config   \- Read 512 bytes of device configuration block data of
+                specified RPMB target of the NVMe device\&. The data read
+                is written to input file specified with \-\-msgfile or \-f
+                option\&.
+write\-config  \- Write 512 byes of device configuration block data
+                from file specified by \-\-msgfile or \-f options to the
+                RPMB target specified with \-\-target or \-t options\&.
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+read\-data     \- Supports authenticated data reading from specified
+                RPMB target (\-\-target or \-t option) at given offset
+                specified with \-\-address or \-o option, using key
+                specified using \-\-keyfile or \-k options\&. \-\-blocks or
+                \-o option should be given to read the amount of data
+                to be read in 512 byte blocks\&.
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+write\-data    \- Supports authenticated data writting to specified RPMB
+                target (\-\-target or \-t option) at given offset
+                specified with \-\-address or \-o option, using key
+                specified using \-\-keyfile or \-k options\&. \-\-blocks or
+                \-o option should be given to indicate amount of data
+                to be written in 512 byte blocks\&.
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+For data transfer (read/write) commands, if the specified size is not
+within the total size supported by a target, the request is failed
+nvme\-rpmb without sending it to device\&. RPMB target 0 is used as the
+default target if \-\-target or \-t is not specified\&. 0x0 is used as the
+default address if no \-address or \-o option is specified,
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.PP
+\-t <target>, \-\-target=<target>
+.RS 4
+RPMB target id\&. This should be one of the supported RPMB targets as reported by
+\fIinfo\fR
+command\&. If nothing is given, default of 0 is used as RPMB target\&.
+.RE
+.PP
+\-k <key>, \-\-key=<key>, \-g <key\-file>, \-\-keyfile=<key\-file>
+.RS 4
+Authentication key to be used for read/write commands\&. This should have been already programmed by
+\fIprogram\-key\fR
+command for given target\&. Key can be specified on command line using \-\-key or \-k options\&. Key can also be specified using file argument specified with \-\-keyfile or \-g options\&.
+.RE
+.PP
+\-f <data\-file>, \-\-msgfile=<data\-file>
+.RS 4
+Name of the file to be used for data transfer commands (read or write)\&. For read command, if an existing file is specified, it will be appended\&.
+.RE
+.PP
+\-d <data>, \-\-msg=<data>
+.RS 4
+These options provide the data on the command line itself\&.
+.RE
+.PP
+\-o <offset>, \-\-address=<offset>
+.RS 4
+The address (in 512 byte sector offset from 0) to be used for data trasnfer commands (read or write) for a specified RPMB target\&.
+.RE
+.PP
+\-b, \-\-blocks=<sectors>
+.RS 4
+The size in 512 byte sectors to be used for data trasnfer commands (read or write) for a specified RPMB target\&.
+.RE
+.SH "EXAMPLES"
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Print RPMB support information of an NVMe device
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# nvme rpmb /dev/nvme0 \-\-cmd=info
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Program
+\fISecreteKey\fR
+as authentication key for target 1
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# nvme rpmb /dev/nvme0 \-\-cmd=program\-key \-key=\*(AqSecretKey\*(Aq \-\-target=1
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Read current write counter of RPMB target 0
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# nvme rpmb /dev/nvme0 \-\-cmd=read\-counter \-\-target=0
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Read configuration data block of target 2 into config\&.bin file
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# nvme rpmb /dev/nvme0 \-\-cmd=read\-config \-\-target=2 \-f config\&.bin
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Write 200 blocks of (512 bytes) from input\&.bin onto target 0
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# nvme rpmb /dev/nvme0 \-c write\-data \-t 0 \-f input\&.bin \-b 200 \-k \*(AqSecreteKey\*(Aq
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Read 200 blocks of (512 bytes) from target 2, at offset 0x100 and save the
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+data onto output\&.bin
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+# nvme rpmb /dev/nvme0 \-c read\-data \-t 2 \-f out\&.bin \-b 200 \-o 0x100
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.SH "NVME"
+.sp
+Part of the nvme\-user suite

--- a/Documentation/nvme-rpmb.html
+++ b/Documentation/nvme-rpmb.html
@@ -1,0 +1,1008 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
+<title>nvme-rpmb(1)</title>
+<style type="text/css">
+/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+
+/* Default font. */
+body {
+  font-family: Georgia,serif;
+}
+
+/* Title font. */
+h1, h2, h3, h4, h5, h6,
+div.title, caption.title,
+thead, p.table.header,
+#toctitle,
+#author, #revnumber, #revdate, #revremark,
+#footer {
+  font-family: Arial,Helvetica,sans-serif;
+}
+
+body {
+  margin: 1em 5% 1em 5%;
+}
+
+a {
+  color: blue;
+  text-decoration: underline;
+}
+a:visited {
+  color: fuchsia;
+}
+
+em {
+  font-style: italic;
+  color: navy;
+}
+
+strong {
+  font-weight: bold;
+  color: #083194;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #527bbd;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+h1, h2, h3 {
+  border-bottom: 2px solid silver;
+}
+h2 {
+  padding-top: 0.5em;
+}
+h3 {
+  float: left;
+}
+h3 + * {
+  clear: left;
+}
+h5 {
+  font-size: 1.0em;
+}
+
+div.sectionbody {
+  margin-left: 0;
+}
+
+hr {
+  border: 1px solid silver;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+ul, ol, li > p {
+  margin-top: 0;
+}
+ul > li     { color: #aaa; }
+ul > li > * { color: black; }
+
+.monospaced, code, pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: inherit;
+  color: navy;
+  padding: 0;
+  margin: 0;
+}
+pre {
+  white-space: pre-wrap;
+}
+
+#author {
+  color: #527bbd;
+  font-weight: bold;
+  font-size: 1.1em;
+}
+#email {
+}
+#revnumber, #revdate, #revremark {
+}
+
+#footer {
+  font-size: small;
+  border-top: 2px solid silver;
+  padding-top: 0.5em;
+  margin-top: 4.0em;
+}
+#footer-text {
+  float: left;
+  padding-bottom: 0.5em;
+}
+#footer-badges {
+  float: right;
+  padding-bottom: 0.5em;
+}
+
+#preamble {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+div.imageblock, div.exampleblock, div.verseblock,
+div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
+div.admonitionblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.admonitionblock {
+  margin-top: 2.0em;
+  margin-bottom: 2.0em;
+  margin-right: 10%;
+  color: #606060;
+}
+
+div.content { /* Block element content. */
+  padding: 0;
+}
+
+/* Block element titles. */
+div.title, caption.title {
+  color: #527bbd;
+  font-weight: bold;
+  text-align: left;
+  margin-top: 1.0em;
+  margin-bottom: 0.5em;
+}
+div.title + * {
+  margin-top: 0;
+}
+
+td div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content + div.title {
+  margin-top: 0.0em;
+}
+
+div.sidebarblock > div.content {
+  background: #ffffee;
+  border: 1px solid #dddddd;
+  border-left: 4px solid #f0f0f0;
+  padding: 0.5em;
+}
+
+div.listingblock > div.content {
+  border: 1px solid #dddddd;
+  border-left: 5px solid #f0f0f0;
+  background: #f8f8f8;
+  padding: 0.5em;
+}
+
+div.quoteblock, div.verseblock {
+  padding-left: 1.0em;
+  margin-left: 1.0em;
+  margin-right: 10%;
+  border-left: 5px solid #f0f0f0;
+  color: #888;
+}
+
+div.quoteblock > div.attribution {
+  padding-top: 0.5em;
+  text-align: right;
+}
+
+div.verseblock > pre.content {
+  font-family: inherit;
+  font-size: inherit;
+}
+div.verseblock > div.attribution {
+  padding-top: 0.75em;
+  text-align: left;
+}
+/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
+div.verseblock + div.attribution {
+  text-align: left;
+}
+
+div.admonitionblock .icon {
+  vertical-align: top;
+  font-size: 1.1em;
+  font-weight: bold;
+  text-decoration: underline;
+  color: #527bbd;
+  padding-right: 0.5em;
+}
+div.admonitionblock td.content {
+  padding-left: 0.5em;
+  border-left: 3px solid #dddddd;
+}
+
+div.exampleblock > div.content {
+  border-left: 3px solid #dddddd;
+  padding-left: 0.5em;
+}
+
+div.imageblock div.content { padding-left: 0; }
+span.image img { border-style: none; vertical-align: text-bottom; }
+a.image:visited { color: white; }
+
+dl {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+dt {
+  margin-top: 0.5em;
+  margin-bottom: 0;
+  font-style: normal;
+  color: navy;
+}
+dd > *:first-child {
+  margin-top: 0.1em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+ol.arabic {
+  list-style-type: decimal;
+}
+ol.loweralpha {
+  list-style-type: lower-alpha;
+}
+ol.upperalpha {
+  list-style-type: upper-alpha;
+}
+ol.lowerroman {
+  list-style-type: lower-roman;
+}
+ol.upperroman {
+  list-style-type: upper-roman;
+}
+
+div.compact ul, div.compact ol,
+div.compact p, div.compact p,
+div.compact div, div.compact div {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+tfoot {
+  font-weight: bold;
+}
+td > div.verse {
+  white-space: pre;
+}
+
+div.hdlist {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+div.hdlist tr {
+  padding-bottom: 15px;
+}
+dt.hdlist1.strong, td.hdlist1.strong {
+  font-weight: bold;
+}
+td.hdlist1 {
+  vertical-align: top;
+  font-style: normal;
+  padding-right: 0.8em;
+  color: navy;
+}
+td.hdlist2 {
+  vertical-align: top;
+}
+div.hdlist.compact tr {
+  margin: 0;
+  padding-bottom: 0;
+}
+
+.comment {
+  background: yellow;
+}
+
+.footnote, .footnoteref {
+  font-size: 0.8em;
+}
+
+span.footnote, span.footnoteref {
+  vertical-align: super;
+}
+
+#footnotes {
+  margin: 20px 0 20px 0;
+  padding: 7px 0 0 0;
+}
+
+#footnotes div.footnote {
+  margin: 0 0 5px 0;
+}
+
+#footnotes hr {
+  border: none;
+  border-top: 1px solid silver;
+  height: 1px;
+  text-align: left;
+  margin-left: 0;
+  width: 20%;
+  min-width: 100px;
+}
+
+div.colist td {
+  padding-right: 0.5em;
+  padding-bottom: 0.3em;
+  vertical-align: top;
+}
+div.colist td img {
+  margin-top: 0.3em;
+}
+
+@media print {
+  #footer-badges { display: none; }
+}
+
+#toc {
+  margin-bottom: 2.5em;
+}
+
+#toctitle {
+  color: #527bbd;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 1.0em;
+  margin-bottom: 0.1em;
+}
+
+div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.toclevel2 {
+  margin-left: 2em;
+  font-size: 0.9em;
+}
+div.toclevel3 {
+  margin-left: 4em;
+  font-size: 0.9em;
+}
+div.toclevel4 {
+  margin-left: 6em;
+  font-size: 0.9em;
+}
+
+span.aqua { color: aqua; }
+span.black { color: black; }
+span.blue { color: blue; }
+span.fuchsia { color: fuchsia; }
+span.gray { color: gray; }
+span.green { color: green; }
+span.lime { color: lime; }
+span.maroon { color: maroon; }
+span.navy { color: navy; }
+span.olive { color: olive; }
+span.purple { color: purple; }
+span.red { color: red; }
+span.silver { color: silver; }
+span.teal { color: teal; }
+span.white { color: white; }
+span.yellow { color: yellow; }
+
+span.aqua-background { background: aqua; }
+span.black-background { background: black; }
+span.blue-background { background: blue; }
+span.fuchsia-background { background: fuchsia; }
+span.gray-background { background: gray; }
+span.green-background { background: green; }
+span.lime-background { background: lime; }
+span.maroon-background { background: maroon; }
+span.navy-background { background: navy; }
+span.olive-background { background: olive; }
+span.purple-background { background: purple; }
+span.red-background { background: red; }
+span.silver-background { background: silver; }
+span.teal-background { background: teal; }
+span.white-background { background: white; }
+span.yellow-background { background: yellow; }
+
+span.big { font-size: 2em; }
+span.small { font-size: 0.6em; }
+
+span.underline { text-decoration: underline; }
+span.overline { text-decoration: overline; }
+span.line-through { text-decoration: line-through; }
+
+div.unbreakable { page-break-inside: avoid; }
+
+
+/*
+ * xhtml11 specific
+ *
+ * */
+
+div.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.tableblock > table {
+  border: 3px solid #527bbd;
+}
+thead, p.table.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.table {
+  margin-top: 0;
+}
+/* Because the table frame attribute is overriden by CSS in most browsers. */
+div.tableblock > table[frame="void"] {
+  border-style: none;
+}
+div.tableblock > table[frame="hsides"] {
+  border-left-style: none;
+  border-right-style: none;
+}
+div.tableblock > table[frame="vsides"] {
+  border-top-style: none;
+  border-bottom-style: none;
+}
+
+
+/*
+ * html5 specific
+ *
+ * */
+
+table.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+thead, p.tableblock.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.tableblock {
+  margin-top: 0;
+}
+table.tableblock {
+  border-width: 3px;
+  border-spacing: 0px;
+  border-style: solid;
+  border-color: #527bbd;
+  border-collapse: collapse;
+}
+th.tableblock, td.tableblock {
+  border-width: 1px;
+  padding: 4px;
+  border-style: solid;
+  border-color: #527bbd;
+}
+
+table.tableblock.frame-topbot {
+  border-left-style: hidden;
+  border-right-style: hidden;
+}
+table.tableblock.frame-sides {
+  border-top-style: hidden;
+  border-bottom-style: hidden;
+}
+table.tableblock.frame-none {
+  border-style: hidden;
+}
+
+th.tableblock.halign-left, td.tableblock.halign-left {
+  text-align: left;
+}
+th.tableblock.halign-center, td.tableblock.halign-center {
+  text-align: center;
+}
+th.tableblock.halign-right, td.tableblock.halign-right {
+  text-align: right;
+}
+
+th.tableblock.valign-top, td.tableblock.valign-top {
+  vertical-align: top;
+}
+th.tableblock.valign-middle, td.tableblock.valign-middle {
+  vertical-align: middle;
+}
+th.tableblock.valign-bottom, td.tableblock.valign-bottom {
+  vertical-align: bottom;
+}
+
+
+/*
+ * manpage specific
+ *
+ * */
+
+body.manpage h1 {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  border-top: 2px solid silver;
+  border-bottom: 2px solid silver;
+}
+body.manpage h2 {
+  border-style: none;
+}
+body.manpage div.sectionbody {
+  margin-left: 3em;
+}
+
+@media print {
+  body.manpage div#toc { display: none; }
+}
+
+
+</style>
+<script type="text/javascript">
+/*<![CDATA[*/
+var asciidoc = {  // Namespace.
+
+/////////////////////////////////////////////////////////////////////
+// Table Of Contents generator
+/////////////////////////////////////////////////////////////////////
+
+/* Author: Mihai Bazon, September 2002
+ * http://students.infoiasi.ro/~mishoo
+ *
+ * Table Of Content generator
+ * Version: 0.4
+ *
+ * Feel free to use this script under the terms of the GNU General Public
+ * License, as long as you do not remove or alter this notice.
+ */
+
+ /* modified by Troy D. Hanson, September 2006. License: GPL */
+ /* modified by Stuart Rackham, 2006, 2009. License: GPL */
+
+// toclevels = 1..4.
+toc: function (toclevels) {
+
+  function getText(el) {
+    var text = "";
+    for (var i = el.firstChild; i != null; i = i.nextSibling) {
+      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
+        text += i.data;
+      else if (i.firstChild != null)
+        text += getText(i);
+    }
+    return text;
+  }
+
+  function TocEntry(el, text, toclevel) {
+    this.element = el;
+    this.text = text;
+    this.toclevel = toclevel;
+  }
+
+  function tocEntries(el, toclevels) {
+    var result = new Array;
+    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
+    // Function that scans the DOM tree for header elements (the DOM2
+    // nodeIterator API would be a better technique but not supported by all
+    // browsers).
+    var iterate = function (el) {
+      for (var i = el.firstChild; i != null; i = i.nextSibling) {
+        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
+          var mo = re.exec(i.tagName);
+          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
+            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
+          }
+          iterate(i);
+        }
+      }
+    }
+    iterate(el);
+    return result;
+  }
+
+  var toc = document.getElementById("toc");
+  if (!toc) {
+    return;
+  }
+
+  // Delete existing TOC entries in case we're reloading the TOC.
+  var tocEntriesToRemove = [];
+  var i;
+  for (i = 0; i < toc.childNodes.length; i++) {
+    var entry = toc.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div'
+     && entry.getAttribute("class")
+     && entry.getAttribute("class").match(/^toclevel/))
+      tocEntriesToRemove.push(entry);
+  }
+  for (i = 0; i < tocEntriesToRemove.length; i++) {
+    toc.removeChild(tocEntriesToRemove[i]);
+  }
+
+  // Rebuild TOC entries.
+  var entries = tocEntries(document.getElementById("content"), toclevels);
+  for (var i = 0; i < entries.length; ++i) {
+    var entry = entries[i];
+    if (entry.element.id == "")
+      entry.element.id = "_toc_" + i;
+    var a = document.createElement("a");
+    a.href = "#" + entry.element.id;
+    a.appendChild(document.createTextNode(entry.text));
+    var div = document.createElement("div");
+    div.appendChild(a);
+    div.className = "toclevel" + entry.toclevel;
+    toc.appendChild(div);
+  }
+  if (entries.length == 0)
+    toc.parentNode.removeChild(toc);
+},
+
+
+/////////////////////////////////////////////////////////////////////
+// Footnotes generator
+/////////////////////////////////////////////////////////////////////
+
+/* Based on footnote generation code from:
+ * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
+ */
+
+footnotes: function () {
+  // Delete existing footnote entries in case we're reloading the footnodes.
+  var i;
+  var noteholder = document.getElementById("footnotes");
+  if (!noteholder) {
+    return;
+  }
+  var entriesToRemove = [];
+  for (i = 0; i < noteholder.childNodes.length; i++) {
+    var entry = noteholder.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
+      entriesToRemove.push(entry);
+  }
+  for (i = 0; i < entriesToRemove.length; i++) {
+    noteholder.removeChild(entriesToRemove[i]);
+  }
+
+  // Rebuild footnote entries.
+  var cont = document.getElementById("content");
+  var spans = cont.getElementsByTagName("span");
+  var refs = {};
+  var n = 0;
+  for (i=0; i<spans.length; i++) {
+    if (spans[i].className == "footnote") {
+      n++;
+      var note = spans[i].getAttribute("data-note");
+      if (!note) {
+        // Use [\s\S] in place of . so multi-line matches work.
+        // Because JavaScript has no s (dotall) regex flag.
+        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
+        spans[i].innerHTML =
+          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+        spans[i].setAttribute("data-note", note);
+      }
+      noteholder.innerHTML +=
+        "<div class='footnote' id='_footnote_" + n + "'>" +
+        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
+        n + "</a>. " + note + "</div>";
+      var id =spans[i].getAttribute("id");
+      if (id != null) refs["#"+id] = n;
+    }
+  }
+  if (n == 0)
+    noteholder.parentNode.removeChild(noteholder);
+  else {
+    // Process footnoterefs.
+    for (i=0; i<spans.length; i++) {
+      if (spans[i].className == "footnoteref") {
+        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
+        href = href.match(/#.*/)[0];  // Because IE return full URL.
+        n = refs[href];
+        spans[i].innerHTML =
+          "[<a href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+      }
+    }
+  }
+},
+
+install: function(toclevels) {
+  var timerId;
+
+  function reinstall() {
+    asciidoc.footnotes();
+    if (toclevels) {
+      asciidoc.toc(toclevels);
+    }
+  }
+
+  function reinstallAndRemoveTimer() {
+    clearInterval(timerId);
+    reinstall();
+  }
+
+  timerId = setInterval(reinstall, 500);
+  if (document.addEventListener)
+    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
+  else
+    window.onload = reinstallAndRemoveTimer;
+}
+
+}
+asciidoc.install();
+/*]]>*/
+</script>
+</head>
+<body class="manpage">
+<div id="header">
+<h1>
+nvme-rpmb(1) Manual Page
+</h1>
+<h2>NAME</h2>
+<div class="sectionbody">
+<p>nvme-rpmb -
+   Send RPMB commands to an NVMe device
+</p>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_synopsis">SYNOPSIS</h2>
+<div class="sectionbody">
+<div class="verseblock">
+<pre class="content"><em>nvme rpmb</em> &lt;device&gt; [--cmd=&lt;command&gt; | -c &lt;command&gt;]
+                    [--msgfile=&lt;data-file&gt; | -f &lt;data-file&gt;]
+                    [--keyfile=&lt;key-file&gt; | -g &lt;key-file&gt;]
+                    [--key=&lt;key&gt; | -k &lt;key&gt;]
+                    [--msg=&lt;data&gt; | -d &lt;data&gt;]
+                    [--address=&lt;offset&gt; | -o &lt;offset&gt;]
+                    [--blocks=&lt;512 byte sectors&gt; | -b &lt;sectors&gt; ]
+                    [--target=&lt;target-id&gt; | -t &lt;id&gt; ]</pre>
+<div class="attribution">
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_description">DESCRIPTION</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>For the NVMe device given, send an nvme rpmb command and provide the results.</p></div>
+<div class="paragraph"><p>The &lt;device&gt; parameter is mandatory and NVMe character device (ex: /dev/nvme0)
+must be specified. If the given device supports RPMB targets, command given
+with --cmd or -c option shall be sent to the controller. If given NVMe device
+doesn&#8217;t support RPMB targets, a message indicating the same shall be printed
+along with controller register values related RPMB.</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_options">OPTIONS</h2>
+<div class="sectionbody">
+<div class="dlist"><dl>
+<dt class="hdlist1">
+-c &lt;command&gt;
+</dt>
+<dt class="hdlist1">
+--cmd=&lt;command&gt;
+</dt>
+<dd>
+<p>
+        RPMB command to be sent to the device. It can be one of the following
+</p>
+<div class="literalblock">
+<div class="content">
+<pre><code>info          - print information regarding supported RPMB targets and
+                access and total sizes. No further arguments are required</code></pre>
+</div></div>
+<div class="literalblock">
+<div class="content">
+<pre><code>program-key   - program 'key' specified with -k option or key read from
+                file specified with --keyfile option to the specified
+                RPMB target given with --target or -t options. As per
+                spec, this is one time action which can't be undone.</code></pre>
+</div></div>
+<div class="literalblock">
+<div class="content">
+<pre><code>read-couter   - Read 'write counter' of specified RPMB target. The
+                counter value read is printed onto STDOUT</code></pre>
+</div></div>
+<div class="literalblock">
+<div class="content">
+<pre><code>read-config   - Read 512 bytes of device configuration block data of
+                specified RPMB target of the NVMe device. The data read
+                is written to input file specified with --msgfile or -f
+                option.
+write-config  - Write 512 byes of device configuration block data
+                from file specified by --msgfile or -f options to the
+                RPMB target specified with --target or -t options.</code></pre>
+</div></div>
+<div class="literalblock">
+<div class="content">
+<pre><code>read-data     - Supports authenticated data reading from specified
+                RPMB target (--target or -t option) at given offset
+                specified with --address or -o option, using key
+                specified using --keyfile or -k options. --blocks or
+                -o option should be given to read the amount of data
+                to be read in 512 byte blocks.</code></pre>
+</div></div>
+<div class="literalblock">
+<div class="content">
+<pre><code>write-data    - Supports authenticated data writting to specified RPMB
+                target (--target or -t option) at given offset
+                specified with --address or -o option, using key
+                specified using --keyfile or -k options. --blocks or
+                -o option should be given to indicate amount of data
+                to be written in 512 byte blocks.</code></pre>
+</div></div>
+<div class="literalblock">
+<div class="content">
+<pre><code>For data transfer (read/write) commands, if the specified size is not
+within the total size supported by a target, the request is failed
+nvme-rpmb without sending it to device. RPMB target 0 is used as the
+default target if --target or -t is not specified. 0x0 is used as the
+default address if no -address or -o option is specified,</code></pre>
+</div></div>
+</dd>
+<dt class="hdlist1">
+-t &lt;target&gt;
+</dt>
+<dt class="hdlist1">
+--target=&lt;target&gt;
+</dt>
+<dd>
+<p>
+        RPMB target id. This should be one of the supported RPMB targets as
+        reported by <em>info</em> command. If nothing is given, default of 0 is used
+        as RPMB target.
+</p>
+</dd>
+<dt class="hdlist1">
+-k &lt;key&gt;
+</dt>
+<dt class="hdlist1">
+--key=&lt;key&gt;
+</dt>
+<dt class="hdlist1">
+-g &lt;key-file&gt;
+</dt>
+<dt class="hdlist1">
+--keyfile=&lt;key-file&gt;
+</dt>
+<dd>
+<p>
+        Authentication key to be used for read/write commands. This should have
+        been already programmed by <em>program-key</em> command for given target. Key
+        can be specified on command line using --key or -k options. Key can
+        also be specified using file argument specified with --keyfile or -g
+        options.
+</p>
+</dd>
+<dt class="hdlist1">
+-f &lt;data-file&gt;
+</dt>
+<dt class="hdlist1">
+--msgfile=&lt;data-file&gt;
+</dt>
+<dd>
+<p>
+        Name of the file to be used for data transfer commands (read or write).
+        For read command, if an existing file is specified, it will be appended.
+</p>
+</dd>
+<dt class="hdlist1">
+-d &lt;data&gt;
+</dt>
+<dt class="hdlist1">
+--msg=&lt;data&gt;
+</dt>
+<dd>
+<p>
+        These options provide the data on the command line itself.
+</p>
+</dd>
+<dt class="hdlist1">
+-o &lt;offset&gt;
+</dt>
+<dt class="hdlist1">
+--address=&lt;offset&gt;
+</dt>
+<dd>
+<p>
+        The address (in 512 byte sector offset from 0) to be used for data
+        trasnfer commands (read or write) for a specified RPMB target.
+</p>
+</dd>
+<dt class="hdlist1">
+-b
+</dt>
+<dt class="hdlist1">
+--blocks=&lt;sectors&gt;
+</dt>
+<dd>
+<p>
+        The size in 512 byte sectors to be used for data trasnfer commands
+        (read or write) for a specified RPMB target.
+</p>
+</dd>
+</dl></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_examples">EXAMPLES</h2>
+<div class="sectionbody">
+<div class="ulist"><ul>
+<li>
+<p>
+Print RPMB support information of an NVMe device
+</p>
+<div class="listingblock">
+<div class="content">
+<pre><code># nvme rpmb /dev/nvme0 --cmd=info</code></pre>
+</div></div>
+</li>
+<li>
+<p>
+Program <em>SecreteKey</em> as authentication key for target 1
+</p>
+<div class="listingblock">
+<div class="content">
+<pre><code># nvme rpmb /dev/nvme0 --cmd=program-key -key='SecretKey' --target=1</code></pre>
+</div></div>
+</li>
+<li>
+<p>
+Read current write counter of RPMB target 0
+</p>
+<div class="listingblock">
+<div class="content">
+<pre><code># nvme rpmb /dev/nvme0 --cmd=read-counter --target=0</code></pre>
+</div></div>
+</li>
+<li>
+<p>
+Read configuration data block of target 2 into config.bin file
+</p>
+<div class="listingblock">
+<div class="content">
+<pre><code># nvme rpmb /dev/nvme0 --cmd=read-config --target=2 -f config.bin</code></pre>
+</div></div>
+</li>
+<li>
+<p>
+Write 200 blocks of (512 bytes) from input.bin onto target 0
+</p>
+<div class="listingblock">
+<div class="content">
+<pre><code># nvme rpmb /dev/nvme0 -c write-data -t 0 -f input.bin -b 200 -k 'SecreteKey'</code></pre>
+</div></div>
+</li>
+<li>
+<p>
+Read 200 blocks of (512 bytes) from target 2, at offset 0x100 and save the
+</p>
+</li>
+<li>
+<p>
+data onto output.bin
+</p>
+<div class="listingblock">
+<div class="content">
+<pre><code># nvme rpmb /dev/nvme0 -c read-data -t 2 -f out.bin -b 200 -o 0x100</code></pre>
+</div></div>
+</li>
+</ul></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_nvme">NVME</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>Part of the nvme-user suite</p></div>
+</div>
+</div>
+</div>
+<div id="footnotes"><hr /></div>
+<div id="footer">
+<div id="footer-text">
+Last updated
+ 2020-08-04 15:06:40 DST
+</div>
+</div>
+</body>
+</html>

--- a/Documentation/nvme-rpmb.txt
+++ b/Documentation/nvme-rpmb.txt
@@ -1,0 +1,150 @@
+nvme-rpmb(1)
+==============
+
+NAME
+----
+nvme-rpmb - Send RPMB commands to an NVMe device
+
+SYNOPSIS
+--------
+[verse]
+'nvme rpmb' <device> [--cmd=<command> | -c <command>]
+		    [--msgfile=<data-file> | -f <data-file>]
+		    [--keyfile=<key-file> | -g <key-file>]
+		    [--key=<key> | -k <key>]
+		    [--msg=<data> | -d <data>]
+		    [--address=<offset> | -o <offset>]
+		    [--blocks=<512 byte sectors> | -b <sectors> ]
+		    [--target=<target-id> | -t <id> ]
+
+DESCRIPTION
+-----------
+For the NVMe device given, send an nvme rpmb command and provide the results.
+
+The <device> parameter is mandatory and NVMe character device (ex: /dev/nvme0)
+must be specified. If the given device supports RPMB targets, command given
+with --cmd or -c option shall be sent to the controller. If given NVMe device
+doesn't support RPMB targets, a message indicating the same shall be printed
+along with controller register values related RPMB.
+
+OPTIONS
+-------
+-c <command>::
+--cmd=<command>::
+	RPMB command to be sent to the device. It can be one of the following
+
+	info          - print information regarding supported RPMB targets and
+			access and total sizes. No further arguments are required
+
+	program-key   - program 'key' specified with -k option or key read from
+			file specified with --keyfile option to the specified
+			RPMB target given with --target or -t options. As per 
+			spec, this is one time action which can't be undone.
+
+	read-couter   - Read 'write counter' of specified RPMB target. The
+			counter value read is printed onto STDOUT
+
+	read-config   - Read 512 bytes of device configuration block data of
+			specified RPMB target of the NVMe device. The data read
+			is written to input file specified with --msgfile or -f
+			option.
+	write-config  - Write 512 byes of device configuration block data
+			from file specified by --msgfile or -f options to the
+			RPMB target specified with --target or -t options.
+
+	read-data     - Supports authenticated data reading from specified
+			RPMB target (--target or -t option) at given offset
+			specified with --address or -o option, using key
+			specified using --keyfile or -k options. --blocks or
+			-o option should be given to read the amount of data
+			to be read in 512 byte blocks.
+
+	write-data    - Supports authenticated data writting to specified RPMB
+			target (--target or -t option) at given offset
+			specified with --address or -o option, using key
+			specified using --keyfile or -k options. --blocks or
+			-o option should be given to indicate amount of data
+			to be written in 512 byte blocks.
+
+	For data transfer (read/write) commands, if the specified size is not
+	within the total size supported by a target, the request is failed
+	nvme-rpmb without sending it to device. RPMB target 0 is used as the
+	default target if --target or -t is not specified. 0x0 is used as the
+	default address if no -address or -o option is specified, 
+	
+-t <target>::
+--target=<target>::
+	RPMB target id. This should be one of the supported RPMB targets as
+	reported by 'info' command. If nothing is given, default of 0 is used
+	as RPMB target.
+
+-k <key>::
+--key=<key>::
+-g <key-file>::
+--keyfile=<key-file>::
+	Authentication key to be used for read/write commands. This should have
+	been already programmed by 'program-key' command for given target. Key
+	can be specified on command line using --key or -k options. Key can
+	also be specified using file argument specified with --keyfile or -g 
+	options.
+
+-f <data-file>::
+--msgfile=<data-file>::
+	Name of the file to be used for data transfer commands (read or write).
+	For read command, if an existing file is specified, it will be appended.
+
+-d <data>::
+--msg=<data>::
+	These options provide the data on the command line itself. 
+-o <offset>::
+--address=<offset>::
+	The address (in 512 byte sector offset from 0) to be used for data 
+	trasnfer commands (read or write) for a specified RPMB target.
+-b::
+--blocks=<sectors>::
+	The size in 512 byte sectors to be used for data trasnfer commands
+	(read or write) for a specified RPMB target.
+
+EXAMPLES
+--------
+* Print RPMB support information of an NVMe device
++
+-----------
+# nvme rpmb /dev/nvme0 --cmd=info
+-----------
++
+* Program 'SecreteKey' as authentication key for target 1
++
+------------
+# nvme rpmb /dev/nvme0 --cmd=program-key -key='SecretKey' --target=1
+------------
++
+* Read current write counter of RPMB target 0
++
+------------
+# nvme rpmb /dev/nvme0 --cmd=read-counter --target=0
+------------
++
+* Read configuration data block of target 2 into config.bin file
++
+------------
+# nvme rpmb /dev/nvme0 --cmd=read-config --target=2 -f config.bin
+------------
++
+* Write 200 blocks of (512 bytes) from input.bin onto target 0
++
+------------
+# nvme rpmb /dev/nvme0 -c write-data -t 0 -f input.bin -b 200 -k 'SecreteKey'
+------------
++
+* Read 200 blocks of (512 bytes) from target 2, at offset 0x100 and save the
+* data onto output.bin
++
+------------
+# nvme rpmb /dev/nvme0 -c read-data -t 2 -f out.bin -b 200 -o 0x100
+------------
+
+NVME
+----
+Part of the nvme-user suite
+

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ override CFLAGS += -DNVME_VERSION='"$(NVME_VERSION)"'
 
 NVME_DPKG_VERSION=1~`lsb_release -sc`
 
-OBJS := nvme-print.o nvme-ioctl.o \
+OBJS := nvme-print.o nvme-ioctl.o nvme-rpmb.o \
 	nvme-lightnvm.o fabrics.o nvme-models.o plugin.o \
 	nvme-status.o nvme-filters.o nvme-topology.o
 

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -76,6 +76,7 @@ COMMAND_LIST(
 	ENTRY("dir-receive", "Submit a Directive Receive command, return results", dir_receive)
 	ENTRY("dir-send", "Submit a Directive Send command, return results", dir_send)
 	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller ", virtual_mgmt)
+	ENTRY("rpmb", "Replay Protection Memory Block commands", rpmb_cmd)
 );
 
 #endif

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1974,7 +1974,7 @@ static void nvme_show_id_ctrl_apsta(__u8 apsta)
 	printf("\n");
 }
 
-static void nvme_show_id_ctrl_rpmbs(__le32 ctrl_rpmbs)
+void nvme_show_id_ctrl_rpmbs(__le32 ctrl_rpmbs)
 {
 	__u32 rpmbs = le32_to_cpu(ctrl_rpmbs);
 	__u32 asz = (rpmbs & 0xFF000000) >> 24;

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Micron Techologies Ltd. All rights reserved.
+ * Copyright (C) 2020 Micron Techology Inc. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -1,0 +1,1003 @@
+/*
+ * Copyright (C) 2020 Micron Techologies Ltd. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version
+ * 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * nvme-rpmb.c - Implementation of NVMe RPMB support commands in Nvme
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <linux/if_alg.h>
+#include <linux/socket.h>
+
+#include "nvme.h"
+#include "nvme-print.h"
+#include "nvme-ioctl.h"
+
+#define CREATE_CMD
+
+
+#ifndef AF_ALG
+#define AF_ALG 38
+#endif
+#ifndef SOL_ALG
+#define SOL_ALG 279
+#endif
+
+#define HMAC_SHA256_ALGO_NAME		"hmac(sha256)"
+#define MD5_HASH_ALGO_NAME		"md5"
+#define HMAC_SHA256_HASH_SIZE		32
+#define MD5_HASH_HASH_SIZE		16
+
+extern int nvme_show_id_ctrl_rpmbs(unsigned int);
+/*
+ * Utility function to create hash value of given data (with given key) using
+ * given hash algorithm; this function uses kernel crypto services
+ */
+unsigned char *create_hash(const char *algo,
+			   int hash_size,
+			   unsigned char *data,
+			   int datalen,
+			   unsigned char *key,
+			   int keylen)
+{
+	int error, infd, outfd = -1;
+	unsigned char *hash = NULL;
+	struct sockaddr_alg provider_sa = {
+		.salg_family = AF_ALG,
+		.salg_type = "hash",
+		.salg_name = { 0 }
+	};
+
+	/* copy algorith name */
+	memcpy(provider_sa.salg_name, algo, strlen(algo));
+
+    	/* open netlink socket connection to algorigm provider and bind */
+    	infd = socket(AF_ALG, SOCK_SEQPACKET, 0);
+	if (infd < 0) {
+		perror("socket");
+		return hash;
+	}
+    	error = bind(infd, (struct sockaddr *)&provider_sa, sizeof(provider_sa));
+	if (error < 0) {
+		perror("bind");
+		goto out;
+	}
+
+	/* if algorithm requires key, set it first - empty keys not accepted !*/
+	if (key != NULL && keylen > 0) {
+        	error = setsockopt(infd, SOL_ALG, ALG_SET_KEY, key, keylen);
+		if (error < 0) {
+			perror("setsockopt");
+			goto out;
+		}
+	}
+		
+    	/* now send data to hash */
+    	outfd = accept(infd, NULL, 0);
+	if (outfd < 0) {
+		perror("accept");
+		goto out;
+	}
+    	error = send(outfd, data, datalen, 0);
+	if (error < 0) {
+		perror("send");
+		goto out;
+	}
+
+	/* read computed hash */
+    	hash = (unsigned char *)calloc(hash_size, 1);
+	if (hash == NULL) {
+        	perror("calloc");
+		goto out;
+    	}
+
+    	error = read(outfd, hash, hash_size);
+	if (error != hash_size) {
+        	perror("read");
+        	free(hash);
+        	hash = NULL;
+    	}
+out:
+    if (outfd > 0) close(outfd);
+    if (infd > 0)  close(infd);
+
+    return hash;
+}
+
+/* Function that computes hmac-sha256 hash of given data and key pair. Returns
+ * byte stream (non-null terminated) upon success, NULL otherwise.
+ */
+unsigned char *
+hmac_sha256(unsigned char *data, int datalen, unsigned char *key, int keylen)
+{
+	return create_hash(HMAC_SHA256_ALGO_NAME,
+			   HMAC_SHA256_HASH_SIZE,
+			   data,
+			   datalen,
+			   key,
+			   keylen);
+}
+
+/* Function that computes md5 of given buffer - md5 hash is used as nonce
+ * Returns byte stream (non-null terminated) upon success, NULL otherwise.
+ */
+unsigned char *
+rpmb_md5(unsigned char *data, int datalen)
+{
+	return create_hash(MD5_HASH_ALGO_NAME,
+			   MD5_HASH_HASH_SIZE,
+			   data,
+			   datalen,
+			   NULL,
+			   0);
+}
+
+/* Read data from given file into buffer and return its length */
+static int read_file(const char *file, unsigned char **data, unsigned int *len)
+{
+	struct stat sb;
+	size_t size;
+	unsigned char   *buf = NULL;
+	int fd;
+	int err = -EINVAL;
+
+	if (file == NULL) return err;
+
+	if ((fd = open(file, O_RDONLY)) < 0) {
+		fprintf(stderr, "Failed to open %s: %s\n", file, strerror(errno));
+		return fd;
+	}
+
+	err = fstat(fd, &sb);
+	if (err < 0) {
+		perror("fstat");
+		goto out;
+	}
+
+	size = sb.st_size;
+	if (posix_memalign((void **)&buf, getpagesize(), size)) {
+		fprintf(stderr, "No memory for reading file :%s\n", file);
+		err = -ENOMEM;
+		goto out;
+	}
+
+	err = read(fd, buf, size);
+	if (err < 0) {
+		err = -errno;
+		fprintf(stderr, "Failed to read data from file"
+				" %s with %s\n", file, strerror(errno));
+		free(buf);
+		goto out;
+	}
+	err -= size;
+	*data = buf; 
+	*len = size;
+out:
+	close(fd);
+	return err;
+}
+
+/* Write given buffer data to specified file */
+static void write_file(unsigned char *data, size_t len, const char *dir,
+			  const char *file, const char *msg)
+{
+	char temp_folder[PATH_MAX] = { 0 };
+	FILE *fp = NULL;
+
+	if (dir != NULL)
+		sprintf(temp_folder, "%s/%s", dir, file);
+	else
+		sprintf(temp_folder, "./%s", file);
+
+	if ((fp = fopen(temp_folder, "ab+")) != NULL) {
+		if (fwrite(data, 1, len,  fp) != len) {
+			fprintf(stderr, "Failed to write %s data to %s\n",
+				 msg, temp_folder);
+		}
+		fclose(fp);
+	} else  {
+		fprintf(stderr, "Failed to open %s file to write %s\n",
+			temp_folder, msg);
+	}
+}
+
+/* Various definitions used in RPMB related support */
+enum rpmb_request_type {
+	RPMB_REQ_AUTH_KEY_PROGRAM = 0x0001,
+	RPMB_REQ_READ_WRITE_CNTR  = 0x0002,
+	RPMB_REQ_AUTH_DATA_WRITE  = 0x0003,
+	RPMB_REQ_AUTH_DATA_READ   = 0x0004,
+	RPMB_REQ_READ_RESULT      = 0x0005,
+	RPMB_REQ_AUTH_DCB_WRITE   = 0x0006,
+	RPMB_REQ_AUTH_DCB_READ    = 0x0007
+};
+	
+enum rpmb_response_type {
+	RPMB_RSP_AUTH_KEY_PROGRAM = (RPMB_REQ_AUTH_KEY_PROGRAM << 8),
+	RPMB_RSP_READ_WRITE_CNTR  = (RPMB_REQ_READ_WRITE_CNTR  << 8),
+	RPMB_RSP_AUTH_DATA_WRITE  = (RPMB_REQ_AUTH_DATA_WRITE  << 8),
+	RPMB_RSP_AUTH_DATA_READ   = (RPMB_REQ_AUTH_DATA_READ   << 8),
+	RPMB_RSP_READ_RESULT      = (RPMB_REQ_READ_RESULT      << 8),
+	RPMB_RSP_AUTH_DCB_WRITE   = (RPMB_REQ_AUTH_DCB_WRITE   << 8),
+	RPMB_RSP_AUTH_DCB_READ    = (RPMB_REQ_AUTH_DCB_READ    << 8)
+};
+
+/* RPMB data frame structure */
+#pragma pack(1)
+struct rpmb_data_frame_t {
+	unsigned char  pad[191];
+	unsigned char  mac[32];
+	unsigned char  target;     /* 0-6, should match with NSSF with SS, SR */
+	unsigned char  nonce[16];
+	unsigned int   write_counter;
+	unsigned int   address;
+	unsigned int   sectors;
+	unsigned short result;
+	unsigned short type;       /* req or response */
+	unsigned char  data[0];    /* in sector count times */
+};
+#pragma pack()
+	
+struct rpmb_config_block_t {
+	unsigned char  bp_enable;
+	unsigned char  bp_lock;
+	unsigned char  rsvd[510]; 
+};
+
+#define RPMB_DATA_FRAME_SIZE  256
+#define RPMB_NVME_SECP        0xEA 
+#define RPMB_NVME_SPSP        0x0001
+
+#define SEND_RPMB_REQ(tgt, size, req, result) \
+nvme_sec_send(fd, 0, tgt, RPMB_NVME_SPSP, RPMB_NVME_SECP, size, size, \
+		(unsigned char *)(req), (result))
+	
+#define RECV_RPMB_RSP(tgt, size, rsp, result) \
+nvme_sec_recv(fd, 0, tgt, RPMB_NVME_SPSP, RPMB_NVME_SECP, size, size, \
+		(unsigned char *)(rsp), (result))
+	
+/* Initialize nonce value in rpmb request frame */
+static void rpmb_nonce_init(struct rpmb_data_frame_t *req)
+{
+	int num = rand();
+	unsigned char *hash = rpmb_md5((unsigned char *)&num, sizeof(num));
+	if (hash) memcpy(req->nonce, hash, sizeof(req->nonce));
+}
+
+/* Read key from a given key buffer or key file */
+static unsigned char *read_rpmb_key(char *keystr, char *keyfile, unsigned int *keysize)
+{
+	unsigned char *keybuf = NULL;
+	
+	if (keystr == NULL) {
+		if (keyfile != NULL)
+			read_file(keyfile, &keybuf, keysize);
+	} else if ((keybuf = (unsigned char *)malloc(strlen(keystr))) != NULL) {
+		*keysize = strlen(keystr);
+		memcpy(keybuf, keystr, *keysize);
+	}
+
+	return keybuf;
+}
+
+/* Initialize RPMB request frame with given values */
+static struct rpmb_data_frame_t *
+rpmb_request_init(unsigned int   req_size,
+		  unsigned short type,
+		  unsigned char  target,
+		  unsigned char  nonce,
+		  unsigned int   addr,
+		  unsigned int   sectors,
+		  unsigned char  *data,
+		  unsigned short data_offset,
+		  unsigned int   data_size)
+{
+	struct rpmb_data_frame_t *req = NULL;
+
+	if ((req = (struct rpmb_data_frame_t *)calloc(req_size, 1)) == NULL) {
+		fprintf(stderr, "Memory allocation failed for request 0x%04x\n",
+			type);
+		return req;
+	}
+
+	req->type = type;
+	req->target = target;
+	req->address = addr;
+	req->sectors = sectors;
+	
+	if (nonce) rpmb_nonce_init(req);
+	if (data)  memcpy((unsigned char *)req + data_offset, data, data_size);
+
+	return req;
+}
+
+/* Process rpmb response and print appropriate error message */
+static int check_rpmb_response( struct rpmb_data_frame_t *req,
+				struct rpmb_data_frame_t *rsp,
+				char *msg)
+{
+	const char *rpmb_result_string [] = {
+		"Operation successful", 
+		"General failure",
+		"Authentication (MAC) failure",
+		"Counter failure (not matching/incrementing failure)",
+		"Address failure (out of range or wrong alignment)",
+		"Write (data/counter/result) failure",
+		"Read (data/counter/result) failure",
+		"Authentication key not yet programmed",
+		"Invalid device configuration block",
+		"Unknown error"
+	};
+	 
+	/* check error status before comparing nonce and mac */
+	if (rsp->result != 0)  {
+		if (rsp->type != ((req->type << 8) & 0xFF00)) {
+			fprintf(stderr, "%s ! non-matching response 0x%04x for"
+				" 0x%04x\n", msg, rsp->type, req->type);
+		} else if ((rsp->result & 0x80) == 0x80) {
+			fprintf(stderr, "%s ! Expired write-counter !\n", msg);
+		} else if (rsp->result) {
+			fprintf(stderr, "%s ! %s\n", msg,
+				rpmb_result_string[rsp->result & 0x7F]);
+		} else if (memcmp(req->nonce, rsp->nonce, 16)) {
+			fprintf(stderr, "%s ! non-matching nonce\n", msg);
+		} else if (memcmp(req->mac, rsp->mac, 32)) {
+			fprintf(stderr, "%s ! non-matching MAC\n", msg);
+		} else if ((req->write_counter + 1) != rsp->write_counter) {
+			fprintf(stderr, "%s ! out-of-sync write-counters\n", msg);
+		}
+	}
+	
+	return (int)(rsp->result);
+}
+
+/* send an initialized rpmb request to the controller and read its response
+ * expected response size give in 'rsp_size'. returns response buffer upon
+ * successful completion (caller must free), NULL otherwise
+ */
+static struct rpmb_data_frame_t *
+rpmb_read_request(int fd, 
+		  struct rpmb_data_frame_t *req,
+	          int req_size,
+	          int rsp_size)
+{
+	struct rpmb_data_frame_t *rsp = NULL;
+	unsigned int result = 0;
+	unsigned char msg[1024] = { 0 };
+	int error;
+
+	sprintf((char *)msg, "RPMB request 0x%04x to target 0x%x",
+		req->type, req->target);
+
+	error = SEND_RPMB_REQ(req->target, req_size, req, &result);
+	if (error != 0) {
+		fprintf(stderr, "%s failed with error = 0x%x, result = %x\n",
+			msg, error, result);
+		goto error_out;
+	}
+
+	/* read the result back */
+	rsp = (struct rpmb_data_frame_t *)calloc(rsp_size, 1);
+	if (rsp == NULL) {
+		fprintf(stderr, "memory alloc failed for %s\n", msg);
+		goto error_out;
+	}
+
+	/* Read result of previous request */
+	error = RECV_RPMB_RSP(req->target, rsp_size, rsp, &result);
+	if (error) {
+		fprintf(stderr, "error 0x%x receiving response for %s\n",
+			error, msg);
+		goto error_out;
+	}
+
+	/* validate response buffer - match target, nonce, and mac */
+	error = check_rpmb_response(req, rsp, (char *)msg);
+	if (error == 0) return rsp;
+
+error_out:
+	if (rsp) free(rsp);
+	return NULL;
+}
+
+/* read current write counter value from controller */
+static int rpmb_read_write_counter(int fd,
+				   unsigned char target,
+				   unsigned int *counter)
+{
+	int error = -1;
+	int req_size = sizeof(struct rpmb_data_frame_t);
+	struct rpmb_data_frame_t *req = NULL;
+	struct rpmb_data_frame_t *rsp = NULL;
+
+	req = rpmb_request_init(req_size, RPMB_REQ_READ_WRITE_CNTR,
+				target, 1, 0, 0, NULL, 0, 0);
+	if (req == NULL) goto out;
+	if ((rsp = rpmb_read_request(fd, req, req_size, req_size)) == NULL) {
+		goto out;
+	}	
+	*counter = rsp->write_counter; 
+	error = 0;
+	
+out:
+	if (req) free(req);
+	if (rsp) free(rsp);
+	return error;
+}
+
+/* Read current device configuration block into specified buffer. It also returns
+ * current write counter value returned as part of response, in case of error it
+ * returns 0
+ */
+static unsigned int rpmb_read_config_block(int fd, unsigned char **config_buf)
+{
+	int req_size = sizeof(struct rpmb_data_frame_t);
+	int cfg_size = sizeof(struct rpmb_config_block_t);
+	int rsp_size = req_size + cfg_size;
+	
+	struct rpmb_data_frame_t   *req = NULL;
+	struct rpmb_data_frame_t   *rsp = NULL;
+	struct rpmb_config_block_t *cfg = NULL;
+	unsigned int retval = 0;
+
+	/* initialize request with nonce, no data on input */
+	req = rpmb_request_init(req_size, RPMB_REQ_AUTH_DCB_READ, 0, 1, 0, 1,
+				0, 0, 0);
+	if ((req == NULL) ||
+	    (rsp = rpmb_read_request(fd, req, req_size, rsp_size)) == NULL)
+	{
+		goto out;
+	}	
+
+	/* copy configuration data to be sent back to caller */
+	cfg = (struct rpmb_config_block_t *)calloc(cfg_size, 1);
+	if (cfg == NULL) {
+		fprintf(stderr, "failed to allocate RPMB config buffer\n");
+		goto out;
+	}
+
+	memcpy(cfg, rsp->data, cfg_size);
+	*config_buf = (unsigned char *)cfg;
+	cfg = NULL;
+	retval = rsp->write_counter;
+out:
+	if (req) free(req);
+	if (rsp) free(rsp);
+	if (cfg) free(cfg);
+	return retval;
+}
+
+
+static int rpmb_auth_data_read(int fd, unsigned char target,
+			       unsigned int offset,
+			       unsigned char **msg_buf,
+			       int msg_size, int acc_size)
+{
+	struct rpmb_data_frame_t *req = NULL;
+	struct rpmb_data_frame_t *rsp = NULL;
+	int req_size = sizeof(struct rpmb_data_frame_t);
+	int chunk_size = (acc_size < msg_size) ? acc_size : msg_size;
+	int xfer = chunk_size;
+	unsigned char *bufp = (unsigned char *)malloc(msg_size * 512);
+	unsigned char *tbufp = bufp;
+	int data_size, rsp_size;
+	int error = -1;
+
+	if (bufp == NULL) {
+		fprintf(stderr, "Failed to allocated memory for read-data req\n");
+		goto out;
+	}
+	
+	while (xfer > 0) {
+		rsp_size = req_size + xfer * 512;
+		req = rpmb_request_init(req_size, RPMB_REQ_AUTH_DATA_READ,
+					target, 1, offset, xfer, 0, 0, 0);
+		if (req == NULL) break;
+		if ((rsp = rpmb_read_request(fd, req, req_size, rsp_size)) == NULL)
+		{
+			fprintf(stderr, "read_request failed\n");
+			free(rsp);
+			goto out;
+		}
+
+		data_size = rsp->sectors * 512;
+		memcpy(tbufp, rsp->data, data_size);
+		offset += rsp->sectors;
+		tbufp += data_size;
+		if (offset + chunk_size > msg_size)
+			xfer = msg_size - offset;
+		else 
+			xfer = chunk_size;
+		free(req);
+		free(rsp);
+	}
+	
+	*msg_buf = bufp;
+	error = offset;
+out:
+	return error;
+}
+
+/* Implementation of programming authentication key to given RPMB target */
+static int rpmb_program_auth_key(int fd, unsigned char target,
+				 unsigned char *key_buf, int key_size)
+{
+	int req_size = sizeof(struct rpmb_data_frame_t);
+	int rsp_size = sizeof(struct rpmb_data_frame_t);
+	
+	struct rpmb_data_frame_t *req = NULL;
+	struct rpmb_data_frame_t *rsp = NULL;
+	
+	int err = -ENOMEM;
+	unsigned int result = 0;
+	
+	req = rpmb_request_init(req_size, RPMB_REQ_AUTH_KEY_PROGRAM, target,
+				0, 0, 0, key_buf, (223 - key_size), key_size);
+	if (req == NULL) {
+		fprintf(stderr, "failed to allocate request buffer memory\n");
+		goto out;
+	}
+
+	/* send request and read the result first */
+	rsp = rpmb_read_request(fd, req, req_size, rsp_size);
+	if (rsp == NULL || rsp->result != 0) {
+		goto out;
+	}
+
+	/* re-use response buffer */
+	memset(rsp, 0, rsp_size);
+	err = RECV_RPMB_RSP(req->target, rsp_size, (unsigned char *)rsp, &result);
+	if (err != 0 || result != 0) {
+		err = check_rpmb_response(req, rsp, "Failed to Program Key");
+	}
+out:
+	if (req) free(req);
+	if (rsp) free(rsp);
+	
+	return err;
+}
+
+
+/* Implementation of RPMB authenticated data write command; this function
+ * transfers msg_size bytes from msg_buf to controller 'addr'. Returns
+ * number of bytes actually written to, otherwise negetive error code
+ * on failures.
+ */
+static int auth_data_write_chunk(int fd, unsigned char tgt, unsigned int addr,
+				 unsigned char *msg_buf, int msg_size,
+				 unsigned char *keybuf, int keysize)
+{
+	int req_size = sizeof(struct rpmb_data_frame_t) + msg_size;
+	int rsp_size = sizeof(struct rpmb_data_frame_t);
+	
+	struct rpmb_data_frame_t *req = NULL;
+	struct rpmb_data_frame_t *rsp = NULL;
+	
+	unsigned int result = 0, write_cntr = 0;
+	unsigned char *mac = NULL;
+	int error  = -ENOMEM;
+
+	/* get current write counter and copy to the request  */
+	error = rpmb_read_write_counter(fd, tgt, &write_cntr);
+	if (error != 0) {
+	   fprintf(stderr, "Failed to read write counter for write-data\n");
+	    goto out;
+	}
+	
+	req = rpmb_request_init(req_size, RPMB_REQ_AUTH_DATA_WRITE, tgt, 0,
+				addr, (msg_size / 512), msg_buf,
+				offsetof(struct rpmb_data_frame_t, data), msg_size);
+	if (req == NULL) {
+		fprintf(stderr, "Memory alloc failed for write-data command\n");
+		goto out;
+	}
+
+	req->write_counter = write_cntr;
+
+	/* compute HMAC hash */
+	mac = hmac_sha256(((unsigned char *)req + 223), req_size - 223,
+			   keybuf, keysize);
+	if (mac == NULL) {
+		fprintf(stderr, "failed to compute HMAC-SHA256\n");
+		error = -1;
+		goto out;
+	}
+
+	memcpy(req->mac, mac, 32);
+	
+	/* send the request and get response */
+	error = SEND_RPMB_REQ(tgt, req_size, (unsigned char *)req, &result);
+	if (error != 0) {
+	    fprintf(stderr, "RPMB request 0x%04x for 0x%x, error: %d, result = %x\n",
+		    req->type, tgt, error, result);
+	    goto out;
+	}
+	
+	/* send the request to get the result and then request to get the response */
+        rsp = (struct rpmb_data_frame_t *)calloc(rsp_size, 1);
+	rsp->target = req->target;
+	rsp->type = RPMB_REQ_READ_RESULT;
+	error = SEND_RPMB_REQ(tgt, rsp_size, (unsigned char *)rsp, &result);
+	if (error != 0 || rsp->result != 0) {
+		fprintf(stderr, "Write-data read result 0x%x, error = 0x%x\n",
+			rsp->result, error);
+		goto out;
+	}
+
+	/* Read final response */
+	memset(rsp, 0, rsp_size);
+	error = RECV_RPMB_RSP(tgt, rsp_size, (unsigned char *)rsp, &result);
+	if (error != 0)
+		fprintf(stderr, "Auth data write recv error = 0x%x\n", error);
+	else 
+    		error = check_rpmb_response(req, rsp, "Failed to write-data");
+out:
+	if (req) free(req);
+	if (rsp) free(rsp);
+	if (mac) free(mac);
+
+	return error;
+}
+
+/* send the request and get response */
+static int rpmb_auth_data_write(int fd, unsigned char target,
+				unsigned int addr, int acc_size,
+				unsigned char *msg_buf, int msg_size,
+				unsigned char *keybuf, int keysize)
+{
+	int chunk_size = acc_size < msg_size ? acc_size : msg_size;
+	int xfer   = chunk_size;
+	int offset = 0;
+
+	while (xfer > 0 ) {
+		if (auth_data_write_chunk(fd, target, (addr + offset / 512),
+				          msg_buf + offset, xfer,
+				          keybuf, keysize) != 0)
+		{
+			/* error writing chunk data */
+			break;	
+		}
+
+		offset += xfer;
+		if (offset + chunk_size > msg_size)
+			xfer = msg_size - offset;
+		else 
+			xfer = chunk_size;
+	}
+
+	return offset;
+}
+
+/* writes given config_block buffer to the drive target 0 */
+static int rpmb_write_config_block(int fd, unsigned char *cfg_buf,
+				   unsigned char *keybuf, int keysize)
+{
+	int cfg_size = sizeof(struct rpmb_config_block_t);
+	int rsp_size = sizeof(struct rpmb_data_frame_t);
+	int req_size = rsp_size + cfg_size;
+	
+	struct rpmb_data_frame_t *req = NULL;
+	struct rpmb_data_frame_t *rsp = NULL;
+	unsigned char *cfg_buf_read = NULL, *mac = NULL;
+	unsigned int write_cntr = 0, result = 0;
+	int   error = -ENOMEM;
+	
+	/* initialize request */
+	req = rpmb_request_init(req_size, RPMB_REQ_AUTH_DCB_WRITE, 0, 0, 0, 1,
+				cfg_buf, offsetof(struct rpmb_data_frame_t, data),
+				cfg_size);
+	if (req == NULL) {
+		fprintf(stderr, "failed to allocate rpmb request buffer\n");
+		goto out; 
+	}
+
+	/* read config block write_counter from controller */
+	write_cntr = rpmb_read_config_block(fd, &cfg_buf_read);
+	if (cfg_buf_read == NULL) {
+	    	fprintf(stderr, "failed to read config block write counter\n");
+		error = -EIO;
+	    	goto out;
+	}
+
+	free(cfg_buf_read);
+	req->write_counter = write_cntr;
+	mac = hmac_sha256(((unsigned char *)req + 223), req_size - 223,
+			   keybuf, keysize);
+	if (mac == NULL) {
+		fprintf(stderr, "failed to compute hmac-sha256 hash\n");
+		error = -EINVAL;
+	    	goto out;
+	}
+	
+	memcpy(req->mac, mac, sizeof(req->mac)); 
+	
+	error = SEND_RPMB_REQ(0, req_size, (unsigned char *)req, &result);
+	if (error != 0) {
+		fprintf(stderr, "Write-config RPMB request, error = 0x%x\n",
+			error);
+		goto out;
+	}
+	
+	/* get response */
+	rsp = (struct rpmb_data_frame_t *)calloc(rsp_size, 1);
+	if (rsp == NULL) {
+		fprintf(stderr, "failed to allocate response buffer memory\n");
+		error = -ENOMEM;
+		goto out;
+	}
+
+	/* get result first */
+	memset(rsp, 0, rsp_size);
+	rsp->target = req->target;
+	rsp->type = RPMB_REQ_READ_RESULT;
+	/* get the response and validate */
+	error = RECV_RPMB_RSP(req->target, rsp_size, rsp, &result);
+	if (error != 0) {
+		fprintf(stderr,"Failed getting write-config response\
+			error = 0x%x\n", error);
+		goto out;
+	}
+	error = check_rpmb_response(req, rsp,
+				  "Failed to retrieve write-config response");
+out:
+	if (req) free(req);
+	if (rsp) free(rsp);
+	if (mac) free(mac);
+	
+	return error;
+}
+
+static bool invalid_xfer_size(int blocks, unsigned int bpsz)
+{
+	return ((blocks <= 0) || 
+		(blocks * 512) > ((bpsz + 1) * 128 * 1024));
+}
+
+/* Handling rpmb sub-command */
+int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *plugin)
+{
+	const char *desc    = "Run RPMB command on the supporting controller";
+	const char *msg     = "data to be written on write-data or write-config commands";
+	const char *mfile   = "data file for read/write-data, read/write-config options";
+	const char *kfile   = "key file that has authentication key to be used";
+	const char *target  = "RPMB target - numerical value of 0 to 6, default 0";
+	const char *address = "Sector offset to read from or write to for an RPMB target, default 0";
+	const char *blocks  = "Number of 512 blocks to read or write";
+	const char *key     = "key to be used for authentication";
+	const char *opt     = "RPMB action - info, program-key, read-counter, write-data, " \
+			      "read-data, write-config and read-config";
+	
+	struct config {
+		char *cmd;
+		char *key;
+		char *msg;
+		char *keyfile;
+		char *msgfile;
+		int  opt;
+		int  address;
+		int  blocks; 
+		char target;
+	};
+	
+	struct config cfg = {
+		.cmd     = "info",
+		.key     = NULL,
+		.msg     = NULL,
+		.msgfile = NULL,
+		.keyfile = NULL,
+		.opt     = 0,
+		.address = 0,
+		.blocks  = 0,
+		.target  = 0,
+	};
+	
+	OPT_ARGS(opts) = {
+		OPT_STRING("cmd",     'c', "command", &cfg.cmd,     opt),
+		OPT_STRING("msgfile", 'f', "FILE",    &cfg.msgfile, mfile),
+		OPT_STRING("keyfile", 'g', "FILE",    &cfg.keyfile, kfile),
+		OPT_STRING("key",     'k', "key",     &cfg.key,     key),
+		OPT_STRING("msg",     'd', "data",    &cfg.msg,     msg),
+		OPT_UINT("address",   'o', &cfg.address,  address),
+		OPT_UINT("blocks",    'b', &cfg.blocks,   blocks),
+		OPT_UINT("target",    't', &cfg.target,   target),
+		OPT_END()
+	};
+	
+	unsigned int write_cntr = 0;
+	unsigned char *key_buf = NULL;
+	unsigned char *msg_buf = NULL;
+	unsigned int msg_size = 0;
+	unsigned int key_size = 0;
+	int fd = -1, err = -1;
+	struct nvme_id_ctrl ctrl;
+
+	union ctrl_rpmbs_reg {
+		struct {
+			unsigned int num_targets:3;
+			unsigned int auth_method:3;
+			unsigned int reserved:10;
+			unsigned int total_size:8;   /* 128K units */
+			unsigned int access_size:8;  /* in 512 byte count */
+		};
+		unsigned int rpmbs;
+	} regs;
+	
+	if ((fd = parse_and_open(argc, argv, desc, opts)) < 0)
+		goto out;
+	
+	/* before parsing  commands, check if controller supports any RPMB targets */
+	err = nvme_identify_ctrl(fd, &ctrl);
+	if (err)
+		goto out;
+	
+	regs.rpmbs = le32_to_cpu(ctrl.rpmbs);
+	if (regs.num_targets == 0) {
+		fprintf(stderr, "No RPMB targets are supported by the drive\n");
+		goto out;
+	}
+	
+	/* parse and validate options; default print rpmb support info */
+	if (cfg.cmd == 0 || strcmp(cfg.cmd, "info") == 0) {
+		nvme_show_id_ctrl_rpmbs(regs.rpmbs);
+		goto out;
+	}
+	
+	if (strcmp(cfg.cmd, "program-key") == 0)
+		cfg.opt = RPMB_REQ_AUTH_KEY_PROGRAM;
+	else if (strcmp(cfg.cmd, "read-counter") == 0)
+		cfg.opt = RPMB_REQ_READ_WRITE_CNTR;
+	else if (strcmp(cfg.cmd, "write-data") == 0)
+		cfg.opt = RPMB_REQ_AUTH_DATA_WRITE;
+	else if (strcmp(cfg.cmd, "read-data") == 0)
+		cfg.opt = RPMB_REQ_AUTH_DATA_READ;
+	else if (strcmp(cfg.cmd, "write-config") == 0)
+		cfg.opt = RPMB_REQ_AUTH_DCB_WRITE;
+	else if (strcmp(cfg.cmd, "read-config") == 0)
+		cfg.opt = RPMB_REQ_AUTH_DCB_READ;
+	else {
+		fprintf(stderr, "Invalid option %s for rpmb command\n", cfg.cmd);
+		goto out;
+	}
+	
+	/* input file/data processing */
+	if (cfg.opt == RPMB_REQ_AUTH_DCB_WRITE || 
+	    cfg.opt == RPMB_REQ_AUTH_DATA_WRITE ||
+	    cfg.opt == RPMB_REQ_AUTH_KEY_PROGRAM)
+	{
+		key_buf = read_rpmb_key(cfg.key, cfg.keyfile, &key_size);
+		if (key_buf == NULL) {
+			fprintf(stderr, "Failed to read key\n");
+			goto out;
+		}
+	
+		if (key_size > 223 || key_size <= 0) {
+			fprintf(stderr, "Invalid key size %d, valid input 1 to 223\n",
+			key_size);
+			goto out;
+		}
+
+		if (cfg.opt == RPMB_REQ_AUTH_DCB_WRITE ||
+		    cfg.opt == RPMB_REQ_AUTH_DATA_WRITE) {
+			if (cfg.msg != NULL) {
+				msg_size = strlen(cfg.msg);
+				msg_buf = (unsigned char *)malloc(msg_size);
+				memcpy(msg_buf, cfg.msg, msg_size);
+			} else {
+				err = read_file(cfg.msgfile, &msg_buf, &msg_size);
+				if (err || msg_size <= 0) {
+					fprintf(stderr, "Failed to read file %s\n",
+						cfg.msgfile);
+					goto out;
+				}
+			}
+		}
+	}
+	
+	switch (cfg.opt) {
+		case RPMB_REQ_READ_WRITE_CNTR:
+			err = rpmb_read_write_counter(fd, cfg.target, &write_cntr);
+			if (err == 0)
+				printf("Write Counter is: %u\n", write_cntr);
+			break;
+	
+		case RPMB_REQ_AUTH_DCB_READ:
+			write_cntr = rpmb_read_config_block(fd, &msg_buf);
+			if (msg_buf == NULL) {
+				fprintf(stderr, "failed read config blk\n");
+				goto out;
+			}
+
+			/* no output file is given, print the data on stdout */
+			if (cfg.msgfile == 0) {
+				struct rpmb_config_block_t *cfg =
+						(struct rpmb_config_block_t *)msg_buf;
+				printf("Boot Parition Protection is %s\n",
+					((cfg->bp_enable & 0x1)  ? "Enabled" : "Disabled"));
+				printf("Boot Parition 1 is %s\n",
+					((cfg->bp_lock & 0x2) ? "Locked" : "Unlocked"));
+				printf("Boot Parition 0 is %s\n",
+					((cfg->bp_lock & 0x1) ? "Locked" : "Unlocked"));
+			} else {
+				printf("Saving received config data to %s file\n", cfg.msgfile);
+				write_file(msg_buf, sizeof(struct rpmb_config_block_t), NULL,
+					   cfg.msgfile, NULL);
+			}
+			err = (write_cntr == 0);
+			break;
+	
+		case RPMB_REQ_AUTH_DATA_READ:
+			/* check if requested data is beyond what target supports */
+			msg_size = cfg.blocks * 512;
+			if (invalid_xfer_size(cfg.blocks, regs.total_size)) {
+				fprintf(stderr, "invalid transfer size %d \n",
+					msg_size);
+				break;
+			}
+			err = rpmb_auth_data_read(fd, cfg.target, cfg.address,
+						  &msg_buf, cfg.blocks,
+						  (regs.access_size + 1));
+			if (err > 0 && msg_buf != NULL) {
+				printf("Writting %d bytes to file %s\n",
+					err * 512, cfg.msgfile);
+				write_file(msg_buf, err * 512, NULL,
+					   cfg.msgfile, NULL);
+			}
+			break;
+	
+		case RPMB_REQ_AUTH_DATA_WRITE:
+			if (invalid_xfer_size(cfg.blocks, regs.total_size) || 
+			    (cfg.blocks * 512) > msg_size) {
+				fprintf(stderr, "invalid transfer size %d\n", 
+					cfg.blocks * 512);
+				break;
+			} else if ((cfg.blocks * 512) < msg_size) {
+				msg_size = cfg.blocks * 512;
+			}
+			err = rpmb_auth_data_write(fd, cfg.target, cfg.address,
+						  ((regs.access_size + 1) * 512),
+						   msg_buf, msg_size,
+						   key_buf, key_size);
+
+			/* print whatever extent of data written to target */
+			printf("Written %d sectors out of %d @target(%d):0x%x\n",
+				err/512, msg_size/512, cfg.target, cfg.address);
+			break;
+
+		case RPMB_REQ_AUTH_DCB_WRITE:
+			err = rpmb_write_config_block(fd, msg_buf, key_buf, key_size);
+			break;
+	
+		case RPMB_REQ_AUTH_KEY_PROGRAM:
+			err = rpmb_program_auth_key(fd, cfg.target, key_buf, key_size);
+			break;
+		default:
+			break;
+	}
+	 
+out:
+	/* release memory  */
+	if (key_buf) free(key_buf);
+	if (msg_buf) free(msg_buf);
+	
+	/* close file descriptor */
+	if (fd > 0) close(fd);
+	
+	return err;
+}

--- a/nvme.c
+++ b/nvme.c
@@ -4720,6 +4720,13 @@ ret:
 	return nvme_status_to_errno(err, false);
 }
 
+/* rpmb_cmd_option is defined in nvme-rpmb.c */
+extern int rpmb_cmd_option(int, char **, struct command *, struct plugin *);
+static int rpmb_cmd(int argc, char **argv, struct command *cmd, struct plugin *plugin)
+{
+	return rpmb_cmd_option(argc, argv, cmd, plugin);
+}
+
 static int passthru(int argc, char **argv, int ioctl_cmd, const char *desc, struct command *cmd)
 {
 	void *data = NULL, *metadata = NULL;


### PR DESCRIPTION
RPMB commands with HMAC-SHA256 computed using Linux kernel crypto services and using MD5 (computed using Linux kernel crypto services) of a random number as nonce. Currently supports
 - read-counter  - read current value of write counter
 - read-data       - read data from specified RPMB target onto given file
 - read-config    - reads configuration block data from specified RPMB target onto given file
 - program-key  - configures given authentication key for an RPMB target
 - write-data      - writes given block of data onto specified RPMB target
-  write-config   - writes device configuration block data to specified RPMB target
- info                  - prints current RPMBs support info of given NVMe device

TODO:
Need to check on what should be abstraction at nvme cli  to support boot partitions (lock, unlock, enable protection etc).