### PR TITLE
nvme: add lsp and uuid index invalid value checks in get log

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1236,6 +1236,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *raw = "output in raw format";
 	const char *uuid_index = "UUID index";
 	int err, fd;
+	unsigned char *log;
 
 	struct config {
 		__u16 lsi;
@@ -1287,33 +1288,47 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	if (!cfg.log_len) {
 		fprintf(stderr, "non-zero log-len is required param\n");
 		err = -EINVAL;
-	} else {
-		unsigned char *log;
-
-		log = malloc(cfg.log_len);
-		if (!log) {
-			perror("could not alloc buffer for log\n");
-			err = -ENOMEM;
-			goto close_fd;
-		}
-
-		err = nvme_get_log14(fd, cfg.namespace_id, cfg.log_id,
-				     cfg.lsp, cfg.lpo, cfg.lsi, cfg.rae,
-				     cfg.uuid_index, cfg.log_len, log);
-		if (!err) {
-			if (!cfg.raw_binary) {
-				printf("Device:%s log-id:%d namespace-id:%#x\n",
-				       devicename, cfg.log_id,
-				       cfg.namespace_id);
-				d(log, cfg.log_len, 16, 1);
-			} else
-				d_raw((unsigned char *)log, cfg.log_len);
-		} else if (err > 0)
-			nvme_show_status(err);
-		else
-			perror("log page");
-		free(log);
+		goto close_fd;
 	}
+
+	if (cfg.lsp > 16) {
+		fprintf(stderr, "invalid lsp param: %u\n", cfg.lsp);
+		errno = EINVAL;
+		err = -1;
+		goto close_fd;
+	}
+
+	if (cfg.uuid_index > 128) {
+		fprintf(stderr, "invalid uuid index param: %u\n", cfg.uuid_index);
+		errno = EINVAL;
+		err = -1;
+		goto close_fd;
+	}
+
+	log = malloc(cfg.log_len);
+	if (!log) {
+		perror("could not alloc buffer for log\n");
+		err = -ENOMEM;
+		goto close_fd;
+	}
+
+	err = nvme_get_log14(fd, cfg.namespace_id, cfg.log_id,
+					cfg.lsp, cfg.lpo, cfg.lsi, cfg.rae,
+					cfg.uuid_index, cfg.log_len, log);
+	if (!err) {
+		if (!cfg.raw_binary) {
+			printf("Device:%s log-id:%d namespace-id:%#x\n",
+					devicename, cfg.log_id,
+					cfg.namespace_id);
+			d(log, cfg.log_len, 16, 1);
+		} else
+			d_raw((unsigned char *)log, cfg.log_len);
+	} else if (err > 0)
+		nvme_show_status(err);
+	else
+		perror("log page");
+	free(log);
+
 close_fd:
 	close(fd);
 ret:


### PR DESCRIPTION
Add the invalid LSP and UUID Index value checks as per the field
lengths. Refactor the get_log function.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>