### PR TITLE
nvme: fix csi data type in list_ns

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1436,7 +1436,7 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 	struct config {
 		__u32 namespace_id;
 		int  all;
-		__u16 csi;
+		__u8 csi;
 	};
 
 	struct config cfg = {


### PR DESCRIPTION
Command Set Identifier (CSI) data type is 8 bits, fix that.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>