### PR TITLE
CSI ignored upon ns create

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1711,7 +1711,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 
 	nvme_init_id_ns(&ns, cfg.nsze, cfg.ncap, cfg.flbas, cfg.dps, cfg.nmic,
 			 cfg.anagrpid, cfg.nvmsetid);
-	err = nvme_ns_mgmt_create(fd, &ns, &nsid, cfg.timeout);
+	err = nvme_ns_mgmt_create_csi(fd, &ns, &nsid, cfg.timeout, cfg.csi);
 	if (!err)
 		printf("%s: Success, created nsid:%d\n", cmd->name, nsid);
 	else if (err > 0)


### PR DESCRIPTION
The CSI value does not get passed upon namespace create after the switch to
libnvme.

Fixes: d9ad647f1e683eb151d8a66b676fbca27f8a9297 (libnvme: Add libnvme submodule)
Signed-off-by: Matias Bjørling <matias.bjorling@wdc.com>