### PR TITLE
Makefile: Add missing define (LIBJSONC_14)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ ifeq ($(HAVE_SYSTEMD),0)
 	override CFLAGS += -DHAVE_SYSTEMD
 endif
 
+ifeq ($(LIBJSONC_14), 0)
+	override CFLAGS += -DLIBJSONC_14
+endif
+
 ifeq ($(LIBJSONC), 0)
 	override LDFLAGS += $(shell pkg-config --libs json-c)
 	override CFLAGS += $(shell pkg-config --cflags json-c)


### PR DESCRIPTION
Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>