### PR TITLE
plugins/zns: update to match new calling convention

### DIFF
--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -231,8 +231,8 @@ static int __zns_mgmt_send(int fd, __u32 namespace_id, __u64 zslba,
 {
 	int err;
 
-	err = nvme_zns_mgmt_send(fd, namespace_id, zslba, select_all, timeout,
-				 zsa, data_len, buf, NULL);
+	err = nvme_zns_mgmt_send(fd, namespace_id, zslba, zsa, select_all,
+				 data_len, buf, timeout, NULL);
 	close(fd);
 	return err;
 }
@@ -639,10 +639,9 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 		}
 	}
 
-	err = nvme_zns_mgmt_recv(fd, cfg.namespace_id,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, cfg.zslba, cfg.zra,
+	err = nvme_zns_mgmt_recv(fd, cfg.namespace_id, cfg.zslba, cfg.zra,
 				 cfg.zrasf, cfg.partial, cfg.data_len, data,
-				 NULL);
+				 NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 	if (!err)
 		printf("zone-mgmt-recv: Success, action:%d zone:%"PRIx64" nsid:%d\n",
 			cfg.zra, (uint64_t)cfg.zslba, cfg.namespace_id);
@@ -763,9 +762,10 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 		goto close_fd;
 	}
 
-	err = nvme_zns_report_zones(fd, cfg.namespace_id,
-				    NVME_DEFAULT_IOCTL_TIMEOUT, 0, 0,
-				    cfg.state, 0, log_len, buff, NULL);
+	err = nvme_zns_report_zones(fd, cfg.namespace_id, 0,
+				    cfg.state, false, false,
+				    log_len, buff,
+				    NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 	if (err > 0) {
 		nvme_show_status(err);
 		goto free_buff;
@@ -807,10 +807,10 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 			log_len = sizeof(struct nvme_zone_report) + ((sizeof(struct nvme_zns_desc) * nr_zones_chunks) + (nr_zones_chunks * zdes));
 		}
 
-		err = nvme_zns_report_zones(fd, cfg.namespace_id,
-					    NVME_DEFAULT_IOCTL_TIMEOUT, offset,
-					    cfg.extended, cfg.state,
-					    cfg.partial, log_len, report, NULL);
+		err = nvme_zns_report_zones(fd, cfg.namespace_id, offset,
+					    cfg.state, cfg.extended,
+					    cfg.partial, log_len, report,
+					    NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (err > 0) {
 			nvme_show_status(err);
 			break;


### PR DESCRIPTION
Pull in the latest libnvme changes to update the zns calling convention
and update the zns plugin accordingly.

Signed-off-by: Hannes Reinecke <hare@suse.de>