### PR TITLE
docs: Don't confuse asciidoc with asciidoctor

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -174,7 +174,7 @@ if want_docs != 'false'
   mandir = join_paths(get_option('mandir'), 'man1')
   htmldir = join_paths(get_option('htmldir'), 'nvme')
 
-  asciidoctor = find_program(['asciidoc', 'asciidoctor'], required : false)
+  asciidoctor = find_program('asciidoc', required: get_option('docs-build'))
   if want_docs_build and asciidoctor.found()
     # Build documentation before installing
 


### PR DESCRIPTION
Apparently, asciidoc and asciidoctor are two different
projects. nvme-cli depends on the former. Depend on asciidoc only and
make it a hard dependency when the user ask to build the doc.

Fixes: 6b18babf40d4 ("docs: Search for 'asciidoctor' as alternative")
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes #1543