### PR TITLE
Fix unitialized variable

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: install libraries
-        run: sudo apt-get install libjson-c-dev
+        run: sudo apt-get install libjson-c-dev libhugetlbfs-dev
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
       # - name: install python dependencies

--- a/nvme.c
+++ b/nvme.c
@@ -6428,7 +6428,7 @@ static int passthru(int argc, char **argv, bool admin,
 	void *data = NULL, *mdata = NULL;
 	int err = 0, dfd, mfd, fd;
 	__u32 result;
-	bool huge;
+	bool huge = false;
 	const char *cmd_name = NULL;
 	struct timeval start_time, end_time;
 


### PR DESCRIPTION
A pretty old gcc version (SLE15/gcc 7.5.0) is complaining with

```
[60/65] Compiling C object 'nvme@exe/nvme.c.o'                            
../nvme.c: In function ‘passthru.constprop’:                              
../nvme.c:125:5: warning: ‘huge’ may be used uninitialized in this function
  if (huge) {                                                             
     ^                                                                    
../nvme.c:6431:7: note: ‘huge’ was declared here                          
  bool huge;                                                              
       ^~~~        
```                                                       
On my local machine, I don't see this warning (gcc 11.2.1). I think the warning
is legit as we could end up calling nvme_free() without ever having called
`nvme_alloc(..., &huge)`               