### PR TITLE
nvme: implement passing csi to Get Log Page as described in TP 4056

### DIFF
--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -96,13 +96,13 @@ int nvme_identify_ns_granularity(int fd, void *data);
 int nvme_zns_identify_ctrl(int fd, void *data);
 int nvme_zns_identify_ns(int fd, __u32 nsid, void *data);
 int nvme_identify_iocs(int fd, __u16 cntid, void *data);
-int nvme_get_log(int fd, __u32 nsid, __u8 log_id, bool rae,
+int nvme_get_log(int fd, __u32 nsid, __u8 log_id, bool rae, __u8 csi,
 		 __u32 data_len, void *data);
 int nvme_get_log14(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
-		   __u16 group_id, bool rae, __u8 uuid_ix,
+		   __u16 group_id, bool rae, __u8 csi, __u8 uuid_ix,
 		   __u32 data_len, void *data);
 int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp,
-		 __u64 lpo, __u16 lsi, bool rae, __u32 data_len,
+		 __u64 lpo, __u16 lsi, bool rae, __u8 csi, __u32 data_len,
 		 void *data);
 int nvme_get_telemetry_log(int fd, void *lp, int generate_report,
 			   int ctrl_gen, size_t log_page_size, __u64 offset);

--- a/nvme-lightnvm.c
+++ b/nvme-lightnvm.c
@@ -522,7 +522,7 @@ int lnvm_do_chunk_log(int fd, __u32 nsid, __u32 data_len, void *data,
 {
 	int err;
 
-	err = nvme_get_log13(fd, nsid, NVM_LID_CHUNK_INFO, 0, 0, 0,
+	err = nvme_get_log13(fd, nsid, NVM_LID_CHUNK_INFO, 0, 0, 0, 0,
 			false, data_len, data);
 	if (err > 0) {
 		fprintf(stderr, "NVMe Status:%s(%x) NSID:%d\n",

--- a/nvme.c
+++ b/nvme.c
@@ -819,7 +819,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 		err = nvme_get_log14(fd, cfg.namespace_id, cfg.log_id,
 				     cfg.lsp, cfg.lpo, 0, cfg.rae,
-				     cfg.uuid_index, cfg.log_len, log);
+				     0, cfg.uuid_index, cfg.log_len, log);
 		if (!err) {
 			if (!cfg.raw_binary) {
 				printf("Device:%s log-id:%d namespace-id:%#x\n",

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -131,7 +131,7 @@ static int get_status(int argc, char **argv, struct command *cmd, struct plugin 
 	if (fd < 0)
 		return fd;
 	
-	err = nvme_get_log(fd, 0xffffffff, 0xc0, false, sizeof(log), &log);
+	err = nvme_get_log(fd, 0xffffffff, 0xc0, false, 0, sizeof(log), &log);
 	if (err) {
 		goto exit;
 	}

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -371,7 +371,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (fd < 0)
 		return fd;
 
-	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false,
+	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false, 0,
 			   sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (cfg.json)
@@ -411,7 +411,7 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 	if (fd < 0)
 		return fd;
 
-	err = nvme_get_log(fd, NVME_NSID_ALL, 0xdd, false,
+	err = nvme_get_log(fd, NVME_NSID_ALL, 0xdd, false, 0,
 			   sizeof(log), log);
 	if (!err) {
 		if (!cfg.raw_binary)
@@ -473,7 +473,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 	if (fd < 0)
 		return fd;
 
-	err = nvme_get_log(fd, NVME_NSID_ALL, 0xc5, false,
+	err = nvme_get_log(fd, NVME_NSID_ALL, 0xc5, false, 0,
 			   sizeof(stats), &stats);
 	if (!err) {
 		if (!cfg.raw_binary)
@@ -895,7 +895,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		flags = BINARY;
 
 	err = nvme_get_log(fd, NVME_NSID_ALL, cfg.write ? 0xc2 : 0xc1,
-			   false, sizeof(stats), &stats);
+			   false, 0, sizeof(stats), &stats);
 	if (!err) {
 		if (flags & JSON)
 			json_lat_stats(&stats, cfg.write);

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -407,7 +407,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (fd < 0)
 		return fd;
 
-	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false,
+	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false, 0,
 			   sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -289,7 +289,7 @@ static int GetLogPageSize(int nFD, unsigned char ucLogID, int *nLogSize)
     LogPageHeader_t *pLogHeader = NULL;
 
     if (ucLogID == 0xC1 || ucLogID == 0xC2 || ucLogID == 0xC4) {
-        err = nvme_get_log(nFD, NVME_NSID_ALL, ucLogID, false, CommonChunkSize, pTmpBuf);
+        err = nvme_get_log(nFD, NVME_NSID_ALL, ucLogID, false, 0, CommonChunkSize, pTmpBuf);
         if (err == 0) {
             pLogHeader = (LogPageHeader_t *) pTmpBuf;
             LogPageHeader_t *pLogHeader1 = (LogPageHeader_t *) pLogHeader;
@@ -397,7 +397,7 @@ static int GetCommonLogPage(int nFD, unsigned char ucLogID, unsigned char **pBuf
         goto exit_status;
     }
     memset(pTempPtr, 0, nBuffSize);
-    err = nvme_get_log(nFD, NVME_NSID_ALL, ucLogID, false, nBuffSize, pTempPtr);
+    err = nvme_get_log(nFD, NVME_NSID_ALL, ucLogID, false, 0, nBuffSize, pTempPtr);
     *pBuffer = pTempPtr;
 
 exit_status:
@@ -1100,7 +1100,7 @@ static int micron_nand_stats(int argc, char **argv, struct command *cmd, struct 
         log_page = 0xFB;
         log_size = FB_log_size;
     }
-    err = nvme_get_log(fd, NVME_NSID_ALL, log_page, false, log_size, extSmartLog);
+    err = nvme_get_log(fd, NVME_NSID_ALL, log_page, false, 0, log_size, extSmartLog);
     if (err) {
         printf("Unable to retrieve extended smart log for the drive\n");
         goto out;
@@ -1777,7 +1777,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *cmd,
             }
             if (bSize != 0 && (dataBuffer = (unsigned char *)malloc(bSize)) != NULL) {
                 memset(dataBuffer, 0, bSize);
-                err = nvme_get_log(fd, NVME_NSID_ALL, aVendorLogs[i].ucLogPage, false, bSize, dataBuffer);
+                err = nvme_get_log(fd, NVME_NSID_ALL, aVendorLogs[i].ucLogPage, false, 0, bSize, dataBuffer);
             }
             break;
 
@@ -1794,12 +1794,12 @@ static int micron_internal_logs(int argc, char **argv, struct command *cmd,
                break;
             }
             memset(dataBuffer, 0, bSize);
-            err = nvme_get_log(fd, NVME_NSID_ALL, aVendorLogs[i].ucLogPage, false, bSize, dataBuffer);
+            err = nvme_get_log(fd, NVME_NSID_ALL, aVendorLogs[i].ucLogPage, false, 0, bSize, dataBuffer);
             maxSize = aVendorLogs[i].nMaxSize - bSize;
             while (err == 0 && maxSize > 0 && ((unsigned int *)dataBuffer)[0] != 0xdeadbeef) {
                 sprintf(msg, "log 0x%x", aVendorLogs[i].ucLogPage);
                 WriteData(dataBuffer, bSize, strCtrlDirName, aVendorLogs[i].strFileName, msg);
-                err = nvme_get_log(fd, NVME_NSID_ALL, aVendorLogs[i].ucLogPage, false, bSize, dataBuffer);
+                err = nvme_get_log(fd, NVME_NSID_ALL, aVendorLogs[i].ucLogPage, false, 0, bSize, dataBuffer);
                 if (err || (((unsigned int *)dataBuffer)[0] == 0xdeadbeef))
                     break;
                 maxSize -= bSize;

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -362,7 +362,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 
 	fd = parse_and_open(argc, argv, desc, opts);
 
-	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false, sizeof(smart_log),
+	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false, 0, sizeof(smart_log),
 			(void *)&smart_log);
 	if (!err) {
 		if (cfg.json)
@@ -444,7 +444,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 
 	fd = parse_and_open(argc, argv, desc, opts);
 
-	err = nvme_get_log(fd, 0xffffffff, cfg.write ? 0xc3 : 0xc1, false, sizeof(stats), (void *)&stats);
+	err = nvme_get_log(fd, 0xffffffff, cfg.write ? 0xc3 : 0xc1, false, 0, sizeof(stats), (void *)&stats);
 	if (!err) {
 		if (!cfg.raw_binary)
 			show_lat_stats(&stats, cfg.write);

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -177,7 +177,7 @@ static int log_pages_supp(int argc, char **argv, struct command *cmd,
 	};
 
 	fd = parse_and_open(argc, argv, desc, opts);
-	err = nvme_get_log(fd, 1, 0xc5, false, sizeof(logPageMap), &logPageMap);
+	err = nvme_get_log(fd, 1, 0xc5, false, 0, sizeof(logPageMap), &logPageMap);
 	if (!err) {
 		if (strcmp(cfg.output_format,"json")) {
 			printf ("Seagate Supported Log-pages count :%d\n",
@@ -741,7 +741,7 @@ static int vs_smart_log(int argc, char **argv, struct command *cmd, struct plugi
 	if (strcmp(cfg.output_format,"json"))
 		printf("Seagate Extended SMART Information :\n");
 
-	err = nvme_get_log(fd, 1, 0xC4, false, sizeof(ExtdSMARTInfo), &ExtdSMARTInfo);
+	err = nvme_get_log(fd, 1, 0xC4, false, 0, sizeof(ExtdSMARTInfo), &ExtdSMARTInfo);
 	if (!err) {
 		if (strcmp(cfg.output_format,"json")) {
 			printf("%-39s %-15s %-19s \n", "Description", "Ext-Smart-Id", "Ext-Smart-Value");
@@ -763,7 +763,7 @@ static int vs_smart_log(int argc, char **argv, struct command *cmd, struct plugi
 		 * Next get Log Page 0xCF
 		 */
 
-		err = nvme_get_log(fd, 1, 0xCF, false, sizeof(logPageCF), &logPageCF);
+		err = nvme_get_log(fd, 1, 0xCF, false, 0, sizeof(logPageCF), &logPageCF);
 		if (!err) {
 			if(strcmp(cfg.output_format,"json")) {
 				/*printf("Seagate DRAM Supercap SMART Attributes :\n");*/
@@ -860,7 +860,7 @@ static int temp_stats(int argc, char **argv, struct command *cmd, struct plugin 
 	}
 
 	/* STEP-2 : Get Max temperature form Ext SMART-id 194 */
-	err = nvme_get_log(fd, 1, 0xC4, false, sizeof(ExtdSMARTInfo), &ExtdSMARTInfo);
+	err = nvme_get_log(fd, 1, 0xC4, false, 0, sizeof(ExtdSMARTInfo), &ExtdSMARTInfo);
 	if (!err) {
 		for(index = 0; index < NUMBER_EXTENDED_SMART_ATTRIBUTES; index++) {
 			if (ExtdSMARTInfo.vendorData[index].AttributeNumber == VS_ATTR_ID_MAX_LIFE_TEMPERATURE) {
@@ -882,7 +882,7 @@ static int temp_stats(int argc, char **argv, struct command *cmd, struct plugin 
 		fprintf(stderr, "NVMe Status:%s(%x)\n",
 			nvme_status_to_string(err), err);
 
-	cf_err = nvme_get_log(fd, 1, 0xCF, false, sizeof(ExtdSMARTInfo), &logPageCF);
+	cf_err = nvme_get_log(fd, 1, 0xCF, false, 0, sizeof(ExtdSMARTInfo), &logPageCF);
 
 	if(!cf_err) {
 		scCurrentTemp = logPageCF.AttrCF.SuperCapCurrentTemperature;
@@ -1011,7 +1011,7 @@ static int vs_pcie_error_log(int argc, char **argv, struct command *cmd, struct 
 	if(strcmp(cfg.output_format,"json"))
 		printf("Seagate PCIe error counters Information :\n");
 
-	err = nvme_get_log(fd, 1, 0xCB, false, sizeof(pcieErrorLog), &pcieErrorLog);
+	err = nvme_get_log(fd, 1, 0xCB, false, 0, sizeof(pcieErrorLog), &pcieErrorLog);
 	if (!err) {
 		if(strcmp(cfg.output_format,"json")) {
 			print_vs_pcie_error_log(pcieErrorLog);
@@ -1099,7 +1099,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 	dump_fd = STDOUT_FILENO;
 	cfg.log_id = (cfg.log_id << 8) | 0x07;
 	err = nvme_get_log13(fd, cfg.namespace_id, cfg.log_id,
-			     NVME_NO_LOG_LSP, offset, 0, false,
+			     NVME_NO_LOG_LSP, offset, 0, false, 0,
 			     sizeof(tele_log), (void *)(&tele_log));
 	if (!err) {
 		maxBlk = tele_log.tele_data_area3;
@@ -1139,7 +1139,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 		memset(log, 0, blksToGet * 512);
 
 		err = nvme_get_log13(fd, cfg.namespace_id, cfg.log_id,
-				     NVME_NO_LOG_LSP, offset, 0, false,
+				     NVME_NO_LOG_LSP, offset, 0, false, 0,
 				     blksToGet * 512, (void *)log);
 		if (!err) {
 			offset += blksToGet * 512;
@@ -1200,7 +1200,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 	log_id = 0x08;
 	err = nvme_get_log13(fd, cfg.namespace_id, log_id,
-			     NVME_NO_LOG_LSP, offset, 0, false,
+			     NVME_NO_LOG_LSP, offset, 0, false, 0,
 			     sizeof(tele_log), (void *)(&tele_log));
 	if (!err) {
 		maxBlk = tele_log.tele_data_area3;
@@ -1239,7 +1239,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 		memset(log, 0, blksToGet * 512);
 
 		err = nvme_get_log13(fd, cfg.namespace_id, log_id,
-				     NVME_NO_LOG_LSP, offset, 0, false,
+				     NVME_NO_LOG_LSP, offset, 0, false, 0,
 				     blksToGet * 512, (void *)log);
 		if (!err) {
 			offset += blksToGet * 512;
@@ -1325,7 +1325,7 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 
 	log_id = 0x08;
 	err = nvme_get_log13(fd, cfg.namespace_id, log_id,
-			     NVME_NO_LOG_LSP, offset, 0, false,
+			     NVME_NO_LOG_LSP, offset, 0, false, 0,
 			     sizeof(tele_log), (void *)(&tele_log));
 	if (!err) {
 		maxBlk = tele_log.tele_data_area3;
@@ -1361,7 +1361,7 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 		memset(log, 0, blksToGet * 512);
 
 		err = nvme_get_log13(fd, cfg.namespace_id, log_id,
-				     NVME_NO_LOG_LSP, offset, 0, false,
+				     NVME_NO_LOG_LSP, offset, 0, false, 0,
 				     blksToGet * 512, (void *)log);
 		if (!err) {
 			offset += blksToGet * 512;

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -142,7 +142,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	};
 
 	fd = parse_and_open(argc, argv, desc, opts);
-	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false,
+	err = nvme_get_log(fd, cfg.namespace_id, 0xca, false, 0,
 		   sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -392,7 +392,7 @@ static int nvme_get_vendor_log(int fd, __u32 namespace_id, int log_page,
 	if (err) {
 		goto end;
 	}
-	err = nvme_get_log(fd, namespace_id, log_page, false,
+	err = nvme_get_log(fd, namespace_id, log_page, false, 0,
 		    log_len, log);
 	if (err) {
 		fprintf(stderr, "%s: couldn't get log 0x%x\n", __func__,

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1342,7 +1342,7 @@ static bool get_dev_mgment_cbs_data(int fd, __u8 log_id, void **cbs_data)
 
 	/* get the log page length */
 	ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_OPCODE,
-			NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, WDC_C2_LOG_BUF_LEN, data);
+			NVME_NO_LOG_LSP, 0, 0, false, 0, uuid_ix, WDC_C2_LOG_BUF_LEN, data);
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : Unable to get C2 Log Page length, ret = 0x%x\n", ret);
 		goto end;
@@ -1362,7 +1362,7 @@ static bool get_dev_mgment_cbs_data(int fd, __u8 log_id, void **cbs_data)
 
 	/* get the log page data */
 	ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_OPCODE,
-			NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, le32_to_cpu(hdr_ptr->length), data);
+			NVME_NO_LOG_LSP, 0, 0, false, 0, uuid_ix, le32_to_cpu(hdr_ptr->length), data);
 
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : Unable to read C2 Log Page data, ret = 0x%x\n", ret);
@@ -1383,7 +1383,7 @@ static bool get_dev_mgment_cbs_data(int fd, __u8 log_id, void **cbs_data)
 		uuid_ix = 0;
 		/* get the log page data */
 		ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_OPCODE,
-				NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, le32_to_cpu(hdr_ptr->length), data);
+				NVME_NO_LOG_LSP, 0, 0, false, 0, uuid_ix, le32_to_cpu(hdr_ptr->length), data);
 
 		hdr_ptr = (struct wdc_c2_log_page_header *)data;
 		sph = (struct wdc_c2_log_subpage_header *)(data + length);
@@ -4167,7 +4167,7 @@ static int wdc_get_c0_log_page(int fd, char *format, int uuid_index)
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE,
-						NVME_NO_LOG_LSP, 0, 0, false, uuid_index, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
+						NVME_NO_LOG_LSP, 0, 0, false, 0, uuid_index, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
 
 				if (strcmp(format, "json"))
 					fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -4214,7 +4214,7 @@ static int wdc_get_c0_log_page(int fd, char *format, int uuid_index)
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE,
-						NVME_NO_LOG_LSP, 0, 0, false, uuid_index, WDC_NVME_EOL_STATUS_LOG_LEN, data);
+						NVME_NO_LOG_LSP, 0, 0, false, 0, uuid_index, WDC_NVME_EOL_STATUS_LOG_LEN, data);
 
 				if (strcmp(format, "json"))
 					fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -4241,7 +4241,7 @@ static int wdc_get_c0_log_page(int fd, char *format, int uuid_index)
 
 			/* Get the 0xC0 log data */
 			ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE,
-					   false, WDC_NVME_EOL_STATUS_LOG_LEN, data);
+					   false, 0, WDC_NVME_EOL_STATUS_LOG_LEN, data);
 
 			if (strcmp(format, "json"))
 				fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -4267,7 +4267,7 @@ static int wdc_get_c0_log_page(int fd, char *format, int uuid_index)
 
 		/* Get the 0xC0 log data */
 		ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_SMART_CLOUD_ATTR_LOG_OPCODE,
-					false, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
+					false, 0, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
 
 		if (strcmp(format, "json"))
 			fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -4408,7 +4408,7 @@ static int wdc_get_ca_log_page(int fd, char *format)
 			memset(data, 0, sizeof (__u8) * WDC_FB_CA_LOG_BUF_LEN);
 
 			ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_DEVICE_INFO_LOG_OPCODE,
-					   false, WDC_FB_CA_LOG_BUF_LEN, data);
+					   false, 0, WDC_FB_CA_LOG_BUF_LEN, data);
 			if (strcmp(format, "json"))
 				fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
 
@@ -4444,7 +4444,7 @@ static int wdc_get_ca_log_page(int fd, char *format)
 			memset(data, 0, sizeof (__u8) * WDC_FB_CA_LOG_BUF_LEN);
 
 			ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_DEVICE_INFO_LOG_OPCODE,
-					   false, WDC_FB_CA_LOG_BUF_LEN, data);
+					   false, 0, WDC_FB_CA_LOG_BUF_LEN, data);
 			if (strcmp(format, "json"))
 				fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
 
@@ -4465,7 +4465,7 @@ static int wdc_get_ca_log_page(int fd, char *format)
 
 			memset(data, 0, sizeof (__u8) * WDC_BD_CA_LOG_BUF_LEN);
 			ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_DEVICE_INFO_LOG_OPCODE,
-					   false, WDC_BD_CA_LOG_BUF_LEN, data);
+					   false, 0, WDC_BD_CA_LOG_BUF_LEN, data);
 			if (strcmp(format, "json"))
 				fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
 
@@ -4528,7 +4528,7 @@ static int wdc_get_c1_log_page(int fd, char *format, uint8_t interval)
 	}
 	memset(data, 0, sizeof (__u8) * WDC_ADD_LOG_BUF_LEN);
 
-	ret = nvme_get_log(fd, 0x01, WDC_NVME_ADD_LOG_OPCODE, false,
+	ret = nvme_get_log(fd, 0x01, WDC_NVME_ADD_LOG_OPCODE, false, 0,
 			   WDC_ADD_LOG_BUF_LEN, data);
 	if (strcmp(format, "json"))
 		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -4582,7 +4582,7 @@ static int wdc_get_d0_log_page(int fd, char *format)
 	memset(data, 0, sizeof (__u8) * WDC_NVME_VU_SMART_LOG_LEN);
 
 	ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_VU_SMART_LOG_OPCODE,
-			   false, WDC_NVME_VU_SMART_LOG_LEN, data);
+			   false, 0, WDC_NVME_VU_SMART_LOG_LEN, data);
 	if (strcmp(format, "json"))
 		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
 
@@ -4998,7 +4998,7 @@ static int wdc_get_fw_act_history(int fd, char *format)
 	memset(data, 0, sizeof (__u8) * WDC_FW_ACT_HISTORY_LOG_BUF_LEN);
 
 	ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_FW_ACT_HISTORY_LOG_ID,
-			   false, WDC_FW_ACT_HISTORY_LOG_BUF_LEN, data);
+			   false, 0, WDC_FW_ACT_HISTORY_LOG_BUF_LEN, data);
 
 	if (strcmp(format, "json"))
 		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -5045,7 +5045,7 @@ static int wdc_get_fw_act_history_C2(int fd, char *format)
 	memset(data, 0, sizeof (__u8) * WDC_FW_ACT_HISTORY_C2_LOG_BUF_LEN);
 
 	ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_GET_FW_ACT_HISTORY_C2_LOG_ID,
-			   false, WDC_FW_ACT_HISTORY_C2_LOG_BUF_LEN, data);
+			   false, 0, WDC_FW_ACT_HISTORY_C2_LOG_BUF_LEN, data);
 
 	if (strcmp(format, "json"))
 		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -5841,7 +5841,7 @@ static int wdc_do_drive_essentials(int fd, char *dir, char *key)
 		memset(dataBuffer, 0, dataBufferSize);
 
 		ret = nvme_get_log(fd, WDC_DE_GLOBAL_NSID, deVULogPagesList[vuLogIdx].logPageId,
-				   false, dataBufferSize, dataBuffer);
+				   false, 0, dataBufferSize, dataBuffer);
 		if (ret) {
 			fprintf(stderr, "ERROR : WDC : nvme_get_log() for log page 0x%x failed, ret = %d\n",
 					deVULogPagesList[vuLogIdx].logPageId, ret);
@@ -6757,7 +6757,7 @@ static int wdc_do_vs_nand_stats(int fd, char *format)
 	}
 
 	ret = nvme_get_log(fd, 0xFFFFFFFF, WDC_NVME_NAND_STATS_LOG_ID,
-			   false, WDC_NVME_NAND_STATS_SIZE, (void*)output);
+			   false, 0, WDC_NVME_NAND_STATS_SIZE, (void*)output);
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : %s : Failed to retreive NAND stats\n", __func__);
 		goto out;

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -891,7 +891,7 @@ static int changed_zone_list(int argc, char **argv, struct command *cmd, struct 
 	}
 
 	err = nvme_get_log(fd, cfg.namespace_id, NVME_LOG_ZONE_CHANGED_LIST, 
-						cfg.rae, sizeof(log), &log);
+						cfg.rae, 2, sizeof(log), &log);
 	if (!err)
 		nvme_show_zns_changed(&log, flags);
 	else if (err > 0)


### PR DESCRIPTION
Added passing Command Set Identifier to Get Log Page as described in TP
4056.

Spec : NVMe - TP 4056 Namespace Types 2020.06.15 - Ratified

Signed-off-by: Andrzej Jakowski <andrzej.jakowski@linux.intel.com>