### PR TITLE
Lf to f

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -15,10 +15,10 @@ static const uint8_t zero_uuid[16] = { 0 };
 static const uint8_t invalid_uuid[16] = {[0 ... 15] = 0xff };
 static const char dash[100] = {[0 ... 99] = '-'};
 
-static long double int128_to_double(__u8 *data)
+static double int128_to_double(__u8 *data)
 {
 	int i;
-	long double result = 0;
+	double result = 0;
 
 	for (i = 0; i < 16; i++) {
 		result *= 256;
@@ -1383,7 +1383,7 @@ void nvme_show_persistent_event_log(void *pevent_log_info,
 		printf("Log Header Length: %u\n", pevent_log_head->head_len);
 		printf("Timestamp: %"PRIu64"\n",
 			le64_to_cpu(pevent_log_head->timestamp));
-		printf("Power On Hours (POH): %'.0Lf\n",
+		printf("Power On Hours (POH): %'.0f\n",
 			int128_to_double(pevent_log_head->poh));
 		printf("Power Cycle Count: %"PRIu64"\n",
 			le64_to_cpu(pevent_log_head->pcc));
@@ -1507,7 +1507,7 @@ void nvme_show_persistent_event_log(void *pevent_log_info,
 					le32_to_cpu(ns_event->nsmgt_cdw10));
 				printf("Namespace Size: %"PRIu64"\n",
 					le64_to_cpu(ns_event->nsze));
-				printf("Namespace Capacity: %'.0Lf\n",
+				printf("Namespace Capacity: %'.0f\n",
 					int128_to_double(ns_event->nscap));
 				printf("Formatted LBA Size: %u\n", ns_event->flbas);
 				printf("End-to-end Data Protection Type Settings: %u\n",
@@ -3192,7 +3192,7 @@ void nvme_show_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 	printf("nabo    : %d\n", le16_to_cpu(ns->nabo));
 	printf("nabspf  : %d\n", le16_to_cpu(ns->nabspf));
 	printf("noiob   : %d\n", le16_to_cpu(ns->noiob));
-	printf("nvmcap  : %.0Lf\n", int128_to_double(ns->nvmcap));
+	printf("nvmcap  : %.0f\n", int128_to_double(ns->nvmcap));
 	if (ns->nsfeat & 0x10) {
 		printf("npwg    : %u\n", le16_to_cpu(ns->npwg));
 		printf("npwa    : %u\n", le16_to_cpu(ns->npwa));
@@ -3530,8 +3530,8 @@ void __nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, enum nvme_print_flags flags,
 	printf("mtfa      : %d\n", le16_to_cpu(ctrl->mtfa));
 	printf("hmpre     : %d\n", le32_to_cpu(ctrl->hmpre));
 	printf("hmmin     : %d\n", le32_to_cpu(ctrl->hmmin));
-	printf("tnvmcap   : %.0Lf\n", int128_to_double(ctrl->tnvmcap));
-	printf("unvmcap   : %.0Lf\n", int128_to_double(ctrl->unvmcap));
+	printf("tnvmcap   : %.0f\n", int128_to_double(ctrl->tnvmcap));
+	printf("unvmcap   : %.0f\n", int128_to_double(ctrl->unvmcap));
 	printf("rpmbs     : %#x\n", le32_to_cpu(ctrl->rpmbs));
 	if (human)
 		nvme_show_id_ctrl_rpmbs(ctrl->rpmbs);
@@ -3923,9 +3923,9 @@ void nvme_show_id_nvmset(struct nvme_id_nvmset *nvmset, unsigned nvmset_id,
 			le32_to_cpu(nvmset->ent[i].random_4k_read_typical));
 		printf("optimal_write_size      : %u\n",
 			le32_to_cpu(nvmset->ent[i].opt_write_size));
-		printf("total_nvmset_cap        : %.0Lf\n",
+		printf("total_nvmset_cap        : %.0f\n",
 			int128_to_double(nvmset->ent[i].total_nvmset_cap));
-		printf("unalloc_nvmset_cap      : %.0Lf\n",
+		printf("unalloc_nvmset_cap      : %.0f\n",
 			int128_to_double(nvmset->ent[i].unalloc_nvmset_cap));
 		printf(".................\n");
 	}
@@ -4406,21 +4406,21 @@ void nvme_show_endurance_log(struct nvme_endurance_group_log *endurance_log,
 	printf("avl_spare_threshold	: %u\n",
 		endurance_log->avl_spare_threshold);
 	printf("percent_used		: %u%%\n", endurance_log->percent_used);
-	printf("endurance_estimate	: %'.0Lf\n",
+	printf("endurance_estimate	: %'.0f\n",
 		int128_to_double(endurance_log->endurance_estimate));
-	printf("data_units_read		: %'.0Lf\n",
+	printf("data_units_read		: %'.0f\n",
 		int128_to_double(endurance_log->data_units_read));
-	printf("data_units_written	: %'.0Lf\n",
+	printf("data_units_written	: %'.0f\n",
 		int128_to_double(endurance_log->data_units_written));
-	printf("media_units_written	: %'.0Lf\n",
+	printf("media_units_written	: %'.0f\n",
 		int128_to_double(endurance_log->media_units_written));
-	printf("host_read_cmds		: %'.0Lf\n",
+	printf("host_read_cmds		: %'.0f\n",
 		int128_to_double(endurance_log->host_read_cmds));
-	printf("host_write_cmds		: %'.0Lf\n",
+	printf("host_write_cmds		: %'.0f\n",
 		int128_to_double(endurance_log->host_write_cmds));
-	printf("media_data_integrity_err: %'.0Lf\n",
+	printf("media_data_integrity_err: %'.0f\n",
 		int128_to_double(endurance_log->media_data_integrity_err));
-	printf("num_err_info_log_entries: %'.0Lf\n",
+	printf("num_err_info_log_entries: %'.0f\n",
 		int128_to_double(endurance_log->num_err_info_log_entries));
 }
 
@@ -4460,25 +4460,25 @@ void nvme_show_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 		smart->percent_used);
 	printf("endurance group critical warning summary: %#x\n",
 		smart->endu_grp_crit_warn_sumry);
-	printf("data_units_read				: %'.0Lf\n",
+	printf("data_units_read				: %'.0f\n",
 		int128_to_double(smart->data_units_read));
-	printf("data_units_written			: %'.0Lf\n",
+	printf("data_units_written			: %'.0f\n",
 		int128_to_double(smart->data_units_written));
-	printf("host_read_commands			: %'.0Lf\n",
+	printf("host_read_commands			: %'.0f\n",
 		int128_to_double(smart->host_reads));
-	printf("host_write_commands			: %'.0Lf\n",
+	printf("host_write_commands			: %'.0f\n",
 		int128_to_double(smart->host_writes));
-	printf("controller_busy_time			: %'.0Lf\n",
+	printf("controller_busy_time			: %'.0f\n",
 		int128_to_double(smart->ctrl_busy_time));
-	printf("power_cycles				: %'.0Lf\n",
+	printf("power_cycles				: %'.0f\n",
 		int128_to_double(smart->power_cycles));
-	printf("power_on_hours				: %'.0Lf\n",
+	printf("power_on_hours				: %'.0f\n",
 		int128_to_double(smart->power_on_hours));
-	printf("unsafe_shutdowns			: %'.0Lf\n",
+	printf("unsafe_shutdowns			: %'.0f\n",
 		int128_to_double(smart->unsafe_shutdowns));
-	printf("media_errors				: %'.0Lf\n",
+	printf("media_errors				: %'.0f\n",
 		int128_to_double(smart->media_errors));
-	printf("num_err_log_entries			: %'.0Lf\n",
+	printf("num_err_log_entries			: %'.0f\n",
 		int128_to_double(smart->num_err_log_entries));
 	printf("Warning Temperature Time		: %u\n",
 		le32_to_cpu(smart->warning_temp_time));

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -53,10 +53,10 @@ struct vtview_save_log_settings {
 	const char*	test_name;
 };
 
-static long double int128_to_double(__u8 *data)
+static double int128_to_double(__u8 *data)
 {
 	int i;
-	long double result = 0;
+	double result = 0;
 
 	for (i = 0; i < 16; i++) {
 		result *= 256;
@@ -151,25 +151,25 @@ static void vt_convert_smart_data_to_human_readable_format(struct vtview_smart_l
 	strcat(text, tempbuff);
 	snprintf(tempbuff, sizeof(tempbuff), "Percentage_Used;%u;", smart->raw_smart.percent_used);
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Data_Units_Read;%0.Lf;", int128_to_double(smart->raw_smart.data_units_read));
+	snprintf(tempbuff, sizeof(tempbuff), "Data_Units_Read;%0.f;", int128_to_double(smart->raw_smart.data_units_read));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Data_Units_Written;%0.Lf;", int128_to_double(smart->raw_smart.data_units_written));
+	snprintf(tempbuff, sizeof(tempbuff), "Data_Units_Written;%0.f;", int128_to_double(smart->raw_smart.data_units_written));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Host_Read_Commands;%0.Lf;", int128_to_double(smart->raw_smart.host_reads));
+	snprintf(tempbuff, sizeof(tempbuff), "Host_Read_Commands;%0.f;", int128_to_double(smart->raw_smart.host_reads));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Host_Write_Commands;%0.Lf;", int128_to_double(smart->raw_smart.host_writes));
+	snprintf(tempbuff, sizeof(tempbuff), "Host_Write_Commands;%0.f;", int128_to_double(smart->raw_smart.host_writes));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Controller_Busy_Time;%0.Lf;", int128_to_double(smart->raw_smart.ctrl_busy_time));
+	snprintf(tempbuff, sizeof(tempbuff), "Controller_Busy_Time;%0.f;", int128_to_double(smart->raw_smart.ctrl_busy_time));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Power_Cycles;%0.Lf;", int128_to_double(smart->raw_smart.power_cycles));
+	snprintf(tempbuff, sizeof(tempbuff), "Power_Cycles;%0.f;", int128_to_double(smart->raw_smart.power_cycles));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Power_On_Hours;%0.Lf;", int128_to_double(smart->raw_smart.power_on_hours));
+	snprintf(tempbuff, sizeof(tempbuff), "Power_On_Hours;%0.f;", int128_to_double(smart->raw_smart.power_on_hours));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Unsafe_Shutdowns;%0.Lf;", int128_to_double(smart->raw_smart.unsafe_shutdowns));
+	snprintf(tempbuff, sizeof(tempbuff), "Unsafe_Shutdowns;%0.f;", int128_to_double(smart->raw_smart.unsafe_shutdowns));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Media_Errors;%0.Lf;", int128_to_double(smart->raw_smart.media_errors));
+	snprintf(tempbuff, sizeof(tempbuff), "Media_Errors;%0.f;", int128_to_double(smart->raw_smart.media_errors));
 	strcat(text, tempbuff);
-	snprintf(tempbuff, sizeof(tempbuff), "Num_Err_Log_Entries;%0.Lf;", int128_to_double(smart->raw_smart.num_err_log_entries));
+	snprintf(tempbuff, sizeof(tempbuff), "Num_Err_Log_Entries;%0.f;", int128_to_double(smart->raw_smart.num_err_log_entries));
 	strcat(text, tempbuff);
 	snprintf(tempbuff, sizeof(tempbuff), "Warning_Temperature_Time;%u;", le32_to_cpu(smart->raw_smart.warning_temp_time));
 	strcat(text, tempbuff);

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -961,10 +961,10 @@ static double calc_percent(uint64_t numerator, uint64_t denominator)
 		(uint64_t)(((double)numerator / (double)denominator) * 100) : 0;
 }
 
-static long double int128_to_double(__u8 *data)
+static double int128_to_double(__u8 *data)
 {
 	int i;
-	long double result = 0;
+	double result = 0;
 
 	for (i = 0; i < 16; i++) {
 		result *= 256;
@@ -4284,9 +4284,9 @@ static void wdc_print_smart_cloud_attr_C0_normal(void *data)
 
 	printf("  SMART Cloud Attributes :- \n");
 
-	printf("  Physical media units written			%.0Lf\n",
+	printf("  Physical media units written			%.0f\n",
 			int128_to_double(&log_data[SCAO_PMUW]));
-	printf("  Physical media units Read			%.0Lf\n",
+	printf("  Physical media units Read			%.0f\n",
 			int128_to_double(&log_data[SCAO_PMUR]));
 	printf("  Bad user nand blocks - Raw			%"PRIu64"\n",
 			(uint64_t)le64_to_cpu(log_data[SCAO_BUNBR] & 0x0000FFFFFFFFFFFF));
@@ -4332,9 +4332,9 @@ static void wdc_print_smart_cloud_attr_C0_normal(void *data)
 			(uint64_t)le64_to_cpu(log_data[SCAO_SVN]));
 	printf("  NUSE - Namespace utilization			%"PRIu64"\n",
 			(uint64_t)le64_to_cpu(log_data[SCAO_NUSE]));
-	printf("  PLP start count				%.0Lf\n",
+	printf("  PLP start count				%.0f\n",
 			int128_to_double(&log_data[SCAO_PSC]));
-	printf("  Endurance estimate				%.0Lf\n",
+	printf("  Endurance estimate				%.0f\n",
 			int128_to_double(&log_data[SCAO_EEST]));
 	printf("  Log page version				 %"PRIu16"\n",
 			(uint16_t)le16_to_cpu(log_data[SCAO_LPV]));
@@ -6967,9 +6967,9 @@ static void wdc_print_nand_stats_normal(__u16 version, void *data)
 	{
 	case 0:
 		printf("  NAND Statistics :- \n");
-		printf("  NAND Writes TLC (Bytes)		         %.0Lf\n",
+		printf("  NAND Writes TLC (Bytes)		         %.0f\n",
 				int128_to_double(nand_stats->nand_write_tlc));
-		printf("  NAND Writes SLC (Bytes)				%.0Lf\n",
+		printf("  NAND Writes SLC (Bytes)				%.0f\n",
 				int128_to_double(nand_stats->nand_write_slc));
 		printf("  NAND Program Failures			  	 %"PRIu32"\n",
 				(uint32_t)le32_to_cpu(nand_stats->nand_prog_failure));
@@ -6988,9 +6988,9 @@ static void wdc_print_nand_stats_normal(__u16 version, void *data)
 		break;
 	case 3:
 		printf("  NAND Statistics V3:- \n");
-		printf("  TLC Units Written				 %.0Lf\n",
+		printf("  TLC Units Written				 %.0f\n",
 				int128_to_double(nand_stats_v3->nand_write_tlc));
-		printf("  SLC Units Written 				 %.0Lf\n",
+		printf("  SLC Units Written 				 %.0f\n",
 				int128_to_double(nand_stats_v3->nand_write_slc));
 		temp_ptr = (__u64 *)nand_stats_v3->bad_nand_block_count;
 		temp_norm = (__u16)(*temp_ptr & 0x000000000000FFFF);
@@ -7041,7 +7041,7 @@ static void wdc_print_nand_stats_normal(__u16 version, void *data)
 				le64_to_cpu(nand_stats_v3->security_version_number));
 		printf("  %% Free Blocks (System)			 %u\n",
 				nand_stats_v3->percent_free_blocks_system);
-		printf("  Data Set Management Commands			 %.0Lf\n",
+		printf("  Data Set Management Commands			 %.0f\n",
 				int128_to_double(nand_stats_v3->trim_completions));
 		printf("  Estimate of Incomplete Trim Data		 %"PRIu64"\n",
 				le64_to_cpu(nand_stats_v3->trim_completions[16]));
@@ -7060,7 +7060,7 @@ static void wdc_print_nand_stats_normal(__u16 version, void *data)
 				le16_to_cpu(temp_norm));
 		printf("  Bad System Nand Block Count - Raw	         %"PRIu64"\n",
 				le64_to_cpu(temp_raw));
-		printf("  Endurance Estimate				 %.0Lf\n",
+		printf("  Endurance Estimate				 %.0f\n",
 				int128_to_double(nand_stats_v3->endurance_estimate));
 		printf("  Thermal Throttling Count			 %u\n",
 				nand_stats_v3->thermal_throttling_st_ct[0]);
@@ -7068,7 +7068,7 @@ static void wdc_print_nand_stats_normal(__u16 version, void *data)
 				nand_stats_v3->thermal_throttling_st_ct[1]);
 		printf("  Unaligned I/O					 %"PRIu64"\n",
 				le64_to_cpu(nand_stats_v3->unaligned_IO));
-		printf("  Physical Media Units Read			 %.0Lf\n",
+		printf("  Physical Media Units Read			 %.0f\n",
 				int128_to_double(nand_stats_v3->physical_media_units));
 		printf("  log page version				 %"PRIu16"\n",
 				le16_to_cpu(nand_stats_v3->log_page_version));

--- a/util/json.c
+++ b/util/json.c
@@ -395,7 +395,7 @@ static void json_print_value(struct json_value *value, void *out)
 		printf( "%llu", value->uint_number);
 		break;
 	case JSON_TYPE_FLOAT:
-		printf( "%.0Lf", value->float_number);
+		printf( "%.0f", value->float_number);
 		break;
 	case JSON_TYPE_OBJECT:
 		json_print_object(value->object, out);

--- a/util/json.h
+++ b/util/json.h
@@ -18,7 +18,7 @@ struct json_value {
 	union {
 		long long integer_number;
 		unsigned long long uint_number;
-		long double float_number;
+		double float_number;
 		char *string;
 		struct json_object *object;
 		struct json_array *array;


### PR DESCRIPTION
When printing long double, zero is shown as nan or not a number after a
patch in glibc to fix CVE-2020-29573, printing doubles does not suffer
from this problem although you have lowered precision.