### PR TITLE
fabrics: avoid segfault when nvme discover fails with the -p option

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -174,6 +174,9 @@ static nvme_ctrl_t create_discover_ctrl(nvme_root_t r, nvme_host_t h,
 	nvme_ctrl_t c;
 
 	c = __create_discover_ctrl(r, h, cfg, trcfg);
+	if (!c)
+		return NULL;
+
 	if (!persistent)
 		return c;
 


### PR DESCRIPTION
If the initial discovery controller creation fails while passing
the -p option to the nvme discover (or connect-all) command, it
could lead to the below segfault:

nvme discover -t rdma -w 192.168.1.114 -a 192.168.1.113 -p
Failed to write to /dev/nvme-fabrics: Connection reset by peer
Segmentation fault (core dumped)

Avoid this segfault by checking if the controller created in
__create_discover_ctrl() is valid before proceeding.

Signed-off-by: Martin George <marting@netapp.com>