### PR TITLE
Fix missing sd-id128 include

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -9,6 +9,11 @@
 #include "nvme.h"
 #include "nvme-ioctl.h"
 
+#ifdef HAVE_SYSTEMD
+#include <systemd/sd-id128.h>
+#define NVME_HOSTNQN_ID SD_ID128_MAKE(c7,f4,61,81,12,be,49,32,8c,83,10,6f,9d,dd,d8,6b)
+#endif
+
 static const char *dev = "/dev/";
 static const char *subsys_dir = "/sys/class/nvme-subsystem/";
 static void free_ctrl(struct nvme_ctrl *c);


### PR DESCRIPTION
It looks like in PR #979 `systemd/sd-id128.h` include was omitted from `nvme-topology.c`.

Without this build fails with:
```
nvme-topology.c: In function ‘uuid_from_systemd’:
nvme-topology.c:760:2: error: unknown type name ‘sd_id128_t’
  760 |  sd_id128_t id;
      |  ^~~~~~~~~~
nvme-topology.c:763:6: warning: implicit declaration of function ‘sd_id128_get_machine_app_specific’ [-Wimplicit-function-declaration]
  763 |  if (sd_id128_get_machine_app_specific(NVME_HOSTNQN_ID, &id) < 0)
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nvme-topology.c:763:40: error: ‘NVME_HOSTNQN_ID’ undeclared (first use in this function); did you mean ‘NVME_IOCTL_ID’?
  763 |  if (sd_id128_get_machine_app_specific(NVME_HOSTNQN_ID, &id) < 0)
      |                                        ^~~~~~~~~~~~~~~
      |                                        NVME_IOCTL_ID
nvme-topology.c:763:40: note: each undeclared identifier is reported only once for each function it appears in
nvme-topology.c:766:24: error: ‘SD_ID128_FORMAT_STR’ undeclared (first use in this function)
  766 |  sprintf(systemd_uuid, SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(id));
      |                        ^~~~~~~~~~~~~~~~~~~
nvme-topology.c:766:45: warning: implicit declaration of function ‘SD_ID128_FORMAT_VAL’ [-Wimplicit-function-declaration]
  766 |  sprintf(systemd_uuid, SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(id));
      |                                             ^~~~~~~~~~~~~~~~~~~
make[2]: *** [Makefile:112: nvme-topology.o] Error 1
```

On a side note it looks like CI lacks dependency on libsystemd-dev which causes -DHAVE_SYSTEMD not being defined, thus this mistake was not caught.
