### PR TITLE
nvme: change system error notification from fprintf to perror

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1453,7 +1453,7 @@ static int discover_from_conf_file(const char *desc, char *argstr,
 
 		argv = calloc(MAX_DISC_ARGS, BUF_SIZE);
 		if (!argv) {
-			fprintf(stderr, "failed to allocate argv vector\n");
+			perror("failed to allocate argv vector\n");
 			free(args);
 			ret = -ENOMEM;
 			goto out;

--- a/nvme.c
+++ b/nvme.c
@@ -395,8 +395,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	hdr = malloc(bs);
 	page_log = malloc(bs);
 	if (!hdr || !page_log) {
-		fprintf(stderr, "Failed to allocate %zu bytes for log: %s\n",
-				bs, strerror(errno));
+		perror("failed to allocate buf for log\n");
 		err = -ENOMEM;
 		goto free_mem;
 	}
@@ -632,7 +631,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	cfg.log_entries = min(cfg.log_entries, ctrl.elpe + 1);
 	err_log = calloc(cfg.log_entries, sizeof(struct nvme_error_log_page));
 	if (!err_log) {
-		fprintf(stderr, "could not alloc buffer for error log\n");
+		perror("could not alloc buffer for error log\n");
 		err = -ENOMEM;
 		goto close_fd;
 	}
@@ -870,7 +869,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	log_size = sizeof(__u64) + cfg.log_entries * sizeof(__u16);
 	pea_log = calloc(log_size, 1);
 	if (!pea_log) {
-		fprintf(stderr, "could not alloc buffer for predictable " \
+		perror("could not alloc buffer for predictable " \
 			"latency event agggregate log entries\n");
 		err = -ENOMEM;
 		goto close_fd;
@@ -942,7 +941,7 @@ static int get_persistent_event_log(int argc, char **argv,
 
 	pevent_log_head = calloc(sizeof(*pevent_log_head), 1);
 	if (!pevent_log_head) {
-		fprintf(stderr, "could not alloc buffer for persistent " \
+		perror("could not alloc buffer for persistent " \
 			"event log header\n");
 		err = -ENOMEM;
 		goto close_fd;
@@ -982,8 +981,7 @@ static int get_persistent_event_log(int argc, char **argv,
 
 	pevent_log_info = nvme_alloc(cfg.log_len, &huge);
 	if (!pevent_log_info) {
-		fprintf(stderr, "could not alloc buffer for persistent " \
-			"event log page\n");
+		perror("could not alloc buffer for persistent event log page\n");
 		err = -ENOMEM;
 		goto close_fd;
 	}
@@ -1074,7 +1072,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	log_size = sizeof(__u64) + cfg.log_entries * sizeof(__u16);
 	endurance_log = calloc(log_size, 1);
 	if (!endurance_log) {
-		fprintf(stderr, "could not alloc buffer for endurance group" \
+		perror("could not alloc buffer for endurance group" \
 			" event agggregate log entries\n");
 		err = -ENOMEM;
 		goto close_fd;
@@ -1232,8 +1230,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 		log = malloc(cfg.log_len);
 		if (!log) {
-			fprintf(stderr, "could not alloc buffer for log: %s\n",
-					strerror(errno));
+			perror("could not alloc buffer for log\n");
 			err = -ENOMEM;
 			goto close_fd;
 		}
@@ -2747,7 +2744,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 		fw_buf = nvme_alloc(fw_size, &huge);
 
 	if (!fw_buf) {
-		fprintf(stderr, "No memory for f/w size:%d\n", fw_size);
+		perror("No memory for f/w size:\n");
 		err = -ENOMEM;
 		goto close_fw_fd;
 	}
@@ -4752,7 +4749,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 
 	buffer = nvme_alloc(buffer_size, &huge);
 	if (!buffer) {
-		fprintf(stderr, "can not allocate io payload\n");
+		perror("can not allocate io payload\n");
 		err = -ENOMEM;
 		goto close_mfd;
 	}
@@ -4782,8 +4779,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		}
 		mbuffer = malloc(mbuffer_size);
 		if (!mbuffer) {
-			fprintf(stderr, "can not allocate io metadata "
-					"payload: %s\n", strerror(errno));
+			perror("can not allocate buf for io metadata payload\n");
 			err = -ENOMEM;
 			goto free_buffer;
 		}
@@ -5399,8 +5395,7 @@ static int passthru(int argc, char **argv, int ioctl_cmd, const char *desc, stru
 	if (cfg.metadata_len) {
 		metadata = malloc(cfg.metadata_len);
 		if (!metadata) {
-			fprintf(stderr, "can not allocate metadata "
-					"payload: %s\n", strerror(errno));
+			perror("can not allocate metadata payload\n");
 			err = -ENOMEM;
 			goto close_wfd;
 		}
@@ -5409,7 +5404,7 @@ static int passthru(int argc, char **argv, int ioctl_cmd, const char *desc, stru
 	if (cfg.data_len) {
 		data = nvme_alloc(cfg.data_len, &huge);
 		if (!data) {
-			fprintf(stderr, "can not allocate data payload\n");
+			perror("can not allocate data payload\n");
 			err = -ENOMEM;
 			goto free_metadata;
 		}


### PR DESCRIPTION
As per the latest comment on PR #933, changing all the memory
failure errors notify using "perror" instead of "fprintf"

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>