### PR TITLE
nvme: add get log page 2.0 spec fields

### DIFF
--- a/Documentation/nvme-get-log.1
+++ b/Documentation/nvme-get-log.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-get-log
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 01/13/2021
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 06/12/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-LOG" "1" "01/13/2021" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-LOG" "1" "06/12/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -33,14 +33,16 @@ nvme-get-log \- Retrieves a log page from an NVMe device
 .sp
 .nf
 \fInvme get\-log\fR <device> [\-\-log\-id=<log\-id> | \-i <log\-id>]
-                      [\-\-log\-len=<log\-len> | \-l <log\-len>]
-                      [\-\-aen=<aen> | \-a <aen>]
-                      [\-\-namespace\-id=<nsid> | \-n <nsid>]
-                      [\-\-raw\-binary | \-b]
-                      [\-\-lpo=<offset> | \-o <offset>]
-                      [\-\-lsp=<field> | \-s <field>]
-                      [\-\-lsi=<field> | \-S <field>]
-                      [\-\-rae | \-r]
+                [\-\-log\-len=<log\-len> | \-l <log\-len>]
+                [\-\-aen=<aen> | \-a <aen>]
+                [\-\-namespace\-id=<nsid> | \-n <nsid>]
+                [\-\-raw\-binary | \-b]
+                [\-\-lpo=<offset> | \-o <offset>]
+                [\-\-lsp=<field> | \-s <field>]
+                [\-\-lsi=<field> | \-S <field>]
+                [\-\-rae | \-r]
+                [\-\-csi=<command_set_identifier> | \-y <command_set_identifier>]
+                [\-\-ot | \-O]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -94,6 +96,16 @@ The log specified field of Log Specific Identifier\&.
 \-r, \-\-rae
 .RS 4
 Retain an Asynchronous Event\&.
+.RE
+.PP
+\-y <command_set_identifier>, \-\-csi=<command_set_identifier>
+.RS 4
+This field specifies the identifier of command set\&. if not issued, NVM Command Set will be selected\&.
+.RE
+.PP
+\-O, \-\-ot
+.RS 4
+Offset Type
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-get-log.html
+++ b/Documentation/nvme-get-log.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 9.0.0rc2" />
+<meta name="generator" content="AsciiDoc 8.6.10" />
 <title>nvme-get-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overridden by CSS in most browsers. */
