### PR TITLE
fabrics: fix 'nvme discover' segfault if nvme sysfs path is unavailable

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -215,6 +215,9 @@ char *parse_conn_arg(const char *conargs, const char delim, const char *field)
 	char *s, *e;
 	size_t cnt;
 
+	if (!conargs)
+		goto empty_field;
+
 	/*
 	 * There are field name overlaps: traddr and host_traddr.
 	 * By chance, both connect arg strings are set up to
@@ -305,6 +308,9 @@ static bool ctrl_matches_connectargs(const char *name, struct connect_args *args
 	cargs.host_traddr = parse_conn_arg(addr, ' ', conarg_host_traddr);
 	cargs.host_iface = parse_conn_arg(addr, ' ', conarg_host_iface);
 
+	if (!cargs.subsysnqn || !cargs.transport)
+		goto out;
+
 	if (!strcmp(cargs.subsysnqn, NVME_DISC_SUBSYS_NAME)) {
 		char *kato_str = nvme_get_ctrl_attr(path, "kato"), *p;
 		unsigned int kato = 0;
@@ -340,6 +346,7 @@ static bool ctrl_matches_connectargs(const char *name, struct connect_args *args
 	     !strcmp(args->host_iface, "none")))
 		found = true;
 
+out:
 	free(cargs.subsysnqn);
 	free(cargs.transport);
 	free(cargs.traddr);
@@ -392,6 +399,9 @@ cleanup_devices:
 static struct connect_args *extract_connect_args(char *argstr)
 {
 	struct connect_args *cargs;
+
+	if (!argstr)
+		return NULL;
 
 	cargs = calloc(1, sizeof(*cargs));
 	if (!cargs)


### PR DESCRIPTION
Avoid dereferencing nvme controller attributes if the corresponding
controller sysfs path is not available.

Signed-off-by: Martin George <marting@netapp.com>