### PR TITLE
nvme: Rename LIBJSONC_14 to CONFIG_JSONC_14

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -33,7 +33,7 @@
 	json_object_object_add(o, k, json_object_new_int(v))
 #define json_object_add_value_int(o, k, v) \
 	json_object_object_add(o, k, json_object_new_int(v))
-#ifdef LIBJSONC_14
+#ifdef CONFIG_JSONC_14
 #define json_object_add_value_uint64(o, k, v) \
 	json_object_object_add(o, k, json_object_new_uint64(v))
 #else


### PR DESCRIPTION
We missed to rename LIBJSONC_14 to CONFIG_JSONC_14 in the nvme.h
header file in 4c3a8c058eb3 ("build: Prefix configuration options").

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1354