### PR TITLE
Discovery fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libnvme"]
 	path = libnvme
-	url = https://github.com/hreinecke/libnvme.git
-	branch = nvme-cli
+	url = https://github.com/linux-nvme/libnvme
+	branch = master

--- a/fabrics.c
+++ b/fabrics.c
@@ -695,6 +695,8 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 
 		d = cfg.device;
 		while ((p = strsep(&d, ",")) != NULL) {
+			if (!strncmp(p, "/dev/", 5))
+				p += 5;
 			c = nvme_scan_ctrl(r, p);
 			if (!c) {
 				nvme_msg(LOG_ERR,

--- a/fabrics.c
+++ b/fabrics.c
@@ -353,7 +353,6 @@ static int discover_from_conf_file(nvme_host_t h, const char *desc,
 		if (!ret) {
 			__discover(c, defcfg, NULL, persistent,
 				   connect, 0);
-				return 0;
 			if (!persistent)
 				ret = nvme_disconnect_ctrl(c);
 			nvme_free_ctrl(c);

--- a/fabrics.c
+++ b/fabrics.c
@@ -439,8 +439,12 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 		ret = ENOMEM;
 		goto out_free;
 	}
-	if (device && !strcmp(device, "none"))
-		device = NULL;
+	if (device) {
+		if (!strcmp(device, "none"))
+			device = NULL;
+		else if (!strncmp(device, "/dev/", 5))
+			device += 5;
+	}
 
 	if (!device && !transport && !traddr) {
 		ret = discover_from_conf_file(h, desc, connect, &cfg);

--- a/fabrics.c
+++ b/fabrics.c
@@ -667,12 +667,11 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 			}
 			ret = nvme_disconnect_ctrl(c);
 			if (!ret)
-				printf("Disconnected %s\n",
-					nvme_ctrl_get_name(c));
+				printf("Disconnected %s\n", p);
 			else
 				nvme_msg(LOG_ERR,
 					 "Failed to disconnect %s: %s\n",
-					 nvme_ctrl_get_name(c), strerror(errno));
+					 p, strerror(errno));
 		}
 	}
 	nvme_free_tree(r);

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -282,7 +282,17 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 			}
 			*((uint32_t *) value_addr) = tmp;
 		} else if (s->config_type == CFG_INCREMENT) {
-			(*((int *)value_addr))++;
+			/*
+			 * Extreme getopt_long fiddling.
+			 *
+			 * As per man page:
+			 * If flag is non-NULL, getopt_long() returns 0,
+			 * and flag  points to a variable which is set to
+			 * val if the option is found.
+			 *
+			 * So we need to increase 'val', not 'value_addr'.
+			 */
+			long_opts[option_index].val++;
 		} else if (s->config_type == CFG_LONG) {
 			*((unsigned long *)value_addr) = strtoul(optarg, &endptr, 0);
 			if (errno || optarg == endptr) {


### PR DESCRIPTION
Heya,

this is the corresponding patchset to the libnvme pull request 'discovery-fixes'.
It fixes the handling of persistent (and non-persistent :-) discovery controllers, and also some crashes which I've encountered on the way.

Once both patchsets are merged one should reset the submodule branch to pointing to the upstream libnvme repository; I'll see if the CI will accept a patch for that even without the merge.