### PR TITLE
nvme: Do not slash escape strings in JSON output

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -57,7 +57,9 @@
 #define json_array_add_value_string(o, v) \
 	json_object_array_add(o, json_object_new_string(v))
 #define json_print_object(o, u)						\
-	printf("%s", json_object_to_json_string_ext(o, JSON_C_TO_STRING_PRETTY))
+	printf("%s", json_object_to_json_string_ext(o,			\
+		JSON_C_TO_STRING_PRETTY |				\
+		JSON_C_TO_STRING_NOSLASHESCAPE))
 #else
 #include "util/json.h"
 #endif


### PR DESCRIPTION
nvme-cli 1.x didn't do any (optional) slash escaping in JSON
output. Don't break backwards compatibility unnecessary.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1411