### PR TITLE
nvme-topology: no error message when openeing of controller fails

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -319,10 +319,8 @@ static int scan_ctrl(struct nvme_ctrl *c, char *p, __u32 ns_instance)
 		return ret;
 
 	fd = open(path, O_RDONLY);
-	if (fd < 0) {
-		fprintf(stderr, "Failed to open %s\n", path);
+	if (fd < 0)
 		goto free;
-	}
 
 	ret = nvme_identify_ctrl(fd, &c->id);
 	if (ret < 0)


### PR DESCRIPTION
scan_ctrl() tries to open the controller device but this operation is
expected to fail for fabric setups when a path is down. This can lead
to the situation where the subsystem is in a healthy state, e.g. at
least one path is in live state. In this scenario a failure is printed
although everything is fine.

This is especially a problem for NVMe/TCP configs where the controller
remains in 'connecting' state for 10 minutes following a path
down. All that time 'nvme list' ends up in errors and that's a major
irritant for end users. This also makes CI automation more complex
than needed.

Just drop the error message as we have other error paths in this
function where we just bail out if they fail without printing an
error message.

Signed-off-by: Daniel Wagner <dwagner@suse.de>