### PR TITLE
Making security-send command more flexible

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -839,7 +839,7 @@ int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid)
 }
 
 int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
-		  __u8 secp, __u32 tl, __u32 data_len, void *data)
+		  __u8 secp, __u32 data_len, void *data)
 {
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_security_send,
@@ -847,7 +847,7 @@ int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
 		.data_len	= data_len,
 		.nsid		= nsid,
 		.cdw10		= secp << 24 | spsp << 8 | nssf,
-		.cdw11		= tl,
+		.cdw11		= data_len,
 	};
 
 	return nvme_submit_admin_passthru(fd, &cmd);

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -139,7 +139,7 @@ int nvme_fw_download(int fd, __u32 offset, __u32 data_len, void *data);
 int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid);
 
 int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
-		  __u8 secp, __u32 tl, __u32 data_len, void *data);
+		  __u8 secp, __u32 data_len, void *data);
 int nvme_sec_recv(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
 		  __u8 secp, __u32 al, __u32 data_len, void *data);
 

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -266,7 +266,7 @@ struct rpmb_config_block_t {
 #define RPMB_NVME_SPSP        0x0001
 
 #define SEND_RPMB_REQ(tgt, size, req) \
-nvme_sec_send(fd, 0, tgt, RPMB_NVME_SPSP, RPMB_NVME_SECP, size, size, \
+nvme_sec_send(fd, 0, tgt, RPMB_NVME_SPSP, RPMB_NVME_SECP, size, \
 		(unsigned char *)(req))
 	
 #define RECV_RPMB_RSP(tgt, size, rsp) \

--- a/nvme.c
+++ b/nvme.c
@@ -3681,7 +3681,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		goto close_sec_fd;
 	}
 
-	memset(sec_buf, 0, cfg.tl); // ensure zero fill if buf_size > sec_size
+	memset(sec_buf, 0, cfg.tl); // ensure zero fill if cfg.tl > sec_size
 
 	err = read(sec_fd, sec_buf, sec_size);
 	if (err < 0) {
@@ -3692,7 +3692,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	}
 
 	err = nvme_sec_send(fd, cfg.namespace_id, cfg.nssf, cfg.spsp, cfg.secp,
-			cfg.tl, cfg.tl, sec_buf);
+			cfg.tl, sec_buf);
 	if (err < 0)
 		perror("security-send");
 	else if (err != 0)

--- a/nvme.c
+++ b/nvme.c
@@ -3614,7 +3614,8 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *nssf = "NVMe Security Specific Field";
 	int err, fd, sec_fd = -1;
 	void *sec_buf;
