### PR TITLE
zns: return response with status to errno conversion

### DIFF
--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -10,6 +10,7 @@
 #include "nvme.h"
 #include "nvme-ioctl.h"
 #include "nvme-print.h"
+#include "nvme-status.h"
 
 #define CREATE_CMD
 #include "zns.h"
@@ -56,7 +57,7 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
 		perror("zns identify controller");
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plugin)
@@ -126,7 +127,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		perror("zns identify namespace");
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int __zns_mgmt_send(int fd, __u32 namespace_id, __u64 zslba,
@@ -195,7 +196,7 @@ free:
 	free(command);
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int get_zdes_bytes(int fd, __u32 nsid)
@@ -341,7 +342,7 @@ free:
 		free(buf);
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int close_zone(int argc, char **argv, struct command *cmd, struct plugin *plugin)
@@ -465,7 +466,7 @@ free:
 	free(buf);
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plugin *plugin)
@@ -545,7 +546,7 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 		free(data);
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int report_zones(int argc, char **argv, struct command *cmd, struct plugin *plugin)
@@ -656,7 +657,7 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 	nvme_free(report, huge);
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int zone_append(int argc, char **argv, struct command *cmd, struct plugin *plugin)
@@ -859,7 +860,7 @@ close_dfd:
 close_ns:
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }
 
 static int changed_zone_list(int argc, char **argv, struct command *cmd, struct plugin *plugin)
@@ -915,5 +916,5 @@ static int changed_zone_list(int argc, char **argv, struct command *cmd, struct 
 
 close_fd:
 	close(fd);
-	return err;
+	return nvme_status_to_errno(err, false);
 }


### PR DESCRIPTION
Currently ZNS plugin nvme device status code 15 bits
being returned to shell which will take only 8 bits.
Convert the nvme status code to linux standard errno
with the help of status_to_errno function and return.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>