### PR TITLE
Nvme 2.0 Changes

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -27,6 +27,7 @@ adoc_sources = [
   'nvme-endurance-log',
   'nvme-error-log',
   'nvme-fid-support-effects-log',
+  'nvme-mi-cmd-support-effects-log',
   'nvme-flush',
   'nvme-format',
   'nvme-fw-commit',

--- a/Documentation/nvme-mi-cmd-support-effects-log.txt
+++ b/Documentation/nvme-mi-cmd-support-effects-log.txt
@@ -1,0 +1,45 @@
+nvme-mi-cmd-support-effects-log(1)
+==================================
+
+NAME
+----
+nvme-mi-cmd-support-effects-log - Send NVMe MI Command Support and Effects log,
+                                  returns results and structure
+
+SYNOPSIS
+--------
+[verse]
+'nvme-mi-cmd-support-effects-log' <device> [-o <fmt> | --output-format=<fmt>]
+					[-H | --human-readable]
+
+DESCRIPTION
+-----------
+For the NVMe device given, sends an MI Command Support and Effects log (id 13h)
+and provides the result and returned log structure.
+
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
+
+On success, the structure may be returned in one of several ways depending
+on the option flags; the structure may be parsed by the program or the
+raw buffer may be printed to stdout.
+
+OPTIONS
+-------
+-o <format>::
+--output-format=<format>::
+    Set the reporting format to 'normal', 'json', or
+    'binary'. Only one output format can be used at a time.
+
+-H::
+--human-readable::
+	This option will parse and format many of the bit fields
+	into human-readable formats.
+
+EXAMPLES
+--------
+nvme mi-cmd-support-effects-log /dev/nvme0 -H
+
+NVME
+----
+Part of the nvme-user suite

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -53,6 +53,7 @@ COMMAND_LIST(
 	ENTRY("self-test-log", "Retrieve the SELF-TEST Log, show it", self_test_log)
 	ENTRY("supported-log-pages", "Retrieve the Supported Log pages details, show it", get_supported_log_pages)
 	ENTRY("fid-support-effects-log", "Retrieve FID Support and Effects log and show it", get_fid_support_effects_log)
+	ENTRY("mi-cmd-support-effects-log", "Retrieve MI Command Support and Effects log and show it", get_mi_cmd_support_effects_log)
 	ENTRY("media-unit-stat-log", "Retrieve the configuration and wear of media units, show it", get_media_unit_stat_log)
 	ENTRY("supported-cap-config-log", "Retrieve the list of Supported Capacity Configuration Descriptors", get_supp_cap_config_log)
 	ENTRY("set-feature", "Set a feature and show the resulting value", set_feature)

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4014,6 +4014,17 @@ static void nvme_show_id_ns_fpi(__u8 fpi)
 	printf("\n");
 }
 
+static void nvme_show_id_ns_nsattr(__u8 nsattr)
+{
+	__u8 rsvd = (nsattr & 0xFE) >> 1;
+	__u8 write_protected = nsattr & 0x1;
+	if (rsvd)
+		printf("  [7:1] : %#x\tReserved\n", rsvd);
+	printf("  [0:0] : %#x\tNamespace %sWrite Protected\n",
+			write_protected, write_protected ? "" : "Not ");
+	printf("\n");
+}
+
 static void nvme_show_id_ns_dlfeat(__u8 dlfeat)
 {
 	__u8 rsvd = (dlfeat & 0xE0) >> 5;
@@ -4223,6 +4234,8 @@ void nvme_show_cmd_set_independent_id_ns(
 		nvme_show_id_ns_fpi(ns->fpi);
 	printf("anagrpid: %u\n", le32_to_cpu(ns->anagrpid));
 	printf("nsattr	: %u\n", ns->nsattr);
+	if (human)
+		nvme_show_id_ns_nsattr(ns->nsattr);
 	printf("nvmsetid: %d\n", le16_to_cpu(ns->nvmsetid));
 	printf("endgid  : %d\n", le16_to_cpu(ns->endgid));
 

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -75,6 +75,8 @@ void nvme_show_boot_part_log(void *bp_log, const char *devname,
 	__u32 size, enum nvme_print_flags flags);
 void nvme_show_fid_support_effects_log(struct nvme_fid_supported_effects_log *fid_log,
 	const char *devname, enum nvme_print_flags flags);
+void nvme_show_mi_cmd_support_effects_log(struct nvme_mi_cmd_supported_effects_log *mi_cmd_log,
+	const char *devname, enum nvme_print_flags flags);
 void nvme_show_media_unit_stat_log(struct nvme_media_unit_stat_log *mus,
 	enum nvme_print_flags flags);
 void nvme_show_supported_cap_config_log(struct nvme_supported_cap_config_list_log *caplog,


### PR DESCRIPTION
Added get_mi_cmd_support_effects_log and help text
Print out new persistent_event_log fields - ehai and pelpid
Added function to print the ID NS NSATTR field in human readable text
Dependent on libnvme commit 3dc85542e84c6ffaff86bea4ca754ccbf75bf89c.  I updated subprojects/libnvme.wrap.  Not sure if there on any other requirements for dependent changes.  