### PR TITLE
Update and document configuration file access

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -29,6 +29,7 @@ SYNOPSIS
 		[--matching               | -m]
 		[--persistent             | -p]
 		[--quiet                  | -S]
+		[--dump-config            | -O]
 
 DESCRIPTION
 -----------
@@ -165,6 +166,10 @@ OPTIONS
 -S::
 --quiet::
 	Suppress error messages.
+
+-O::
+--dump-config::
+	Print out resulting JSON configuration file to stdout.
 
 
 EXAMPLES

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -17,6 +17,7 @@ SYNOPSIS
 		[--hostnqn=<hostnqn>      | -q <hostnqn>]
 		[--hostid=<hostid>        | -I <hostid>]
 		[--raw=<filename>         | -r <filename>]
+		[--cfg-file=<cfg>         | -C <cfg>]
 		[--keep-alive-tmo=<#>     | -k <#>]
 		[--reconnect-delay=<#>    | -c <#>]
 		[--ctrl-loss-tmo=<#>	  | -l <#>]
@@ -108,6 +109,14 @@ OPTIONS
 	This field will take the output of the 'nvme connect-all' command
 	and dump it to a raw binary file. By default 'nvme connect-all' will
 	dump the output to stdout.
+
+-C <cfg>::
+--config-file=<cfg>::
+	Use the specified JSON configuration file instead of the
+	default /etc/nvme/config.json file or 'none' to not read in
+	an existing configuration file. The JSON configuration file
+	format is documented in
+	https://github.com/linux-nvme/libnvme/doc/config-schema.json
 
 -k <#>::
 --keep-alive-tmo=<#>::

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -17,6 +17,7 @@ SYNOPSIS
 		[--host-iface=<iface>     | -f <iface>]
 		[--hostnqn=<hostnqn>      | -q <hostnqn>]
 		[--hostid=<hostid>        | -I <hostid>]
+		[--config-file=<cfg>      | -C <cfg> ]
 		[--nr-io-queues=<#>       | -i <#>]
 		[--nr-write-queues=<#>    | -W <#>]
 		[--nr-poll-queues=<#>     | -P <#>]
@@ -92,6 +93,14 @@ OPTIONS
 --hostid=<hostid>::
 	UUID(Universally Unique Identifier) to be discovered which should be
 	formatted.
+
+-C <cfg>::
+--config-file=<cfg>::
+	Use the specified JSON configuration file instead of the
+	default /etc/nvme/config.json file or 'none' to not read in
+	an existing configuration file. The JSON configuration file
+	format is documented in
+	https://github.com/linux-nvme/libnvme/doc/config-schema.json
 
 -i <#>::
 --nr-io-queues=<#>::

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -28,6 +28,7 @@ SYNOPSIS
 		[--disable-sqflow         | -d]
 		[--hdr-digest             | -g]
 		[--data-digest            | -G]
+		[--dump-config            | -O]
 
 DESCRIPTION
 -----------
@@ -139,6 +140,10 @@ OPTIONS
 -G::
 --data-digest::
 	Generates/verifies data digest (TCP).
+
+-O::
+--dump-config::
+	Print out resulting JSON configuration file to stdout.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -18,6 +18,7 @@ SYNOPSIS
 		[--hostid=<hostid>        | -I <hostid>]
 		[--raw=<filename>	  | -r <filename>]
 		[--device=<device>        | -d <device>]
+		[--cfg-file=<cfg>         | -C <cfg> ]
 		[--keep-alive-tmo=<sec>   | -k <sec>]
 		[--reconnect-delay=<#>	  | -c <#>]
 		[--ctrl-loss-tmo=<#>	  | -l <#>]
@@ -132,6 +133,14 @@ OPTIONS
 --device=<device>::
 	This field takes a device as input. Device is in the format of nvme*,
 	eg. nvme0, nvme1
+
+-C <cfg>::
+--config-file=<cfg>::
+	Use the specified JSON configuration file instead of the
+	default /etc/nvme/config.json file or 'none' to not read in
+	an existing configuration file. The JSON configuration file
+	format is documented in
+	https://github.com/linux-nvme/libnvme/doc/config-schema.json
 
 -k <#>::
 --keep-alive-tmo=<#>::

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -29,6 +29,7 @@ SYNOPSIS
 		[--queue-size=<#>         | -Q <#>]
 		[--persistent             | -p]
 		[--quiet                  | -S]
+		[--dump-config            | -O]
 		[--output-format=<fmt>    | -o <fmt>]
 
 DESCRIPTION
@@ -183,6 +184,10 @@ OPTIONS
 -S::
 --quiet::
 	Suppress already connected errors.
+
+-O::
+--dump-config::
+	Print out resulting JSON configuration file to stdout.
 
 -o <format>::
 --output-format=<format>::

--- a/fabrics.c
+++ b/fabrics.c
@@ -307,11 +307,7 @@ static int discover_from_conf_file(nvme_host_t h, const char *desc,
 	FILE *f;
 	enum nvme_print_flags flags;
 	char *format = "normal";
-
-	struct nvme_fabrics_config cfg = {
-		.tos = -1,
-		.ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO,
-	};
+	struct nvme_fabrics_config cfg;
 
 	OPT_ARGS(opts) = {
 		NVMF_OPTS(cfg),
@@ -322,6 +318,8 @@ static int discover_from_conf_file(nvme_host_t h, const char *desc,
 		OPT_INCR("verbose",      'v', &verbose,       "Increase logging verbosity"),
 		OPT_END()
 	};
+
+	nvmf_default_config(&cfg);
 
 	ret = flags = validate_output_format(format);
 	if (ret < 0)
@@ -399,11 +397,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	unsigned int verbose = 0;
 	int ret;
 	char *format = "normal";
-
-	struct nvme_fabrics_config cfg = {
-		.tos = -1,
-	};
-
+	struct nvme_fabrics_config cfg;
 	char *device = NULL;
 
 	OPT_ARGS(opts) = {
@@ -417,6 +411,8 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 		OPT_INCR("verbose",      'v', &verbose,       "Increase logging verbosity"),
 		OPT_END()
 	};
+
+	nvmf_default_config(&cfg);
 
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
@@ -556,11 +552,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	nvme_host_t h;
 	nvme_ctrl_t c;
 	int ret;
-
-	struct nvme_fabrics_config cfg = {
-		.tos = -1,
-		.ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO,
-	};
+	struct nvme_fabrics_config cfg;
 
 	OPT_ARGS(opts) = {
 		OPT_STRING("nqn", 'n', "NAME", &subsysnqn, nvmf_nqn),
@@ -569,6 +561,8 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 		OPT_INCR("verbose", 'v', &verbose, "Increase logging verbosity"),
 		OPT_END()
 	};
+
+	nvmf_default_config(&cfg);
 
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)

--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -35,6 +35,7 @@ make install-spec DESTDIR=%{buildroot} PREFIX=/usr
 %{_sysconfdir}/nvme/hostnqn
 %{_sysconfdir}/nvme/hostid
 %{_sysconfdir}/nvme/discovery.conf
+%ghost %{_sysconfdir}/nvme/config.json
 %{_sysconfdir}/udev/rules.d/70-nvmf-autoconnect.rules
 %{_sysconfdir}/udev/rules.d/71-nvmf-iopolicy-netapp.rules
 %{_libdir}/dracut/dracut.conf.d/70-nvmf-autoconnect.conf


### PR DESCRIPTION
This patchset adds a new option 'dump-config' to print out the resulting JSON configuration to stdout, and also documents the 'config-file' commandline parameter.