### PR TITLE
nvme: add multiple update detected result value in fw commit

### DIFF
--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -843,14 +843,19 @@ int nvme_fw_download(int fd, __u32 offset, __u32 data_len, void *data)
 	return nvme_submit_admin_passthru(fd, &cmd);
 }
 
-int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid)
+int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid, __u32 *result)
 {
+	int err;
+
 	struct nvme_admin_cmd cmd = {
 		.opcode		= nvme_admin_activate_fw,
 		.cdw10		= (bpid << 31) | (action << 3) | slot,
 	};
 
-	return nvme_submit_admin_passthru(fd, &cmd);
+	err = nvme_submit_admin_passthru(fd, &cmd);
+	if (!err && result)
+		*result = cmd.result;
+	return err;
 }
 
 int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -137,7 +137,7 @@ int nvme_ns_attachment(int fd, __u32 nsid, __u16 num_ctrls,
 		       __u16 *ctrlist, bool attach);
 
 int nvme_fw_download(int fd, __u32 offset, __u32 data_len, void *data);
-int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid);
+int nvme_fw_commit(int fd, __u8 slot, __u8 action, __u8 bpid, __u32 *result);
 
 int nvme_sec_send(int fd, __u32 nsid, __u8 nssf, __u16 spsp,
 		  __u8 secp, __u32 tl, __u32 data_len, void *data);

--- a/nvme.c
+++ b/nvme.c
@@ -3025,6 +3025,7 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 	const char *action = "[0-7]: commit action";
 	const char *bpid = "[0,1]: boot partition identifier, if applicable (default: 0)";
 	int err = -1, fd;
+	__u32 result;
 
 	struct config {
 		__u8 slot;
@@ -3068,7 +3069,7 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 		goto close_fd;
 	}
 
-	err = nvme_fw_commit(fd, cfg.slot, cfg.action, cfg.bpid);
+	err = nvme_fw_commit(fd, cfg.slot, cfg.action, cfg.bpid, &result);
 	if (err < 0)
 		perror("fw-commit");
 	else if (err != 0)
@@ -3092,6 +3093,16 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 		if (cfg.action == 6 || cfg.action == 7)
 			printf(" bpid:%d", cfg.bpid);
 		printf("\n");
+	}
+
+	if (err >= 0) {
+		printf("Multiple Update Detected (MUD) Value: %u\n", result);
+		if (result & 0x1)
+			printf("Detected an overlapping firmware/boot partition image update command "\
+				"sequence due to processing a command from a Management Endpoint");
+		if ((result >> 1) & 0x1)
+			printf("Detected an overlapping firmware/boot partition image update command "\
+				"sequence due to processing a command from an Admin SQ on a controller");
 	}
 
 close_fd:


### PR DESCRIPTION
Add Multiple Update Detected (MUD) field in FW Commit command
CQE CDW0 as per NVMe 2.0 Spec.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>