### PR TITLE
build: Update libnvme.wrap

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 851f1867d58b2d76279dd145e10867bed91dee77
+revision = 8d371dd5e25b37202f01739791094682cbd1bb4b
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Get "tree: always allocate config file in nvme_read_config()" from upstream.

Signed-off-by: Hannes Reinecke <hare@suse.de>