### PR TITLE
fabrics: error message for nvme discover/connect-all with no params

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -526,6 +526,7 @@ static int discover_from_conf_file(nvme_root_t r, nvme_host_t h,
 
 	f = fopen(PATH_NVMF_DISC, "r");
 	if (f == NULL) {
+		fprintf(stderr, "No params given and no %s\n", PATH_NVMF_DISC);
 		errno = ENOENT;
 		return -1;
 	}


### PR DESCRIPTION
Currently when nvme discover or connect-all is called without
passing any params, it simply blanks out without any meaningful
error. So add an appropriate error message for such scenarios,
similar to what's done in the erstwhile nvme-cli-monolithic branch.

Signed-off-by: Martin George <marting@netapp.com>