### PR TITLE
nvme: add CDW2 and CDW3 support for Write Zeroes and Verify Command

### DIFF
--- a/Documentation/nvme-verify.1
+++ b/Documentation/nvme-verify.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-verify
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/07/2021
+.\"      Date: 07/08/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-VERIFY" "1" "07/07/2021" "NVMe" "NVMe Manual"
+.TH "NVME\-VERIFY" "1" "07/08/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -41,6 +41,7 @@ nvme-verify \- Send an NVMe Verify command, return results
             [\-\-ref\-tag=<reftag> | \-r <reftag>]
             [\-\-app\-tag\-mask=<appmask> | \-m <appmask>]
             [\-\-app\-tag=<apptag> | \-a <apptag>]
+            [\-\-storage\-tag<storage\-tag> | \-S <storage\-tag>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -130,6 +131,11 @@ Optional application tag mask when used with protection information\&.
 \-\-app\-tag=<apptag>, \-a <apptag>
 .RS 4
 Optional application tag when used with protection information\&.
+.RE
+.PP
+\-\-storage\-tag=<storage\-tag>, \-S <storage\-tag>
+.RS 4
+Variable Sized Expected Logical Block Storage Tag(ELBST) and Expected Logical Block Reference Tag (ELBRT), CDW2 and CDW3 (00:47) bits\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-verify.html
+++ b/Documentation/nvme-verify.html
@@ -757,7 +757,8 @@ nvme-verify(1) Manual Page
             [--prinfo=&lt;prinfo&gt; | -p &lt;prinfo&gt;]
             [--ref-tag=&lt;reftag&gt; | -r &lt;reftag&gt;]
             [--app-tag-mask=&lt;appmask&gt; | -m &lt;appmask&gt;]
-            [--app-tag=&lt;apptag&gt; | -a &lt;apptag&gt;]</pre>
+            [--app-tag=&lt;apptag&gt; | -a &lt;apptag&gt;]
+            [--storage-tag&lt;storage-tag&gt; | -S &lt;storage-tag&gt;]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -909,6 +910,18 @@ metadata is passes.</p></td>
         Optional application tag when used with protection information.
 </p>
 </dd>
+<dt class="hdlist1">
+--storage-tag=&lt;storage-tag&gt;
+</dt>
+<dt class="hdlist1">
+-S &lt;storage-tag&gt;
+</dt>
+<dd>
+<p>
+        Variable Sized Expected Logical Block Storage Tag(ELBST) and Expected Logical
+        Block Reference Tag (ELBRT), CDW2 and CDW3 (00:47) bits.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -929,7 +942,7 @@ metadata is passes.</p></td>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-07-07 01:41:43 IST
+ 2021-07-07 23:04:31 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-verify.txt
+++ b/Documentation/nvme-verify.txt
@@ -17,6 +17,7 @@ SYNOPSIS
             [--ref-tag=<reftag> | -r <reftag>]
             [--app-tag-mask=<appmask> | -m <appmask>]
             [--app-tag=<apptag> | -a <apptag>]
+            [--storage-tag<storage-tag> | -S <storage-tag>]
 
 DESCRIPTION
 -----------
@@ -72,6 +73,11 @@ metadata is passes.
 --app-tag=<apptag>::
 -a <apptag>::
 	Optional application tag when used with protection information.
+
+--storage-tag=<storage-tag>::
+-S <storage-tag>::
+	Variable Sized Expected Logical Block Storage Tag(ELBST) and Expected Logical
+	Block Reference Tag (ELBRT), CDW2 and CDW3 (00:47) bits.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-write-zeroes.1
+++ b/Documentation/nvme-write-zeroes.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-zeroes
-.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 07/08/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ZEROES" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-ZEROES" "1" "07/08/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -42,6 +42,7 @@ nvme-write-zeroes \- Send an NVMe write zeroes command, return results
                         [\-\-limited\-retry | \-l]
                         [\-\-force\-unit\-access | \-f]
                         [\-\-namespace\-id=<nsid> | \-n <nsid>]
+                        [\-\-storage\-tag<storage\-tag> | \-S <storage\-tag>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -137,19 +138,14 @@ Set the force\-unit access flag\&.
 .RS 4
 Namespace ID use in the command\&.
 .RE
-.sp
-EXAMPLES EXAMPLES
-.sp
-.if n \{\
+.PP
+\-\-storage\-tag=<storage\-tag>, \-n <storage\-tag>
 .RS 4
-.\}
-.nf
-No examples yet\&.
-
-NVME
-.fi
-.if n \{\
+Variable Sized Expected Logical Block Storage Tag(ELBST) and Expected Logical Block Reference Tag (ELBRT), CDW2 and CDW3 (00:47) bits\&.
 .RE
-.\}
+.SH "EXAMPLES"
+.sp
+No examples yet\&.
+.SH "NVME"
 .sp
 Part of the nvme\-user suite

--- a/Documentation/nvme-write-zeroes.html
+++ b/Documentation/nvme-write-zeroes.html
@@ -758,7 +758,8 @@ nvme-zeroes(1) Manual Page
                         [--deac | -d]
                         [--limited-retry | -l]
                         [--force-unit-access | -f]
-                        [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]</pre>
+                        [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
+                        [--storage-tag&lt;storage-tag&gt; | -S &lt;storage-tag&gt;]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -920,15 +921,30 @@ metadata is passes.</p></td>
         Namespace ID use in the command.
 </p>
 </dd>
+<dt class="hdlist1">
+--storage-tag=&lt;storage-tag&gt;
+</dt>
+<dt class="hdlist1">
+-n &lt;storage-tag&gt;
+</dt>
+<dd>
+<p>
+        Variable Sized Expected Logical Block Storage Tag(ELBST) and Expected Logical
+        Block Reference Tag (ELBRT), CDW2 and CDW3 (00:47) bits.
+</p>
+</dd>
 </dl></div>
-<div class="paragraph"><p>EXAMPLES
-EXAMPLES</p></div>
-<div class="listingblock">
-<div class="content">
-<pre><code>No examples yet.
-
-NVME</code></pre>
-</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_examples">EXAMPLES</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>No examples yet.</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_nvme">NVME</h2>
+<div class="sectionbody">
 <div class="paragraph"><p>Part of the nvme-user suite</p></div>
 </div>
 </div>
@@ -937,7 +953,7 @@ NVME</code></pre>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2019-09-18 00:00:58 JST
+ 2021-07-07 01:54:21 IST
 </div>
 </div>
 </body>

--- a/Documentation/nvme-write-zeroes.txt
+++ b/Documentation/nvme-write-zeroes.txt
@@ -18,6 +18,7 @@ SYNOPSIS
 			[--limited-retry | -l]
 			[--force-unit-access | -f]
 			[--namespace-id=<nsid> | -n <nsid>]
+			[--storage-tag<storage-tag> | -S <storage-tag>]
 
 DESCRIPTION
 -----------
@@ -77,7 +78,11 @@ metadata is passes.
 -n <nsid>::
 	Namespace ID use in the command.
 
-EXAMPLES
+--storage-tag=<storage-tag>::
+-n <storage-tag>::
+	Variable Sized Expected Logical Block Storage Tag(ELBST) and Expected Logical
+	Block Reference Tag (ELBRT), CDW2 and CDW3 (00:47) bits.
+
 EXAMPLES
 --------
 No examples yet.

--- a/nvme-ioctl.c
+++ b/nvme-ioctl.c
@@ -146,11 +146,14 @@ int nvme_io(int fd, __u8 opcode, __u64 slba, __u16 nblocks, __u16 control,
 }
 
 int nvme_verify(int fd, __u32 nsid, __u64 slba, __u16 nblocks,
-		__u16 control, __u32 reftag, __u16 apptag, __u16 appmask)
+		__u16 control, __u32 reftag, __u16 apptag, __u16 appmask,
+		__u64 storage_tag)
 {
 	struct nvme_passthru_cmd cmd = {
 		.opcode		= nvme_cmd_verify,
 		.nsid		= nsid,
+		.cdw2		= storage_tag & 0xffffffff,
+		.cdw3		= (storage_tag >> 32) & 0xffff,
 		.cdw10		= slba & 0xffffffff,
 		.cdw11		= slba >> 32,
 		.cdw12		= nblocks | (control << 16),
@@ -174,11 +177,14 @@ int nvme_passthru_io(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
 }
 
 int nvme_write_zeros(int fd, __u32 nsid, __u64 slba, __u16 nlb,
-		     __u16 control, __u32 reftag, __u16 apptag, __u16 appmask)
+		     __u16 control, __u32 reftag, __u16 apptag, __u16 appmask,
+			 __u64 storage_tag)
 {
 	struct nvme_passthru_cmd cmd = {
 		.opcode		= nvme_cmd_write_zeroes,
 		.nsid		= nsid,
+		.cdw2		= storage_tag & 0xffffffff,
+		.cdw3		= (storage_tag >> 32) & 0xffff,
 		.cdw10		= slba & 0xffffffff,
 		.cdw11		= slba >> 32,
 		.cdw12		= nlb | (control << 16),

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -38,12 +38,14 @@ int nvme_passthru_io(int fd, __u8 opcode, __u8 flags, __u16 rsvd,
 		     void *metadata, __u32 timeout);
 
 int nvme_write_zeros(int fd, __u32 nsid, __u64 slba, __u16 nlb,
-		     __u16 control, __u32 reftag, __u16 apptag, __u16 appmask);
+		__u16 control, __u32 reftag, __u16 apptag, __u16 appmask,
+		__u64 storage_tag);
 
 int nvme_write_uncorrectable(int fd, __u32 nsid, __u64 slba, __u16 nlb);
 
 int nvme_verify(int fd, __u32 nsid, __u64 slba, __u16 nblocks,
-		__u16 control, __u32 reftag, __u16 apptag, __u16 appmask);
+		__u16 control, __u32 reftag, __u16 apptag, __u16 appmask,
+		__u64 storage_tag);
 
 int nvme_flush(int fd, __u32 nsid);
 

--- a/nvme.c
+++ b/nvme.c
@@ -4171,6 +4171,8 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	const char *ref_tag = "reference tag (for end to end PI)";
 	const char *app_tag_mask = "app tag mask (for end to end PI)";
 	const char *app_tag = "app tag (for end to end PI)";
+	const char *storage_tag = "storage tag, CDW2 and CDW3 (00:47) bits "\
+		"(for end to end PI)";
 	const char *deac = "Set DEAC bit, requesting controller to deallocate specified logical blocks";
 
 	struct config {
@@ -4181,6 +4183,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		__u16 app_tag_mask;
 		__u16 block_count;
 		__u8  prinfo;
+		__u64 storage_tag;
 		int   deac;
 		int   limited_retry;
 		int   force_unit_access;
@@ -4193,6 +4196,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		.ref_tag         = 0,
 		.app_tag_mask    = 0,
 		.app_tag         = 0,
+		.storage_tag	 = 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -4206,6 +4210,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_UINT("ref-tag",           'r', &cfg.ref_tag,           ref_tag),
 		OPT_SHRT("app-tag-mask",      'm', &cfg.app_tag_mask,      app_tag_mask),
 		OPT_SHRT("app-tag",           'a', &cfg.app_tag,           app_tag),
+		OPT_SUFFIX("storage-tag",     'S', &cfg.storage_tag,       storage_tag),
 		OPT_END()
 	};
 
@@ -4236,7 +4241,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	}
 
 	err = nvme_write_zeros(fd, cfg.namespace_id, cfg.start_block, cfg.block_count,
-			control, cfg.ref_tag, cfg.app_tag, cfg.app_tag_mask);
+			control, cfg.ref_tag, cfg.app_tag, cfg.app_tag_mask, cfg.storage_tag);
 	if (err < 0)
 		perror("write-zeroes");
 	else if (err != 0)
@@ -5182,6 +5187,8 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 	const char *ref_tag = "reference tag (for end to end PI)";
 	const char *app_tag_mask = "app tag mask (for end to end PI)";
 	const char *app_tag = "app tag (for end to end PI)";
+	const char *storage_tag = "storage tag, CDW2 and CDW3 (00:47) bits "\
+		"(for end to end PI)";
 
 	struct config {
 		__u64 start_block;
@@ -5191,6 +5198,7 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		__u16 app_tag_mask;
 		__u16 block_count;
 		__u8  prinfo;
+		__u64 storage_tag;
 		int   limited_retry;
 		int   force_unit_access;
 	};
@@ -5205,6 +5213,7 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		.app_tag_mask      = 0,
 		.limited_retry     = 0,
 		.force_unit_access = 0,
+		.storage_tag	   = 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -5217,6 +5226,7 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		OPT_UINT("ref-tag",           'r', &cfg.ref_tag,           ref_tag),
 		OPT_SHRT("app-tag",           'a', &cfg.app_tag,           app_tag),
 		OPT_SHRT("app-tag-mask",      'm', &cfg.app_tag_mask,      app_tag_mask),
+		OPT_SUFFIX("storage-tag",     'S', &cfg.storage_tag,       storage_tag),
 		OPT_END()
 	};
 
@@ -5246,7 +5256,7 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 	}
 
 	err = nvme_verify(fd, cfg.namespace_id, cfg.start_block, cfg.block_count,
-				control, cfg.ref_tag, cfg.app_tag, cfg.app_tag_mask);
+				control, cfg.ref_tag, cfg.app_tag, cfg.app_tag_mask, cfg.storage_tag);
 	if (err < 0)
 		perror("verify");
 	else if (err != 0)


### PR DESCRIPTION
Added support for the Variable Sized Expected Logical Block Storage Tag(ELBST)
and Expected Logical Block Reference Tag (ELBRT), CDW2 and CDW3 (00:47) bits
for NVM commands Write Zeroes and Verify commands.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>