### PR TITLE
Fail on busy namespace

### DIFF
--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -543,3 +543,14 @@ void argconfig_register_help_func(argconfig_help_func * f)
 		}
 	}
 }
+
+int get_opt_flag(const char *opt_name,
+		    const struct argconfig_commandline_options *options)
+{
+	const struct argconfig_commandline_options *s;
+
+	for (s = options; (s->option != NULL) && (s != NULL); s++)
+		if (!strcmp(s->option, opt_name))
+			return (*(int *) s->default_value);
+	return -1;
+}

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -127,4 +127,6 @@ int argconfig_parse_comma_sep_array_long(char *string,
 void argconfig_register_help_func(argconfig_help_func * f);
 
 void print_word_wrapped(const char *s, int indent, int start);
+int get_opt_flag(const char *option_name,
+		    const struct argconfig_commandline_options *options);
 #endif


### PR DESCRIPTION
To avoid formarting an in use namespace accidently i added a new function called `parse_and_open_exclusive()`. This opens 
the device file in exclusive mode `O_EXCL.` If this fails with the error EBUSY an error messages hints to the `--force` command line option. By calling `nvme format` with  the `--force` option it will continue formating the namespace.

This patch fixes issue: https://github.com/linux-nvme/nvme-cli/issues/1095