### PR TITLE
nvme-print: split pmrmsc into pmrmscl and pmrmscu

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -180,7 +180,8 @@ enum {
 	NVME_REG_PMRSTS = 0x0e08,	/* Persistent Memory Region Status */
 	NVME_REG_PMREBS = 0x0e0c,	/* Persistent Memory Region Elasticity Buffer Size */
 	NVME_REG_PMRSWTP= 0x0e10,	/* Persistent Memory Region Sustained Write Throughput */
-	NVME_REG_PMRMSC = 0x0e14,	/* Persistent Memory Region Controller Memory Space Control */
+	NVME_REG_PMRMSCL= 0x0e14,	/* Persistent Memory Region Controller Memory Space Control Lower */
+	NVME_REG_PMRMSCU= 0x0e18,	/* Persistent Memory Region Controller Memory Space Control Upper*/
 	NVME_REG_DBS	= 0x1000,	/* SQ 0 Tail Doorbell */
 };
 


### PR DESCRIPTION
Split the PMR Memory Space Control register 64 bits into
PMR Memory Space Control Lower and Upper 32 bits each as
per NVM Express Spec. 1.4b changes.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>