### PR TITLE
nvme-cli: Ignore traddr case

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -511,7 +511,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 			/* Check if device matches command-line options */
 			if (strcmp(nvme_ctrl_get_subsysnqn(c), subsysnqn) ||
 			    strcmp(nvme_ctrl_get_transport(c), transport) ||
-			    strcmp(nvme_ctrl_get_traddr(c), traddr) ||
+			    strcasecmp(nvme_ctrl_get_traddr(c), traddr) ||
 			    (cfg.host_traddr && nvme_ctrl_get_host_traddr(c) &&
 			     strcmp(nvme_ctrl_get_host_traddr(c),
 				    cfg.host_traddr)) ||


### PR DESCRIPTION
There was is no requirement in the NVME-FC specification that traddr
needs to be upper or lower case. Given the case difference, the
connect-all fails the match logic. Switch to strcasecmp for a
case insensitive compare.

Based on 1264c6323937 ("nvme-cli: Make connect-all matching be case
insensitive")

Signed-off-by: Daniel Wagner <dwagner@suse.de>