### PR TITLE
TP8013 & 8014 support

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -10,6 +10,7 @@ SYNOPSIS
 [verse]
 'nvme connect-all'
 		[--transport=<trtype>     | -t <trtype>]
+		[--nqn=<subnqn>           | -n <subnqn>]
 		[--traddr=<traddr>        | -a <traddr>]
 		[--trsvcid=<trsvcid>      | -s <trsvcid>]
 		[--host-traddr=<traddr>   | -w <traddr>]
@@ -64,6 +65,10 @@ OPTIONS
 |tcp |The network fabric is a TCP/IP network.
 |loop|Connect to a NVMe over Fabrics target on the local host
 |=================
+
+-n <subnqn>::
+--nqn <subnqn>::
+	This field specifies the name for the NVMe subsystem to connect to.
 
 -a <traddr>::
 --traddr=<traddr>::

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -10,6 +10,7 @@ SYNOPSIS
 [verse]
 'nvme discover'
 		[--transport=<trtype>     | -t <trtype>]
+		[--nqn=<subnqn>           | -n <subnqn>]
 		[--traddr=<traddr>        | -a <traddr>]
 		[--trsvcid=<trsvcid>      | -s <trsvcid>]
 		[--host-traddr=<traddr>   | -w <traddr>]
@@ -86,6 +87,10 @@ OPTIONS
 |tcp |The network fabric is a TCP/IP network.
 |loop|Connect to a NVMe over Fabrics target on the local host
 |=================
+
+-n <subnqn>::
+--nqn <subnqn>::
+	This field specifies the name for the NVMe subsystem to connect to.
 
 -a <traddr>::
 --traddr=<traddr>::

--- a/fabrics.c
+++ b/fabrics.c
@@ -368,6 +368,7 @@ static int discover_from_conf_file(nvme_host_t h, const char *desc,
 				     traddr, host_traddr, host_iface, trsvcid);
 		if (!c)
 			goto next;
+		nvme_ctrl_set_discovery_ctrl(c, true);
 		errno = 0;
 		ret = nvmf_add_ctrl(h, c, &cfg, false);
 		if (!ret) {
@@ -519,6 +520,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 			ret = errno;
 			goto out_free;
 		}
+		nvme_ctrl_set_discovery_ctrl(c, true);
 		ret = nvmf_add_ctrl(h, c, &cfg, false);
 		if (ret) {
 			nvme_msg(LOG_ERR,

--- a/fabrics.c
+++ b/fabrics.c
@@ -133,6 +133,7 @@ static void print_discovery_log(struct nvmf_discovery_log *log, int numrec)
 		printf("trsvcid: %s\n", e->trsvcid);
 		printf("subnqn:  %s\n", e->subnqn);
 		printf("traddr:  %s\n", e->traddr);
+		printf("eflags:  %s\n", nvmf_eflags_str(e->eflags));
 
 		switch (e->trtype) {
 		case NVMF_TRTYPE_RDMA:
@@ -185,6 +186,7 @@ static void json_discovery_log(struct nvmf_discovery_log *log, int numrec)
 		json_object_add_value_string(entry, "trsvcid", e->trsvcid);
 		json_object_add_value_string(entry, "subnqn", e->subnqn);
 		json_object_add_value_string(entry, "traddr", e->traddr);
+		json_object_add_value_uint(entry, "eflags", e->eflags);
 
 		switch (e->trtype) {
 		case NVMF_TRTYPE_RDMA:


### PR DESCRIPTION
Hi all,

here's now the companion patch to support TP8013 & TP8014 for nvme-cli.
The biggest difference here is that we now have the '--nqn' argument for 'discover' and 'connect-all', allowing to connect to a unique discovery controller NQN. And of course we now decode the new fields and values in the discovery log page entry.