### PR TITLE
nvme: support ns generic device to submit_io

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -667,6 +667,30 @@ char *nvme_char_from_block(char *dev)
 	return path;
 }
 
+int nvme_logical_block_size_from_ns_char(const char *dev)
+{
+	int ret;
+	int id, nsid;
+	char *path = NULL;
+	char *s;
+
+	ret = sscanf(dev, "ng%dn%d", &id, &nsid);
+	if (ret != 2)
+		return -EINVAL;
+
+	if (asprintf(&path, "/sys/block/nvme%dn%d/queue", id, nsid) < 0)
+		path = NULL;
+
+	if (!path)
+		return -EINVAL;
+
+	s = nvme_get_ctrl_attr(path, "logical_block_size");
+	if (!s)
+		return -EINVAL;
+
+	return atoi(s);
+}
+
 void *mmap_registers(const char *dev)
 {
 	int fd;

--- a/nvme.c
+++ b/nvme.c
@@ -156,6 +156,11 @@ static bool is_blkdev(void)
 	return S_ISBLK(nvme_stat.st_mode);
 }
 
+static bool is_ns_chardev(void)
+{
+	return !strncmp(devicename, "ng", 2) && S_ISCHR(nvme_stat.st_mode);
+}
+
 static int open_dev(char *dev)
 {
 	int err, fd;
@@ -5020,8 +5025,13 @@ static int submit_io(int opcode, char *command, const char *desc,
 		goto close_mfd;
 	}
 
-	if (ioctl(fd, BLKSSZGET, &logical_block_size) < 0)
-		goto close_mfd;
+	if (is_ns_chardev()) {
+		logical_block_size =
+			nvme_logical_block_size_from_ns_char(devicename);
+	} else {
+		if (ioctl(fd, BLKSSZGET, &logical_block_size) < 0)
+			goto close_mfd;
+	}
 
 	buffer_size = (cfg.block_count + 1) * logical_block_size;
 	if (cfg.data_size < buffer_size) {

--- a/nvme.h
+++ b/nvme.h
@@ -121,6 +121,7 @@ enum nvme_print_flags validate_output_format(const char *format);
 int __id_ctrl(int argc, char **argv, struct command *cmd,
 	struct plugin *plugin, void (*vs)(__u8 *vs, struct json_object *root));
 char *nvme_char_from_block(char *block);
+int nvme_logical_block_size_from_ns_char(const char *dev);
 void *mmap_registers(const char *dev);
 
 extern int current_index;


### PR DESCRIPTION
Retrieve `logical_block_size` sysfs attribute when I/O subcommand(e.g.,
read, write, ...) is given instead requesting BLKSSZGET ioctl to the
generic device which is not supported.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>