### PR TITLE
nvme-status: return negative status if !errno

### DIFF
--- a/nvme-status.c
+++ b/nvme-status.c
@@ -141,8 +141,11 @@ __u8 nvme_status_to_errno(int status, bool fabrics)
 	if (!status)
 		return 0;
 
-	if (status < 0)
-		return errno;
+	if (status < 0) {
+		if (errno)
+			return errno;
+		return status;
+	}
 
 	/*
 	 * The actual status code is enough with masking 0xff, but we need to


### PR DESCRIPTION
'errno' is set to errno value when system calls are returning with an
error (e.g., ioctl).  But, If a command fails without any system call,
then it needs to return the raw negative error value.

For example, if we don't provide any options for connect command:

	root@vm:~# nvme connect
	need a transport (-t) argument
	root@vm:~# echo $?
	0

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>