### PR TITLE
build: Use Feature option for OpenSSL

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,17 +57,10 @@ conf.set('LIBHUGETLBFS', have_libhugetlbfs, description: 'Is libhugetlbfs availa
 libz_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 
 # Check for OpenSSL availability
-want_openssl = get_option('openssl')
-if want_openssl != 'false'
-  openssl_dep = dependency('openssl', version: '>=1.1.0',
-                           required: want_openssl == 'true',
-                           fallback : ['openssl', 'openssl_dep'])
-  have_openssl = openssl_dep.found()
-else
-  openssl_dep = []
-  have_openssl = false
-endif
-conf.set('OPENSSL', have_openssl, description: 'Is OpenSSL available?')
+openssl_dep = dependency('openssl', version: '>=1.1.0',
+                         required: get_option('openssl'),
+                         fallback : ['openssl', 'openssl_dep'])
+conf.set('OPENSSL', openssl_dep.found(), description: 'Is OpenSSL available?')
 
 # Set the nvme-cli version
 conf.set('NVME_VERSION', '"' + meson.project_version() + '"')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,4 +4,4 @@ option('systemddir', type : 'string', value : 'lib/systemd/', description : 'dir
 option('htmldir', type : 'string', value : '', description : 'directory for HTML documentation')
 
 option('docs', type : 'combo', choices : ['false', 'html', 'man', 'all'], description : 'install documentation')
-option('openssl', type : 'combo', choices : ['auto', 'true', 'false'], description : 'OpenSSL support')
+option('openssl', type : 'feature', value: 'auto', description : 'OpenSSL support')


### PR DESCRIPTION
Simplify the OpenSSL logic by using meson's Feature option.

Suggested-by: Eli Schwartz <eschwartz93@gmail.com>
Signed-off-by: Daniel Wagner <dwagner@suse.de>