### PR TITLE
tests: print log info in next line

### DIFF
--- a/tests/nvme_fw_log_test.py
+++ b/tests/nvme_fw_log_test.py
@@ -63,7 +63,7 @@ class TestNVMeFwLogCmd(TestNVMe):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         fw_log_output = proc.communicate()[0]
-        print(fw_log_output + "\n")
+        print("\n" + fw_log_output + "\n")
         err = proc.wait()
         return err
 


### PR DESCRIPTION
printing log info as looks as below
nvme_fw_log_test.TestNVMeFwLogCmd.test_fw_log ...
Firmware Log for device:nvme0
afi  : 0x1
frs1 : xxxxxxx

Signed-off-by: Arunpandian J <apj.arun@samsung.com>