### PR TITLE
nvme: print controller id in hex consistently in list-ctrl

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1193,7 +1193,7 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 		__u16 num = le16_to_cpu(cntlist->num);
 
 		for (i = 0; i < (min(num, 2048)); i++)
-			printf("[%4u]:%#x\n", i, le16_to_cpu(cntlist->identifier[i]));
+			printf("[%4u]:0x%x\n", i, le16_to_cpu(cntlist->identifier[i]));
 	}
 	else if (err > 0)
 		nvme_show_status(err);


### PR DESCRIPTION
When printing the controller ids for the 'list-ctrl' command, the
cntlid=0 case will be printed out to 0 without 0x prefix which the other
controller IDs are with.

Before:
	root@vm:~# nvme list-ctrl /dev/nvme0 -n 1 -c 0
	[   0]:0
	[   1]:0x1

After:
	root@vm:~# nvme list-ctrl /dev/nvme0 -n 1 -c 0
	[   0]:0x0
	[   1]:0x1

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>