### PR TITLE
nvme: Add Command Set Idendifier and Offset Type to get_log

### DIFF
--- a/Documentation/nvme-get-log.1
+++ b/Documentation/nvme-get-log.1
@@ -2,12 +2,12 @@
 .\"     Title: nvme-get-log
 .\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 01/13/2021
+.\"      Date: 12/14/2021
 .\"    Manual: NVMe Manual
 .\"    Source: NVMe
 .\"  Language: English
 .\"
-.TH "NVME\-GET\-LOG" "1" "01/13/2021" "NVMe" "NVMe Manual"
+.TH "NVME\-GET\-LOG" "1" "12/14/2021" "NVMe" "NVMe Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -33,14 +33,16 @@ nvme-get-log \- Retrieves a log page from an NVMe device
 .sp
 .nf
 \fInvme get\-log\fR <device> [\-\-log\-id=<log\-id> | \-i <log\-id>]
-                      [\-\-log\-len=<log\-len> | \-l <log\-len>]
-                      [\-\-aen=<aen> | \-a <aen>]
-                      [\-\-namespace\-id=<nsid> | \-n <nsid>]
-                      [\-\-raw\-binary | \-b]
-                      [\-\-lpo=<offset> | \-o <offset>]
-                      [\-\-lsp=<field> | \-s <field>]
-                      [\-\-lsi=<field> | \-S <field>]
-                      [\-\-rae | \-r]
+              [\-\-log\-len=<log\-len> | \-l <log\-len>]
+              [\-\-aen=<aen> | \-a <aen>]
+              [\-\-namespace\-id=<nsid> | \-n <nsid>]
+              [\-\-raw\-binary | \-b]
+              [\-\-lpo=<offset> | \-o <offset>]
+              [\-\-lsp=<field> | \-s <field>]
+              [\-\-lsi=<field> | \-S <field>]
+              [\-\-rae | \-r]
+              [\-\-csi=<command_set_identifier> | \-y <command_set_identifier>]
+              [\-\-ot=<offset_type> | \-O <offset_type>]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -94,6 +96,16 @@ The log specified field of Log Specific Identifier\&.
 \-r, \-\-rae
 .RS 4
 Retain an Asynchronous Event\&.
+.RE
+.PP
+\-y <command_set_identifier>, \-\-csi=<command_set_identifier>
+.RS 4
+This field specifies the identifier of command set\&. if not issued, NVM Command Set will be selected\&.
+.RE
+.PP
+\-O, \-\-ot
+.RS 4
+This field specifies the offset type\&. If set to false, the Log Page Offset Lower field and the Log Page Offset Upper field specify the byte offset into the log page to be returned\&. If set to true, the Log Page Offset Lower field and the Log Page Offset Upper field specify the index into the list of data structures in the log page to be returned\&. The default is byte offset\&. If the option is specified the index mode is used\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-get-log.html
+++ b/Documentation/nvme-get-log.html
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
 <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
-<meta name="generator" content="AsciiDoc 9.0.0rc2" />
+<meta name="generator" content="AsciiDoc" />
 <title>nvme-get-log(1)</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -750,14 +750,16 @@ nvme-get-log(1) Manual Page
 <div class="sectionbody">
 <div class="verseblock">
 <pre class="content"><em>nvme get-log</em> &lt;device&gt; [--log-id=&lt;log-id&gt; | -i &lt;log-id&gt;]
