### PR TITLE
nvme: fix segfault in nvme telemetry-log error handling

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -482,7 +482,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 		fprintf(stderr, "Failed to open output file %s: %s!\n",
 				cfg.file_name, strerror(errno));
 		err = output;
-		goto free_mem;
+		goto close_fd;
 	}
 
 	if (cfg.ctrl_init)
@@ -526,10 +526,10 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 		return -1;
 	}
 
+	free(log);
+
 close_output:
 	close(output);
-free_mem:
-	free(log);
 close_fd:
 	close(fd);
 ret:


### PR DESCRIPTION
After the upgrade to libnvme, the nvme telemetry-log command
segfaults for error scenarios as shown below:

NVMe status: Invalid Log Page: The log page indicated is invalid(0x4009)
Failed to acquire telemetry log 16393!
Segmentation fault (core dumped)

Freeing the telemetry log page header for error scenarios is already
handled in the libnvme. So avoid freeing this again here, which led to
this segfault.

Signed-off-by: Martin George <marting@netapp.com>