### PR TITLE
fabrics: fix 'nvme connect' segfault if transport type is omitted

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1070,6 +1070,8 @@ static void set_discovery_kato(struct fabrics_config *cfg)
 
 static void discovery_trsvcid(struct fabrics_config *fabrics_cfg, bool discover)
 {
+	if (!fabrics_cfg->transport)
+		return;
 	if (!strcmp(fabrics_cfg->transport, "tcp")) {
 		if (discover) {
 			/* Default port for NVMe/TCP discovery controllers */


### PR DESCRIPTION
Check if the transport type is available before dereferencing
it in discovery_trsvcid().

Fixes: 362c90f ("fabrics: add default port number for NVMe/TCP I/O
controllers")
Signed-off-by: Martin George <marting@netapp.com>