### PR TITLE
nvme: use libnvme for printing status

### DIFF
--- a/nvme-print.h
+++ b/nvme-print.h
@@ -105,7 +105,6 @@ void nvme_show_zns_report_zones(void *report, __u32 descs,
 	__u8 ext_size, __u32 report_size, unsigned long flags);
 
 const char *nvme_cmd_to_string(int admin, __u8 opcode);
-const char *nvme_status_to_string(__u16 status);
 const char *nvme_select_to_string(int sel);
 const char *nvme_feature_to_string(enum nvme_features_id feature);
 const char *nvme_register_to_string(int reg);

--- a/nvme.h
+++ b/nvme.h
@@ -80,7 +80,6 @@ unsigned long long elapsed_utime(struct timeval start_time,
 					struct timeval end_time);
 
 /* nvme-print.c */
-const char *nvme_status_to_string(uint16_t status);
 const char *nvme_select_to_string(int sel);
 
 void d(unsigned char *buf, int len, int width, int group);

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -12,6 +12,8 @@
 #include "nvme.h"
 #include "libnvme.h"
 #include "plugin.h"
+#include "linux/types.h"
+#include "nvme-print.h"
 
 #define CREATE_CMD
 #include "dera-nvme.h"
@@ -200,7 +202,7 @@ static int get_status(int argc, char **argv, struct command *cmd, struct plugin 
 
 exit:
 	if (err > 0)
-		fprintf(stderr, "\nNVMe status:%s(0x%x)\n",	nvme_status_to_string(err), err);
+		nvme_show_status(err);
 
 	return err;
 }

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -10,6 +10,7 @@
 #include "libnvme.h"
 #include "plugin.h"
 #include "linux/types.h"
+#include "nvme-print.h"
 
 #define CREATE_CMD
 #include "intel-nvme.h"
