### PR TITLE
Fixup persistent discover controller usage

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -509,7 +509,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 		c = nvme_scan_ctrl(r, device);
 		if (c) {
 			/* Check if device matches command-line options */
-			if (strcmp(nvme_ctrl_get_subsysnqn(c), subsysnqn) ||
+			if (!nvme_ctrl_is_discovery_ctrl(c) ||
 			    strcmp(nvme_ctrl_get_transport(c), transport) ||
 			    strcasecmp(nvme_ctrl_get_traddr(c), traddr) ||
 			    (cfg.host_traddr && nvme_ctrl_get_host_traddr(c) &&

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 8d083ce7f25fccf610ed1de6e10aa16db1920d98
+revision = 67b0d97672024febaa6ba7b2e2cf2cc792162d1b
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
For unique discovery subsystems we fail to pick up persistent discovery controllers.

Fixes issue #1435.

Signed-off-by: Hannes Reinecke <hare@suse.de>