### PR TITLE
Compability for older json-c releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ override CPPFLAGS += -D_GNU_SOURCE -D__CHECK_ENDIAN__ -I.
 LIBUUID = $(shell $(LD) -o /dev/null -luuid >/dev/null 2>&1; echo $$?)
 LIBHUGETLBFS = $(shell $(LD) -o /dev/null -lhugetlbfs >/dev/null 2>&1; echo $$?)
 HAVE_SYSTEMD = $(shell pkg-config --exists libsystemd  --atleast-version=242; echo $$?)
-LIBJSONC = $(shell pkg-config --atleast-version=0.14 json-c; echo $$?)
+LIBJSONC_14 = $(shell pkg-config --atleast-version=0.14 json-c; echo $$?)
+LIBJSONC = $(shell pkg-config json-c; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =

--- a/fabrics.c
+++ b/fabrics.c
@@ -159,7 +159,7 @@ static void json_discovery_log(struct nvmf_discovery_log *log, int numrec)
 
 	root = json_create_object();
 	entries = json_create_array();
-	json_object_add_value_uint(root, "genctr", le64_to_cpu(log->genctr));
+	json_object_add_value_uint64(root, "genctr", le64_to_cpu(log->genctr));
 	json_object_add_value_array(root, "records", entries);
 
 	for (i = 0; i < numrec; i++) {
@@ -178,7 +178,8 @@ static void json_discovery_log(struct nvmf_discovery_log *log, int numrec)
 					     nvmf_subtype_str(e->subtype));
 		json_object_add_value_string(entry,"treq",
 					     nvmf_treq_str(e->treq));
-		json_object_add_value_uint(entry, "portid", e->portid);
+		json_object_add_value_uint(entry, "portid",
+					   le16_to_cpu(e->portid));
 		json_object_add_value_string(entry, "trsvcid", e->trsvcid);
 		json_object_add_value_string(entry, "subnqn", e->subnqn);
 		json_object_add_value_string(entry, "traddr", e->traddr);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -161,9 +161,9 @@ static void json_nvme_id_ns(struct nvme_id_ns *ns)
 
 	root = json_create_object();
 
-	json_object_add_value_uint(root, "nsze", le64_to_cpu(ns->nsze));
-	json_object_add_value_uint(root, "ncap", le64_to_cpu(ns->ncap));
-	json_object_add_value_uint(root, "nuse", le64_to_cpu(ns->nuse));
+	json_object_add_value_uint64(root, "nsze", le64_to_cpu(ns->nsze));
+	json_object_add_value_uint64(root, "ncap", le64_to_cpu(ns->ncap));
+	json_object_add_value_uint64(root, "nuse", le64_to_cpu(ns->nuse));
 	json_object_add_value_int(root, "nsfeat", ns->nsfeat);
 	json_object_add_value_int(root, "nlbaf", ns->nlbaf);
 	json_object_add_value_int(root, "flbas", ns->flbas);
@@ -394,7 +394,7 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries)
 	for (i = 0; i < entries; i++) {
 		struct json_object *error = json_create_object();
 
-		json_object_add_value_uint(error, "error_count",
+		json_object_add_value_uint64(error, "error_count",
 			le64_to_cpu(err_log[i].error_count));
 		json_object_add_value_int(error, "sqid",
 			le16_to_cpu(err_log[i].sqid));
@@ -406,13 +406,13 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries)
 			le16_to_cpu(err_log[i].status_field & 0x1));
 		json_object_add_value_int(error, "parm_error_location",
 			le16_to_cpu(err_log[i].parm_error_location));
