### PR TITLE
nvme-topology: fix controller check in scan_subsystem()

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -384,7 +384,8 @@ static int scan_subsystem(struct nvme_subsystem *s, __u32 ns_instance, int nsid)
 			n->name = strdup(ns[i]->d_name);
 			for (j = 0; j < s->nr_ctrls; j++) {
 				n->ctrl = &s->ctrls[j];
-				if (!scan_namespace(n))
+				if (!strcmp(n->ctrl->state, "live") &&
+						!scan_namespace(n))
 					break;
 			}
 		}


### PR DESCRIPTION
Fix the current check in scan_subsystem() so that it iterates
through all the available controllers till it gets a 'live'
controller for that namespace.

Fixes: ce9d818 ("nvme-topology: scan all controllers in
scan_subsystem()")
Signed-off-by: Martin George <marting@netapp.com>