### PR TITLE
submit_io(): fix "nvme compare" to pass correct command

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -6602,7 +6602,9 @@ static int submit_io(int opcode, char *command, const char *desc,
 		.result		= NULL,
 	};
 	gettimeofday(&start_time, NULL);
-	if (opcode & 1)
+	if (opcode == nvme_cmd_compare)
+		err = nvme_compare(&args);
+	else if (opcode & 1)
 		err = nvme_write(&args);
 	else
 		err = nvme_read(&args);


### PR DESCRIPTION
Since "18de3a6d Convert to libnvme", an "nvme compare" was being
converted incorrectly into an "nvme write" in submit_io().

Fixes #1562.

Signed-off-by: John Levon <john.levon@nutanix.com>