### PR TITLE
nvme: fix get lba status command nsid and data len fields

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -880,12 +880,14 @@ int nvme_sec_recv(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
 	return err;
 }
 
-int nvme_get_lba_status(int fd, __u64 slba, __u32 mndw, __u8 atype, __u16 rl,
-		void *data)
+int nvme_get_lba_status(int fd, __u32 namespace_id, __u64 slba, __u32 mndw,
+		__u8 atype, __u16 rl, void *data)
 {
 	struct nvme_admin_cmd cmd = {
 		.opcode =  nvme_admin_get_lba_status,
+		.nsid = namespace_id,
 		.addr = (__u64)(uintptr_t) data,
+		.data_len = (mndw + 1) * 4,
 		.cdw10 = slba & 0xffffffff,
 		.cdw11 = slba >> 32,
 		.cdw12 = mndw,

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -155,8 +155,8 @@ int nvme_subsystem_reset(int fd);
 int nvme_reset_controller(int fd);
 int nvme_ns_rescan(int fd);
 
-int nvme_get_lba_status(int fd, __u64 slba, __u32 mndw, __u8 atype, __u16 rl,
-		void *data);
+int nvme_get_lba_status(int fd, __u32 namespace_id, __u64 slba, __u32 mndw,
+		__u8 atype, __u16 rl, void *data);
 int nvme_dir_send(int fd, __u32 nsid, __u16 dspec, __u8 dtype, __u8 doper,
 		  __u32 data_len, __u32 dw12, void *data, __u32 *result);
 int nvme_dir_recv(int fd, __u32 nsid, __u16 dspec, __u8 dtype, __u8 doper,

--- a/nvme.c
+++ b/nvme.c
@@ -4815,6 +4815,7 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Information about potentially unrecoverable LBAs.";
+	const char *namespace_id = "Desired Namespace";
 	const char *slba = "Starting LBA(SLBA) in 64-bit address of the first"\
 			    " logical block addressed by this command";
 	const char *mndw = "Maximum Number of Dwords(MNDW) specifies maximum"\
@@ -4831,6 +4832,7 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 	void *buf;
 
 	struct config {
+		__u32 namespace_id;
 		__u64 slba;
 		__u32 mndw;
 		__u8 atype;
@@ -4839,6 +4841,7 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 	};
 
 	struct config cfg = {
+		.namespace_id = 0,
 		.slba = 0,
 		.mndw = 0,
 		.atype = 0,
@@ -4847,6 +4850,7 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 	};
 
 	OPT_ARGS(opts) = {
+		OPT_UINT("namespace-id", 'n', &cfg.namespace_id,  namespace_id),
 		OPT_SUFFIX("start-lba",  's', &cfg.slba,          slba),
 		OPT_UINT("max-dw",       'm', &cfg.mndw,          mndw),
 		OPT_BYTE("action",       'a', &cfg.atype,         atype),
@@ -4876,8 +4880,8 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 		goto close_fd;
 	}
 
-	err = nvme_get_lba_status(fd, cfg.slba, cfg.mndw, cfg.atype, cfg.rl,
-			buf);
+	err = nvme_get_lba_status(fd, cfg.namespace_id, cfg.slba, cfg.mndw,
+			cfg.atype, cfg.rl, buf);
 	if (!err)
 		nvme_show_lba_status(buf, buf_len, flags);
 	else if (err > 0)


### PR DESCRIPTION
In get lba status admin command, host shall specify valid and
desired namespace, adding NSID field to receive from user and
also assign data len fields as per the given MNDW value.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>