### PR TITLE
nvme-topology: fix build error for unused variable

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -763,7 +763,6 @@ int uuid_from_systemd(char *systemd_uuid)
 {
 #ifdef HAVE_SYSTEMD
 	sd_id128_t id;
-	char *ret;
 
 	if (sd_id128_get_machine_app_specific(NVME_HOSTNQN_ID, &id) < 0)
 		return -ENXIO;


### PR DESCRIPTION
Fix the following build error.

nvme-topology.c: In function ‘uuid_from_systemd’:
nvme-topology.c:766:8: error: unused variable ‘ret’ [-Werror=unused-variable]
  766 |  char *ret;
      |        ^~~

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>