### PR TITLE
Add Timeout Parameter for Zone Management Commands

### DIFF
--- a/Documentation/nvme-zns-close-zone.1
+++ b/Documentation/nvme-zns-close-zone.1
@@ -32,9 +32,10 @@ nvme-zns-close-zone \- Closes one or all zones
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme zns close\-zone nvme zns id\-ctrl\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
-                                                [\-\-start\-lba=<LBA> | \-s <LBA>]
-                                                [\-\-select\-all | \-a]
+\fInvme zns close\-zone\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
+                             [\-\-start\-lba=<LBA> | \-s <LBA>]
+                             [\-\-select\-all | \-a]
+                             [\-\-timeout=<timeout> | \-t <timeout>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -56,6 +57,11 @@ The starting LBA of the zone to close\&.
 \-a, \-\-select\-all
 .RS 4
 Select all zones for this action
+.RE
+.PP
+\-t <timeout>, \-\-timeout=<timeout>
+.RS 4
+Override default timeout value\&. In milliseconds\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-zns-finish-zone.1
+++ b/Documentation/nvme-zns-finish-zone.1
@@ -32,9 +32,10 @@ nvme-zns-finish-zone \- Finishes one or all zones
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme zns finish\-zone nvme zns id\-ctrl\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
-                                                [\-\-start\-lba=<LBA> | \-s <LBA>]
-                                                [\-\-select\-all | \-a]
+\fInvme zns finish\-zone\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
+                              [\-\-start\-lba=<LBA> | \-s <LBA>]
+                              [\-\-select\-all | \-a]
+                              [\-\-timeout=<timeout> | \-t <timeout>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -56,6 +57,11 @@ The starting LBA of the zone to finish\&.
 \-a, \-\-select\-all
 .RS 4
 Select all zones for this action\&.
+.RE
+.PP
+\-t <timeout>, \-\-timeout=<timeout>
+.RS 4
+Override default timeout value\&. In milliseconds\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-zns-offline-zone.1
+++ b/Documentation/nvme-zns-offline-zone.1
@@ -32,9 +32,10 @@ nvme-zns-offline-zone \- Offlines one or all zones
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme zns offline\-zone nvme zns id\-ctrl\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
-                                                [\-\-start\-lba=<LBA> | \-s <LBA>]
-                                                [\-\-select\-all | \-a]
+\fInvme zns offline\-zone\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
+                               [\-\-start\-lba=<LBA> | \-s <LBA>]
+                               [\-\-select\-all | \-a]
+                               [\-\-timeout=<timeout> | \-t <timeout>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -56,6 +57,11 @@ The starting LBA of the zone to offline\&.
 \-a, \-\-select\-all
 .RS 4
 Select all zones for this action
+.RE
+.PP
+\-t <timeout>, \-\-timeout=<timeout>
+.RS 4
+Override default timeout value\&. In milliseconds\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-zns-open-zone.1
+++ b/Documentation/nvme-zns-open-zone.1
@@ -32,9 +32,10 @@ nvme-zns-open-zone \- Opens one or all zones
 .SH "SYNOPSIS"
 .sp
 .nf
-\fInvme zns open\-zone nvme zns id\-ctrl\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
-                                                [\-\-start\-lba=<LBA> | \-s <LBA>]
-                                                [\-\-select\-all | \-a]
+\fInvme zns open\-zone\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
+                            [\-\-start\-lba=<LBA> | \-s <LBA>]
+                            [\-\-select\-all | \-a]
+                            [\-\-timeout=<timeout> | \-t <timeout>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -56,6 +57,11 @@ The starting LBA of the zone to open\&.
 \-a, \-\-select\-all
 .RS 4
 Select all zones for this action
+.RE
+.PP
+\-t <timeout>, \-\-timeout=<timeout>
+.RS 4
+Override default timeout value\&. In milliseconds\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-zns-reset-zone.1
+++ b/Documentation/nvme-zns-reset-zone.1
@@ -33,8 +33,9 @@ nvme-zns-reset-zone \- Resets one or all zones
 .sp
 .nf
 \fInvme zns reset\-zone\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
-                               [\-\-start\-lba=<LBA> | \-s <LBA>]
-                               [\-\-select\-all | \-a]
+                             [\-\-start\-lba=<LBA> | \-s <LBA>]
+                             [\-\-select\-all | \-a]
+                             [\-\-timeout=<timeout> | \-t <timeout>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -56,6 +57,11 @@ The starting LBA of the zone to reset\&.
 \-a, \-\-select\-all
 .RS 4
 Select all zones for this action
+.RE
+.PP
+\-t <timeout>, \-\-timeout=<timeout>
+.RS 4
+Override default timeout value\&. In milliseconds\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-zns-set-zone-desc.1
+++ b/Documentation/nvme-zns-set-zone-desc.1
@@ -33,8 +33,9 @@ nvme-zns-set-zone-desc \- Set extended descriptor data for a zone
 .sp
 .nf
 \fInvme zns setzone\-desc\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
-                                 [\-\-start\-lba=<IONUM>, \-s <IONUM>]
-                                 [\-data=<FILE>, \-d <FILE>]
+                               [\-\-start\-lba=<IONUM>, \-s <IONUM>]
+                               [\-data=<FILE>, \-d <FILE>]
+                               [\-\-timeout=<timeout> | \-t <timeout>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -54,6 +55,11 @@ The starting LBA of the zone to manage send\&.
 \-d <FILE, \-data=<FILE>
 .RS 4
 Optional file for data (default stdin)
+.RE
+.PP
+\-t <timeout>, \-\-timeout=<timeout>
+.RS 4
+Override default timeout value\&. In milliseconds\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-zns-zone-mgmt-send.1
+++ b/Documentation/nvme-zns-zone-mgmt-send.1
@@ -33,11 +33,12 @@ nvme-zns-zone-mgmt-send \- Zone Management Send command
 .sp
 .nf
 \fInvme zns zone\-mgmt\-send\fR <device> [\-\-namespace\-id=<NUM> | \-n <NUM>]
-                                   [\-\-start\-lba=<IONUM>, \-s <IONUM>]
-                                   [\-\-select\-all, \-a]
-                                   [\-\-zsa=<NUM>, \-z <NUM>]
-                                   [\-\-data\-len=<IONUM>, \-l <IONUM>]
-                                   [\-data=<FILE>, \-d <FILE>]
+                                 [\-\-start\-lba=<IONUM>, \-s <IONUM>]
+                                 [\-\-select\-all, \-a]
+                                 [\-\-zsa=<NUM>, \-z <NUM>]
+                                 [\-\-data\-len=<IONUM>, \-l <IONUM>]
+                                 [\-data=<FILE>, \-d <FILE>]
+                                 [\-\-timeout=<timeout> | \-t <timeout>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -77,6 +78,11 @@ Buffer length if data required
 \-d <FILE, \-data=<FILE>
 .RS 4
 Optional file for data (default stdin)
+.RE
+.PP
+\-t <timeout>, \-\-timeout=<timeout>
+.RS 4
+Override default timeout value\&. In milliseconds\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -981,7 +981,7 @@ int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result)
 }
 
 int nvme_zns_mgmt_send(int fd, __u32 nsid, __u64 slba, bool select_all,
-		       enum nvme_zns_send_action zsa, __u32 data_len,
+		       __u32 timeout, enum nvme_zns_send_action zsa, __u32 data_len,
 		       void *data)
 {
 	__u32 cdw10 = slba & 0xffffffff;
@@ -996,6 +996,7 @@ int nvme_zns_mgmt_send(int fd, __u32 nsid, __u64 slba, bool select_all,
 		.cdw13		= cdw13,
 		.addr		= (__u64)(uintptr_t)data,
 		.data_len	= data_len,
+		.timeout_ms	= timeout,
 	};
 
 	return nvme_submit_io_passthru(fd, &cmd);

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -164,7 +164,7 @@ int nvme_self_test_log(int fd, __u32 nsid, struct nvme_self_test_log *self_test_
 int nvme_virtual_mgmt(int fd, __u32 cdw10, __u32 cdw11, __u32 *result);
 
 int nvme_zns_mgmt_send(int fd, __u32 nsid, __u64 slba, bool select_all,
-		       enum nvme_zns_send_action zsa, __u32 data_len,
+		       __u32 timeout, enum nvme_zns_send_action zsa, __u32 data_len,
 		       void *data);
 int nvme_zns_mgmt_recv(int fd, __u32 nsid, __u64 slba,
 		       enum nvme_zns_recv_action zra, __u8 zrasf,


### PR DESCRIPTION
- Enabled the option to set the timeout value used for each of the zone management commands, specifically to allow for longer timeouts with the zone-reset command. 
- The default timeout for zone reset is also increased to 90 seconds.