### PR TITLE
fabrics: Introduce force flag to overwrite persistence logic

### DIFF
--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -33,6 +33,7 @@ SYNOPSIS
 		[--quiet                  | -S]
 		[--dump-config            | -O]
 		[--output-format=<fmt>    | -o <fmt>]
+		[--force]
 
 DESCRIPTION
 -----------
@@ -207,6 +208,11 @@ OPTIONS
 --output-format=<format>::
               Set the reporting format to 'normal', 'json', or
               'binary'. Only one output format can be used at a time.
+
+--force::
+	Disable the built-in persitent discover connection rules.
+	Combined with --persistent flag, always create new
+	persistent discovery connection.
 
 EXAMPLES
 --------

--- a/common.h
+++ b/common.h
@@ -1,6 +1,8 @@
 #ifndef _COMMON_H
 #define _COMMON_H
 
+#include <string.h>
+
 #include "ccan/endian/endian.h"
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))

--- a/fabrics.c
+++ b/fabrics.c
@@ -524,6 +524,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 					"ignoring ctrl device %s, "
 					"command-line options do not match\n",
 					device);
+				nvme_free_ctrl(c);
 				c = NULL;
 				persistent = false;
 			} else {


### PR DESCRIPTION
The persistence flag will be overwritten by the built in logic. Allow
the user to overwrite this by providing a force command line option.

The code is a bit hard to follow, hence linearize it using forward
jumps. This allows use to centralize the overwrite logic and reduces
my head to hurt.

Signed-off-by: Daniel Wagner <dwagner@suse.de>


There is the wish to bring back a feature from 1.x branch which allows
the user always to create new discovery connection. This was done
in 1.x by looking at the KATO value. But this seems a bit fragile.
So I think it's better to introduce a explicit --force flag to overwrite
the logic.
See also:  https://github.com/linux-nvme/nvme-cli/commit/14d0e0f7e0c1b420da65783881c064e49ac7d6d7
