### PR TITLE
fabrics: Switch connect and persistent argument for __disover

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -312,8 +312,7 @@ static int __discover(nvme_ctrl_t c, const struct nvme_fabrics_config *defcfg,
 			if (child) {
 				if (discover)
 					__discover(child, defcfg, raw,
-						   persistent,
-						   true, flags);
+						   true, persistent, flags);
 				if (e->subtype != NVME_NQN_NVME &&
 				    !persistent) {
 					nvme_disconnect_ctrl(child);


### PR DESCRIPTION
The order of the connect and persistent argument for the recursive
call to __discover is in the wrong order:

  __discover(.., bool connect, bool persistent, enum nvme_print_flags flags)

Signed-off-by: Daniel Wagner <dwagner@suse.de>