### PR TITLE
intel_nvme: fixed typo

### DIFF
--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -454,7 +454,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 	struct intel_temp_stats stats;
 	int err, fd;
 
-	const char *desc = "Get Intel Marketing Name log and show it.";
+	const char *desc = "Get Temperature Statistics log and show it.";
 	const char *raw = "dump output in binary format";
 	struct config {
 		int  raw_binary;


### PR DESCRIPTION
There is a typo in intel-nvme.c, it should probably read something like "Retrieve Intel Temperature Statistics log, show it". 
Instead it reads "Get Intel Marketing Name log and show it".