### PR TITLE
nvme: update to nvme_scan_filter_t modifications

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -571,7 +571,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 			nvme_strerror(errno));
 		return -errno;
 	}
-	ret = nvme_scan_topology(r, NULL);
+	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
@@ -763,7 +763,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
-	ret = nvme_scan_topology(r, NULL);
+	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
@@ -859,7 +859,7 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
-	ret = nvme_scan_topology(r, NULL);
+	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
@@ -946,7 +946,7 @@ int nvmf_disconnect_all(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
-	ret = nvme_scan_topology(r, NULL);
+	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));
@@ -1017,7 +1017,7 @@ int nvmf_config(const char *desc, int argc, char **argv)
 		return -errno;
 	}
 	if (scan_tree) {
-		ret = nvme_scan_topology(r, NULL);
+		ret = nvme_scan_topology(r, NULL, NULL);
 		if (ret < 0) {
 			fprintf(stderr, "Failed to scan topoplogy: %s\n",
 				nvme_strerror(errno));
@@ -1156,7 +1156,7 @@ int nvmf_dim(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
-	ret = nvme_scan_topology(r, NULL);
+	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2373,7 +2373,44 @@ void nvme_show_supported_cap_config_log(
 	}
 }
 
-static void nvme_show_subsystem(nvme_root_t r, unsigned int nsid)
+static unsigned int nvme_show_subsystem_multipath(nvme_subsystem_t s)
+{
+	nvme_ns_t n;
+	unsigned int i = 0;
+
+	nvme_subsystem_for_each_ns(s, n) {
+		nvme_path_t p;
+
+		nvme_namespace_for_each_path(n, p) {
+			nvme_ctrl_t c = nvme_path_get_ctrl(p);
+
+			printf(" +- %s %s %s %s %s\n",
+			       nvme_ctrl_get_name(c),
+			       nvme_ctrl_get_transport(c),
+			       nvme_ctrl_get_address(c),
+			       nvme_ctrl_get_state(c),
+			       nvme_path_get_ana_state(p));
+			i++;
+		}
+	}
+
+	return i;
+}
+
+static void nvme_show_subsystem_ctrls(nvme_subsystem_t s)
+{
+	nvme_ctrl_t c;
+
+	nvme_subsystem_for_each_ctrl(s, c) {
+		printf(" +- %s %s %s %s\n",
+			nvme_ctrl_get_name(c),
+			nvme_ctrl_get_transport(c),
+			nvme_ctrl_get_address(c),
+			nvme_ctrl_get_state(c));
+	}
+}
+
+static void nvme_show_subsystem(nvme_root_t r)
 {
 	nvme_host_t h;
 
@@ -2381,29 +2418,72 @@ static void nvme_show_subsystem(nvme_root_t r, unsigned int nsid)
 		nvme_subsystem_t s;
 
 		nvme_for_each_subsystem(h, s) {
-			nvme_ctrl_t c;
-
 			printf("%s - NQN=%s\n", nvme_subsystem_get_name(s),
 			       nvme_subsystem_get_nqn(s));
 			printf("\\\n");
 
-			nvme_subsystem_for_each_ctrl(s, c) {
-				const char *ana_state =
-					nvme_ctrl_get_ana_state(c, nsid);
-				printf(" +- %s %s %s %s %s\n",
-				       nvme_ctrl_get_name(c),
-				       nvme_ctrl_get_transport(c),
-				       nvme_ctrl_get_address(c),
-				       nvme_ctrl_get_state(c),
-				       ana_state ? : "");
-			}
+			if (!nvme_show_subsystem_multipath(s))
+				nvme_show_subsystem_ctrls(s);
 		}
 	}
 }
 
-static void json_print_nvme_subsystem_list(nvme_root_t r, unsigned int nsid)
+static unsigned int json_print_nvme_subsystem_multipath(nvme_subsystem_t s,
+						        json_object *paths)
 {
-	struct json_object *host_attrs, *subsystem_attrs, *path_attrs;
+	nvme_ns_t n;
+	unsigned int i = 0;
+
+	nvme_subsystem_for_each_ns(s, n) {
+		nvme_path_t p;
+
+		nvme_namespace_for_each_path(n, p) {
+			struct json_object *path_attrs;
+			nvme_ctrl_t c = nvme_path_get_ctrl(p);
+
+			path_attrs = json_create_object();
+			json_object_add_value_string(path_attrs, "Name",
+						     nvme_ctrl_get_name(c));
+			json_object_add_value_string(path_attrs, "Transport",
+						     nvme_ctrl_get_transport(c));
+			json_object_add_value_string(path_attrs, "Address",
+						     nvme_ctrl_get_address(c));
+			json_object_add_value_string(path_attrs, "State",
+						     nvme_ctrl_get_state(c));
+			json_object_add_value_string(path_attrs, "ANAState",
+						     nvme_path_get_ana_state(p));
+			json_array_add_value_object(paths, path_attrs);
+			i++;
+		}
+	}
+
+	return i;
+}
+
+static void json_print_nvme_subsystem_ctrls(nvme_subsystem_t s,
+					    json_object *paths)
+{
+	nvme_ctrl_t c;
+
+	nvme_subsystem_for_each_ctrl(s, c) {
+		struct json_object *path_attrs;
+
+		path_attrs = json_create_object();
+		json_object_add_value_string(path_attrs, "Name",
+					     nvme_ctrl_get_name(c));
+		json_object_add_value_string(path_attrs, "Transport",
+					     nvme_ctrl_get_transport(c));
+		json_object_add_value_string(path_attrs, "Address",
+					     nvme_ctrl_get_address(c));
+		json_object_add_value_string(path_attrs, "State",
+					     nvme_ctrl_get_state(c));
+		json_array_add_value_object(paths, path_attrs);
+	}
+}
+
+static void json_print_nvme_subsystem_list(nvme_root_t r)
+{
+	struct json_object *host_attrs, *subsystem_attrs;
 	struct json_object *subsystems, *paths;
 	struct json_object *root;
 	nvme_host_t h;
@@ -2420,8 +2500,6 @@ static void json_print_nvme_subsystem_list(nvme_root_t r, unsigned int nsid)
 					     nvme_host_get_hostid(h));
 		subsystems = json_create_array();
 		nvme_for_each_subsystem(h, s) {
-			nvme_ctrl_t c;
-
 			subsystem_attrs = json_create_object();
 			json_object_add_value_string(subsystem_attrs, "Name",
 						     nvme_subsystem_get_name(s));
@@ -2431,25 +2509,9 @@ static void json_print_nvme_subsystem_list(nvme_root_t r, unsigned int nsid)
 			json_array_add_value_object(subsystems, subsystem_attrs);
 			paths = json_create_array();
 
-			nvme_subsystem_for_each_ctrl(s, c) {
-				path_attrs = json_create_object();
-				json_object_add_value_string(path_attrs, "Name",
-							     nvme_ctrl_get_name(c));
-				json_object_add_value_string(path_attrs, "Transport",
-							     nvme_ctrl_get_transport(c));
-				json_object_add_value_string(path_attrs, "Address",
-							     nvme_ctrl_get_address(c));
-				json_object_add_value_string(path_attrs, "State",
-							     nvme_ctrl_get_state(c));
-				if (nsid != NVME_NSID_ALL) {
-					const char *ana_state =
-						nvme_ctrl_get_ana_state(c, nsid);
-					if (ana_state)
-						json_object_add_value_string(path_attrs,
-									     "ANAState", ana_state);
-				}
-				json_array_add_value_object(paths, path_attrs);
-			}
+			if (!json_print_nvme_subsystem_multipath(s, paths))
+				json_print_nvme_subsystem_ctrls(s, paths);
+
 			json_object_add_value_array(subsystem_attrs, "Paths",
 						    paths);
 		}
@@ -2461,12 +2523,11 @@ static void json_print_nvme_subsystem_list(nvme_root_t r, unsigned int nsid)
 	json_free_object(root);
 }
 
