### PR TITLE
nvme: add identify controller nvm command set support

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -1686,6 +1686,16 @@ struct nvme_zns_id_ns {
 	__u8			vs[256];
 };
 
+struct nvme_id_ctrl_nvm {
+    __u8     vsl;
+    __u8     wzsl;
+    __u8     wusl;
+    __u8     dmrl;
+    __u32    dmrsl;
+    __u64    dmsl;
+    __u8     rsvd16[4080];
+};
+
 /**
  * struct nvme_zns_id_ctrl -
  * @zasl:

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -14,6 +14,7 @@ COMMAND_LIST(
 	ENTRY("id-ns-granularity", "Send NVMe Identify Namespace Granularity List, display structure", id_ns_granularity)
 	ENTRY("list-ns", "Send NVMe Identify List, display structure", list_ns)
 	ENTRY("list-ctrl", "Send NVMe Identify Controller List, display structure", list_ctrl)
+	ENTRY("nvm-id-ctrl", "Send NVMe Identify Controller NVM Command Set, display structure", nvm_id_ctrl)
 	ENTRY("list-secondary", "List Secondary Controllers associated with a Primary Controller", list_secondary_ctrl)
 	ENTRY("ns-descs", "Send NVMe Namespace Descriptor List, display structure", ns_descs)
 	ENTRY("id-nvmset", "Send NVMe Identify NVM Set List, display structure", id_nvmset)

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -439,6 +439,11 @@ int nvme_identify_uuid(int fd, void *data)
 	return nvme_identify(fd, 0, NVME_ID_CNS_UUID_LIST, data);
 }
 
+int nvme_identify_ctrl_nvm(int fd, void *data)
+{
+	return nvme_identify13(fd, 0, NVME_ID_CNS_CSI_ID_CTRL, 0, data);
+}
+
 int nvme_zns_identify_ns(int fd, __u32 nsid, void *data)
 {
 	return nvme_identify13(fd, nsid, NVME_ID_CNS_CSI_ID_NS, 2 << 24, data);

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -81,6 +81,7 @@ int nvme_identify_nvmset(int fd, __u16 nvmset_id, void *data);
 int nvme_identify_uuid(int fd, void *data);
 int nvme_identify_secondary_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
 int nvme_identify_ns_granularity(int fd, void *data);
+int nvme_identify_ctrl_nvm(int fd, void *data);
 int nvme_zns_identify_ctrl(int fd, void *data);
 int nvme_zns_identify_ns(int fd, __u32 nsid, void *data);
 int nvme_identify_iocs(int fd, __u16 cntid, void *data);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3606,6 +3606,40 @@ void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode)
 	__nvme_show_id_ctrl(ctrl, mode, NULL);
 }
 
+static void json_nvme_id_ctrl_nvm(struct nvme_id_ctrl_nvm *ctrl_nvm)
+{
+	struct json_object *root;
+
+	root = json_create_object();
+	json_object_add_value_uint(root, "vsl", ctrl_nvm->vsl);
+	json_object_add_value_uint(root, "wzsl", ctrl_nvm->wzsl);
+	json_object_add_value_uint(root, "wusl", ctrl_nvm->wusl);
+	json_object_add_value_uint(root, "dmrl", ctrl_nvm->dmrl);
+	json_object_add_value_uint(root, "dmrsl", ctrl_nvm->dmrsl);
+	json_object_add_value_uint(root, "dmsl", ctrl_nvm->dmsl);
+
+	json_print_object(root, NULL);
+	printf("\n");
+	json_free_object(root);
+}
+
+void nvme_show_id_ctrl_nvm(struct nvme_id_ctrl_nvm *ctrl_nvm,
+	enum nvme_print_flags flags)
+{
+	if (flags & BINARY)
+		return d_raw((unsigned char *)ctrl_nvm, sizeof(*ctrl_nvm));
+	else if (flags & JSON)
+		return json_nvme_id_ctrl_nvm(ctrl_nvm);
+
+	printf("NVMe Identify Controller NVM:\n");
+	printf("vsl    : %u\n", ctrl_nvm->vsl);
+	printf("wzsl   : %u\n", ctrl_nvm->wzsl);
+	printf("wusl   : %u\n", ctrl_nvm->wusl);
+	printf("dmrl   : %u\n", ctrl_nvm->dmrl);
+	printf("dmrsl  : %u\n", le32_to_cpu(ctrl_nvm->dmrsl));
+	printf("dmsl   : %"PRIu64"\n", le64_to_cpu(ctrl_nvm->dmsl));
+}
+
 static void json_nvme_zns_id_ctrl(struct nvme_zns_id_ctrl *ctrl, unsigned int mode)
 {
 	struct json_object *root;

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -79,6 +79,8 @@ void nvme_directive_show(__u8 type, __u8 oper, __u16 spec, __u32 nsid, __u32 res
 void nvme_show_select_result(__u32 result);
 
 void nvme_show_zns_id_ctrl(struct nvme_zns_id_ctrl *ctrl, unsigned int mode);
+void nvme_show_id_ctrl_nvm(struct nvme_id_ctrl_nvm *ctrl_nvm,
+	enum nvme_print_flags flags);
 void nvme_show_zns_id_ns(struct nvme_zns_id_ns *ns,
 	struct nvme_id_ns *id_ns, unsigned long flags);
 void nvme_show_zns_changed( struct nvme_zns_changed_zone_log *log,

--- a/nvme.c
+++ b/nvme.c
@@ -1716,6 +1716,50 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
 	return __id_ctrl(argc, argv, cmd, plugin, NULL);
 }
 
+static int nvm_id_ctrl(int argc, char **argv, struct command *cmd,
+	struct plugin *plugin)
+{
+	const char *desc = "Send an Identify Controller NVM Command Set "\
+		"command to the given device and report information about "\
+		"the specified controller in various formats.";
+	enum nvme_print_flags flags;
+	struct nvme_id_ctrl_nvm ctrl_nvm;
+	int fd, err = -1;
+
+	struct config {
+		char *output_format;
+	};
+
+	struct config cfg = {
+		.output_format = "normal",
+	};
+
+	OPT_ARGS(opts) = {
+		OPT_FMT("output-format",  'o', &cfg.output_format,   output_format),
+		OPT_END()
+	};
+
+	fd = parse_and_open(argc, argv, desc, opts);
+	if (fd < 0)
+		goto ret;
+
+	err = flags = validate_output_format(cfg.output_format);
+	if (flags < 0)
+		goto close_fd;
+
+	err = nvme_identify_ctrl_nvm(fd, &ctrl_nvm);
+	if (!err)
+		nvme_show_id_ctrl_nvm(&ctrl_nvm, flags);
+	else if (err > 0)
+		nvme_show_status(err);
+	else
+		perror("nvm identify controller");
+close_fd:
+	close(fd);
+ret:
+	return nvme_status_to_errno(err, false);
+}
+
 static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Send Namespace Identification Descriptors command to the "\


### PR DESCRIPTION
This will add the support for the identify controller nvm
command set. This is to impose size limit on non-mdts IO
commands as per TP 4040.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>
Co-Authored-By: Karthik Balan  <karthik.b82@samsung.com>