### PR TITLE
fabrics: Add DIM command

### DIFF
--- a/Documentation/cmds-main.txt
+++ b/Documentation/cmds-main.txt
@@ -160,6 +160,9 @@ linknvme:nvme-connect-all[1]::
 linknvme:nvme-connect[1]::
 	Connect to an NVMe-over-Fabrics subsystem
 
+linknvme:nvme-dim[1]::
+	Send Discovery Information Management command to a Discovery Controller
+
 linknvme:nvme-disconnect[1]::
 	Disconnect from an NVMe-over-Fabrics subsystem
 

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -16,6 +16,7 @@ adoc_sources = [
   'nvme-dera-stat',
   'nvme-detach-ns',
   'nvme-device-self-test',
+  'nvme-dim',
   'nvme-dir-receive',
   'nvme-dir-send',
   'nvme-disconnect',

--- a/Documentation/nvme-dim.txt
+++ b/Documentation/nvme-dim.txt
@@ -1,0 +1,75 @@
+nvme-dim(1)
+===========
+
+NAME
+----
+nvme-dim - Send Discovery Information Management command to one or more Discovery Controllers.
+
+SYNOPSIS
+--------
+[verse]
+'nvme dim'
+		[--task=<task>     | -t <task>]
+		[--nqn=<nqn>       | -n <nqn>]
+		[--device=<device> | -d <device>]
+
+DESCRIPTION
+-----------
+Send Discovery Information Management (DIM) command to one or more Discovery
+Controllers. The DIM command allows performing two types of tasks: register or
+deregister.
+
+The DIM command is used to explicitly register with Discovery Controllers (DC),
+especially with Central Discovery Controllers (CDC). CDCs maintain a database (DB)
+of all the Hosts and Storage Susbsystems in a network. The register task is used
+to add a host to the CDC's DB. The deregister task is used to remove a host from
+the CDC's DB.
+
+During a register operation the host will send mandatory information such as the
+Host's NQN and ID, as well as the Host's hostname and the Operating System's
+version that it is running on. There is also an optional Host Symbolic Name
+that can be registered with the CDC.
+
+This command can only be applied to existing DC connections previously created
+with the nvme-discover(1) command using the --persistent option.
+
+OPTIONS
+-------
+-t <task>::
+--task <task>::
+	The task to perform: "register" or "deregister".
+
+-n <subnqn>::
+--nqn <nqn>::
+	The DIM command will be sent to the Discovery Controller (DC) matching this
+	NQN. A list of comma-separated NQNs can be supplied to apply the command to
+	more than one DC.
+
+-d <device>::
+--device <device>::
+	The DIM command will be sent to the Discovery Controllers (DC) associated
+	with this NVMe device handle. A list of comma-separated device handles can
+	be supplied to apply the command to more than one DC.
+
+EXAMPLES
+--------
+* Register with the Central Discovery Controller (CDC) named
+nqn.1988-11.com.dell:SFSS:1:20220118125153e8:
++
+------------
+# nvme dim --task=register --nqn=nqn.1988-11.com.dell:SFSS:1:20220118125153e8
+------------
+
+* Deregister from Central Discovery Controller (CDC) associated with nvme4
++
+------------
+# nvme dim --task=deregister --device=nvme4
+------------
+
+SEE ALSO
+--------
+nvme-discover(1)
+
+NVME
+----
+Part of the nvme-user suite

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -100,7 +100,7 @@ _cmds="list list-subsys id-ctrl id-ns \
 	show-hostnqn dir-receive dir-send virt-mgmt \
 	rpmb boot-part-log fid-support-effects-log \
 	supported-log-pages lockdown media-unit-stat-log \
-	supported-cap-config-log"
+	supported-cap-config-log dim"
 
 # Add plugins:
 for plugin in "${!_plugin_subcmds[@]}"; do
@@ -487,6 +487,9 @@ nvme_list_opts () {
 			--ctrl-loss-tmo= -l --fast-io-fail-tmo= -f \
 			--tos= -T --duplicate-connect -D --disable-sqflow -d\
 			--hdr-digest -g --data-digest -G --output-format= -o"
+			;;
+		"dim")
+		opts+=" --task -t --nqn -n --device -d"
 			;;
 		"disconnect")
 		opts+=" --nqn -n --device -d"

--- a/fabrics.h
+++ b/fabrics.h
@@ -6,5 +6,6 @@ extern int nvmf_connect(const char *desc, int argc, char **argv);
 extern int nvmf_disconnect(const char *desc, int argc, char **argv);
 extern int nvmf_disconnect_all(const char *desc, int argc, char **argv);
 extern int nvmf_config(const char *desc, int argc, char **argv);
+extern int nvmf_dim(const char *desc, int argc, char **argv);
 
 #endif

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -103,6 +103,7 @@ COMMAND_LIST(
 	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller ", virtual_mgmt)
 	ENTRY("rpmb", "Replay Protection Memory Block commands", rpmb_cmd)
 	ENTRY("lockdown", "Submit a Lockdown command,return result", lockdown_cmd)
+	ENTRY("dim", "Send Discovery Information Management command to a Discovery Controller", dim_cmd)
 );
 
 #endif

--- a/nvme.c
+++ b/nvme.c
@@ -7889,6 +7889,12 @@ static int config_cmd(int argc, char **argv, struct command *command, struct plu
 	return nvmf_config(desc, argc, argv);
 }
 
+static int dim_cmd(int argc, char **argv, struct command *command, struct plugin *plugin)
+{
+	const char *desc = "Send Discovery Information Management command to a Discovery Controller (DC)";
+	return nvmf_dim(desc, argc, argv);
+}
+
 void register_extension(struct plugin *plugin)
 {
 	plugin->parent = &nvme;


### PR DESCRIPTION
TP8010 defines the DIM command (Discovery Information Management)
as a way to Register-with or Deregister-from a Discovery
Controller. This is used for NVMe-over-Fabrics when connecting to
Central Discovery Controllers (CDC).

Signed-off-by: Martin Belanger <martin.belanger@dell.com>
