### PR TITLE
nvme: Fix --force flag inversion

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -277,7 +277,7 @@ int parse_and_open(int argc, char **argv, const char *desc,
 
 	for (s = opts; s && s->option; s++) {
 		if (!strcmp(s->option, "force")) {
-			if (! *(int *)s->default_value)
+			if (*(int *)s->default_value)
 				flags |= O_EXCL;
 			break;
 		}


### PR DESCRIPTION
argparse sets the default_value member when the argument has been
provided by the user. But in parse_and_open we set O_EXCL when --force
is not used.

It also introduced a regression in the 'id-ns' where the --force flag
is used to determine which function is used to identify the
namespace (nvme_identify_allocated_ns() vs nvme_identify_ns()).

Fixes: 2100609 ("nvme: open namespace exclusive by default")

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1356 