### PR TITLE
nvme: open namespace exclusive by default

### DIFF
--- a/Documentation/nvme-compare.1
+++ b/Documentation/nvme-compare.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-compare
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/09/2021
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-COMPARE" "1" "07/09/2021" "NVMe" "NVMe Manual"
+.TH "NVME\-COMPARE" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -51,6 +51,7 @@ nvme-compare \- Send an NVMe Compare command, provide results
                         [\-\-dry\-run | \-w]
                         [\-\-latency | \-t]
                         [\-\-storage\-tag\-check<storage\-tag\-check> | \-C <storage\-tag\-check>]
+                        [\-\-force]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -207,6 +208,11 @@ Print out the latency the IOCTL took (in us)\&.
 \-\-storage\-tag\-check=<storage\-tag\-check>, \-C <storage\-tag\-check>
 .RS 4
 This bit specifies the Storage Tag field shall be checked as part of end\-to\-end data protection processing\&.
+.RE
+.PP
+\-\-force
+.RS 4
+Ignore namespace is currently busy and perfome the operation even though\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-compare.html
+++ b/Documentation/nvme-compare.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-compare(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -767,7 +767,8 @@ nvme-compare(1) Manual Page
                         [--show-command | -v]
                         [--dry-run | -w]
                         [--latency | -t]
-                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]</pre>
+                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]
+                        [--force]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -1053,6 +1054,15 @@ metadata is passes.</p></td>
         data protection processing.
 </p>
 </dd>
