### PR TITLE
Input expects device name without /dev

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -305,6 +305,11 @@ static bool ctrl_matches_connectargs(char *name, struct connect_args *args)
 		return found;
 
 	addr = nvme_get_ctrl_attr(path, "address");
+	if (!addr) {
+		fprintf(stderr, "nvme_get_ctrl_attr failed\n");
+		return found;
+	}
+
 	cargs.subsysnqn = nvme_get_ctrl_attr(path, "subsysnqn");
 	cargs.transport = nvme_get_ctrl_attr(path, "transport");
 	cargs.traddr = parse_conn_arg(addr, ' ', conarg_traddr);

--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -60,8 +60,10 @@ char *nvme_get_ctrl_attr(char *path, const char *attr)
 		goto err_free_path;
 
 	fd = open(attrpath, O_RDONLY);
-	if (fd < 0)
+	if (fd < 0) {
+		fprintf(stderr, "Failed to open %s: %s\n", attrpath, strerror(errno));
 		goto err_free_value;
+	}
 
 	ret = read(fd, value, 1024);
 	if (ret < 0) {


### PR DESCRIPTION
But don't segfault if user gets this incorrect, instead provide helpful
info.