### PR TITLE
nvme: Modify show-regs to not issuing any command

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 2657a4154575b469c45337a37b43fce3ef18f9a2
+revision = 115441c1de95a82019a4905b6286bc0e78efb586
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
if using command on show-regs
it's not possible to check reigsters (eg CSTS) for checking device status
When device status is invalid to handle command(with hang)

skip issue nvme_get_properties for fabrics by default
add fabircs option to get properties with command
revert mmap_registers as v1.16 to skip issuing commands from scan ctrl/ns

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>
Co-authored-by: Beomsoo Kim <beomsooo.kim@samsung.com>