### PR TITLE
Add option to print device name on connect

### DIFF
--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -28,6 +28,7 @@ SYNOPSIS
 		[--disable-sqflow         | -d]
 		[--hdr-digest             | -g]
 		[--data-digest            | -G]
+		[--output-format=<fmt>    | -o <fmt>]
 
 DESCRIPTION
 -----------
@@ -139,6 +140,12 @@ OPTIONS
 -G::
 --data-digest::
 	Generates/verifies data digest (TCP).
+
+-o <format>::
+--output-format=<format>::
+	Set the reporting format to 'normal' or 'json'. Only one output format can
+	be used at a time. When this option is specified, the device associated with
+	the connection will be printed. Nothing is printed otherwise.
 
 EXAMPLES
 --------


### PR DESCRIPTION
When creating a connection (i.e. `nvme connect`) we need to know which device was create so that when we later disconnect, we'll know which device to pass to `nvme disconnect`.

This adds the `--output-format` option to the `nvme connect` command. By default, the device name is not printed. One needs to specify `--output-format normal` or `--output-format json` to print the device name in "normal" or "json" format.