### PR TITLE
nvme: add the LBA format upper in Format NVM Command

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -749,7 +749,11 @@ int nvme_get_feature(int fd, __u32 nsid, __u8 fid, __u8 sel, __u32 cdw11,
 int nvme_format(int fd, __u32 nsid, __u8 lbaf, __u8 ses, __u8 pi,
 		__u8 pil, __u8 ms, __u32 timeout)
 {
-	__u32 cdw10 = lbaf | ms << 4 | pi << 5 | pil << 8 | ses << 9;
+	__u8 lbafl = lbaf & 0xf;
+	__u8 lbafu = (lbaf >> 4) & 0x3;
+	__u32 cdw10 = lbafl | ms << 4 | pi << 5 | pil << 8 | ses << 9 |
+                     lbafu << 12;
+
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_format_nvm,
 		.nsid		= nsid,

--- a/nvme.c
+++ b/nvme.c
@@ -3347,7 +3347,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		"data erase) or delete data encryption key if specified. "\
 		"Can also be used to change LBAF to change the namespaces reported physical block format.";
 	const char *namespace_id = "identifier of desired namespace";
-	const char *lbaf = "LBA format to apply (required)";
+	const char *lbaf = "[0-63]: LBA format lower (LBAFL) and upper (LBAFU), "\
+		"mention directly LBAF format that needs be applied (required)";
 	const char *ses = "[0-2]: secure erase";
 	const char *pil = "[0-1]: protection info location last/first 8 bytes of metadata";
 	const char *pi = "[0-3]: protection info off/Type 1/Type 2/Type 3";
@@ -3492,7 +3493,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		err = -EINVAL;
 		goto close_fd;
 	}
-	if (cfg.lbaf > 15) {
+	if (cfg.lbaf > 63) {
 		fprintf(stderr, "invalid lbaf:%d\n", cfg.lbaf);
 		err = -EINVAL;
 		goto close_fd;


### PR DESCRIPTION
Add the LBAFU in FormatNVM command as per the NVMe 2.0
Base Specification.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>