### PR TITLE
fabrics: ctrl_loss_tmo setting is invalid for 'loop'

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -88,7 +88,7 @@ static struct config {
 	bool persistent;
 	bool quiet;
 	bool matching_only;
-} cfg = { .ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO };
+} cfg = { .ctrl_loss_tmo = -1 };
 
 struct connect_args {
 	char *subsysnqn;
@@ -869,6 +869,9 @@ static int build_options(char *argstr, int max_len, bool discover)
 			fprintf(stderr, "need a address (-a) argument\n");
 			return -EINVAL;
 		}
+		/* Use the default ctrl loss timeout if unset */
+		if (cfg.ctrl_loss_tmo == -1)
+			cfg.ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO;
 	}
 
 	/* always specify nqn as first arg - this will init the string */


### PR DESCRIPTION
The 'ctrl_loss_tmo' setting is invalid for 'loop' devices, so move
the default to '-1' (for 'unset'), and only set the default timeout
if discovery is not done on a loop device and the user has not
specified another value.

Fixes: 68bc869 ("fabrics: fix passing ctrl_loss_tmo=0 by default")
Signed-off-by: Hannes Reinecke <hare@suse.de>