### PR TITLE
autoconnect: replace network.target with network-online.target

### DIFF
--- a/nvmf-autoconnect/systemd/nvmf-autoconnect.service
+++ b/nvmf-autoconnect/systemd/nvmf-autoconnect.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Connect NVMe-oF subsystems automatically during boot
 ConditionPathExists=/etc/nvme/discovery.conf
-After=network.target
+After=network-online.target
 Before=remote-fs-pre.target
 
 [Service]


### PR DESCRIPTION
One of my test machines failed to discover the nvme-tcp target during boot
despite the fact that I added the necessary configuration under
/etc/nvme/discovery.conf and I enabled the systemd service script
"nvmf-autoconnect".

I found out that the problem is in the systemd nvmf-autoconnect service:
The script depends on a systemd service called "network.target"
but, according to the following post [1], network.target is not intended
to be used during boot.

To be sure that the network card is really configured before trying to connect to the target,
we should use "network-online.target" instead.

[1] https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

"network.target has very little meaning during start-up. It only indicates that the network management stack is up after it has been reached. Whether any network interfaces are already configured when it is reached is undefined. "
[...]
"network-online.target is a target that actively waits until the nework is "up", where the definition of "up" is defined by the network management software. Usually it indicates a configured, routable IP address of some kind. Its primary purpose is to actively delay activation of services until the network is set up. "