### PR TITLE
meson: remove rpm dependencies when build as static

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -148,6 +148,11 @@ configure_file(
 )
 
 ################################################################################
+libtype = get_option('default_library')
+if libtype == 'static'
+  requires = ''
+endif
+
 substs = configuration_data()
 substs.set('NAME',    meson.project_name())
 substs.set('VERSION', meson.project_version())


### PR DESCRIPTION
Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>

When the meson build with static library, does not need rpm Requires