### PR TITLE
Initialize create_ns config values

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2294,11 +2294,16 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	struct config cfg = {
+		.nsze		= 0,
+		.ncap		= 0,
 		.flbas		= 0xff,
+		.dps		= 0,
+		.nmic		= 0,
 		.anagrpid	= 0,
 		.nvmsetid	= 0,
 		.bs		= 0x00,
 		.timeout	= 120000,
+		.csi		= 0,
 	};
 
 	OPT_ARGS(opts) = {


### PR DESCRIPTION
If left unspecified by the user default to not using protection
information (dps=0), not being multipath (nmic=0), and using the NVM
command set (csi=0).

Also zero out the nsze and ncap values to avoid using garbage data if
the user forgot to specify one or both.

Fixes issues using uninitialized data.

Signed-off-by: Brandon Paupore <brandon.paupore@wdc.com>