### PR TITLE
fabrics: update discovery.conf error message

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1433,7 +1433,7 @@ static int discover_from_conf_file(const char *desc, char *argstr,
 
 	f = fopen(PATH_NVMF_DISC, "r");
 	if (f == NULL) {
-		fprintf(stderr, "No discover params given and no %s conf\n",
+		fprintf(stderr, "No discover params given and no %s\n",
 			PATH_NVMF_DISC);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Remove the extra "conf" in the error message when the open on
/etc/nvme/discovery.conf fails.

Signed-off-by: Martin George <marting@netapp.com>