### PR TITLE
nvme-print: fix ZNS MAR/MOR print format

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3016,7 +3016,7 @@ void nvme_show_zns_id_ns(struct nvme_zns_id_ns *ns,
 			printf("mar     : %u\tActive Resources\n", le32_to_cpu(ns->mar) + 1);
 		}
 	} else {
-		printf("mar     : %u\n", le32_to_cpu(ns->mar));
+		printf("mar     : %#x\n", le32_to_cpu(ns->mar));
 	}
 
 	if (human) {
@@ -3026,7 +3026,7 @@ void nvme_show_zns_id_ns(struct nvme_zns_id_ns *ns,
 			printf("mor     : %u\tOpen Resources\n", le32_to_cpu(ns->mor) + 1);
 		}
 	} else {
-		printf("mor     : %d\n", le32_to_cpu(ns->mor));
+		printf("mor     : %#x\n", le32_to_cpu(ns->mor));
 	}
 
 	if (!le32_to_cpu(ns->rrl) && human)


### PR DESCRIPTION
MAR is currently printed as unsigned.
MOR is currently printed as signed.
They should use the same print format.

Printing MOR as unsigned on a controller that has no limit,
shows as -1, which doesn't make sense.

Since no limit is represented as 0xffffffff in the ZNS spec,
printing MAR/MOR as hex makes the most sense.

Signed-off-by: Niklas Cassel <niklas.cassel@wdc.com>