### PR TITLE
nvme: refactor and improve the passthru function

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -44,7 +44,7 @@ static const char *nvme_ana_state_to_string(enum nvme_ana_state state)
 	return "invalid state";
 }
 
-static const char *nvme_cmd_to_string(int admin, __u8 opcode)
+const char *nvme_cmd_to_string(int admin, __u8 opcode)
 {
 	if (admin) {
 		switch (opcode) {

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -11,7 +11,7 @@ uint64_t int48_to_long(__u8 *data);
 
 void nvme_show_status(__u16 status);
 void nvme_show_relatives(const char *name);
-
+const char *nvme_cmd_to_string(int admin, __u8 opcode);
 void __nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode,
 	void (*vendor_show)(__u8 *vs, struct json_object *root));
 void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, unsigned int mode);


### PR DESCRIPTION
Refactor and improve the passthru, io-passthru and admin-passthru
result printing based on the command opcode and type by using the
cmd_to_string.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>