### PR TITLE
argconfig: Do not use default value loading by getopt_long_only

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -74,8 +74,8 @@ struct feat_cfg {
 	__u32 cdw11;
 	__u8  uuid_index;
 	__u32 data_len;
-	int  raw_binary;
-	int  human_readable;
+	bool  raw_binary;
+	bool  human_readable;
 };
 
 static struct stat nvme_stat;
@@ -318,15 +318,15 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	struct config {
 		__u32	namespace_id;
 		char	*output_format;
-		int	raw_binary;
-		int	human_readable;
+		bool	raw_binary;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.namespace_id	= NVME_NSID_ALL,
 		.output_format	= "normal",
-		.raw_binary	= 0,
-		.human_readable	= 0,
+		.raw_binary	= false,
+		.human_readable	= false,
 	};
 
 
@@ -450,13 +450,13 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 	struct config {
 		char	*file_name;
 		__u32	host_gen;
-		int	ctrl_init;
+		bool	ctrl_init;
 		int	data_area;
 	};
 	struct config cfg = {
 		.file_name	= NULL,
 		.host_gen	= 1,
-		.ctrl_init	= 0,
+		.ctrl_init	= false,
 		.data_area	= 3,
 	};
 
@@ -620,15 +620,15 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 
 	struct config {
 		char	*output_format;
-		int	human_readable;
-		int	raw_binary;
+		bool	human_readable;
+		bool	raw_binary;
 		int	csi;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.human_readable	= 0,
-		.raw_binary	= 0,
+		.human_readable	= false,
+		.raw_binary	= false,
 		.csi		= -1,
 	};
 
