### PR TITLE
nvme-print: Show ANA state only for one namespace

### DIFF
--- a/nvme-print.h
+++ b/nvme-print.h
@@ -88,7 +88,8 @@ void nvme_show_id_ns_descs(void *data, unsigned nsid, enum nvme_print_flags flag
 void nvme_show_lba_status(struct nvme_lba_status *list, unsigned long len,
 	enum nvme_print_flags flags);
 void nvme_show_list_items(nvme_root_t t, enum nvme_print_flags flags);
-void nvme_show_subsystem_list(nvme_root_t t, enum nvme_print_flags flags);
+void nvme_show_subsystem_list(nvme_root_t t, bool show_ana,
+			      enum nvme_print_flags flags);
 void nvme_show_id_nvmset(struct nvme_id_nvmset_list *nvmset, unsigned nvmset_id,
 	enum nvme_print_flags flags);
 void nvme_show_primary_ctrl_cap(const struct nvme_primary_ctrl_cap *cap,

--- a/nvme.c
+++ b/nvme.c
@@ -2526,6 +2526,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	const char *verbose = "Increase output verbosity";
 	nvme_scan_filter_t filter = NULL;
 	int err;
+	int nsid = NVME_NSID_ALL;
 
 	struct config {
 		char	*output_format;
@@ -2574,7 +2575,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	}
 
 	if (devicename) {
-		int subsys_num, nsid;
+		int subsys_num;
 
 		if (sscanf(devicename,"nvme%dn%d",
 			   &subsys_num, &nsid) != 2) {
@@ -2592,7 +2593,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 		goto ret;
 	}
 
-	nvme_show_subsystem_list(r, flags);
+	nvme_show_subsystem_list(r, nsid != NVME_NSID_ALL, flags);
 
 ret:
 	if (r)


### PR DESCRIPTION
'nvme list-subsys' shows the state of all controllers belonging to a
subsystem. The ANA state is a per namespace attribute hence it only
makes sense to show it if the user lists the subsystem for a
namespace.

Fixes: 7435ed9ae6a6 ("nvme-print: Show paths from the first namespace only")
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1542