### PR TITLE
nvme: fix dsm and copy commands free up buffers

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4090,6 +4090,8 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	else
 		printf("NVMe DSM: success\n");
 
+	free(dsm);
+
 close_fd:
 	close(fd);
 ret:
@@ -4218,6 +4220,8 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 		nvme_show_status(err);
 	else
 		printf("NVMe Copy: success\n");
+
+	free(copy);
 
 close_fd:
 	close(fd);


### PR DESCRIPTION
In DSM and Copy Commands buffers which dyamically allocated
not freed, fixing that.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>