### PR TITLE
nvme: remove spurious command show 'rsvd'

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4588,7 +4588,6 @@ static int submit_io(int opcode, char *command, const char *desc,
 		printf("flags        : %02x\n", 0);
 		printf("control      : %04x\n", control);
 		printf("nblocks      : %04x\n", cfg.block_count);
-		printf("rsvd         : %04x\n", 0);
 		printf("metadata     : %"PRIx64"\n", (uint64_t)(uintptr_t)mbuffer);
 		printf("addr         : %"PRIx64"\n", (uint64_t)(uintptr_t)buffer);
 		printf("slba         : %"PRIx64"\n", (uint64_t)cfg.start_block);


### PR DESCRIPTION
Remove spurious showing attribute 'rsvd'.  This even is not from the
user input.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>