### PR TITLE
connect: Set errno to zero on nvmf_add_ctrl() success

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -688,6 +688,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 		fprintf(stderr, "no controller found: %s\n",
 			nvme_strerror(errno));
 	else {
+		errno = 0;
 		if (flags == NORMAL)
 			print_connect_msg(c);
 		else if (flags == JSON)


### PR DESCRIPTION
The libnvme's nvmf_add_ctrl() might return zero (success) while
having errno set to a non-zero value due to lots of calls inside.
And since nvmf_connect() returns errno primarily, make sure
it's zeroed on success.

See related https://github.com/linux-nvme/libnvme/pull/292