### PR TITLE
fabrics: skip connect if the transport types don't match

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -386,6 +386,10 @@ static int __discover(nvme_ctrl_t c, struct nvme_fabrics_config *defcfg,
 			nvme_ctrl_t child;
 			int tmo = defcfg->keep_alive_tmo;
 
+			/* Skip connect if the transport types don't match */
+			if (strcmp(nvme_ctrl_get_transport(c), nvmf_trtype_str(e->trtype)))
+				continue;
+
 			if (e->subtype == NVME_NQN_DISC)
 				set_discovery_kato(defcfg);
 


### PR DESCRIPTION
Discovery log page data may include records belonging to different
transport types. If during a nvme connect-all, a connect is attempted
on a record that doesn't match the transport type passed here, it
would end up in a connect failure for that record. For e.g. one would
see the following error if a connect is attempted on a tcp record,
but the transport type passed here is 'fc' and its associated params:

nvme_tcp: malformed src address passed: nn-0xXXXX:pn-0xYYYY

Fix this by proceeding with the connect only if the transport types
match for a given record during the connect-all.

[marting: backport from monolithic branch]
Signed-off-by: Martin George <marting@netapp.com>