### PR TITLE
Fixup compiler warnings

### DIFF
--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -186,7 +186,7 @@ static int get_status(int argc, char **argv, struct command *cmd, struct plugin 
 	printf("fw_loader_version                   : %.*s\n", 8, log.fw_loader_version);
 	printf("uefi_driver_version                 : %.*s\n", 8, log.uefi_driver_version);
 
-	if (log.pcie_volt_status >= 0 && log.pcie_volt_status <= sizeof(volt_status) / sizeof(const char *)){
+	if (log.pcie_volt_status <= sizeof(volt_status) / sizeof(const char *)){
 		printf("pcie_volt_status                    : %s\n", volt_status[log.pcie_volt_status]);
 	}
 	else{

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -522,7 +522,7 @@ enum FormatUnit {
 #define US_IN_S 1000000
 #define US_IN_MS 1000
 
-static const enum FormatUnit get_seconds_magnitude(__u32 microseconds)
+static enum FormatUnit get_seconds_magnitude(__u32 microseconds)
 {
 	if (microseconds > US_IN_S)
 		return S;
@@ -532,7 +532,7 @@ static const enum FormatUnit get_seconds_magnitude(__u32 microseconds)
 		return US;
 }
 
-static const float convert_seconds(__u32 microseconds)
+static float convert_seconds(__u32 microseconds)
 {
 	float divisor = 1.0;
 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -5406,7 +5406,7 @@ static int wdc_drive_status(int argc, char **argv, struct command *command,
 		fprintf(stderr, "ERROR : WDC : Get Format Corrupt Reason Failed\n");
 
 	printf("  Drive Status :- \n");
-	if (le32_to_cpu(eol_status) >= 0) {
+	if ((int)le32_to_cpu(eol_status) >= 0) {
 		printf("  Percent Used:				%"PRIu32"%%\n",
 				le32_to_cpu(eol_status));
 	}

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -375,15 +375,17 @@ static int zone_mgmt_send(int argc, char **argv, struct command *cmd, struct plu
 
 	if (cfg.zsa == NVME_ZNS_ZSA_SET_DESC_EXT) {
 		if(!cfg.data_len) {
-			cfg.data_len = get_zdes_bytes(fd, cfg.namespace_id);
-			if (!cfg.data_len || cfg.data_len < 0) {
+			int data_len = get_zdes_bytes(fd, cfg.namespace_id);
+
+			if (data_len == 0) {
 				fprintf(stderr, 
 					"Zone Descriptor Extensions are not supported\n");
 				goto close_fd;
-			} else if (cfg.data_len < 0) {
-				err = cfg.data_len;
+			} else if (data_len < 0) {
+				err = data_len;
 				goto close_fd;
 			}
+			cfg.data_len = data_len;
 		}
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
 			fprintf(stderr, "can not allocate feature payload\n");
@@ -478,7 +480,7 @@ static int set_zone_desc(int argc, char **argv, struct command *cmd, struct plug
 
 	int fd, ffd = STDIN_FILENO, err;
 	void *buf = NULL;
-	__u32 data_len;
+	int data_len;
 
 	struct config {
 		__u64	zslba;


### PR DESCRIPTION
Compiling with additional compiler options generates some warnings;
fix them.

Signed-off-by: Hannes Reinecke <hare@suse.de>