### PR TITLE
nvme-print: add discovery async event config field

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5963,6 +5963,7 @@ void nvme_feature_show_fields(enum nvme_feat fid, unsigned int result,
 		break;
 	case NVME_FEAT_ASYNC_EVENT:
 		printf("\tZone Descriptor Changed Notices: %s\n", ((result >> 27) & 0x1) ? "Send async event":"Do not send async event");
+		printf("\tDiscovery Log Page Change Notices: %s\n", ((result & 0x80000000) >> 31) ? "Send async event":"Do not send async event");
 		printf("\tEndurance Group Event Aggregate Log Change Notices: %s\n", ((result & 0x00004000) >> 14) ? "Send async event":"Do not send async event");
 		printf("\tLBA Status Information Notices  : %s\n", ((result & 0x00002000) >> 13) ? "Send async event":"Do not send async event");
 		printf("\tPredictable Latency Event Aggregate Log Change Notices: %s\n", ((result & 0x00001000) >> 12) ? "Send async event":"Do not send async event");


### PR DESCRIPTION
Add a new async event config field for discovery log page
change notices.

Signed-off-by: Martin George <marting@netapp.com>