### PR TITLE
nvme: Move timeout and result argument

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -272,6 +272,8 @@ static int send_rpmb_req(int fd, unsigned char tgt, int size,
 	struct nvme_security_send_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= NULL,
 		.nsid		= 0,
 		.nssf		= tgt,
 		.spsp0		= RPMB_NVME_SPSP,
@@ -280,8 +282,6 @@ static int send_rpmb_req(int fd, unsigned char tgt, int size,
 		.tl		= 0,
 		.data_len	= size,
 		.data		= (void *)req,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= NULL,
 	};
 
 	return nvme_security_send(&args);
@@ -294,6 +294,8 @@ static int recv_rpmb_rsp(int fd, int tgt, int size,
 	struct nvme_security_receive_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= NULL,
 		.nsid		= 0,
 		.nssf		= tgt,
 		.spsp0		= RPMB_NVME_SPSP,
@@ -302,8 +304,6 @@ static int recv_rpmb_rsp(int fd, int tgt, int size,
 		.al		= 0,
 		.data_len	= size,
 		.data		= (void *)rsp,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= NULL,
 	};
 
 	return nvme_security_receive(&args);

--- a/nvme.c
+++ b/nvme.c
@@ -507,6 +507,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 		struct nvme_get_features_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= &result,
 			.fid		= NVME_FEAT_FID_HOST_BEHAVIOR,
 			.nsid		= NVME_NSID_ALL,
 			.sel		= 0,
@@ -514,8 +516,6 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 			.uuidx		= 0,
 			.data_len	= len,
 			.data		= buf,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= &result,
 		};
 		err = nvme_get_features(&args);
 		if (err > 0) {
@@ -1637,6 +1637,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	struct nvme_get_log_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= NULL,
 		.lid		= cfg.log_id,
 		.nsid		= cfg.namespace_id,
 		.lpo		= cfg.lpo,
@@ -1648,8 +1650,6 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		.ot		= cfg.ot,
 		.len		= cfg.log_len,
 		.log		= log,
-		.timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= NULL,
 	};
 	err = nvme_get_log(&args);
 	if (!err) {
@@ -3005,12 +3005,12 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 	struct nvme_virtual_mgmt_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.act		= cfg.act,
 		.rt		= cfg.rt,
 		.cntlid		= cfg.cntlid,
 		.nr		= cfg.nr,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 	err = nvme_virtual_mgmt(&args);
 	if (!err) {
@@ -3185,10 +3185,10 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 	struct nvme_dev_self_test_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
-		.nsid		= cfg.namespace_id,
-		.stc		= cfg.stc,
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 		.result		= NULL,
+		.nsid		= cfg.namespace_id,
+		.stc		= cfg.stc,
 	};
 	err = nvme_dev_self_test(&args);
 	if (!err) {

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1071,6 +1071,8 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		struct nvme_get_features_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= &result,
 			.fid		= 0xf7,
 			.nsid		= 0,
 			.sel		= 0,
@@ -1078,8 +1080,6 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 			.uuidx		= 0,
 			.data_len	= sizeof(thresholds),
 			.data		= thresholds,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= &result,
 		};
 		err = nvme_get_features(&args);
 		if (err) {
@@ -1564,6 +1564,8 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	struct nvme_get_features_args args_get = {
 		.args_size	= sizeof(args_get),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1571,13 +1573,13 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		.uuidx		= 0,
 		.data_len	= data_len,
 		.data		= buf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 
 	struct nvme_set_features_args args_set = {
 		.args_size	= sizeof(args_set),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,
@@ -1587,8 +1589,6 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		.cdw15		= 0,
 		.data_len	= data_len,
 		.data		= buf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 
 	switch (option) {
@@ -1685,6 +1685,8 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 		struct nvme_set_features_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= &result,
 			.fid		= fid,
 			.nsid		= nsid,
 			.cdw11		= cfg.write ? 0x1 : 0x0,
@@ -1694,8 +1696,6 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 			.cdw15		= 0,
 			.data_len	= sizeof(thresholds),
 			.data		= thresholds,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= &result,
 		};
 		err = nvme_set_features(&args);
 

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -497,6 +497,8 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
     struct nvme_get_features_args args = {
 	    .args_size		= sizeof(args),
 	    .fd			= fd,
+	    .timeout		= NVME_DEFAULT_IOCTL_TIMEOUT,
+	    .result		= &result,
 	    .fid		= feature_id,
 	    .nsid		= 0,
 	    .sel		= 0,
@@ -504,8 +506,6 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
 	    .uuidx		= 0,
 	    .data_len		= 0,
 	    .data		= NULL,
-	    .timeout		= NVME_DEFAULT_IOCTL_TIMEOUT,
-	    .result		= &result,
     };
     err = nvme_get_features(&args);
     if (err < 0) {
@@ -552,6 +552,8 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
 	    .fd			= fd,
+	    .timeout		= NVME_DEFAULT_IOCTL_TIMEOUT,
+	    .result		= &result,
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -561,8 +563,6 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
 	    .cdw15		= 0,
 	    .data_len		= 0,
 	    .data		= NULL,
-	    .timeout		= NVME_DEFAULT_IOCTL_TIMEOUT,
-	    .result		= &result,
     };
     err = nvme_set_features(&args);
     if (err < 0) {
@@ -624,6 +624,8 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
 	    .fd			= fd,
+	    .timeout		= NVME_DEFAULT_IOCTL_TIMEOUT,
+	    .result		= &result,
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -633,8 +635,6 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
 	    .cdw15		= 0,
 	    .data_len		= 0,
 	    .data		= NULL,
-	    .timeout		= NVME_DEFAULT_IOCTL_TIMEOUT,
-	    .result		= &result,
     };
     err = nvme_set_features(&args);
     if (err < 0) {
@@ -876,11 +876,11 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 		struct nvme_fw_download_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
 			.offset		= offset,
 			.data_len	= xfer,
 			.data		= fw_buf,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= NULL,
 		};
 		err = nvme_fw_download(&args);
 		if (err < 0) {
@@ -1081,6 +1081,8 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
     struct nvme_set_features_args args = {
         .args_size      = sizeof(args),
         .fd             = fd,
+        .timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
+        .result         = &result,
         .fid            = cfg.feature_id,
         .nsid           = 0,
         .cdw11          = cfg.value,
@@ -1090,8 +1092,6 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
         .cdw15          = 0,
         .data_len       = 0,
         .data           = NULL,
-        .timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
-        .result         = &result,
     };
     err = nvme_set_features(&args);
     if (err < 0) {
@@ -1170,6 +1170,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 	struct nvme_get_features_args args_get = {
 		.args_size	= sizeof(args_get),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1177,13 +1179,13 @@ static int mb_set_lat_stats(int argc, char **argv,
 		.uuidx		= 0,
 		.data_len	= data_len,
 		.data		= buf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 
 	struct nvme_set_features_args args_set = {
 		.args_size	= sizeof(args_set),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,
@@ -1193,8 +1195,6 @@ static int mb_set_lat_stats(int argc, char **argv,
 		.cdw15		= 0,
 		.data_len	= data_len,
 		.data		= buf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 
 	if (fd < 0)

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -558,11 +558,11 @@ static int micron_selective_download(int argc, char **argv,
 	struct nvme_fw_download_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= NULL,
 		.offset		= offset,
 		.data_len	= xfer,
 		.data		= fw_buf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= NULL,
 	};
         err = nvme_fw_download(&args);
         if (err < 0) {
@@ -646,6 +646,8 @@ static int micron_smbus_option(int argc, char **argv,
 	struct nvme_get_features_args args = {
                 .args_size      = sizeof(args),
                 .fd             = fd,
+                .timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
+                .result         = &result,
                 .fid            = fid,
                 .nsid           = 1,
                 .sel            = opt.value,
@@ -653,8 +655,6 @@ static int micron_smbus_option(int argc, char **argv,
                 .uuidx          = 0,
                 .data_len       = 0,
                 .data           = NULL,
-                .timeout        = NVME_DEFAULT_IOCTL_TIMEOUT,
-                .result         = &result,
         };
         err = nvme_get_features(&args);
         if (err == 0) {

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1130,6 +1130,8 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 		struct nvme_get_log_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
 			.lid		= cfg.log_id,
 			.nsid		= cfg.namespace_id,
 			.lpo		= offset,
@@ -1141,8 +1143,6 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 			.ot		= false,
 			.len		= blksToGet * 512,
 			.log		= (void *)log,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= NULL,
 		};
 		err = nvme_get_log(&args);
 		if (!err) {
@@ -1242,6 +1242,8 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 		struct nvme_get_log_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
 			.lid		= log_id,
 			.nsid		= cfg.namespace_id,
 			.lpo		= offset,
@@ -1253,8 +1255,6 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 			.ot		= false,
 			.len		= blksToGet * 512,
 			.log		= (void *)log,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= NULL,
 		};
 		err = nvme_get_log(&args);
 		if (!err) {
@@ -1376,6 +1376,8 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 		struct nvme_get_log_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
 			.lid		= log_id,
 			.nsid		= cfg.namespace_id,
 			.lpo		= offset,
@@ -1387,8 +1389,6 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 			.ot		= false,
 			.len		= blksToGet * 512,
 			.log		= (void *)log,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= NULL,
 		};
 		err = nvme_get_log(&args);
 		if (!err) {

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -229,6 +229,8 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 	struct nvme_get_features_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= cfg.feature_id,
 		.nsid		= cfg.namespace_id,
 		.sel		= cfg.sel,
@@ -236,8 +238,6 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 		.uuidx		= 0,
 		.data_len	= cfg.data_len,
 		.data		= buf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 	err = nvme_get_features(&args);
 	if (!err) {
@@ -354,6 +354,8 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 	struct nvme_set_features_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= cfg.feature_id,
 		.nsid		= cfg.namespace_id,
 		.cdw11		= cfg.value,
@@ -363,8 +365,6 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 		.cdw15		= 0,
 		.data_len	= cfg.data_len,
 		.data		= buf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 	err = nvme_set_features(&args);
 	if (err < 0) {

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -550,6 +550,8 @@ static int clear_correctable_errors(int argc, char **argv, struct command *cmd,
 	struct nvme_set_features_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= feature_id,
 		.nsid		= namespace_id,
 		.cdw11		= value,
@@ -559,8 +561,6 @@ static int clear_correctable_errors(int argc, char **argv, struct command *cmd,
 		.cdw15		= 0,
 		.data_len	= 0,
 		.data		= NULL,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 	err = nvme_set_features(&args);
 	if (err)

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1758,6 +1758,8 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 		struct nvme_get_log_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
 			.lid		= lid,
 			.nsid		= 0xFFFFFFFF,
 			.lpo		= 0,
@@ -1769,8 +1771,6 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, int fd, __u8 log_id, void **c
 			.ot		= false,
 			.len		= le32_to_cpu(hdr_ptr->length),
 			.log		= data,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= NULL,
 		};
 		ret = nvme_get_log(&args);
 
@@ -2175,13 +2175,13 @@ static int wdc_do_cap_telemetry_log(int fd, char *file, __u32 bs, int type, int 
 	struct nvme_get_features_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.fid		= NVME_FEAT_FID_HOST_BEHAVIOR,
 		.nsid		= NVME_NSID_ALL,
 		.sel		= 0,
 		.cdw11		= 0,
 		.uuidx		= 0,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 
 	switch (data_area) {
@@ -5037,6 +5037,8 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 				struct nvme_get_log_args args = {
 					.args_size	= sizeof(args),
 					.fd		= fd,
+					.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+					.result		= NULL,
 					.lid		= WDC_NVME_GET_EOL_STATUS_LOG_OPCODE,
 					.nsid		= namespace_id,
 					.lpo		= 0,
@@ -5048,8 +5050,6 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 					.ot		= false,
 					.len		= WDC_NVME_SMART_CLOUD_ATTR_LEN,
 					.log		= data,
-					.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-					.result		= NULL,
 				};
 				ret = nvme_get_log(&args);
 
@@ -5100,6 +5100,8 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 				struct nvme_get_log_args args = {
 					.args_size	= sizeof(args),
 					.fd		= fd,
+					.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+					.result		= NULL,
 					.lid		= WDC_NVME_GET_EOL_STATUS_LOG_OPCODE,
 					.nsid		= NVME_NSID_ALL,
 					.lpo		= 0,
@@ -5111,8 +5113,6 @@ static int wdc_get_c0_log_page(nvme_root_t r, int fd, char *format,
 					.ot		= false,
 					.len		= WDC_NVME_EOL_STATUS_LOG_LEN,
 					.log		= data,
-					.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-					.result		= NULL,
 				};
 				ret = nvme_get_log(&args);
 
@@ -6192,6 +6192,8 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *com
 		struct nvme_get_log_args args = {
 			.args_size	= sizeof(args),
 			.fd		= fd,
+			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+			.result		= NULL,
 			.lid		= WDC_NVME_GET_SMART_CLOUD_ATTR_LOG_OPCODE,
 			.nsid		= 0xFFFFFFFF,
 			.lpo		= 0,
@@ -6203,8 +6205,6 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *com
 			.ot		= false,
 			.len		= WDC_NVME_SMART_CLOUD_ATTR_LEN,
 			.log		= data,
-			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-			.result		= NULL,
 		};
 		ret = nvme_get_log(&args);
 

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -272,6 +272,8 @@ static int zns_mgmt_send(int argc, char **argv, struct command *cmd, struct plug
 	struct nvme_zns_mgmt_send_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= cfg.timeout,
+		.result		= &result,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= zsa,
@@ -279,8 +281,6 @@ static int zns_mgmt_send(int argc, char **argv, struct command *cmd, struct plug
 		.zsaso		= 0,
 		.data_len	= 0,
 		.data		= NULL,
-		.timeout	= cfg.timeout,
-		.result		= &result,
 	};
 	err = nvme_zns_mgmt_send(&args);
 	if (!err) {
@@ -435,6 +435,8 @@ static int zone_mgmt_send(int argc, char **argv, struct command *cmd, struct plu
 	struct nvme_zns_mgmt_send_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= cfg.zsa,
@@ -442,8 +444,6 @@ static int zone_mgmt_send(int argc, char **argv, struct command *cmd, struct plu
 		.zsaso		= cfg.zsaso,
 		.data_len	= cfg.data_len,
 		.data		= buf,
-		.timeout	= cfg.timeout,
-		.result		= NULL,
 	};
 	err = nvme_zns_mgmt_send(&args);
 	if (!err)
@@ -525,6 +525,8 @@ static int open_zone(int argc, char **argv, struct command *cmd, struct plugin *
 	struct nvme_zns_mgmt_send_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= NVME_ZNS_ZSA_OPEN,
@@ -532,8 +534,6 @@ static int open_zone(int argc, char **argv, struct command *cmd, struct plugin *
 		.zsaso		= cfg.zrwaa,
 		.data_len	= 0,
 		.data		= NULL,
-		.timeout	= cfg.timeout,
-		.result		= NULL,
 	};
 	err = nvme_zns_mgmt_send(&args);
 	if (!err)
@@ -638,6 +638,8 @@ static int set_zone_desc(int argc, char **argv, struct command *cmd, struct plug
 	struct nvme_zns_mgmt_send_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= NVME_ZNS_ZSA_SET_DESC_EXT,
@@ -645,8 +647,6 @@ static int set_zone_desc(int argc, char **argv, struct command *cmd, struct plug
 		.zsaso		= cfg.zrwaa,
 		.data_len	= data_len,
 		.data		= buf,
-		.timeout	= cfg.timeout,
-		.result		= NULL,
 	};
 	err = nvme_zns_mgmt_send(&args);
 	if (!err)
@@ -705,6 +705,8 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *cmd, struct pl
 	struct nvme_zns_mgmt_send_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= cfg.timeout,
+		.result		= NULL,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.lba,
 		.zsa		= NVME_ZNS_ZSA_ZRWA_FLUSH,
@@ -712,8 +714,6 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *cmd, struct pl
 		.zsaso		= 0,
 		.data_len	= 0,
 		.data		= NULL,
-		.timeout	= cfg.timeout,
-		.result		= NULL,
 	};
 	err = nvme_zns_mgmt_send(&args);
 	if (!err)
@@ -797,6 +797,8 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 	struct nvme_zns_mgmt_recv_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= NULL,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zra		= cfg.zra,
@@ -804,8 +806,6 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 		.zras_feat	= cfg.partial,
 		.data_len	= cfg.data_len,
 		.data		= data,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= NULL,
 	};
 	err = nvme_zns_mgmt_recv(&args);
 	if (!err)
@@ -1178,6 +1178,8 @@ static int zone_append(int argc, char **argv, struct command *cmd, struct plugin
 	struct nvme_zns_append_args args = {
 		.args_size	= sizeof(args),
 		.fd		= fd,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 		.nsid		= cfg.namespace_id,
 		.zslba		= cfg.zslba,
 		.nlb		= nblocks,
@@ -1189,8 +1191,6 @@ static int zone_append(int argc, char **argv, struct command *cmd, struct plugin
 		.data		= buf,
 		.metadata_len	= cfg.metadata_size,
 		.metadata	= mbuf,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result		= &result,
 	};
 
 	gettimeofday(&start_time, NULL);


### PR DESCRIPTION
libnvme reorganized the layout of the struct with the goal to have all
holes filled. Along the hole filling also the common arguments have
been grouped together. Hence move the timeout and result argument to
the common area of the struct.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

depends on https://github.com/linux-nvme/libnvme/issues/169