### PR TITLE
nvme-print: check namespace in nvme_ctrl_for_each_path()

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6704,8 +6704,11 @@ static void nvme_show_detailed_list(nvme_root_t r)
 				}
 
 				nvme_ctrl_for_each_path(c, p) {
+					n = nvme_path_get_ns(p);
+					if (!n)
+						continue;
 					printf("%s%s", first ? "": ", ",
-					       nvme_ns_get_name(nvme_path_get_ns(p)));
+					       nvme_ns_get_name(n));
 					first = false;
 				}
 				printf("\n");


### PR DESCRIPTION
We should check if the namespace is available when scanning all
paths in nvme_ctrl_for_each_path(); a controller might be resetting
and might not be able to access the namespaces here.

Signed-off-by: Hannes Reinecke <hare@suse.de>