### PR TITLE
nvme: Adapt to logging changes in libnvme

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -105,4 +105,5 @@ void d(unsigned char *buf, int len, int width, int group);
 void d_raw(unsigned char *buf, unsigned len);
 uint64_t int48_to_long(uint8_t *data);
 
+int map_log_level(int verbose, bool quiet);
 #endif /* _NVME_H */

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = fcf7edfe4daf298ef4a2790666a9ba7b579f34e1
+revision = 5b397aa3a2a70331373d321cf357055d3b1e7e4c
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
libnvme allows to define which file descriptor should be used for
logging. This is only for the fabric related interface relevant hence
this is attached to the nvme_root_r object.

Use common code for this into a helper which maps the verbose command
line levels to the correct log levels and setup nvme_root_r
accordingly.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See
- https://github.com/linux-nvme/libnvme/pull/202
- https://github.com/linux-nvme/libnvme/pull/207