### PR TITLE
nvme_smart_log_test: call smart log for all ns based on LPA 

### DIFF
--- a/tests/nvme_smart_log_test.py
+++ b/tests/nvme_smart_log_test.py
@@ -83,4 +83,6 @@ class TestNVMeSmartLogCmd(TestNVMe):
     def test_smart_log(self):
         """ Testcase main """
         assert_equal(self.get_smart_log_ctrl(), 0)
-        assert_equal(self.get_smart_log_all_ns(), 0)
+        smlp = self.supp_check_id_ctrl("lpa")
+        if smlp & 0x1 == True:
+            assert_equal(self.get_smart_log_all_ns(), 0)

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -478,3 +478,26 @@ class TestNVMe(object):
                                   encoding='utf-8')
         run_io_result = run_io.communicate()[1]
         assert_equal(run_io_result, None)
+
+    def supp_check_id_ctrl(self, key):
+        """ Wrapper for support check.
+            - Args:
+                - key : search key.
+            - Returns:
+                - value for key requested.
+        """
+        id_ctrl = "nvme id-ctrl " + self.ctrl
+        print("\n" + id_ctrl)
+        proc = subprocess.Popen(id_ctrl,
+                                shell=True,
+                                stdout=subprocess.PIPE,
+                                encoding='utf-8')
+        err = proc.wait()
+        assert_equal(err, 0, "ERROR : nvme Identify controller Data \
+                     structure failed")
+        for line in proc.stdout:
+            if key in line:
+                key = line.replace(",", "", 1)
+        print(key)
+        val = (key.split(':'))[1].strip()
+        return int(val, 16)


### PR DESCRIPTION
bug fix - added check condition in nvme_smart_log_test.py to check smart log support per namespace
and call accordingly.
added supp_check_id_ctrl wrapper in nvme_test.py to check support
based on passed key value to make it generic.

Signed-off-by: Arunpandian J <apj.arun@samsung.com>