### PR TITLE
Revert force exclusive

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4524,7 +4524,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 				"Namespace is currently busy.\n");
 			if (!cfg.force)
 				fprintf(stderr,
-				"Use the force [--force|-f] option to ignore that.\n");
+				"Use the force [--force] option to ignore that.\n");
 		} else {
 			argconfig_print_help(desc, opts);
 		}
@@ -4647,7 +4647,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		nvme_show_relatives(devicename);
 		fprintf(stderr, "WARNING: Format may irrevocably delete this device's data.\n"
 			"You have 10 seconds to press Ctrl-C to cancel this operation.\n\n"
-			"Use the force [--force|-f] option to suppress this warning.\n");
+			"Use the force [--force] option to suppress this warning.\n");
 		sleep(10);
 		fprintf(stderr, "Sending format operation ... \n");
 	}


### PR DESCRIPTION
There was a bit of confusion due to the attempt to open always the device exclusively. As we had some fallouts let's revert the offending change completely and only fix what it tried to attempt. The blame is mine as I didn't really understand what the change did.

While at it also try to document a few things by renaming variables.

So in case we need O_EXCL access we should just use the open_exclusive() instead of parse_and_open().

Fixes: #1380 