### PR TITLE
nvme-print: Show mec field in human output instead of vwci

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4568,7 +4568,7 @@ void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, enum nvme_print_flags flags,
 		nvme_show_id_ctrl_vwci(ctrl->vwci);
 	printf("mec       : %u\n", ctrl->mec);
 	if (human)
-		nvme_show_id_ctrl_mec(ctrl->vwci);
+		nvme_show_id_ctrl_mec(ctrl->mec);
 
 	printf("oacs      : %#x\n", le16_to_cpu(ctrl->oacs));
 	if (human)


### PR DESCRIPTION
Looks like a copy&past error for the human output.

Reported-by: mgerdts
Signed-off-by: Daniel Wagner <dwagner@suse.de>
Fix: 43460fcce21b ("nvme: add identify controller structure 2.0 spec. fields")

Fixes: ##1514