### PR TITLE
netapp-nvme: fix ontapdevices segfault in json output

### DIFF
--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -334,7 +334,7 @@ static void netapp_ontapdevices_print(struct ontapdevice_info *devices,
 	} else if (format == NJSON) {
 		/* prepare for json output */
 		root = json_create_object();
-		json_devices = json_create_object();
+		json_devices = json_create_array();
 	}
 
 	for (i = 0; i < count; i++) {
@@ -357,6 +357,8 @@ static void netapp_ontapdevices_print(struct ontapdevice_info *devices,
 		/* complete the json output */
 		json_object_add_value_array(root, "ONTAPdevices", json_devices);
 		json_print_object(root, NULL);
+		printf("\n");
+		json_free_object(root);
 	}
 }
 


### PR DESCRIPTION
After the upgrade to libnvme, the NetApp plugin for ontapdevices
now segfaults due to the wrong json object type as shown below:

nvme: json_object.c:1194: json_object_array_add:
Assertion `json_object_get_type(jso) == json_type_array' failed.
Aborted (core dumped)

Fix this by passing the appropriate json array type for
ontapdevices. Include a couple of minor changes here as well -
add a newline to the end of the json output, and then free the
json root device.

Signed-off-by: Martin George <marting@netapp.com>