### PR TITLE
Add lbstm option to create-ns

### DIFF
--- a/Documentation/nvme-create-ns.1
+++ b/Documentation/nvme-create-ns.1
@@ -40,6 +40,7 @@ nvme-create-ns \- Send NVMe Namespace management command to create namespace, re
                         [\-\-anagrp\-id=<anagrpid> | \-a <anagrpid>]
                         [\-\-nvmset\-id=<nvmsetid> | \-i <nvmsetid>]
                         [\-\-csi=<command_set_identifier> | \-y <command_set_identifier>]
+                        [\-\-lbstm=<lbstm> | \-l <lbstm>]
                         [\-\-block\-size=<block\-size> | \-b <block\-size>]
                         [\-\-timeout=<timeout> | \-t <timeout>]
 DESCRIPTION
@@ -94,6 +95,11 @@ This field specifies the identifier of the NVM Set\&.
 \-y <command_set_identifier>, \-\-csi=<command_set_identifier>
 .RS 4
 This field specifies the identifier of command set\&. if not issued, NVM Command Set will be selected\&.
+.RE
+.PP
+\-l <lbstm>, \-\-lbstm=<lbstm>
+.RS 4
+Logical Block Storage Tag Mask for end-to-end protection\&.
 .RE
 .PP
 \-b, \-\-block\-size

--- a/Documentation/nvme-create-ns.html
+++ b/Documentation/nvme-create-ns.html
@@ -757,6 +757,7 @@ nvme-create-ns(1) Manual Page
                         [--anagrp-id=&lt;anagrpid&gt; | -a &lt;anagrpid&gt;]
                         [--nvmset-id=&lt;nvmsetid&gt; | -i &lt;nvmsetid&gt;]
                         [--csi=&lt;command_set_identifier&gt; | -y &lt;command_set_identifier&gt;]
+                        [--lbstm=&lt;lbstm&gt; | -l &lt;lbstm&gt;]
                         [--block-size=&lt;block-size&gt; | -b &lt;block-size&gt;]
                         [--timeout=&lt;timeout&gt; | -t &lt;timeout&gt;]
 DESCRIPTION</pre>
@@ -863,6 +864,17 @@ OPTIONS</code></pre>
 <p>
         This field specifies the identifier of command set.
         if not issued, NVM Command Set will be selected.
+</p>
+</dd>
+<dt class="hdlist1">
+-l &lt;lbstm&gt;
+</dt>
+<dt class="hdlist1">
+--lbstm=&lt;lbstm&gt;
+</dt>
+<dd>
+<p>
+        Logical Block Storage Tag Mask for end-to-end protection.
 </p>
 </dd>
 <dt class="hdlist1">

--- a/Documentation/nvme-create-ns.txt
+++ b/Documentation/nvme-create-ns.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 			[--anagrp-id=<anagrpid> | -a <anagrpid>]
 			[--nvmset-id=<nvmsetid> | -i <nvmsetid>]
 			[--csi=<command_set_identifier> | -y <command_set_identifier>]
+			[--lbstm=<lbstm> | -l <lbstm>]
 			[--block-size=<block-size> | -b <block-size>]
 			[--timeout=<timeout> | -t <timeout>]
 DESCRIPTION
@@ -63,6 +64,10 @@ OPTIONS
 --csi=<command_set_identifier>::
 	This field specifies the identifier of command set.
 	if not issued, NVM Command Set will be selected.
+
+-l <lbstm>::
+--lbstm=<lbstm>::
+	Logical Block Storage Tag Mask for end-to-end protection.
 
 -b::
 --block-size::

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 131ee681a0e394b291cd407442886dbdf9fe124c
+revision = f21bb58eb8e4ee7820a9c043aa031565305afc9d
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Depends on changes in libnvme commit f054255, including removing nvme_init_id_ns and instead just setting fields directly in create_ns.

Signed-off-by: Brandon Paupore <brandon.paupore@wdc.com>