### PR TITLE
monolithic: fabrics: fix a buffer overrun

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -883,7 +883,7 @@ static char *hostnqn_generate_systemd(void)
 
 static char *hostnqn_read_dmi(void)
 {
-	char uuid[16];
+	char uuid[37];
 	char *ret = NULL;
 
 	if (uuid_from_dmi(uuid) < 0)


### PR DESCRIPTION
the uuid buffer size must be at least 37 bytes to avoid
corrupting the memory

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>