### PR TITLE
nvme: fix securuty send and receive commands result field

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -839,7 +839,7 @@ int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid)
 }
 
 int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
-		  __u8 secp, __u32 tl, __u32 data_len, void *data, __u32 *result)
+		  __u8 secp, __u32 tl, __u32 data_len, void *data)
 {
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_security_send,
@@ -849,16 +849,12 @@ int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
 		.cdw10		= secp << 24 | spsp << 8 | nssf,
 		.cdw11		= tl,
 	};
-	int err;
 
-	err = nvme_submit_admin_passthru(fd, &cmd);
-	if (!err && result)
-		*result = cmd.result;
-	return err;
+	return nvme_submit_admin_passthru(fd, &cmd);
 }
 
 int nvme_sec_recv(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
-		  __u8 secp, __u32 al, __u32 data_len, void *data, __u32 *result)
+		  __u8 secp, __u32 al, __u32 data_len, void *data)
 {
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_security_recv,
@@ -868,12 +864,8 @@ int nvme_sec_recv(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
 		.addr		= (__u64)(uintptr_t) data,
 		.data_len	= data_len,
 	};
-	int err;
 
-	err = nvme_submit_admin_passthru(fd, &cmd);
-	if (!err && result)
-		*result = cmd.result;
-	return err;
+	return nvme_submit_admin_passthru(fd, &cmd);
 }
 
 int nvme_get_lba_status(int fd, __u32 namespace_id, __u64 slba, __u32 mndw,

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -139,9 +139,9 @@ int nvme_fw_download(int fd, __u32 offset, __u32 data_len, void *data);
 int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid);
 
 int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
-		  __u8 secp, __u32 tl, __u32 data_len, void *data, __u32 *result);
+		  __u8 secp, __u32 tl, __u32 data_len, void *data);
 int nvme_sec_recv(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
-		  __u8 secp, __u32 al, __u32 data_len, void *data, __u32 *result);
+		  __u8 secp, __u32 al, __u32 data_len, void *data);
 
 int nvme_subsystem_reset(int fd);
 int nvme_reset_controller(int fd);

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -265,13 +265,13 @@ struct rpmb_config_block_t {
 #define RPMB_NVME_SECP        0xEA 
 #define RPMB_NVME_SPSP        0x0001
 
-#define SEND_RPMB_REQ(tgt, size, req, result) \
+#define SEND_RPMB_REQ(tgt, size, req) \
 nvme_sec_send(fd, 0, tgt, RPMB_NVME_SPSP, RPMB_NVME_SECP, size, size, \
-		(unsigned char *)(req), (result))
+		(unsigned char *)(req))
 	
-#define RECV_RPMB_RSP(tgt, size, rsp, result) \
+#define RECV_RPMB_RSP(tgt, size, rsp) \
 nvme_sec_recv(fd, 0, tgt, RPMB_NVME_SPSP, RPMB_NVME_SECP, size, size, \
-		(unsigned char *)(rsp), (result))
+		(unsigned char *)(rsp))
 	
 /* Initialize nonce value in rpmb request frame */
 static void rpmb_nonce_init(struct rpmb_data_frame_t *req)
