### PR TITLE
id-ctrl vs for Amazon Elastic Block Store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ UTIL_OBJS := util/argconfig.o util/suffix.o util/json.o util/parser.o
 
 PLUGIN_OBJS :=					\
 	plugins/intel/intel-nvme.o		\
+	plugins/amzn/amzn-nvme.o		\
 	plugins/lnvm/lnvm-nvme.o		\
 	plugins/memblaze/memblaze-nvme.o	\
 	plugins/wdc/wdc-nvme.o			\

--- a/plugins/amzn/amzn-nvme.c
+++ b/plugins/amzn/amzn-nvme.c
@@ -1,0 +1,60 @@
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <inttypes.h>
+
+#include "linux/nvme_ioctl.h"
+
+#include "common.h"
+#include "nvme.h"
+#include "nvme-print.h"
+#include "nvme-ioctl.h"
+#include "json.h"
+#include "plugin.h"
+
+#include "argconfig.h"
+#include "suffix.h"
+
+#define CREATE_CMD
+#include "amzn-nvme.h"
+
+struct nvme_vu_id_ctrl_field {
+	__u8			bdev[32];
+	__u8			reserved0[992];
+};
+
+static void json_amzn_id_ctrl(struct nvme_vu_id_ctrl_field *id,
+	char *bdev,
+	struct json_object *root)
+{
+	json_object_add_value_string(root, "bdev", bdev);
+}
+
+static void amzn_id_ctrl(__u8 *vs, struct json_object *root)
+{
+	struct nvme_vu_id_ctrl_field* id = (struct nvme_vu_id_ctrl_field *)vs;
+
+	char bdev[32] = { 0 };
+
+	int len = 0;
+	while (len < 31) {
+		if (id->bdev[++len] == ' ') {
+			break;
+		}
+	}
+	snprintf(bdev, len+1, "%s", id->bdev);
+
+	if (root) {
+		json_amzn_id_ctrl(id, bdev, root);
+		return;
+	}
+
+	printf("bdev      : %s\n", bdev);
+}
+
+static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin)
+{
+	return __id_ctrl(argc, argv, cmd, plugin, amzn_id_ctrl);
+}

--- a/plugins/amzn/amzn-nvme.h
+++ b/plugins/amzn/amzn-nvme.h
@@ -1,0 +1,17 @@
+#undef CMD_INC_FILE
+#define CMD_INC_FILE plugins/amzn/amzn-nvme
+
+#if !defined(AMZN_NVME) || defined(CMD_HEADER_MULTI_READ)
+#define AMZN_NVME
+
+#include "cmd.h"
+
+PLUGIN(NAME("amzn", "Amazon vendor specific extensions"),
+	COMMAND_LIST(
+		ENTRY("id-ctrl", "Send NVMe Identify Controller", id_ctrl)
+	)
+);
+
+#endif
+
+#include "define_cmd.h"


### PR DESCRIPTION
This allows the user to extract useful information from the vendor-specific field when querying Elastic Block Storage devices attached by Amazon Web Services. In particular, this field is populated with the block device that was requested by the user in the API call, which is of the form `/dev/sdc` or `/dev/xvdc` rather than `/dev/nvme2`. This plugin reduces the need for operating system maintainers to include vendor-specific packages in their distribution.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
https://github.com/aws/amazon-ec2-utils/blob/master/ebsnvme-id