### PR TITLE
Fix memory leak when nvme_scan_toplopy return failed

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -575,6 +575,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
+		nvme_free_tree(r);
 		return ret;
 	}
 
@@ -766,6 +767,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
+		nvme_free_tree(r);
 		return ret;
 	}
 	nvme_read_config(r, config_file);
@@ -861,6 +863,7 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
+		nvme_free_tree(r);
 		return ret;
 	}
 
@@ -947,6 +950,7 @@ int nvmf_disconnect_all(const char *desc, int argc, char **argv)
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
+		nvme_free_tree(r);
 		return ret;
 	}
 
@@ -1017,6 +1021,7 @@ int nvmf_config(const char *desc, int argc, char **argv)
 		if (ret < 0) {
 			fprintf(stderr, "Failed to scan topoplogy: %s\n",
 				nvme_strerror(errno));
+			nvme_free_tree(r);
 			return ret;
 		}
 	}
@@ -1155,6 +1160,7 @@ int nvmf_dim(const char *desc, int argc, char **argv)
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
+		nvme_free_tree(r);
 		return ret;
 	}
 

--- a/nvme.c
+++ b/nvme.c
@@ -2503,7 +2503,7 @@ static bool nvme_match_device_filter(nvme_subsystem_t s)
 static int list_subsys(int argc, char **argv, struct command *cmd,
 		struct plugin *plugin)
 {
-	nvme_root_t r;
+	nvme_root_t r = NULL;
 	enum nvme_print_flags flags;
 	const char *desc = "Retrieve information for subsystems";
 	const char *verbose = "Increase output verbosity";
@@ -2577,9 +2577,9 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	}
 
 	nvme_show_subsystem_list(r, nsid, flags);
-	nvme_free_tree(r);
-
 ret:
+	if (r)
+		nvme_free_tree(r);
 	return err;
 }
 
@@ -2631,6 +2631,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	if (err < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
+		nvme_free_tree(r);
 		return err;
 	}
 


### PR DESCRIPTION
If nvme_scan_toplopy return failed,  need to free the previously calloc struct nvme_root structure pointer  'r'.

Signed-off-by: Wu Bo <wubo.linux@gmail.com>