### PR TITLE
tests: Add support for linting and formatting of Python code

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -11,18 +11,16 @@ nvmetests
 1. Common Package Dependencies
 ------------------------------
 
-    1. Python(>= 2.7.5 or >= 3.3)
-    2. nose(http://nose.readthedocs.io/en/latest/)
-    3. nose2(Installation guide http://nose2.readthedocs.io/)
-    4. pep8(https://pypi.python.org/pypi/setuptools-pep8)
-    5. flake8(https://pypi.python.org/pypi/flake8)
-    6. pylint(https://www.pylint.org/)
-    7. Epydoc(http://epydoc.sourceforge.net/)
-    8. nvme-cli(https://github.com/linux-nvme/nvme-cli.git)
+    1. Python(>= 3.3)
+    2. nose2 (Installation guide http://nose2.readthedocs.io/)
+    3. flake8 (https://pypi.python.org/pypi/flake8)
+    4. mypy (https://pypi.org/project/mypy/)
+    5. autopep8 (https://pypi.org/project/autopep8/)
+    6. isort (https://pypi.org/project/isort/)
 
     Python package management system pip can be used to install most of the
     listed packages(https://pip.pypa.io/en/stable/installing/) :-
-    $ pip install nose nose2 pep8 flake8 pylint epydoc
+    $ pip install nose2 flake8 mypy autopep8 isort
 
 2. Overview
 -----------
@@ -76,12 +74,12 @@ nvmetests
     6. Before writing a new function have a look into TestNVMe to see if it
        can be reused.
     7. Once testcase is ready make sure :-
-           a. Run pep8, flake8, pylint on the testcase and fix errors/warnings.
-              -Example "$ make static_check" will run pep8, flake8 and pylint on
-              all the python files in current directory.
-           b. Execute make doc to generate the documentation.
-              -Example "$ make doc" will create and update existing
-              documentation.
+           a. Run flake8, mypy, autopep8 and isort on the testcase and fix
+	      errors/warnings.
+               - Example "$ ninja -C .build lint-python" will run flake8 and
+	         mypy on all the python files in current directory.
+	       - Example "$ ninja -C .build fomrat-python" will run autopep8 and
+	         isort on all the python files in the current directory.
 
 4. Running testcases with framework
 -----------------------------------
@@ -89,5 +87,5 @@ nvmetests
        $ nose2 --verbose nvme_writezeros_test
        $ nose2 --verbose nvme_read_write_test
 
-    2. Running all the testcases with Makefile :-
-       $ make run
+    2. Running all the testcases with ninja :-
+       $ ninja test -C .build

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,3 +30,45 @@ if runtests.found()
          timeout: 500)
   endforeach
 endif
+
+python_module = import('python')
+
+python = python_module.find_installation('python3')
+
+mypy = find_program(
+    'mypy',
+    required : false,
+)
+flake8 = find_program(
+    'flake8',
+    required : false,
+)
+linter_script = files('run_py_linters.py')
+
+if mypy.found() and flake8.found()
+    run_target(
+        'lint-python',
+        command : [python, linter_script, 'lint'],
+    )
+else
+    message('Mypy or Flake8 not found. Python linting disabled')
+endif
+
+
+autopep8 = find_program(
+    'autopep8',
+    required : false,
+)
+isort = find_program(
+    'isort',
+    required : false,
+)
+
+if autopep8.found() and isort.found()
+    run_target(
+        'format-python',
+        command : [python, linter_script, 'format'],
+    )
+else
+    message('autopep8 or isort not found. Python formating disabled')
+endif

--- a/tests/nvme_attach_detach_ns_test.py
+++ b/tests/nvme_attach_detach_ns_test.py
@@ -28,6 +28,7 @@ NVMe Namespace Management Testcase:-
 """
 
 import time
+
 from nose.tools import assert_equal
 from nvme_test import TestNVMe
 

--- a/tests/nvme_create_max_ns_test.py
+++ b/tests/nvme_create_max_ns_test.py
@@ -28,6 +28,7 @@ NVMe Namespace Management Testcase:-
 """
 
 import time
+
 from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
@@ -50,7 +51,8 @@ class TestNVMeCreateMaxNS(TestNVMe):
         TestNVMe.__init__(self)
         self.dps = 0
         self.flbas = 0
-        self.nsze = int(self.get_ncap() / self.get_format() / self.get_max_ns())
+        self.nsze = int(self.get_ncap() /
+                        self.get_format() / self.get_max_ns())
         self.ncap = self.nsze
         self.setup_log_dir(self.__class__.__name__)
         self.max_ns = self.get_max_ns()

--- a/tests/nvme_format_test.py
+++ b/tests/nvme_format_test.py
@@ -35,8 +35,9 @@ Namespace Format testcase :-
            - Delete Namespace.
 """
 
-import time
 import subprocess
+import time
+
 from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
@@ -130,8 +131,8 @@ class TestNVMeFormatCmd(TestNVMe):
 
         # iterate through all supported format
         for i in range(0, len(self.lba_format_list)):
-            print("\nlba format " + str(self.lba_format_list[i]) + \
-                  " lbad       " + str(self.lbads_list[i]) + \
+            print("\nlba format " + str(self.lba_format_list[i]) +
+                  " lbad       " + str(self.lbads_list[i]) +
                   " ms         " + str(self.ms_list[i]))
             metadata_size = 1 if self.ms_list[i] == '8' else 0
             err = self.create_and_validate_ns(self.default_nsid,

--- a/tests/nvme_fw_log_test.py
+++ b/tests/nvme_fw_log_test.py
@@ -25,6 +25,7 @@ NVMe Firmware Log Testcase :-
 """
 
 import subprocess
+
 from nose.tools import assert_equal
 from nvme_test import TestNVMe
 

--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -33,6 +33,7 @@ Test the Mandatory features with get features command:-
 """
 
 import subprocess
+
 from nose.tools import assert_equal
 from nvme_test import TestNVMe
 

--- a/tests/nvme_id_ns_test.py
+++ b/tests/nvme_id_ns_test.py
@@ -26,6 +26,7 @@ NVme Identify Namespace Testcase:-
 """
 
 import subprocess
+
 from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
@@ -78,7 +79,7 @@ class TestNVMeIdentifyNamespace(TestNVMe):
                 - 0 on success, error code on failure.
         """
         err = 0
-        for namespace  in self.ns_list:
+        for namespace in self.ns_list:
             err = self.get_id_ns(str(namespace))
         return err
 

--- a/tests/nvme_read_write_test.py
+++ b/tests/nvme_read_write_test.py
@@ -27,6 +27,7 @@ NVMe Read/Write Testcae:-
 """
 
 import filecmp
+
 from nose.tools import assert_equal
 from nvme_test_io import TestNVMeIO
 
@@ -41,6 +42,7 @@ class TestNVMeReadWriteTest(TestNVMeIO):
               - compare_file : data file to use in nvme compare command.
               - test_log_dir : directory for logs, temp files.
     """
+
     def __init__(self):
         """ Pre Section for TestNVMeReadWriteTest """
         TestNVMeIO.__init__(self)

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -20,15 +20,16 @@
 """ Base class for all the testcases
 """
 
-import re
-import os
-import sys
 import json
 import mmap
-import stat
-import time
+import os
+import re
 import shutil
+import stat
 import subprocess
+import sys
+import time
+
 from nose import tools
 from nose.tools import assert_equal
 from nvme_test_logger import TestNVMeLogger

--- a/tests/nvme_test_io.py
+++ b/tests/nvme_test_io.py
@@ -20,6 +20,7 @@
 """ Inherit TestNVMeIO for nvme read/write operations """
 
 import os
+
 from nose import tools
 from nvme_test import TestNVMe
 

--- a/tests/nvme_test_logger.py
+++ b/tests/nvme_test_logger.py
@@ -26,6 +26,7 @@ import sys
 
 class TestNVMeLogger(object):
     """ Represents Logger for NVMe Testframework.  """
+
     def __init__(self, log_file_path):
         """ Logger setup
             - Args:

--- a/tests/nvme_writezeros_test.py
+++ b/tests/nvme_writezeros_test.py
@@ -28,6 +28,7 @@ NVMe Write Zeros:-
 """
 
 import filecmp
+
 from nose.tools import assert_equal
 from nvme_test_io import TestNVMeIO
 
@@ -44,6 +45,7 @@ class TestNVMeWriteZeros(TestNVMeIO):
               - block_count: Number of blocks to use in IO.
               - test_log_dir : directory for logs, temp files.
     """
+
     def __init__(self):
         """ Pre Section for TestNVMeWriteZeros """
         TestNVMeIO.__init__(self)

--- a/tests/run_py_linters.py
+++ b/tests/run_py_linters.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# Copied from https://github.com/python-sdbus/python-sdbus
+# Copyright (C) 2020, 2021 igo95862
+
+# This file is part of nvme-cli
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from os import environ
+from pathlib import Path
+from subprocess import run
+from typing import List
+
+source_root = Path(environ['MESON_SOURCE_ROOT'])
+build_dir = Path(environ['MESON_BUILD_ROOT'])
+
+tests_dir = source_root / 'tests'
+
+all_python_modules = [
+    tests_dir,
+]
+
+mypy_cache_dir = build_dir / '.mypy_cache'
+
+
+def run_mypy(path: Path) -> None:
+    print(f"Running mypy on {path}")
+    run(
+        args=(
+            'mypy', '--strict',
+            '--cache-dir', mypy_cache_dir,
+            '--python-version', '3.8',
+            '--namespace-packages',
+            '--ignore-missing-imports',
+            path,
+        ),
+        check=False,
+        env={'MYPYPATH': str(tests_dir.absolute()), **environ},
+    )
+
+
+def linter_main() -> None:
+    run(
+        args=(
+            'flake8',
+            *all_python_modules,
+        ),
+        check=False,
+    )
+
+    for x in all_python_modules:
+        run_mypy(x)
+
+
+def get_all_python_files() -> List[Path]:
+    python_files: List[Path] = []
+
+    for python_module in all_python_modules:
+        if python_module.is_dir():
+            for a_file in python_module.iterdir():
+                if a_file.suffix == '.py':
+                    python_files.append(a_file)
+        else:
+            python_files.append(python_module)
+
+    return python_files
+
+
+def formater_main() -> None:
+    all_python_files = get_all_python_files()
+
+    run(
+        args=('autopep8', '--in-place', *all_python_files),
+        check=False,
+    )
+
+    run(
+        args=(
+            'isort',
+            '-m', 'VERTICAL_HANGING_INDENT',
+            '--trailing-comma',
+            *all_python_files,
+        ),
+        check=False,
+    )
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument(
+        'mode',
+        choices=('lint', 'format'),
+    )
+
+    args = parser.parse_args()
+
+    mode = args.mode
+
+    if mode == 'lint':
+        linter_main()
+    elif mode == 'format':
+        formater_main()
+    else:
+        raise ValueError('Unknown mode', mode)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When switching from the Makefiles to meson we forgot to add build targets to for Python code linting and formatting. While at also update the documentation,

Fixes: #1396
