### PR TITLE
Log connect errors

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -409,7 +409,7 @@ static int __discover(nvme_ctrl_t c, struct nvme_fabrics_config *defcfg,
 					nvme_disconnect_ctrl(child);
 					nvme_free_ctrl(child);
 				}
-			} else if (errno == EALREADY && !quiet) {
+			} else if (errno == ENVME_CONNECT_ALREADY && !quiet) {
 				char *traddr = log->entries[i].traddr;
 
 				space_strip_len(NVMF_TRADDR_SIZE, traddr);

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 91f66d582c1f107971042afa57614f08f0fc6d76
+revision = 2657a4154575b469c45337a37b43fce3ef18f9a2
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
fabrics: Already connected uses a different error code

The libnvme library reports connection errors with it's own error
codes, e.g. ENVME_CONNECT_ALREADY stands for already connected. Update
the connect-all call so that it prints 'already connected' again.

Fixes: #1505