### PR TITLE
add limits.h to files using PATH_MAX where it was missing

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <linux/if_alg.h>
 #include <linux/socket.h>
+#include <limits.h>
 
 #include "nvme.h"
 #include "nvme-print.h"

--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include <limits.h>
 
 #include "nvme.h"
 #include "nvme-ioctl.h"


### PR DESCRIPTION
Commits 21f40f38b and 3e0520eca introduced new uses of PATH_MAX, but
did not add the limits.h header.  This resulted in nvme-cli failing
to build on ppc64le systems using the musl C library.

Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>