### PR TITLE
zns: fix report-zone slba offset along with libnvme

### DIFF
--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -807,8 +807,8 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 			log_len = sizeof(struct nvme_zone_report) + ((sizeof(struct nvme_zns_desc) * nr_zones_chunks) + (nr_zones_chunks * zdes));
 		}
 
-		err = nvme_zns_report_zones(fd, cfg.namespace_id,
-					    NVME_DEFAULT_IOCTL_TIMEOUT, offset,
+		err = nvme_zns_report_zones(fd, cfg.namespace_id, offset,
+					    NVME_DEFAULT_IOCTL_TIMEOUT,
 					    cfg.extended, cfg.state,
 					    cfg.partial, log_len, report, NULL);
 		if (err > 0) {


### PR DESCRIPTION
nvme_zns_report_zones in libnvme has argument:

int nvme_zns_report_zones(int fd, __u32 nsid, __u64 slba, __u32 timeout,
                          bool extended, enum nvme_zns_report_options opts,
                          bool partial, __u32 data_len, void *data,
                          __u32 *result)

The SLBA is the third argument and nvme-cli should pass the `offset` to
the third not fourth which is timeout.

In case more than one zone_mgmt_recv commands needed, zones will be
reported from the 0 SLBA over and over and over again.

Signed-off-by: Minwoo Im <minwoo.im.dev@gmail.com>