### PR TITLE
nvme: fix formatNVM command

### DIFF
--- a/Documentation/nvme-format.1
+++ b/Documentation/nvme-format.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-format
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 02/04/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FORMAT" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-FORMAT" "1" "02/04/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -38,7 +38,7 @@ nvme-format \- Format an NVMe device
                     [\-\-ses=<ses> | \-s <ses>]
                     [\-\-pil=<pil> | \-p <pil>]
                     [\-\-pi=<pi> | \-i <pi>]
-                    [\-\-ms=<ms> | \-m <ms>]
+                    [\-\-mset=<mset> | \-m <mset>]
                     [\-\-reset | \-r ]
                     [\-\-force | \-f ]
                     [\-\-timeout=<timeout> | \-t <timeout> ]
@@ -158,7 +158,7 @@ T}
 .sp 1
 .RE
 .PP
-\-m <ms>, \-\-ms=<ms>
+\-m <mset>, \-\-mset=<mset>
 .RS 4
 Metadata Settings: This field is set to \(oq1\(cq if the metadata is transferred as part of an extended data LBA\&. This field is cleared to \(oq0\(cq if the metadata is transferred as part of a separate buffer\&. The metadata may include protection information, based on the Protection Information (PI) field\&. Defaults to 0\&.
 .RE

--- a/Documentation/nvme-format.html
+++ b/Documentation/nvme-format.html
@@ -755,7 +755,7 @@ nvme-format(1) Manual Page
                     [--ses=&lt;ses&gt; | -s &lt;ses&gt;]
                     [--pil=&lt;pil&gt; | -p &lt;pil&gt;]
                     [--pi=&lt;pi&gt; | -i &lt;pi&gt;]
-                    [--ms=&lt;ms&gt; | -m &lt;ms&gt;]
+                    [--mset=&lt;mset&gt; | -m &lt;mset&gt;]
                     [--reset | -r ]
                     [--force | -f ]
                     [--timeout=&lt;timeout&gt; | -t &lt;timeout&gt; ]</pre>
@@ -950,10 +950,10 @@ cellspacing="0" cellpadding="4">
 </div>
 </dd>
 <dt class="hdlist1">
--m &lt;ms&gt;
+-m &lt;mset&gt;
 </dt>
 <dt class="hdlist1">
---ms=&lt;ms&gt;
+--mset=&lt;mset&gt;
 </dt>
 <dd>
 <p>
@@ -1038,7 +1038,7 @@ information:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2019-09-18 00:00:58 JST
+ 2021-02-04 14:02:41 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-format.txt
+++ b/Documentation/nvme-format.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 		    [--ses=<ses> | -s <ses>]
 		    [--pil=<pil> | -p <pil>]
 		    [--pi=<pi> | -i <pi>]
-		    [--ms=<ms> | -m <ms>]
+		    [--mset=<mset> | -m <mset>]
 		    [--reset | -r ]
 		    [--force | -f ]
 		    [--timeout=<timeout> | -t <timeout> ]
@@ -115,8 +115,8 @@ cryptographically. This is accomplished by deleting the encryption key.
 |4–7|Reserved
 |=================
 
--m <ms>::
---ms=<ms>::
+-m <mset>::
+--mset=<mset>::
 	Metadata Settings: This field is set to ‘1’ if the metadata
 	is transferred as part of an extended data LBA. This field is
 	cleared to ‘0’ if the metadata is transferred as part of a

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -338,8 +338,8 @@ _nvme () {
 			-p':alias of --pil'
 			--pi=':protection information? 0 - off, 1 - Type 1 on, 2 - Type 2 on, 3 - Type 3 on'
 			-i':alias of --pi'
-			--ms=':extended format? 0 - off (metadata in separate buffer), 1 - on (extended LBA used)'
-			-m':alias of --ms'
+			--mset=':extended format? 0 - off (metadata in separate buffer), 1 - on (extended LBA used)'
+			-m':alias of --mset'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme format options" _format

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -108,7 +108,7 @@ nvme_list_opts () {
 			;;
 		"format")
 		opts+=" --namespace-id= -n --timeout= -t --lbaf= -l \
-			--ses= -s --pil= -p -pi= -i --ms= -m --reset -r"
+			--ses= -s --pil= -p -pi= -i --mset= -m --reset -r"
 			;;
 		"fw-activate")
 		opts+=" --action= -a --slot= -s"

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -742,9 +742,9 @@ int nvme_get_feature(int fd, __u32 nsid, __u8 fid, __u8 sel, __u32 cdw11,
 }
 
 int nvme_format(int fd, __u32 nsid, __u8 lbaf, __u8 ses, __u8 pi,
-		__u8 pil, __u8 ms, __u32 timeout)
+		__u8 pil, __u8 mset, __u32 timeout)
 {
-	__u32 cdw10 = lbaf | ms << 4 | pi << 5 | pil << 8 | ses << 9;
+	__u32 cdw10 = lbaf | mset << 4 | pi << 5 | pil << 8 | ses << 9;
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_format_nvm,
 		.nsid		= nsid,

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -133,7 +133,7 @@ int nvme_get_feature(int fd, __u32 nsid, __u8 fid, __u8 sel,
 		     __u32 cdw11, __u32 data_len, void *data, __u32 *result);
 
 int nvme_format(int fd, __u32 nsid, __u8 lbaf, __u8 ses, __u8 pi,
-		__u8 pil, __u8 ms, __u32 timeout);
+		__u8 pil, __u8 mset, __u32 timeout);
 
 int nvme_ns_create(int fd, __u64 nsze, __u64 ncap, __u8 flbas, __u8 dps,
 		__u8 nmic, __u32 anagrpid, __u16 nvmsetid, __u8 csi,


### PR DESCRIPTION
Remove unassigned variable "lbads" and change metadata
settings config parameter from "ms" to "mset" (as per
NVM Express)."ms" is reference for metadata size in general.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>