### PR TITLE
rpm: use meson configuration instead of default macros

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,11 +16,8 @@ project(
 cc = meson.get_compiler('c')
 
 prefixdir  = get_option('prefix')
-libdir     = join_paths(prefixdir, get_option('libdir'))
-includedir = join_paths(prefixdir, get_option('includedir'))
 datadir    = join_paths(prefixdir, get_option('datadir'))
 mandir     = join_paths(prefixdir, get_option('mandir'))
-bindir     = join_paths(prefixdir, get_option('bindir'))
 sbindir    = join_paths(prefixdir, get_option('sbindir'))
 sysconfdir = join_paths(prefixdir, get_option('sysconfdir'))
 
@@ -163,9 +160,11 @@ substs.set('LICENSE', meson.project_license()[0])
 substs.set('UDEVRULESDIR', udevrulesdir)
 substs.set('DRACUTRILESDIR', dracutrulesdir)
 substs.set('REQUIRES', requires)
-substs.set('BINDIR', bindir)
+substs.set('DATADIR', datadir)
+substs.set('MANDIR', mandir)
 substs.set('SBINDIR', sbindir)
 substs.set('SYSCONFDIR', sysconfdir)
+substs.set('SYSTEMDDIR', systemddir)
 substs.set('SYSTEMCTL', get_option('systemctl'))
 
 configure_file(

--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -16,38 +16,38 @@ cli rpm installs core management tools with minimal dependencies.
 
 %install
 meson install --destdir %{buildroot} --skip-subprojects
-touch %{buildroot}%{_prefix}%{_sysconfdir}/nvme/hostnqn
-touch %{buildroot}%{_prefix}%{_sysconfdir}/nvme/hostid
+touch %{buildroot}@SYSCONFDIR@/nvme/hostnqn
+touch %{buildroot}@SYSCONFDIR@/nvme/hostid
 
 %files
 %defattr(-,root,root)
-%{_sbindir}/nvme
-%{_mandir}/man1/nvme*.1*
-%{_datadir}/bash-completion/completions/nvme
-%{_datadir}/zsh/site-functions/_nvme
-%dir %{_prefix}%{_sysconfdir}/nvme
-%{_prefix}%{_sysconfdir}/nvme/hostnqn
-%{_prefix}%{_sysconfdir}/nvme/hostid
-%{_prefix}%{_sysconfdir}/nvme/discovery.conf
-%ghost %{_prefix}%{_sysconfdir}/nvme/config.json
-%{_udevrulesdir}/70-nvmf-autoconnect.rules
-%{_udevrulesdir}/71-nvmf-iopolicy-netapp.rules
+@SBINDIR@/nvme
+@MANDIR@/man1/nvme*.1*
+@DATADIR@/bash-completion/completions/nvme
+@DATADIR@/zsh/site-functions/_nvme
+%dir @SYSCONFDIR@/nvme
+@SYSCONFDIR@/nvme/hostnqn
+@SYSCONFDIR@/nvme/hostid
+@SYSCONFDIR@/nvme/discovery.conf
+%ghost @SYSCONFDIR@/nvme/config.json
+@UDEVRULESDIR@/70-nvmf-autoconnect.rules
+@UDEVRULESDIR@/71-nvmf-iopolicy-netapp.rules
 @DRACUTRILESDIR@/70-nvmf-autoconnect.conf
-%{_unitdir}/nvmf-connect@.service
-%{_unitdir}/nvmefc-boot-connections.service
-%{_unitdir}/nvmf-connect.target
-%{_unitdir}/nvmf-autoconnect.service
+@SYSTEMDDIR@/nvmf-connect@.service
+@SYSTEMDDIR@/nvmefc-boot-connections.service
+@SYSTEMDDIR@/nvmf-connect.target
+@SYSTEMDDIR@/nvmf-autoconnect.service
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %post
 if [ $1 -eq 1 ]; then # 1 : This package is being installed for the first time
-	if [ ! -s %{_prefix}%{_sysconfdir}/nvme/hostnqn ]; then
-		echo $(%{_sbindir}/nvme gen-hostnqn) > %{_prefix}%{_sysconfdir}/nvme/hostnqn
+	if [ ! -s @SYSCONFDIR@/nvme/hostnqn ]; then
+		echo $(@SBINDIR@/nvme gen-hostnqn) > @SYSCONFDIR@/nvme/hostnqn
         fi
-        if [ ! -s %{_prefix}%{_sysconfdir}/nvme/hostid ]; then
-                uuidgen > %{_prefix}%{_sysconfdir}/nvme/hostid
+        if [ ! -s @SYSCONFDIR@/nvme/hostid ]; then
+                uuidgen > @SYSCONFDIR@/nvme/hostid
         fi
 
 	# apply udev and systemd changes that we did


### PR DESCRIPTION
meson:
	remove duplicate line (SYSCONFIGDIR)
	remove unused variables (libdir, includedir, bindir)
	add configuration data of installation directory

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>
