### PR TITLE
nvme-ioctl: remove unused function nvme_passthru_io

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -161,18 +161,6 @@ int nvme_verify(int fd, __u32 nsid, __u64 slba, __u16 nblocks,
 	return nvme_submit_io_passthru(fd, &cmd);
 }
 
-int nvme_passthru_io(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
-		     __u32 nsid, __u32 cdw2, __u32 cdw3, __u32 cdw10,
-		     __u32 cdw11, __u32 cdw12, __u32 cdw13, __u32 cdw14,
-		     __u32 cdw15, __u32 data_len, void *data,
-		     __u32 metadata_len, void *metadata, __u32 timeout_ms)
-{
-	return nvme_passthru(fd, NVME_IOCTL_IO_CMD, opcode, flags, rsvd, nsid,
-			     cdw2, cdw3, cdw10, cdw11, cdw12, cdw13, cdw14,
-			     cdw15, data_len, data, metadata_len, metadata,
-			     timeout_ms, NULL);
-}
-
 int nvme_write_zeros(int fd, __u32 nsid, __u64 slba, __u16 nlb,
 		     __u16 control, __u32 reftag, __u16 apptag, __u16 appmask)
 {

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -29,14 +29,6 @@ int nvme_io(int fd, __u8 opcode, __u64 slba, __u16 nblocks, __u16 control,
 	      __u32 dsmgmt, __u32 reftag, __u16 apptag,
 	      __u16 appmask, void *data, void *metadata);
 
-/* NVME_IO_CMD */
-int nvme_passthru_io(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
-		     __u32 nsid, __u32 cdw2, __u32 cdw3,
-		     __u32 cdw10, __u32 cdw11, __u32 cdw12,
-		     __u32 cdw13, __u32 cdw14, __u32 cdw15,
-		     __u32 data_len, void *data, __u32 metadata_len,
-		     void *metadata, __u32 timeout);
-
 int nvme_write_zeros(int fd, __u32 nsid, __u64 slba, __u16 nlb,
 		     __u16 control, __u32 reftag, __u16 apptag, __u16 appmask);
 


### PR DESCRIPTION
This function has not been called from anywhere, so remove it.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>