### PR TITLE
nvme: Remove invalid device node from nvme list

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6054,11 +6054,16 @@ static void json_simple_ns(struct nvme_namespace *n, struct json_object *devices
 	struct json_object *device_attrs;
 	char formatter[41] = { 0 };
 	double nsze, nuse;
-	int index = -1;
+	int ret, index = -1;
 	long long lba;
 	char *devnode;
+	struct stat st;
 
 	if (asprintf(&devnode, "%s%s", n->ctrl->path, n->name) < 0)
+		return;
+
+	ret = stat(devnode, &st);
+	if (ret < 0)
 		return;
 
 	device_attrs = json_create_object();


### PR DESCRIPTION
normal print result
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     S39XNX0J6C3BBA       91721190020910SAM0PM1725A0004T00035000   1           0.00   B /   4.19  TB      4 KiB +  0 B   MVP41G7A
/dev/nvme0n2     S39XNX0J6C3BBA       91721190020910SAM0PM1725A0004T00035000   2           4.19  MB /   4.19  MB      4 KiB +  0 B   MVP41G7A

json print result (nvme0c0n* are invaild devices name, so will be removed from list)
[root@localhost nvme-cli]# nvme list -o json
{
  "Devices" : [
    {
      "NameSpace" : 1,
      "DevicePath" : "/dev/nvme0c0n1",
      ...
      "SectorSize" : 1
    },
    {
      "NameSpace" : 2,
      "DevicePath" : "/dev/nvme0c0n2",
      ...
      "SectorSize" : 1
    },
    {
      "NameSpace" : 1,
      "DevicePath" : "/dev/nvme0n1",
      ...
      "SectorSize" : 4096
    },
    {
      "NameSpace" : 2,
      "DevicePath" : "/dev/nvme0n2",
      ...
      "SectorSize" : 4096
    }
  ]
}

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>