### PR TITLE
nvme: fix device self test log

### DIFF
--- a/Documentation/nvme-self-test-log.1
+++ b/Documentation/nvme-self-test-log.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-self-test-log
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 01/23/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SELF\-TEST\-LO" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-SELF\-TEST\-LO" "1" "01/23/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -32,7 +32,8 @@ nvme-self-test-log \- Retrieve the log information initited by device\-self\-tes
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme self\-test\fR\-log <device> [\-\-output\-format=<FMT> | \-o <FMT>]
+\fInvme self\-test\fR\-log <device> [\-\-log\-entries=<entries> | \-e <entries>]
+                    [\-\-output\-format=<FMT> | \-o <FMT>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -44,6 +45,11 @@ On success, the returned log structure may be returned in one of several ways de
 .sp
 By default the log is printed out in the normal readable format\&.
 .SH "OPTION"
+.PP
+\-e <entries>, \-\-log\-entries=<entries>
+.RS 4
+Specifies how many DST log entries the program should request from the device\&. This must be at least one, and shouldn\(cqt exceed the 20 entries\&. Defaults to 20 DST log entries\&.
+.RE
 .PP
 \-o <format>, \-\-output\-format=<format>
 .RS 4

--- a/Documentation/nvme-self-test-log.html
+++ b/Documentation/nvme-self-test-log.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-self-test-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -433,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overridden by CSS in most browsers. */
+/* Because the table frame attribute is overriden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -746,7 +749,8 @@ nvme-self-test-log(1) Manual Page
 <h2 id="_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="verseblock">
-<pre class="content"><em>nvme self-test</em>-log &lt;device&gt; [--output-format=&lt;FMT&gt; | -o &lt;FMT&gt;]</pre>
+<pre class="content"><em>nvme self-test</em>-log &lt;device&gt; [--log-entries=&lt;entries&gt; | -e &lt;entries&gt;]
+                    [--output-format=&lt;FMT&gt; | -o &lt;FMT&gt;]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -770,6 +774,19 @@ json format.</p></div>
 <h2 id="_option">OPTION</h2>
 <div class="sectionbody">
 <div class="dlist"><dl>
+<dt class="hdlist1">
+-e &lt;entries&gt;
+</dt>
+<dt class="hdlist1">
+--log-entries=&lt;entries&gt;
+</dt>
+<dd>
+<p>
+        Specifies how many DST log entries the program should request from
+        the device. This must be at least one, and shouldn&#8217;t exceed the
+        20 entries. Defaults to 20 DST log entries.
+</p>
+</dd>
 <dt class="hdlist1">
 -o &lt;format&gt;
 </dt>
@@ -829,7 +846,8 @@ Get the self-test-log and print it in a json format:
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-06-15 13:12:28 MDT
+Last updated
+ 2021-01-23 16:07:45 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-self-test-log.txt
+++ b/Documentation/nvme-self-test-log.txt
@@ -8,7 +8,8 @@ nvme-self-test-log - Retrieve the log information initited by device-self-test a
 SYNOPSIS
 --------
 [verse]
-'nvme self-test'-log <device> [--output-format=<FMT> | -o <FMT>] 
+'nvme self-test'-log <device> [--log-entries=<entries> | -e <entries>]
+                    [--output-format=<FMT> | -o <FMT>] 
 
 DESCRIPTION
 -----------
@@ -28,6 +29,12 @@ By default the log is printed out in the normal readable format.
 
 OPTION
 -------
+-e <entries>::
+--log-entries=<entries>::
+	Specifies how many DST log entries the program should request from
+	the device. This must be at least one, and shouldn't exceed the
+	20 entries. Defaults to 20 DST log entries.
+
 -o <format>::
 --output-format=<format>::
               Set the reporting format to 'normal', 'json', or

--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -650,12 +650,14 @@ enum {
 	NVME_ST_VALID_SCT		= 1 << 2,
 	NVME_ST_VALID_SC		= 1 << 3,
 	NVME_ST_REPORTS			= 20,
+	NVME_ST_LOG_ENTRY_SIZE	= 28,
+	NVME_ST_LOG_HEAD_SIZE	= 4,
 };
 
 struct nvme_self_test_log {
 	__u8                      crnt_dev_selftest_oprn;
 	__u8                      crnt_dev_selftest_compln;
-	__u8                      rsvd[2];
+	__u8                      rsvd2[2];
 	struct nvme_self_test_res result[20];
 } __attribute__((packed));
 

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -591,10 +591,10 @@ int nvme_ana_log(int fd, void *ana_log, size_t ana_log_len, int rgo)
 			true, ana_log_len, ana_log);
 }
 
-int nvme_self_test_log(int fd, __u32 nsid, struct nvme_self_test_log *self_test_log)
+int nvme_self_test_log(int fd, __u32 size, struct nvme_self_test_log *self_test_log)
 {
-	return nvme_get_log(fd, nsid, NVME_LOG_DEVICE_SELF_TEST, false,
-		NVME_NO_LOG_LSP, sizeof(*self_test_log), self_test_log);
+	return nvme_get_log(fd, NVME_NSID_ALL, NVME_LOG_DEVICE_SELF_TEST, false,
+		NVME_NO_LOG_LSP, size, self_test_log);
 }
 
 int nvme_effects_log(int fd, struct nvme_effects_log_page *effects_log)

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -167,7 +167,7 @@ int nvme_get_property(int fd, int offset, uint64_t *value);
 int nvme_sanitize(int fd, __u8 sanact, __u8 ause, __u8 owpass, __u8 oipbp,
 		  __u8 no_dealloc, __u32 ovrpat);
 int nvme_self_test_start(int fd, __u32 nsid, __u32 cdw10);
-int nvme_self_test_log(int fd, __u32 nsid, struct nvme_self_test_log *self_test_log);
+int nvme_self_test_log(int fd, __u32 size, struct nvme_self_test_log *self_test_log);
 int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result);
 
 int nvme_zns_mgmt_send(int fd, __u32 nsid, __u64 slba, bool select_all,

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -26,8 +26,8 @@ void nvme_show_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 	const char *devname, enum nvme_print_flags flags);
 void nvme_show_ana_log(struct nvme_ana_rsp_hdr *ana_log, const char *devname,
 	enum nvme_print_flags flags, size_t len);
-void nvme_show_self_test_log(struct nvme_self_test_log *self_test, const char *devname,
-	enum nvme_print_flags flags);
+void nvme_show_self_test_log(struct nvme_self_test_log *self_test, __u8 dst_entries,
+	__u32 size, const char *devname, enum nvme_print_flags flags);
 void nvme_show_fw_log(struct nvme_firmware_log_page *fw_log, const char *devname,
 	enum nvme_print_flags flags);
 void nvme_show_effects_log(struct nvme_effects_log_page *effects, unsigned int flags);


### PR DESCRIPTION
Namespace ID no need to mention for the device self test log,
removing nsid and adding DST log entries field

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>