### PR TITLE
fabrics: skip connect if transport type doesn't match

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1354,6 +1354,10 @@ static bool should_connect(struct nvmf_disc_rsp_page_entry *entry)
 	if (cargs_match_found(entry))
 		return false;
 
+	/* skip connect if the transport type doesn't match */
+	if (strcmp(fabrics_cfg.transport, trtype_str(entry->trtype)))
+		return false;
+
 	if (!fabrics_cfg.matching_only || !fabrics_cfg.traddr)
 		return true;
 


### PR DESCRIPTION
Discovery log page data may include records belonging to different
transport types. If during a nvme connect-all, a connect is attempted
on a record that doesn't match the transport type passed here, it
would end up in a connect failure for that record. For e.g. one would
see the below error if a connect is attempted on a tcp record but the
transport type passed here is 'fc' and its associated parameters:

nvme_tcp: malformed src address passed: nn-0xXXXX:pn-0xYYYY

Fix this by proceeding with the connect only if the appropriate
transport type matches a given record during the connect-all.

Signed-off-by: Martin George <marting@netapp.com>