### PR TITLE
nvme-topology: Check if state variable is a valid string

### DIFF
--- a/nvme-topology.c
+++ b/nvme-topology.c
@@ -384,8 +384,9 @@ static int scan_subsystem(struct nvme_subsystem *s, __u32 ns_instance, int nsid)
 			n->name = strdup(ns[i]->d_name);
 			for (j = 0; j < s->nr_ctrls; j++) {
 				n->ctrl = &s->ctrls[j];
-				if (!strcmp(n->ctrl->state, "live") &&
-						!scan_namespace(n))
+				if (n->ctrl->state &&
+				    !strcmp(n->ctrl->state, "live") &&
+				    !scan_namespace(n))
 					break;
 			}
 		}


### PR DESCRIPTION
The state variable might not be initialized at all, that is it can be
NULL. strcmp is not able to handle NULL gracefully.

Fixes: bace574bbe55 ("nvme-topology: fix controller check in scan_subsystem()")
Reported-by: mgerdts (github)
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1426