### PR TITLE
[nvme-cli] Add support for data area 4 to get-telemetry-log

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 1eae1f1c7b15444ddb22dd33c647306caa20beb2
+revision = ee30b6824f1209417e314d2c5b2e8d22b8707b6e
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Added size pointer and data area parms to the libnvme functions:  nvme_get_ctrl_telemetry, nvme_get_host_telemetry, and nvme_get_new_host_telemetry.   The size will be calculated by those functions based on the passed data area parm and they returned to the calling function via the size pointer.

Since additional parameters were added, this pull request is dependent on the libnvme pull request (https://github.com/linux-nvme/libnvme/pull/213) that contains the changes to the  nvme_get_ctrl_telemetry, nvme_get_host_telemetry, and nvme_get_new_host_telemetry functions.

Signed-off-by: Jeff Lien <jeff.lien@wdc.com>