### PR TITLE
common.h: remove unused macros

### DIFF
--- a/common.h
+++ b/common.h
@@ -3,16 +3,10 @@
 
 #include "ccan/endian/endian.h"
 
-#define __round_mask(x, y) ((__typeof__(x))((y)-1))
-#define round_up(x, y) ((((x)-1) | __round_mask(x, y))+1)
-
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 #define min(x, y) ((x) > (y) ? (y) : (x))
 #define max(x, y) ((x) > (y) ? (x) : (y))
-
-#define __stringify_1(x...) #x
-#define __stringify(x...)  __stringify_1(x)
 
 static inline uint32_t mmio_read32(void *addr)
 {
@@ -32,11 +26,5 @@ static inline uint64_t mmio_read64(void *addr)
 
 	return ((uint64_t) high << 32) | low;
 }
-
-#if __has_attribute(__fallthrough__)
-# define fallthrough                    __attribute__((__fallthrough__))
-#else
-# define fallthrough                    do {} while (0)  /* fallthrough */
-#endif
 
 #endif


### PR DESCRIPTION
round_up is not used
__stringify is defined in define_cmd and used
__fallthrough__ not used, occur error from lower version of GCC

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>