### PR TITLE
zns: fix showing system error in report_zones

### DIFF
--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -618,8 +618,11 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 
 		err = nvme_zns_report_zones(fd, cfg.namespace_id, 0,
 			0, cfg.state, 0, sizeof(r), &r);
-		if (err) {
+		if (err > 0) {
 			nvme_show_status(err);
+			goto close_fd;
+		} else if (err < 0) {
+			perror("zns report-zones");
 			goto close_fd;
 		}
 		cfg.num_descs = le64_to_cpu(r.nr_zones);


### PR DESCRIPTION
If nvme_zns_report_zones() returns system error(negative) value, it
should not be passed to nvme_show_status() which parses NVMe completion
status code in case of positive value from the ioctl.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>

---
`NVMe status: Unknown(0xffff)` -> `zns report-zones: Inappropriate ioctl for device`