### PR TITLE
nvme-print: Show paths from the first namespace only

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2376,22 +2376,23 @@ void nvme_show_supported_cap_config_log(
 static unsigned int nvme_show_subsystem_multipath(nvme_subsystem_t s)
 {
 	nvme_ns_t n;
+	nvme_path_t p;
 	unsigned int i = 0;
 
-	nvme_subsystem_for_each_ns(s, n) {
-		nvme_path_t p;
+	n = nvme_subsystem_first_ns(s);
+	if (!n)
+		return 0;
 
-		nvme_namespace_for_each_path(n, p) {
-			nvme_ctrl_t c = nvme_path_get_ctrl(p);
+	nvme_namespace_for_each_path(n, p) {
+		nvme_ctrl_t c = nvme_path_get_ctrl(p);
 
-			printf(" +- %s %s %s %s %s\n",
-			       nvme_ctrl_get_name(c),
-			       nvme_ctrl_get_transport(c),
-			       nvme_ctrl_get_address(c),
-			       nvme_ctrl_get_state(c),
-			       nvme_path_get_ana_state(p));
-			i++;
-		}
+		printf(" +- %s %s %s %s %s\n",
+		       nvme_ctrl_get_name(c),
+		       nvme_ctrl_get_transport(c),
+		       nvme_ctrl_get_address(c),
+		       nvme_ctrl_get_state(c),
+		       nvme_path_get_ana_state(p));
+		i++;
 	}
 
 	return i;


### PR DESCRIPTION
When listing the subsystem, show the path from the first namespace
only. Every namespace has the same paths for a subsystem. This avoids
listening the same controllers for each namespace.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1529 

```bash
# ./nvme list-subsys
nvme-subsys1 - NQN=nqn.1988-11.com.dell:powerstore:00:f03028e73ef7D032D81E
\
 +- nvme1 tcp traddr=10.162.198.42,trsvcid=4420 live non-optimized
 +- nvme2 tcp traddr=10.162.198.45,trsvcid=4420 live optimized
```