### PR TITLE
build: Use CONFIG_JSONC consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ endif
 ifeq ($(LIBJSONC), 0)
 	override LDFLAGS += $(shell pkg-config --libs json-c)
 	override CFLAGS += $(shell pkg-config --cflags json-c)
-	override CFLAGS += -DCONFIG_LIBJSONC
+	override CFLAGS += -DCONFIG_JSONC
 endif
 
 ifneq ("$(wildcard $(LIBNVMEDIR)/Makefile)","")

--- a/nvme.h
+++ b/nvme.h
@@ -22,7 +22,7 @@
 #include <sys/time.h>
 
 #include "plugin.h"
-#ifdef CONFIG_LIBJSONC
+#ifdef CONFIG_JSONC
 #include <json.h>
 
 #define json_create_object(o) json_object_new_object(o)


### PR DESCRIPTION
The config flag for json-c hasn't been updated to the consistent
naming scheme everywhere. Let's use prefix it with CONFIG and use the
correct library name which is json-c.

Signed-off-by: Daniel Wagner <dwagner@suse.de>