### PR TITLE
nvme-print: Fix json output for list-subsys

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2307,7 +2307,7 @@ static void json_print_nvme_subsystem_list(nvme_root_t r)
 	struct json_object *root;
 	nvme_host_t h;
 
-	root = json_create_object();
+	root = json_create_array();
 
 	nvme_for_each_host(r, h) {
 		nvme_subsystem_t s;


### PR DESCRIPTION
The root needs to be an array an not an object.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

This fixes:
```
nvme: /home/abuild/rpmbuild/BUILD/json-c-json-c-0.15-20200726/json_object.c:1490: json_object_array_add: Assertion `json_object_get_type(jso) == json_type_array' failed.

Program received signal SIGABRT, Aborted.
```