### PR TITLE
fabrics: fix infinite loop on invalid parameters

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1241,7 +1241,8 @@ retry:
 		ret = do_discover(argstr, true, flags);
 	} else
 		ret = add_ctrl(argstr);
-	if (ret == -EINVAL && e->treq & NVMF_TREQ_DISABLE_SQFLOW) {
+	if (ret == -EINVAL && disable_sqflow &&
+	    e->treq & NVMF_TREQ_DISABLE_SQFLOW) {
 		/* disable_sqflow param might not be supported, try without it */
 		disable_sqflow = false;
 		goto retry;


### PR DESCRIPTION
When parsing the discovery entries results in invalid parameters
for a given connection we'll enter an infinite loop as the -EINVAL
error code is always assumed to indicate a wrong 'disable_sqflow'
setting.

Signed-off-by: Hannes Reinecke <hare@suse.de>