### PR TITLE
netapp-nvme: fix smdevices segfault in json output

### DIFF
--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -258,7 +258,7 @@ static void netapp_smdevices_print(struct smdevice_info *devices, int count, int
 	else if (format == NJSON) {
 		/* prepare for json output */
 		root = json_create_object();
-		json_devices = json_create_object();
+		json_devices = json_create_array();
 	}
 
 	for (i = 0; i < count; i++) {
@@ -290,6 +290,8 @@ static void netapp_smdevices_print(struct smdevice_info *devices, int count, int
 		/* complete the json output */
 		json_object_add_value_array(root, "SMdevices", json_devices);
 		json_print_object(root, NULL);
+		printf("\n");
+		json_free_object(root);
 	}
 }
 


### PR DESCRIPTION
After the upgrade to libnvme, the NetApp plugin for smdevices
segfaults due to the wrong json object type as shown below:

nvme: json_object.c:1194: json_object_array_add:
Assertion `json_object_get_type(jso) == json_type_array' failed.
Aborted (core dumped)

Fix this by passing the appropriate json array type for smdevices.
Also include a couple of minor changes as well - add a newline to
the end of the json output, and then free the json root device.

Signed-off-by: Martin George <marting@netapp.com>
Tested-by: Clayton Skaggs <claytons@netapp.com>