### PR TITLE
build: Set minimum version for json-c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ ifeq ($(HAVE_SYSTEMD),0)
 endif
 
 ifeq ($(LIBJSONC), 0)
-	override LDFLAGS += -ljson-c
+	override LDFLAGS += $(shell pkg-config --libs json-c)
+	override CFLAGS += $(shell pkg-config --cflags json-c)
 	override CFLAGS += -DLIBJSONC
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -31,8 +31,8 @@ libuuid = dependency('uuid', required: true)
 conf.set('LIBUUID', libuuid.found(), description: 'Is libuuid required?')
 
 # Check for libjson-c availability
-libjson = dependency('json-c', required: true)
-conf.set('LIBJSONC', libjson.found(), description: 'Is json-c required?')
+json_c = dependency('json-c', version: '>=0.13', fallback : ['json-c', 'json_c'])
+conf.set('CONFIG_JSONC', json_c.found(), description: 'Is json-c required?')
 
 # Check for libhugetlbfs  availability
 libhugetlbfs = dependency('hugetlbfs', required: false)
@@ -78,5 +78,5 @@ subdir('util')
 executable(
     'nvme',
     sources,
-    dependencies: [ libnvme_dep, libuuid, libjson ],
+    dependencies: [ libnvme_dep, libuuid, json_c ],
 )

--- a/nvme.h
+++ b/nvme.h
@@ -23,7 +23,7 @@
 
 #include "plugin.h"
 #ifdef LIBJSONC
-#include <json-c/json.h>
+#include <json.h>
 
 #define json_create_object(o) json_object_new_object(o)
 #define json_create_array(a) json_object_new_array(a)


### PR DESCRIPTION
Set minimum version for json-c to 0.13.

nvme-cli uses json_util_get_last_err() which got introduced in 0.13,
released in December 2017.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes #1185 