### PR TITLE
meson: rename host config to config.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ override CFLAGS += -I$(CCANDIR)
 
 ifeq ($(LIBUUID),0)
 	override LDFLAGS += -luuid
-	override CFLAGS += -DLIBUUID
+	override CFLAGS += -DCONFIG_LIBUUID
 	override LIB_DEPENDS += uuid
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ libnvme_dep = dependency('libnvme', fallback : ['libnvme', 'libnvme_dep'])
 
 # Check for libuuid availability
 libuuid = dependency('uuid', required: true)
-conf.set('LIBUUID', libuuid.found(), description: 'Is libuuid required?')
+conf.set('CONFIG_LIBUUID', libuuid.found(), description: 'Is libuuid required?')
 
 # Check for libjson-c availability
 json_c = dependency('json-c', version: '>=0.13', fallback : ['json-c', 'json_c'])
@@ -73,7 +73,7 @@ conf.set10(
 )
 
 configure_file(
-    output: 'config-host.h',
+    output: 'config.h',
     configuration: conf
 )
 
@@ -90,7 +90,7 @@ configure_file(
 
 ################################################################################
 add_project_arguments(['-fomit-frame-pointer', '-D_GNU_SOURCE',
-                       '-include', 'config-host.h'], language : 'c')
+                       '-include', 'config.h'], language : 'c')
 incdir = include_directories(['ccan'])
 
 ################################################################################

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2615,7 +2615,7 @@ static const char *nvme_uuid_to_string(uuid_t uuid)
 {
 	/* large enough to hold uuid str (37) + null-termination byte */
 	static char uuid_str[40];
-#ifdef LIBUUID
+#ifdef CONFIG_LIBUUID
 	uuid_unparse_lower(uuid, uuid_str);
 #else
 	static const char *hex_digits = "0123456789abcdef";
@@ -3444,7 +3444,7 @@ static void json_nvme_id_ns_descs(void *data)
 		__u8 eui64[NVME_NIDT_EUI64_LEN];
 		__u8 nguid[NVME_NIDT_NGUID_LEN];
 
-#ifdef LIBUUID
+#ifdef CONFIG_LIBUUID
 		uuid_t uuid;
 #endif
 		__u8 csi;
@@ -3485,7 +3485,7 @@ static void json_nvme_id_ns_descs(void *data)
 			nidt_name = "nguid";
 			break;
 
-#ifdef LIBUUID
+#ifdef CONFIG_LIBUUID
 		case NVME_NIDT_UUID:
 			memcpy(desc.uuid, data + off, sizeof(desc.uuid));
 			uuid_unparse_lower(desc.uuid, json_str);
@@ -3538,7 +3538,7 @@ void nvme_show_id_ns_descs(void *data, unsigned nsid, enum nvme_print_flags flag
 {
 	int pos, len = 0;
 	int i;
-#ifdef LIBUUID
+#ifdef CONFIG_LIBUUID
 	uuid_t uuid;
 	char uuid_str[37];
 #endif
@@ -3575,7 +3575,7 @@ void nvme_show_id_ns_descs(void *data, unsigned nsid, enum nvme_print_flags flag
 			printf("\n");
 			len = sizeof(nguid);
 			break;
-#ifdef LIBUUID
+#ifdef CONFIG_LIBUUID
 		case NVME_NIDT_UUID:
 			memcpy(uuid, data + pos + sizeof(*cur), 16);
 			uuid_unparse_lower(uuid, uuid_str);


### PR DESCRIPTION
ccan expects the availability of config.h, so change the build config name to config.h.

Hmm. Why did the meson ci build not pick this up?