-void nvme_show_subsystem_list(nvme_root_t r, unsigned int nsid,
-			      enum nvme_print_flags flags)
+void nvme_show_subsystem_list(nvme_root_t r, enum nvme_print_flags flags)
 {
 	if (flags & JSON)
-		return json_print_nvme_subsystem_list(r, nsid);
-	nvme_show_subsystem(r, nsid);
+		return json_print_nvme_subsystem_list(r);
+	nvme_show_subsystem(r);
 }
 
 static void nvme_show_registers_cap(struct nvme_bar_cap *cap)

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -87,8 +87,7 @@ void nvme_show_id_ns_descs(void *data, unsigned nsid, enum nvme_print_flags flag
 void nvme_show_lba_status(struct nvme_lba_status *list, unsigned long len,
 	enum nvme_print_flags flags);
 void nvme_show_list_items(nvme_root_t t, enum nvme_print_flags flags);
-void nvme_show_subsystem_list(nvme_root_t t, unsigned int nsid,
-			      enum nvme_print_flags flags);
+void nvme_show_subsystem_list(nvme_root_t t, enum nvme_print_flags flags);
 void nvme_show_id_nvmset(struct nvme_id_nvmset_list *nvmset, unsigned nvmset_id,
 	enum nvme_print_flags flags);
 void nvme_show_primary_ctrl_cap(const struct nvme_primary_ctrl_cap *cap,

--- a/nvme.c
+++ b/nvme.c
@@ -2478,22 +2478,35 @@ ret:
 	return err;
 }
 
-static bool nvme_match_device_filter(nvme_subsystem_t s)
+static bool nvme_match_device_filter(nvme_subsystem_t s,
+		nvme_ctrl_t c, nvme_ns_t ns, void *f_args)
 {
-	nvme_ctrl_t c;
-	nvme_ns_t n;
+	int ret, instance, nsid, s_num;
+	char *devname = f_args;
 
-	if (!devicename || !strlen(devicename))
+	if (!devname || !strlen(devname))
 		return true;
 
-	nvme_subsystem_for_each_ctrl(s, c) {
-		if (!strncmp(devicename, nvme_ctrl_get_name(c),
-			     strlen(nvme_ctrl_get_name(c))))
+	ret = sscanf(devname, "nvme%dn%d", &instance, &nsid);
+	if (ret != 2)
+		return true;
+
+	if (s) {
+		ret = sscanf(nvme_subsystem_get_name(s), "nvme-subsys%d",
+			     &s_num);
+		if (ret == 1 && s_num == instance)
 			return true;
 	}
+	if (c) {
+		s = nvme_ctrl_get_subsystem(c);
 
-	nvme_subsystem_for_each_ns(s, n) {
-		if (!strcmp(devicename, nvme_ns_get_name(n)))
+		ret = sscanf(nvme_subsystem_get_name(s), "nvme-subsys%d",
+			     &s_num);
+		if (ret == 1 && s_num == instance)
+			return true;
+	}
+	if (ns) {
+		if (!strcmp(devname, nvme_ns_get_name(ns)))
 			return true;
 	}
 
@@ -2508,7 +2521,6 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	const char *desc = "Retrieve information for subsystems";
 	const char *verbose = "Increase output verbosity";
 	nvme_scan_filter_t filter = NULL;
-	__u32 nsid = NVME_NSID_ALL;
 	int err;
 
 	struct config {
@@ -2558,7 +2570,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	}
 
 	if (devicename) {
-		int subsys_num;
+		int subsys_num, nsid;
 
 		if (sscanf(devicename,"nvme%dn%d",
 			   &subsys_num, &nsid) != 2) {
@@ -2569,14 +2581,15 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 		filter = nvme_match_device_filter;
 	}
 
-	err = nvme_scan_topology(r, filter);
+	err = nvme_scan_topology(r, filter, (void *)devicename);
 	if (err) {
 		fprintf(stderr, "Failed to scan topology: %s\n",
 			nvme_strerror(errno));
 		goto ret;
 	}
 
-	nvme_show_subsystem_list(r, nsid, flags);
+	nvme_show_subsystem_list(r, flags);
+
 ret:
 	if (r)
 		nvme_free_tree(r);
@@ -2627,7 +2640,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 			nvme_strerror(errno));
 		return -errno;
 	}
-	err = nvme_scan_topology(r, NULL);
+	err = nvme_scan_topology(r, NULL, NULL);
 	if (err < 0) {
 		fprintf(stderr, "Failed to scan topoplogy: %s\n",
 			 nvme_strerror(errno));

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 008a2dacdc0d29f57ec7cfd5bd6e89bf4d531081
+revision = 20b6c2dd48335581fe2ff0cdef9f757fd81ad7ba
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
nvme: update to nvme_scan_filter_t modifications

The scan filter in libnvme has been updated, so update the code
to make use of it.

Signed-off-by: Hannes Reinecke <hare@suse.de>
[dwagner: show also paths for discvoery controller]
Signed-off-by: Daniel Wagner <dwagner@suse.de>


Replaces #1482 and #1481
