### PR TITLE
fabrics: avoid segfault if transport type is omitted

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -478,6 +478,8 @@ static nvme_ctrl_t lookup_discover_ctrl(nvme_root_t r, struct tr_config *trcfg)
 static char *get_default_trsvcid(const char *transport,
 			         bool discovery_ctrl)
 {
+	if (!transport)
+		return NULL;
 	if (!strcmp(transport, "tcp")) {
 		if (discovery_ctrl) {
 			/* Default port for NVMe/TCP discovery controllers */


### PR DESCRIPTION
A nvme discover or connect-all would currently end up in a
segfault if the transport type is omitted as shown below:

nvme discover -w 192.168.1.114 -a 192.168.1.160
Segmentation fault (core dumped)

Avoid this segfault by checking if the transport type is
available before proceeding in get_default_trsvcid().

Signed-off-by: Martin George <marting@netapp.com>