### PR TITLE
nvme: Make gen-hostnqn use partition UUID on IBM POWER systems

### DIFF
--- a/scripts/gen-hostnqn.sh
+++ b/scripts/gen-hostnqn.sh
@@ -2,7 +2,11 @@
 
 LC_ALL=C
 
-UUID=$(dmidecode -s system-uuid | tr -d '[:space:]')
+if [ -e "/proc/device-tree/ibm,partition-uuid" ] ; then
+	UUID=$(tr -d '\0' < /proc/device-tree/ibm,partition-uuid)
+else
+	UUID=$(dmidecode -s system-uuid | tr -d '[:space:]')
+fi
 
 if [ -z "$UUID" ] ; then
 	>&2 echo "No UUID found, can't determine hostnqn."


### PR DESCRIPTION
IBM POWER systems expose a platform created UUID in the device
tree. Use that as the UUID in the host NQN.

Signed-off-by: Brian King <brking@linux.vnet.ibm.com>