### PR TITLE
nvme: Adapt to API rework

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -555,8 +555,16 @@ static int micron_selective_download(int argc, char **argv,
     while (fw_size > 0) {
         xfer = min(xfer, fw_size);
 
-        err = nvme_fw_download(fd, offset, xfer, fw_buf,
-			       NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_fw_download_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.offset		= offset,
+		.data_len	= xfer,
+		.data		= fw_buf,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= NULL,
+	};
+        err = nvme_fw_download(&args);
         if (err < 0) {
             perror("fw-download");
             goto out;
@@ -585,7 +593,6 @@ static int micron_smbus_option(int argc, char **argv,
                                struct command *cmd, struct plugin *plugin)
 {
     __u32 result = 0;
-    __u32 cdw10 = 0;
     __u32 cdw11 = 0;
     const char *desc = "Enable/Disable/Get status of SMBUS option on controller";
     const char *option = "enable or disable or status";
@@ -636,9 +643,20 @@ static int micron_smbus_option(int argc, char **argv,
         }
     }
     else if (!strcmp(opt.option, "status")) {
-        cdw10 = opt.value;
-        err = nvme_get_features(fd, fid, 1, 0, cdw10, 0, 0, NULL,
-				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
+	struct nvme_get_features_args args = {
+                .args_size      = sizeof(args),
+                .fd             = fd,
+                .fid            = fid,
+                .nsid           = 1,
+                .sel            = opt.value,
+                .cdw11          = 0,
+                .uuidx          = 0,
+                .data_len       = 0,
+                .data           = NULL,
+                .timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
+                .result         = &result,
+        };
+        err = nvme_get_features(&args);
         if (err == 0) {
             printf("SMBus status on the drive: %s (returns %s temperature) \n",
                     (result & 1) ? "enabled" : "disabled",
@@ -1845,8 +1863,20 @@ static int GetFeatureSettings(int fd, const char *dir)
             bufp = NULL;
         }
 
-        err = nvme_get_features(fd, fmap[i].id, 1, 0, 0x0, 0, len, bufp,
-				NVME_DEFAULT_IOCTL_TIMEOUT, &attrVal);
+	struct nvme_get_features_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.fid		= fmap[i].id,
+		.nsid		= 1,
+		.sel		= 0,
+		.cdw11		= 0x0,
+		.uuidx		= 0,
+		.data_len	= len,
+		.data		= bufp,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &attrVal,
+	};
+        err = nvme_get_features(&args);
         if (err == 0) {
             sprintf(msg, "feature: 0x%X", fmap[i].id);
             WriteData((__u8*)&attrVal, sizeof(attrVal), dir, fmap[i].file, msg);
@@ -2320,25 +2350,65 @@ static int micron_telemetry_cntrl_option(int argc, char **argv,
     }
 
     if (!strcmp(opt.option, "enable")) {
-        err = nvme_set_features(fd, fid, 1, 1, 0, (opt.select & 0x1),
-				0, 0, 0, 0, NVME_DEFAULT_IOCTL_TIMEOUT, &result);
+        struct nvme_set_features_args args = {
+                .args_size      = sizeof(args),
+                .fd             = fd,
+                .fid            = fid,
+                .nsid           = 1,
+                .cdw11          = 1,
+                .cdw12          = 0,
+                .save           = (opt.select & 0x1),
+                .uuidx          = 0,
+                .cdw15          = 0,
+                .data_len       = 0,
+                .data           = NULL,
+                .timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
+                .result         = &result,
+        };
+        err = nvme_set_features(&args);
         if (err == 0) {
             printf("successfully set controller telemetry option\n");
         } else {
             printf("Failed to set controller telemetry option\n");
         }
     } else if (!strcmp(opt.option, "disable")) {
-        err = nvme_set_features(fd, fid, 1, 0, 0, (opt.select & 0x1),
-				0, 0, 0, 0, NVME_DEFAULT_IOCTL_TIMEOUT, &result);
+        struct nvme_set_features_args args = {
+                .args_size      = sizeof(args),
+                .fd             = fd,
+                .fid            = fid,
+                .nsid           = 1,
+                .cdw11          = 0,
+                .cdw12          = 0,
+                .save           = (opt.select & 0x1),
+                .uuidx          = 0,
+                .cdw15          = 0,
+                .data_len       = 0,
+                .data           = NULL,
+                .timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
+                .result         = &result,
+        };
+	err = nvme_set_features(&args);
         if (err == 0) {
             printf("successfully disabled controller telemetry option\n");
         } else {
             printf("Failed to disable controller telemetry option\n");
         }
     } else if (!strcmp(opt.option, "status")) {
-        opt.select &= 0x3;
-        err = nvme_get_features(fd, fid, 1, opt.select, 0, 0, 0, 0,
-				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
+        ;
+	struct nvme_get_features_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.fid		= fid,
+		.nsid		= 1,
+		.sel		= opt.select & 0x3,
+		.cdw11		= 0,
+		.uuidx		= 0,
+		.data_len	= 0,
+		.data		= NULL,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
+	};
+        err = nvme_get_features(&args);
         if (err == 0) {
             printf("Controller telemetry option : %s\n",
                     (result) ? "enabled" : "disabled");

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -356,7 +356,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 
 	fd = parse_and_open(argc, argv, desc, opts);
 
-	err = nvme_get_nsid_log(fd, 0xca, cfg.namespace_id,
+	err = nvme_get_nsid_log(fd, false, 0xca, cfg.namespace_id,
 		sizeof(smart_log), (void *)&smart_log);
 	if (!err) {
 		if (cfg.json)

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1089,7 +1089,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 	dump_fd = STDOUT_FILENO;
 	cfg.log_id = (cfg.log_id << 8) | 0x07;
-	err = nvme_get_nsid_log(fd, cfg.log_id, cfg.namespace_id,
+	err = nvme_get_nsid_log(fd, false, cfg.log_id, cfg.namespace_id,
 			     sizeof(tele_log), (void *)(&tele_log));
 	if (!err) {
 		maxBlk = tele_log.tele_data_area3;
@@ -1127,10 +1127,24 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		memset(log, 0, blksToGet * 512);
 
-		err = nvme_get_log(fd, cfg.log_id, cfg.namespace_id, offset,
-				   0, 0, true, 0, NVME_CSI_NVM, false,
-				   blksToGet * 512, (void *)log,
-				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+		struct nvme_get_log_args args = {
+			.args_size	= sizeof(args),
+			.fd		= fd,
+			.lid		= cfg.log_id,
+			.nsid		= cfg.namespace_id,
+			.lpo		= offset,
+			.lsp		= 0,
+			.lsi		= 0,
+			.rae		= true,
+			.uuidx		= 0,
+			.csi		= NVME_CSI_NVM,
+			.ot		= false,
+			.len		= blksToGet * 512,
+			.log		= (void *)log,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
+		};
+		err = nvme_get_log(&args);
 		if (!err) {
 			offset += blksToGet * 512;
 
@@ -1188,7 +1202,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 	dump_fd = STDOUT_FILENO;
 
 	log_id = 0x08;
-	err = nvme_get_nsid_log(fd, log_id, cfg.namespace_id,
+	err = nvme_get_nsid_log(fd, false, log_id, cfg.namespace_id,
 			     sizeof(tele_log), (void *)(&tele_log));
 	if (!err) {
 		maxBlk = tele_log.tele_data_area3;
@@ -1225,10 +1239,24 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		memset(log, 0, blksToGet * 512);
 
-		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0,
-				   true, 0, NVME_CSI_NVM, false,
-				   blksToGet * 512, (void *)log,
-				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+		struct nvme_get_log_args args = {
+			.args_size	= sizeof(args),
+			.fd		= fd,
+			.lid		= log_id,
+			.nsid		= cfg.namespace_id,
+			.lpo		= offset,
+			.lsp		= 0,
+			.lsi		= 0,
+			.rae		= true,
+			.uuidx		= 0,
+			.csi		= NVME_CSI_NVM,
+			.ot		= false,
+			.len		= blksToGet * 512,
+			.log		= (void *)log,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
+		};
+		err = nvme_get_log(&args);
 		if (!err) {
 			offset += blksToGet * 512;
 
@@ -1311,7 +1339,7 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 	}
 
 	log_id = 0x08;
-	err = nvme_get_nsid_log(fd, log_id, cfg.namespace_id,
+	err = nvme_get_nsid_log(fd, false, log_id, cfg.namespace_id,
 			     sizeof(tele_log), (void *)(&tele_log));
 	if (!err) {
 		maxBlk = tele_log.tele_data_area3;
@@ -1345,10 +1373,24 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 
 		memset(log, 0, blksToGet * 512);
 
-		err = nvme_get_log(fd, log_id, cfg.namespace_id, offset, 0, 0,
-				   true, 0, NVME_CSI_NVM, false,
-				   blksToGet * 512, (void *)log,
-				   NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+		struct nvme_get_log_args args = {
+			.args_size	= sizeof(args),
+			.fd		= fd,
+			.lid		= log_id,
+			.nsid		= cfg.namespace_id,
+			.lpo		= offset,
+			.lsp		= 0,
+			.lsi		= 0,
+			.rae		= true,
+			.uuidx		= 0,
+			.csi		= NVME_CSI_NVM,
+			.ot		= false,
+			.len		= blksToGet * 512,
+			.log		= (void *)log,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
+		};
+		err = nvme_get_log(&args);
 		if (!err) {
 			offset += blksToGet * 512;
 

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -390,7 +390,7 @@ static int nvme_get_vendor_log(int fd, __u32 namespace_id, int log_page,
 	if (err) {
 		goto end;
 	}
-	err = nvme_get_nsid_log(fd, log_page, namespace_id, log_len, log);
+	err = nvme_get_nsid_log(fd, false, log_page, namespace_id, log_len, log);
 	if (err) {
 		fprintf(stderr, "%s: couldn't get log 0x%x\n", __func__,
 			log_page);
@@ -547,9 +547,22 @@ static int clear_correctable_errors(int argc, char **argv, struct command *cmd,
 	if (err)
 		goto end;
 
-	err = nvme_set_features(fd, feature_id, namespace_id, value, cdw12,
-				save, 0, 0, 0, NULL,
-				NVME_DEFAULT_IOCTL_TIMEOUT, &result);
+	struct nvme_set_features_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.fid		= feature_id,
+		.nsid		= namespace_id,
+		.cdw11		= value,
+		.cdw12		= cdw12,
+		.save		= save,
+		.uuidx		= 0,
+		.cdw15		= 0,
+		.data_len	= 0,
+		.data		= NULL,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
+	};
+	err = nvme_set_features(&args);
 	if (err)
 		fprintf(stderr, "%s: couldn't clear PCIe correctable errors \n",
 			__func__);

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -129,7 +129,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
     if (fd < 0)
         return fd;
 
-    err = nvme_get_nsid_log(fd, 0xca, cfg.namespace_id,
+    err = nvme_get_nsid_log(fd, false, 0xca, cfg.namespace_id,
 			    sizeof(smart_log), &smart_log);
     if (!err) {
         if (!cfg.raw_binary)

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -269,8 +269,20 @@ static int zns_mgmt_send(int argc, char **argv, struct command *cmd, struct plug
 		}
 	}
 
-	err = nvme_zns_mgmt_send(fd, cfg.namespace_id, cfg.zslba, zsa,
-		cfg.select_all, 0, 0, NULL, cfg.timeout, &result);
+	struct nvme_zns_mgmt_send_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.nsid		= cfg.namespace_id,
+		.slba		= cfg.zslba,
+		.zsa		= zsa,
+		.select_all	= cfg.select_all,
+		.zsaso		= 0,
+		.data_len	= 0,
+		.data		= NULL,
+		.timeout	= cfg.timeout,
+		.result		= &result,
+	};
+	err = nvme_zns_mgmt_send(&args);
 	if (!err) {
 		if (zsa == NVME_ZNS_ZSA_RESET)
 			zcapc = result & 0x1;
@@ -420,8 +432,20 @@ static int zone_mgmt_send(int argc, char **argv, struct command *cmd, struct plu
 		}
 	}
 
-	err = nvme_zns_mgmt_send(fd, cfg.namespace_id, cfg.zslba, cfg.zsa,
-			cfg.select_all, cfg.zsaso, cfg.data_len, buf, cfg.timeout, NULL);
+	struct nvme_zns_mgmt_send_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.nsid		= cfg.namespace_id,
+		.slba		= cfg.zslba,
+		.zsa		= cfg.zsa,
+		.select_all	= cfg.select_all,
+		.zsaso		= cfg.zsaso,
+		.data_len	= cfg.data_len,
+		.data		= buf,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
+	};
+	err = nvme_zns_mgmt_send(&args);
 	if (!err)
 		printf("zone-mgmt-send: Success, action:%d zone:%"PRIx64" "
 			"all:%d nsid:%d\n",
@@ -498,8 +522,20 @@ static int open_zone(int argc, char **argv, struct command *cmd, struct plugin *
 		}
 	}
 
-	err = nvme_zns_mgmt_send(fd, cfg.namespace_id, cfg.zslba, NVME_ZNS_ZSA_OPEN,
-		cfg.select_all, cfg.zrwaa, 0, NULL, cfg.timeout, NULL);
+	struct nvme_zns_mgmt_send_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.nsid		= cfg.namespace_id,
+		.slba		= cfg.zslba,
+		.zsa		= NVME_ZNS_ZSA_OPEN,
+		.select_all	= cfg.select_all,
+		.zsaso		= cfg.zrwaa,
+		.data_len	= 0,
+		.data		= NULL,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
+	};
+	err = nvme_zns_mgmt_send(&args);
 	if (!err)
 		printf("zns-open-zone: Success zone slba:%"PRIx64" nsid:%d\n",
 			(uint64_t)cfg.zslba, cfg.namespace_id);
@@ -599,9 +635,20 @@ static int set_zone_desc(int argc, char **argv, struct command *cmd, struct plug
 		goto close_ffd;
 	}
 
-	err = nvme_zns_mgmt_send(fd, cfg.namespace_id, cfg.zslba,
-		NVME_ZNS_ZSA_SET_DESC_EXT, 0, cfg.zrwaa, data_len, buf,
-		cfg.timeout, NULL);
+	struct nvme_zns_mgmt_send_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.nsid		= cfg.namespace_id,
+		.slba		= cfg.zslba,
+		.zsa		= NVME_ZNS_ZSA_SET_DESC_EXT,
+		.select_all	= 0,
+		.zsaso		= cfg.zrwaa,
+		.data_len	= data_len,
+		.data		= buf,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
+	};
+	err = nvme_zns_mgmt_send(&args);
 	if (!err)
 		printf("set-zone-desc: Success, zone:%"PRIx64" nsid:%d\n",
 			(uint64_t)cfg.zslba, cfg.namespace_id);
@@ -655,8 +702,20 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *cmd, struct pl
 		}
 	}
 
-	err = nvme_zns_mgmt_send(fd, cfg.namespace_id, cfg.lba,
-		NVME_ZNS_ZSA_ZRWA_FLUSH, 0, 0, 0, NULL, cfg.timeout, NULL);
+	struct nvme_zns_mgmt_send_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.nsid		= cfg.namespace_id,
+		.slba		= cfg.lba,
+		.zsa		= NVME_ZNS_ZSA_ZRWA_FLUSH,
+		.select_all	= 0,
+		.zsaso		= 0,
+		.data_len	= 0,
+		.data		= NULL,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
+	};
+	err = nvme_zns_mgmt_send(&args);
 	if (!err)
 		printf("zrwa-flush-zone: Success, lba:%"PRIx64" nsid:%d\n",
 			(uint64_t)cfg.lba, cfg.namespace_id);
@@ -735,9 +794,20 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 		}
 	}
 
-	err = nvme_zns_mgmt_recv(fd, cfg.namespace_id, cfg.zslba, cfg.zra,
-				 cfg.zrasf, cfg.partial, cfg.data_len, data,
-				 NVME_DEFAULT_IOCTL_TIMEOUT, NULL);
+	struct nvme_zns_mgmt_recv_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.nsid		= cfg.namespace_id,
+		.slba		= cfg.zslba,
+		.zra		= cfg.zra,
+		.zrasf		= cfg.zrasf,
+		.zras_feat	= cfg.partial,
+		.data_len	= cfg.data_len,
+		.data		= data,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= NULL,
+	};
+	err = nvme_zns_mgmt_recv(&args);
 	if (!err)
 		printf("zone-mgmt-recv: Success, action:%d zone:%"PRIx64" nsid:%d\n",
 			cfg.zra, (uint64_t)cfg.zslba, cfg.namespace_id);
@@ -1105,11 +1175,26 @@ static int zone_append(int argc, char **argv, struct command *cmd, struct plugin
 	if (cfg.piremap)
 		control |= NVME_IO_ZNS_APPEND_PIREMAP;
 
+	struct nvme_zns_append_args args = {
+		.args_size	= sizeof(args),
+		.fd		= fd,
+		.nsid		= cfg.namespace_id,
+		.zslba		= cfg.zslba,
+		.nlb		= nblocks,
+		.control	= control,
+		.ilbrt		= cfg.ref_tag,
+		.lbat		= cfg.lbat,
+		.lbatm		= cfg.lbatm,
+		.data_len	= cfg.data_size,
+		.data		= buf,
+		.metadata_len	= cfg.metadata_size,
+		.metadata	= mbuf,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
+	};
+
 	gettimeofday(&start_time, NULL);
-	err = nvme_zns_append(fd, cfg.namespace_id, cfg.zslba, nblocks,
-			      control, cfg.ref_tag, cfg.lbat, cfg.lbatm,
-			      cfg.data_size, buf, cfg.metadata_size, mbuf,
-			      NVME_DEFAULT_IOCTL_TIMEOUT, &result);
+	err = nvme_zns_append(&args);
 	gettimeofday(&end_time, NULL);
 	if (cfg.latency)
 		printf(" latency: zone append: %llu us\n",

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 35936185e376082cb26da205fd923c0f1c417c12
+revision = c921be9f1be46a2dea78bcd8d32c0a9df6f17b4e
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
libnvme changed the calling API, which uses an an argument structure
instead of passing all arguments one by one. Update all call sites
accordingly.

Signed-off-by: Daniel Wagner <dwagner@suse.de>