### PR TITLE
nvme-cli: ctrl-loss-tmo should accept -1 as value

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -69,7 +69,7 @@ const char *conarg_host_traddr = "host_traddr";
 const char *conarg_host_iface = "host_iface";
 
 struct fabrics_config fabrics_cfg = {
-	.ctrl_loss_tmo = -1,
+	.ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO,
 	.fast_io_fail_tmo = -1,
 	.output_format = "normal",
 };
@@ -965,7 +965,7 @@ add_int_argument(char **argstr, int *max_len, char *arg_str, int arg,
 {
 	int len;
 
-	if ((arg && !allow_zero) || (arg != -1 && allow_zero)) {
+	if (arg || allow_zero) {
 		len = snprintf(*argstr, *max_len, ",%s=%d", arg_str, arg);
 		if (len < 0)
 			return -EINVAL;
@@ -1006,9 +1006,6 @@ int build_options(char *argstr, int max_len, bool discover)
 			msg(LOG_ERR, "need a address (-a) argument\n");
 			return -EINVAL;
 		}
-		/* Use the default ctrl loss timeout if unset */
-		if (fabrics_cfg.ctrl_loss_tmo == -1)
-			fabrics_cfg.ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO;
 	}
 
 	/* always specify nqn as first arg - this will init the string */
@@ -1044,10 +1041,12 @@ int build_options(char *argstr, int max_len, bool discover)
 	    (strncmp(fabrics_cfg.transport, "loop", 4) &&
 	     add_int_argument(&argstr, &max_len, "ctrl_loss_tmo",
 			      fabrics_cfg.ctrl_loss_tmo, true)) ||
+	    (fabrics_cfg.fast_io_fail_tmo != -1 &&
 	    add_int_argument(&argstr, &max_len, "fast_io_fail_tmo",
-				fabrics_cfg.fast_io_fail_tmo, true) ||
+				fabrics_cfg.fast_io_fail_tmo, true)) ||
+	    (fabrics_cfg.tos != -1 &&
 	    add_int_argument(&argstr, &max_len, "tos",
-				fabrics_cfg.tos, true) ||
+				fabrics_cfg.tos, true)) ||
 	    add_bool_argument(&argstr, &max_len, "duplicate_connect",
 				fabrics_cfg.duplicate_connect) ||
 	    add_bool_argument(&argstr, &max_len, "disable_sqflow",


### PR DESCRIPTION
When passing the parameter --ctrl-loss-tmo=-1
nvme-cli silently drops it and replaces its value with the
default one (600) despite the fact that -1 is valid
and accepted by the kernel.
ctrl_loss_tmo < 0 means that it will try to reconnect forever

This is due to the fact that -1 is treated like "variable unset"
by nvme-cli and the add_int_argument() function ignores
all arguments with such a value if allow_zero is true (the latter seems
to be completely unintended).

This patch fixes the bug by:

1) removing the "arg == -1" condition from add_int_argument() and letting
   the caller take care of checking if -1 is an acceptable value
   for a particular argument.

2) initializing ctrl_loss_tmo to its default value instead of -1.

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>