### PR TITLE
nvme: Call nvme_identify_*list with correct nsid offset

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1965,10 +1965,10 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 	}
 
 	if (cfg.all)
-		err = nvme_identify_allocated_ns_list(fd, cfg.namespace_id,
+		err = nvme_identify_allocated_ns_list(fd, cfg.namespace_id - 1,
 						      &ns_list);
 	else
-		err = nvme_identify_active_ns_list(fd, cfg.namespace_id,
+		err = nvme_identify_active_ns_list(fd, cfg.namespace_id - 1,
 						   &ns_list);
 	if (!err)
 		nvme_show_list_ns(&ns_list, flags);


### PR DESCRIPTION
Commit 81bb8289f642 ("nvme: update list-ns nsid option") changed the
start index for the namespace argument. But the merge back from the
monolithic branch was incomplete and missed to update the index offset
when calling nvme_identify_allocated_ns_list and
nvme_identify_active_ns_list.

Signed-off-by: Daniel Wagner <dwagner@suse.de>