-                      [--log-len=&lt;log-len&gt; | -l &lt;log-len&gt;]
-                      [--aen=&lt;aen&gt; | -a &lt;aen&gt;]
-                      [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
-                      [--raw-binary | -b]
-                      [--lpo=&lt;offset&gt; | -o &lt;offset&gt;]
-                      [--lsp=&lt;field&gt; | -s &lt;field&gt;]
-                      [--lsi=&lt;field&gt; | -S &lt;field&gt;]
-                      [--rae | -r]</pre>
+              [--log-len=&lt;log-len&gt; | -l &lt;log-len&gt;]
+              [--aen=&lt;aen&gt; | -a &lt;aen&gt;]
+              [--namespace-id=&lt;nsid&gt; | -n &lt;nsid&gt;]
+              [--raw-binary | -b]
+              [--lpo=&lt;offset&gt; | -o &lt;offset&gt;]
+              [--lsp=&lt;field&gt; | -s &lt;field&gt;]
+              [--lsi=&lt;field&gt; | -S &lt;field&gt;]
+              [--rae | -r]
+              [--csi=&lt;command_set_identifier&gt; | -y &lt;command_set_identifier&gt;]
+              [--ot=&lt;offset_type&gt; | -O &lt;offset_type&gt;]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -886,6 +888,36 @@ program to parse.</p></div>
         Retain an Asynchronous Event.
 </p>
 </dd>
+<dt class="hdlist1">
+-y &lt;command_set_identifier&gt;
+</dt>
+<dt class="hdlist1">
+--csi=&lt;command_set_identifier&gt;
+</dt>
+<dd>
+<p>
+        This field specifies the identifier of command set.
+        if not issued, NVM Command Set will be selected.
+</p>
+</dd>
+<dt class="hdlist1">
+-O
+</dt>
+<dt class="hdlist1">
+--ot
+</dt>
+<dd>
+<p>
+        This field specifies the offset type. If set to false, the
+        Log Page Offset Lower field and the Log Page Offset Upper
+        field specify the byte offset into the log page to be returned.
+        If set to true, the Log Page Offset Lower field and the Log
+        Page Offset Upper field specify the index into the list of
+        data structures in the log page to be returned.
+        The default is byte offset. If the option is specified
+        the index mode is used.
+</p>
+</dd>
 </dl></div>
 </div>
 </div>
@@ -930,7 +962,7 @@ Have the program return the raw log page in binary:
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-01-13 23:17:32 JST
+ 2021-12-14 15:16:07 CET
 </div>
 </div>
 </body>

--- a/Documentation/nvme-get-log.txt
+++ b/Documentation/nvme-get-log.txt
@@ -9,14 +9,16 @@ SYNOPSIS
 --------
 [verse]
 'nvme get-log' <device> [--log-id=<log-id> | -i <log-id>]
-		      [--log-len=<log-len> | -l <log-len>]
-		      [--aen=<aen> | -a <aen>]
-		      [--namespace-id=<nsid> | -n <nsid>]
-		      [--raw-binary | -b]
-		      [--lpo=<offset> | -o <offset>]
-		      [--lsp=<field> | -s <field>]
-		      [--lsi=<field> | -S <field>]
-		      [--rae | -r]
+	      [--log-len=<log-len> | -l <log-len>]
+	      [--aen=<aen> | -a <aen>]
+	      [--namespace-id=<nsid> | -n <nsid>]
+	      [--raw-binary | -b]
+	      [--lpo=<offset> | -o <offset>]
+	      [--lsp=<field> | -s <field>]
+	      [--lsi=<field> | -S <field>]
+	      [--rae | -r]
+	      [--csi=<command_set_identifier> | -y <command_set_identifier>]
+	      [--ot=<offset_type> | -O <offset_type>]
 
 DESCRIPTION
 -----------
@@ -76,6 +78,22 @@ OPTIONS
 -r::
 --rae::
 	Retain an Asynchronous Event.
+
+-y <command_set_identifier>::
+--csi=<command_set_identifier>::
+	This field specifies the identifier of command set.
+	if not issued, NVM Command Set will be selected.
+
+-O::
+--ot::
+	This field specifies the offset type. If set to false, the
+	Log Page Offset Lower field and the Log Page Offset Upper
+	field specify the byte offset into the log page to be returned.
+	If set to true, the Log Page Offset Lower field and the Log
+	Page Offset Upper field specify the index into the list of
+	data structures in the log page to be returned.
+	The default is byte offset. If the option is specified
+	the index mode is used.
 
 EXAMPLES
 --------

--- a/nvme.c
+++ b/nvme.c
@@ -1541,6 +1541,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *rae = "retain an asynchronous event";
 	const char *raw = "output in raw format";
 	const char *uuid_index = "UUID index";
+	const char *csi = "command set identifier";
+	const char *offset_type = "offset type";
 	int err, fd;
 	unsigned char *log;
 
@@ -1553,6 +1555,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		__u64 lpo;
 		__u8  lsp;
 		__u8  uuid_index;
+		__u8  csi;
+		int   ot;
 		int   rae;
 		int   raw_binary;
 	};
@@ -1566,6 +1570,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		.lsi          = NVME_LOG_LSI_NONE,
 		.rae          = 0,
 		.uuid_index   = 0,
+		.csi          = NVME_CSI_NVM,
+		.ot           = 0,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1579,6 +1585,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		OPT_FLAG("rae",          'r', &cfg.rae,          rae),
 		OPT_BYTE("uuid-index",   'U', &cfg.uuid_index,   uuid_index),
 		OPT_FLAG("raw-binary",   'b', &cfg.raw_binary,   raw),
+		OPT_BYTE("csi",          'y', &cfg.csi,          csi),
+		OPT_FLAG("ot",           'O', &cfg.ot,           offset_type),
 		OPT_END()
 	};
 
@@ -1597,7 +1605,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		goto close_fd;
 	}
 
