### PR TITLE
build: wrapdb for OpenSSL and zlib, detect libhugetblfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,8 @@ version
 ccan/config.h
 ccan/tools/configurator/configurator
 
-subprojects/libnvme
-subprojects/json-c-*
-subprojects/packagecache
+subprojects
+!subprojects/*.wrap
 
 cscope.*
 

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ libhugetlbfs = dependency('hugetlbfs', required: false)
 conf.set('LIBHUGETLBFS', libhugetlbfs.found(), description: 'Is libhugetlbfs required?')
 
 # Check for zlib availability
-libz_dep = dependency('zlib', required: true)
+libz_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 
 # Check for OpenSSL availability
 want_openssl = get_option('openssl')

--- a/meson.build
+++ b/meson.build
@@ -42,9 +42,16 @@ if json_c.found()
   conf.set('LIBJSONC_14', json_c.version().version_compare('>=0.14'), description: 'Is json-c at least 0.14?')
 endif
 
-# Check for libhugetlbfs  availability
-libhugetlbfs = dependency('hugetlbfs', required: false)
-conf.set('LIBHUGETLBFS', libhugetlbfs.found(), description: 'Is libhugetlbfs required?')
+# Check for libhugetlbfs availability
+if cc.has_header(['hugetlbfs.h'])
+  libhugetlbfs_dep = cc.find_library('hugetlbfs',
+                                     required : false)
+  have_libhugetlbfs = libhugetlbfs_dep.found()
+else
+  libhugetlbfs_dep = []
+  have_libhugetlbfs = false
+endif
+conf.set('LIBHUGETLBFS', have_libhugetlbfs, description: 'Is libhugetlbfs available?')
 
 # Check for zlib availability
 libz_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
@@ -193,7 +200,8 @@ subdir('Documentation')
 executable(
   'nvme',
   sources,
-  dependencies: [ libnvme_dep, libuuid, json_c, libz_dep, openssl_dep ],
+  dependencies: [ libnvme_dep, libuuid, json_c, libz_dep, openssl_dep,
+                  libhugetlbfs_dep ],
   include_directories: incdir,
   install: true,
   install_dir: get_option('sbindir')

--- a/meson.build
+++ b/meson.build
@@ -49,9 +49,18 @@ conf.set('LIBHUGETLBFS', libhugetlbfs.found(), description: 'Is libhugetlbfs req
 # Check for zlib availability
 libz_dep = dependency('zlib', required: true)
 
-# Check for open-ssl availability
-libopenssl = dependency('openssl', version: '>=1.1.0', required: false)
-conf.set('OPENSSL', libopenssl.found(), description: 'Is open-ssl required?')
+# Check for OpenSSL availability
+want_openssl = get_option('openssl')
+if want_openssl != 'false'
+  openssl_dep = dependency('openssl', version: '>=1.1.0',
+                           required: want_openssl == 'true',
+                           fallback : ['openssl', 'openssl_dep'])
+  have_openssl = openssl_dep.found()
+else
+  openssl_dep = []
+  have_openssl = false
+endif
+conf.set('OPENSSL', have_openssl, description: 'Is OpenSSL required?')
 
 # Set the nvme-cli version
 conf.set('NVME_VERSION', '"' + meson.project_version() + '"')
@@ -184,7 +193,7 @@ subdir('Documentation')
 executable(
   'nvme',
   sources,
-  dependencies: [ libnvme_dep, libuuid, json_c, libz_dep, libopenssl ],
+  dependencies: [ libnvme_dep, libuuid, json_c, libz_dep, openssl_dep ],
   include_directories: incdir,
   install: true,
   install_dir: get_option('sbindir')

--- a/meson.build
+++ b/meson.build
@@ -33,12 +33,12 @@ libnvme_dep = dependency('libnvme', fallback : ['libnvme', 'libnvme_dep'])
 
 # Check for libuuid availability
 libuuid = dependency('uuid', required: true)
-conf.set('CONFIG_LIBUUID', libuuid.found(), description: 'Is libuuid required?')
+conf.set('CONFIG_LIBUUID', libuuid.found(), description: 'Is libuuid available?')
 
 # Check for libjson-c availability
 json_c = dependency('json-c', version: '>=0.13', fallback : ['json-c', 'json_c_dep'])
 if json_c.found()
-  conf.set('CONFIG_JSONC', true, description: 'Is json-c required?')
+  conf.set('CONFIG_JSONC', true, description: 'Is json-c available?')
   conf.set('LIBJSONC_14', json_c.version().version_compare('>=0.14'), description: 'Is json-c at least 0.14?')
 endif
 
@@ -67,7 +67,7 @@ else
   openssl_dep = []
   have_openssl = false
 endif
-conf.set('OPENSSL', have_openssl, description: 'Is OpenSSL required?')
+conf.set('OPENSSL', have_openssl, description: 'Is OpenSSL available?')
 
 # Set the nvme-cli version
 conf.set('NVME_VERSION', '"' + meson.project_version() + '"')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('systemddir', type : 'string', value : 'lib/systemd/', description : 'dir
 option('htmldir', type : 'string', value : '', description : 'directory for HTML documentation')
 
 option('docs', type : 'combo', choices : ['false', 'html', 'man', 'all'], description : 'install documentation')
+option('openssl', type : 'combo', choices : ['auto', 'true', 'false'], description : 'OpenSSL support')

--- a/subprojects/openssl.wrap
+++ b/subprojects/openssl.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = openssl-1.1.1l
+source_url = https://www.openssl.org/source/openssl-1.1.1l.tar.gz
+source_filename = openssl-1.1.1l.tar.gz
+source_hash = 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1
+patch_filename = openssl_1.1.1l-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openssl_1.1.1l-2/get_patch
+patch_hash = 852521fb016fa2deee8ebf9ffeeee0292c6de86a03c775cf72ac04e86f9f177e
+
+[provide]
+libcrypto = libcrypto_dep
+libssl = libssl_dep
+openssl = openssl_dep
+

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = zlib-1.2.11
+source_url = http://zlib.net/fossils/zlib-1.2.11.tar.gz
+source_filename = zlib-1.2.11.tar.gz
+source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.2.11-5/get_patch
+patch_filename = zlib-1.2.11-5-wrap.zip
+patch_hash = 728c8e24acbc2e6682fbd950fec39e2fc77528af361adb87259f8a8511434004
+
+[provide]
+zlib = zlib_dep
+


### PR DESCRIPTION
meson wrapdb has support for OpenSSL and zlib. Let's make use of it. This allows building/deploying nvme-cli on systems which have either outdated or no support for those libraries.