### PR TITLE
Add device to json output

### DIFF
--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -28,6 +28,7 @@ SYNOPSIS
 		[--queue-size=<#>         | -Q <#>]
 		[--persistent             | -p]
 		[--quiet                  | -S]
+		[--output-format=<fmt>    | -o <fmt>]
 
 DESCRIPTION
 -----------
@@ -174,6 +175,11 @@ OPTIONS
 -S::
 --quiet::
 	Suppress already connected errors.
+
+-o <format>::
+--output-format=<format>::
+              Set the reporting format to 'normal', 'json', or
+              'binary'. Only one output format can be used at a time.
 
 EXAMPLES
 --------


### PR DESCRIPTION
When using `nvme discover -o json ...` the output will include an entry named "`device`" as in this example.
```
{
  "device" : "nvme2",
  "genctr" : 4,
  "records" : [
    {
      "trtype" : "tcp",
      "adrfam" : "ipv4",
      "subtype" : "nvme subsystem",
      "treq" : "not specified, sq flow control disable supported",
      "portid" : 1,
      "trsvcid" : "8009",
      "subnqn" : "storage1",
      "traddr" : "127.0.0.1",
      "sectype" : "none"
    },
    {
      "trtype" : "tcp",
      "adrfam" : "ipv4",
      "subtype" : "nvme subsystem",
      "treq" : "not specified, sq flow control disable supported",
      "portid" : 1,
      "trsvcid" : "8009",
      "subnqn" : "storage2",
      "traddr" : "127.0.0.1",
      "sectype" : "none"
    }
  ]
}
```