### PR TITLE
nvme: remove unused functions nvme_{read, write, compare}

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -145,30 +145,6 @@ int nvme_io(int fd, __u8 opcode, __u64 slba, __u16 nblocks, __u16 control,
 	return ioctl(fd, NVME_IOCTL_SUBMIT_IO, &io);
 }
 
-int nvme_read(int fd, __u64 slba, __u16 nblocks, __u16 control, __u32 dsmgmt,
-	      __u32 reftag, __u16 apptag, __u16 appmask, void *data,
-	      void *metadata)
-{
-	return nvme_io(fd, nvme_cmd_read, slba, nblocks, control, dsmgmt,
-		       reftag, apptag, appmask, data, metadata);
-}
-
-int nvme_write(int fd, __u64 slba, __u16 nblocks, __u16 control, __u32 dsmgmt,
-	       __u32 reftag, __u16 apptag, __u16 appmask, void *data,
-	       void *metadata)
-{
-	return nvme_io(fd, nvme_cmd_write, slba, nblocks, control, dsmgmt,
-		       reftag, apptag, appmask, data, metadata);
-}
-
-int nvme_compare(int fd, __u64 slba, __u16 nblocks, __u16 control, __u32 dsmgmt,
-		 __u32 reftag, __u16 apptag, __u16 appmask, void *data,
-		 void *metadata)
-{
-	return nvme_io(fd, nvme_cmd_compare, slba, nblocks, control, dsmgmt,
-		       reftag, apptag, appmask, data, metadata);
-}
-
 int nvme_verify(int fd, __u32 nsid, __u64 slba, __u16 nblocks,
 		__u16 control, __u32 reftag, __u16 apptag, __u16 appmask)
 {

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -29,18 +29,6 @@ int nvme_io(int fd, __u8 opcode, __u64 slba, __u16 nblocks, __u16 control,
 	      __u32 dsmgmt, __u32 reftag, __u16 apptag,
 	      __u16 appmask, void *data, void *metadata);
 
-int nvme_read(int fd, __u64 slba, __u16 nblocks, __u16 control,
-	      __u32 dsmgmt, __u32 reftag, __u16 apptag,
-	      __u16 appmask, void *data, void *metadata);
-
-int nvme_write(int fd, __u64 slba, __u16 nblocks, __u16 control,
-	       __u32 dsmgmt, __u32 reftag, __u16 apptag,
-	       __u16 appmask, void *data, void *metadata);
-
-int nvme_compare(int fd, __u64 slba, __u16 nblocks, __u16 control,
-		 __u32 dsmgmt, __u32 reftag, __u16 apptag,
-		 __u16 appmask, void *data, void *metadata);
-
 /* NVME_IO_CMD */
 int nvme_passthru_io(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
 		     __u32 nsid, __u32 cdw2, __u32 cdw3,


### PR DESCRIPTION
Functions nvme_write, nvme_read, nvme_compare are
not being called in place. Removing these unused
functions.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>