### PR TITLE
gen-hostnqn: Remove UUID validation heuristic

### DIFF
--- a/scripts/gen-hostnqn.sh
+++ b/scripts/gen-hostnqn.sh
@@ -23,24 +23,6 @@ if ! [[ $UUID =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ 
 	exit 2
 fi
 
-# HEURISTIC:
-# (1) if any one given character occurs more than 50% of the time, it is likely
-# that the UUID is fake.
-# (2) if the first or the last group consists of mostly the same character, it
-# is likely that the UUID is fake.
-FIRST_GROUP="$(echo $UUID | cut -d'-' -f1)"
-LAST_GROUP="$(echo $UUID | cut -d'-' -f5)"
-for i in {{0..9},{a..f}} ; do
-	COUNT_TOTAL="${UUID//[^$i]}"
-	COUNT_FIRST="${FIRST_GROUP//[^$i]}"
-	COUNT_LAST="${LAST_GROUP//[^$i]}"
-	if [ ${#COUNT_TOTAL} -ge 16 ] || [ ${#COUNT_FIRST} -ge 7 ] || [ ${#COUNT_LAST} -ge 11 ] ; then
-		>&2 echo "UUID is too repetitive. This may be a false alert."
-		>&2 echo "Repetitive UUID: ${UUID}"
-		exit 3
-	fi
-done
-
 HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:${UUID}"
 
 echo $HOSTNQN


### PR DESCRIPTION
The validation heuristic is getting triggered for valid system UUID
such as 37383638-3330-4d32-3237-33353032394e. The only UUID validation
is already implemented. Remove the heuristic as it blocks valid use
UUIDs and doesn't protect from misuse anyway.

Signed-off: Daniel Wagner <dwagner@suse.de>