### PR TITLE
Add support for new PCI device ID for SN655 Drive

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -75,6 +75,7 @@
 #define WDC_NVME_SN650_DEV_ID_2             0x2702
 #define WDC_NVME_SN650_DEV_ID_3             0x2720
 #define WDC_NVME_SN650_DEV_ID_4             0x2721
+#define WDC_NVME_SN655_DEV_ID               0x2722
 #define WDC_NVME_SN450_DEV_ID_1             0x2712
 #define WDC_NVME_SN450_DEV_ID_2             0x2713
 #define WDC_NVME_SXSLCL_DEV_ID				0x2001
@@ -1339,6 +1340,7 @@ static __u64 wdc_get_drive_capabilities(nvme_root_t r, int fd) {
 		case WDC_NVME_SN650_DEV_ID_2:
 		case WDC_NVME_SN650_DEV_ID_3:
 		case WDC_NVME_SN650_DEV_ID_4:
+		case WDC_NVME_SN655_DEV_ID:
 		case WDC_NVME_SN450_DEV_ID_1:
 		case WDC_NVME_SN450_DEV_ID_2:
 			/* verify the 0xC0 log page is supported */

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -4,7 +4,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "1.15.5"
+#define WDC_PLUGIN_VERSION   "1.16.0"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
Also, update the WDC plugin version to 1.16.0