-		json_object_add_value_uint(error, "lba",
+		json_object_add_value_uint64(error, "lba",
 			le64_to_cpu(err_log[i].lba));
 		json_object_add_value_uint(error, "nsid",
 			le32_to_cpu(err_log[i].nsid));
 		json_object_add_value_int(error, "vs", err_log[i].vs);
 		json_object_add_value_int(error, "trtype", err_log[i].trtype);
-		json_object_add_value_uint(error, "cs",
+		json_object_add_value_uint64(error, "cs",
 			le64_to_cpu(err_log[i].cs));
 		json_object_add_value_int(error, "trtype_spec_info",
 			le16_to_cpu(err_log[i].trtype_spec_info));
@@ -460,9 +460,9 @@ static void json_nvme_resv_report(struct nvme_resv_status *status,
 				le16_to_cpu(status->regctl_ds[i].cntlid));
 			json_object_add_value_int(rc, "rcsts",
 				status->regctl_ds[i].rcsts);
-			json_object_add_value_uint(rc, "hostid",
+			json_object_add_value_uint64(rc, "hostid",
 				le64_to_cpu(status->regctl_ds[i].hostid));
-			json_object_add_value_uint(rc, "rkey",
+			json_object_add_value_uint64(rc, "rkey",
 				le64_to_cpu(status->regctl_ds[i].rkey));
 
 			json_array_add_value_object(rcs, rc);
@@ -483,7 +483,7 @@ static void json_nvme_resv_report(struct nvme_resv_status *status,
 				le16_to_cpu(status->regctl_eds[i].cntlid));
 			json_object_add_value_int(rc, "rcsts",
 				status->regctl_eds[i].rcsts);
-			json_object_add_value_uint(rc, "rkey",
+			json_object_add_value_uint64(rc, "rkey",
 				le64_to_cpu(status->regctl_eds[i].rkey));
 			for (j = 0; j < 16; j++)
 				sprintf(hostid + j * 2, "%02x",
@@ -724,7 +724,7 @@ static void json_ana_log(struct nvme_ana_log *ana_log, const char *devname)
 	json_object_add_value_string(root,
 			"Asymmetric Namespace Access Log for NVMe device",
 			devname);
-	json_object_add_value_uint(root, "chgcnt",
+	json_object_add_value_uint64(root, "chgcnt",
 			le64_to_cpu(hdr->chgcnt));
 	json_object_add_value_uint(root, "ngrps", le16_to_cpu(hdr->ngrps));
 
@@ -791,14 +791,15 @@ static void json_self_test_log(struct nvme_self_test_log *self_test, __u8 dst_en
 			self_test->result[i].seg);
 		json_object_add_value_int(valid_attrs, "Valid Diagnostic Information",
 			self_test->result[i].vdi);
-		json_object_add_value_uint(valid_attrs, "Power on hours",
+		json_object_add_value_uint64(valid_attrs, "Power on hours",
 			le64_to_cpu(self_test->result[i].poh));
 		if (self_test->result[i].vdi & NVME_ST_VALID_DIAG_INFO_NSID)
 			json_object_add_value_int(valid_attrs, "Namespace Identifier",
 				le32_to_cpu(self_test->result[i].nsid));
-		if (self_test->result[i].vdi & NVME_ST_VALID_DIAG_INFO_FLBA)
-			json_object_add_value_uint(valid_attrs, "Failing LBA",
+		if (self_test->result[i].vdi & NVME_ST_VALID_DIAG_INFO_FLBA) {
+			json_object_add_value_uint64(valid_attrs, "Failing LBA",
 				le64_to_cpu(self_test->result[i].flba));
+		}
 		if (self_test->result[i].vdi & NVME_ST_VALID_DIAG_INFO_SCT)
 			json_object_add_value_int(valid_attrs, "Status Code Type",
 				self_test->result[i].sct);
@@ -936,21 +937,21 @@ void json_predictable_latency_per_nvmset(
 		plpns_log->status);
 	json_object_add_value_uint(root, "event_type",
 		le16_to_cpu(plpns_log->event_type));
-	json_object_add_value_uint(root, "dtwin_reads_typical",
+	json_object_add_value_uint64(root, "dtwin_reads_typical",
 		le64_to_cpu(plpns_log->dtwin_rt));
-	json_object_add_value_uint(root, "dtwin_writes_typical",
+	json_object_add_value_uint64(root, "dtwin_writes_typical",
 		le64_to_cpu(plpns_log->dtwin_wt));
-	json_object_add_value_uint(root, "dtwin_time_maximum",
+	json_object_add_value_uint64(root, "dtwin_time_maximum",
 		le64_to_cpu(plpns_log->dtwin_tmax));
-	json_object_add_value_uint(root, "ndwin_time_minimum_high",
+	json_object_add_value_uint64(root, "ndwin_time_minimum_high",
 		le64_to_cpu(plpns_log->ndwin_tmin_hi));
-	json_object_add_value_uint(root, "ndwin_time_minimum_low",
+	json_object_add_value_uint64(root, "ndwin_time_minimum_low",
 		le64_to_cpu(plpns_log->ndwin_tmin_lo));
-	json_object_add_value_uint(root, "dtwin_reads_estimate",
+	json_object_add_value_uint64(root, "dtwin_reads_estimate",
 		le64_to_cpu(plpns_log->dtwin_re));
-	json_object_add_value_uint(root, "dtwin_writes_estimate",
+	json_object_add_value_uint64(root, "dtwin_writes_estimate",
 		le64_to_cpu(plpns_log->dtwin_we));
-	json_object_add_value_uint(root, "dtwin_time_estimate",
+	json_object_add_value_uint64(root, "dtwin_time_estimate",
 		le64_to_cpu(plpns_log->dtwin_te));
 
 	json_print_object(root, NULL);
@@ -1007,7 +1008,7 @@ void json_predictable_latency_event_agg_log(
 
 	root = json_create_object();
 	num_entries = le64_to_cpu(pea_log->num_entries);
-	json_object_add_value_uint(root, "num_entries_avail",
+	json_object_add_value_uint64(root, "num_entries_avail",
 		num_entries);
 	valid = json_create_array();
 
@@ -1124,17 +1125,17 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 			pevent_log_head->lid);
 		json_object_add_value_uint(root, "total_num_of_events",
 			le32_to_cpu(pevent_log_head->tnev));
-		json_object_add_value_uint(root, "total_log_len",
+		json_object_add_value_uint64(root, "total_log_len",
 			le64_to_cpu(pevent_log_head->tll));
 		json_object_add_value_uint(root, "log_revision",
 			pevent_log_head->rv);
 		json_object_add_value_uint(root, "log_header_len",
 			le16_to_cpu(pevent_log_head->lhl));
-		json_object_add_value_uint(root, "timestamp",
+		json_object_add_value_uint64(root, "timestamp",
 			le64_to_cpu(pevent_log_head->ts));
 		json_object_add_value_float(root, "power_on_hours",
 			int128_to_double(pevent_log_head->poh));
-		json_object_add_value_uint(root, "power_cycle_count",
+		json_object_add_value_uint64(root, "power_cycle_count",
 			le64_to_cpu(pevent_log_head->pcc));
 		json_object_add_value_uint(root, "pci_vid",
 			le16_to_cpu(pevent_log_head->vid));
@@ -1179,7 +1180,7 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 			pevent_entry_head->ehl);
 		json_object_add_value_uint(valid_attrs, "ctrl_id",
 			le16_to_cpu(pevent_entry_head->cntlid));
-		json_object_add_value_uint(valid_attrs, "event_time_stamp",
+		json_object_add_value_uint64(valid_attrs, "event_time_stamp",
 			le64_to_cpu(pevent_entry_head->ets));
 		json_object_add_value_uint(valid_attrs, "vu_info_len",
 			le16_to_cpu(pevent_entry_head->vsil));
@@ -1262,9 +1263,9 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 			break;
 		case NVME_PEL_FW_COMMIT_EVENT:
 			fw_commit_event = pevent_log_info + offset;
-			json_object_add_value_uint(valid_attrs, "old_fw_rev",
+			json_object_add_value_uint64(valid_attrs, "old_fw_rev",
 				le64_to_cpu(fw_commit_event->old_fw_rev));
-			json_object_add_value_uint(valid_attrs, "new_fw_rev",
+			json_object_add_value_uint64(valid_attrs, "new_fw_rev",
 				le64_to_cpu(fw_commit_event->new_fw_rev));
 			json_object_add_value_uint(valid_attrs, "fw_commit_action",
 				fw_commit_event->fw_commit_action);
@@ -1280,9 +1281,9 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 			break;
 		case NVME_PEL_TIMESTAMP_EVENT:
 			ts_change_event = pevent_log_info + offset;
-			json_object_add_value_uint(valid_attrs, "prev_ts",
+			json_object_add_value_uint64(valid_attrs, "prev_ts",
 				le64_to_cpu(ts_change_event->previous_timestamp));
-			json_object_add_value_uint(valid_attrs,
+			json_object_add_value_uint64(valid_attrs,
 				"ml_secs_since_reset",
 				le64_to_cpu(ts_change_event->ml_secs_since_reset));
 			break;
@@ -1293,7 +1294,7 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 			por_info_list = por_info_len / sizeof(*por_event);
 
 			fw_rev = pevent_log_info + offset;
-			json_object_add_value_uint(valid_attrs, "fw_rev",
+			json_object_add_value_uint64(valid_attrs, "fw_rev",
 				le64_to_cpu(*fw_rev));
 			for (int i = 0; i < por_info_list; i++) {
 				por_event = pevent_log_info + offset +
@@ -1306,9 +1307,9 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 					por_event->op_in_prog);
 				json_object_add_value_uint(valid_attrs, "ctrl_power_cycle",
 					le32_to_cpu(por_event->ctrl_power_cycle));
-				json_object_add_value_uint(valid_attrs, "power_on_ml_secs",
+				json_object_add_value_uint64(valid_attrs, "power_on_ml_secs",
 					le64_to_cpu(por_event->power_on_ml_seconds));
-				json_object_add_value_uint(valid_attrs, "ctrl_time_stamp",
+				json_object_add_value_uint64(valid_attrs, "ctrl_time_stamp",
 					le64_to_cpu(por_event->ctrl_time_stamp));
 			}
 			break;
@@ -1321,9 +1322,9 @@ void json_persistent_event_log(void *pevent_log_info, __u32 size)
 			ns_event = pevent_log_info + offset;
 			json_object_add_value_uint(valid_attrs, "nsmgt_cdw10",
 				le32_to_cpu(ns_event->nsmgt_cdw10));
-			json_object_add_value_uint(valid_attrs, "nsze",
+			json_object_add_value_uint64(valid_attrs, "nsze",
 				le64_to_cpu(ns_event->nsze));
-			json_object_add_value_float(valid_attrs, "nscap",
+			json_object_add_value_uint64(valid_attrs, "nscap",
 				le64_to_cpu(ns_event->nscap));
 			json_object_add_value_uint(valid_attrs, "flbas",
 				ns_event->flbas);
@@ -1665,7 +1666,7 @@ void json_endurance_group_event_agg_log(
 	struct json_object *valid;
 
 	root = json_create_object();
-	json_object_add_value_uint(root, "num_entries_avail",
+	json_object_add_value_uint64(root, "num_entries_avail",
 		le64_to_cpu(endurance_log->num_entries));
 	valid = json_create_array();
 
@@ -1742,7 +1743,7 @@ void json_lba_status_log(void *lba_status)
 			for (int i = 0; i < num_lba_desc; i++) {
 				range_desc = lba_status + offset;
 				desc = json_create_object();
-				json_object_add_value_uint(desc, "rslba",
+				json_object_add_value_uint64(desc, "rslba",
 					le64_to_cpu(range_desc->rslba));
 				json_object_add_value_uint(desc, "rnlb",
 					le32_to_cpu(range_desc->rnlb));
@@ -1830,7 +1831,7 @@ static void json_resv_notif_log(struct nvme_resv_notification_log *resv)
 	struct json_object *root;
 
 	root = json_create_object();
-	json_object_add_value_uint(root, "count",
+	json_object_add_value_uint64(root, "count",
 		le64_to_cpu(resv->lpc));
 	json_object_add_value_uint(root, "rn_log_type",
 		resv->rnlpt);
@@ -4172,7 +4173,7 @@ static void json_nvme_id_ctrl_nvm(struct nvme_id_ctrl_nvm *ctrl_nvm)
 	json_object_add_value_uint(root, "wusl", ctrl_nvm->wusl);
 	json_object_add_value_uint(root, "dmrl", ctrl_nvm->dmrl);
 	json_object_add_value_uint(root, "dmrsl", le32_to_cpu(ctrl_nvm->dmrsl));
-	json_object_add_value_uint(root, "dmsl", le64_to_cpu(ctrl_nvm->dmsl));
+	json_object_add_value_uint64(root, "dmsl", le64_to_cpu(ctrl_nvm->dmsl));
 
 	json_print_object(root, NULL);
 	printf("\n");
@@ -4480,9 +4481,12 @@ static void json_nvme_zns_report_zones(void *report, __u32 descs,
 			(report + sizeof(*r) + i * (sizeof(*desc) + ext_size));
 		zone = json_create_object();
 
-		json_object_add_value_uint(zone, "slba", le64_to_cpu(desc->zslba));
-		json_object_add_value_uint(zone, "wp", le64_to_cpu(desc->wp));
-		json_object_add_value_uint(zone, "cap", le64_to_cpu(desc->zcap));
+		json_object_add_value_uint64(zone, "slba",
+					     le64_to_cpu(desc->zslba));
+		json_object_add_value_uint64(zone, "wp",
+					     le64_to_cpu(desc->wp));
+		json_object_add_value_uint64(zone, "cap",
+					     le64_to_cpu(desc->zcap));
 		json_object_add_value_string(zone, "state",
 			zone_state_to_string(desc->zs >> 4));
 		json_object_add_value_string(zone, "type",
@@ -4851,9 +4855,9 @@ static void json_nvme_id_ns_granularity_list(
 	for (i = 0; i <= glist->num_descriptors; i++) {
 		struct json_object *entry = json_create_object();
 
-		json_object_add_value_uint(entry, "namespace-size-granularity",
+		json_object_add_value_uint64(entry, "namespace-size-granularity",
 			le64_to_cpu(glist->entry[i].nszegran));
-		json_object_add_value_uint(entry, "namespace-capacity-granularity",
+		json_object_add_value_uint64(entry, "namespace-capacity-granularity",
 			le64_to_cpu(glist->entry[i].ncapgran));
 		json_array_add_value_object(entries, entry);
 	}

--- a/nvme.h
+++ b/nvme.h
@@ -30,9 +30,20 @@
 #define json_free_object(o) json_object_put(o)
 #define json_free_array(a) json_object_put(a)
 #define json_object_add_value_uint(o, k, v) \
-	json_object_object_add(o, k, json_object_new_uint64(v))
+	json_object_object_add(o, k, json_object_new_int(v))
 #define json_object_add_value_int(o, k, v) \
-	json_object_object_add(o, k, json_object_new_int64(v))
+	json_object_object_add(o, k, json_object_new_int(v))
+#ifdef LIBJSONC_14
+#define json_object_add_value_uint64(o, k, v) \
+	json_object_object_add(o, k, json_object_new_uint64(v))
+#else
+#define json_object_add_value_uint64(o, k, v) \
+	if ((v) > UINT_MAX) {						\
+		nvme_msg(LOG_ERR, "Value overflow in %s", k);		\
+		json_object_object_add(o, k, json_object_new_int(-1));	\
+	} else								\
+		json_object_object_add(o, k, json_object_new_int(v))
+#endif
 #define json_object_add_value_float(o, k, v) \
 	json_object_object_add(o, k, json_object_new_double(v))
 #define json_object_add_value_string(o, k, v) \

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -4759,27 +4759,27 @@ static void wdc_print_smart_cloud_attr_C0_json(void *data)
 	uint16_t smart_log_ver = 0;
 
 	root = json_create_object();
-	json_object_add_value_int(root, "Physical media units written hi",
+	json_object_add_value_uint64(root, "Physical media units written hi",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW+8] & 0xFFFFFFFFFFFFFFFF));
-	json_object_add_value_int(root, "Physical media units written lo",
+	json_object_add_value_uint64(root, "Physical media units written lo",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW] & 0xFFFFFFFFFFFFFFFF));
-	json_object_add_value_int(root, "Physical media units read hi",
+	json_object_add_value_uint64(root, "Physical media units read hi",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR+8] & 0xFFFFFFFFFFFFFFFF));
-	json_object_add_value_int(root, "Physical media units read lo",
+	json_object_add_value_uint64(root, "Physical media units read lo",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR] & 0xFFFFFFFFFFFFFFFF));
-	json_object_add_value_uint(root, "Bad user nand blocks - Raw",
+	json_object_add_value_uint64(root, "Bad user nand blocks - Raw",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_BUNBR] & 0x0000FFFFFFFFFFFF));
 	json_object_add_value_uint(root, "Bad user nand blocks - Normalized",
 			(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BUNBN]));
-	json_object_add_value_uint(root, "Bad system nand blocks - Raw",
+	json_object_add_value_uint64(root, "Bad system nand blocks - Raw",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_BSNBR] & 0x0000FFFFFFFFFFFF));
 	json_object_add_value_uint(root, "Bad system nand blocks - Normalized",
 			(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BSNBN]));
-	json_object_add_value_uint(root, "XOR recovery count",
+	json_object_add_value_uint64(root, "XOR recovery count",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_XRC]));
-	json_object_add_value_uint(root, "Uncorrectable read error count",
+	json_object_add_value_uint64(root, "Uncorrectable read error count",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UREC]));
-	json_object_add_value_uint(root, "Soft ecc error count",
+	json_object_add_value_uint64(root, "Soft ecc error count",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SEEC]));
 	json_object_add_value_uint(root, "End to end corrected errors",
 			(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EECE]));
@@ -4787,7 +4787,7 @@ static void wdc_print_smart_cloud_attr_C0_json(void *data)
 			(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EEDC]));
 	json_object_add_value_uint(root, "System data percent used",
 			(__u8)log_data[SCAO_SDPU]);
-	json_object_add_value_uint(root, "Refresh counts",
+	json_object_add_value_uint64(root, "Refresh counts",
 			(uint64_t)(le64_to_cpu(*(uint64_t *)&log_data[SCAO_RFSC])& 0x00FFFFFFFFFFFFFF));
 	json_object_add_value_uint(root, "Max User data erase counts",
 			(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_MXUDEC]));
@@ -4797,7 +4797,7 @@ static void wdc_print_smart_cloud_attr_C0_json(void *data)
 			(__u8)log_data[SCAO_NTTE]);
 	json_object_add_value_uint(root, "Current throttling status",
 			(__u8)log_data[SCAO_CTS]);
-	json_object_add_value_uint(root, "PCIe correctable error count",
+	json_object_add_value_uint64(root, "PCIe correctable error count",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PCEC]));
 	json_object_add_value_uint(root, "Incomplete shutdowns",
 			(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_ICS]));
@@ -4805,11 +4805,11 @@ static void wdc_print_smart_cloud_attr_C0_json(void *data)
 			(__u8)log_data[SCAO_PFB]);
 	json_object_add_value_uint(root, "Capacitor health",
 			(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_CPH]));
-	json_object_add_value_uint(root, "Unaligned I/O",
+	json_object_add_value_uint64(root, "Unaligned I/O",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UIO]));
-	json_object_add_value_uint(root, "Security Version Number",
+	json_object_add_value_uint64(root, "Security Version Number",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SVN]));
-	json_object_add_value_uint(root, "NUSE - Namespace utilization",
+	json_object_add_value_uint64(root, "NUSE - Namespace utilization",
 			(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_NUSE]));
 	json_object_add_value_uint(root, "PLP start count",
 			int128_to_double(&log_data[SCAO_PSC]));
@@ -4833,7 +4833,7 @@ static void wdc_print_smart_cloud_attr_C0_json(void *data)
 				(__u8)log_data[SCAO_MAVF]);
 		json_object_add_value_uint(root, "NVMe Errata Version",
 				(__u8)log_data[SCAO_NEV]);
-		json_object_add_value_uint(root, "PCIe Link Retraining Count",
+		json_object_add_value_uint64(root, "PCIe Link Retraining Count",
 				(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PLRC]));
 	}
 	json_print_object(root, NULL);
@@ -7721,11 +7721,11 @@ static void wdc_print_nand_stats_json(__u16 version, void *data)
 				le32_to_cpu(nand_stats->nand_erase_failure));
 		json_object_add_value_uint(root, "Bad Block Count",
 				le32_to_cpu(nand_stats->bad_block_count));
-		json_object_add_value_uint(root, "NAND XOR/RAID Recovery Trigger Events",
+		json_object_add_value_uint64(root, "NAND XOR/RAID Recovery Trigger Events",
 				le64_to_cpu(nand_stats->nand_rec_trigger_event));
-		json_object_add_value_uint(root, "E2E Error Counter",
+		json_object_add_value_uint64(root, "E2E Error Counter",
 				le64_to_cpu(nand_stats->e2e_error_counter));
-		json_object_add_value_uint(root, "Number Successful NS Resizing Events",
+		json_object_add_value_uint64(root, "Number Successful NS Resizing Events",
 				le64_to_cpu(nand_stats->successful_ns_resize_event));
 
 		json_print_object(root, NULL);
@@ -7743,13 +7743,13 @@ static void wdc_print_nand_stats_json(__u16 version, void *data)
 		temp_raw = ((*temp_ptr & 0xFFFFFFFFFFFF0000) >> 16);
 		json_object_add_value_uint(root, "Bad NAND Blocks Count - Normalized",
 				le16_to_cpu(temp_norm));
-		json_object_add_value_uint(root, "Bad NAND Blocks Count - Raw",
+		json_object_add_value_uint64(root, "Bad NAND Blocks Count - Raw",
 				le64_to_cpu(temp_raw));
-		json_object_add_value_uint(root, "NAND XOR Recovery count",
+		json_object_add_value_uint64(root, "NAND XOR Recovery count",
 				le64_to_cpu(nand_stats_v3->xor_recovery_count));
-		json_object_add_value_uint(root, "UECC Read Error count",
+		json_object_add_value_uint64(root, "UECC Read Error count",
 				le64_to_cpu(nand_stats_v3->uecc_read_error_count));
-		json_object_add_value_uint(root, "SSD End to End corrected errors",
+		json_object_add_value_uint64(root, "SSD End to End corrected errors",
 				le64_to_cpu(nand_stats_v3->ssd_correction_counts[0]));
 		json_object_add_value_uint(root, "SSD End to End detected errors",
 				le32_to_cpu(nand_stats_v3->ssd_correction_counts[8]));
@@ -7757,54 +7757,54 @@ static void wdc_print_nand_stats_json(__u16 version, void *data)
 				le32_to_cpu(nand_stats_v3->ssd_correction_counts[12]));
 		json_object_add_value_uint(root, "System data % life-used",
 				nand_stats_v3->percent_life_used);
-		json_object_add_value_uint(root, "User Data Erase Counts - SLC Min",
+		json_object_add_value_uint64(root, "User Data Erase Counts - SLC Min",
 				le64_to_cpu(nand_stats_v3->user_data_erase_counts[0]));
-		json_object_add_value_uint(root, "User Data Erase Counts - SLC Max",
+		json_object_add_value_uint64(root, "User Data Erase Counts - SLC Max",
 				le64_to_cpu(nand_stats_v3->user_data_erase_counts[1]));
-		json_object_add_value_uint(root, "User Data Erase Counts - TLC Min",
+		json_object_add_value_uint64(root, "User Data Erase Counts - TLC Min",
 				le64_to_cpu(nand_stats_v3->user_data_erase_counts[2]));
-		json_object_add_value_uint(root, "User Data Erase Counts - TLC Max",
+		json_object_add_value_uint64(root, "User Data Erase Counts - TLC Max",
 				le64_to_cpu(nand_stats_v3->user_data_erase_counts[3]));
 		temp_ptr = (__u64 *)nand_stats_v3->program_fail_count;
 		temp_norm = (__u16)(*temp_ptr & 0x000000000000FFFF);
 		temp_raw = ((*temp_ptr & 0xFFFFFFFFFFFF0000) >> 16);
 		json_object_add_value_uint(root, "Program Fail Count - Normalized",
 				le16_to_cpu(temp_norm));
-		json_object_add_value_uint(root, "Program Fail Count - Raw",
+		json_object_add_value_uint64(root, "Program Fail Count - Raw",
 				le64_to_cpu(temp_raw));
 		temp_ptr = (__u64 *)nand_stats_v3->erase_fail_count;
 		temp_norm = (__u16)(*temp_ptr & 0x000000000000FFFF);
 		temp_raw = ((*temp_ptr & 0xFFFFFFFFFFFF0000) >> 16);
 		json_object_add_value_uint(root, "Erase Fail Count - Normalized",
 				le16_to_cpu(temp_norm));
-		json_object_add_value_uint(root, "Erase Fail Count - Raw",
+		json_object_add_value_uint64(root, "Erase Fail Count - Raw",
 				le64_to_cpu(temp_raw));
 		json_object_add_value_uint(root, "PCIe Correctable Error Count",
 				le16_to_cpu(nand_stats_v3->correctable_error_count));
 		json_object_add_value_uint(root, "% Free Blocks (User)",
 				nand_stats_v3->percent_free_blocks_user);
-		json_object_add_value_uint(root, "Security Version Number",
+		json_object_add_value_uint64(root, "Security Version Number",
 				le64_to_cpu(nand_stats_v3->security_version_number));
 		json_object_add_value_uint(root, "% Free Blocks (System)",
 				nand_stats_v3->percent_free_blocks_system);
 		json_object_add_value_float(root, "Data Set Management Commands",
 				int128_to_double(nand_stats_v3->trim_completions));
-		json_object_add_value_uint(root, "Estimate of Incomplete Trim Data",
+		json_object_add_value_uint64(root, "Estimate of Incomplete Trim Data",
 				le64_to_cpu(nand_stats_v3->trim_completions[16]));
 		json_object_add_value_uint(root, "%% of completed trim",
 				nand_stats_v3->trim_completions[24]);
 		json_object_add_value_uint(root, "Background Back-Pressure-Guage",
 				nand_stats_v3->back_pressure_guage);
-		json_object_add_value_uint(root, "Soft ECC Error Count",
+		json_object_add_value_uint64(root, "Soft ECC Error Count",
 				le64_to_cpu(nand_stats_v3->soft_ecc_error_count));
-		json_object_add_value_uint(root, "Refresh Count",
+		json_object_add_value_uint64(root, "Refresh Count",
 				le64_to_cpu(nand_stats_v3->refresh_count));
 		temp_ptr = (__u64 *)nand_stats_v3->bad_sys_nand_block_count;
 		temp_norm = (__u16)(*temp_ptr & 0x000000000000FFFF);
 		temp_raw = ((*temp_ptr & 0xFFFFFFFFFFFF0000) >> 16);
 		json_object_add_value_uint(root, "Bad System Nand Block Count - Normalized",
 				le16_to_cpu(temp_norm));
-		json_object_add_value_uint(root, "Bad System Nand Block Count - Raw",
+		json_object_add_value_uint64(root, "Bad System Nand Block Count - Raw",
 				le64_to_cpu(temp_raw));
 		json_object_add_value_float(root, "Endurance Estimate",
 				int128_to_double(nand_stats_v3->endurance_estimate));
@@ -7812,7 +7812,7 @@ static void wdc_print_nand_stats_json(__u16 version, void *data)
 				nand_stats_v3->thermal_throttling_st_ct[0]);
 		json_object_add_value_uint(root, "Thermal Throttling Count",
 				nand_stats_v3->thermal_throttling_st_ct[1]);
-		json_object_add_value_uint(root, "Unaligned I/O",
+		json_object_add_value_uint64(root, "Unaligned I/O",
 				le64_to_cpu(nand_stats_v3->unaligned_IO));
 		json_object_add_value_float(root, "Physical Media Units Read",
 				int128_to_double(nand_stats_v3->physical_media_units));
@@ -7876,38 +7876,38 @@ static void wdc_print_pcie_stats_json(struct wdc_vs_pcie_stats *pcie_stats)
 	struct json_object *root;
 	root = json_create_object();
 
-	json_object_add_value_uint(root, "Unsupported Request Error Counter",
+	json_object_add_value_uint64(root, "Unsupported Request Error Counter",
 			le64_to_cpu(pcie_stats->unsupportedRequestErrorCount));
-	json_object_add_value_uint(root, "ECRC Error Status Counter",
+	json_object_add_value_uint64(root, "ECRC Error Status Counter",
 			le64_to_cpu(pcie_stats->ecrcErrorStatusCount));
-	json_object_add_value_uint(root, "Malformed TLP Status Counter",
+	json_object_add_value_uint64(root, "Malformed TLP Status Counter",
 			le64_to_cpu(pcie_stats->malformedTlpStatusCount));
 
-	json_object_add_value_uint(root, "Receiver Overflow Status Counter",
+	json_object_add_value_uint64(root, "Receiver Overflow Status Counter",
 			le64_to_cpu(pcie_stats->receiverOverflowStatusCount));
-	json_object_add_value_uint(root, "Unexpected Completion Status Counter",
+	json_object_add_value_uint64(root, "Unexpected Completion Status Counter",
 			le64_to_cpu(pcie_stats->unexpectedCmpltnStatusCount));
-	json_object_add_value_uint(root, "Complete Abort Status Counter",
+	json_object_add_value_uint64(root, "Complete Abort Status Counter",
 			le64_to_cpu(pcie_stats->completeAbortStatusCount));
-	json_object_add_value_uint(root, "Completion Timeout Status Counter",
+	json_object_add_value_uint64(root, "Completion Timeout Status Counter",
 			le64_to_cpu(pcie_stats->cmpltnTimoutStatusCount));
-	json_object_add_value_uint(root, "Flow Control Error Status Counter",
+	json_object_add_value_uint64(root, "Flow Control Error Status Counter",
 			le64_to_cpu(pcie_stats->flowControlErrorStatusCount));
-	json_object_add_value_uint(root, "Poisoned TLP Status Counter",
+	json_object_add_value_uint64(root, "Poisoned TLP Status Counter",
 			le64_to_cpu(pcie_stats->poisonedTlpStatusCount));
-	json_object_add_value_uint(root, "Dlink Protocol Error Status Counter",
+	json_object_add_value_uint64(root, "Dlink Protocol Error Status Counter",
 			le64_to_cpu(pcie_stats->dLinkPrtclErrorStatusCount));
-	json_object_add_value_uint(root, "Advisory Non Fatal Error Status Counter",
+	json_object_add_value_uint64(root, "Advisory Non Fatal Error Status Counter",
 			le64_to_cpu(pcie_stats->advsryNFatalErrStatusCount));
-	json_object_add_value_uint(root, "Replay Timer TO Status Counter",
+	json_object_add_value_uint64(root, "Replay Timer TO Status Counter",
 			le64_to_cpu(pcie_stats->replayTimerToStatusCount));
-	json_object_add_value_uint(root, "Replay Number Rollover Status Counter",
+	json_object_add_value_uint64(root, "Replay Number Rollover Status Counter",
 			le64_to_cpu(pcie_stats->replayNumRolloverStCount));
-	json_object_add_value_uint(root, "Bad DLLP Status Counter",
+	json_object_add_value_uint64(root, "Bad DLLP Status Counter",
 			le64_to_cpu(pcie_stats->badDllpStatusCount));
-	json_object_add_value_uint(root, "Bad TLP Status Counter",
+	json_object_add_value_uint64(root, "Bad TLP Status Counter",
 			le64_to_cpu(pcie_stats->badTlpStatusCount));
-	json_object_add_value_uint(root, "Receiver Error Status Counter",
+	json_object_add_value_uint64(root, "Receiver Error Status Counter",
 			le64_to_cpu(pcie_stats->receiverErrStatusCount));
 
 	json_print_object(root, NULL);


### PR DESCRIPTION
commit 0b63a8b7cfb7 ("Check json-c libversion, recover commit d127537")
broke building on older releases when using 'make'.
Add a compability code to enable building on older json-c releases.

Signed-off-by: Hannes Reinecke <hare@suse.de>