### PR TITLE
nvme: use filter for 'list-subsys <devname>'

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2429,6 +2429,27 @@ ret:
 	return err;
 }
 
+static bool nvme_match_device_filter(nvme_subsystem_t s)
+{
+	nvme_ctrl_t c;
+	nvme_ns_t n;
+
+	if (!devicename || !strlen(devicename))
+		return true;
+
+	nvme_subsystem_for_each_ctrl(s, c) {
+		if (strcmp(devicename, nvme_ctrl_get_name(c)) >= 0)
+			return true;
+	}
+
+	nvme_subsystem_for_each_ns(s, n) {
+		if (!strcmp(devicename, nvme_ns_get_name(n)))
+			return true;
+	}
+
+	return false;
+}
+
 static int list_subsys(int argc, char **argv, struct command *cmd,
 		struct plugin *plugin)
 {
@@ -2436,6 +2457,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	enum nvme_print_flags flags;
 	const char *desc = "Retrieve information for subsystems";
 	const char *verbose = "Increase output verbosity";
+	nvme_scan_filter_t filter = NULL;
 	__u32 nsid = NVME_NSID_ALL;
 	int err;
 
@@ -2486,24 +2508,18 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	}
 
 	if (devicename) {
-		const char *n;
-		char *eptr = NULL;
+		int subsys_num;
 
-		n = strrchr(devicename, 'n');
-		if (!n) {
+		if (sscanf(devicename,"nvme%dn%d",
+			   &subsys_num, &nsid) != 2) {
 			fprintf(stderr, "Invalid device name %s\n", devicename);
 			err = -EINVAL;
 			goto ret;
 		}
-		nsid = strtoul(n + 1, &eptr, 10);
-		if (eptr == n + 1) {
-			fprintf(stderr, "Invalid device nsid %s\n", devicename);
-			err = -EINVAL;
-			goto ret;
-		}
+		filter = nvme_match_device_filter;
 	}
 
-	err = nvme_scan_topology(r, NULL);
+	err = nvme_scan_topology(r, filter);
 	if (err) {
 		fprintf(stderr, "Failed to scan topology: %s\n",
 			nvme_strerror(errno));

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = f21bb58eb8e4ee7820a9c043aa031565305afc9d
+revision = 39af9fccfb5c4de5c32b890eaf4f9fbca71dbf19
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
When a device name is specified for 'nvme list-subsys' we should
be printing out only those parts of the tree which relate to the
specified device name, not the entire tree.

Signed-off-by: Hannes Reinecke <hare@suse.de>