### PR TITLE
Update to add 'result' and 'timeout' arguments

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -268,11 +268,11 @@ struct rpmb_config_block_t {
 
 #define SEND_RPMB_REQ(tgt, size, req) \
 nvme_security_send(fd, 0, tgt, RPMB_NVME_SPSP, 0, RPMB_NVME_SECP, 0, size, \
-		(unsigned char *)(req), NULL)
+		   (unsigned char *)(req), NVME_DEFAULT_IOCTL_TIMEOUT, NULL)
 	
 #define RECV_RPMB_RSP(tgt, size, rsp) \
 nvme_security_receive(fd, 0, tgt, RPMB_NVME_SPSP, 0, RPMB_NVME_SECP, 0, size, \
-		(unsigned char *)(rsp), NULL)
+		      (unsigned char *)(rsp), NVME_DEFAULT_IOCTL_TIMEOUT, NULL)
 	
 /* Initialize nonce value in rpmb request frame */
 static void rpmb_nonce_init(struct rpmb_data_frame_t *req)

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1066,7 +1066,8 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		__u32 result;
 
 		err = nvme_get_features(fd, 0xf7, 0, 0, cfg.write ? 0x1 : 0x0, 0,
-				       sizeof(thresholds), thresholds, &result);
+				       sizeof(thresholds), thresholds,
+					NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 		if (err) {
 			fprintf(stderr, "Quering thresholds failed. ");
 			nvme_show_status(err);
@@ -1548,7 +1549,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	switch (option) {
 	case None:
 		err = nvme_get_features(fd, fid, nsid, sel, cdw11, 0, data_len, buf,
-					&result);
+					NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 		if (!err) {
 			printf(
 				"Latency Statistics Tracking (FID 0x%X) is currently (%i).\n",
@@ -1561,7 +1562,8 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	case True:
 	case False:
 		err = nvme_set_features(fd, fid, nsid, option, cdw12, save, 0,
-					0, data_len, buf, &result);
+					0, data_len, buf,
+					NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 		if (err > 0) {
 			nvme_show_status(err);
 		} else if (err < 0) {
@@ -1640,7 +1642,8 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 
 		err = nvme_set_features(fd, fid, nsid, cfg.write ? 0x1 : 0x0,
 					cdw12, save, 0, 0, sizeof(thresholds),
-					thresholds, &result);
+					thresholds, NVME_DEFAULT_IOCTL_TIMEOUT,
+					&result);
 
 		if (err > 0) {
 			nvme_show_status(err);

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -491,7 +491,8 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
     fd = parse_and_open(argc, argv, desc, opts);
     if (fd < 0) return fd;
 
-    err = nvme_get_features(fd, feature_id, 0, 0, 0, 0, 0, NULL, &result);
+    err = nvme_get_features(fd, feature_id, 0, 0, 0, 0, 0, NULL,
+			    NVME_DEFAULT_IOCTL_TIMEOUT, &result);
     if (err < 0) {
         perror("get-feature");
     }
@@ -534,7 +535,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     if (fd < 0) return fd;
 
     err = nvme_set_features(fd, cfg.feature_id, 0, cfg.value, 0, cfg.save,
-			    0, 0, 0, NULL, &result);
+			    0, 0, 0, NULL, NVME_DEFAULT_IOCTL_TIMEOUT, &result);
     if (err < 0) {
         perror("set-feature");
     }
@@ -592,7 +593,7 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
     cfg.value = (param1 << MB_FEAT_HIGH_LATENCY_VALUE_SHIFT) | param2;
 
     err = nvme_set_features(fd, cfg.feature_id, 0, cfg.value, 0, 0, 0, 0, 0,
-			    NULL, &result);
+			    NULL, NVME_DEFAULT_IOCTL_TIMEOUT, &result);
     if (err < 0) {
         perror("set-feature");
     }
@@ -829,7 +830,8 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 	while (fw_size > 0) {
 		xfer = min(xfer, fw_size);
 
-		err = nvme_fw_download(fd, offset, xfer, fw_buf);
+		err = nvme_fw_download(fd, offset, xfer, fw_buf,
+				       NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (err < 0) {
 			perror("fw-download");
 			goto out;
@@ -1028,7 +1030,7 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
 
 
     err = nvme_set_features(fd, cfg.feature_id, 0, cfg.value, 0, cfg.save,
-			    0, 0, 0, NULL, &result);
+			    0, 0, 0, NULL, NVME_DEFAULT_IOCTL_TIMEOUT, &result);
     if (err < 0) {
         perror("set-feature");
     }
@@ -1107,7 +1109,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 	switch (option) {
 	case None:
 		err = nvme_get_features(fd, nsid, fid, sel, cdw11, 0,
-					data_len, buf, &result);
+					data_len, buf,
+					NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 		if (!err) {
 			printf(
 				"Latency Statistics Tracking (FID 0x%X) is currently (%i).\n",
@@ -1120,7 +1123,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 	case True:
 	case False:
 	        err = nvme_set_features(fd, fid, nsid, option, cdw12, save,
-					0, 0, data_len, buf, &result);
+					0, 0, data_len, buf,
+					NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 		if (err > 0) {
 			nvme_show_status(err);
 		} else if (err < 0) {

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -555,7 +555,8 @@ static int micron_selective_download(int argc, char **argv,
     while (fw_size > 0) {
         xfer = min(xfer, fw_size);
 
-        err = nvme_fw_download(fd, offset, xfer, fw_buf);
+        err = nvme_fw_download(fd, offset, xfer, fw_buf,
+			       NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
         if (err < 0) {
             perror("fw-download");
             goto out;
@@ -636,7 +637,8 @@ static int micron_smbus_option(int argc, char **argv,
     }
     else if (!strcmp(opt.option, "status")) {
         cdw10 = opt.value;
-        err = nvme_get_features(fd, fid, 1, 0, cdw10, 0, 0, NULL, &result);
+        err = nvme_get_features(fd, fid, 1, 0, cdw10, 0, 0, NULL,
+				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
         if (err == 0) {
             printf("SMBus status on the drive: %s (returns %s temperature) \n",
                     (result & 1) ? "enabled" : "disabled",
@@ -1843,7 +1845,8 @@ static int GetFeatureSettings(int fd, const char *dir)
             bufp = NULL;
         }
 
-        err = nvme_get_features(fd, fmap[i].id, 1, 0, 0x0, 0, len, bufp, &attrVal);
+        err = nvme_get_features(fd, fmap[i].id, 1, 0, 0x0, 0, len, bufp,
+				NVME_DEFAULT_IOCTL_TIMEOUT, &attrVal);
         if (err == 0) {
             sprintf(msg, "feature: 0x%X", fmap[i].id);
             WriteData((__u8*)&attrVal, sizeof(attrVal), dir, fmap[i].file, msg);
@@ -2317,14 +2320,16 @@ static int micron_telemetry_cntrl_option(int argc, char **argv,
     }
 
     if (!strcmp(opt.option, "enable")) {
-        err = nvme_set_features(fd, fid, 1, 1, 0, (opt.select & 0x1), 0, 0, 0, 0, &result);
+        err = nvme_set_features(fd, fid, 1, 1, 0, (opt.select & 0x1),
+				0, 0, 0, 0, NVME_DEFAULT_IOCTL_TIMEOUT, &result);
         if (err == 0) {
             printf("successfully set controller telemetry option\n");
         } else {
             printf("Failed to set controller telemetry option\n");
         }
     } else if (!strcmp(opt.option, "disable")) {
-        err = nvme_set_features(fd, fid, 1, 0, 0, (opt.select & 0x1), 0, 0, 0, 0, &result);
+        err = nvme_set_features(fd, fid, 1, 0, 0, (opt.select & 0x1),
+				0, 0, 0, 0, NVME_DEFAULT_IOCTL_TIMEOUT, &result);
         if (err == 0) {
             printf("successfully disabled controller telemetry option\n");
         } else {
@@ -2332,7 +2337,8 @@ static int micron_telemetry_cntrl_option(int argc, char **argv,
         }
     } else if (!strcmp(opt.option, "status")) {
         opt.select &= 0x3;
-        err = nvme_get_features(fd, fid, 1, opt.select, 0, 0, 0, 0, &result);
+        err = nvme_get_features(fd, fid, 1, opt.select, 0, 0, 0, 0,
+				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
         if (err == 0) {
             printf("Controller telemetry option : %s\n",
                     (result) ? "enabled" : "disabled");

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1127,8 +1127,10 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		memset(log, 0, blksToGet * 512);
 
-		err = nvme_get_log(fd, cfg.log_id, cfg.namespace_id, offset, 0, 0, true,
-				   0, 0, blksToGet * 512, (void *)log);
+		err = nvme_get_log(fd, cfg.log_id, cfg.namespace_id, offset,
+				   0, 0, true, 0, 0, blksToGet * 512,
+				   (void *)log, NVME_DEFAULT_IOCTL_TIMEOUT,
+				   NULL);
 		if (!err) {
 			offset += blksToGet * 512;
 
@@ -1223,8 +1225,9 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		memset(log, 0, blksToGet * 512);
 
-		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0, true,
-				   0, 0, blksToGet * 512, (void *)log);
+		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0,
+				   true, 0, 0, blksToGet * 512, (void *)log,
+				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (!err) {
 			offset += blksToGet * 512;
 
@@ -1341,8 +1344,9 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 
 		memset(log, 0, blksToGet * 512);
 
-		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0, true,
-				   0, 0, blksToGet * 512, (void *)log);
+		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0,
+				   true, 0, 0, blksToGet * 512, (void *)log,
+				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (!err) {
 			offset += blksToGet * 512;
 

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -227,7 +227,8 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 	}
 
 	err = nvme_get_features(fd, cfg.feature_id, cfg.namespace_id, cfg.sel,
-				cfg.cdw11, 0, cfg.data_len, buf, &result);
+				cfg.cdw11, 0, cfg.data_len, buf,
+				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 	if (!err) {
 #if 0
 		printf("get-feature:0x%02x (%s), %s value: %#08x\n", cfg.feature_id,
@@ -340,7 +341,8 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 	}
 
 	err = nvme_set_features(fd, cfg.feature_id, cfg.namespace_id, cfg.value,
-				0, cfg.save, 0, 0, cfg.data_len, buf, &result);
+				0, cfg.save, 0, 0, cfg.data_len, buf,
+				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 	if (err < 0) {
 		perror("set-feature");
 		goto free;

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -547,8 +547,9 @@ static int clear_correctable_errors(int argc, char **argv, struct command *cmd,
 	if (err)
 		goto end;
 
-	err = nvme_set_features(fd, feature_id, namespace_id, value, cdw12, save,
-				0, 0, 0, NULL, &result);
+	err = nvme_set_features(fd, feature_id, namespace_id, value, cdw12,
+				save, 0, 0, 0, NULL,
+				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 	if (err)
 		fprintf(stderr, "%s: couldn't clear PCIe correctable errors \n",
 			__func__);

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1682,7 +1682,9 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 	memset(data, 0, sizeof (__u8) * WDC_C2_LOG_BUF_LEN);
 
 	/* get the log page length */
-	ret = nvme_get_log(fd, lid, 0xFFFFFFFF, NVME_LOG_LSP_NONE, 0, 0, false, uuid_ix, 0, WDC_C2_LOG_BUF_LEN, data);
+	ret = nvme_get_log(fd, lid, 0xFFFFFFFF, NVME_LOG_LSP_NONE, 0, 0,
+			   false, uuid_ix, 0, WDC_C2_LOG_BUF_LEN, data,
+			   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : Unable to get 0x%x Log Page length, ret = 0x%x\n", lid, ret);
 		goto end;
@@ -1701,8 +1703,10 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 	}
 
 	/* get the log page data */
-	ret = nvme_get_log(fd, WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_OPCODE, 0xFFFFFFFF, 0,
-			NVME_LOG_LSP_NONE, 0, false, uuid_ix, 0, le32_to_cpu(hdr_ptr->length), data);
+	ret = nvme_get_log(fd, WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_OPCODE,
+			   0xFFFFFFFF, 0, NVME_LOG_LSP_NONE, 0, false,
+			   uuid_ix, 0, le32_to_cpu(hdr_ptr->length), data,
+			   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : Unable to read C2 Log Page data, ret = 0x%x\n", ret);
@@ -1722,8 +1726,10 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 		/* not found with uuid = 1 try with uuid = 0 */
 		uuid_ix = 0;
 		/* get the log page data */
-		ret = nvme_get_log(fd, WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_OPCODE, 0xFFFFFFFF, 0,
-				NVME_LOG_LSP_NONE, 0, false, uuid_ix, 0, le32_to_cpu(hdr_ptr->length), data);
+		ret = nvme_get_log(fd, WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_OPCODE,
+				   0xFFFFFFFF, 0, NVME_LOG_LSP_NONE, 0, false,
+				   uuid_ix, 0, le32_to_cpu(hdr_ptr->length),
+				   data, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 		hdr_ptr = (struct wdc_c2_log_page_header *)data;
 		sph = (struct wdc_c2_log_subpage_header *)(data + length);
@@ -2149,8 +2155,10 @@ static int wdc_do_cap_telemetry_log(int fd, char *file, __u32 bs, int type, int 
 		}
 		memset(buf, 0, len);
 
-		err = nvme_get_features(fd, NVME_NSID_ALL, NVME_FEAT_FID_HOST_BEHAVIOR, 0, 0,
-				0, len, buf, &result);
+		err = nvme_get_features(fd, NVME_NSID_ALL,
+					NVME_FEAT_FID_HOST_BEHAVIOR, 0, 0, 0,
+					len, buf, NVME_DEFAULT_IOCTL_TIMEOUT,
+					&result);
 		if (err > 0) {
 			nvme_show_status(err);
 		} else if (err < 0) {
@@ -4979,7 +4987,8 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log(fd, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE, namespace_id, 0,
-						NVME_LOG_LSP_NONE, 0, false, uuid_index, 0, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
+						   NVME_LOG_LSP_NONE, 0, false, uuid_index, 0, WDC_NVME_SMART_CLOUD_ATTR_LEN, data,
+						   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 				if (strcmp(format, "json"))
 					nvme_show_status(ret);
@@ -5026,7 +5035,8 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log(fd, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE, NVME_NSID_ALL, 0,
-						NVME_LOG_LSP_NONE, 0, false, uuid_index, 0, WDC_NVME_EOL_STATUS_LOG_LEN, data);
+						   NVME_LOG_LSP_NONE, 0, false, uuid_index, 0, WDC_NVME_EOL_STATUS_LOG_LEN, data,
+						   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 				if (strcmp(format, "json"))
 					nvme_show_status(ret);
@@ -6101,8 +6111,10 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *com
 		}
 
 		/* Get the 0xC0 log data */
-		ret = nvme_get_log(fd, WDC_NVME_GET_SMART_CLOUD_ATTR_LOG_OPCODE, 0xFFFFFFFF, 0,
-				NVME_LOG_LSP_NONE, 0, false, uuid_index, 0, WDC_NVME_SMART_CLOUD_ATTR_LEN, data);
+		ret = nvme_get_log(fd, WDC_NVME_GET_SMART_CLOUD_ATTR_LOG_OPCODE,
+				   0xFFFFFFFF, 0, NVME_LOG_LSP_NONE, 0, false,
+				   uuid_index, 0, WDC_NVME_SMART_CLOUD_ATTR_LEN,
+				   data, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 		if (ret == 0) {
 			/* Verify GUID matches */

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -231,8 +231,8 @@ static int __zns_mgmt_send(int fd, __u32 namespace_id, __u64 zslba,
 {
 	int err;
 
-	err = nvme_zns_mgmt_send(fd, namespace_id, zslba, select_all, timeout, zsa,
-			data_len, buf);
+	err = nvme_zns_mgmt_send(fd, namespace_id, zslba, select_all, timeout,
+				 zsa, data_len, buf, NULL);
 	close(fd);
 	return err;
 }
@@ -639,8 +639,10 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 		}
 	}
 
-	err = nvme_zns_mgmt_recv(fd, cfg.namespace_id, cfg.zslba, cfg.zra,
-		cfg.zrasf, cfg.partial, cfg.data_len, data);
+	err = nvme_zns_mgmt_recv(fd, cfg.namespace_id,
+				 NVME_DEFAULT_IOCTL_TIMEOUT, cfg.zslba, cfg.zra,
+				 cfg.zrasf, cfg.partial, cfg.data_len, data,
+				 NULL);
 	if (!err)
 		printf("zone-mgmt-recv: Success, action:%d zone:%"PRIx64" nsid:%d\n",
 			cfg.zra, (uint64_t)cfg.zslba, cfg.namespace_id);
@@ -761,8 +763,9 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 		goto close_fd;
 	}
 
-	err = nvme_zns_report_zones(fd, cfg.namespace_id, 0,
-		0, cfg.state, 0, log_len, buff);
+	err = nvme_zns_report_zones(fd, cfg.namespace_id,
+				    NVME_DEFAULT_IOCTL_TIMEOUT, 0, 0,
+				    cfg.state, 0, log_len, buff, NULL);
 	if (err > 0) {
 		nvme_show_status(err);
 		goto free_buff;
@@ -804,8 +807,10 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 			log_len = sizeof(struct nvme_zone_report) + ((sizeof(struct nvme_zns_desc) * nr_zones_chunks) + (nr_zones_chunks * zdes));
 		}
 
-		err = nvme_zns_report_zones(fd, cfg.namespace_id, offset,
-			cfg.extended, cfg.state, cfg.partial, log_len, report);
+		err = nvme_zns_report_zones(fd, cfg.namespace_id,
+					    NVME_DEFAULT_IOCTL_TIMEOUT, offset,
+					    cfg.extended, cfg.state,
+					    cfg.partial, log_len, report, NULL);
 		if (err > 0) {
 			nvme_show_status(err);
 			break;
@@ -1001,7 +1006,7 @@ static int zone_append(int argc, char **argv, struct command *cmd, struct plugin
 	err = nvme_zns_append(fd, cfg.namespace_id, cfg.zslba, nblocks,
 			      control, cfg.ref_tag, cfg.lbat, cfg.lbatm,
 			      cfg.data_size, buf, cfg.metadata_size, mbuf,
-			      &result);
+			      NVME_DEFAULT_IOCTL_TIMEOUT, &result);
 	gettimeofday(&end_time, NULL);
 	if (cfg.latency)
 		printf(" latency: zone append: %llu us\n",


### PR DESCRIPTION
With the latest libnvme update the ioctl wrapper functions have
been sanitized to always include a 'timeout' and 'result' argument.

Signed-off-by: Hannes Reinecke <hare@suse.de>