### PR TITLE
nvmf: Remove --matching from systemd service file

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -28,7 +28,6 @@ SYNOPSIS
 		[--nr-write-queues=<#>    | -W <#>]
 		[--nr-poll-queues=<#>     | -P <#>]
 		[--queue-size=<#>         | -Q <#>]
-		[--matching               | -m]
 		[--persistent             | -p]
 		[--quiet                  | -S]
 		[--dump-config            | -O]
@@ -165,12 +164,6 @@ OPTIONS
 	Overrides the default number of elements in the I/O queues created
 	by the driver. This option will be ignored for discovery, but will be
 	passed on to the subsequent connect call.
-
--m::
---matching::
-	If a traddr was specified on the command line or in the configuration
-	file, only create controllers for discovery records that match the
-	given traddr, rather than for all entries in the discovery log page.
 
 -p::
 --persistent::

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -459,7 +459,7 @@ nvme_list_opts () {
 			--tos= -T --hdr-digest= -g --data-digest -G \
 			--nr-io-queues= -i --nr-write-queues= -W \
 			--nr-poll-queues= -P --queue-size= -Q \
-			--persistent -p --quiet -S --matching -m \
+			--persistent -p --quiet -S \
 			--output-format= -o"
 			;;
 		"connect-all")
@@ -471,7 +471,7 @@ nvme_list_opts () {
 			--tos= -T --hdr-digest= -g --data-digest -G \
 			--nr-io-queues= -i --nr-write-queues= -W \
 			--nr-poll-queues= -P --queue-size= -Q \
-			--persistent -p --quiet -S --matching -m \
+			--persistent -p --quiet -S \
 			--output-format= -o"
 			;;
 		"connect")

--- a/nvmf-autoconnect/systemd/nvmf-connect@.service
+++ b/nvmf-autoconnect/systemd/nvmf-connect@.service
@@ -11,4 +11,4 @@ Requires=nvmf-connect.target
 [Service]
 Type=simple
 Environment="CONNECT_ARGS=%i"
-ExecStart=/bin/sh -c "nvme connect-all --matching --quiet `/bin/echo -e '${CONNECT_ARGS}'`"
+ExecStart=/bin/sh -c "nvme connect-all --quiet `/bin/echo -e '${CONNECT_ARGS}'`"


### PR DESCRIPTION
'--matching' is not a great concept. The whole point of a discovery
log is to return different port addresses from the one we're using.

Thus the '--matching' logic was dropped when switching over the
libnvme but we forgot to remove it from the systemd service file.

Signed-off-by: Daniel Wagner <dwagner@suse.de>