+/* Because the table frame attribute is overriden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -750,14 +750,16 @@ nvme-get-log(1) Manual Page
 <div class="sectionbody">
 <div class="verseblock">
 <pre class="content"><em>nvme get-log</em> &lt;device&gt; [--log-id=&lt;log-id&gt; | -i &lt;log-id&gt;]
-                      [--log-len=&lt;log-len&gt; | -l &lt;log-len&gt;]
-                      [--aen=&lt;aen&gt; | -a &lt;aen&gt;]
-                      [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
-                      [--raw-binary | -b]
-                      [--lpo=&lt;offset&gt; | -o &lt;offset&gt;]
-                      [--lsp=&lt;field&gt; | -s &lt;field&gt;]
-                      [--lsi=&lt;field&gt; | -S &lt;field&gt;]
-                      [--rae | -r]</pre>
+                [--log-len=&lt;log-len&gt; | -l &lt;log-len&gt;]
+                [--aen=&lt;aen&gt; | -a &lt;aen&gt;]
+                [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
+                [--raw-binary | -b]
+                [--lpo=&lt;offset&gt; | -o &lt;offset&gt;]
+                [--lsp=&lt;field&gt; | -s &lt;field&gt;]
+                [--lsi=&lt;field&gt; | -S &lt;field&gt;]
+                [--rae | -r]
+                [--csi=&lt;command_set_identifier&gt; | -y &lt;command_set_identifier&gt;]
+                [--ot | -O]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -886,6 +888,29 @@ program to parse.</p></div>
         Retain an Asynchronous Event.
 </p>
 </dd>
+<dt class="hdlist1">
+-y &lt;command_set_identifier&gt;
+</dt>
+<dt class="hdlist1">
+--csi=&lt;command_set_identifier&gt;
+</dt>
+<dd>
+<p>
+        This field specifies the identifier of command set.
+        if not issued, NVM Command Set will be selected.
+</p>
+</dd>
+<dt class="hdlist1">
+-O
+</dt>
+<dt class="hdlist1">
+--ot
+</dt>
+<dd>
+<p>
+        Offset Type
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -930,7 +955,7 @@ Have the program return the raw log page in binary:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-01-13 23:17:32 JST
+ 2021-06-12 14:47:50 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-get-log.txt
+++ b/Documentation/nvme-get-log.txt
@@ -9,14 +9,16 @@ SYNOPSIS
 --------
 [verse]
 'nvme get-log' <device> [--log-id=<log-id> | -i <log-id>]
-		      [--log-len=<log-len> | -l <log-len>]
-		      [--aen=<aen> | -a <aen>]
-		      [--namespace-id=<nsid> | -n <nsid>]
-		      [--raw-binary | -b]
-		      [--lpo=<offset> | -o <offset>]
-		      [--lsp=<field> | -s <field>]
-		      [--lsi=<field> | -S <field>]
-		      [--rae | -r]
+                [--log-len=<log-len> | -l <log-len>]
+                [--aen=<aen> | -a <aen>]
+                [--namespace-id=<nsid> | -n <nsid>]
+                [--raw-binary | -b]
+                [--lpo=<offset> | -o <offset>]
+                [--lsp=<field> | -s <field>]
+                [--lsi=<field> | -S <field>]
+                [--rae | -r]
+                [--csi=<command_set_identifier> | -y <command_set_identifier>]
+                [--ot | -O]
 
 DESCRIPTION
 -----------
@@ -76,6 +78,15 @@ OPTIONS
 -r::
 --rae::
 	Retain an Asynchronous Event.
+
+-y <command_set_identifier>::
+--csi=<command_set_identifier>::
+	This field specifies the identifier of command set.
+	if not issued, NVM Command Set will be selected.
+
+-O::
+--ot::
+	Offset Type
 
 EXAMPLES
 --------

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -88,7 +88,7 @@ int nvme_identify_iocs(int fd, __u16 cntid, void *data);
 int nvme_get_log(int fd, __u32 nsid, __u8 log_id, bool rae,
 		 __u8 lsp, __u32 data_len, void *data);
 int nvme_get_log14(int fd, __u32 nsid, __u8 log_id, __u8 lsp, __u64 lpo,
-		   __u16 group_id, bool rae, __u8 uuid_ix,
+		   __u16 group_id, bool rae, __u8 uuid_ix, __u8 csi, bool ot,
 		   __u32 data_len, void *data);
 int nvme_get_log13(int fd, __u32 nsid, __u8 log_id, __u8 lsp,
 		 __u64 lpo, __u16 lsi, bool rae, __u32 data_len,

--- a/nvme.c
+++ b/nvme.c
@@ -1257,6 +1257,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *rae = "retain an asynchronous event";
 	const char *raw = "output in raw format";
 	const char *uuid_index = "UUID index";
+	const char *csi = "command set identifier";
+	const char *offset_type = "offset type";
 	int err = -1, fd;
 	unsigned char *log;
 
@@ -1269,6 +1271,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		__u64 lpo;
 		__u8  lsp;
 		__u8  uuid_index;
+		__u8  csi;
+		int   ot;
 		int   rae;
 		int   raw_binary;
 	};
@@ -1282,6 +1286,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		.lsi          = 0,
 		.rae          = 0,
 		.uuid_index   = 0,
+		.csi          = 0,
+		.ot           = 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1294,6 +1300,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		OPT_SHRT("lsi",          'S', &cfg.lsi,          lsi),
 		OPT_FLAG("rae",          'r', &cfg.rae,          rae),
 		OPT_BYTE("uuid-index",   'U', &cfg.uuid_index,   uuid_index),
+		OPT_BYTE("csi",          'y', &cfg.csi,          csi),
+		OPT_FLAG("ot",           'O', &cfg.ot,           offset_type),
 		OPT_FLAG("raw-binary",   'b', &cfg.raw_binary,   raw),
 		OPT_END()
 	};
@@ -1314,7 +1322,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		goto close_fd;
 	}
 
-	if (cfg.lsp > 16) {
+	if (cfg.lsp > 128) {
 		fprintf(stderr, "invalid lsp param: %u\n", cfg.lsp);
 		errno = EINVAL;
 		err = -1;
@@ -1337,7 +1345,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	err = nvme_get_log14(fd, cfg.namespace_id, cfg.log_id,
 					cfg.lsp, cfg.lpo, cfg.lsi, cfg.rae,
-					cfg.uuid_index, cfg.log_len, log);
+					cfg.uuid_index, cfg.csi, cfg.ot, cfg.log_len, log);
 	if (!err) {
 		if (!cfg.raw_binary) {
 			printf("Device:%s log-id:%d namespace-id:%#x\n",

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1621,7 +1621,7 @@ static bool get_dev_mgment_cbs_data(int fd, __u8 log_id, void **cbs_data)
 	memset(data, 0, sizeof (__u8) * WDC_C2_LOG_BUF_LEN);
 
 	/* get the log page length */