@@ -379,17 +379,16 @@ rpmb_read_request(int fd,
 	          int rsp_size)
 {
 	struct rpmb_data_frame_t *rsp = NULL;
-	unsigned int result = 0;
 	unsigned char msg[1024] = { 0 };
 	int error;
 
 	sprintf((char *)msg, "RPMB request 0x%04x to target 0x%x",
 		req->type, req->target);
 
-	error = SEND_RPMB_REQ(req->target, req_size, req, &result);
+	error = SEND_RPMB_REQ(req->target, req_size, req);
 	if (error != 0) {
-		fprintf(stderr, "%s failed with error = 0x%x, result = %x\n",
-			msg, error, result);
+		fprintf(stderr, "%s failed with error = 0x%x\n",
+			msg, error);
 		goto error_out;
 	}
 
@@ -401,7 +400,7 @@ rpmb_read_request(int fd,
 	}
 
 	/* Read result of previous request */
-	error = RECV_RPMB_RSP(req->target, rsp_size, rsp, &result);
+	error = RECV_RPMB_RSP(req->target, rsp_size, rsp);
 	if (error) {
 		fprintf(stderr, "error 0x%x receiving response for %s\n",
 			error, msg);
@@ -546,7 +545,6 @@ static int rpmb_program_auth_key(int fd, unsigned char target,
 	struct rpmb_data_frame_t *rsp = NULL;
 	
 	int err = -ENOMEM;
-	unsigned int result = 0;
 	
 	req = rpmb_request_init(req_size, RPMB_REQ_AUTH_KEY_PROGRAM, target,
 				0, 0, 0, key_buf, (223 - key_size), key_size);
@@ -563,8 +561,8 @@ static int rpmb_program_auth_key(int fd, unsigned char target,
 
 	/* re-use response buffer */
 	memset(rsp, 0, rsp_size);
-	err = RECV_RPMB_RSP(req->target, rsp_size, (unsigned char *)rsp, &result);
-	if (err != 0 || result != 0) {
+	err = RECV_RPMB_RSP(req->target, rsp_size, (unsigned char *)rsp);
+	if (err != 0) {
 		err = check_rpmb_response(req, rsp, "Failed to Program Key");
 	}
 out:
@@ -590,7 +588,7 @@ static int auth_data_write_chunk(int fd, unsigned char tgt, unsigned int addr,
 	struct rpmb_data_frame_t *req = NULL;
 	struct rpmb_data_frame_t *rsp = NULL;
 	
-	unsigned int result = 0, write_cntr = 0;
+	unsigned int write_cntr = 0;
 	unsigned char *mac = NULL;
 	int error  = -ENOMEM;
 
@@ -623,10 +621,10 @@ static int auth_data_write_chunk(int fd, unsigned char tgt, unsigned int addr,
 	memcpy(req->mac, mac, 32);
 	
 	/* send the request and get response */
-	error = SEND_RPMB_REQ(tgt, req_size, (unsigned char *)req, &result);
+	error = SEND_RPMB_REQ(tgt, req_size, (unsigned char *)req);
 	if (error != 0) {
-	    fprintf(stderr, "RPMB request 0x%04x for 0x%x, error: %d, result = %x\n",
-		    req->type, tgt, error, result);
+	    fprintf(stderr, "RPMB request 0x%04x for 0x%x, error: %d\n",
+		    req->type, tgt, error);
 	    goto out;
 	}
 	
@@ -634,7 +632,7 @@ static int auth_data_write_chunk(int fd, unsigned char tgt, unsigned int addr,
         rsp = (struct rpmb_data_frame_t *)calloc(rsp_size, 1);
 	rsp->target = req->target;
 	rsp->type = RPMB_REQ_READ_RESULT;
-	error = SEND_RPMB_REQ(tgt, rsp_size, (unsigned char *)rsp, &result);
+	error = SEND_RPMB_REQ(tgt, rsp_size, (unsigned char *)rsp);
 	if (error != 0 || rsp->result != 0) {
 		fprintf(stderr, "Write-data read result 0x%x, error = 0x%x\n",
 			rsp->result, error);
@@ -643,7 +641,7 @@ static int auth_data_write_chunk(int fd, unsigned char tgt, unsigned int addr,
 
 	/* Read final response */
 	memset(rsp, 0, rsp_size);
-	error = RECV_RPMB_RSP(tgt, rsp_size, (unsigned char *)rsp, &result);
+	error = RECV_RPMB_RSP(tgt, rsp_size, (unsigned char *)rsp);
 	if (error != 0)
 		fprintf(stderr, "Auth data write recv error = 0x%x\n", error);
 	else 
@@ -696,7 +694,7 @@ static int rpmb_write_config_block(int fd, unsigned char *cfg_buf,
 	struct rpmb_data_frame_t *req = NULL;
 	struct rpmb_data_frame_t *rsp = NULL;
 	unsigned char *cfg_buf_read = NULL, *mac = NULL;
-	unsigned int write_cntr = 0, result = 0;
+	unsigned int write_cntr = 0;
 	int   error = -ENOMEM;
 	
 	/* initialize request */
@@ -728,7 +726,7 @@ static int rpmb_write_config_block(int fd, unsigned char *cfg_buf,
 	
 	memcpy(req->mac, mac, sizeof(req->mac)); 
 	
-	error = SEND_RPMB_REQ(0, req_size, (unsigned char *)req, &result);
+	error = SEND_RPMB_REQ(0, req_size, (unsigned char *)req);
 	if (error != 0) {
 		fprintf(stderr, "Write-config RPMB request, error = 0x%x\n",
 			error);
@@ -748,7 +746,7 @@ static int rpmb_write_config_block(int fd, unsigned char *cfg_buf,
 	rsp->target = req->target;
 	rsp->type = RPMB_REQ_READ_RESULT;
 	/* get the response and validate */
-	error = RECV_RPMB_RSP(req->target, rsp_size, rsp, &result);
+	error = RECV_RPMB_RSP(req->target, rsp_size, rsp);
 	if (error != 0) {
 		fprintf(stderr,"Failed getting write-config response\
 			error = 0x%x\n", error);

--- a/nvme.c
+++ b/nvme.c
@@ -3618,7 +3618,6 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	int err, fd, sec_fd = -1;
 	void *sec_buf;
 	unsigned int sec_size;
-	__u32 result;
 
 	struct config {
 		__u32 namespace_id;
@@ -3680,13 +3679,13 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	}
 
 	err = nvme_sec_send(fd, cfg.namespace_id, cfg.nssf, cfg.spsp, cfg.secp,
-			cfg.tl, sec_size, sec_buf, &result);
+			cfg.tl, sec_size, sec_buf);
 	if (err < 0)
 		perror("security-send");
 	else if (err != 0)
 		fprintf(stderr, "NVME Security Send Command Error:%d\n", err);
 	else
-		printf("NVME Security Send Command Success:%d\n", result);
+		printf("NVME Security Send Command Success\n");
 
 free:
 	free(sec_buf);
@@ -4997,7 +4996,6 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *nssf = "NVMe Security Specific Field";
 	int err, fd;
 	void *sec_buf = NULL;
-	__u32 result;
 
 	struct config {
 		__u32 namespace_id;
@@ -5041,16 +5039,15 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 	}
 
 	err = nvme_sec_recv(fd, cfg.namespace_id, cfg.nssf, cfg.spsp,
-			cfg.secp, cfg.al, cfg.size, sec_buf, &result);
+			cfg.secp, cfg.al, cfg.size, sec_buf);
 	if (err < 0)
 		perror("security receive");
 	else if (err != 0)
 		fprintf(stderr, "NVME Security Receive Command Error:%d\n",
 									err);
 	else {
+		printf("NVME Security Receive Command Success\n");
 		if (!cfg.raw_binary) {
-			printf("NVME Security Receive Command Success:%d\n",
-							result);
 			d(sec_buf, cfg.size, 16, 1);
 		} else if (cfg.size)
 			d_raw((unsigned char *)sec_buf, cfg.size);


### PR DESCRIPTION
Security Send and Receive commands doesn't fill the CQE CDW0,
remove uncessary passing of result field in both the commands.
The changes are made in RPMB related files since it is dependent
on these commands. RPMB operations only result field as part of
the dataframe and this result is completely different from the
CQE CDW0.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>