### PR TITLE
fabrics: Correctly stringify discovery.conf and config.json paths

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -42,8 +42,8 @@
 #include "libnvme.h"
 #include "nvme-print.h"
 
-#define PATH_NVMF_DISC		"SYSCONFDIR/nvme/discovery.conf"
-#define PATH_NVMF_CONFIG	"SYSCONFDIR/nvme/config.json"
+#define PATH_NVMF_DISC		SYSCONFDIR "/nvme/discovery.conf"
+#define PATH_NVMF_CONFIG	SYSCONFDIR "/nvme/config.json"
 #define MAX_DISC_ARGS		32
 #define MAX_DISC_RETRIES	10
 

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ systemddir     = join_paths(prefixdir, get_option('systemddir'))
 conf = configuration_data()
 requires = ''
 
-conf.set('SYSCONFDIR', sysconfdir)
+conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 
 libnvme_dep = dependency('libnvme', fallback : ['libnvme', 'libnvme_dep'])
 


### PR DESCRIPTION
Port 'fabrics: Correctly stringify default hostnqn and hostid paths' from libnvme.

Signed-off-by: Hannes Reinecke <hare@suse.de>