### PR TITLE
nvme-ioctl: remove unused function nvme_identify_ns_list

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -401,11 +401,6 @@ int nvme_identify_ns_list_csi(int fd, __u32 nsid, __u8 csi, bool all, void *data
 	return nvme_identify13(fd, nsid, cns, csi << 24, data);
 }
 
-int nvme_identify_ns_list(int fd, __u32 nsid, bool all, void *data)
-{
-	return nvme_identify_ns_list_csi(fd, nsid, 0x0, all, data);
-}
-
 int nvme_identify_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data)
 {
 	int cns = nsid ? NVME_ID_CNS_CTRL_NS_LIST : NVME_ID_CNS_CTRL_LIST;

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -73,7 +73,6 @@ int nvme_identify13(int fd, __u32 nsid, __u32 cdw10, __u32 cdw11, void *data);
 int nvme_identify(int fd, __u32 nsid, __u32 cdw10, void *data);
 int nvme_identify_ctrl(int fd, void *data);
 int nvme_identify_ns(int fd, __u32 nsid, bool present, void *data);
-int nvme_identify_ns_list(int fd, __u32 nsid, bool all, void *data);
 int nvme_identify_ns_list_csi(int fd, __u32 nsid, __u8 csi, bool all, void *data);
 int nvme_identify_ctrl_list(int fd, __u32 nsid, __u16 cntid, void *data);
 int nvme_identify_ns_descs(int fd, __u32 nsid, void *data);


### PR DESCRIPTION
Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>