### PR TITLE
fabrics: decode 'current' discovery subsystem

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -142,8 +142,9 @@ static inline const char *adrfam_str(__u8 adrfam)
 }
 
 static const char * const subtypes[] = {
-	[NVME_NQN_DISC]		= "discovery subsystem",
+	[NVME_NQN_DISC]		= "discovery subsystem referral",
 	[NVME_NQN_NVME]		= "nvme subsystem",
+	[NVME_NQN_CURR]		= "current subsystem",
 };
 
 static inline const char *subtype_str(__u8 subtype)
@@ -1163,6 +1164,7 @@ retry:
 
 	switch (e->subtype) {
 	case NVME_NQN_DISC:
+	case NVME_NQN_CURR:
 		discover = true;
 	case NVME_NQN_NVME:
 		break;

--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -75,8 +75,9 @@ static inline uint64_t le64_to_cpu(__le64 x)
 #define NVME_NSID_ALL		0xffffffff
 
 enum nvme_subsys_type {
-	NVME_NQN_DISC	= 1,		/* Discovery type target subsystem */
+	NVME_NQN_DISC	= 1,		/* Referral Discovery type target subsystem */
 	NVME_NQN_NVME	= 2,		/* NVME type target subsystem */
+	NVME_NQN_CURR	= 3,		/* Current Discovery type target subsystem */
 };
 
 /* Address Family codes for Discovery Log Page entry ADRFAM field */


### PR DESCRIPTION
TP8014 added a new discovery log page entry type '3' for the
'current discovery subsystem'; decode it accordingly.

Signed-off-by: Hannes Reinecke <hare@suse.de>