+<dt class="hdlist1">
+--force
+</dt>
+<dd>
+<p>
+    Ignore namespace is currently busy and perfome the operation
+    even though.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -1073,7 +1083,7 @@ metadata is passes.</p></td>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-07-09 14:16:50 IST
+ 2021-12-15 10:28:49 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-compare.txt
+++ b/Documentation/nvme-compare.txt
@@ -27,6 +27,7 @@ SYNOPSIS
 			[--dry-run | -w]
 			[--latency | -t]
 			[--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+			[--force]
 
 DESCRIPTION
 -----------
@@ -144,6 +145,10 @@ metadata is passes.
 -C <storage-tag-check>::
 	This bit specifies the Storage Tag field shall be checked as part of end-to-end
 	data protection processing.
+
+--force::
+    Ignore namespace is currently busy and perfome the operation
+    even though.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-format.1
+++ b/Documentation/nvme-format.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-format
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-FORMAT" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-FORMAT" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -40,7 +40,7 @@ nvme-format \- Format an NVMe device
                     [\-\-pi=<pi> | \-i <pi>]
                     [\-\-ms=<ms> | \-m <ms>]
                     [\-\-reset | \-r ]
-                    [\-\-force | \-f ]
+                    [\-\-force ]
                     [\-\-timeout=<timeout> | \-t <timeout> ]
 .fi
 .SH "DESCRIPTION"
@@ -168,7 +168,7 @@ Metadata Settings: This field is set to \(oq1\(cq if the metadata is transferred
 Issue a reset after successful format\&. Must use the character device for this\&.
 .RE
 .PP
-\-f, \-\-force
+\-\-force
 .RS 4
 Just send the command immediately without warning of the implications\&.
 .RE

--- a/Documentation/nvme-format.html
+++ b/Documentation/nvme-format.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-format(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -757,7 +757,7 @@ nvme-format(1) Manual Page
                     [--pi=&lt;pi&gt; | -i &lt;pi&gt;]
                     [--ms=&lt;ms&gt; | -m &lt;ms&gt;]
                     [--reset | -r ]
-                    [--force | -f ]
+                    [--force ]
                     [--timeout=&lt;timeout&gt; | -t &lt;timeout&gt; ]</pre>
 <div class="attribution">
 </div></div>
@@ -977,9 +977,6 @@ cellspacing="0" cellpadding="4">
 </p>
 </dd>
 <dt class="hdlist1">
--f
-</dt>
-<dt class="hdlist1">
 --force
 </dt>
 <dd>
@@ -1038,7 +1035,7 @@ information:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2019-09-18 00:00:58 JST
+ 2021-12-15 10:13:26 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-format.txt
+++ b/Documentation/nvme-format.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 		    [--pi=<pi> | -i <pi>]
 		    [--ms=<ms> | -m <ms>]
 		    [--reset | -r ]
-		    [--force | -f ]
+		    [--force ]
 		    [--timeout=<timeout> | -t <timeout> ]
 
 DESCRIPTION
@@ -128,7 +128,6 @@ cryptographically. This is accomplished by deleting the encryption key.
 	Issue a reset after successful format. Must use the character
 	device for this.
 
--f::
 --force::
 	Just send the command immediately without warning of the implications.
 

--- a/Documentation/nvme-id-ns.1
+++ b/Documentation/nvme-id-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ID\-NS" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-ID\-NS" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -33,7 +33,7 @@ nvme-id-ns \- Send NVMe Identify Namespace, return result and structure
 .sp
 .nf
 \fInvme id\-ns\fR <device> [\-v | \-\-vendor\-specific] [\-b | \-\-raw\-binary]
-                    [\-\-namespace\-id=<nsid> | \-n <nsid>] [\-f | \-\-force]
+                    [\-\-namespace\-id=<nsid> | \-n <nsid>] [\-\-force]
                     [\-\-human\-readable | \-H]
                     [\-\-output\-format=<fmt> | \-o <fmt>]
 .fi
@@ -51,7 +51,7 @@ On success, the structure may be returned in one of several ways depending on th
 Retrieve the identify namespace structure for the given nsid\&. This is required for the character devices, or overrides the block nsid if given\&.
 .RE
 .PP
-\-f, \-\-force
+\-\-force
 .RS 4
 Request controller return the identify namespace structure even if the namespace is not attached to the controller\&. This is valid only for controllers at or newer than revision 1\&.2\&. Controllers at revision lower than this may interpret the command incorrectly\&.
 .RE

--- a/Documentation/nvme-id-ns.html
+++ b/Documentation/nvme-id-ns.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-id-ns(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -750,7 +750,7 @@ nvme-id-ns(1) Manual Page
 <div class="sectionbody">
 <div class="verseblock">
 <pre class="content"><em>nvme id-ns</em> &lt;device&gt; [-v | --vendor-specific] [-b | --raw-binary]
-                    [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;] [-f | --force]
+                    [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;] [--force]
                     [--human-readable | -H]
                     [--output-format=&lt;fmt&gt; | -o &lt;fmt&gt;]</pre>
 <div class="attribution">
@@ -790,9 +790,6 @@ raw buffer may be printed to stdout.</p></div>
         if given.
 </p>
 </dd>
-<dt class="hdlist1">
--f
-</dt>
 <dt class="hdlist1">
 --force
 </dt>
@@ -955,7 +952,7 @@ int main(int argc, char **argv)
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-11-29 13:36:39 GMT
+ 2021-12-15 10:13:40 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-id-ns.txt
+++ b/Documentation/nvme-id-ns.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme id-ns' <device> [-v | --vendor-specific] [-b | --raw-binary]
-		    [--namespace-id=<nsid> | -n <nsid>] [-f | --force]
+		    [--namespace-id=<nsid> | -n <nsid>] [--force]
 		    [--human-readable | -H]
 		    [--output-format=<fmt> | -o <fmt>]
 
@@ -37,7 +37,6 @@ OPTIONS
 	is required for the character devices, or overrides the block nsid
 	if given.
 
--f::
 --force::
 	Request controller return the identify namespace structure even
 	if the namespace is not attached to the controller. This is valid

--- a/Documentation/nvme-lnvm-id-ns.1
+++ b/Documentation/nvme-lnvm-id-ns.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-lnvm-id-ns
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-LNVM\-ID\-NS" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-LNVM\-ID\-NS" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -33,7 +33,7 @@ nvme-lnvm-id-ns \- Identify Geometry for LightNVM NVMe device
 .sp
 .nf
 \fInvme lnvm\-id\-ns\fR <device> [\-\-namespace\-id=<nsid> | \-n <nsid>]
-                        [\-\-force | \-f]
+                        [\-\-force ]
                         [\-\-raw\-binary | \-b]
                         [\-\-human\-readable | \-H]
 .fi
@@ -47,7 +47,7 @@ Send an Identify Geometry command to the given LightNVM device, returns properti
 Retrieve the geometry from the selected namespace\&.
 .RE
 .PP
-\-\-force, \-f
+\-\-force
 .RS 4
 Try to read the data and assume it is a LightNVM device
 .RE

--- a/Documentation/nvme-lnvm-id-ns.html
+++ b/Documentation/nvme-lnvm-id-ns.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-lnvm-id-ns(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -750,7 +750,7 @@ nvme-lnvm-id-ns(1) Manual Page
 <div class="sectionbody">
 <div class="verseblock">
 <pre class="content"><em>nvme lnvm-id-ns</em> &lt;device&gt; [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
-                        [--force | -f]
+                        [--force ]
                         [--raw-binary | -b]
                         [--human-readable | -H]</pre>
 <div class="attribution">
@@ -782,9 +782,6 @@ format.</p></div>
 </dd>
 <dt class="hdlist1">
 --force
-</dt>
-<dt class="hdlist1">
--f
 </dt>
 <dd>
 <p>
@@ -843,7 +840,7 @@ Retrieve the geometry from nvme0
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2019-10-12 00:12:24 JST
+ 2021-12-15 10:13:53 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-lnvm-id-ns.txt
+++ b/Documentation/nvme-lnvm-id-ns.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme lnvm-id-ns' <device> [--namespace-id=<nsid> | -n <nsid>]
-			[--force | -f]
+			[--force ]
 			[--raw-binary | -b]
 			[--human-readable | -H]
 
@@ -26,7 +26,6 @@ OPTIONS
 	Retrieve the geometry from the selected namespace.
 
 --force::
--f::
 	Try to read the data and assume it is a LightNVM device
 
 --raw-binary::

--- a/Documentation/nvme-read.1
+++ b/Documentation/nvme-read.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-read
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/09/2021
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-READ" "1" "07/09/2021" "NVMe" "NVMe Manual"
+.TH "NVME\-READ" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -51,6 +51,7 @@ nvme-read \- Send an NVMe Read command, provide results
                         [\-\-dry\-run | \-w]
                         [\-\-latency | \-t]
                         [\-\-storage\-tag\-check<storage\-tag\-check> | \-C <storage\-tag\-check>]
+                        [\-\-force]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -183,6 +184,11 @@ Print out the latency the IOCTL took (in us)\&.
 \-\-storage\-tag\-check=<storage\-tag\-check>, \-C <storage\-tag\-check>
 .RS 4
 This bit specifies the Storage Tag field shall be checked as part of end\-to\-end data protection processing\&.
+.RE
+.PP
+\-\-force
+.RS 4
+Ignore namespace is currently busy and perfome the operation even though\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-read.html
+++ b/Documentation/nvme-read.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-read(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -767,7 +767,8 @@ nvme-read(1) Manual Page
                         [--show-command | -v]
                         [--dry-run | -w]
                         [--latency | -t]
-                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]</pre>
+                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]
+                        [--force]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -1026,6 +1027,15 @@ metadata is passes.</p></td>
         data protection processing.
 </p>
 </dd>
+<dt class="hdlist1">
+--force
+</dt>
+<dd>
+<p>
+    Ignore namespace is currently busy and perfome the operation
+    even though.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -1046,7 +1056,7 @@ metadata is passes.</p></td>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-07-09 14:16:42 IST
+ 2021-12-15 10:28:16 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-read.txt
+++ b/Documentation/nvme-read.txt
@@ -27,6 +27,7 @@ SYNOPSIS
 			[--dry-run | -w]
 			[--latency | -t]
 			[--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+			[--force]
 
 DESCRIPTION
 -----------
@@ -133,6 +134,10 @@ metadata is passes.
 -C <storage-tag-check>::
 	This bit specifies the Storage Tag field shall be checked as part of end-to-end
 	data protection processing.
+
+--force::
+    Ignore namespace is currently busy and perfome the operation
+    even though.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-sanitize.1
+++ b/Documentation/nvme-sanitize.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-sanitize
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-SANITIZE" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-SANITIZE" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -38,6 +38,7 @@ nvme-sanitize \- Send NVMe Sanitize Command, return result
               [\-\-ause | \-u]
               [\-\-sanact=<action> | \-a <action>]
               [\-\-ovrpat=<overwrite\-pattern> | \-p <overwrite\-pattern>]
+              [\-\-force]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -76,6 +77,11 @@ Sanitize Action: 000b \- Reserved 001b \- Exit Failure Mode 010b \- Start a Bloc
 \-p <overwrite\-pattern>, \-\-ovrpat=<overwrite\-pattern>
 .RS 4
 Overwrite Pattern: This field is ignored unless the Sanitize Action field in Command Dword 10 is set to 011b (i\&.e\&., Overwrite)\&. This field specifies a 32\-bit pattern that is used for the Overwrite sanitize operation\&.
+.RE
+.PP
+\-\-force
+.RS 4
+Ignore namespace is currently busy and perfome the operation even though\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-sanitize.html
+++ b/Documentation/nvme-sanitize.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.9" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-sanitize(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -753,7 +754,8 @@ nvme-sanitize(1) Manual Page
               [--owpass=&lt;overwrite-pass-count&gt; | -n &lt;overwrite-pass-count&gt;]
               [--ause | -u]
               [--sanact=&lt;action&gt; | -a &lt;action&gt;]
-              [--ovrpat=&lt;overwrite-pattern&gt; | -p &lt;overwrite-pattern&gt;]</pre>
+              [--ovrpat=&lt;overwrite-pattern&gt; | -p &lt;overwrite-pattern&gt;]
+              [--force]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -865,6 +867,15 @@ provides the result.</p></div>
     sanitize operation.
 </p>
 </dd>
+<dt class="hdlist1">
+--force
+</dt>
+<dd>
+<p>
+    Ignore namespace is currently busy and perfome the operation
+    even though.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -896,7 +907,7 @@ Has the program issue Sanitize Command :
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2017-06-28 18:52:37 PDT
+ 2021-12-15 10:25:04 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-sanitize.txt
+++ b/Documentation/nvme-sanitize.txt
@@ -14,6 +14,7 @@ SYNOPSIS
               [--ause | -u]
               [--sanact=<action> | -a <action>]
               [--ovrpat=<overwrite-pattern> | -p <overwrite-pattern>]
+	      [--force]
 
 DESCRIPTION
 -----------
@@ -77,6 +78,10 @@ OPTIONS
     Command Dword 10 is set to 011b (i.e., Overwrite). This field
     specifies a 32-bit pattern that is used for the Overwrite
     sanitize operation.
+
+--force::
+    Ignore namespace is currently busy and perfome the operation
+    even though.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-write-uncor.1
+++ b/Documentation/nvme-write-uncor.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-uncor
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 10/20/2020
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-UNCOR" "1" "10/20/2020" "NVMe" "NVMe Manual"
+.TH "NVME\-UNCOR" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -35,6 +35,7 @@ nvme-write-uncor \- Send an NVMe write uncorrectable command, return results
 \fInvme\-write\-uncorr\fR <device> [\-\-start\-block=<slba> | \-s <slba>]
                         [\-\-block\-count=<nlb> | \-c <nlb>]
                         [\-\-namespace\-id=<nsid> | \-n <nsid>]
+                        [\-\-force]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -54,6 +55,11 @@ Number of logical blocks to write uncorrectable\&.
 \-\-namespace\-id=<nsid>, \-n <nsid>
 .RS 4
 Namespace ID use in the command\&.
+.RE
+.PP
+\-\-force
+.RS 4
+Ignore namespace is currently busy and perfome the operation even though\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-write-uncor.html
+++ b/Documentation/nvme-write-uncor.html
@@ -1,9 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
     "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.8" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-uncor(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -94,7 +95,9 @@ ul > li > * { color: black; }
   padding: 0;
   margin: 0;
 }
-
+pre {
+  white-space: pre-wrap;
+}
 
 #author {
   color: #527bbd;
@@ -223,7 +226,7 @@ div.exampleblock > div.content {
 }
 
 div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; }
+span.image img { border-style: none; vertical-align: text-bottom; }
 a.image:visited { color: white; }
 
 dl {
@@ -748,7 +751,8 @@ nvme-uncor(1) Manual Page
 <div class="verseblock">
 <pre class="content"><em>nvme-write-uncorr</em> &lt;device&gt; [--start-block=&lt;slba&gt; | -s &lt;slba&gt;]
                         [--block-count=&lt;nlb&gt; | -c &lt;nlb&gt;]
-                        [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]</pre>
+                        [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
+                        [--force]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -797,6 +801,15 @@ blocks.</p></div>
         Namespace ID use in the command.
 </p>
 </dd>
+<dt class="hdlist1">
+--force
+</dt>
+<dd>
+<p>
+    Ignore namespace is currently busy and perfome the operation
+    even though.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -816,7 +829,8 @@ blocks.</p></div>
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-27 10:11:58 EST
+Last updated
+ 2021-12-15 10:26:18 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-write-uncor.txt
+++ b/Documentation/nvme-write-uncor.txt
@@ -11,6 +11,7 @@ SYNOPSIS
 'nvme-write-uncorr' <device> [--start-block=<slba> | -s <slba>]
 			[--block-count=<nlb> | -c <nlb>]
 			[--namespace-id=<nsid> | -n <nsid>]
+			[--force]
 
 DESCRIPTION
 -----------
@@ -30,6 +31,10 @@ OPTIONS
 --namespace-id=<nsid>::
 -n <nsid>::
 	Namespace ID use in the command.
+
+--force::
+    Ignore namespace is currently busy and perfome the operation
+    even though.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-write-zeroes.1
+++ b/Documentation/nvme-write-zeroes.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-zeroes
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/09/2021
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-ZEROES" "1" "07/09/2021" "NVMe" "NVMe Manual"
+.TH "NVME\-ZEROES" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -44,6 +44,7 @@ nvme-write-zeroes \- Send an NVMe write zeroes command, return results
                         [\-\-namespace\-id=<nsid> | \-n <nsid>]
                         [\-\-storage\-tag<storage\-tag> | \-S <storage\-tag>]
                         [\-\-storage\-tag\-check<storage\-tag\-check> | \-C <storage\-tag\-check>]
+                        [\-\-force]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -148,6 +149,11 @@ Variable Sized Expected Logical Block Storage Tag(ELBST) and Expected Logical Bl
 \-\-storage\-tag\-check=<storage\-tag\-check>, \-C <storage\-tag\-check>
 .RS 4
 This bit specifies the Storage Tag field shall be checked as part of end\-to\-end data protection processing\&.
+.RE
+.PP
+\-\-force
+.RS 4
+Ignore namespace is currently busy and perfome the operation even though\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-write-zeroes.html
+++ b/Documentation/nvme-write-zeroes.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-zeroes(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -760,7 +760,8 @@ nvme-zeroes(1) Manual Page
                         [--force-unit-access | -f]
                         [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
                         [--storage-tag&lt;storage-tag&gt; | -S &lt;storage-tag&gt;]
-                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]</pre>
+                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]
+                        [--force]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -946,6 +947,15 @@ metadata is passes.</p></td>
         data protection processing.
 </p>
 </dd>
+<dt class="hdlist1">
+--force
+</dt>
+<dd>
+<p>
+    Ignore namespace is currently busy and perfome the operation
+    even though.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -966,7 +976,7 @@ metadata is passes.</p></td>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-07-09 13:42:09 IST
+ 2021-12-15 10:26:48 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-write-zeroes.txt
+++ b/Documentation/nvme-write-zeroes.txt
@@ -20,6 +20,7 @@ SYNOPSIS
 			[--namespace-id=<nsid> | -n <nsid>]
 			[--storage-tag<storage-tag> | -S <storage-tag>]
 			[--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+			[--force]
 
 DESCRIPTION
 -----------
@@ -88,6 +89,10 @@ metadata is passes.
 -C <storage-tag-check>::
 	This bit specifies the Storage Tag field shall be checked as part of end-to-end
 	data protection processing.
+
+--force::
+    Ignore namespace is currently busy and perfome the operation
+    even though.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-write.1
+++ b/Documentation/nvme-write.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: nvme-write
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 07/09/2021
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 12/15/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-WRITE" "1" "07/09/2021" "NVMe" "NVMe Manual"
+.TH "NVME\-WRITE" "1" "12/15/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -51,6 +51,7 @@ nvme-write \- Send an NVMe write command, provide results
                         [\-\-dry\-run | \-w]
                         [\-\-latency | \-t]
                         [\-\-storage\-tag\-check<storage\-tag\-check> | \-C <storage\-tag\-check>]
+                        [\-\-force]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -193,6 +194,11 @@ Print out the latency the IOCTL took (in us)\&.
 \-\-storage\-tag\-check=<storage\-tag\-check>, \-C <storage\-tag\-check>
 .RS 4
 This bit specifies the Storage Tag field shall be checked as part of end\-to\-end data protection processing\&.
+.RE
+.PP
+\-\-force
+.RS 4
+Ignore namespace is currently busy and perfome the operation even though\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-write.html
+++ b/Documentation/nvme-write.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 8.6.10" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-write(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -436,7 +436,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }
@@ -767,7 +767,8 @@ nvme-write(1) Manual Page
                         [--show-command | -v]
                         [--dry-run | -w]
                         [--latency | -t]
-                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]</pre>
+                        [--storage-tag-check&lt;storage-tag-check&gt; | -C &lt;storage-tag-check&gt;]
+                        [--force]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -1048,6 +1049,15 @@ metadata is passes.</p></td>
         data protection processing.
 </p>
 </dd>
+<dt class="hdlist1">
+--force
+</dt>
+<dd>
+<p>
+    Ignore namespace is currently busy and perfome the operation
+    even though.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -1068,7 +1078,7 @@ metadata is passes.</p></td>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-07-09 14:16:34 IST
+ 2021-12-15 10:28:34 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-write.txt
+++ b/Documentation/nvme-write.txt
@@ -27,6 +27,7 @@ SYNOPSIS
 			[--dry-run | -w]
 			[--latency | -t]
 			[--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+			[--force]
 
 DESCRIPTION
 -----------
@@ -141,6 +142,10 @@ metadata is passes.
 -C <storage-tag-check>::
 	This bit specifies the Storage Tag field shall be checked as part of end-to-end
 	data protection processing.
+
+--force::
+    Ignore namespace is currently busy and perfome the operation
+    even though.
 
 EXAMPLES
 --------

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6909,10 +6909,3 @@ void nvme_show_list_items(nvme_root_t r, enum nvme_print_flags flags)
 	else
 		nvme_show_simple_list(r);
 }
-
-void nvme_show_busy_namespace(char *namespace) {
-	fprintf(stderr, "Failed to open %s.\n"\
-		"Namespace is currently busy.\n"\
-		"Use the force [--force] option to ignore that.\n",
-		namespace);
-}

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6909,3 +6909,10 @@ void nvme_show_list_items(nvme_root_t r, enum nvme_print_flags flags)
 	else
 		nvme_show_simple_list(r);
 }
+
+void nvme_show_busy_namespace(char *namespace) {
+	fprintf(stderr, "Failed to open %s.\n"\
+		"Namespace is currently busy.\n"\
+		"Use the force [--force] option to ignore that.\n",
+		namespace);
+}

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -120,6 +120,7 @@ void nvme_show_zns_report_zones(void *report, __u32 descs,
 void json_nvme_finish_zone_list(__u64 nr_zones, 
 	struct json_object *zone_list);
 void nvme_show_list_item(nvme_ns_t n);
+void nvme_show_busy_namespace(char *namespace);
 
 const char *nvme_cmd_to_string(int admin, __u8 opcode);
 const char *nvme_select_to_string(int sel);

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -120,7 +120,6 @@ void nvme_show_zns_report_zones(void *report, __u32 descs,
 void json_nvme_finish_zone_list(__u64 nr_zones, 
 	struct json_object *zone_list);
 void nvme_show_list_item(nvme_ns_t n);
-void nvme_show_busy_namespace(char *namespace);
 
 const char *nvme_cmd_to_string(int admin, __u8 opcode);
 const char *nvme_select_to_string(int sel);

--- a/nvme.c
+++ b/nvme.c
@@ -242,27 +242,30 @@ static int get_dev(int argc, char **argv, int flags)
 int parse_and_open(int argc, char **argv, const char *desc,
 	const struct argconfig_commandline_options *opts)
 {
+	const struct argconfig_commandline_options *s;
+	int flags = O_RDONLY;
 	int ret;
 
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
-	ret = get_dev(argc, argv, O_RDONLY);
-	if (ret < 0)
-		argconfig_print_help(desc, opts);
+	for (s = opts; (s->option != NULL) && (s != NULL); s++) {
+		if (!strcmp(s->option, "force")) {
+			if (! *(int *) s->default_value)
+				flags |= O_EXCL;
+			break;
+		}
+	}
 
+	ret = get_dev(argc, argv, flags);
+	if (ret < 0) {
+		if (errno == EBUSY)
+			nvme_show_busy_namespace(basename(argv[optind]));
+		else
+			argconfig_print_help(desc, opts);
+	}
 	return ret;
-}
-
-int open_exclusive(int argc, char **argv, int force)
-{
-    int flags = O_RDONLY;
-
-	if (!force)
-		flags |= O_EXCL;
-
-    return get_dev(argc, argv, flags);
 }
 
 enum nvme_print_flags validate_output_format(const char *format)
@@ -3716,6 +3719,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *ause_desc = "Allow unrestricted sanitize exit.";
 	const char *sanact_desc = "Sanitize action.";
 	const char *ovrpat_desc = "Overwrite pattern.";
+	const char *force_desc = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 
 	int fd, ret;
 
@@ -3726,6 +3730,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 		int    ause;
 		__u8   sanact;
 		__u32  ovrpat;
+		int    force;
 	};
 
 	struct config cfg = {
@@ -3735,6 +3740,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 		.ause = 0,
 		.sanact = 0,
 		.ovrpat = 0,
+		.force = 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -3744,6 +3750,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 		OPT_FLAG("ause",       'u', &cfg.ause,       ause_desc),
 		OPT_BYTE("sanact",     'a', &cfg.sanact,     sanact_desc),
 		OPT_UINT("ovrpat",     'p', &cfg.ovrpat,     ovrpat_desc),
+		OPT_FLAG("force",      'f', &cfg.force,      force_desc),
 		OPT_END()
 	};
 
@@ -4106,24 +4113,6 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		OPT_SUFFIX("block-size", 'b', &cfg.bs,           bs),
 		OPT_END()
 	};
-
-	err = argconfig_parse(argc, argv, desc, opts);
-	if (err)
-		goto ret;
-
-	err = fd = open_exclusive(argc, argv, cfg.force);
-	if (fd < 0) {
-		if (errno == EBUSY) {
-			fprintf(stderr, "Failed to open %s.\n",
-                basename(argv[optind]));
-			fprintf(stderr,
-				"Namespace is currently busy.\n"
-				"Use the force [--force|-f] option to ignore that.\n");
-		} else {
-			argconfig_print_help(desc, opts);
-		}
-		goto ret;
-	}
 
 	err = fd = parse_and_open(argc, argv, desc, opts);
 	if (fd < 0)
@@ -4738,23 +4727,27 @@ static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin
 	const char *namespace_id = "desired namespace";
 	const char *start_block = "64-bit LBA of first block to access";
 	const char *block_count = "number of blocks (zeroes based) on device to access";
+	const char *force_desc = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 
 	struct config {
 		__u64 start_block;
 		__u32 namespace_id;
 		__u16 block_count;
+		int force;
 	};
 
 	struct config cfg = {
 		.start_block     = 0,
 		.namespace_id    = 0,
 		.block_count     = 0,
+		.force           = 0,
 	};
 
 	OPT_ARGS(opts) = {
 		OPT_UINT("namespace-id",  'n', &cfg.namespace_id, namespace_id),
 		OPT_SUFFIX("start-block", 's', &cfg.start_block,  start_block),
 		OPT_SHRT("block-count",   'c', &cfg.block_count,  block_count),
+		OPT_FLAG("force",         'f', &cfg.force,        force_desc),
 		OPT_END()
 	};
 
@@ -4795,7 +4788,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	const char *start_block = "64-bit LBA of first block to access";
 	const char *block_count = "number of blocks (zeroes based) on device to access";
 	const char *limited_retry = "limit media access attempts";
-	const char *force = "force device to commit data before command completes";
+	const char *force_unit_access = "force device to commit data before command completes";
 	const char *prinfo = "PI and check field";
 	const char *ref_tag = "reference tag (for end to end PI)";
 	const char *app_tag_mask = "app tag mask (for end to end PI)";
@@ -4805,6 +4798,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	const char *deac = "Set DEAC bit, requesting controller to deallocate specified logical blocks";
 	const char *storage_tag_check = "This bit specifies the Storage Tag field shall be checked as "\
 		"part of end-to-end data protection processing";
+	const char *force = "The \"I know what I'm doing\" flag, open device even it is already used";
 
 	struct config {
 		__u64 start_block;
@@ -4819,6 +4813,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		int   limited_retry;
 		int   force_unit_access;
 		int   storage_tag_check;
+		int   force;
 	};
 
 	struct config cfg = {
@@ -4830,6 +4825,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		.app_tag         	= 0,
 		.storage_tag	 	= 0,
 		.storage_tag_check 	= 0,
+		.force        		= 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -4838,13 +4834,14 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_SHRT("block-count",       'c', &cfg.block_count,       block_count),
 		OPT_FLAG("deac",              'd', &cfg.deac,              deac),
 		OPT_FLAG("limited-retry",     'l', &cfg.limited_retry,     limited_retry),
-		OPT_FLAG("force-unit-access", 'f', &cfg.force_unit_access, force),
+		OPT_FLAG("force-unit-access", 'f', &cfg.force_unit_access, force_unit_access),
 		OPT_BYTE("prinfo",            'p', &cfg.prinfo,            prinfo),
 		OPT_UINT("ref-tag",           'r', &cfg.ref_tag,           ref_tag),
 		OPT_SHRT("app-tag-mask",      'm', &cfg.app_tag_mask,      app_tag_mask),
 		OPT_SHRT("app-tag",           'a', &cfg.app_tag,           app_tag),
 		OPT_SUFFIX("storage-tag",     'S', &cfg.storage_tag,       storage_tag),
 		OPT_FLAG("storage-tag-check", 'C', &cfg.storage_tag_check, storage_tag_check),
+		OPT_FLAG("force",               0, &cfg.force,             force),
 		OPT_END()
 	};
 
@@ -5520,7 +5517,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	const char *app_tag = "app tag (for end to end PI)";
 	const char *limited_retry = "limit num. media access attempts";
 	const char *latency = "output latency statistics";
-	const char *force = "force device to commit data before command completes";
+	const char *force_unit_access = "force device to commit data before command completes";
 	const char *show = "show command before sending";
 	const char *dry = "show command instead of sending";
 	const char *dtype = "directive type (for write-only)";
@@ -5530,6 +5527,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		"checked as part of end-to-end data protection processing";
 	const char *storage_tag = "storage tag, CDW2 and CDW3 (00:47) bits "\
 		"(for end to end PI)";
+	const char *force = "The \"I know what I'm doing\" flag, open device even it is already in use";
 
 	struct config {
 		__u32 namespace_id;
@@ -5553,22 +5551,24 @@ static int submit_io(int opcode, char *command, const char *desc,
 		int   show;
 		int   dry_run;
 		int   latency;
+		int   force;
 	};
 
 	struct config cfg = {
 		.namespace_id		= 0,
 		.start_block		= 0,
 		.block_count		= 0,
-		.data_size		= 0,
+		.data_size			= 0,
 		.metadata_size		= 0,
-		.ref_tag		= 0,
-		.data			= "",
-		.metadata		= "",
-		.prinfo			= 0,
+		.ref_tag			= 0,
+		.data				= "",
+		.metadata			= "",
+		.prinfo				= 0,
 		.app_tag_mask		= 0,
-		.app_tag		= 0,
+		.app_tag			= 0,
 		.storage_tag_check	= 0,
 		.storage_tag		= 0,
+		.force			 	= 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -5585,7 +5585,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		OPT_SHRT("app-tag",           'a', &cfg.app_tag,           app_tag),
 		OPT_SUFFIX("storage-tag",     'g', &cfg.storage_tag,       storage_tag),
 		OPT_FLAG("limited-retry",     'l', &cfg.limited_retry,     limited_retry),
-		OPT_FLAG("force-unit-access", 'f', &cfg.force_unit_access, force),
+		OPT_FLAG("force-unit-access", 'f', &cfg.force_unit_access, force_unit_access),
 		OPT_FLAG("storage-tag-check", 'C', &cfg.storage_tag_check, storage_tag_check),
 		OPT_BYTE("dir-type",          'T', &cfg.dtype,             dtype),
 		OPT_SHRT("dir-spec",          'S', &cfg.dspec,             dspec),
@@ -5593,8 +5593,12 @@ static int submit_io(int opcode, char *command, const char *desc,
 		OPT_FLAG("show-command",      'v', &cfg.show,              show),
 		OPT_FLAG("dry-run",           'w', &cfg.dry_run,           dry),
 		OPT_FLAG("latency",           't', &cfg.latency,           latency),
+		OPT_FLAG("force",               0, &cfg.force,             force),
 		OPT_END()
 	};
+
+	if (opcode != nvme_cmd_write)
+		cfg.force = 1;
 
 	err = fd = parse_and_open(argc, argv, desc, opts);
 	if (fd < 0)

--- a/nvme.c
+++ b/nvme.c
@@ -250,9 +250,9 @@ int parse_and_open(int argc, char **argv, const char *desc,
 	if (ret)
 		return ret;
 
-	for (s = opts; (s->option != NULL) && (s != NULL); s++) {
+	for (s = opts; s && s->option; s++) {
 		if (!strcmp(s->option, "force")) {
-			if (! *(int *) s->default_value)
+			if (! *(int *)s->default_value)
 				flags |= O_EXCL;
 			break;
 		}
@@ -260,9 +260,12 @@ int parse_and_open(int argc, char **argv, const char *desc,
 
 	ret = get_dev(argc, argv, flags);
 	if (ret < 0) {
-		if (errno == EBUSY)
-			nvme_show_busy_namespace(basename(argv[optind]));
-		else
+		if (errno == EBUSY) {
+			fprintf(stderr, "Failed to open %s.\n" \
+				"Namespace is currently busy.\n" \
+				"Use the force [--force] option to ignore that.\n",
+				basename(argv[optind]));
+		} else
 			argconfig_print_help(desc, opts);
 	}
 	return ret;
@@ -2544,7 +2547,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 
 	OPT_ARGS(opts) = {
 		OPT_UINT("namespace-id",    'n', &cfg.namespace_id,    namespace_id),
-		OPT_FLAG("force",           'f', &cfg.force,           force),
+		OPT_FLAG("force",             0, &cfg.force,           force),
 		OPT_FLAG("vendor-specific", 'v', &cfg.vendor_specific, vendor_specific),
 		OPT_FLAG("raw-binary",      'b', &cfg.raw_binary,      raw),
 		OPT_FMT("output-format",    'o', &cfg.output_format,   output_format),
@@ -3750,7 +3753,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 		OPT_FLAG("ause",       'u', &cfg.ause,       ause_desc),
 		OPT_BYTE("sanact",     'a', &cfg.sanact,     sanact_desc),
 		OPT_UINT("ovrpat",     'p', &cfg.ovrpat,     ovrpat_desc),
-		OPT_FLAG("force",      'f', &cfg.force,      force_desc),
+		OPT_FLAG("force",        0, &cfg.force,      force_desc),
 		OPT_END()
 	};
 
@@ -4109,7 +4112,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		OPT_BYTE("pil",          'p', &cfg.pil,          pil),
 		OPT_BYTE("ms",           'm', &cfg.ms,           ms),
 		OPT_FLAG("reset",        'r', &cfg.reset,        reset),
-		OPT_FLAG("force",        'f', &cfg.force,        force),
+		OPT_FLAG("force",          0, &cfg.force,        force),
 		OPT_SUFFIX("block-size", 'b', &cfg.bs,           bs),
 		OPT_END()
 	};
@@ -4747,7 +4750,7 @@ static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin
 		OPT_UINT("namespace-id",  'n', &cfg.namespace_id, namespace_id),
 		OPT_SUFFIX("start-block", 's', &cfg.start_block,  start_block),
 		OPT_SHRT("block-count",   'c', &cfg.block_count,  block_count),
-		OPT_FLAG("force",         'f', &cfg.force,        force_desc),
+		OPT_FLAG("force",           0, &cfg.force,        force_desc),
 		OPT_END()
 	};
 


### PR DESCRIPTION
All data modifying functions open the namespace exclusive. With the --force or -f
option this can be bypassed.

Signed-off-by: Olaf Schmerse <olaf.schmerse@ionos.com>