### PR TITLE
meson_options: Include system sub directory

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,7 @@
 option('version-tag', type : 'string', description : 'override the git version string')
 option('udevrulesdir', type : 'string', value : 'lib/udev/rules.d', description : 'directory for udev rules files')
 option('dracutrulesdir', type : 'string', value : 'lib/dracut/dracut.conf.d/', description : 'directory for dracut rules files')
-option('systemddir', type : 'string', value : 'lib/systemd/', description : 'directory for systemd files')
+option('systemddir', type : 'string', value : 'lib/systemd/system', description : 'directory for systemd files')
 option('htmldir', type : 'string', value : '', description : 'directory for HTML documentation')
 option('systemctl', type : 'string', value : '/usr/bin/systemctl', description : 'path to systemctl binary')
 


### PR DESCRIPTION
It's unclear to me if we want `system` included in `meson_options.txt` or if it should be implicitly appended in `meson.build`?