### PR TITLE
 fabrics: Only update KATO for discovery controllers

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -312,8 +312,7 @@ static int __discover(nvme_ctrl_t c, const struct nvme_fabrics_config *defcfg,
 			if (child) {
 				if (discover)
 					__discover(child, defcfg, raw,
-						   persistent,
-						   true, flags);
+						   true, persistent, flags);
 				if (e->subtype != NVME_NQN_NVME &&
 				    !persistent) {
 					nvme_disconnect_ctrl(child);


### PR DESCRIPTION
The keep alive timeout value should only be updated on discovery
controllers. __discovery(..., connect=true, ...) is also called for
normal controllers, hence we can't set the nvme_fabrics_config on top
level. Instead we have to move set_discover_kato down in the call
chain right before we connect it. Also we have to make sure not update
the default nvme_fabrics_config.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1476 