@@ -375,8 +376,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -411,8 +411,7 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 		else
 			d_raw((unsigned char *)&log, sizeof(log));
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -472,8 +471,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 		else
 			d_raw((unsigned char *)&stats, sizeof(stats));
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -1059,8 +1057,8 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		err = nvme_get_features(fd, 0xf7, 0, 0, cfg.write ? 0x1 : 0x0, 0,
 				       sizeof(thresholds), thresholds, &result);
 		if (err) {
-			fprintf(stderr, "Quering thresholds failed. NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+			fprintf(stderr, "Quering thresholds failed. ");
+			nvme_show_status(err);
 			goto close_fd;
 		}
 
@@ -1089,8 +1087,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		else
 			d_raw((unsigned char *)&stats, sizeof(stats));
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		nvme_show_status(err);
 close_fd:
 	close(fd);
 	return err;
@@ -1467,8 +1464,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 	err = 0;
  out:
 	if (err > 0) {
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	} else if (err < 0) {
 		perror("intel log");
 		err = EIO;
@@ -1547,8 +1543,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		err = nvme_set_features(fd, fid, nsid, option, cdw12, save, 0,
 					0, data_len, buf, &result);
 		if (err > 0) {
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+			nvme_show_status(err);
 		} else if (err < 0) {
 			perror("Enable latency tracking");
 			fprintf(stderr, "Command failed while parsing.\n");
@@ -1607,8 +1602,8 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 	err = nvme_get_log_simple(fd, 0xc2,
 			   sizeof(media_version), media_version);
 	if (err) {
-		fprintf(stderr, "Querying media version failed. NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		fprintf(stderr, "Querying media version failed. ");
+		nvme_show_status(err);
 		goto close_fd;
 	}
 
@@ -1629,8 +1624,7 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 					thresholds, &result);
 
 		if (err > 0) {
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+			nvme_show_status(err);
 		} else if (err < 0) {
 			perror("Enable latency tracking");
 			fprintf(stderr, "Command failed while parsing.\n");

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -12,6 +12,9 @@
 #include "nvme.h"
 #include "libnvme.h"
 #include <limits.h>
+#include "linux/types.h"
+#include "nvme-print.h"
+
 #define CREATE_CMD
 #include "micron-nvme.h"
 
@@ -555,8 +558,7 @@ static int micron_selective_download(int argc, char **argv,
             perror("fw-download");
             goto out;
         } else if (err != 0) {
-            fprintf(stderr, "NVME Admin command error:%s(%x)\n",
-                    nvme_status_to_string(err), err);
+	    nvme_show_status(err);
             goto out;
         }
         fw_buf += xfer;
@@ -933,8 +935,7 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
         if (err == 0 && (err = (int)result) == 0)
             printf("Device correctable errors cleared!\n");
 	else if (err > 0)
-	    fprintf(stderr, "NVMe status: %s(%#x)\n",
-		    nvme_status_to_string(err), err);
+	    nvme_show_status(err);
         else
             printf("Error clearing Device correctable errors = 0x%x\n", err);
         goto out;
@@ -1395,8 +1396,8 @@ static int micron_nand_stats(int argc, char **argv,
 out:
     close(fd);
     if (err > 0)
-	fprintf(stderr, "NVMe status: %s(%#x)\n", nvme_status_to_string(err),
-		err);
+	nvme_show_status(err);
+
     return nvme_status_to_errno(err, false);
 }
 
@@ -2139,8 +2140,7 @@ static int micron_ocp_smart_health_logs(int argc, char **argv, struct command *c
 out:
     close(fd);
     if (err > 0)
-	fprintf(stderr, "NVMe status: %s(%#x)\n", nvme_status_to_string(err),
-		err);
+	nvme_show_status(err);
     return nvme_status_to_errno(err, false);
 }
 

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -13,6 +13,8 @@
 #include "nvme.h"
 #include "libnvme.h"
 #include "plugin.h"
+#include "linux/types.h"
+#include "nvme-print.h"
 
 #define CREATE_CMD
 #include "sfx-nvme.h"
@@ -364,8 +366,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -442,8 +443,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		else
 			d_raw((unsigned char *)&stats, sizeof(stats));
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -574,8 +574,7 @@ static int sfx_get_bad_block(int argc, char **argv, struct command *cmd, struct 
 	if (err < 0) {
 		perror("get-bad-block");
 	} else if (err != 0) {
-		fprintf(stderr, "NVMe IO command error:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	} else {
 		bd_table_show(data_buf, buf_size);
 		printf("ScaleFlux get bad block table: success\n");
@@ -781,8 +780,7 @@ static int change_cap(int argc, char **argv, struct command *cmd, struct plugin 
 	if (err < 0)
 		perror("sfx-change-cap");
 	else if (err != 0)
-		fprintf(stderr, "NVMe IO command error:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	else {
 		printf("ScaleFlux change-capacity: success\n");
 		ioctl(fd, BLKRRPART);
@@ -898,9 +896,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *cmd, struct pl
 				if (err < 0)
 					perror("identify-namespace");
 				else
-					fprintf(stderr,
-						"NVMe Admin command error:%s(%x)\n",
-						nvme_status_to_string(err), err);
+					nvme_show_status(err);
 				return err;
 			}
 			/*
@@ -932,8 +928,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *cmd, struct pl
 		printf("ScaleFlux set-feature:%#02x (%s), value:%d\n", cfg.feature_id,
 			sfx_feature_to_string(cfg.feature_id), cfg.value);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 
 	return err;
 }
@@ -981,8 +976,7 @@ static int sfx_get_feature(int argc, char **argv, struct command *cmd, struct pl
 		printf("ScaleFlux get-feature:%02x (%s), value:%d\n", cfg.feature_id,
 			sfx_feature_to_string(cfg.feature_id), result);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 
 	return err;
 

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -31,6 +31,8 @@
 #include "nvme.h"
 #include "libnvme.h"
 #include "plugin.h"
+#include "linux/types.h"
+#include "nvme-print.h"
 
 #define CREATE_CMD
 
@@ -195,8 +197,7 @@ static int log_pages_supp(int argc, char **argv, struct command *cmd,
 	}
 
 	if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -770,8 +771,7 @@ static int vs_smart_log(int argc, char **argv, struct command *cmd, struct plugi
 		} else if (!strcmp(cfg.output_format, "json"))
 			json_print_object(root, NULL);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
 
 	return err;
 }
@@ -871,8 +871,7 @@ static int temp_stats(int argc, char **argv, struct command *cmd, struct plugin 
 		}
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
 
 	cf_err = nvme_get_log_simple(fd, 0xCF, sizeof(ExtdSMARTInfo), &logPageCF);
 
@@ -1011,7 +1010,7 @@ static int vs_pcie_error_log(int argc, char **argv, struct command *cmd, struct 
 			json_vs_pcie_error_log(pcieErrorLog);
 
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(err), err);
+		nvme_show_status(err);
 
 	return err;
 }
@@ -1106,8 +1105,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 		} else
 			seaget_d_raw((unsigned char *)(&tele_log), sizeof(tele_log), dump_fd);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	else
 		perror("log page");
 
@@ -1140,8 +1138,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 			} else
 				seaget_d_raw((unsigned char *)log, blksToGet * 512, dump_fd);
 		} else if (err > 0)
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+			nvme_show_status(err);
 		else
 			perror("log page");
 
@@ -1204,8 +1201,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 		} else
 			seaget_d_raw((unsigned char *)(&tele_log), sizeof(tele_log), dump_fd);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	else
 		perror("log page");
 
@@ -1238,8 +1234,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 			} else
 				seaget_d_raw((unsigned char *)log, blksToGet * 512, dump_fd);
 		} else if (err > 0)
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+			nvme_show_status(err);
 		else
 			perror("log page");
 
@@ -1323,8 +1318,7 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 		*/
 		seaget_d_raw((unsigned char *)(&tele_log), sizeof(tele_log), dump_fd);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	else
 		perror("log page");
 
@@ -1354,8 +1348,7 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 			seaget_d_raw((unsigned char *)log, blksToGet * 512, dump_fd);
 
 		} else if (err > 0)
-			fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+			nvme_show_status(err);
 		else
 			perror("log page");
 

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -9,6 +9,8 @@
 #include "nvme.h"
 #include "libnvme.h"
 #include "plugin.h"
+#include "linux/types.h"
+#include "nvme-print.h"
 
 #define CREATE_CMD
 #include "shannon-nvme.h"
@@ -144,8 +146,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}
 	else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-					nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -244,8 +245,7 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 		}
 #endif
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	if (buf)
 		free(buf);
 	return err;
@@ -353,8 +353,7 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 		if (buf)
 			d(buf, cfg.data_len, 16, 1);
 	} else if (err > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
-				nvme_status_to_string(err), err);
+		nvme_show_status(err);
 
 free:
 	if (buf)

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -10,6 +10,8 @@
 #include "nvme.h"
 #include "libnvme.h"
 #include "plugin.h"
+#include "linux/types.h"
+#include "nvme-print.h"
 
 #define CREATE_CMD
 #include "toshiba-nvme.h"
@@ -471,7 +473,7 @@ static int vendor_log(int argc, char **argv, struct command *cmd, struct plugin 
 		fprintf(stderr, "%s: couldn't get vendor log 0x%x\n", __func__, cfg.log);
 end:
 	if (err > 0)
-		fprintf(stderr, "%s: NVMe Status:%s(%x)\n", __func__, nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }
 
@@ -513,8 +515,8 @@ static int internal_log(int argc, char **argv, struct command *cmd, struct plugi
 	if (err < 0)
 		fprintf(stderr, "%s: couldn't get fw log \n", __func__);
 	if (err > 0)
-		fprintf(stderr, "%s: NVMe Status:%s(%x)\n", __func__,
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
+
 	return err;
 }
 
@@ -552,7 +554,6 @@ static int clear_correctable_errors(int argc, char **argv, struct command *cmd,
 			__func__);
 end:
 	if (err > 0)
-		fprintf(stderr, "%s: NVMe Status:%s(%x)\n", __func__,
-			nvme_status_to_string(err), err);
+		nvme_show_status(err);
 	return err;
 }

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -7,6 +7,8 @@
 #include "nvme.h"
 #include "libnvme.h"
 #include "plugin.h"
+#include "linux/types.h"
+#include "nvme-print.h"
 
 #define CREATE_CMD
 #include "ymtc-nvme.h"
@@ -136,7 +138,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
             d_raw((unsigned char *)&smart_log, sizeof(smart_log));
     }
     if (err > 0)
-        fprintf(stderr, "NVMe Status:%s(%x)\n", nvme_status_to_string(err), err);
+        nvme_show_status(err);
 
     return err;
 }


### PR DESCRIPTION
With commit fe62ba7 ("util: Add nvme_status_to_string()") libnvme
now has a 'nvme_status_to_string()' function, which clashes with
the one provided here.
So drop the function in favour of the libnvme one, and convert
all plugins to use nvme_show_status().

Signed-off-by: Hannes Reinecke <hare@suse.de>