### PR TITLE
build: Sync libnvme wrap revision to the git submodule one

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = head
+revision = a4418dfb319d73edf1ca166c9665875a2faa439f


### PR DESCRIPTION
Stop tracking the HEAD version of libnvme with meson's wrap.  Instead
sync it with the git submodule revision. This avoids all sort of
inconsistenies.

Signed-off-by: Daniel Wagner <dwagner@suse.de>