### PR TITLE
add fuse field for write and compare commands

### DIFF
--- a/Documentation/nvme-compare.1
+++ b/Documentation/nvme-compare.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-compare
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 03/31/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-COMPARE" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-COMPARE" "1" "03/31/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -47,6 +47,7 @@ nvme-compare \- Send an NVMe Compare command, provide results
                         [\-\-dir\-type=<type> | \-T <type>]
                         [\-\-dir\-spec=<spec> | \-S <spec>]
                         [\-\-dsm=<dsm> | \-D <dsm>]
+                        [\-\-fuse=<fuse> | \-F <fuse>]
                         [\-\-show\-command | \-v]
                         [\-\-dry\-run | \-w]
                         [\-\-latency | \-t]
@@ -183,6 +184,11 @@ Optional field for directive specifics\&. When used with write streams, this val
 \-D <dsm>, \-\-dsm=<dsm>
 .RS 4
 The optional data set management attributes for this command\&. The argument for this is the lower 16 bits of the DSM field in a write command; the upper 16 bits of the field come from the directive specific field, if used\&. This may be used to set attributes for the LBAs being written, like access frequency, type, latency, among other things, as well as yet to be defined types\&. Please consult the NVMe specification for detailed breakdown of how to use this field\&.
+.RE
+.PP
+\-F <fuse>, \-\-fuse=<fuse>
+.RS 4
+a fused operation, a complex command is created by \(lqfusing\(rq together two simpler commands\&. This field specifies whether this command is part of a fused operation and if so, which command it is in the sequence\&.
 .RE
 .PP
 \-v, \-\-show\-cmd

--- a/Documentation/nvme-compare.html
+++ b/Documentation/nvme-compare.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-compare(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -761,6 +764,7 @@ nvme-compare(1) Manual Page
                         [--dir-type=&lt;type&gt; | -T &lt;type&gt;]
                         [--dir-spec=&lt;spec&gt; | -S &lt;spec&gt;]
                         [--dsm=&lt;dsm&gt; | -D &lt;dsm&gt;]
+                        [--fuse=&lt;fuse&gt; | -F &lt;fuse&gt;]
                         [--show-command | -v]
                         [--dry-run | -w]
                         [--latency | -t]</pre>
@@ -1003,6 +1007,19 @@ metadata is passes.</p></td>
 </p>
 </dd>
 <dt class="hdlist1">
+-F &lt;fuse&gt;
+</dt>
+<dt class="hdlist1">
+--fuse=&lt;fuse&gt;
+</dt>
+<dd>
+<p>
+        a fused operation, a complex command is created by “fusing” together
+        two simpler commands. This field specifies whether this command is
+        part of a fused operation and if so, which command it is in the sequence.
+</p>
+</dd>
+<dt class="hdlist1">
 -v
 </dt>
 <dt class="hdlist1">
@@ -1056,7 +1073,8 @@ metadata is passes.</p></td>
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-12-17 13:07:47 MST
+Last updated
+ 2021-03-31 18:49:19 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-compare.txt
+++ b/Documentation/nvme-compare.txt
@@ -23,6 +23,7 @@ SYNOPSIS
 			[--dir-type=<type> | -T <type>]
 			[--dir-spec=<spec> | -S <spec>]
 			[--dsm=<dsm> | -D <dsm>]
+			[--fuse=<fuse> | -F <fuse>]
 			[--show-command | -v]
 			[--dry-run | -w]
 			[--latency | -t]
@@ -124,6 +125,12 @@ metadata is passes.
 	among other things, as well as yet to be defined types. Please
 	consult the NVMe specification for detailed breakdown of how to
 	use this field.
+
+-F <fuse>::
+--fuse=<fuse>::
+	a fused operation, a complex command is created by “fusing” together
+	two simpler commands. This field specifies whether this command is
+	part of a fused operation and if so, which command it is in the sequence.
 
 -v::
 --show-cmd::

--- a/Documentation/nvme-write.1
+++ b/Documentation/nvme-write.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-write
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 03/31/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WRITE" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-WRITE" "1" "03/31/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -47,6 +47,7 @@ nvme-write \- Send an NVMe write command, provide results
                         [\-\-dir\-type=<type> | \-T <type>]
                         [\-\-dir\-spec=<spec> | \-S <spec>]
                         [\-\-dsm=<dsm> | \-D <dsm>]
+                        [\-\-fuse=<fuse> | \-F <fuse>]
                         [\-\-show\-command | \-v]
                         [\-\-dry\-run | \-w]
                         [\-\-latency | \-t]
@@ -169,6 +170,11 @@ Optional field for directive specifics\&. When used with write streams, this val
 \-D <dsm>, \-\-dsm=<dsm>
 .RS 4
 The optional data set management attributes for this command\&. The argument for this is the lower 16 bits of the DSM field in a write command; the upper 16 bits of the field come from the directive specific field, if used\&. This may be used to set attributes for the LBAs being written, like access frequency, type, latency, among other things, as well as yet to be defined types\&. Please consult the NVMe specification for detailed breakdown of how to use this field\&.
+.RE
+.PP
+\-F <fuse>, \-\-fuse=<fuse>
+.RS 4
+a fused operation, a complex command is created by \(lqfusing\(rq together two simpler commands\&. This field specifies whether this command is part of a fused operation and if so, which command it is in the sequence\&.
 .RE
 .PP
 \-v, \-\-show\-cmd

--- a/Documentation/nvme-write.html
+++ b/Documentation/nvme-write.html
@@ -764,6 +764,7 @@ nvme-write(1) Manual Page
                         [--dir-type=&lt;type&gt; | -T &lt;type&gt;]
                         [--dir-spec=&lt;spec&gt; | -S &lt;spec&gt;]
                         [--dsm=&lt;dsm&gt; | -D &lt;dsm&gt;]
+                        [--fuse=&lt;fuse&gt; | -F &lt;fuse&gt;]
                         [--show-command | -v]
                         [--dry-run | -w]
                         [--latency | -t]</pre>
@@ -1001,6 +1002,19 @@ metadata is passes.</p></td>
 </p>
 </dd>
 <dt class="hdlist1">
+-F &lt;fuse&gt;
+</dt>
+<dt class="hdlist1">
+--fuse=&lt;fuse&gt;
+</dt>
+<dd>
+<p>
+        a fused operation, a complex command is created by “fusing” together
+        two simpler commands. This field specifies whether this command is
+        part of a fused operation and if so, which command it is in the sequence.
+</p>
+</dd>
+<dt class="hdlist1">
 -v
 </dt>
 <dt class="hdlist1">
@@ -1055,7 +1069,7 @@ metadata is passes.</p></td>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-11-29 13:31:13 GMT
+ 2021-03-31 18:48:02 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-write.txt
+++ b/Documentation/nvme-write.txt
@@ -23,6 +23,7 @@ SYNOPSIS
 			[--dir-type=<type> | -T <type>]
 			[--dir-spec=<spec> | -S <spec>]
 			[--dsm=<dsm> | -D <dsm>]
+			[--fuse=<fuse> | -F <fuse>]
 			[--show-command | -v]
 			[--dry-run | -w]
 			[--latency | -t]
@@ -121,6 +122,12 @@ metadata is passes.
 	among other things, as well as yet to be defined types. Please
 	consult the NVMe specification for detailed breakdown of how to
 	use this field.
+
+-F <fuse>::
+--fuse=<fuse>::
+	a fused operation, a complex command is created by “fusing” together
+	two simpler commands. This field specifies whether this command is
+	part of a fused operation and if so, which command it is in the sequence.
 
 -v::
 --show-cmd::

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -124,13 +124,13 @@ int nvme_passthru(int fd, unsigned long ioctl_cmd, __u8 opcode,
 	return err;
 }
 
-int nvme_io(int fd, __u8 opcode, __u64 slba, __u16 nblocks, __u16 control,
-	    __u32 dsmgmt, __u32 reftag, __u16 apptag, __u16 appmask, void *data,
-	    void *metadata)
+int nvme_io(int fd, __u8 opcode, __u8 flags, __u64 slba, __u16 nblocks,
+		__u16 control, __u32 dsmgmt, __u32 reftag, __u16 apptag,
+		__u16 appmask, void *data, void *metadata)
 {
 	struct nvme_user_io io = {
 		.opcode		= opcode,
-		.flags		= 0,
+		.flags		= flags,
 		.control	= control,
 		.nblocks	= nblocks,
 		.rsvd		= 0,

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -25,8 +25,8 @@ int nvme_passthru(int fd, unsigned long ioctl_cmd, __u8 opcode, __u8 flags,
 
 
 /* NVME_SUBMIT_IO */
-int nvme_io(int fd, __u8 opcode, __u64 slba, __u16 nblocks, __u16 control,
-	      __u32 dsmgmt, __u32 reftag, __u16 apptag,
+int nvme_io(int fd, __u8 opcode, __u8 flags, __u64 slba, __u16 nblocks,
+		  __u16 control, __u32 dsmgmt, __u32 reftag, __u16 apptag,
 	      __u16 appmask, void *data, void *metadata);
 
 /* NVME_IO_CMD */

--- a/nvme.c
+++ b/nvme.c
@@ -4688,6 +4688,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	bool huge;
 	struct nvme_id_ns ns;
 	__u8 lba_index, ms = 0;
+	__u8 flags = 0;
 
 	const char *start_block = "64-bit addr of first block to access";
 	const char *block_count = "number of blocks (zeroes based) on device to access";
@@ -4887,7 +4888,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 
 	if (cfg.show) {
 		printf("opcode       : %02x\n", opcode);
-		printf("flags        : %02x\n", 0);
+		printf("flags        : %02x\n", flags);
 		printf("control      : %04x\n", control);
 		printf("nblocks      : %04x\n", cfg.block_count);
 		printf("metadata     : %"PRIx64"\n", (uint64_t)(uintptr_t)mbuffer);
@@ -4902,8 +4903,9 @@ static int submit_io(int opcode, char *command, const char *desc,
 		goto free_mbuffer;
 
 	gettimeofday(&start_time, NULL);
-	err = nvme_io(fd, opcode, cfg.start_block, cfg.block_count, control, dsmgmt,
-			cfg.ref_tag, cfg.app_tag, cfg.app_tag_mask, buffer, mbuffer);
+	err = nvme_io(fd, opcode, flags, cfg.start_block, cfg.block_count,
+			control, dsmgmt, cfg.ref_tag, cfg.app_tag, cfg.app_tag_mask,
+			buffer, mbuffer);
 	gettimeofday(&end_time, NULL);
 	if (cfg.latency)
 		printf(" latency: %s: %llu us\n",

--- a/nvme.c
+++ b/nvme.c
@@ -4690,6 +4690,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	__u8 lba_index, ms = 0;
 	__u8 flags = 0;
 
+	const char *fuse = "specifies this command is part of a fused operation";
 	const char *start_block = "64-bit addr of first block to access";
 	const char *block_count = "number of blocks (zeroes based) on device to access";
 	const char *data_size = "size of data in bytes";
@@ -4723,6 +4724,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		__u16 dsmgmt;
 		__u16 app_tag_mask;
 		__u16 app_tag;
+		__u8 fuse;
 		int   limited_retry;
 		int   force_unit_access;
 		int   show;
@@ -4741,6 +4743,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		.prinfo          = 0,
 		.app_tag_mask    = 0,
 		.app_tag         = 0,
+		.fuse            = 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -4759,6 +4762,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		OPT_BYTE("dir-type",          'T', &cfg.dtype,             dtype),
 		OPT_SHRT("dir-spec",          'S', &cfg.dspec,             dspec),
 		OPT_SHRT("dsm",               'D', &cfg.dsmgmt,            dsm),
+		OPT_BYTE("fuse",              'F', &cfg.fuse,              fuse),
 		OPT_FLAG("show-command",      'v', &cfg.show,              show),
 		OPT_FLAG("dry-run",           'w', &cfg.dry_run,           dry),
 		OPT_FLAG("latency",           't', &cfg.latency,           latency),
@@ -4773,6 +4777,11 @@ static int submit_io(int opcode, char *command, const char *desc,
 	if (cfg.prinfo > 0xf) {
 		err = -EINVAL;
 		goto close_fd;
+	}
+
+	if (cfg.fuse) {
+		cfg.fuse = opcode & 1 ? cfg.fuse : 0;
+		flags = cfg.fuse;
 	}
 
 	dsmgmt = cfg.dsmgmt;

--- a/nvme.c
+++ b/nvme.c
@@ -4679,7 +4679,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	void *buffer, *mbuffer = NULL;
 	int err = 0;
 	int dfd, mfd, fd;
-	int flags = opcode & 1 ? O_RDONLY : O_WRONLY | O_CREAT;
+	int file_flags = opcode & 1 ? O_RDONLY : O_WRONLY | O_CREAT;
 	int mode = S_IRUSR | S_IWUSR |S_IRGRP | S_IWGRP| S_IROTH;
 	__u16 control = 0;
 	__u32 dsmgmt = 0, nsid = 0;
@@ -4792,7 +4792,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	}
 
 	if (strlen(cfg.data)) {
-		dfd = open(cfg.data, flags, mode);
+		dfd = open(cfg.data, file_flags, mode);
 		if (dfd < 0) {
 			perror(cfg.data);
 			err = -EINVAL;
@@ -4801,7 +4801,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		mfd = dfd;
 	}
 	if (strlen(cfg.metadata)) {
-		mfd = open(cfg.metadata, flags, mode);
+		mfd = open(cfg.metadata, file_flags, mode);
 		if (mfd < 0) {
 			perror(cfg.metadata);
 			err = -EINVAL;


### PR DESCRIPTION
This PR does the necessary changes to have the `CDW0 bits 8:15 which represented as flags` and adds `fuse` field  in `submit_io`
as a user cli input.