### PR TITLE
[nvme-cli] Fix binary option in commands that display data

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1710,9 +1710,7 @@ void d(unsigned char *buf, int len, int width, int group)
 
 void d_raw(unsigned char *buf, unsigned len)
 {
-	unsigned i;
-	for (i = 0; i < len; i++)
-		putchar(*(buf+i));
+	d((__u8 *)buf, le32_to_cpu(len), 16, 1);
 }
 
 void nvme_show_status(__u16 status)


### PR DESCRIPTION
With the current version of d_raw function, the binary data displayed is unreadable.  Here's an example from the id-ctrl command:
sudo nvme id-ctrl /dev/nvme0 -b
\ufffd\ufffd203920640006        WDC CL SN730 SDBQNTY-256G-2020          FO008M2OD  \ufffd@B\ufffdei2`e\ufffd;e`fD_nqn.2018-01.com.wdc:nguid:E8238FA6BF53-0001-001B444A4619F749\ufffd\ufffd\ufffd\ufffd\ufffd	\ufffd	

With the change from this PR, here's what the binary data looks like:
sudo ./nvme id-ctrl /dev/nvme0 -b
       0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0000: b7 15 b7 15 32 30 33 39 32 30 36 34 30 30 30 36 "....203920640006"
0010: 20 20 20 20 20 20 20 20 57 44 43 20 43 4c 20 53 "........WDC.CL.S"
0020: 4e 37 33 30 20 53 44 42 51 4e 54 59 2d 32 35 36 "N730.SDBQNTY-256"
0030: 47 2d 32 30 32 30 20 20 20 20 20 20 20 20 20 20 "G-2020.........."
0040: 46 4f 30 30 38 4d 32 4f 04 44 1b 00 00 07 17 20 "FO008M2O.D......"
0050: 00 03 01 00 20 a1 07 00 40 42 0f 00 00 03 00 00 "........@B......"
0060: 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "................"
0070: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "................"
...