### PR TITLE
Add missing sub-command links from main man page

### DIFF
--- a/Documentation/cmds-main.txt
+++ b/Documentation/cmds-main.txt
@@ -17,7 +17,10 @@ linknvme:nvme-format[1]::
 	Format namespace(s)
 
 linknvme:nvme-fw-activate[1]::
-	F/W Activate
+	F/W Activate (in old version < 1.2)
+
+linknvme:nvme-fw-commit[1]::
+	F/W Commit (in > 1.2)
 
 linknvme:nvme-fw-download[1]::
 	F/W Download
@@ -34,14 +37,23 @@ linknvme:nvme-get-log[1]::
 linknvme:nvme-telemetry-log[1]::
 	Telemetry Host-Initiated Log
 
+linknvme:nvme-changed-ns-list-log[1]::
+	Retrieve Changed Namespace List Log
+
 linknvme:nvme-smart-log[1]::
 	Retrieve Smart Log
+
+linknvme:nvme-ana-log[1]::
+	Retreive ANA(Asymmetric Namespace Access) Log
 
 linknvme:nvme-endurance-log[1]::
 	Retrieve endurance Log
 
 linknvme:nvme-effects-log[1]::
 	Retrieve effects Log
+
+linknvme:nvme-self-test-log[1]::
+	Retrieve Device Self-test Log
 
 linknvme:nvme-get-ns-id[1]::
 	Retrieve namespace identifier
@@ -54,6 +66,12 @@ linknvme:nvme-id-ctrl[1]::
 
 linknvme:nvme-id-ns[1]::
 	Identify Namespace
+
+linknvme:nvme-id-nvmset[1]::
+	Identify NVM Set List
+
+linknvme:nvme-id-iocs[1]::
+	Identify I/O Command Set
 
 linknvme:nvme-create-ns[1]::
 	Create a new namespace
@@ -81,6 +99,15 @@ linknvme:nvme-list[1]::
 
 linknvme:nvme-list-ctrl[1]::
 	List controller in NVMe subsystem
+
+linknvme:nvme-list-subsys[1]::
+	List NVMe subsystems
+
+linknvme:nvme-reset[1]::
+	Reset a NVMe controller
+
+linknvme:nvme-device-self-test[1]::
+	Issue Device Self-test Command
 
 linknvme:nvme-read[1]::
 	Issue IO Read Command
@@ -111,6 +138,12 @@ linknvme:nvme-security-recv[1]::
 
 linknvme:nvme-security-send[1]::
 	Security Send
+
+linknvme:nvme-dsm[1]::
+	Issue Data Set Management Command
+
+linknvme:nvme-copy[1]::
+	Issue Simple Copy Command
 
 linknvme:nvme-set-feature[1]::
 	Set Feature

--- a/Documentation/nvme.1
+++ b/Documentation/nvme.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme
 .\"    Author: [see the "Authors" section]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 12/01/2020
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME" "1" "12/01/2020" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -85,7 +85,12 @@ Format namespace(s)
 .PP
 \fBnvme-fw-activate\fR(1)
 .RS 4
-F/W Activate
+F/W Activate (in old version < 1\&.2)
+.RE
+.PP
+\fBnvme-fw-commit\fR(1)
+.RS 4
+F/W Commit (in > 1\&.2)
 .RE
 .PP
 \fBnvme-fw-download\fR(1)
@@ -113,9 +118,19 @@ Generic Get Log
 Telemetry Host\-Initiated Log
 .RE
 .PP
+\fBnvme-changed-ns-list-log\fR(1)
+.RS 4
+Retrieve Changed Namespace List Log
+.RE
+.PP
 \fBnvme-smart-log\fR(1)
 .RS 4
 Retrieve Smart Log
+.RE
+.PP
+\fBnvme-ana-log\fR(1)
+.RS 4
+Retreive ANA(Asymmetric Namespace Access) Log
 .RE
 .PP
 \fBnvme-endurance-log\fR(1)
@@ -126,6 +141,11 @@ Retrieve endurance Log
 \fBnvme-effects-log\fR(1)
 .RS 4
 Retrieve effects Log
+.RE
+.PP
+\fBnvme-self-test-log\fR(1)
+.RS 4
+Retrieve Device Self\-test Log
 .RE
 .PP
 \fBnvme-get-ns-id\fR(1)
@@ -146,6 +166,16 @@ Identify Controller
 \fBnvme-id-ns\fR(1)
 .RS 4
 Identify Namespace
+.RE
+.PP
+\fBnvme-id-nvmset\fR(1)
+.RS 4
+Identify NVM Set List
+.RE
+.PP
+\fBnvme-id-iocs\fR(1)
+.RS 4
+Identify I/O Command Set
 .RE
 .PP
 \fBnvme-create-ns\fR(1)
