### PR TITLE
nvme: allow fw commit action values 0x4 and 0x5

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3511,7 +3511,7 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 		err = -1;
 		goto close_fd;
 	}
-	if (cfg.action > 7 || cfg.action == 4 || cfg.action == 5) {
+	if (cfg.action > 7) {
 		fprintf(stderr, "invalid action:%d\n", cfg.action);
 		errno = EINVAL;
 		err = -1;


### PR DESCRIPTION
Allow FW Commit action values from 0 to 7 including reserved fields 0x4
and 0x5, device shall throw appropriate error status code and status type.

Signed-off-by: Gollu Appalanaidu <anaidu.gollu@samsung.com>