### PR TITLE
 nvme: support ns generic device to submit_io

### DIFF
--- a/nvme-private.h
+++ b/nvme-private.h
@@ -63,7 +63,6 @@ int scan_subsystems(struct nvme_topology *t, const char *subsysnqn,
 		    __u32 ns_instance, int nsid, char *dev_dir);
 void free_topology(struct nvme_topology *t);
 char *get_nvme_subsnqn(char *path);
-char *nvme_get_ctrl_attr(const char *path, const char *attr);
 
 int uuid_from_dmi(char *uuid);
 int uuid_from_systemd(char *uuid);

--- a/nvme.c
+++ b/nvme.c
@@ -5665,8 +5665,9 @@ static int submit_io(int opcode, char *command, const char *desc,
 		goto close_mfd;
 	}
 
-	if (ioctl(fd, BLKSSZGET, &logical_block_size) < 0)
-		goto close_mfd;
+	if (nvme_get_logical_block_size(fd, cfg.namespace_id,
+					&logical_block_size) < 0)
+			goto close_mfd;
 
 	buffer_size = (cfg.block_count + 1) * logical_block_size;
 	if (cfg.data_size < buffer_size) {

--- a/nvme.h
+++ b/nvme.h
@@ -83,7 +83,6 @@ extern const char *output_format;
 enum nvme_print_flags validate_output_format(const char *format);
 int __id_ctrl(int argc, char **argv, struct command *cmd,
 	struct plugin *plugin, void (*vs)(uint8_t *vs, struct json_object *root));
-char *nvme_char_from_block(char *block);
 
 extern int current_index;
 void *nvme_alloc(size_t len, bool *huge);


### PR DESCRIPTION
Rewrite of the daa6f93 ("nvme: support ns generic device to submit_io") patch from the monolithic branch.

This PR depends on https://github.com/linux-nvme/libnvme/pull/151