### PR TITLE
nvme.spec.in: using specific directory for nvme command on %post

### DIFF
--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -49,7 +49,7 @@ rm -rf $RPM_BUILD_ROOT
 %post
 if [ $1 -eq 1 ]; then # 1 : This package is being installed for the first time
 	if [ ! -s %{_sysconfdir}/nvme/hostnqn ]; then
-		echo $(nvme gen-hostnqn) > %{_sysconfdir}/nvme/hostnqn
+		echo $(%{_sbindir}/nvme gen-hostnqn) > %{_sysconfdir}/nvme/hostnqn
         fi
         if [ ! -s %{_sysconfdir}/nvme/hostid ]; then
                 uuidgen > %{_sysconfdir}/nvme/hostid


### PR DESCRIPTION
${_sbindir} could be placed in out of default bin directories
so just 'nvme gen-hostnqn' would not work with 'nvme command not found'

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>