### PR TITLE
nvme: add fix for sanitize OWPASS value and log page structure

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -1295,6 +1295,7 @@ struct nvme_sanitize_log_page {
 	__le32			est_ovrwrt_time_with_no_deallocate;
 	__le32			est_blk_erase_time_with_no_deallocate;
 	__le32			est_crypto_erase_time_with_no_deallocate;
+	__u8			rsvd32[480];
 };
 
 /*

--- a/nvme.c
+++ b/nvme.c
@@ -2815,8 +2815,8 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	}
 
 	if (cfg.sanact == NVME_SANITIZE_ACT_OVERWRITE) {
-		if (cfg.owpass > 16) {
-			fprintf(stderr, "OWPASS out of range [0-16]\n");
+		if (cfg.owpass >= 16) {
+			fprintf(stderr, "OWPASS out of range [0-15]\n");
 			ret = -EINVAL;
 			goto close_fd;
 		}


### PR DESCRIPTION
Added fix for OWPASS value in sanitize command's CDW10, a value
of 0h specifies 16 overwrite passes.

Added the complete log data structure memebers, currently reseved
fields are ignored currently.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>