### PR TITLE
nvme-cli: Add lsi option for get-log command

### DIFF
--- a/Documentation/nvme-get-log.1
+++ b/Documentation/nvme-get-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-get-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"      Date: 01/13/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-LOG" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-LOG" "1" "01/13/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -39,6 +39,7 @@ nvme-get-log \- Retrieves a log page from an NVMe device
                       [\-\-raw\-binary | \-b]
                       [\-\-lpo=<offset> | \-o <offset>]
                       [\-\-lsp=<field> | \-s <field>]
+                      [\-\-lsi=<field> | \-S <field>]
                       [\-\-rae | \-r]
 .fi
 .SH "DESCRIPTION"
@@ -83,6 +84,11 @@ The log page offset specifies the location within a log page to start returning 
 \-s <field>, \-\-lsp=<field>
 .RS 4
 The log specified field of LID\&.
+.RE
+.PP
+\-S <field>, \-\-lsi=<field>
+.RS 4
+The log specified field of Log Specific Identifier\&.
 .RE
 .PP
 \-r, \-\-rae

--- a/Documentation/nvme-get-log.html
+++ b/Documentation/nvme-get-log.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc 9.0.0rc2" />
 <title>nvme-get-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -756,6 +756,7 @@ nvme-get-log(1) Manual Page
                       [--raw-binary | -b]
                       [--lpo=&lt;offset&gt; | -o &lt;offset&gt;]
                       [--lsp=&lt;field&gt; | -s &lt;field&gt;]
+                      [--lsi=&lt;field&gt; | -S &lt;field&gt;]
                       [--rae | -r]</pre>
 <div class="attribution">
 </div></div>
@@ -864,6 +865,17 @@ program to parse.</p></div>
 </p>
 </dd>
 <dt class="hdlist1">
+-S &lt;field&gt;
+</dt>
+<dt class="hdlist1">
+--lsi=&lt;field&gt;
+</dt>
+<dd>
+<p>
+        The log specified field of Log Specific Identifier.
+</p>
+</dd>
+<dt class="hdlist1">
 -r
 </dt>
 <dt class="hdlist1">
@@ -918,7 +930,7 @@ Have the program return the raw log page in binary:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2019-09-18 00:00:58 JST
+ 2021-01-13 23:17:32 JST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-get-log.txt
+++ b/Documentation/nvme-get-log.txt
@@ -15,6 +15,7 @@ SYNOPSIS
 		      [--raw-binary | -b]
 		      [--lpo=<offset> | -o <offset>]
 		      [--lsp=<field> | -s <field>]
+		      [--lsi=<field> | -S <field>]
 		      [--rae | -r]
 
 DESCRIPTION
@@ -67,6 +68,10 @@ OPTIONS
 -s <field>::
 --lsp=<field>::
 	The log specified field of LID.
+
+-S <field>::
+--lsi=<field>::
+	The log specified field of Log Specific Identifier.
 
 -r::
 --rae::

--- a/nvme.c
+++ b/nvme.c
@@ -1231,12 +1231,14 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *aen = "result of the aen, use to override log id";
 	const char *lsp = "log specific field";
 	const char *lpo = "log page offset specifies the location within a log page from where to start returning data";
+	const char *lsi = "log specific identifier specifies an identifier that is required for a particular log page";
 	const char *rae = "retain an asynchronous event";
 	const char *raw = "output in raw format";
 	const char *uuid_index = "UUID index";
 	int err, fd;
 
 	struct config {
+		__u16 lsi;
 		__u32 namespace_id;
 		__u8  log_id;
 		__u32 log_len;
@@ -1254,6 +1256,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		.log_len      = 0,
 		.lpo          = NVME_NO_LOG_LPO,
 		.lsp          = NVME_NO_LOG_LSP,
+		.lsi          = 0,
 		.rae          = 0,
 		.uuid_index   = 0,
 	};
@@ -1265,6 +1268,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		OPT_UINT("aen",          'a', &cfg.aen,          aen),
 		OPT_LONG("lpo",          'o', &cfg.lpo,          lpo),
 		OPT_BYTE("lsp",          's', &cfg.lsp,          lsp),
+		OPT_SHRT("lsi",          'S', &cfg.lsi,          lsi),
 		OPT_FLAG("rae",          'r', &cfg.rae,          rae),
 		OPT_BYTE("uuid-index",   'U', &cfg.uuid_index,   uuid_index),
 		OPT_FLAG("raw-binary",   'b', &cfg.raw_binary,   raw),
@@ -1294,7 +1298,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		}
 
 		err = nvme_get_log14(fd, cfg.namespace_id, cfg.log_id,
-				     cfg.lsp, cfg.lpo, 0, cfg.rae,
+				     cfg.lsp, cfg.lpo, cfg.lsi, cfg.rae,
 				     cfg.uuid_index, cfg.log_len, log);
 		if (!err) {
 			if (!cfg.raw_binary) {


### PR DESCRIPTION
Previously lsi is set as 0 as hard coded value by the get-log command.
To set this parameter by the command add lsi option for the command.

Signed-off-by: Tokunori Ikegami <ikegami.t@gmail.com>