### PR TITLE
Don't print error on failed to open in nvme-topology.c

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -60,10 +60,8 @@ char *nvme_get_ctrl_attr(char *path, const char *attr)
 		goto err_free_path;
 
 	fd = open(attrpath, O_RDONLY);
-	if (fd < 0) {
-		fprintf(stderr, "Failed to open %s: %s\n", attrpath, strerror(errno));
+	if (fd < 0)
 		goto err_free_value;
-	}
 
 	ret = read(fd, value, 1024);
 	if (ret < 0) {


### PR DESCRIPTION
Sometimes opens are intentionally attempted and allowed fail, such as
the "nvme list" command.