### PR TITLE
nvme-cli: fix typos in reservation actions

### DIFF
--- a/Documentation/nvme-resv-register.1
+++ b/Documentation/nvme-resv-register.1
@@ -98,7 +98,7 @@ T}
 .sp 1
 .RE
 .PP
-\-a <rrega>, \-\-rrega=<rrega>
+\-r <rrega>, \-\-rrega=<rrega>
 .RS 4
 Reservation Register Action: This field specifies the registration action that is performed by the command\&.
 .TS

--- a/Documentation/nvme-resv-register.html
+++ b/Documentation/nvme-resv-register.html
@@ -861,7 +861,7 @@ a power loss.</p></td>
 </div>
 </dd>
 <dt class="hdlist1">
--a &lt;rrega&gt;
+-r &lt;rrega&gt;
 </dt>
 <dt class="hdlist1">
 --rrega=&lt;rrega&gt;

--- a/Documentation/nvme-resv-register.txt
+++ b/Documentation/nvme-resv-register.txt
@@ -62,7 +62,7 @@ are cleared on a power on.
 a power loss.
 |=================
 
--a <rrega>::
+-r <rrega>::
 --rrega=<rrega>::
 	Reservation Register Action: This field specifies the registration
 	action that is performed by the command.

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -558,7 +558,7 @@ _nvme () {
 			-p':alias for --prkey'
 			--rtype=':hexadecimal reservation type'
 			-t':alias for --rtype'
-			--racqa=':reservation acquiry action'
+			--racqa=':reservation acquire action'
 			-a':alias for --racqa'
 			--iekey=':ignore existing reservation key'
 			-i':alias for --iekey'
@@ -611,7 +611,7 @@ _nvme () {
 			--cptpl=':change persistence through power loss setting'
 			-p':alias for --cptpl'
 			--rrega=':reservation registration action to perform'
-			-a':alias for --rrega'
+			-r':alias for --rrega'
 			--iekey':ignore existing reservation key'
 			-i':alias for --iekey'
 			)

--- a/nvme.c
+++ b/nvme.c
@@ -4384,7 +4384,7 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	const char *crkey = "current reservation key";
 	const char *prkey = "pre-empt reservation key";
 	const char *rtype = "reservation type";
-	const char *racqa = "reservation acquiry action";
+	const char *racqa = "reservation acquire action";
 	const char *iekey = "ignore existing res. key";
 	int err, fd;
 


### PR DESCRIPTION
Fix typos in short option for reservation register action and the full
name of reservation acquire action.