-	if (cfg.lsp > 16) {
+	if (cfg.lsp > 128) {
 		perror("invalid lsp param\n");
 		err = -EINVAL;
 		goto close_fd;
@@ -1618,7 +1626,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	err = nvme_get_log(fd, cfg.log_id, cfg.namespace_id,
 			   cfg.lpo, cfg.lsp, cfg.lsi, cfg.rae,
-			   cfg.uuid_index, NVME_CSI_NVM,
+			   cfg.uuid_index, cfg.csi, cfg.ot,
 			   cfg.log_len, log, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 	if (!err) {
 		if (!cfg.raw_binary) {

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1128,9 +1128,9 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 		memset(log, 0, blksToGet * 512);
 
 		err = nvme_get_log(fd, cfg.log_id, cfg.namespace_id, offset,
-				   0, 0, true, 0, 0, blksToGet * 512,
-				   (void *)log, NVME_DEFAULT_IOCTL_TIMEOUT,
-				   NULL);
+				   0, 0, true, 0, NVME_CSI_NVM, false,
+				   blksToGet * 512, (void *)log,
+				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (!err) {
 			offset += blksToGet * 512;
 
@@ -1226,7 +1226,8 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 		memset(log, 0, blksToGet * 512);
 
 		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0,
-				   true, 0, 0, blksToGet * 512, (void *)log,
+				   true, 0, NVME_CSI_NVM, false,
+				   blksToGet * 512, (void *)log,
 				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (!err) {
 			offset += blksToGet * 512;
@@ -1345,7 +1346,8 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 		memset(log, 0, blksToGet * 512);
 
 		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0,
-				   true, 0, 0, blksToGet * 512, (void *)log,
+				   true, 0, NVME_CSI_NVM, false,
+				   blksToGet * 512, (void *)log,
 				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 		if (!err) {
 			offset += blksToGet * 512;

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1683,7 +1683,8 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 
 	/* get the log page length */
 	ret = nvme_get_log(fd, lid, 0xFFFFFFFF, NVME_LOG_LSP_NONE, 0, 0,
-			   false, uuid_ix, 0, WDC_C2_LOG_BUF_LEN, data,
+			   false, uuid_ix, NVME_CSI_NVM, false,
+			   WDC_C2_LOG_BUF_LEN, data,
 			   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : Unable to get 0x%x Log Page length, ret = 0x%x\n", lid, ret);
@@ -1704,7 +1705,8 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 
 	/* get the log page data */
 	ret = nvme_get_log(fd, lid, 0xFFFFFFFF, 0, NVME_LOG_LSP_NONE, 0, false,
-			   uuid_ix, 0, le32_to_cpu(hdr_ptr->length), data,
+			   uuid_ix, NVME_CSI_NVM, false,
+			   le32_to_cpu(hdr_ptr->length), data,
 			   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 	if (ret) {
@@ -1726,7 +1728,8 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 		uuid_ix = 0;
 		/* get the log page data */
 		ret = nvme_get_log(fd, lid, 0xFFFFFFFF, 0, NVME_LOG_LSP_NONE, 0, false,
-				   uuid_ix, 0, le32_to_cpu(hdr_ptr->length),
+				   uuid_ix, NVME_CSI_NVM, false,
+				   le32_to_cpu(hdr_ptr->length),
 				   data, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 		hdr_ptr = (struct wdc_c2_log_page_header *)data;
@@ -4979,7 +4982,8 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log(fd, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE, namespace_id, 0,
-						   NVME_LOG_LSP_NONE, 0, false, uuid_index, 0, WDC_NVME_SMART_CLOUD_ATTR_LEN, data,
+						   NVME_LOG_LSP_NONE, 0, false, uuid_index, NVME_CSI_NVM,
+						   false, WDC_NVME_SMART_CLOUD_ATTR_LEN, data,
 						   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 				if (strcmp(format, "json"))
@@ -5027,7 +5031,9 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 
 				/* Get the 0xC0 log data */
 				ret = nvme_get_log(fd, WDC_NVME_GET_EOL_STATUS_LOG_OPCODE, NVME_NSID_ALL, 0,
-						   NVME_LOG_LSP_NONE, 0, false, uuid_index, 0, WDC_NVME_EOL_STATUS_LOG_LEN, data,
+						   NVME_LOG_LSP_NONE, 0, false, uuid_index,
+						   NVME_CSI_NVM, false,
+						   WDC_NVME_EOL_STATUS_LOG_LEN, data,
 						   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 				if (strcmp(format, "json"))
@@ -6105,8 +6111,9 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *com
 		/* Get the 0xC0 log data */
 		ret = nvme_get_log(fd, WDC_NVME_GET_SMART_CLOUD_ATTR_LOG_OPCODE,
 				   0xFFFFFFFF, 0, NVME_LOG_LSP_NONE, 0, false,
-				   uuid_index, 0, WDC_NVME_SMART_CLOUD_ATTR_LEN,
-				   data, NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+				   uuid_index, NVME_CSI_NVM, false,
+				   WDC_NVME_SMART_CLOUD_ATTR_LEN, data,
+				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
 
 		if (ret == 0) {
 			/* Verify GUID matches */

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 80c3074b5dc20232a86e663a062d10d0319119de
+revision = e4ab11b3fac33b397932a562b634533d9985073e


### PR DESCRIPTION
Add Command Set Identifier (CSI) and Offset Type (OT) support to
get_log as per the Spec 2.0.

Signed-off-by: Daniel Wagner <dwagner@suse.de>