### PR TITLE
Change IOCTL for read, write and compare commands

### DIFF
--- a/linux/nvme_ioctl.h
+++ b/linux/nvme_ioctl.h
@@ -18,21 +18,6 @@
 #include <linux/types.h>
 #include <sys/ioctl.h>
 
-struct nvme_user_io {
-	__u8	opcode;
-	__u8	flags;
-	__u16	control;
-	__u16	nblocks;
-	__u16	rsvd;
-	__u64	metadata;
-	__u64	addr;
-	__u64	slba;
-	__u32	dsmgmt;
-	__u32	reftag;
-	__u16	apptag;
-	__u16	appmask;
-};
-
 struct nvme_passthru_cmd {
 	__u8	opcode;
 	__u8	flags;
@@ -80,7 +65,6 @@ struct nvme_passthru_cmd64 {
 
 #define NVME_IOCTL_ID		_IO('N', 0x40)
 #define NVME_IOCTL_ADMIN_CMD	_IOWR('N', 0x41, struct nvme_admin_cmd)
-#define NVME_IOCTL_SUBMIT_IO	_IOW('N', 0x42, struct nvme_user_io)
 #define NVME_IOCTL_IO_CMD	_IOWR('N', 0x43, struct nvme_passthru_cmd)
 #define NVME_IOCTL_RESET	_IO('N', 0x44)
 #define NVME_IOCTL_SUBSYS_RESET	_IO('N', 0x45)

--- a/nvme-ioctl.h
+++ b/nvme-ioctl.h
@@ -25,9 +25,9 @@ int nvme_passthru(int fd, unsigned long ioctl_cmd, __u8 opcode, __u8 flags,
 
 
 /* NVME_SUBMIT_IO */
-int nvme_io(int fd, __u8 opcode, __u64 slba, __u16 nblocks, __u16 control,
-	      __u32 dsmgmt, __u32 reftag, __u16 apptag,
-	      __u16 appmask, void *data, void *metadata);
+int nvme_io(int fd, __u8 opcode, __u32 nsid, __u64 slba, __u16 nblocks,
+	      __u16 control, __u32 dsmgmt, __u32 reftag, __u16 apptag,
+	      __u16 appmask, __u64 storage_tag, void *data, void *metadata);
 
 /* NVME_IO_CMD */
 int nvme_passthru_io(int fd, __u8 opcode, __u8 flags, __u16 rsvd,


### PR DESCRIPTION
Change the IOCTL and depricate SQE structure for NVM commands
Read, Write and Compare Commands to add support for the Storage
Tag field (CDW2 and CDW3).

Remove the unsed nvme_user_io structure and NVME_IOCTL_SUBMIT_IO.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>