### PR TITLE
cmds-main: Add media unit status log and supported capacity config list log pages in main commands list

### DIFF
--- a/Documentation/cmds-main.txt
+++ b/Documentation/cmds-main.txt
@@ -168,3 +168,9 @@ linknvme:nvme-disconnect-all[1]::
 
 linknvme:nvme-get-property[1]::
 	Reads and shows NVMe-over-Fabrics controller property
+
+linknvme:nvme-media-unit-stat-log[1]::
+	Retrieve and show the configuration and wear of media units
+
+linknvme:nvme-supported-cap-config-log[1]::
+	Retrieve and show the list of Supported Capacity Configuration Descriptors


### PR DESCRIPTION
updated main commands list with media unit status log and supported capacity config list log pages in cmds-main.txt

Signed-off-by: Arunpandian J <apj.arun@samsung.com>