@@ -191,6 +221,21 @@ List all nvme controllers
 \fBnvme-list-ctrl\fR(1)
 .RS 4
 List controller in NVMe subsystem
+.RE
+.PP
+\fBnvme-list-subsys\fR(1)
+.RS 4
+List NVMe subsystems
+.RE
+.PP
+\fBnvme-reset\fR(1)
+.RS 4
+Reset a NVMe controller
+.RE
+.PP
+\fBnvme-device-self-test\fR(1)
+.RS 4
+Issue Device Self\-test Command
 .RE
 .PP
 \fBnvme-read\fR(1)
@@ -241,6 +286,16 @@ Security Receive
 \fBnvme-security-send\fR(1)
 .RS 4
 Security Send
+.RE
+.PP
+\fBnvme-dsm\fR(1)
+.RS 4
+Issue Data Set Management Command
+.RE
+.PP
+\fBnvme-copy\fR(1)
+.RS 4
+Issue Simple Copy Command
 .RE
 .PP
 \fBnvme-set-feature\fR(1)

--- a/Documentation/nvme.html
+++ b/Documentation/nvme.html
@@ -839,7 +839,15 @@ available, run "nvme help".</p></div>
 </dt>
 <dd>
 <p>
-        F/W Activate
+        F/W Activate (in old version &lt; 1.2)
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-fw-commit.html">nvme-fw-commit(1)</a>
+</dt>
+<dd>
+<p>
+        F/W Commit (in &gt; 1.2)
 </p>
 </dd>
 <dt class="hdlist1">
@@ -883,11 +891,27 @@ available, run "nvme help".</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
+<a href="nvme-changed-ns-list-log.html">nvme-changed-ns-list-log(1)</a>
+</dt>
+<dd>
+<p>
+        Retrieve Changed Namespace List Log
+</p>
+</dd>
+<dt class="hdlist1">
 <a href="nvme-smart-log.html">nvme-smart-log(1)</a>
 </dt>
 <dd>
 <p>
         Retrieve Smart Log
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-ana-log.html">nvme-ana-log(1)</a>
+</dt>
+<dd>
+<p>
+        Retreive ANA(Asymmetric Namespace Access) Log
 </p>
 </dd>
 <dt class="hdlist1">
@@ -904,6 +928,14 @@ available, run "nvme help".</p></div>
 <dd>
 <p>
         Retrieve effects Log
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-self-test-log.html">nvme-self-test-log(1)</a>
+</dt>
+<dd>
+<p>
+        Retrieve Device Self-test Log
 </p>
 </dd>
 <dt class="hdlist1">
@@ -936,6 +968,22 @@ available, run "nvme help".</p></div>
 <dd>
 <p>
         Identify Namespace
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-id-nvmset.html">nvme-id-nvmset(1)</a>
+</dt>
+<dd>
+<p>
+        Identify NVM Set List
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-id-iocs.html">nvme-id-iocs(1)</a>
+</dt>
+<dd>
+<p>
+        Identify I/O Command Set
 </p>
 </dd>
 <dt class="hdlist1">
@@ -1008,6 +1056,30 @@ available, run "nvme help".</p></div>
 <dd>
 <p>
         List controller in NVMe subsystem
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-list-subsys.html">nvme-list-subsys(1)</a>
+</dt>
+<dd>
+<p>
+        List NVMe subsystems
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-reset.html">nvme-reset(1)</a>
+</dt>
+<dd>
+<p>
+        Reset a NVMe controller
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-device-self-test.html">nvme-device-self-test(1)</a>
+</dt>
+<dd>
+<p>
+        Issue Device Self-test Command
 </p>
 </dd>
 <dt class="hdlist1">
@@ -1088,6 +1160,22 @@ available, run "nvme help".</p></div>
 <dd>
 <p>
         Security Send
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-dsm.html">nvme-dsm(1)</a>
+</dt>
+<dd>
+<p>
+        Issue Data Set Management Command
+</p>
+</dd>
+<dt class="hdlist1">
+<a href="nvme-copy.html">nvme-copy(1)</a>
+</dt>
+<dd>
+<p>
+        Issue Simple Copy Command
 </p>
 </dd>
 <dt class="hdlist1">
@@ -1190,7 +1278,7 @@ NVM-Express Site</a>.</p></div>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2020-02-15 08:33:28 JST
+ 2020-07-11 13:12:07 KST
 </div>
 </div>
 </body>


### PR DESCRIPTION
```
This patch adds missing subcommands to the main man page.

Issue: https://github.com/linux-nvme/nvme-cli/issues/793
Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>
```