-	unsigned int sec_size;
+	unsigned int sec_size, buf_size;
+	int nread = 0;
 
 	struct config {
 		__u32 namespace_id;
@@ -3646,23 +3647,38 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	if (fd < 0)
 		goto ret;
 
-	sec_fd = open(cfg.file, O_RDONLY);
-	if (sec_fd < 0) {
-		fprintf(stderr, "Failed to open %s: %s\n",
-				cfg.file, strerror(errno));
-		err = -EINVAL;
-		goto close_fd;
+	if ((cfg.tl & 3) != 0)
+		fprintf(stderr, "WARNING: transfer length not dword-aligned; data will be truncated\n");
+
+	if (strlen(cfg.file) == 0) {
+		sec_fd = STDIN_FILENO;
+
+		if (cfg.tl || ioctl(sec_fd, FIONREAD, &nread) < 0)
+			sec_size = cfg.tl;
+		else
+			sec_size = ((unsigned int) nread + 3) & ~3; // align to avoid truncation
+	} else {
+		sec_fd = open(cfg.file, O_RDONLY);
+		if (sec_fd < 0) {
+			fprintf(stderr, "Failed to open %s: %s\n",
+					cfg.file, strerror(errno));
+			err = -EINVAL;
+			goto close_fd;
+		}
+
+		err = fstat(sec_fd, &sb);
+		if (err < 0) {
+			perror("fstat");
+			goto close_sec_fd;
+		}
+
+		sec_size = sb.st_size;
 	}
 
-	err = fstat(sec_fd, &sb);
-	if (err < 0) {
-		perror("fstat");
-		goto close_sec_fd;
-	}
+	buf_size = cfg.tl ? cfg.tl : sec_size;
 
-	sec_size = sb.st_size;
-	if (posix_memalign(&sec_buf, getpagesize(), sec_size)) {
-		fprintf(stderr, "No memory for security size:%d\n", sec_size);
+	if (posix_memalign(&sec_buf, getpagesize(), buf_size)) {
+		fprintf(stderr, "No memory for security size:%d\n", buf_size);
 		err = -ENOMEM;
 		goto close_sec_fd;
 	}
@@ -3676,7 +3692,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	}
 
 	err = nvme_sec_send(fd, cfg.namespace_id, cfg.nssf, cfg.spsp, cfg.secp,
-			cfg.tl, sec_size, sec_buf);
+			buf_size, buf_size, sec_buf);
 	if (err < 0)
 		perror("security-send");
 	else if (err != 0)

--- a/nvme.c
+++ b/nvme.c
@@ -3614,8 +3614,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *nssf = "NVMe Security Specific Field";
 	int err, fd, sec_fd = -1;
 	void *sec_buf;
-	unsigned int sec_size, buf_size;
-	int nread = 0;
+	unsigned int sec_size;
 
 	struct config {
 		__u32 namespace_id;
@@ -3647,13 +3646,17 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	if (fd < 0)
 		goto ret;
 
+	if (cfg.tl == 0) {
+		fprintf(stderr, "--tl unspecified or zero\n");
+		err = -EINVAL;
+		goto close_fd;
+	}
+	if ((cfg.tl & 3) != 0)
+		fprintf(stderr, "WARNING: --tl not dword aligned; unaligned bytes may be truncated\n");
+
 	if (strlen(cfg.file) == 0) {
 		sec_fd = STDIN_FILENO;
-
-		if (cfg.tl || ioctl(sec_fd, FIONREAD, &nread) < 0)
-			sec_size = cfg.tl;
-		else
-			sec_size = (unsigned int) nread;
+		sec_size = cfg.tl;
 	} else {
 		sec_fd = open(cfg.file, O_RDONLY);
 		if (sec_fd < 0) {
@@ -3669,19 +3672,16 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 			goto close_sec_fd;
 		}
 
-		sec_size = sb.st_size;
+		sec_size = cfg.tl > sb.st_size ? cfg.tl : sb.st_size;
 	}
 
-	buf_size = cfg.tl ? cfg.tl : sec_size;
-	buf_size = (buf_size + 3) & ~3; // dword align to avoid truncation
-
-	if (posix_memalign(&sec_buf, getpagesize(), buf_size)) {
-		fprintf(stderr, "No memory for security size:%d\n", buf_size);
+	if (posix_memalign(&sec_buf, getpagesize(), cfg.tl)) {
+		fprintf(stderr, "No memory for security size:%d\n", cfg.tl);
 		err = -ENOMEM;
 		goto close_sec_fd;
 	}
 
-	memset(sec_buf, 0, buf_size); // ensure zero fill if buf_size > sec_size
+	memset(sec_buf, 0, cfg.tl); // ensure zero fill if buf_size > sec_size
 
 	err = read(sec_fd, sec_buf, sec_size);
 	if (err < 0) {
@@ -3692,7 +3692,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	}
 
 	err = nvme_sec_send(fd, cfg.namespace_id, cfg.nssf, cfg.spsp, cfg.secp,
-			buf_size, buf_size, sec_buf);
+			cfg.tl, cfg.tl, sec_buf);
 	if (err < 0)
 		perror("security-send");
 	else if (err != 0)


### PR DESCRIPTION
 by allowing data from stdin, and assuming transfer length to match input size if not specified.

resolve #951 