-	ret = nvme_get_log14(fd, 0xFFFFFFFF, lid, NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, WDC_C2_LOG_BUF_LEN, data);
+	ret = nvme_get_log14(fd, 0xFFFFFFFF, lid, NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, 0, false, WDC_C2_LOG_BUF_LEN, data);
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : Unable to get 0x%x Log Page length, ret = 0x%x\n", lid, ret);
 		goto end;
@@ -1640,7 +1640,7 @@ static bool get_dev_mgment_cbs_data(int fd, __u8 log_id, void **cbs_data)
 	}
 
 	/* get the log page data */
-	ret = nvme_get_log14(fd, 0xFFFFFFFF, lid, NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, le32_to_cpu(hdr_ptr->length), data);
+	ret = nvme_get_log14(fd, 0xFFFFFFFF, lid, NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, 0, false, le32_to_cpu(hdr_ptr->length), data);
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : Unable to read 0x%x Log Page data, ret = 0x%x\n", lid, ret);
 		goto end;
@@ -1659,7 +1659,7 @@ static bool get_dev_mgment_cbs_data(int fd, __u8 log_id, void **cbs_data)
 		/* not found with uuid = 1 try with uuid = 0 */
 		uuid_ix = 0;
 		/* get the log page data */
-		ret = nvme_get_log14(fd, 0xFFFFFFFF, lid, NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, le32_to_cpu(hdr_ptr->length), data);
+		ret = nvme_get_log14(fd, 0xFFFFFFFF, lid, NVME_NO_LOG_LSP, 0, 0, false, uuid_ix, 0, false, le32_to_cpu(hdr_ptr->length), data);
 		hdr_ptr = (struct wdc_c2_log_page_header *)data;
 		sph = (struct wdc_c2_log_subpage_header *)(data + length);
 		found = wdc_get_dev_mng_log_entry(hdr_ptr->length, log_id, hdr_ptr, &sph);
@@ -4641,7 +4641,7 @@ static int wdc_get_c0_log_page(int fd, char *format, int uuid_index)
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE,
-						NVME_NO_LOG_LSP, 0, 0, false, uuid_index, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
+						NVME_NO_LOG_LSP, 0, 0, false, uuid_index, 0, false, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
 
 				if (strcmp(format, "json"))
 					fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -4688,7 +4688,7 @@ static int wdc_get_c0_log_page(int fd, char *format, int uuid_index)
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE,
-						NVME_NO_LOG_LSP, 0, 0, false, uuid_index, WDC_NVME_EOL_STATUS_LOG_LEN, data);
+						NVME_NO_LOG_LSP, 0, 0, false, uuid_index, 0, false, WDC_NVME_EOL_STATUS_LOG_LEN, data);
 
 				if (strcmp(format, "json"))
 					fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(ret), ret);
@@ -5613,7 +5613,7 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *com
 
 		/* Get the 0xC0 log data */
 		ret = nvme_get_log14(fd, 0xFFFFFFFF, WDC_NVME_GET_SMART_CLOUD_ATTR_LOG_OPCODE,
-				NVME_NO_LOG_LSP, 0, 0, false, uuid_index, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
+				NVME_NO_LOG_LSP, 0, 0, false, uuid_index, 0, false, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
 
 		if (ret == 0) {
 			/* Verify GUID matches */


### PR DESCRIPTION
Add the Offset Type (OT) and Command Set Identifier (CSI) in
get_log and to nvme_get_log14 function as per the Spec 2.0.

Based on the requirement this can be added for the nvme_get_log13
and nvme_get_log when implementing specific log pages that use
these two parameters.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>