### PR TITLE
Update nvme-print.c:  Only print FW slots that contain  a valid FW image revision number

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -523,7 +523,7 @@ static void json_fw_log(struct nvme_firmware_slot *fw_log, const char *devname)
 	json_object_add_value_int(fwsi, "Active Firmware Slot (afi)",
 		fw_log->afi);
 	for (i = 0; i < 7; i++) {
-		if (fw_log->frs[i]) {
+		if (fw_log->frs[i][0]) {
 			snprintf(fmt, sizeof(fmt), "Firmware Rev Slot %d",
 				i + 1);
 			frs = (__le64 *)&fw_log->frs[i];
@@ -5683,7 +5683,7 @@ void nvme_show_fw_log(struct nvme_firmware_slot *fw_log,
 	printf("Firmware Log for device:%s\n", devname);
 	printf("afi  : %#x\n", fw_log->afi);
 	for (i = 0; i < 7; i++) {
-		if (fw_log->frs[i]) {
+		if (fw_log->frs[i][0]) {
 			frs = (__le64 *)&fw_log->frs[i];
 			printf("frs%d : %#016"PRIx64" (%s)\n", i + 1,
 				le64_to_cpu(*frs),


### PR DESCRIPTION
Existing 2.0 branch prints all 7 fw slots including the ones with null.   The check for a valid FW revision number is no longer working due to the change of the definition of frs in  the nvme_firmware_slot struct in the latest libnvme.   Current definition uses "char    frs[7][8]" instead of old definition of  "__u64      frs[7]".