### PR TITLE
Binary output support for list-ctrl command

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4160,6 +4160,8 @@ void nvme_show_list_ctrl(struct nvme_ctrl_list *ctrl_list,
 	int i;
 	__u16 num = le16_to_cpu(ctrl_list->num);
 
+	if (flags & BINARY)
+		return d_raw((unsigned char *)ctrl_list, sizeof(*ctrl_list));
 	if (flags & JSON)
 		return json_nvme_list_ctrl(ctrl_list, num);
 

--- a/nvme.c
+++ b/nvme.c
@@ -1371,10 +1371,6 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
 		goto close_fd;
-	if (flags != JSON && flags != NORMAL) {
-		err = -EINVAL;
-		goto close_fd;
-	}
 
 	if (posix_memalign((void *)&cntlist, getpagesize(), 0x1000)) {
 		fprintf(stderr, "can not allocate controller list payload\n");


### PR DESCRIPTION
Simple addition to handling the BINARY flag option.

Example
```
# nvme list-ctrl --namespace-id=1 --output-format=binary /dev/nvme1 | hexdump
0000000 0001 0001 0000 0000 0000 0000 0000 0000
0000010 0000 0000 0000 0000 0000 0000 0000 0000
*
0001000
```

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>