### PR TITLE
nvme: modify flbas rsvd bits to be used

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3567,14 +3567,19 @@ static void nvme_show_id_ns_nsfeat(__u8 nsfeat)
 
 static void nvme_show_id_ns_flbas(__u8 flbas)
 {
-	__u8 rsvd = (flbas & 0xE0) >> 5;
+	__u8 rsvd = (flbas & 0x80) >> 7;
+	__u8 msb2_lbaf = (flbas & NVME_NS_FLBAS_HIGHER_MASK) >> 5;
 	__u8 mdedata = (flbas & 0x10) >> 4;
-	__u8 lbaf = flbas & 0xF;
+	__u8 lsb4_lbaf = flbas & NVME_NS_FLBAS_LOWER_MASK;
+
 	if (rsvd)
-		printf("  [7:5] : %#x\tReserved\n", rsvd);
+		printf("  [7:7] : %#x\tReserved\n", rsvd);
+	printf("  [6:5] : %#x\tMost significant 2 bits of Current LBA Format Selected\n",
+		msb2_lbaf);
 	printf("  [4:4] : %#x\tMetadata Transferred %s\n",
 		mdedata, mdedata ? "at End of Data LBA" : "in Separate Contiguous Buffer");
-	printf("  [3:0] : %#x\tCurrent LBA Format Selected\n", lbaf);
+	printf("  [3:0] : %#x\tLeast significant 4 bits of Current LBA Format Selected\n",
+		lsb4_lbaf);
 	printf("\n");
 }
 
@@ -3710,6 +3715,7 @@ void nvme_show_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 	bool human = flags & VERBOSE;
 	int vs = flags & VS;
 	int i;
+	__u8 flbas;
 
 	if (flags & BINARY)
 		return d_raw((unsigned char *)ns, sizeof(*ns));
@@ -3780,7 +3786,7 @@ void nvme_show_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 	for (i = 0; i < 8; i++)
 		printf("%02x", ns->eui64[i]);
 	printf("\n");
-
+	nvme_id_ns_flbas_to_lbaf_inuse(ns->flbas, &flbas);
 	for (i = 0; i <= ns->nlbaf; i++) {
 		if (human)
 			printf("LBA Format %2d : Metadata Size: %-3d bytes - "
@@ -3790,12 +3796,11 @@ void nvme_show_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 				ns->lbaf[i].rp == 3 ? "Degraded" :
 					ns->lbaf[i].rp == 2 ? "Good" :
 					ns->lbaf[i].rp == 1 ? "Better" : "Best",
-				i == (ns->flbas & 0xf) ? "(in use)" : "");
+				i == flbas ? "(in use)" : "");
 		else
 			printf("lbaf %2d : ms:%-3d lbads:%-2d rp:%#x %s\n", i,
 				le16_to_cpu(ns->lbaf[i].ms), ns->lbaf[i].ds,
-				ns->lbaf[i].rp,
-				i == (ns->flbas & 0xf) ? "(in use)" : "");
+				ns->lbaf[i].rp,	i == flbas ? "(in use)" : "");
 	}
 
 	if (vs) {
@@ -4448,8 +4453,10 @@ void nvme_show_zns_id_ns(struct nvme_zns_id_ns *ns,
 	struct nvme_id_ns *id_ns, unsigned long flags)
 {
 	int human = flags & VERBOSE, vs = flags & VS;
-	uint8_t lbaf = id_ns->flbas & NVME_NS_FLBAS_LBA_MASK;
+	uint8_t lbaf;
 	int i;
+
+	nvme_id_ns_flbas_to_lbaf_inuse(id_ns->flbas, &lbaf);
 
 	if (flags & BINARY)
 		return d_raw((unsigned char *)ns, sizeof(*ns));

--- a/nvme.c
+++ b/nvme.c
@@ -4270,7 +4270,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 			}
 			goto close_fd;
 		}
-		prev_lbaf = ns.flbas & 0xf;
+		nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &prev_lbaf);
 
 		if (cfg.bs) {
 			for (i = 0; i < 16; ++i) {
@@ -5919,7 +5919,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 			perror("identify namespace");
 			goto free_buffer;
 		}
-		lba_index = ns.flbas & NVME_NS_FLBAS_LBA_MASK;
+		nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &lba_index);
 		ms = ns.lbaf[lba_index].ms;
 		mbuffer_size = (cfg.block_count + 1) * ms;
 		if (ms && cfg.metadata_size < mbuffer_size) {

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -207,7 +207,9 @@ static void huawei_print_list_head(struct huawei_list_element_len element_len)
 static void huawei_print_list_item(struct huawei_list_item list_item,
 									struct huawei_list_element_len element_len)
 {
-	long long int lba = 1 << list_item.ns.lbaf[(list_item.ns.flbas & 0x0f)].ds;
+	__u8 lba_index;
+	nvme_id_ns_flbas_to_lbaf_inuse(list_item.ns.flbas, &lba_index);
+	long long int lba = 1 << list_item.ns.lbaf[lba_index].ds;
 	double nsze       = le64_to_cpu(list_item.ns.nsze) * lba;
 	double nuse       = le64_to_cpu(list_item.ns.nuse) * lba;
 

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -121,6 +121,8 @@ static void vt_convert_smart_data_to_human_readable_format(struct vtview_smart_l
 	double capacity;
 	char *curlocale;
 	char *templocale;
+	__u8 lba_index;
+	nvme_id_ns_flbas_to_lbaf_inuse(smart->raw_ns.flbas, &lba_index);
 
 	curlocale = setlocale(LC_ALL, NULL);
 	templocale = strdup(curlocale);
@@ -130,7 +132,7 @@ static void vt_convert_smart_data_to_human_readable_format(struct vtview_smart_l
 
 	setlocale(LC_ALL, "C");
 
-	long long int lba = 1 << smart->raw_ns.lbaf[(smart->raw_ns.flbas & 0x0f)].ds;
+	long long int lba = 1 << smart->raw_ns.lbaf[lba_index].ds;
 	capacity = le64_to_cpu(smart->raw_ns.nsze) * lba;
 
 	snprintf(tempbuff, sizeof(tempbuff), "log;%s;%lu;%s;%s;%-.*s;", smart->raw_ctrl.sn, smart->time_stamp, smart->path,

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 209c5abbeb27eca607cbc3adfb0509b0f4cd7722
+revision = 014c8e9cda65327e0bf28c510a39e491cf268017
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
flbas Bits 6:5 indicate the most significant 2 bits of
the Format Index of the supported LBA Format indicated
in this data structure that was used to format the namespace

using libnvme util function nvme_id_ns_flbas_to_lbaf_inuse
to extract currently used lba index

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>

linux-nvme/libnvme#164