### PR TITLE
fabrics: do not print 'unrecognized' address family for loop

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -130,7 +130,9 @@ static void print_discovery_log(struct nvmf_discovery_log *log, int numrec)
 
 		printf("=====Discovery Log Entry %d======\n", i);
 		printf("trtype:  %s\n", nvmf_trtype_str(e->trtype));
-		printf("adrfam:  %s\n", nvmf_adrfam_str(e->adrfam));
+		printf("adrfam:  %s\n",
+			e->traddr && strlen(e->traddr) ?
+			nvmf_adrfam_str(e->adrfam): "");
 		printf("subtype: %s\n", nvmf_subtype_str(e->subtype));
 		printf("treq:    %s\n", nvmf_treq_str(e->treq));
 		printf("portid:  %d\n", e->portid);


### PR DESCRIPTION
fabrics implementations like 'loop' do not have a transport address,
and consequently the address family value doesn't make any sense here.
So do not try to translate the address family to a printable string
if the address itself is empty.

Signed-off-by: Hannes Reinecke <hare@suse.de>