### PR TITLE
nvme-print: print generic ns chardev in verbose mode

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6650,6 +6650,10 @@ static void nvme_show_details_ns(struct nvme_namespace *n, bool ctrl)
 
 	char usage[128];
 	char format[128];
+	char generic[128];
+
+	int instance;
+	int head_instance;
 
 	if (!n->ctrl)
 		return;
@@ -6659,7 +6663,10 @@ static void nvme_show_details_ns(struct nvme_namespace *n, bool ctrl)
 	sprintf(format,"%3.0f %2sB + %2d B", (double)lba, l_suffix,
 		le16_to_cpu(n->ns.lbaf[(n->ns.flbas & 0x0f)].ms));
 
-	printf("%-12s %-8d %-26s %-16s ", n->name, n->nsid, usage, format);
+	sscanf(n->name, "nvme%dn%d", &instance, &head_instance);
+	sprintf(generic, "ng%dn%d", instance, head_instance);
+
+	printf("%-12s %-16s %-8d %-26s %-16s ", n->name, generic, n->nsid, usage, format);
 
 	if (ctrl)
 		printf("%s", n->ctrl->name);
@@ -6731,8 +6738,8 @@ static void nvme_show_detailed_list(struct nvme_topology *t)
 	}
 
 	printf("\nNVM Express Namespaces\n\n");
-	printf("%-12s %-8s %-26s %-16s %-16s\n", "Device", "NSID", "Usage", "Format", "Controllers");
-	printf("%-.12s %-.8s %-.26s %-.16s %-.16s\n", dash, dash, dash, dash, dash);
+	printf("%-12s %-12s %-8s %-26s %-16s %-16s\n", "Device", "Generic", "NSID", "Usage", "Format", "Controllers");
+	printf("%-.12s %-.12s %-.8s %-.26s %-.16s %-.16s\n", dash, dash, dash, dash, dash, dash);
 
 	for (i = 0; i < t->nr_subsystems; i++) {
 		struct nvme_subsystem *s = &t->subsystems[i];


### PR DESCRIPTION
Generic device (e.g., /dev/ng0n1) is mapped to a block device (e.g.,
/dev/nvme0n1).  This chardev can be taken in case that block device is
failed to initialize from the kernel due to some reasons (e.g.,
metadata initialization failed).  This generic node information can be
shown in the verbose list mode with HIDDEN block device (nvme0n1 in the
below example).

root@localhost:~# nvme list -v
NVM Express Subsystems

Subsystem        Subsystem-NQN                                                                                    Controllers
---------------- ------------------------------------------------------------------------------------------------ ----------------
nvme-subsys0     nqn.2019-08.org.qemu:subsys0                                                                     nvme0

NVM Express Controllers

Device   SN                   MN                                       FR       TxPort Address        Subsystem    Namespaces
-------- -------------------- ---------------------------------------- -------- ------ -------------- ------------ ----------------
nvme0    foo                  QEMU NVMe Ctrl                           1.0      pcie   0000:00:06.0   nvme-subsys0 nvme0n1, nvme0n2

NVM Express Namespaces

Device       Generic      NSID     Usage                      Format           Controllers
------------ ------------ -------- -------------------------- ---------------- ----------------
nvme0n1      ng0n1            1          0.00   B /   0.00   B      1   B +  0 B   nvme0
nvme0n2      ng0n2            2        268.44  MB / 268.44  MB      4 KiB +  0 B   nvme0

The nvme0n1 is failed to initialize and it shows 0.00 B size which is
invalid.  In this case, we can take /dev/ng0n1 alternatively from the
application through generic I/O path.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>