### PR TITLE
Support to shared libnvme builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,7 @@ verify-no-dep: nvme.c nvme.h $(OBJS) $(UTIL_OBJS) NVME-VERSION-FILE
 nvme.o: nvme.c nvme.h nvme-print.h util/argconfig.h util/suffix.h fabrics.h
 	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) $(INC) -c $<
 
-%.o: %.c %.h nvme.h linux/nvme.h nvme-print.h util/argconfig.h
-	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) $(INC) -o $@ -c $<
-
-%.o: %.c nvme.h linux/nvme.h nvme-print.h util/argconfig.h
+%.o: %.c
 	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) $(INC) -o $@ -c $<
 
 doc: $(NVME)

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ PLUGIN_OBJS :=					\
 libnvme:
 	$(MAKE) -C $(LIBNVMEDIR)
 
-nvme: nvme.c nvme.h libnvme $(OBJS) $(PLUGIN_OBJS) $(UTIL_OBJS) NVME-VERSION-FILE
+nvme: nvme.o libnvme $(OBJS) $(PLUGIN_OBJS) $(UTIL_OBJS) NVME-VERSION-FILE
 	$(QUIET_CC)$(CC) $(CPPFLAGS) $(CFLAGS) $(INC) $< -o $(NVME) $(OBJS) $(PLUGIN_OBJS) $(UTIL_OBJS) $(LDFLAGS)
 
 verify-no-dep: nvme.c nvme.h $(OBJS) $(UTIL_OBJS) NVME-VERSION-FILE


### PR DESCRIPTION
Support building nvme-cli using a shared version of libvnme. The Makefile checks first if libnvme has been checked out as git submodule in under libvnme and uses this as first preference. If this fails pkg-config is used to determine if a shared libnvme exists.