@@ -712,12 +712,12 @@ static int get_supported_log_pages(int argc, char **argv, struct command *cmd,
 
 	struct config {
 		char	*output_format;
-		int	verbose;
+		bool	verbose;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.verbose	= 0
+		.verbose	= false
 	};
 
 	OPT_ARGS(opts) = {
@@ -767,13 +767,13 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	struct config {
 		__u32	log_entries;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.log_entries	= 64,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -841,12 +841,12 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 
 	struct config {
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -890,12 +890,12 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 
 	struct config {
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -944,13 +944,13 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 	struct config {
 		__u16	nvmset_id;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.nvmset_id	= 1,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1007,14 +1007,14 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 		__u64	log_entries;
 		bool	rae;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.log_entries	= 2044,
 		.rae		= false,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1096,14 +1096,14 @@ static int get_persistent_event_log(int argc, char **argv,
 		__u8	action;
 		__u32	log_len;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.action		= 0xff,
 		.log_len	= 0,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1227,14 +1227,14 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 		__u64	log_entries;
 		bool	rae;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.log_entries	= 2044,
 		.rae		= false,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1536,13 +1536,13 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *cmd,
 	struct config {
 		__u16	domainid;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.domainid	= 0,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1592,13 +1592,13 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *cmd,
 	struct config {
 		__u16	domainid;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.domainid	= 0,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1661,11 +1661,11 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		__u64	lpo;
 		__u8	lsp;
 		__u16	lsi;
-		int	rae;
+		bool	rae;
 		__u8	uuid_index;
-		int	raw_binary;
+		bool	raw_binary;
 		__u8	csi;
-		int	ot;
+		bool	ot;
 	};
 
 	struct config cfg = {
@@ -1676,11 +1676,11 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		.lpo		= NVME_LOG_LPO_NONE,
 		.lsp		= NVME_LOG_LSP_NONE,
 		.lsi		= NVME_LOG_LSI_NONE,
-		.rae		= 0,
+		.rae		= false,
 		.uuid_index	= NVME_UUID_NONE,
-		.raw_binary	= 0,
+		.raw_binary	= false,
 		.csi		= NVME_CSI_NVM,
-		.ot		= 0,
+		.ot		= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1784,15 +1784,15 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	struct config {
 		bool	rae;
 		char	*output_format;
-		int	human_readable;
-		int	raw_binary;
+		bool	human_readable;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.rae		= false,
 		.output_format	= "normal",
-		.human_readable	= 0,
-		.raw_binary	= 0,
+		.human_readable	= false,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1840,12 +1840,12 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 
 	struct config {
 		char	*output_format;
-		int	human_readable;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.human_readable	= 0,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -1954,15 +1954,15 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	struct config {
 		__u32	namespace_id;
-		int	all;
 		int	csi;
+		bool	all;
 		char	*output_format;
 	};
 
 	struct config cfg = {
 		.namespace_id	= 1,
 		.csi		= -1,
-		.all		= 0,
+		.all		= false,
 		.output_format = "normal",
 	};
 
@@ -2038,14 +2038,14 @@ static int id_ns_lba_format(int argc, char **argv, struct command *cmd, struct p
 	struct config {
 		__u16	lba_format_index;
 		__u8	uuid_index;
-		int	verbose;
+		bool	verbose;
 		char	*output_format;
 	};
 
 	struct config cfg = {
 		.lba_format_index	= 0,
 		.uuid_index		= NVME_UUID_NONE,
-		.verbose		= 0,
+		.verbose		= false,
 		.output_format		= "normal",
 	};
 
@@ -2527,12 +2527,12 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 
 	struct config {
 		char	*output_format;
-		int	verbose;
+		bool	verbose;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.verbose	= 0,
+		.verbose	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -2590,17 +2590,17 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	int err, fd;
 
 	struct config {
-		int	vendor_specific;
+		bool	vendor_specific;
 		char	*output_format;
-		int	raw_binary;
-		int	human_readable;
+		bool	raw_binary;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
-		.vendor_specific	= 0,
+		.vendor_specific	= false,
 		.output_format		= "normal",
-		.raw_binary		= 0,
-		.human_readable		= 0,
+		.raw_binary		= false,
+		.human_readable		= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -2705,14 +2705,14 @@ static int nvm_id_ns(int argc, char **argv, struct command *cmd,
 		__u32	namespace_id;
 		__u8	uuid_index;
 		char	*output_format;
-		int	verbose;
+		bool	verbose;
 	};
 
 	struct config cfg = {
 		.namespace_id	= 0,
 		.uuid_index	= NVME_UUID_NONE,
 		.output_format	= "normal",
-		.verbose	= 0,
+		.verbose	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -2780,14 +2780,14 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *cmd, stru
 	struct config {
 		__u16	lba_format_index;
 		__u8	uuid_index;
-		int	verbose;
+		bool	verbose;
 		char	*output_format;
 	};
 
 	struct config cfg = {
 		.lba_format_index	= 0,
 		.uuid_index		= NVME_UUID_NONE,
-		.verbose		= 0,
+		.verbose		= false,
 		.output_format		= "normal",
 	};
 
@@ -2844,13 +2844,13 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 	struct config {
 		__u32	namespace_id;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.namespace_id	= 0,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -2915,20 +2915,20 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 
 	struct config {
 		__u32	namespace_id;
-		int	force;
-		int	vendor_specific;
-		int	raw_binary;
+		bool	force;
+		bool	vendor_specific;
+		bool	raw_binary;
 		char	*output_format;
-		int	human_readable;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.namespace_id		= 0,
-		.force			= 0,
-		.vendor_specific	= 0,
-		.raw_binary		= 0,
+		.force			= false,
+		.vendor_specific	= false,
+		.raw_binary		= false,
 		.output_format		= "normal",
-		.human_readable		= 0,
+		.human_readable		= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -2996,16 +2996,16 @@ static int cmd_set_independent_id_ns(int argc, char **argv,
 
 	struct config {
 		__u32	namespace_id;
-		int	raw_binary;
+		bool	raw_binary;
 		char	*output_format;
-		int	human_readable;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.namespace_id	= 0,
-		.raw_binary	= 0,
+		.raw_binary	= false,
 		.output_format	= "normal",
-		.human_readable	= 0,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -3164,14 +3164,14 @@ static int id_uuid(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	struct config {
 		char	*output_format;
-		int	raw_binary;
-		int	human_readable;
+		bool	raw_binary;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.raw_binary	= 0,
-		.human_readable	= 0,
+		.raw_binary	= false,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -3413,13 +3413,13 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *cmd, struct 
 	struct config {
 		__u16	cntlid;
 		char	*output_format;
-		int	human_readable;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.cntlid		= 0,
 		.output_format	= "normal",
-		.human_readable	= 0,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -3597,13 +3597,13 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 	struct config {
 		__u8	dst_entries;
 		char	*output_format;
-		int	verbose;
+		bool	verbose;
 	};
 
 	struct config cfg = {
 		.dst_entries	= NVME_LOG_ST_MAX_RESULTS,
 		.output_format	= "normal",
-		.verbose	= 0,
+		.verbose	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -3789,10 +3789,10 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 		.namespace_id	= 0,
 		.sel		= 0,
 		.data_len	= 0,
-		.raw_binary	= 0,
+		.raw_binary	= false,
 		.cdw11		= 0,
 		.uuid_index	= 0,
-		.human_readable	= 0,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -4160,19 +4160,19 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	int fd, err;
 
 	struct config {
-		int	no_dealloc;
-		int	oipbp;
+		bool	no_dealloc;
+		bool	oipbp;
 		__u8	owpass;
-		int	ause;
+		bool	ause;
 		__u8	sanact;
 		__u32	ovrpat;
 	};
 
 	struct config cfg = {
-		.no_dealloc	= 0,
-		.oipbp		= 0,
+		.no_dealloc	= false,
+		.oipbp		= false,
 		.owpass		= 0,
-		.ause		= 0,
+		.ause		= false,
 		.sanact		= 0,
 		.ovrpat		= 0,
 	};
@@ -4347,12 +4347,12 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 
 	struct config {
 		char	*output_format;
-		int	human_readable;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.human_readable	= 0,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -4407,12 +4407,12 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 
 	struct config {
 		int	offset;
-		int	human_readable;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.offset		= -1,
-		.human_readable	= 0,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -4546,8 +4546,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		__u8	pi;
 		__u8	pil;
 		__u8	ms;
-		int	reset;
-		int	force;
+		bool	reset;
+		bool	force;
 		__u64	bs;
 	};
 
@@ -4559,8 +4559,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		.pi		= 0,
 		.pil		= 0,
 		.ms		= 0,
-		.reset		= 0,
-		.force		= 0,
+		.reset		= false,
+		.force		= false,
 		.bs		= 0,
 	};
 
@@ -4814,7 +4814,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 		__u8	uuid_index;
 		__u32	data_len;
 		char	*file;
-		int	save;
+		bool	save;
 	};
 
 	struct config cfg = {
@@ -4824,7 +4824,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 		.uuid_index	= 0,
 		.data_len	= 0,
 		.file		= "",
-		.save		= 0,
+		.save		= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -5112,8 +5112,8 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		__u16	dspec;
 		__u8	doper;
 		__u16	endir;
-		int	human_readable;
-		int	raw_binary;
+		bool	human_readable;
+		bool	raw_binary;
 		char	*file;
 	};
 
@@ -5125,8 +5125,8 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		.dspec		= 0,
 		.doper		= 0,
 		.endir		= 1,
-		.human_readable	= 0,
-		.raw_binary	= 0,
+		.human_readable	= false,
+		.raw_binary	= false,
 		.file		= "",
 	};
 
@@ -5338,29 +5338,30 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		__u32	namespace_id;
 		__u64	start_block;
 		__u16	block_count;
-		int	deac;
-		int	limited_retry;
-		int	force_unit_access;
+		bool	deac;
+		bool	limited_retry;
+		bool	force_unit_access;
 		__u8	prinfo;
 		__u32	ref_tag;
 		__u16	app_tag_mask;
 		__u16	app_tag;
 		__u64	storage_tag;
-		int	storage_tag_check;
+		bool	storage_tag_check;
 	};
 
 	struct config cfg = {
 		.namespace_id		= 0,
 		.start_block		= 0,
 		.block_count		= 0,
-		.deac			= 0,
-		.limited_retry		= 0,
+		.deac			= false,
+		.limited_retry		= false,
+		.force_unit_access	= false,
 		.prinfo			= 0,
 		.ref_tag		= 0,
 		.app_tag_mask		= 0,
 		.app_tag		= 0,
 		.storage_tag		= 0,
-		.storage_tag_check	= 0,
+		.storage_tag_check	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -5460,9 +5461,9 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 		char	*ctx_attrs;
 		char	*blocks;
 		char	*slbas;
-		int	ad;
-		int	idw;
-		int	idr;
+		bool	ad;
+		bool	idw;
+		bool	idr;
 		__u32	cdw11;
 	};
 
@@ -5471,9 +5472,9 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 		.ctx_attrs	= "",
 		.blocks		= "",
 		.slbas		= "",
-		.ad		= 0,
-		.idw		= 0,
-		.idr		= 0,
+		.ad		= false,
+		.idw		= false,
+		.idr		= false,
 		.cdw11		= 0,
 	};
 
@@ -5577,8 +5578,8 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 		__u64	sdlba;
 		char	*slbas;
 		char	*nlbs;
-		int	lr;
-		int	fua;
+		bool	lr;
+		bool	fua;
 		__u8	prinfow;
 		__u8	prinfor;
 		__u32	ilbrt;
@@ -5597,8 +5598,8 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 		.sdlba		= 0,
 		.slbas		= "",
 		.nlbs		= "",
-		.lr		= 0,
-		.fua		= 0,
+		.lr		= false,
+		.fua		= false,
 		.prinfow	= 0,
 		.prinfor	= 0,
 		.ilbrt		= 0,
@@ -5765,7 +5766,7 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 		__u64	prkey;
 		__u8	rtype;
 		__u8	racqa;
-		int	iekey;
+		bool	iekey;
 	};
 
 	struct config cfg = {
@@ -5774,7 +5775,7 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 		.prkey		= 0,
 		.rtype		= 0,
 		.racqa		= 0,
-		.iekey		= 0,
+		.iekey		= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -5849,7 +5850,7 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 		__u64	nrkey;
 		__u8	rrega;
 		__u8	cptpl;
-		int	iekey;
+		bool	iekey;
 	};
 
 	struct config cfg = {
@@ -5857,7 +5858,7 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 		.crkey		= 0,
 		.nrkey		= 0,
 		.rrega		= 0,
-		.cptpl		= 0,
+		.cptpl		= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -6024,15 +6025,15 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 		__u32	numd;
 		__u8	eds;
 		char	*output_format;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
 		.namespace_id	= 0,
 		.numd		= 0,
-		.eds		= 0,
+		.eds		= false,
 		.output_format	= "normal",
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -6163,16 +6164,16 @@ static int submit_io(int opcode, char *command, const char *desc,
 		__u16	app_tag_mask;
 		__u16	app_tag;
 		__u64	storage_tag;
-		int	limited_retry;
-		int	force_unit_access;
-		int	storage_tag_check;
+		bool	limited_retry;
+		bool	force_unit_access;
+		bool	storage_tag_check;
 		__u8	dtype;
 		__u16	dspec;
 		__u8	dsmgmt;
-		int	show;
-		int	dry_run;
-		int	latency;
-		int	force;
+		bool	show;
+		bool	dry_run;
+		bool	latency;
+		bool	force;
 	};
 
 	struct config cfg = {
@@ -6188,16 +6189,16 @@ static int submit_io(int opcode, char *command, const char *desc,
 		.app_tag_mask		= 0,
 		.app_tag		= 0,
 		.storage_tag		= 0,
-		.limited_retry		= 0,
-		.force_unit_access	= 0,
-		.storage_tag_check	= 0,
+		.limited_retry		= false,
+		.force_unit_access	= false,
+		.storage_tag_check	= false,
 		.dtype			= 0,
 		.dspec			= 0,
 		.dsmgmt			= 0,
-		.show			= 0,
-		.dry_run		= 0,
-		.latency		= 0,
-		.force			= 0,
+		.show			= false,
+		.dry_run		= false,
+		.latency		= false,
+		.force			= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -6499,28 +6500,28 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		__u32	namespace_id;
 		__u64	start_block;
 		__u16	block_count;
-		int	limited_retry;
-		int	force_unit_access;
+		bool	limited_retry;
+		bool	force_unit_access;
 		__u8	prinfo;
 		__u32	ref_tag;
 		__u16	app_tag;
 		__u16	app_tag_mask;
 		__u64	storage_tag;
-		int	storage_tag_check;
+		bool	storage_tag_check;
 	};
 
 	struct config cfg = {
 		.namespace_id		= 0,
 		.start_block		= 0,
 		.block_count		= 0,
-		.limited_retry		= 0,
-		.force_unit_access	= 0,
+		.limited_retry		= false,
+		.force_unit_access	= false,
 		.prinfo			= 0,
 		.ref_tag		= 0,
 		.app_tag		= 0,
 		.app_tag_mask		= 0,
 		.storage_tag		= 0,
-		.storage_tag_check	= 0,
+		.storage_tag_check	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -6616,7 +6617,7 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 		__u8	secp;
 		__u16	spsp;
 		__u32	al;
-		int	raw_binary;
+		bool	raw_binary;
 	};
 
 	struct config cfg = {
@@ -6626,7 +6627,7 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 		.secp		= 0,
 		.spsp		= 0,
 		.al		= 0,
-		.raw_binary	= 0,
+		.raw_binary	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -6886,23 +6887,23 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 	struct config {
 		__u32	namespace_id;
 		__u32	data_len;
-		int	raw_binary;
+		bool	raw_binary;
 		__u8	dtype;
 		__u16	dspec;
 		__u8	doper;
 		__u16	nsr; /* dw12 for NVME_DIR_ST_RCVOP_STATUS */
-		int	human_readable;
+		bool	human_readable;
 	};
 
 	struct config cfg = {
 		.namespace_id	= 1,
 		.data_len	= 0,
-		.raw_binary	= 0,
+		.raw_binary	= false,
 		.dtype		= 0,
 		.dspec		= 0,
 		.doper		= 0,
 		.nsr		= 0,
-		.human_readable	= 0,
+		.human_readable	= false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -7163,13 +7164,13 @@ static int passthru(int argc, char **argv, bool admin,
 		__u32	cdw15;
 		char	*input_file;
 		char	*metadata;
-		int	raw_binary;
-		int	show_command;
-		int	dry_run;
-		int	read;
-		int	write;
+		bool	raw_binary;
+		bool	show_command;
+		bool	dry_run;
+		bool	read;
+		bool	write;
 		__u8	prefill;
-		int	latency;
+		bool	latency;
 	};
 
 	struct config cfg = {
@@ -7191,12 +7192,12 @@ static int passthru(int argc, char **argv, bool admin,
 		.cdw15		= 0,
 		.input_file	= "",
 		.metadata	= "",
-		.raw_binary	= 0,
-		.show_command	= 0,
-		.dry_run	= 0,
-		.read		= 0,
-		.write		= 0,
-		.latency	= 0,
+		.raw_binary	= false,
+		.show_command	= false,
+		.dry_run	= false,
+		.read		= false,
+		.write		= false,
+		.latency	= false,
 	};
 
 	OPT_ARGS(opts) = {

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1537,8 +1537,8 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"enable", 'e', "", CFG_NONE, &cfg.enable, no_argument, enable_desc},
-		{"disable", 'd', "", CFG_NONE, &cfg.disable, no_argument, disable_desc},
+		{"enable", 'e', "", CFG_FLAG, &cfg.enable, no_argument, enable_desc},
+		{"disable", 'd', "", CFG_FLAG, &cfg.disable, no_argument, disable_desc},
 		{NULL}
 	};
 

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -347,8 +347,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 
 	struct config {
 		__u32 namespace_id;
-		int   raw_binary;
-		int   json;
+		bool  raw_binary;
+		bool  json;
 	};
 
 	struct config cfg = {
@@ -389,7 +389,7 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 	int err, fd;
 
 	struct config {
-		int  raw_binary;
+		bool  raw_binary;
 	};
 
 	struct config cfg = {
@@ -449,7 +449,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 	const char *desc = "Get Temperature Statistics log and show it.";
 	const char *raw = "dump output in binary format";
 	struct config {
-		int  raw_binary;
+		bool  raw_binary;
 	};
 
 	struct config cfg = {
@@ -1032,9 +1032,9 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	const char *write = "Get write statistics (read default)";
 
 	struct config {
-		int  raw_binary;
-		int json;
-		int  write;
+		bool raw_binary;
+		bool json;
+		bool write;
 	};
 
 	struct config cfg = {
@@ -1637,12 +1637,12 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 	__u32 result;
 
 	struct config {
-		int write;
+		bool write;
 		char *bucket_thresholds;
 	};
 
 	struct config cfg = {
-		.write = 0,
+		.write = false,
 		.bucket_thresholds = "",
 	};
 

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -1148,8 +1148,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"enable", 'e', "", CFG_NONE, &cfg.enable, no_argument, enable_desc},
-		{"disable", 'd', "", CFG_NONE, &cfg.disable, no_argument, disable_desc},
+		{"enable", 'e', "", CFG_FLAG, &cfg.enable, no_argument, enable_desc},
+		{"disable", 'd', "", CFG_FLAG, &cfg.disable, no_argument, disable_desc},
 		{NULL}
 	};
 

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -439,7 +439,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 	const char *raw = "dump output in binary format";
 	struct config {
 		__u32 namespace_id;
-		int   raw_binary;
+		bool  raw_binary;
 	};
 
 	struct config cfg = {
@@ -531,7 +531,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     struct config {
         __u32 feature_id;
         __u32 value;
-        int   save;
+        bool  save;
     };
 
     struct config cfg = {
@@ -1022,7 +1022,7 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, st
     const char *write = "Get write statistics (read default)";
 
     struct config {
-        int  write;
+        bool  write;
     };
     struct config cfg = {
         .write = 0,

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -338,8 +338,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	const char *json= "Dump output in json format";
 	struct config {
 		__u32 namespace_id;
-		int   raw_binary;
-		int   json;
+		bool  raw_binary;
+		bool  json;
 	};
 
 	struct config cfg = {
@@ -422,8 +422,8 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	const char *raw = "dump output in binary format";
 	const char *write = "Get write statistics (read default)";
 	struct config {
-		int  raw_binary;
-		int  write;
+		bool raw_binary;
+		bool write;
 	};
 
 	struct config cfg = {
@@ -607,8 +607,8 @@ static int query_cap_info(int argc, char **argv, struct command *cmd, struct plu
 	const char *raw = "dump output in binary format";
 	const char *json= "Dump output in json format";
 	struct config {
-		int   raw_binary;
-		int   json;
+		bool  raw_binary;
+		bool  json;
 	};
 	struct config cfg;
 
@@ -736,9 +736,9 @@ static int change_cap(int argc, char **argv, struct command *cmd, struct plugin 
 	struct config {
 		__u64 cap_in_byte;
 		__u32 capacity_in_gb;
-		int   raw_binary;
-		int   json;
-		int   force;
+		bool  raw_binary;
+		bool  json;
+		bool  force;
 	};
 
 	struct config cfg = {
@@ -853,7 +853,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *cmd, struct pl
 		__u32 namespace_id;
 		__u32 feature_id;
 		__u32 value;
-		__u32 force;
+		bool  force;
 	};
 	struct config cfg = {
 		.namespace_id = 1,

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1025,7 +1025,7 @@ static int vs_clr_pcie_correctable_errs(int argc, char **argv, struct command *c
 	__u32 result;
 
 	struct config {
-		int   save;
+		bool   save;
 	};
 
 	struct config cfg = {
@@ -1068,7 +1068,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 	struct config {
 		__u32 namespace_id;
 		__u32 log_id;
-		int   raw_binary;
+		bool  raw_binary;
 	};
 
 	struct config cfg = {
@@ -1182,7 +1182,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 	struct config {
 		__u32 namespace_id;
-		int   raw_binary;
+		bool  raw_binary;
 	};
 
 	struct config cfg = {

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -123,7 +123,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	const char *raw = "dump output in binary format";
 	struct config {
 		__u32 namespace_id;
-		int   raw_binary;
+		bool  raw_binary;
 	};
 
 	struct config cfg = {
@@ -180,8 +180,8 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 		__u8  sel;
 		__u32 cdw11;
 		__u32 data_len;
-		int  raw_binary;
-		int  human_readable;
+		bool  raw_binary;
+		bool  human_readable;
 	};
 
 	struct config cfg = {
@@ -293,7 +293,7 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 		__u32 feature_id;
 		__u32 value;
 		__u32 data_len;
-		int   save;
+		bool  save;
 	};
 
 	struct config cfg = {

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -2975,7 +2975,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *command
 		__u64 file_size;
 		__u64 offset;
 		char *type;
-		int verbose;
+		bool verbose;
 	};
 
 	struct config cfg = {
@@ -2985,7 +2985,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *command
 		.file_size = 0,
 		.offset = 0,
 		.type = NULL,
-		.verbose = 0,
+		.verbose = false,
 	};
 
 	OPT_ARGS(opts) = {
@@ -6338,15 +6338,15 @@ static int wdc_vs_telemetry_controller_option(int argc, char **argv, struct comm
 
 
 	struct config {
-		int disable;
-		int enable;
-		int status;
+		bool disable;
+		bool enable;
+		bool status;
 	};
 
 	struct config cfg = {
-		.disable = 0,
-		.enable = 0,
-		.status = 0,
+		.disable = false,
+		.enable = false,
+		.status = false,
 	};
 
 	OPT_ARGS(opts) = {

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -112,7 +112,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
     const char *raw = "dump output in binary format";
     struct config {
         __u32 namespace_id;
-        int   raw_binary;
+        bool  raw_binary;
     };
 
     struct config cfg = {

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -171,8 +171,8 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 	struct config {
 		char *output_format;
 		__u32 namespace_id;
-		int human_readable;
-		int vendor_specific;
+		bool human_readable;
+		bool vendor_specific;
 	};
 
 	struct config cfg = {
@@ -350,7 +350,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *cmd, struct plu
 	struct config {
 		__u64	zslba;
 		__u32	namespace_id;
-		__u8	zsaso;
+		bool	zsaso;
 		bool	select_all;
 		__u8	zsa;
 		int   	data_len;
@@ -857,7 +857,7 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 		__u32 namespace_id;
 		int   num_descs;
 		int   state;
-		int   verbose;
+		bool  verbose;
 		bool  extended;
 		bool  partial;
 	};
@@ -1041,15 +1041,15 @@ static int zone_append(int argc, char **argv, struct command *cmd, struct plugin
 		__u64  zslba;
 		__u64  data_size;
 		__u64  metadata_size;
-		int    limited_retry;
-		int    fua;
+		bool   limited_retry;
+		bool   fua;
 		__u32  namespace_id;
 		__u32  ref_tag;
 		__u16  lbat;
 		__u16  lbatm;
 		__u8   prinfo;
-		int    piremap;
-		int   latency;
+		bool   piremap;
+		bool   latency;
 	};
 
 	struct config cfg = {};

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -351,7 +351,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 				goto out;
 			}
 			*((FILE **) value_addr) = f;
-		} else if (s->config_type == CFG_NONE) {
+		} else if (s->config_type == CFG_FLAG) {
 			*((bool *)value_addr) = true;
 		}
 	}

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <stdbool.h>
 
 static argconfig_help_func *help_funcs[MAX_HELP_FUNC] = { NULL };
 
@@ -176,17 +177,8 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		if (s->option && strlen(s->option)) {
 			long_opts[option_index].name = s->option;
 			long_opts[option_index].has_arg = s->argument_type;
-
-			if (s->argument_type == no_argument
-			    && s->default_value != NULL) {
-				value_addr = (void *)(char *)s->default_value;
-
-				long_opts[option_index].flag = value_addr;
-				long_opts[option_index].val = 1;
-			} else {
-				long_opts[option_index].flag = NULL;
-				long_opts[option_index].val = 0;
-			}
+			long_opts[option_index].flag = NULL;
+			long_opts[option_index].val = 0;
 		}
 		option_index++;
 	}
@@ -219,11 +211,6 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 			}
 			if (option_index == options_count)
 				continue;
-			if (long_opts[option_index].flag &&
-	                    options[option_index].config_type == CFG_NONE) {
-				*(uint8_t *)(long_opts[option_index].flag) = 1;
-				continue;
-			}
 		}
 
 		s = &options[option_index];
@@ -283,20 +270,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 			}
 			*((uint32_t *) value_addr) = tmp;
 		} else if (s->config_type == CFG_INCREMENT) {
-			/*
-			 * Extreme getopt_long fiddling.
-			 *
-			 * As per man page:
-			 * If flag is non-NULL, getopt_long() returns 0,
-			 * and flag  points to a variable which is set to
-			 * val if the option is found.
-			 *
-			 * So we need to increase 'val', not 'value_addr'.
-			 */
-			if (!c)
-				long_opts[option_index].val++;
-			else
-				*((int *)value_addr) += 1;
+			*((int *)value_addr) += 1;
 		} else if (s->config_type == CFG_LONG) {
 			*((unsigned long *)value_addr) = strtoul(optarg, &endptr, 0);
 			if (errno || optarg == endptr) {
@@ -377,6 +351,8 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 				goto out;
 			}
 			*((FILE **) value_addr) = f;
+		} else if (s->config_type == CFG_NONE) {
+			*((bool *)value_addr) = true;
 		}
 	}
 	free(short_opts);

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -38,7 +38,7 @@
 #include <stdarg.h>
 
 enum argconfig_types {
-	CFG_NONE,
+	CFG_FLAG,
 	CFG_STRING,
 	CFG_INT,
 	CFG_SIZE,
@@ -65,7 +65,7 @@ enum argconfig_types {
 #define OPT_END() { NULL }
 
 #define OPT_FLAG(l, s, v, d) \
-	{l, s, NULL, CFG_NONE, v, no_argument, d}
+	{l, s, NULL, CFG_FLAG, v, no_argument, d}
 
 #define OPT_SUFFIX(l, s, v, d) \
 	{l, s, "IONUM", CFG_LONG_SUFFIX, v, required_argument, d}


### PR DESCRIPTION
getopt_long_only() is able to load the default values directly. Though
the type has to be 'int'. If the target type of argument not 'int'
getopt_long_only will overwrite adjacent memory location.

Reduce the complexity by not using this feature.

Instead use the type bool because libnvme uses bool in 'struct
nvme_fabrics_config'.

Fixes: #1459 
