### PR TITLE
Fix dead assignment

### DIFF
--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -166,7 +166,7 @@ static int zns_mgmt_send(int argc, char **argv, struct command *cmd, struct plug
 
 	err = fd = parse_and_open(argc, argv, desc, opts);
 	if (fd < 0)
-		return errno;
+		goto ret;
 
 	err = asprintf(&command, "%s-%s", plugin->name, cmd->name);
 	if (err < 0)
@@ -194,6 +194,7 @@ free:
 	free(command);
 close_fd:
 	close(fd);
+ret:
 	return nvme_status_to_errno(err, false);
 }
 


### PR DESCRIPTION
This patch fixes a bug in the error handling in `zns_mgmt_send`, where error
cause was not reported correctly.

Signed-off-by: Andreas Hindborg <andreas.hindborg@wdc.com>