### PR TITLE
ci: add python version to setup-python environment

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -17,6 +17,8 @@ jobs:
         run: sudo apt-get install libjson-c-dev libhugetlbfs-dev
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
       # - name: install python dependencies
       #   run: |
       #     python -m pip install --upgrade pip
@@ -33,6 +35,8 @@ jobs:
         run: sudo apt-get install -y libpam-dev libcap-ng-dev
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
       - uses: BSFishy/meson-build@v1.0.3
         with:
           setup-options: --werror -Duuid:werror=false --wrap-mode=forcefallback
@@ -47,6 +51,8 @@ jobs:
         run: sudo apt-get install -y libpam-dev libcap-ng-dev
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
       - uses: BSFishy/meson-build@v1.0.3
         with:
           setup-options: --werror -Duuid:werror=false --wrap-mode=forcefallback --default-library=static


### PR DESCRIPTION
v4 of the setup-python helper wants to know the python version number.

Signed-off-by: Daniel Wagner <dwagner@suse.de>