### PR TITLE
nvme: add 'gen-tls-key' and 'check-tls-key' options

### DIFF
--- a/Documentation/nvme-check-tls-key.txt
+++ b/Documentation/nvme-check-tls-key.txt
@@ -1,0 +1,31 @@
+nvme-check-tls-key(1)
+========================
+
+NAME
+----
+nvme-check-tls-key - Check a generated NVMe TLS PSK
+
+SYNOPSIS
+--------
+[verse]
+'nvme check-tls-key' [--key=<key> ]
+
+DESCRIPTION
+-----------
+Checks if the key is a valid NVMe TLS PSK in the PSK interchange format
+NVMeTLSkey-1:01:VRLbtnN9AQb2WXW3c9+wEf/DRLz0QuLdbYvEhwtdWwNf9LrZ:
+
+
+OPTIONS
+-------
+-k <key>::
+--key=<key>::
+	Key to be checked.
+
+EXAMPLES
+--------
+No Examples
+
+NVME
+----
+Part of the nvme-user suite

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -1,0 +1,40 @@
+nvme-gen-tls-key(1)
+======================
+
+NAME
+----
+nvme-gen-tls-key - Generate a NVMe TLS PSK
+
+SYNOPSIS
+--------
+[verse]
+'nvme gen-tls-key' [--hmac=<hmac-id> | -h <hmac-id>]
+		      [--secret=<secret> | -s <secret> ]
+
+DESCRIPTION
+-----------
+Generate a base64-encoded NVMe TLS pre-shared key (PSK) in
+the PSK interchange format
+NVMeTLSkey-1:01:VRLbtnN9AQb2WXW3c9+wEf/DRLz0QuLdbYvEhwtdWwNf9LrZ:
+and prints it to stdout.
+
+OPTIONS
+-------
+-h <hmac-id>::
+--hmac=<hmac-id>::
+	Select a HMAC algorithm to use. Possible values are:
+	1 - SHA-256 (default)
+	2 - SHA-384
+
+-s <secret>::
+--secret=<secret>::
+	Secret value (in hexadecimal) to be used for the key. If none are
+	provided a random value is used.
+
+EXAMPLES
+--------
+No Examples
+
+NVME
+----
+Part of the nvme-user suite

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -90,6 +90,8 @@ COMMAND_LIST(
 	ENTRY("show-hostnqn", "Show NVMeoF host NQN", show_hostnqn_cmd)
 	ENTRY("gen-dhchap-key", "Generate NVMeoF DH-HMAC-CHAP host key", gen_dhchap_key)
 	ENTRY("check-dhchap-key", "Validate NVMeoF DH-HMAC-CHAP host key", check_dhchap_key)
+	ENTRY("gen-tls-key", "Generate NVMeoF TLS PSK", gen_tls_key)
+	ENTRY("check-tls-key", "Validate NVMeoF TLS PSK", check_tls_key)
 	ENTRY("dir-receive", "Submit a Directive Receive command, return results", dir_receive)
 	ENTRY("dir-send", "Submit a Directive Send command, return results", dir_send)
 	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller ", virtual_mgmt)


### PR DESCRIPTION
Add options to generate and check an NVMe TLS PSK.

Signed-off-by: Hannes Reinecke <hare@suse.de>