### PR TITLE
rpmbuild: install directories using Makefile's variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,10 @@ deb-light: $(NVME) pkg nvme.control.in
 	dpkg-deb --build nvme-$(NVME_VERSION)
 
 rpm: dist
-	$(RPMBUILD) --define '_libdir ${LIBDIR}' -ta nvme-$(NVME_VERSION).tar.gz
+	$(RPMBUILD) --define '_prefix $(DESTDIR)$(PREFIX)' \
+	--define '_libdir $(DESTDIR)${LIBDIR}' \
+	--define '_sysconfdir $(DESTDIR)$(SYSCONFDIR)' \
+	-ta nvme-$(NVME_VERSION).tar.gz
 
 .PHONY: default doc all clean clobber install-man install-bin install
 .PHONY: dist pkg dist-orig deb deb-light rpm FORCE test


### PR DESCRIPTION
rpmbuild cause error on the system which is using difference RPM macros

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>