### PR TITLE
docs: Introduce documentation build option

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -151,12 +151,13 @@ adoc_sources = [
 ]
 
 want_docs = get_option('docs')
+want_docs_build = get_option('docs-build')
 if want_docs != 'false'
   mandir = join_paths(get_option('mandir'), 'man1')
   htmldir = join_paths(get_option('htmldir'), 'nvme')
 
   asciidoctor = find_program('asciidoc', required : false)
-  if asciidoctor.found()
+  if want_docs_build and asciidoctor.found()
     # Build documentation before installing
 
     # man pages

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('systemddir', type : 'string', value : 'lib/systemd/', description : 'dir
 option('htmldir', type : 'string', value : '', description : 'directory for HTML documentation')
 
 option('docs', type : 'combo', choices : ['false', 'html', 'man', 'all'], description : 'install documentation')
+option('docs-build', type : 'boolean', value : 'false',  description : 'build documentation')


### PR DESCRIPTION
Build the documentation only if explicitly asked to build it. If not
fallback to install the precompiled versions.

Signed-off-by: Daniel Wagner <dwagner@suse.de>