### PR TITLE
Bug fix unsigned int and int should use 64bit api for json-c

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -30,9 +30,9 @@
 #define json_free_object(o) json_object_put(o)
 #define json_free_array(a) json_object_put(a)
 #define json_object_add_value_uint(o, k, v) \
-	json_object_object_add(o, k, json_object_new_int(v))
+	json_object_object_add(o, k, json_object_new_uint64(v))
 #define json_object_add_value_int(o, k, v) \
-	json_object_object_add(o, k, json_object_new_int(v))
+	json_object_object_add(o, k, json_object_new_int64(v))
 #define json_object_add_value_float(o, k, v) \
 	json_object_object_add(o, k, json_object_new_double(v))
 #define json_object_add_value_string(o, k, v) \


### PR DESCRIPTION
unsigned int should use json_object_new_uint64(json-c >= 0.14-20200419)
    Error examples
    nsze    : 0xe8e088b0
    {
      "nsze":-387938128
    }
    After fix this
    {
      "nsze":3907029168
    }
json_object_add_value_int also should use json_object_new_int64
    since util/json.h support long long type, and other codes are using it for 64bit values

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>