### PR TITLE
fabrics: Honor config file for connect-all

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -666,6 +666,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 		nvme_free_tree(r);
 		return ret;
 	}
+	nvme_read_config(r, config_file);
 
 	if (!hostnqn)
 		hostnqn = hnqn = nvmf_hostnqn_from_file();


### PR DESCRIPTION
The command line option -J config.json allows to provide a
configuration via a JSON file. We handle this correctly for the
'connect' case but fail to apply the configuration for 'connect-all'
because we missed to add nvme_read_config() in this path.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1521