### PR TITLE
Fix openssl library dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HAVE_SYSTEMD = $(shell pkg-config --exists libsystemd  --atleast-version=242; ec
 LIBJSONC_14 = $(shell pkg-config --atleast-version=0.14 json-c; echo $$?)
 LIBJSONC = $(shell pkg-config json-c; echo $$?)
 LIBZ = $(shell $(LD) -o /dev/null -lz >/dev/null 2>&1; echo $$?)
-LIBOPENSSL = $(shell pkg-config --atleast-version=1.1.0 openssl; echo $$?)
+LIBOPENSSL = $(shell pkg-config --max-version=1.1.0 openssl; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HAVE_SYSTEMD = $(shell pkg-config --exists libsystemd  --atleast-version=242; ec
 LIBJSONC_14 = $(shell pkg-config --atleast-version=0.14 json-c; echo $$?)
 LIBJSONC = $(shell pkg-config json-c; echo $$?)
 LIBZ = $(shell $(LD) -o /dev/null -lz >/dev/null 2>&1; echo $$?)
-LIBOPENSSL = $(shell pkg-config --max-version=1.1.0 openssl; echo $$?)
+LIBOPENSSL = $(shell pkg-config --max-version=1.1.1k openssl; echo $$?)
 NVME = nvme
 INSTALL ?= install
 DESTDIR =

--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ conf.set('LIBHUGETLBFS', have_libhugetlbfs, description: 'Is libhugetlbfs availa
 libz_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 
 # Check for OpenSSL availability
-openssl_dep = dependency('openssl', version: '<=1.1.0',
+openssl_dep = dependency('openssl', version: '<=1.1.1k',
                          required: get_option('openssl'),
                          fallback : ['openssl', 'openssl_dep'])
 conf.set('OPENSSL', openssl_dep.found(), description: 'Is OpenSSL available?')

--- a/meson.build
+++ b/meson.build
@@ -57,7 +57,7 @@ conf.set('LIBHUGETLBFS', have_libhugetlbfs, description: 'Is libhugetlbfs availa
 libz_dep = dependency('zlib', fallback : ['zlib', 'zlib_dep'])
 
 # Check for OpenSSL availability
-openssl_dep = dependency('openssl', version: '>=1.1.0',
+openssl_dep = dependency('openssl', version: '<=1.1.0',
                          required: get_option('openssl'),
                          fallback : ['openssl', 'openssl_dep'])
 conf.set('OPENSSL', openssl_dep.found(), description: 'Is OpenSSL available?')


### PR DESCRIPTION
The new openssl code has a dependency on  legacy APIs from version 1.1.1 or less.

See: https://github.com/linux-nvme/nvme-cli/issues/1295