### PR TITLE
docs: Search for 'asciidoctor' as alternative

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -174,7 +174,7 @@ if want_docs != 'false'
   mandir = join_paths(get_option('mandir'), 'man1')
   htmldir = join_paths(get_option('htmldir'), 'nvme')
 
-  asciidoctor = find_program('asciidoc', required : false)
+  asciidoctor = find_program(['asciidoc', 'asciidoctor'], required : false)
   if want_docs_build and asciidoctor.found()
     # Build documentation before installing
 


### PR DESCRIPTION
There are alternative binary names for asciidoctor. Search for
'asciidoc' or 'asciidoctor' when building the docs.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

See #1543 