### PR TITLE
Fix failures during 'nvme list'

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -68,7 +68,7 @@ int nvme_get_nsid(int fd)
 	int err = fstat(fd, &nvme_stat);
 
 	if (err < 0)
-		return -errno;
+		return err;
 
 	return ioctl(fd, NVME_IOCTL_ID);
 }


### PR DESCRIPTION
Calling 'nvme list' on a system where some controllers are undergoing a reset will lead to failures in the output as the current code only tries the first controller to fetch information about the namespace.
With this the next available controller is checked if the current one returns an error.