### PR TITLE
nvme: get_ns_id command fails on nvme device

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3256,7 +3256,7 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 		goto ret;
 
 	err = nvme_get_nsid(fd, &nsid);
-	if (err <= 0) {
+	if (err < 0) {
 		fprintf(stderr, "get namespace ID: %s\n", nvme_strerror(errno));
 		err = errno;
 		goto close_fd;


### PR DESCRIPTION
The get-ns-id command currently prints the perror status for a
given nvme device instead of its nsid. Fix this by properly
checking the return status of the nvme_get_nsid() function.

Signed-off-by: Martin George <marting@netapp.com>