### PR TITLE
nvme-print: fix 'nvme list -o json' segfault

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -7206,8 +7206,8 @@ static void json_simple_list(nvme_root_t r)
 				json_array_add_value_object(jdevices,
 							    json_list_item(n));
 		}
-		json_object_add_value_object(jroot, "devices", jdevices);
 	}
+	json_object_add_value_array(jroot, "devices", jdevices);
 	json_print_object(jroot, NULL);
 	printf("\n");
 	json_free_object(jroot);


### PR DESCRIPTION
After the recent upgrade to libnvme, 'nvme list -o json' segfaults
due to incorrect json object type passed here. So fix this by passing
the appropriate json object type and invoking it outside the
nvme_for_each_host loop.

Signed-off-by: Martin George <marting@netapp.com>