### PR TITLE
nvme: fix timestamp feature in set feature

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3606,8 +3606,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 
 	if (buf) {
 	  /* if feature ID is 0x0E, get timestamp value by -v option */
-        if ((NVME_FEAT_TIMESTAMP == cfg.feature_id) &&  (0 != cfg.value)) {
-            cfg.data_len = NVME_FEAT_TIMESTAMP_DATA_SIZE;
+        if (NVME_FEAT_TIMESTAMP == cfg.feature_id && cfg.value) {
             memcpy(buf, &cfg.value, NVME_FEAT_TIMESTAMP_DATA_SIZE);
         }
         else {
@@ -3631,7 +3630,6 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
             if (NVME_FEAT_TIMESTAMP == cfg.feature_id) {
                 number = strtoul(buf, &endptr, STRTOUL_AUTO_BASE);
                 memset(buf, 0, cfg.data_len);
-                cfg.data_len = NVME_FEAT_TIMESTAMP_DATA_SIZE;
                 memcpy(buf, &number, NVME_FEAT_TIMESTAMP_DATA_SIZE);
             }
         }


### PR DESCRIPTION
In Timestamp feature structure size is 8 bytes, since the 6th
and 7th bytes are reserved no need to change the data len
parameter to 6 bytes. Another fix required for the data len of
time stamp i.e. mentioned as 13, it fixed and sent it as PR #983

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>