### PR TITLE
Add "json" option to discover command

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1312,6 +1312,8 @@ static int do_discover(char *argstr, bool connect)
 		return -errno;
 	ret = nvmf_get_log_page_discovery(dev_name, &log, &numrec, &status);
 	free(dev_name);
+	if (cfg.persistent)
+		printf("Persistent device: nvme%d\n", instance);
 	if (!cfg.device && !cfg.persistent) {
 		err = remove_ctrl(instance);
 		if (err)

--- a/fabrics.c
+++ b/fabrics.c
@@ -669,11 +669,11 @@ static char * copy_and_strip(char * buf, const char *str, int max)
 	strncpy(buf, str, max);
 	for (i = max - 1; i >= 0; i--)
 		if (buf[i] != '\0' && buf[i] != ' ')
-            break;
+			break;
 		else
-            buf[i] = '\0';
+			buf[i] = '\0';
 
-    return buf;
+	return buf;
 }
 
 static void print_discovery_log_human(struct nvmf_disc_rsp_page_hdr *log,
@@ -792,7 +792,7 @@ static void print_discovery_log_json(struct nvmf_disc_rsp_page_hdr *log,
 	records = NULL;
 
 	json_print_object(root, NULL);
-    printf("\n");
+	printf("\n");
 
 out:
 	if (records) json_free_array(records);

--- a/fabrics.c
+++ b/fabrics.c
@@ -733,8 +733,8 @@ static void print_discovery_log_json(struct nvmf_disc_rsp_page_hdr *log,
 	struct json_object *root = NULL;
 	struct json_object *record = NULL;
 	struct json_array  *records = NULL;
-	char   trsvcid[NVMF_TRSVCID_SIZE];
-	char   traddr[NVMF_TRADDR_SIZE];
+	char   trsvcid[NVMF_TRSVCID_SIZE+1];
+	char   traddr[NVMF_TRADDR_SIZE+1];
 	char   dev_name[STRLEN("nvme") + DECIMAL_STR_MAX(int)];
 
 	root = json_create_object();
@@ -762,11 +762,11 @@ static void print_discovery_log_json(struct nvmf_disc_rsp_page_hdr *log,
 		json_object_add_value_int(record, "portid", e->portid);
 		json_object_add_value_string(record, "trsvcid",
                                      copy_and_strip(trsvcid, e->trsvcid,
-                                                    sizeof(trsvcid)));
+                                                    sizeof(trsvcid)-1));
 		json_object_add_value_string(record, "subnqn",  e->subnqn);
 		json_object_add_value_string(record, "traddr",
                                      copy_and_strip(traddr, e->traddr,
-                                                    sizeof(traddr)));
+                                                    sizeof(traddr)-1));
 
 		switch (e->trtype) {
 		case NVMF_TRTYPE_RDMA:


### PR DESCRIPTION
The `discover` command now has a `--json` option. When the option is enabled, the output will be printed in JSON format. This makes it easier for other programs (like a Python script) to parse the output.