### PR TITLE
util/base64: fix missing sys/types.h include

### DIFF
--- a/util/base64.c
+++ b/util/base64.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <sys/types.h>
 
 static const char base64_table[65] =
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";


### PR DESCRIPTION
needed for u_int32_t