### PR TITLE
nvme: remove buf allocation check since NULL free is acceptable

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -412,7 +412,7 @@ rpmb_read_request(int fd,
 	if (error == 0) return rsp;
 
 error_out:
-	if (rsp) free(rsp);
+	free(rsp);
 	return NULL;
 }
 
@@ -436,8 +436,8 @@ static int rpmb_read_write_counter(int fd,
 	error = 0;
 	
 out:
-	if (req) free(req);
-	if (rsp) free(rsp);
+	free(req);
+	free(rsp);
 	return error;
 }
 
@@ -477,9 +477,9 @@ static unsigned int rpmb_read_config_block(int fd, unsigned char **config_buf)
 	cfg = NULL;
 	retval = rsp->write_counter;
 out:
-	if (req) free(req);
-	if (rsp) free(rsp);
-	if (cfg) free(cfg);
+	free(req);
+	free(rsp);
+	free(cfg);
 	return retval;
 }
 
@@ -566,8 +566,8 @@ static int rpmb_program_auth_key(int fd, unsigned char target,
 		err = check_rpmb_response(req, rsp, "Failed to Program Key");
 	}
 out:
-	if (req) free(req);
-	if (rsp) free(rsp);
+	free(req);
+	free(rsp);
 	
 	return err;
 }
@@ -647,9 +647,9 @@ static int auth_data_write_chunk(int fd, unsigned char tgt, unsigned int addr,
 	else 
     		error = check_rpmb_response(req, rsp, "Failed to write-data");
 out:
-	if (req) free(req);
-	if (rsp) free(rsp);
-	if (mac) free(mac);
+	free(req);
+	free(rsp);
+	free(mac);
 
 	return error;
 }
@@ -755,9 +755,9 @@ static int rpmb_write_config_block(int fd, unsigned char *cfg_buf,
 	error = check_rpmb_response(req, rsp,
 				  "Failed to retrieve write-config response");
 out:
-	if (req) free(req);
-	if (rsp) free(rsp);
-	if (mac) free(mac);
+	free(req);
+	free(rsp);
+	free(mac);
 	
 	return error;
 }
@@ -991,8 +991,8 @@ int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *p
 	 
 out:
 	/* release memory  */
-	if (key_buf) free(key_buf);
-	if (msg_buf) free(msg_buf);
+	free(key_buf);
+	free(msg_buf);
 	
 	/* close file descriptor */
 	if (fd > 0) close(fd);

--- a/nvme.c
+++ b/nvme.c
@@ -1825,8 +1825,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	nvme_show_subsystem_list(&t, flags);
 free:
 	free_topology(&t);
-	if (subsysnqn)
-		free(subsysnqn);
+	free(subsysnqn);
 ret:
 	return nvme_status_to_errno(err, false);
 }
@@ -2765,8 +2764,7 @@ static int get_feature(int argc, char **argv, struct command *cmd, struct plugin
 	} else
 		perror("get-feature");
 
-	if (buf)
-		free(buf);
+	free(buf);
 
 close_fd:
 	close(fd);
@@ -3687,8 +3685,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 close_ffd:
 	close(ffd);
 free:
-	if (buf)
-		free(buf);
+	free(buf);
 close_fd:
 	close(fd);
 ret:
@@ -3934,8 +3931,7 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 close_ffd:
 	close(ffd);
 free:
-	if (buf)
-		free(buf);
+	free(buf);
 close_fd:
 	close(fd);
 ret:
@@ -4952,8 +4948,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	}
 
 free_mbuffer:
-	if (cfg.metadata_size)
-		free(mbuffer);
+	free(mbuffer);
 free_buffer:
 	nvme_free(buffer, huge);
 close_mfd:
@@ -5363,8 +5358,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 	else if (err < 0)
 		perror("dir-receive");
 
-	if (cfg.data_len)
-		free(buf);
+	free(buf);
 close_fd:
 	close(fd);
 ret:
@@ -5578,11 +5572,9 @@ static int passthru(int argc, char **argv, int ioctl_cmd, uint8_t cmd_type,
 			d_raw((unsigned char *)data, cfg.data_len);
 	}
 free_data:
-	if (cfg.data_len)
-		nvme_free(data, huge);
+	nvme_free(data, huge);
 free_metadata:
-	if (cfg.metadata_len)
-		free(metadata);
+	free(metadata);
 close_wfd:
 	if (strlen(cfg.input_file))
 		close(wfd);


### PR DESCRIPTION
Cleaning up all the nvme-cli source filses where buffer allocation
check is ther before free up, NULL free is acceptable perfectly as
Chaitanya mentioned in another patch.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>