### PR TITLE
nvme: add rae field in sanitize-log

### DIFF
--- a/Documentation/nvme-sanitize-log.1
+++ b/Documentation/nvme-sanitize-log.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-sanitize-log
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 04/05/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SANITIZE\-LOG" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-SANITIZE\-LOG" "1" "04/05/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -32,7 +32,7 @@ nvme-sanitize-log \- Send NVMe sanitize\-log Command, return result
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme sanitize\-log\fR <device> [\-\-output\-format=<fmt> | \-o <fmt>]
+\fInvme sanitize\-log\fR <device> [\-\-rae | \-r] [\-\-output\-format=<fmt> | \-o <fmt>]
                              [\-\-human\-readable | \-H]
                              [\-\-raw\-binary | \-b]
 .fi
@@ -99,6 +99,11 @@ Sanitize Progress \- percentage complete
 .sp
 On success it returns 0, error code otherwise\&.
 .SH "OPTIONS"
+.PP
+\-r, \-\-rae
+.RS 4
+Retain an Asynchronous Event\&.
+.RE
 .PP
 \-o <format>, \-\-output\-format=<format>
 .RS 4

--- a/Documentation/nvme-sanitize-log.html
+++ b/Documentation/nvme-sanitize-log.html
@@ -749,7 +749,7 @@ nvme-sanitize-log(1) Manual Page
 <h2 id="_synopsis">SYNOPSIS</h2>
 <div class="sectionbody">
 <div class="verseblock">
-<pre class="content"><em>nvme sanitize-log</em> &lt;device&gt; [--output-format=&lt;fmt&gt; | -o &lt;fmt&gt;]
+<pre class="content"><em>nvme sanitize-log</em> &lt;device&gt; [--rae | -r] [--output-format=&lt;fmt&gt; | -o &lt;fmt&gt;]
                              [--human-readable | -H]
                              [--raw-binary | -b]</pre>
 <div class="attribution">
@@ -816,6 +816,17 @@ If cleared to 0, then non-volatile storage in the NVM subsystem has been written
 <div class="sectionbody">
 <div class="dlist"><dl>
 <dt class="hdlist1">
+-r
+</dt>
+<dt class="hdlist1">
+--rae
+</dt>
+<dd>
+<p>
+        Retain an Asynchronous Event.
+</p>
+</dd>
+<dt class="hdlist1">
 -o &lt;format&gt;
 </dt>
 <dt class="hdlist1">
@@ -881,7 +892,7 @@ Has the program issue Sanitize-log Command :
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2019-11-08 02:18:28 JST
+ 2021-04-05 15:38:33 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-sanitize-log.txt
+++ b/Documentation/nvme-sanitize-log.txt
@@ -8,7 +8,7 @@ nvme-sanitize-log - Send NVMe sanitize-log Command, return result
 SYNOPSIS
 --------
 [verse]
-'nvme sanitize-log' <device> [--output-format=<fmt> | -o <fmt>]
+'nvme sanitize-log' <device> [--rae | -r] [--output-format=<fmt> | -o <fmt>]
 			     [--human-readable | -H]
 			     [--raw-binary | -b]
 
@@ -54,6 +54,10 @@ On success it returns 0, error code otherwise.
 
 OPTIONS
 -------
+-r::
+--rae::
+	Retain an Asynchronous Event.
+
 -o <format>::
 --output-format=<format>::
               Set the reporting format to 'normal', 'json', or

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -594,9 +594,9 @@ int nvme_discovery_log(int fd, struct nvmf_disc_rsp_page_hdr *log, __u32 size)
 	return nvme_get_log(fd, 0, NVME_LOG_DISC, false, NVME_NO_LOG_LSP, size, log);
 }
 
-int nvme_sanitize_log(int fd, struct nvme_sanitize_log_page *sanitize_log)
+int nvme_sanitize_log(int fd, bool rae, struct nvme_sanitize_log_page *sanitize_log)
 {
-	return nvme_get_log(fd, 0, NVME_LOG_SANITIZE, false,
+	return nvme_get_log(fd, 0, NVME_LOG_SANITIZE, rae,
 			NVME_NO_LOG_LSP, sizeof(*sanitize_log), sanitize_log);
 }
 

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -104,7 +104,7 @@ int nvme_smart_log(int fd, __u32 nsid, struct nvme_smart_log *smart_log);
 int nvme_ana_log(int fd, void *ana_log, size_t ana_log_len, int rgo);
 int nvme_effects_log(int fd, struct nvme_effects_log_page *effects_log);
 int nvme_discovery_log(int fd, struct nvmf_disc_rsp_page_hdr *log, __u32 size);
-int nvme_sanitize_log(int fd, struct nvme_sanitize_log_page *sanitize_log);
+int nvme_sanitize_log(int fd, bool rae, struct nvme_sanitize_log_page *sanitize_log);
 int nvme_predictable_latency_per_nvmset_log(int fd,
 		__u16 nvmset_id, struct nvme_predlat_per_nvmset_log_page *plpns_log);
 int nvme_predictable_latency_event_agg_log(int fd, void *pea_log,

--- a/nvme.c
+++ b/nvme.c
@@ -1319,6 +1319,7 @@ ret:
 static int sanitize_log(int argc, char **argv, struct command *command, struct plugin *plugin)
 {
 	const char *desc = "Retrieve sanitize log and show it.";
+	const char *rae = "Retain an Asynchronous Event";
 	const char *raw = "show log in binary format";
 	const char *human_readable = "show log in readable format";
 	struct nvme_sanitize_log_page sanitize_log;
@@ -1326,16 +1327,19 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	int fd, err;
 
 	struct config {
+		bool  rae;
 		int   raw_binary;
 		int   human_readable;
 		char *output_format;
 	};
 
 	struct config cfg = {
+		.rae = false,
 		.output_format = "normal",
 	};
 
 	OPT_ARGS(opts) = {
+		OPT_FLAG("rae",           'r', &cfg.rae,            rae),
 		OPT_FMT("output-format",  'o', &cfg.output_format,  output_format),
 		OPT_FLAG("human-readable",'H', &cfg.human_readable, human_readable),
 		OPT_FLAG("raw-binary",    'b', &cfg.raw_binary,     raw),
@@ -1354,7 +1358,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_sanitize_log(fd, &sanitize_log);
+	err = nvme_sanitize_log(fd, cfg.rae, &sanitize_log);
 	if (!err)
 		nvme_show_sanitize_log(&sanitize_log, devicename, flags);
 	else if (err > 0)


### PR DESCRIPTION
Added Retain Asynchronous Event (RAE) field for sanitize
log.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>