### PR TITLE
build: Make CI build fail on warnings.

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -23,4 +23,5 @@ jobs:
       #     pip install nose nose2
       - uses: BSFishy/meson-build@v1.0.3
         with:
+          setup-options: --werror
           action: build

--- a/nvme.c
+++ b/nvme.c
@@ -3260,7 +3260,7 @@ ret:
 
 static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	const char *desc = "Get namespce ID of a the block device.";
+	const char *desc = "Get namespace ID of a the block device.";
 	int err = 0, fd;
 	unsigned int nsid;
 
@@ -3274,7 +3274,7 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 
 	err = nvme_get_nsid(fd, &nsid);
 	if (err <= 0) {
-		fprintf(stderr, devicename);
+		fprintf(stderr, "get namespace ID: %s\n", nvme_strerror(errno));
 		err = errno;
 		goto close_fd;
 	}


### PR DESCRIPTION
Currently, warnings are hidden in the logs and the build is marked as
succeeded. Mark all warnings as error so that we see them show up in
the review process.

Signed-off-by: Daniel Wagner <dwagner@suse.de>