### PR TITLE
nvme-rpmb: Add limits.h due to missing PATH_MAX definition

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <linux/if_alg.h>
 #include <linux/socket.h>
+#include <limits.h>
 
 #include "nvme.h"
 #include "libnvme.h"


### PR DESCRIPTION
Commit 21f40f38b introduced new use of PATH_MAX, but did not add the
limits.h header.  This resulted in nvme-cli failing to build on
ppc64le systems using the musl C library.

Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>
[dwagner: removed nvme-topology.c bits]
Signed-off-by: Daniel Wagner <dwagner@suse.de>

The nvme-topology.c part has been moved into libnvme/src/nvme/fabrics. 
which has the necessary include.
Resolves  #1019