### PR TITLE
nvme-topology: fix returning invalid value in scan_subsystems()

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -554,7 +554,7 @@ int scan_subsystems(struct nvme_topology *t, const char *subsysnqn,
 {
 	struct nvme_subsystem *s;
 	struct dirent **subsys;
-	int ret, i, j = 0;
+	int ret = 0, i, j = 0;
 
 	t->nr_subsystems = scandir(subsys_dir, &subsys, scan_subsys_filter,
 				   alphasort);


### PR DESCRIPTION
Let's say we have multiple three subsystems in the system.  If we run
a simple 'nvme list' command, then scan_subsystems() will never set the
'ret' value which is a local variable.  This should be initialized to a
initial value to avoid invalid value returning.

This patch fixes returning invalid value from the scan_subsystems() in
case of multi-subsystems found.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>