### PR TITLE
nvme-print: fix Namespace ID to decimal format

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5393,7 +5393,7 @@ static void nvme_show_details_ns(struct nvme_namespace *n, bool ctrl)
 	sprintf(format,"%3.0f %2sB + %2d B", (double)lba, l_suffix,
 		le16_to_cpu(n->ns.lbaf[(n->ns.flbas & 0x0f)].ms));
 
-	printf("%-12s %-8x %-26s %-16s ", n->name, n->nsid, usage, format);
+	printf("%-12s %-8d %-26s %-16s ", n->name, n->nsid, usage, format);
 
 	if (ctrl)
 		printf("%s", n->ctrl->name);


### PR DESCRIPTION
```
As kernel sysfs shows nsid as a decimal format, nvme-cli should print
Namespace ID as decimal format.  Additionally, of course, the following
two commands results should be consistant:

	- nvme list
	- nvme list --verbose

The following examples is for case of nsid=32.

root@vm:~/work/nvme-cli.git# ./nvme list
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     deadbeef             QEMU NVMe Ctrl                           32          1.05  MB /   1.05  MB    512   B +  0 B   1.0
root@vm:~/work/nvme-cli.git# ./nvme list --verbose                                                                                                                            NVM Express Subsystems

Subsystem        Subsystem-NQN                                                                                    Controllers
---------------- ------------------------------------------------------------------------------------------------ ----------------
nvme-subsys0     nqn.2019-08.org.qemu:deadbeef                                                                    nvme0

NVM Express Controllers

Device   SN                   MN                                       FR       TxPort Address        Subsystem    Namespaces
-------- -------------------- ---------------------------------------- -------- ------ -------------- ------------ ----------------
nvme0    deadbeef             QEMU NVMe Ctrl                           1.0      pcie   0000:01:00.0   nvme-subsys0 nvme0n1
NVM Express Namespaces

Device       NSID     Usage                      Format           Controllers
------------ -------- -------------------------- ---------------- ----------------
nvme0n1      20         1.05  MB /   1.05  MB    512   B +  0 B   nvme0
             ^^^^^^^^
This absolutely should be same with the `nvme list` result as decimal.

This patch fixed list --verbose nsid to decimal format.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>
```