### PR TITLE
fabrics: Fix memory leak for nvme discover command

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -520,6 +520,7 @@ out_free:
 		free(hnqn);
 	if (hid)
 		free(hid);
+	nvme_free_tree(r);
 
 	return ret;
 }


### PR DESCRIPTION
fabrics: Fix memory leak for nvme discover command

Signed-off-by: Wu Bo <wubo.linux@gmail.com>