### PR TITLE
fix dsm and copy range setup

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -251,8 +251,9 @@ int nvme_dsm(int fd, __u32 nsid, __u32 cdw11, struct nvme_dsm_range *dsm,
 	return nvme_submit_io_passthru(fd, &cmd);
 }
 
-struct nvme_dsm_range *nvme_setup_dsm_range(__u32 *ctx_attrs, __u32 *llbas,
-					    __u64 *slbas, __u16 nr_ranges)
+struct nvme_dsm_range *nvme_setup_dsm_range(int *ctx_attrs, int *llbas,
+					    unsigned long long *slbas,
+					    __u16 nr_ranges)
 {
 	int i;
 	struct nvme_dsm_range *dsm = malloc(nr_ranges * sizeof(*dsm));
@@ -295,8 +296,8 @@ int nvme_copy(int fd, __u32 nsid, struct nvme_copy_range *copy, __u64 sdlba,
 	return nvme_submit_io_passthru(fd, &cmd);
 }
 
-struct nvme_copy_range *nvme_setup_copy_range(__u16 *nlbs, __u64 *slbas,
-		__u32 *eilbrts, __u16 *elbatms, __u16 *elbats, __u16 nr)
+struct nvme_copy_range *nvme_setup_copy_range(int *nlbs, unsigned long long *slbas,
+		int *eilbrts, int *elbatms, int *elbats, __u16 nr)
 {
 	struct nvme_copy_range *copy = malloc(nr * sizeof(*copy));
 	if (!copy) {

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -61,16 +61,16 @@ int nvme_flush(int fd, __u32 nsid);
 
 int nvme_dsm(int fd, __u32 nsid, __u32 cdw11, struct nvme_dsm_range *dsm,
 	     __u16 nr_ranges);
-struct nvme_dsm_range *nvme_setup_dsm_range(__u32 *ctx_attrs,
-					    __u32 *llbas, __u64 *slbas,
+struct nvme_dsm_range *nvme_setup_dsm_range(int *ctx_attrs, int *llbas,
+					    unsigned long long *slbas,
 					    __u16 nr_ranges);
 
 int nvme_copy(int fd, __u32 nsid, struct nvme_copy_range *copy, __u64 sdlba,
 		__u16 nr, __u8 prinfor, __u8 prinfow, __u8 dtype, __u16 dspec,
 		__u8 format, int lr, int fua, __u32 ilbrt, __u16 lbatm,
 		__u16 lbat);
-struct nvme_copy_range *nvme_setup_copy_range(__u16 *nlbs, __u64 *slbas,
-		__u32 *eilbrts, __u16 *elbatms, __u16 *elbats, __u16 nr);
+struct nvme_copy_range *nvme_setup_copy_range(int *nlbs, unsigned long long *slbas,
+		int *eilbrts, int *elbatms, int *elbats, __u16 nr);
 
 int nvme_resv_acquire(int fd, __u32 nsid, __u8 rtype, __u8 racqa,
 		      bool iekey, __u64 crkey, __u64 nrkey);

--- a/nvme.c
+++ b/nvme.c
@@ -3561,7 +3561,7 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	if (!cfg.cdw11)
 		cfg.cdw11 = (cfg.ad << 2) | (cfg.idw << 1) | (cfg.idr << 0);
 
-	dsm = nvme_setup_dsm_range((__u32 *)ctx_attrs, (__u32 *)nlbs, (__u64 *)slbas, nr);
+	dsm = nvme_setup_dsm_range(ctx_attrs, nlbs, slbas, nr);
 	if (!dsm) {
 		fprintf(stderr, "failed to allocate data set payload\n");
 		err = -ENOMEM;
@@ -3688,9 +3688,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 		goto close_fd;
 	}
 
-	copy = nvme_setup_copy_range((__u16 *)nlbs, (__u64 *)slbas,
-			(__u32 *)eilbrts, (__u16 *)elbatms, (__u16 *)elbats,
-			nr);
+	copy = nvme_setup_copy_range(nlbs, slbas, eilbrts, elbatms, elbats, nr);
 	if (!copy) {
 		fprintf(stderr, "failed to allocate payload\n");
 		err = -ENOMEM;


### PR DESCRIPTION
The argconfig array helpers parse into int and unsigned long long
arrays. In the copy function we are casting an int* to __u16* and we end
up with wrong values. Instead, just use the types in the setup functions
directly and convert the individual values as part of calling the
cpu_to_le* helpers.

While copy is the one that is immediately broken on most systems, do
this for DSM as well since it breaks on systems where int is not 32
bits.

Fixes: 5dc44e6c21a1 ("add support for issuing simple copy commands")
Signed-off-by: Klaus Jensen <k.jensen@samsung.com>