### PR TITLE
nvme: fix errno for non nvme device return errors

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -242,7 +242,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	const char *raw = "output in binary format";
 	const char *human_readable = "show info in readable format";
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32 namespace_id;
@@ -297,7 +297,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	const char *desc = "Retrieve ANA log for the given device in " \
 			    "decoded format (default), json or binary.";
 	void *ana_log;
-	int err, fd;
+	int err = -1, fd;
 	int groups = 0; /* Right now get all the per ANA group NSIDS */
 	size_t ana_log_len;
 	struct nvme_id_ctrl ctrl;
@@ -339,7 +339,8 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	ana_log = malloc(ana_log_len);
 	if (!ana_log) {
 		perror("malloc");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -367,7 +368,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	const size_t bs = 512;
 	struct nvme_telemetry_log_page_hdr *hdr;
 	size_t full_size, offset = bs;
-	int err = 0, fd, output;
+	int err = -1, fd, output;
 	void *page_log;
 
 	struct config {
@@ -397,7 +398,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 
 	if (!cfg.file_name) {
 		fprintf(stderr, "Please provide an output file!\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -406,7 +408,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	page_log = malloc(bs);
 	if (!hdr || !page_log) {
 		perror("failed to allocate buf for log\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto free_mem;
 	}
 	memset(hdr, 0, bs);
@@ -446,7 +449,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 		break;
 	default:
 		fprintf(stderr, "Invalid data area requested\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_output;
 	}
 
@@ -491,7 +495,7 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 	const char *desc = "Retrieves endurance groups log page and prints the log.";
 	const char *group_id = "The endurance group identifier";
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		char *output_format;
@@ -537,7 +541,7 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 	const char *human_readable = "show log in readable format";
 	struct nvme_effects_log_page effects;
 
-	int err, fd;
+	int err = -1, fd;
 	enum nvme_print_flags flags;
 
 	struct config {
@@ -592,7 +596,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	struct nvme_error_log_page *err_log;
 	struct nvme_id_ctrl ctrl;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32 log_entries;
@@ -624,7 +628,8 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 
 	if (!cfg.log_entries) {
 		fprintf(stderr, "non-zero log-entries is required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -634,7 +639,8 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 		goto close_fd;
 	} else if (err) {
 		fprintf(stderr, "could not identify controller\n");
-		err = -ENODEV;
+		errno = ENODEV;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -642,7 +648,8 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	err_log = calloc(cfg.log_entries, sizeof(struct nvme_error_log_page));
 	if (!err_log) {
 		perror("could not alloc buffer for error log\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -667,7 +674,7 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 	const char *raw = "use binary output";
 	struct nvme_firmware_log_page fw_log;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		int raw_binary;
@@ -715,7 +722,7 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 			"(default) or binary.";
 	const char *raw = "output in binary format";
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		int   raw_binary;
@@ -766,7 +773,7 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 	const char *raw = "use binary output";
 	struct nvme_predlat_per_nvmset_log_page plpns_log;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u16 nvmset_id;
@@ -826,7 +833,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	void *pea_log;
 	struct nvme_id_ctrl ctrl;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 	__u32 log_size;
 
 	struct config {
@@ -862,7 +869,8 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 
 	if (!cfg.log_entries) {
 		fprintf(stderr, "non-zero log-entries is required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -881,7 +889,8 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	if (!pea_log) {
 		perror("could not alloc buffer for predictable " \
 			"latency event agggregate log entries\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -915,7 +924,7 @@ static int get_persistent_event_log(int argc, char **argv,
 	void *pevent_log_info;
 	struct nvme_persistent_event_log_head *pevent_log_head = NULL;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 	bool huge;
 
 	struct config {
@@ -960,7 +969,8 @@ static int get_persistent_event_log(int argc, char **argv,
 	if (!pevent_log_head) {
 		perror("could not alloc buffer for persistent " \
 			"event log header\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -999,7 +1009,8 @@ static int get_persistent_event_log(int argc, char **argv,
 	pevent_log_info = nvme_alloc(cfg.log_len, &huge);
 	if (!pevent_log_info) {
 		perror("could not alloc buffer for persistent event log page\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 	err = nvme_persistent_event_log(fd, cfg.action,
@@ -1035,7 +1046,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	void *endurance_log;
 	struct nvme_id_ctrl ctrl;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 	__u32 log_size;
 
 	struct config {
@@ -1071,7 +1082,8 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 
 	if (!cfg.log_entries) {
 		fprintf(stderr, "non-zero log-entries is required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1081,7 +1093,8 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 		goto close_fd;
 	} else if (err) {
 		fprintf(stderr, "could not identify controller\n");
-		err = -ENODEV;
+		errno = ENODEV;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1091,7 +1104,8 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	if (!endurance_log) {
 		perror("could not alloc buffer for endurance group" \
 			" event agggregate log entries\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1121,7 +1135,7 @@ static int get_lba_status_log(int argc, char **argv,
 	const char *rae = "Retain an Asynchronous Event";
 	void *lab_status;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 	__u32 lslplen;
 
 	struct config {
@@ -1160,7 +1174,8 @@ static int get_lba_status_log(int argc, char **argv,
 	lab_status = calloc(lslplen, 1);
 	if (!lab_status) {
 		perror("could not alloc buffer for lba status log");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1189,7 +1204,7 @@ static int get_resv_notif_log(int argc, char **argv,
 		"json or binary.";
 	struct nvme_resv_notif_log resv;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		char *output_format;
@@ -1242,7 +1257,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *rae = "retain an asynchronous event";
 	const char *raw = "output in raw format";
 	const char *uuid_index = "UUID index";
-	int err, fd;
+	int err = -1, fd;
 	unsigned char *log;
 
 	struct config {
@@ -1294,7 +1309,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	if (!cfg.log_len) {
 		fprintf(stderr, "non-zero log-len is required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1350,7 +1366,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	const char *human_readable = "show log in readable format";
 	struct nvme_sanitize_log_page sanitize_log;
 	enum nvme_print_flags flags;
-	int fd, err;
+	int fd, err = -1;
 
 	struct config {
 		bool  rae;
@@ -1403,7 +1419,7 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 		"given device is part of, or optionally controllers attached to a specific namespace.";
 	const char *controller = "controller to display";
 	const char *namespace_id = "optional namespace attached to controller";
-	int err, fd;
+	int err = -1, fd;
 	struct nvme_controller_list *cntlist;
 	enum nvme_print_flags flags;
 
@@ -1439,7 +1455,8 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 
 	if (posix_memalign((void *)&cntlist, getpagesize(), 0x1000)) {
 		fprintf(stderr, "can not allocate controller list payload\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1465,7 +1482,7 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *namespace_id = "first nsid returned list should start from";
 	const char *csi = "I/O command set identifier";
 	const char *all = "show all namespaces in the subsystem, whether attached or inactive";
-	int err, fd;
+	int err = -1, fd;
 	__le32 ns_list[1024];
 	enum nvme_print_flags flags;
 
@@ -1502,7 +1519,8 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 	}
 
 	if (!cfg.namespace_id) {
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		fprintf(stderr, "invalid nsid parameter\n");
 		goto close_fd;
 	}
@@ -1531,7 +1549,7 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		"the namespace is not already inactive, once deleted.";
 	const char *namespace_id = "namespace to delete";
 	const char *timeout = "timeout value, in milliseconds";
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32	namespace_id;
@@ -1578,7 +1596,7 @@ ret:
 
 static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, struct command *cmd)
 {
-	int err, num, i, fd, list[2048];
+	int err = -1, num, i, fd, list[2048];
 	__u16 ctrlist[2048];
 
 	const char *namespace_id = "namespace to attach";
@@ -1607,7 +1625,8 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	if (!cfg.namespace_id) {
 		fprintf(stderr, "%s: namespace-id parameter required\n",
 						cmd->name);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1619,7 +1638,8 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	if (num == -1) {
 		fprintf(stderr, "%s: controller id list is malformed\n",
 						cmd->name);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1680,7 +1700,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	const char *bs = "target block size, specify only if \'FLBAS\' "\
 		"value not entered";
 
-	int err = 0, fd, i;
+	int err = -1, fd, i;
 	struct nvme_id_ns ns;
 	__u32 nsid;
 
@@ -1726,7 +1746,8 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	if (cfg.flbas != 0xff && cfg.bs != 0x00) {
 		fprintf(stderr,
 			"Invalid specification of both FLBAS and Block Size, please specify only one\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.bs) {
@@ -1734,7 +1755,8 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 			fprintf(stderr,
 				"Invalid value for block size (%"PRIu64"). Block size must be a power of two\n",
 				(uint64_t)cfg.bs);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 		err = nvme_identify_ns(fd, NVME_NSID_ALL, 0, &ns);
@@ -1762,7 +1784,8 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		fprintf(stderr,
 			"Please correct block size, or specify FLBAS directly\n");
 
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -1791,7 +1814,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	const char *desc = "Retrieve information for subsystems";
 	const char *verbose = "Increase output verbosity";
 	__u32 ns_instance = 0;
-	int err, nsid = 0;
+	int err = -1, nsid = 0;
 
 	struct config {
 		char *output_format;
@@ -1822,7 +1845,8 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 		if (sscanf(devicename, "nvme%dn%d", &id, &ns_instance) != 2) {
 			fprintf(stderr, "%s is not a NVMe namespace device\n",
 				argv[optind]);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto ret;
 		}
 		sprintf(path, "/dev/%s", devicename);
@@ -1830,7 +1854,8 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 		if (fd < 0) {
 			fprintf(stderr, "Cannot read nsid from %s\n",
 				devicename);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto ret;
 		}
 		nsid = nvme_get_nsid(fd);
@@ -1838,7 +1863,8 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 		if (nsid < 0) {
 			fprintf(stderr, "Cannot read nsid from %s\n",
 				devicename);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto ret;
 		}
 		sprintf(path, "/sys/block/%s/device", devicename);
@@ -1846,7 +1872,8 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 		if (!subsysnqn) {
 			fprintf(stderr, "Cannot read subsys NQN from %s\n",
 				devicename);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto ret;
 		}
 		optind++;
@@ -1856,7 +1883,8 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	if (flags < 0)
 		goto free;
 	if (flags != JSON && flags != NORMAL) {
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto free;
 	}
 	if (cfg.verbose)
@@ -1882,7 +1910,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	const char *verbose = "Increase output verbosity";
 	struct nvme_topology t = { };
 	enum nvme_print_flags flags;
-	int err = 0;
+	int err = -1;
 
 	struct config {
 		char *device_dir;
@@ -1941,7 +1969,7 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	const char *human_readable = "show identify in readable format";
 	enum nvme_print_flags flags;
 	struct nvme_id_ctrl ctrl;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		int vendor_specific;
@@ -2046,7 +2074,7 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *raw = "show descriptors in binary format";
 	const char *namespace_id = "identifier of desired namespace";
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 	void *nsdescs;
 
 	struct config {
@@ -2087,7 +2115,8 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	if (posix_memalign(&nsdescs, getpagesize(), 0x1000)) {
 		fprintf(stderr, "can not allocate controller list payload\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -2119,7 +2148,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 
 	enum nvme_print_flags flags;
 	struct nvme_id_ns ns;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32 namespace_id;
@@ -2188,7 +2217,7 @@ static int id_ns_granularity(int argc, char **argv, struct command *cmd, struct 
 
 	struct nvme_id_ns_granularity_list *granularity_list;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		char *output_format;
@@ -2213,7 +2242,8 @@ static int id_ns_granularity(int argc, char **argv, struct command *cmd, struct 
 
 	if (posix_memalign((void *)&granularity_list, getpagesize(), NVME_IDENTIFY_DATA_SIZE)) {
 		fprintf(stderr, "can not allocate granularity list payload\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -2241,7 +2271,7 @@ static int id_nvmset(int argc, char **argv, struct command *cmd, struct plugin *
 
 	struct nvme_id_nvmset nvmset;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u16 nvmset_id;
@@ -2291,7 +2321,7 @@ static int id_uuid(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	struct nvme_id_uuid_list uuid_list;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		int   raw_binary;
@@ -2435,7 +2465,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 		"8h: Secondary Assign\n"\
 		"9h: Secondary Online";
 	const char *nr = "Number of Controller Resources(NR)";
-	int fd, err;
+	int fd, err = -1;
 	__u32 result, cdw10;
 
 	struct config {
@@ -2488,7 +2518,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *cmd, struct 
 	const char *human_readable = "show info in readable format";
 	struct nvme_primary_ctrl_caps caps;
 
-	int err, fd;
+	int err = -1, fd;
 	enum nvme_print_flags flags;
 
 	struct config {
@@ -2539,7 +2569,7 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 
 	struct nvme_secondary_controllers_list *sc_list;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u16 cntid;
@@ -2573,13 +2603,15 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 
 	if (!cfg.num_entries) {
 		fprintf(stderr, "non-zero num-entries is required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
 	if (posix_memalign((void *)&sc_list, getpagesize(), sizeof(*sc_list))) {
 		fprintf(stderr, "can not allocate controller list payload\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -2610,7 +2642,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 		"2h Start a extended device self-test operation\n"\
 		"eh Start a vendor specific device self-test operation\n"\
 		"fh abort the device self-test operation\n";
-	int fd, err;
+	int fd, err = -1;
 
 	struct config {
 		__u32 namespace_id;
@@ -2661,7 +2693,7 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 
 	struct nvme_self_test_log self_test_log;
 	enum nvme_print_flags flags;
-	int err, fd;
+	int err = -1, fd;
 	__u32 log_size;
 
 	struct config {
@@ -2726,7 +2758,7 @@ static int get_feature(int argc, char **argv, struct command *cmd, struct plugin
 	const char *cdw11 = "dword 11 for interrupt vector config";
 	const char *human_readable = "show feature in readable format";
 	const char *uuid_index = "specify uuid index";
-	int err, fd;
+	int err = -1, fd;
 	__u32 result;
 	void *buf = NULL;
 
@@ -2780,12 +2812,14 @@ static int get_feature(int argc, char **argv, struct command *cmd, struct plugin
 
 	if (cfg.sel > 7) {
 		fprintf(stderr, "invalid 'select' param:%d\n", cfg.sel);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (!cfg.feature_id) {
 		fprintf(stderr, "feature-id required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -2808,7 +2842,8 @@ static int get_feature(int argc, char **argv, struct command *cmd, struct plugin
 	if (cfg.data_len) {
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
 			fprintf(stderr, "can not allocate feature payload\n");
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto close_fd;
 		}
 		memset(buf, 0, cfg.data_len);
@@ -2857,7 +2892,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	const char *fw = "firmware file (required)";
 	const char *xfer = "transfer chunksize limit";
 	const char *offset = "starting dword offset, default 0";
-	int err, fd, fw_fd = -1;
+	int err = -1, fd, fw_fd = -1;
 	unsigned int fw_size;
 	struct stat sb;
 	void *fw_buf, *buf;
@@ -2891,7 +2926,8 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	if (fw_fd < 0) {
 		fprintf(stderr, "Failed to open firmware file %s: %s\n",
 				cfg.fw, strerror(errno));
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -2904,7 +2940,8 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	fw_size = sb.st_size;
 	if ((fw_size & 0x3) || (fw_size == 0)) {
 		fprintf(stderr, "Invalid size:%d for f/w image\n", fw_size);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fw_fd;
 	}
 
@@ -2918,7 +2955,8 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 
 	if (!fw_buf) {
 		perror("No memory for f/w size:\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fw_fd;
 	}
 
@@ -2977,7 +3015,7 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 	const char *slot = "[0-7]: firmware slot for commit action";
 	const char *action = "[0-7]: commit action";
 	const char *bpid = "[0,1]: boot partition identifier, if applicable (default: 0)";
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u8 slot;
@@ -3004,17 +3042,20 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 
 	if (cfg.slot > 7) {
 		fprintf(stderr, "invalid slot:%d\n", cfg.slot);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.action > 7 || cfg.action == 4 || cfg.action == 5) {
 		fprintf(stderr, "invalid action:%d\n", cfg.action);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.bpid > 1) {
 		fprintf(stderr, "invalid boot partition id:%d\n", cfg.bpid);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -3053,7 +3094,7 @@ ret:
 static int subsystem_reset(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Resets the NVMe subsystem\n";
-	int err, fd;
+	int err = -1, fd;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
@@ -3080,7 +3121,7 @@ ret:
 static int reset(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Resets the NVMe controller\n";
-	int err, fd;
+	int err = -1, fd;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
@@ -3131,7 +3172,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *sanact_desc = "Sanitize action.";
 	const char *ovrpat_desc = "Overwrite pattern.";
 
-	int fd, ret;
+	int fd, ret = -1;
 
 	struct config {
 		int    no_dealloc;
@@ -3173,14 +3214,16 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 		break;
 	default:
 		fprintf(stderr, "Invalid Sanitize Action\n");
-		ret = -EINVAL;
+		errno = EINVAL;
+		ret = -1;
 		goto close_fd;
 	}
 
 	if (cfg.sanact == NVME_SANITIZE_ACT_EXIT) {
 	       if (cfg.ause || cfg.no_dealloc) {
 			fprintf(stderr, "SANACT is Exit Failure Mode\n");
-			ret = -EINVAL;
+			errno = EINVAL;
+			ret = -1;
 			goto close_fd;
 	       }
 	}
@@ -3188,13 +3231,15 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	if (cfg.sanact == NVME_SANITIZE_ACT_OVERWRITE) {
 		if (cfg.owpass >= 16) {
 			fprintf(stderr, "OWPASS out of range [0-15]\n");
-			ret = -EINVAL;
+			errno = EINVAL;
+			ret = -1;
 			goto close_fd;
 		}
 	} else {
 		if (cfg.owpass || cfg.oipbp || cfg.ovrpat) {
 			fprintf(stderr, "SANACT is not Overwrite\n");
-			ret = -EINVAL;
+			errno = EINVAL;
+			ret = -1;
 			goto close_fd;
 		}
 	}
@@ -3221,7 +3266,7 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 
 	enum nvme_print_flags flags;
 	bool fabrics = true;
-	int fd, err;
+	int fd, err = -1;
 	void *bar;
 
 	struct config {
@@ -3279,7 +3324,7 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 	const char *offset = "offset of the requested property";
 	const char *human_readable = "show property in readable format";
 
-	int fd, err;
+	int fd, err = -1;
 	uint64_t value;
 
 	struct config {
@@ -3304,7 +3349,8 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 
 	if (cfg.offset == -1) {
 		fprintf(stderr, "offset required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -3329,7 +3375,7 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 			   "for NVMe ove Fabric";
 	const char *offset = "the offset of the property";
 	const char *value = "the value of the property to be set";
-	int fd, err;
+	int fd, err = -1;
 
 	struct config {
 		int offset;
@@ -3353,12 +3399,14 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 
 	if (cfg.offset == -1) {
 		fprintf(stderr, "offset required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.value == -1) {
 		fprintf(stderr, "value required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -3397,7 +3445,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 	struct nvme_id_ns ns;
 	struct nvme_id_ctrl ctrl;
-	int err, fd, i;
+	int err = -1, fd, i;
 	int block_size;
 	__u8 prev_lbaf = 0;
 
@@ -3446,7 +3494,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	if (cfg.lbaf != 0xff && cfg.bs !=0) {
 		fprintf(stderr,
 			"Invalid specification of both LBAF and Block Size, please specify only one\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.bs) {
@@ -3454,7 +3503,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 			fprintf(stderr,
 				"Invalid value for block size (%"PRIu64"), must be a power of two\n",
 				       (uint64_t) cfg.bs);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 	}
@@ -3485,7 +3535,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 			"Invalid namespace ID, "
 			"specify a namespace to format or use '-n 0xffffffff' "
 			"to format all namespaces on this controller.\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -3516,7 +3567,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 					(uint64_t)cfg.bs);
 				fprintf(stderr,
 					"Please correct block size, or specify LBAF directly\n");
-				err = -EINVAL;
+				errno = EINVAL;
+				err = -1;
 				goto close_fd;
 			}
 		} else  if (cfg.lbaf == 0xff)
@@ -3528,27 +3580,32 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	/* ses & pi checks set to 7 for forward-compatibility */
 	if (cfg.ses > 7) {
 		fprintf(stderr, "invalid secure erase settings:%d\n", cfg.ses);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.lbaf > 63) {
 		fprintf(stderr, "invalid lbaf:%d\n", cfg.lbaf);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.pi > 7) {
 		fprintf(stderr, "invalid pi:%d\n", cfg.pi);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.pil > 1) {
 		fprintf(stderr, "invalid pil:%d\n", cfg.pil);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 	if (cfg.ms > 1) {
 		fprintf(stderr, "invalid ms:%d\n", cfg.ms);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -3635,7 +3692,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	const char *cdw12 = "feature cdw12, if used";
 	const char *save = "specifies that the controller shall save the attribute";
 	const char *uuid_index = "specify uuid index";
-	int err;
+	int err = -1;
 	__u32 result;
 	void *buf = NULL;
 	int fd, ffd = STDIN_FILENO;
@@ -3693,7 +3750,8 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 
 	if (!cfg.feature_id) {
 		fprintf(stderr, "feature-id required param\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -3709,7 +3767,8 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	if (cfg.data_len) {
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
 			fprintf(stderr, "can not allocate feature payload\n");
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto close_fd;
 		}
 		memset(buf, 0, cfg.data_len);
@@ -3723,9 +3782,10 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
             if (strlen(cfg.file)) {
                 ffd = open(cfg.file, O_RDONLY);
                 if (ffd <= 0) {
+                    errno = EINVAL;
                     fprintf(stderr, "Failed to open file %s: %s\n",
                     cfg.file, strerror(errno));
-                    err = -EINVAL;
+                    err = -1;
                     goto free;
                 }
             }
@@ -3792,7 +3852,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *tl = "transfer length (cf. SPC-4)";
 	const char *namespace_id = "desired namespace";
 	const char *nssf = "NVMe Security Specific Field";
-	int err, fd, sec_fd = -1;
+	int err = -1, fd, sec_fd = -1;
 	void *sec_buf;
 	unsigned int sec_size;
 
@@ -3830,7 +3890,8 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	if (sec_fd < 0) {
 		fprintf(stderr, "Failed to open %s: %s\n",
 				cfg.file, strerror(errno));
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -3843,7 +3904,8 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	sec_size = sb.st_size;
 	if (posix_memalign(&sec_buf, getpagesize(), sec_size)) {
 		fprintf(stderr, "No memory for security size:%d\n", sec_size);
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_sec_fd;
 	}
 
@@ -3887,7 +3949,7 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *endir = "directive enable";
 	const char *ttype = "target directive type to be enabled/disabled";
 	const char *human_readable = "show directive in readable format";
-	int err, fd;
+	int err = -1, fd;
 	__u32 result;
 	__u32 dw12 = 0;
 	void *buf = NULL;
@@ -3940,14 +4002,16 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		case NVME_DIR_SND_ID_OP_ENABLE:
 			if (!cfg.ttype) {
 				fprintf(stderr, "target-dir required param\n");
-				err = -EINVAL;
+				errno = EINVAL;
+				err = -1;
 				goto close_fd;
 			}
 			dw12 = cfg.ttype << 8 | cfg.endir;
 			break;
 		default:
 			fprintf(stderr, "invalid directive operations for Identify Directives\n");
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 		break;
@@ -3958,20 +4022,23 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 			break;
 		default:
 			fprintf(stderr, "invalid directive operations for Streams Directives\n");
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 		break;
 	default:
 		fprintf(stderr, "invalid directive type\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
 
 	if (cfg.data_len) {
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto close_fd;
 		}
 		memset(buf, 0, cfg.data_len);
@@ -3983,7 +4050,8 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 			if (ffd <= 0) {
 				fprintf(stderr, "Failed to open file %s: %s\n",
 						cfg.file, strerror(errno));
-				err = -EINVAL;
+				errno = EINVAL;
+				err = -1;
 				goto free;
 			}
 		}
@@ -4026,7 +4094,7 @@ ret:
 
 static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err, fd;
+	int err = -1, fd;
 	const char *desc = "The Write Uncorrectable command is used to set a "\
 			"range of logical blocks to invalid.";
 	const char *namespace_id = "desired namespace";
@@ -4081,7 +4149,7 @@ ret:
 
 static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err, fd;
+	int err = -1, fd;
 	__u16 control = 0;
 	const char *desc = "The Write Zeroes command is used to set a "\
 			"range of logical blocks to zero.";
@@ -4137,7 +4205,9 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		goto ret;
 
 	if (cfg.prinfo > 0xf) {
-		err = -EINVAL;
+		fprintf(stderr, "invalid prinfo: %u\n", cfg.prinfo);
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4186,7 +4256,7 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	const char *idr = "Attribute Integral Dataset for Read";
 	const char *cdw11 = "All the command DWORD 11 attributes. Use instead of specifying individual attributes";
 
-	int err, fd;
+	int err = -1, fd;
 	uint16_t nr, nc, nb, ns;
 	int ctx_attrs[256] = {0,};
 	int nlbs[256] = {0,};
@@ -4237,7 +4307,8 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	nr = max(nc, max(nb, ns));
 	if (!nr || nr > 256) {
 		fprintf(stderr, "No range definition provided\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4254,7 +4325,8 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	dsm = nvme_setup_dsm_range(ctx_attrs, nlbs, slbas, nr);
 	if (!dsm) {
 		fprintf(stderr, "failed to allocate data set payload\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4299,7 +4371,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	const char *d_dspec = "directive specific (write part)";
 	const char *d_format = "source range entry format";
 
-	int err, fd;
+	int err = -1, fd;
 	uint16_t nr, nb, ns, nrts, natms, nats;
 	int nlbs[128] = { 0 };
 	unsigned long long slbas[128] = {0,};
@@ -4373,7 +4445,8 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	nr = max(nb, max(ns, max(nrts, max(natms, nats))));
 	if (!nr || nr > 128) {
 		fprintf(stderr, "invalid range\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4388,7 +4461,8 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	copy = nvme_setup_copy_range(nlbs, slbas, eilbrts, elbatms, elbats, nr);
 	if (!copy) {
 		fprintf(stderr, "failed to allocate payload\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4418,7 +4492,7 @@ static int flush(int argc, char **argv, struct command *cmd, struct plugin *plug
 		"flushed by the controller, from any namespace, depending on controller and "\
 		"associated namespace status.";
 	const char *namespace_id = "identifier of desired namespace";
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32 namespace_id;
@@ -4472,7 +4546,7 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	const char *rtype = "reservation type";
 	const char *racqa = "reservation acquire action";
 	const char *iekey = "ignore existing res. key";
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32 namespace_id;
@@ -4514,7 +4588,8 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	}
 	if (cfg.racqa > 7) {
 		fprintf(stderr, "invalid racqa:%d\n", cfg.racqa);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4544,7 +4619,7 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 	const char *nrkey = "new reservation key";
 	const char *rrega = "reservation registration action";
 	const char *cptpl = "change persistence through power loss setting";
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32 namespace_id;
@@ -4586,13 +4661,15 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 	}
 	if (cfg.cptpl > 3) {
 		fprintf(stderr, "invalid cptpl:%d\n", cfg.cptpl);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
 	if (cfg.rrega > 7) {
 		fprintf(stderr, "invalid rrega:%d\n", cfg.rrega);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4626,7 +4703,7 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 	const char *iekey = "ignore existing res. key";
 	const char *rtype = "reservation type";
 	const char *rrela = "reservation release action";
-	int err, fd;
+	int err = -1, fd;
 
 	struct config {
 		__u32 namespace_id;
@@ -4666,7 +4743,8 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 	}
 	if (cfg.rrela > 7) {
 		fprintf(stderr, "invalid rrela:%d\n", cfg.rrela);
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4699,7 +4777,7 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 
 	struct nvme_reservation_status *status;
 	enum nvme_print_flags flags;
-	int err, fd, size;
+	int err = -1, fd, size;
 
 	struct config {
 		__u32 namespace_id;
@@ -4752,7 +4830,8 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 
 	if (posix_memalign((void **)&status, getpagesize(), size)) {
 		fprintf(stderr, "No memory for resv report:%d\n", size);
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 	memset(status, 0, size);
@@ -4784,7 +4863,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 {
 	struct timeval start_time, end_time;
 	void *buffer, *mbuffer = NULL;
-	int err = 0;
+	int err = -1;
 	int dfd, mfd, fd;
 	int flags = opcode & 1 ? O_RDONLY : O_WRONLY | O_CREAT;
 	int mode = S_IRUSR | S_IWUSR |S_IRGRP | S_IWGRP| S_IROTH;
@@ -4877,7 +4956,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 
 	dfd = mfd = opcode & 1 ? STDIN_FILENO : STDOUT_FILENO;
 	if (cfg.prinfo > 0xf) {
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -4891,7 +4971,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 		if (cfg.dtype > 0xf) {
 			fprintf(stderr, "Invalid directive type, %x\n",
 				cfg.dtype);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 		control |= cfg.dtype << 4;
@@ -4902,7 +4983,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 		dfd = open(cfg.data, flags, mode);
 		if (dfd < 0) {
 			perror(cfg.data);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 		mfd = dfd;
@@ -4911,14 +4993,16 @@ static int submit_io(int opcode, char *command, const char *desc,
 		mfd = open(cfg.metadata, flags, mode);
 		if (mfd < 0) {
 			perror(cfg.metadata);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_dfd;
 		}
 	}
 
 	if (!cfg.data_size)	{
 		fprintf(stderr, "data size not provided\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_mfd;
 	}
 
@@ -4936,7 +5020,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 	buffer = nvme_alloc(buffer_size, &huge);
 	if (!buffer) {
 		perror("can not allocate io payload\n");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_mfd;
 	}
 
@@ -4966,7 +5051,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 		mbuffer = malloc(mbuffer_size);
 		if (!mbuffer) {
 			perror("can not allocate buf for io metadata payload\n");
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto free_buffer;
 		}
 		memset(mbuffer, 0, mbuffer_size);
@@ -5023,12 +5109,14 @@ static int submit_io(int opcode, char *command, const char *desc,
 		if (!(opcode & 1) && write(dfd, (void *)buffer, cfg.data_size) < 0) {
 			fprintf(stderr, "write: %s: failed to write buffer to output file\n",
 					strerror(errno));
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 		} else if (!(opcode & 1) && cfg.metadata_size &&
 				write(mfd, (void *)mbuffer, mbuffer_size) < 0) {
 			fprintf(stderr, "write: %s: failed to write meta-data buffer to output file\n",
 					strerror(errno));
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 		} else
 			fprintf(stderr, "%s: Success\n", command);
 	}
@@ -5073,7 +5161,7 @@ static int write_cmd(int argc, char **argv, struct command *cmd, struct plugin *
 
 static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err, fd;
+	int err = -1, fd;
 	__u16 control = 0;
 	const char *desc = "Verify specified logical blocks on the given device.";
 	const char *namespace_id = "desired namespace";
@@ -5128,7 +5216,9 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		goto err;
 
 	if (cfg.prinfo > 0xf) {
-		err = EINVAL;
+		fprintf(stderr, "invalid 'prinfo' param:%u\n", cfg.prinfo);
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -5176,7 +5266,7 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *raw = "dump output in binary format";
 	const char *namespace_id = "desired namespace";
 	const char *nssf = "NVMe Security Specific Field";
-	int err, fd;
+	int err = -1, fd;
 	void *sec_buf = NULL;
 
 	struct config {
@@ -5215,7 +5305,8 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 		if (posix_memalign(&sec_buf, getpagesize(), cfg.size)) {
 			fprintf(stderr, "No memory for security size:%d\n",
 								cfg.size);
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto close_fd;
 		}
 	}
@@ -5260,7 +5351,7 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 
 	enum nvme_print_flags flags;
 	unsigned long buf_len;
-	int err, fd;
+	int err = -1, fd;
 	void *buf;
 
 	struct config {
@@ -5304,7 +5395,8 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 
 	if (!cfg.atype) {
 		fprintf(stderr, "action type (--action) has to be given\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -5312,7 +5404,8 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 	buf = calloc(1, buf_len);
 	if (!buf) {
 		perror("could not alloc memory for get lba status");
-		err = -ENOMEM;
+		errno = ENOMEM;
+		err = -1;
 		goto close_fd;
 	}
 
@@ -5345,7 +5438,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 	const char *human_readable = "show directive in readable format";
 
 	enum nvme_print_flags flags = NORMAL;
-	int err, fd;
+	int err = -1, fd;
 	__u32 result;
 	__u32 dw12 = 0;
 	void *buf = NULL;
@@ -5400,7 +5493,8 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 			break;
 		default:
 			fprintf(stderr, "invalid directive operations for Identify Directives\n");
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 		break;
@@ -5419,19 +5513,22 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 			break;
 		default:
 			fprintf(stderr, "invalid directive operations for Streams Directives\n");
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 		break;
 	default:
 		fprintf(stderr, "invalid directive type\n");
-		err = -EINVAL;
+		errno = EINVAL;
+		err = -1;
 		goto close_fd;
 	}
 
 	if (cfg.data_len) {
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto close_fd;
 		}
 		memset(buf, 0, cfg.data_len);
@@ -5490,7 +5587,7 @@ static int passthru(int argc, char **argv, int ioctl_cmd, uint8_t cmd_type,
 	const char *latency = "output latency statistics";
 
 	void *data = NULL, *metadata = NULL;
-	int err = 0, wfd = STDIN_FILENO, fd;
+	int err = -1, wfd = STDIN_FILENO, fd;
 	__u32 result;
 	bool huge;
 	const char *cmd_name = NULL;
@@ -5578,7 +5675,8 @@ static int passthru(int argc, char **argv, int ioctl_cmd, uint8_t cmd_type,
 			   S_IRUSR | S_IRGRP | S_IROTH);
 		if (wfd < 0) {
 			perror(cfg.input_file);
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto close_fd;
 		}
 	}
@@ -5587,7 +5685,8 @@ static int passthru(int argc, char **argv, int ioctl_cmd, uint8_t cmd_type,
 		metadata = malloc(cfg.metadata_len);
 		if (!metadata) {
 			perror("can not allocate metadata payload\n");
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto close_wfd;
 		}
 		memset(metadata, cfg.prefill, cfg.metadata_len);
@@ -5596,7 +5695,8 @@ static int passthru(int argc, char **argv, int ioctl_cmd, uint8_t cmd_type,
 		data = nvme_alloc(cfg.data_len, &huge);
 		if (!data) {
 			perror("can not allocate data payload\n");
-			err = -ENOMEM;
+			errno = ENOMEM;
+			err = -1;
 			goto free_metadata;
 		}
 
@@ -5611,7 +5711,8 @@ static int passthru(int argc, char **argv, int ioctl_cmd, uint8_t cmd_type,
 		memset(data, cfg.prefill, cfg.data_len);
 		if (!cfg.read && !cfg.write) {
 			fprintf(stderr, "data direction not given\n");
-			err = -EINVAL;
+			errno = EINVAL;
+			err = -1;
 			goto free_data;
 		} else if (cfg.write) {
 			if (read(wfd, data, cfg.data_len) < 0) {


### PR DESCRIPTION
Fix the shell return error numbers(errno) in overall
nvme.c file.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>