### PR TITLE
nvme: address 1.4 to 1.4b changes for Change NS event type

### DIFF
--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -781,7 +781,8 @@ struct nvme_change_ns_event {
 	__le32	nsmgt_cdw10;
 	__u8	rsvd4[4];
 	__le64	nsze;
-	__u8	nscap[16];
+	__u8	rsvd16[8];
+	__le64	nscap;
 	__u8	flbas;
 	__u8	dps;
 	__u8	nmic;

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1267,9 +1267,8 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 				le32_to_cpu(ns_event->nsmgt_cdw10));
 			json_object_add_value_uint(valid_attrs, "nsze",
 				le64_to_cpu(ns_event->nsze));
-			long double nscap = int128_to_double(ns_event->nscap);
-			json_object_add_value_float(valid_attrs, "nscap",
-				nscap);
+			json_object_add_value_uint(valid_attrs, "nscap",
+				le64_to_cpu(ns_event->nscap));
 			json_object_add_value_uint(valid_attrs, "flbas",
 				ns_event->flbas);
 			json_object_add_value_uint(valid_attrs, "dps",
@@ -1506,8 +1505,8 @@ void nvme_show_persistent_event_log(void *pevent_log_info,
 				le32_to_cpu(ns_event->nsmgt_cdw10));
 			printf("Namespace Size: %"PRIu64"\n",
 				le64_to_cpu(ns_event->nsze));
-			printf("Namespace Capacity: %'.0Lf\n",
-				int128_to_double(ns_event->nscap));
+			printf("Namespace Capacity: %"PRIu64"\n",
+				le64_to_cpu(ns_event->nscap));
 			printf("Formatted LBA Size: %u\n", ns_event->flbas);
 			printf("End-to-end Data Protection Type Settings: %u\n",
 				ns_event->dps);


### PR DESCRIPTION
In NVMe 1.4 spec. Change Namespace Event Type (06h) of persistent
event log Data Format - NCAP field was assigned with 16 bytes. Now
in 1.4b spec. its modified to 8 bytes.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>