### PR TITLE
Build against json-c library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ override CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__
 LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
 LIBHUGETLBFS = $(shell $(LD) -o /dev/null -lhugetlbfs >/dev/null 2>&1; echo $$?)
 HAVE_SYSTEMD = $(shell pkg-config --exists libsystemd  --atleast-version=242; echo $$?)
+LIBJSONC = $(shell $(LD) -o /dev/null -ljson-c >/dev/null 2>&1; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =
@@ -37,6 +38,11 @@ ifeq ($(HAVE_SYSTEMD),0)
 	override CFLAGS += -DHAVE_SYSTEMD
 endif
 
+ifeq ($(LIBJSONC), 0)
+	override LDFLAGS += -ljson-c
+	override CFLAGS += -DLIBJSONC
+endif
+
 RPMBUILD = rpmbuild
 TAR = tar
 RM = rm -f
@@ -62,7 +68,10 @@ OBJS := nvme-print.o nvme-ioctl.o nvme-rpmb.o \
 	nvme-lightnvm.o fabrics.o nvme-models.o plugin.o \
 	nvme-status.o nvme-filters.o nvme-topology.o
 
-UTIL_OBJS := util/argconfig.o util/suffix.o util/json.o util/parser.o
+UTIL_OBJS := util/argconfig.o util/suffix.o util/parser.o
+ifneq ($(LIBJSONC), 0)
+override UTIL_OBJS += util/json.o
+endif
 
 PLUGIN_OBJS :=					\
 	plugins/intel/intel-nvme.o		\

--- a/fabrics.c
+++ b/fabrics.c
@@ -706,7 +706,7 @@ static void print_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 static void json_discovery_log(struct nvmf_disc_rsp_page_hdr *log, int numrec)
 {
 	struct json_object *root;
-	struct json_array *entries;
+	struct json_object *entries;
 	int i;
 
 	root = json_create_object();

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5,8 +5,8 @@
 #include <time.h>
 #include <sys/stat.h>
 
+#include "nvme.h"
 #include "nvme-print.h"
-#include "util/json.h"
 #include "nvme-models.h"
 #include "util/suffix.h"
 #include "common.h"
@@ -133,7 +133,7 @@ static void json_nvme_id_ns(struct nvme_id_ns *ns)
 		eui64_buf[2 * sizeof(ns->eui64) + 1];
 	char *nguid = nguid_buf, *eui64 = eui64_buf;
 	struct json_object *root;
-	struct json_array *lbafs;
+	struct json_object *lbafs;
 	int i;
 
 	long double nvmcap = int128_to_double(ns->nvmcap);
@@ -212,7 +212,7 @@ static void json_nvme_id_ctrl(struct nvme_id_ctrl *ctrl,
 			void (*vs)(__u8 *vs, struct json_object *root))
 {
 	struct json_object *root;
-	struct json_array *psds;
+	struct json_object *psds;
 
 	long double tnvmcap = int128_to_double(ctrl->tnvmcap);
 	long double unvmcap = int128_to_double(ctrl->unvmcap);
@@ -353,7 +353,7 @@ static void json_nvme_id_ctrl(struct nvme_id_ctrl *ctrl,
 static void json_error_log(struct nvme_error_log_page *err_log, int entries)
 {
 	struct json_object *root;
-	struct json_array *errors;
+	struct json_object *errors;
 	int i;
 
 	root = json_create_object();
@@ -396,7 +396,7 @@ static void json_nvme_resv_report(struct nvme_reservation_status *status,
 				  int bytes, __u32 cdw11)
 {
 	struct json_object *root;
-	struct json_array *rcs;
+	struct json_object *rcs;
 	int i, j, regctl, entries;
 
 	regctl = status->regctl[0] | (status->regctl[1] << 8);
@@ -678,8 +678,8 @@ static void json_ana_log(struct nvme_ana_rsp_hdr *ana_log, const char *devname)
 	int offset = sizeof(struct nvme_ana_rsp_hdr);
 	struct nvme_ana_rsp_hdr *hdr = ana_log;
 	struct nvme_ana_group_desc *ana_desc;
-	struct json_array *desc_list;
-	struct json_array *ns_list;
+	struct json_object *desc_list;
+	struct json_object *ns_list;
 	struct json_object *desc;
 	struct json_object *nsid;
 	struct json_object *root;
@@ -735,7 +735,7 @@ static void json_self_test_log(struct nvme_self_test_log *self_test, __u8 dst_en
 {
 	struct json_object *valid_attrs;
 	struct json_object *root;
-	struct json_array *valid;
+	struct json_object *valid;
 	int i;
 	__u32 num_entries;
 
@@ -950,7 +950,7 @@ void json_predictable_latency_event_agg_log(
 {
 	struct json_object *root;
 	struct json_object *valid_attrs;
-	struct json_array *valid;
+	struct json_object *valid;
 	__u64 num_iter;
 	__u64 num_entries;
 
@@ -1033,7 +1033,7 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 {
 	struct json_object *root;
 	struct json_object *valid_attrs;
-	struct json_array *valid;
+	struct json_object *valid;
 	__u32 offset, por_info_len, por_info_list;
 	__u64 *fw_rev;
 	char key[128];
@@ -1580,7 +1580,7 @@ void json_endurance_group_event_agg_log(
 {
 	struct json_object *root;
 	struct json_object *valid_attrs;
-	struct json_array *valid;
+	struct json_object *valid;
 
 	root = json_create_object();
 	json_object_add_value_uint(root, "num_entries_avail",
@@ -1628,8 +1628,8 @@ void json_lba_status_log(void *lba_status)
 	struct json_object *root;
 	struct json_object *desc;
 	struct json_object *element;
-	struct json_array *desc_list;
-	struct json_array *elements_list;
+	struct json_object *desc_list;
+	struct json_object *elements_list;
 	struct nvme_lba_status_hdr *hdr;
 	struct nvme_lba_status_ns_element *ns_element;
 	struct nvme_lba_status_range_desc *range_desc;
@@ -1675,7 +1675,7 @@ void json_lba_status_log(void *lba_status)
 
 		json_object_add_value_array(element, "descs", desc_list);
 		json_array_add_value_object(elements_list, element);
-    }
+	}
 
 	json_object_add_value_array(root, "ns_elements", elements_list);
 	json_print_object(root, NULL);
@@ -1800,7 +1800,7 @@ static void nvme_show_subsystem(struct nvme_subsystem *s)
 static void json_print_nvme_subsystem_list(struct nvme_topology *t)
 {
 	struct json_object *subsystem_attrs, *path_attrs;
-	struct json_array *subsystems, *paths;
+	struct json_object *subsystems, *paths;
 	struct json_object *root;
 	int i, j;
 
@@ -3492,7 +3492,7 @@ static void json_nvme_id_ns_descs(void *data)
 	} desc;
 
 	struct json_object *root;
-	struct json_array *json_array = NULL;
+	struct json_object *json_array = NULL;
 
 	off_t off;
 	int pos, len = 0;
@@ -3911,7 +3911,7 @@ void json_nvme_zns_id_ns(struct nvme_zns_id_ns *ns,
 	struct nvme_id_ns *id_ns)
 {
 	struct json_object *root;
-	struct json_array *lbafs;
+	struct json_object *lbafs;
 	int i;
 
 	root = json_create_object();
@@ -4135,7 +4135,7 @@ void nvme_show_zns_report_zones(void *report, __u32 descs,
 static void json_nvme_id_nvmset(struct nvme_id_nvmset *nvmset)
 {
 	__u32 nent = nvmset->nid;
-	struct json_array *entries;
+	struct json_object *entries;
 	struct json_object *root;
 	int i;
 
@@ -4205,7 +4205,7 @@ static void json_nvme_list_secondary_ctrl(const struct nvme_secondary_controller
 {
 	const struct nvme_secondary_controller_entry *sc_entry = &sc_list->sc_entry[0];
 	__u32 nent = min(sc_list->num, count);
-	struct json_array *entries;
+	struct json_object *entries;
 	struct json_object *root;
 	int i;
 
@@ -4285,7 +4285,7 @@ static void json_nvme_id_ns_granularity_list(
 {
 	int i;
 	struct json_object *root;
-	struct json_array *entries;
+	struct json_object *entries;
 
 	root = json_create_object();
 
@@ -4341,7 +4341,7 @@ void nvme_show_id_ns_granularity_list(const struct nvme_id_ns_granularity_list *
 static void json_nvme_id_uuid_list(const struct nvme_id_uuid_list *uuid_list)
 {
 	struct json_object *root;
-	struct json_array *entries;
+	struct json_object *entries;
 	int i;
 
 	root = json_create_object();
@@ -5896,7 +5896,7 @@ static void json_detail_list(struct nvme_topology *t)
 {
 	int i, j, k;
 	struct json_object *root;
-	struct json_array *devices;
+	struct json_object *devices;
 	char formatter[41] = { 0 };
 
 	root = json_create_object();
@@ -5905,7 +5905,7 @@ static void json_detail_list(struct nvme_topology *t)
 	for (i = 0; i < t->nr_subsystems; i++) {
 		struct nvme_subsystem *s = &t->subsystems[i];
 		struct json_object *subsys_attrs;
-		struct json_array *namespaces, *ctrls;
+		struct json_object *namespaces, *ctrls;
 
 		subsys_attrs = json_create_object();
 		json_object_add_value_string(subsys_attrs, "Subsystem", s->name);
@@ -5916,7 +5916,7 @@ static void json_detail_list(struct nvme_topology *t)
 		for (j = 0; j < s->nr_ctrls; j++) {
 			struct json_object *ctrl_attrs = json_create_object();
 			struct nvme_ctrl *c = &s->ctrls[j];
-			struct json_array *namespaces;
+			struct json_object *namespaces;
 
 			json_object_add_value_string(ctrl_attrs, "Controller", c->name);
 			if (c->transport)
@@ -5978,7 +5978,7 @@ static void json_detail_list(struct nvme_topology *t)
 	json_free_object(root);
 }
 
-static void json_simple_ns(struct nvme_namespace *n, struct json_array *devices)
+static void json_simple_ns(struct nvme_namespace *n, struct json_object *devices)
 {
 	struct json_object *device_attrs;
 	char formatter[41] = { 0 };
@@ -6040,7 +6040,7 @@ static void json_simple_ns(struct nvme_namespace *n, struct json_array *devices)
 static void json_simple_list(struct nvme_topology *t)
 {
 	struct json_object *root;
-	struct json_array *devices;
+	struct json_object *devices;
 	int i, j, k;
 
 	root = json_create_object();

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -2,7 +2,6 @@
 #define NVME_PRINT_H
 
 #include "nvme.h"
-#include "util/json.h"
 #include <inttypes.h>
 
 void d(unsigned char *buf, int len, int width, int group);

--- a/nvme.h
+++ b/nvme.h
@@ -22,7 +22,32 @@
 #include <sys/time.h>
 
 #include "plugin.h"
+#ifdef LIBJSONC
+#include <json-c/json.h>
+
+#define json_create_object(o) json_object_new_object(o)
+#define json_create_array(a) json_object_new_array(a)
+#define json_free_object(o) json_object_put(o)
+#define json_free_array(a) json_object_put(a)
+#define json_object_add_value_uint(o, k, v) \
+	json_object_object_add(o, k, json_object_new_int(v))
+#define json_object_add_value_int(o, k, v) \
+	json_object_object_add(o, k, json_object_new_int(v))
+#define json_object_add_value_float(o, k, v) \
+	json_object_object_add(o, k, json_object_new_double(v))
+#define json_object_add_value_string(o, k, v) \
+	json_object_object_add(o, k, json_object_new_string(v))
+#define json_object_add_value_array(o, k, v) \
+	json_object_object_add(o, k, v)
+#define json_object_add_value_object(o, k, v) \
+	json_object_object_add(o, k, v)
+#define json_array_add_value_object(o, k) \
+	json_object_array_add(o, k)
+#define json_print_object(o, u)						\
+	printf("%s", json_object_to_json_string_ext(o, JSON_C_TO_STRING_PRETTY))
+#else
 #include "util/json.h"
+#endif
 #include "util/argconfig.h"
 #include "linux/nvme.h"
 

--- a/plugins/amzn/amzn-nvme.c
+++ b/plugins/amzn/amzn-nvme.c
@@ -11,7 +11,6 @@
 #include "nvme.h"
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
-#include "json.h"
 #include "plugin.h"
 
 #include "argconfig.h"

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -32,7 +32,6 @@
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
 #include "plugin.h"
-#include "json.h"
 
 #include "argconfig.h"
 #include "suffix.h"
@@ -143,7 +142,7 @@ static void huawei_json_print_list_items(struct huawei_list_item *list_items,
 					 unsigned len)
 {
 	struct json_object *root;
-	struct json_array *devices;
+	struct json_object *devices;
 	struct json_object *device_attrs;
 	char formatter[128] = { 0 };
 	int index, i = 0;

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -11,7 +11,6 @@
 #include "nvme.h"
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
-#include "json.h"
 #include "plugin.h"
 
 #include "argconfig.h"

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -680,7 +680,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *cmd,
     };
     bool is_json = false;
     struct json_object *root;
-    struct json_array *logPages;
+    struct json_object *logPages;
     int fd;
 
     OPT_ARGS(opts) = {
@@ -870,7 +870,7 @@ static int micron_pcie_stats(int argc, char **argv,
     if (is_json) {
 
         struct json_object *root = json_create_object();
-        struct json_array  *pcieErrors = json_create_array();
+        struct json_object *pcieErrors = json_create_array();
         struct json_object *stats = json_create_object();
 
         json_object_add_value_array(root, "PCIE Stats", pcieErrors);
@@ -1207,7 +1207,7 @@ static void print_micron_vs_logs(
 static void print_smart_cloud_health_log(__u8 *buf, bool is_json)
 {
     struct json_object *root;
-    struct json_array *logPages;
+    struct json_object *logPages;
     struct json_object *stats = NULL;
     int    field_count = sizeof(ocp_c0_log_page)/sizeof(ocp_c0_log_page[0]);
 
@@ -1232,7 +1232,7 @@ static void print_smart_cloud_health_log(__u8 *buf, bool is_json)
 static void print_nand_stats_fb(__u8 *buf, __u8 *buf2, __u8 nsze, bool is_json)
 {
     struct json_object *root;
-    struct json_array *logPages;
+    struct json_object *logPages;
     struct json_object *stats = NULL;
     int    field_count = sizeof(fb_log_page)/sizeof(fb_log_page[0]);
 
@@ -1276,7 +1276,7 @@ static void print_nand_stats_d0(__u8 *buf, __u8 oacs, bool is_json)
     if (is_json) {
         struct json_object *root = json_create_object();
         struct json_object *stats = json_create_object();
-        struct json_array  *logPages = json_create_array();
+        struct json_object *logPages = json_create_array();
 
         json_object_add_value_array(root,
                                     "Extended Smart Log Page : 0xD0",

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -25,7 +25,6 @@
 
 #include "nvme.h"
 #include "nvme-ioctl.h"
-#include "json.h"
 
 #include "suffix.h"
 
@@ -197,7 +196,7 @@ static void netapp_get_ontap_labels(char *vsname, char *nspath,
 			vol_name, "/", ns_name);
 }
 
-static void netapp_smdevice_json(struct json_array *devices, char *devname,
+static void netapp_smdevice_json(struct json_object *devices, char *devname,
 		char *arrayname, char *volname, int nsid, char *nguid,
 		char *ctrl, char *astate, char *size, long long lba,
 		long long nsze)
@@ -219,7 +218,7 @@ static void netapp_smdevice_json(struct json_array *devices, char *devname,
 	json_array_add_value_object(devices, device_attrs);
 }
 
-static void netapp_ontapdevice_json(struct json_array *devices, char *devname,
+static void netapp_ontapdevice_json(struct json_object *devices, char *devname,
 		char *vsname, char *nspath, int nsid, char *uuid,
 		char *size, long long lba, long long nsze)
 {
@@ -241,7 +240,7 @@ static void netapp_ontapdevice_json(struct json_array *devices, char *devname,
 static void netapp_smdevices_print(struct smdevice_info *devices, int count, int format)
 {
 	struct json_object *root = NULL;
-	struct json_array *json_devices = NULL;
+	struct json_object *json_devices = NULL;
 	int i, slta;
 	char array_label[ARRAY_LABEL_LEN / 2 + 1];
 	char volume_label[VOLUME_LABEL_LEN / 2 + 1];
@@ -266,7 +265,7 @@ static void netapp_smdevices_print(struct smdevice_info *devices, int count, int
 	else if (format == NJSON) {
 		/* prepare for json output */
 		root = json_create_object();
-		json_devices = json_create_array();
+		json_devices = json_create_object();
 	}
 
 	for (i = 0; i < count; i++) {
@@ -304,7 +303,7 @@ static void netapp_ontapdevices_print(struct ontapdevice_info *devices,
 		int count, int format)
 {
 	struct json_object *root = NULL;
-	struct json_array *json_devices = NULL;
+	struct json_object *json_devices = NULL;
 	char vsname[ONTAP_LABEL_LEN] = " ";
 	char nspath[ONTAP_NS_PATHLEN] = " ";
 	long long lba;
@@ -332,7 +331,7 @@ static void netapp_ontapdevices_print(struct ontapdevice_info *devices,
 	} else if (format == NJSON) {
 		/* prepare for json output */
 		root = json_create_object();
-		json_devices = json_create_array();
+		json_devices = json_create_object();
 	}
 
 	for (i = 0; i < count; i++) {

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -17,7 +17,6 @@
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
 #include "nvme-status.h"
-#include "json.h"
 #include "plugin.h"
 
 #include "argconfig.h"

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -36,7 +36,6 @@
 #include "plugin.h"
 #include "argconfig.h"
 #include "suffix.h"
-#include "json.h"
 
 #define CREATE_CMD
 
@@ -132,7 +131,7 @@ static char *log_pages_supp_print(__u32 pageID)
 static void json_log_pages_supp(log_page_map *logPageMap)
 {
 	struct json_object *root;
-	struct json_array *logPages;
+	struct json_object *logPages;
 	__u32 i = 0;
 
 	root = json_create_object();
@@ -494,7 +493,7 @@ static void json_print_smart_log(struct json_object *root,
 				 EXTENDED_SMART_INFO_T *ExtdSMARTInfo )
 {
 	/*struct json_object *root; */
-	struct json_array *lbafs;
+	struct json_object *lbafs;
 	int index = 0;
 
 	static __u64 lsbGbErased = 0, msbGbErased = 0, lsbLifWrtToFlash = 0, msbLifWrtToFlash = 0,
@@ -651,7 +650,7 @@ static void json_print_smart_log_CF(struct json_object *root,
 				    vendor_log_page_CF *pLogPageCF)
 {
 	/*struct json_object *root;*/
-	struct json_array *logPages;
+	struct json_object *logPages;
 	unsigned int currentTemp, maxTemp;
 	char buf[40];
 
@@ -716,11 +715,9 @@ static int vs_smart_log(int argc, char **argv, struct command *cmd, struct plugi
 	EXTENDED_SMART_INFO_T   ExtdSMARTInfo;
 	vendor_log_page_CF      logPageCF;
 	int fd;
-	struct json_object *root;
-	struct json_array *lbafs;
+	struct json_object *root = json_create_object();
+	struct json_object *lbafs = json_create_array();
 	struct json_object *lbafs_ExtSmart, *lbafs_DramSmart;
-	root = json_create_object();
-	lbafs = json_create_array();
 
 	const char *desc = "Retrieve Seagate Extended SMART information for the given device ";
 	const char *output_format = "output in binary format";

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -11,7 +11,6 @@
 #include "nvme.h"
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
-#include "json.h"
 #include "plugin.h"
 
 #include "argconfig.h"

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -37,7 +37,6 @@
 #include "nvme-print.h"
 #include "nvme-ioctl.h"
 #include "plugin.h"
-#include "json.h"
 #include "nvme-status.h"
 
 #include "argconfig.h"

--- a/util/json.c
+++ b/util/json.c
@@ -19,9 +19,9 @@ struct json_object *json_create_object(void)
 	return test;
 }
 
-struct json_array *json_create_array(void)
+struct json_object *json_create_array(void)
 {
-	void *test = calloc(1, sizeof(struct json_array));
+	void *test = calloc(1, sizeof(struct json_object));
 	if (!test)
 		fail_and_notify();
 	return test;
@@ -146,7 +146,7 @@ static struct json_value *json_create_value_object(struct json_object *obj)
 	return value;
 }
 
-static struct json_value *json_create_value_array(struct json_array *array)
+static struct json_value *json_create_value_array(struct json_object *array)
 {
 	struct json_value *value = malloc(sizeof(struct json_value));
 
@@ -173,7 +173,7 @@ void json_free_object(struct json_object *obj)
 	free(obj);
 }
 
-void json_free_array(struct json_array *array)
+void json_free_array(struct json_object *array)
 {
 	int i;
 
@@ -206,7 +206,7 @@ static void json_free_value(struct json_value *value)
 	free(value);
 }
 
-static int json_array_add_value(struct json_array *array, struct json_value *value)
+static int json_array_add_value(struct json_object *array, struct json_value *value)
 {
 	struct json_value **values = realloc(array->values,
 		sizeof(struct json_value *) * (array->value_cnt + 1));
@@ -255,7 +255,7 @@ int json_object_add_value_type(struct json_object *obj, const char *name, int ty
 	else if (type == JSON_TYPE_OBJECT)
 		value = json_create_value_object(va_arg(args, struct json_object *));
 	else
-		value = json_create_value_array(va_arg(args, struct json_array *));
+		value = json_create_value_array(va_arg(args, struct json_object *));
 	va_end(args);
 
 	if (!value)
@@ -274,8 +274,8 @@ int json_object_add_value_type(struct json_object *obj, const char *name, int ty
 	return 0;
 }
 
-static void json_print_array(struct json_array *array, void *);
-int json_array_add_value_type(struct json_array *array, int type, ...)
+static void json_print_array(struct json_object *array, void *);
+int json_array_add_value_type(struct json_object *array, int type, ...)
 {
 	struct json_value *value;
 	va_list args;
@@ -293,7 +293,7 @@ int json_array_add_value_type(struct json_array *array, int type, ...)
 	else if (type == JSON_TYPE_OBJECT)
 		value = json_create_value_object(va_arg(args, struct json_object *));
 	else
-		value = json_create_value_array(va_arg(args, struct json_array *));
+		value = json_create_value_array(va_arg(args, struct json_object *));
 	va_end(args);
 
 	if (!value)
@@ -309,7 +309,7 @@ int json_array_add_value_type(struct json_array *array, int type, ...)
 
 static int json_value_level(struct json_value *value);
 static int json_pair_level(struct json_pair *pair);
-static int json_array_level(struct json_array *array);
+static int json_array_level(struct json_object *array);
 static int json_object_level(struct json_object *object)
 {
 	if (object->parent == NULL)
@@ -322,7 +322,7 @@ static int json_pair_level(struct json_pair *pair)
 	return json_object_level(pair->parent) + 1;
 }
 
-static int json_array_level(struct json_array *array)
+static int json_array_level(struct json_object *array)
 {
 	return json_value_level(array->parent);
 }
@@ -342,7 +342,7 @@ static void json_print_level(int level, void *out)
 }
 
 static void json_print_pair(struct json_pair *pair, void *);
-static void json_print_array(struct json_array *array, void *);
+static void json_print_array(struct json_object *array, void *);
 static void json_print_value(struct json_value *value, void *);
 void json_print_object(struct json_object *obj, void *out)
 {
@@ -366,7 +366,7 @@ static void json_print_pair(struct json_pair *pair, void *out)
 	json_print_value(pair->value, out);
 }
 
-static void json_print_array(struct json_array *array, void *out)
+static void json_print_array(struct json_object *array, void *out)
 {
 	int i;
 

--- a/util/json.h
+++ b/util/json.h
@@ -2,7 +2,6 @@
 #define __JSON__H
 
 struct json_object;
-struct json_array;
 struct json_pair;
 
 #define JSON_TYPE_STRING 0
@@ -21,22 +20,18 @@ struct json_value {
 		long double float_number;
 		char *string;
 		struct json_object *object;
-		struct json_array *array;
+		struct json_object *array;
 	};
 	int parent_type;
 	union {
 		struct json_pair *parent_pair;
-		struct json_array *parent_array;
+		struct json_object *parent_array;
 	};
 };
 
-struct json_array {
+struct json_object {
 	struct json_value **values;
 	int value_cnt;
-	struct json_value *parent;
-};
-
-struct json_object {
 	struct json_pair **pairs;
 	int pair_cnt;
 	struct json_value *parent;
@@ -49,10 +44,10 @@ struct json_pair {
 };
 
 struct json_object *json_create_object(void);
-struct json_array *json_create_array(void);
+struct json_object *json_create_array(void);
 
 void json_free_object(struct json_object *obj);
-void json_free_array(struct json_array *array);
+void json_free_array(struct json_object *array);
 
 int json_object_add_value_type(struct json_object *obj, const char *name, int type, ...);
 #define json_object_add_value_int(obj, name, val) \
@@ -67,7 +62,7 @@ int json_object_add_value_type(struct json_object *obj, const char *name, int ty
 	json_object_add_value_type((obj), name, JSON_TYPE_OBJECT, (val))
 #define json_object_add_value_array(obj, name, val) \
 	json_object_add_value_type((obj), name, JSON_TYPE_ARRAY, (val))
-int json_array_add_value_type(struct json_array *array, int type, ...);
+int json_array_add_value_type(struct json_object *array, int type, ...);
 #define json_array_add_value_int(obj, val) \
 	json_array_add_value_type((obj), JSON_TYPE_INTEGER, (val))
 #define json_array_add_value_uint(obj, val) \


### PR DESCRIPTION
For future improvements like parsing json configurations we should be building against a 'real' json library; that'll save us having to implement the necessary functions ourselves. And as json-c has a quite similar structure we can use is as a drop-in replacement for our internal json functions.

Signed-off-by: Hannes Reinecke <hare@suse.de>