### PR TITLE
add surrounding white spaces in 70-nvmf-autoconnect.conf.in

### DIFF
--- a/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
+++ b/nvmf-autoconnect/dracut-conf/70-nvmf-autoconnect.conf.in
@@ -1,1 +1,1 @@
-install_items+="@@UDEVRULESDIR@@/70-nvmf-autoconnect.rules"
+install_items+=" @@UDEVRULESDIR@@/70-nvmf-autoconnect.rules "


### PR DESCRIPTION
```
/usr/lib/dracut/dracut.conf.d/70-nvmf-autoconnect.conf:install_items+="/usr/lib/udev/rules.d/70-nvmf-autoconnect.rules"

dracut: WARNING: <key>+=" <values> ": <values> should have surrounding white spaces!
dracut: WARNING: This will lead to unwanted side effects! Please fix the configuration file.
```