### PR TITLE
tests: Port to nose2 and unittest

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -67,10 +67,10 @@ nvmetests
        test_*.
     3. Based on the requirement one can inherit TestNVMe or TestNVMeIO
        class.
-    4. Write test precondition code into __init__. Make sure you are calling
-       super class __init__.
-    5. Write test post condition code into __del__. Make sure you are calling
-       super class __del__.
+    4. Write test precondition code into setUp. Make sure you are calling
+       super class setUp.
+    5. Write test post condition code into tearDown. Make sure you are calling
+       super class tearDown.
     6. Before writing a new function have a look into TestNVMe to see if it
        can be reused.
     7. Once testcase is ready make sure :-
@@ -83,9 +83,9 @@ nvmetests
 
 4. Running testcases with framework
 -----------------------------------
-    1. Running single testcase with nose2 :-
-       $ nose2 --verbose nvme_writezeros_test
-       $ nose2 --verbose nvme_read_write_test
+    1. Running single testcase (in the source tree) with nose2 :-
+       $ nose2 --verbose --start-dir tests nvme_writezeros_test
+       $ nose2 --verbose --start-dir tests nvme_read_write_test
 
-    2. Running all the testcases with ninja :-
+    2. Running all the testcases (in the build root directory) with ninja :-
        $ ninja test -C .build

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,38 +1,49 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+infra = [
+  'config.json',
+  'nvme_test.py',
+  'nvme_test_io.py',
+  'nvme_test_logger.py',
+  'nvme_simple_template_test.py',
+]
+
 tests = [
-  'nvme_attach_detach_ns_test',
-  'nvme_compare_test',
-  'nvme_create_max_ns_test',
-  'nvme_error_log_test',
-  'nvme_flush_test',
-  'nvme_format_test',
-  'nvme_fw_log_test',
-  'nvme_get_features_test',
-  'nvme_id_ctrl_test',
-  'nvme_id_ns_test',
-  'nvme_read_write_test',
-  'nvme_simple_template_test',
-  'nvme_smart_log_test',
-  'nvme_test_io',
-  'nvme_test_logger',
-  'nvme_test',
-  'nvme_writeuncor_test',
-  'nvme_writezeros_test',
-  'nvme_copy_test',
-  'nvme_dsm_test',
-  'nvme_verify_test',
-  'nvme_lba_status_log_test',
-  'nvme_get_lba_status_test',
+  'nvme_attach_detach_ns_test.py',
+  'nvme_compare_test.py',
+  'nvme_create_max_ns_test.py',
+  'nvme_error_log_test.py',
+  'nvme_flush_test.py',
+  'nvme_format_test.py',
+  'nvme_fw_log_test.py',
+  'nvme_get_features_test.py',
+  'nvme_id_ctrl_test.py',
+  'nvme_id_ns_test.py',
+  'nvme_read_write_test.py',
+  'nvme_smart_log_test.py',
+  'nvme_writeuncor_test.py',
+  'nvme_writezeros_test.py',
+  'nvme_copy_test.py',
+  'nvme_dsm_test.py',
+  'nvme_verify_test.py',
+  'nvme_lba_status_log_test.py',
+  'nvme_get_lba_status_test.py',
 ]
 
 runtests = find_program('nose2', required : false)
 
 if runtests.found()
+  foreach file : infra + tests
+    configure_file(
+      input: file,
+      output: file,
+      copy: true)
+  endforeach
+
   foreach t : tests
-    test(t, runtests,
-         args: ['--verbose', '--start-dir', meson.current_source_dir(), t],
-         workdir: meson.current_source_dir(),
+    t_name = t.split('.')[0]
+    test(t_name, runtests,
+         args: ['--verbose', '--start-dir', meson.build_root() + '/tests', t_name],
          env: ['PATH=' + meson.build_root() + ':/usr/bin:/usr/sbin'],
          timeout: 500)
   endforeach

--- a/tests/nvme_attach_detach_ns_test.py
+++ b/tests/nvme_attach_detach_ns_test.py
@@ -31,7 +31,6 @@ NVMe Namespace Management Testcase:-
 
 import time
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -48,9 +47,9 @@ class TestNVMeAttachDetachNSCmd(TestNVMe):
               - ctrl_id : controller id.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeAttachDetachNSCmd """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.dps = 0
         self.flbas = 0
         self.nsze = 0x1400000
@@ -60,7 +59,7 @@ class TestNVMeAttachDetachNSCmd(TestNVMe):
         self.delete_all_ns()
         time.sleep(1)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeAttachDetachNSCmd
 
@@ -68,13 +67,13 @@ class TestNVMeAttachDetachNSCmd(TestNVMe):
             - Atttach it to controller.
             - Call super class's destructor.
         """
-        assert_equal(self.create_and_validate_ns(self.default_nsid,
-                                                 self.nsze,
-                                                 self.ncap,
-                                                 self.flbas,
-                                                 self.dps), 0)
+        self.assertEqual(self.create_and_validate_ns(self.default_nsid,
+                                                     self.nsze,
+                                                     self.ncap,
+                                                     self.flbas,
+                                                     self.dps), 0)
         self.attach_ns(self.ctrl_id, self.default_nsid)
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def test_attach_detach_ns(self):
         """ Testcase main """
@@ -83,11 +82,11 @@ class TestNVMeAttachDetachNSCmd(TestNVMe):
                                           self.ncap,
                                           self.flbas,
                                           self.dps)
-        assert_equal(err, 0)
-        assert_equal(self.attach_ns(self.ctrl_id, self.default_nsid), 0)
+        self.assertEqual(err, 0)
+        self.assertEqual(self.attach_ns(self.ctrl_id, self.default_nsid), 0)
 
         self.run_ns_io(self.default_nsid, 0)
 
-        assert_equal(self.detach_ns(self.ctrl_id, self.default_nsid), 0)
-        assert_equal(self.delete_and_validate_ns(self.default_nsid), 0)
+        self.assertEqual(self.detach_ns(self.ctrl_id, self.default_nsid), 0)
+        self.assertEqual(self.delete_and_validate_ns(self.default_nsid), 0)
         self.nvme_reset_ctrl()

--- a/tests/nvme_compare_test.py
+++ b/tests/nvme_compare_test.py
@@ -30,7 +30,6 @@ NVMe Compare Command Testcase:-
 
 """
 
-from nose.tools import assert_equal, assert_not_equal
 from nvme_test_io import TestNVMeIO
 
 
@@ -46,9 +45,9 @@ class TestNVMeCompareCmd(TestNVMeIO):
               - test_log_dir : directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeCompareCmd """
-        TestNVMeIO.__init__(self)
+        super().setUp()
         self.data_size = 1024
         self.start_block = 1023
         self.setup_log_dir(self.__class__.__name__)
@@ -57,9 +56,9 @@ class TestNVMeCompareCmd(TestNVMeIO):
         self.create_data_file(self.write_file, self.data_size, "15")
         self.create_data_file(self.compare_file, self.data_size, "25")
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeCompareCmd """
-        TestNVMeIO.__del__(self)
+        super().tearDown()
 
     def nvme_compare(self, cmp_file):
         """ Wrapper for nvme compare command.
@@ -76,6 +75,6 @@ class TestNVMeCompareCmd(TestNVMeIO):
 
     def test_nvme_compare(self):
         """ Testcase main """
-        assert_equal(self.nvme_write(), 0)
-        assert_not_equal(self.nvme_compare(self.compare_file), 0)
-        assert_equal(self.nvme_compare(self.write_file), 0)
+        self.assertEqual(self.nvme_write(), 0)
+        self.assertNotEqual(self.nvme_compare(self.compare_file), 0)
+        self.assertEqual(self.nvme_compare(self.write_file), 0)

--- a/tests/nvme_copy_test.py
+++ b/tests/nvme_copy_test.py
@@ -13,7 +13,6 @@ NVMe Copy Testcase:-
 
 """
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -28,18 +27,18 @@ class TestNVMeCopy(TestNVMe):
               - test_log_dir :  directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeCopy """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.start_block = 0
         self.range = 1
         self.slbs = 1
         self.namespace = 1
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeCopy """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def copy(self):
         """ Wrapper for nvme copy
@@ -57,4 +56,4 @@ class TestNVMeCopy(TestNVMe):
 
     def test_copy(self):
         """ Testcase main """
-        assert_equal(self.copy(), 0)
+        self.assertEqual(self.copy(), 0)

--- a/tests/nvme_create_max_ns_test.py
+++ b/tests/nvme_create_max_ns_test.py
@@ -31,7 +31,6 @@ NVMe Namespace Management Testcase:-
 
 import time
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -48,9 +47,9 @@ class TestNVMeCreateMaxNS(TestNVMe):
               - ctrl_id : controller id.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeAttachDetachNSCmd """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.dps = 0
         self.flbas = 0
         self.nsze = int(self.get_ncap() /
@@ -62,7 +61,7 @@ class TestNVMeCreateMaxNS(TestNVMe):
         self.delete_all_ns()
         time.sleep(1)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeAttachDetachNSCmd
 
@@ -70,13 +69,13 @@ class TestNVMeCreateMaxNS(TestNVMe):
             - Atttach it to controller.
             - Call super class's destructor.
         """
-        assert_equal(self.create_and_validate_ns(self.default_nsid,
-                                                 self.nsze,
-                                                 self.ncap,
-                                                 self.flbas,
-                                                 self.dps), 0)
+        self.assertEqual(self.create_and_validate_ns(self.default_nsid,
+                                                     self.nsze,
+                                                     self.ncap,
+                                                     self.flbas,
+                                                     self.dps), 0)
         self.attach_ns(self.ctrl_id, self.default_nsid)
-        TestNVMe.__del__(self)
+        super.tearDown()
 
     def test_attach_detach_ns(self):
         """ Testcase main """
@@ -87,15 +86,15 @@ class TestNVMeCreateMaxNS(TestNVMe):
                                               self.ncap,
                                               self.flbas,
                                               self.dps)
-            assert_equal(err, 0)
+            self.assertEqual(err, 0)
             print("##### Attaching " + str(nsid))
-            assert_equal(self.attach_ns(self.ctrl_id, nsid), 0)
+            self.assertEqual(self.attach_ns(self.ctrl_id, nsid), 0)
             print("##### Running IOs in " + str(nsid))
             self.run_ns_io(nsid, 0)
 
         for nsid in range(1, self.max_ns):
             print("##### Detaching " + str(nsid))
-            assert_equal(self.detach_ns(self.ctrl_id, nsid), 0)
+            self.assertEqual(self.detach_ns(self.ctrl_id, nsid), 0)
             print("#### Deleting " + str(nsid))
-            assert_equal(self.delete_and_validate_ns(nsid), 0)
+            self.assertEqual(self.delete_and_validate_ns(nsid), 0)
         self.nvme_reset_ctrl()

--- a/tests/nvme_dsm_test.py
+++ b/tests/nvme_dsm_test.py
@@ -13,7 +13,6 @@ NVMe DSM Testcase:-
 
 """
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -27,17 +26,17 @@ class TestNVMeDsm(TestNVMe):
               - test_log_dir :  directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeDsm """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.start_block = 0
         self.range = 0
         self.namespace = 1
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeDsm """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def dsm(self):
         """ Wrapper for nvme verify
@@ -54,4 +53,4 @@ class TestNVMeDsm(TestNVMe):
 
     def test_dsm(self):
         """ Testcase main """
-        assert_equal(self.dsm(), 0)
+        self.assertEqual(self.dsm(), 0)

--- a/tests/nvme_error_log_test.py
+++ b/tests/nvme_error_log_test.py
@@ -26,7 +26,6 @@ NVMe Smart Log Verification Testcase:-
 
 """
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -38,18 +37,18 @@ class TestNVMeErrorLogCmd(TestNVMe):
         - Attributes:
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeErrorLogCmd """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeErrorLogCmd
 
             - Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def get_error_log_ctrl(self):
         """ Wrapper for executing error-log on controller.
@@ -62,4 +61,4 @@ class TestNVMeErrorLogCmd(TestNVMe):
 
     def test_get_error_log(self):
         """ Testcase main """
-        assert_equal(self.get_error_log_ctrl(), 0)
+        self.assertEqual(self.get_error_log_ctrl(), 0)

--- a/tests/nvme_flush_test.py
+++ b/tests/nvme_flush_test.py
@@ -26,7 +26,6 @@ NVMe Flush Command Testcase:-
 
 """
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -38,14 +37,14 @@ class TestNVMeFlushCmd(TestNVMe):
         - Attributes:
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeFlushCmd """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeFlushCmd """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def nvme_flush(self):
         """ Wrapper for nvme flush command.
@@ -60,4 +59,4 @@ class TestNVMeFlushCmd(TestNVMe):
 
     def test_nvme_flush(self):
         """ Testcase main """
-        assert_equal(self.nvme_flush(), 0)
+        self.assertEqual(self.nvme_flush(), 0)

--- a/tests/nvme_format_test.py
+++ b/tests/nvme_format_test.py
@@ -40,7 +40,6 @@ Namespace Format testcase :-
 import subprocess
 import time
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -61,9 +60,9 @@ class TestNVMeFormatCmd(TestNVMe):
               - test_log_dir : directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeFormatCmd """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.dps = 0                 # ns data protection settings
         self.flbas = 0               # ns formattes logical block settings
         self.nsze = 0x1400000        # ns size
@@ -77,7 +76,7 @@ class TestNVMeFormatCmd(TestNVMe):
         self.delete_all_ns()
         time.sleep(1)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeFormatCmd
 
@@ -85,22 +84,22 @@ class TestNVMeFormatCmd(TestNVMe):
             - Atttach it to controller.
             - Call super class's destructor.
         """
-        assert_equal(self.create_and_validate_ns(self.default_nsid,
-                                                 self.nsze,
-                                                 self.ncap,
-                                                 self.flbas,
-                                                 self.dps), 0)
+        self.assertEqual(self.create_and_validate_ns(self.default_nsid,
+                                                     self.nsze,
+                                                     self.ncap,
+                                                     self.flbas,
+                                                     self.dps), 0)
         self.attach_ns(self.ctrl_id, self.default_nsid)
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def attach_detach_primary_ns(self):
         """ Extract supported format information using default namespace """
-        assert_equal(self.create_and_validate_ns(self.default_nsid,
-                                                 self.nsze,
-                                                 self.ncap,
-                                                 self.flbas,
-                                                 self.dps), 0)
-        assert_equal(self.attach_ns(self.ctrl_id, self.default_nsid), 0)
+        self.assertEqual(self.create_and_validate_ns(self.default_nsid,
+                                                     self.nsze,
+                                                     self.ncap,
+                                                     self.flbas,
+                                                     self.dps), 0)
+        self.assertEqual(self.attach_ns(self.ctrl_id, self.default_nsid), 0)
         # read lbaf information
         id_ns = "nvme id-ns " + self.ctrl + \
                 " -n1 | grep ^lbaf | awk '{print $2}' | tr -s \"\\n\" \" \""
@@ -122,8 +121,8 @@ class TestNVMeFormatCmd(TestNVMe):
             proc = subprocess.Popen(id_ns, shell=True, stdout=subprocess.PIPE,
                                     encoding='utf-8')
             self.ms_list = proc.stdout.read().strip().split(" ")
-            assert_equal(self.detach_ns(self.ctrl_id, self.default_nsid), 0)
-            assert_equal(self.delete_and_validate_ns(self.default_nsid), 0)
+            self.assertEqual(self.detach_ns(self.ctrl_id, self.default_nsid), 0)
+            self.assertEqual(self.delete_and_validate_ns(self.default_nsid), 0)
             self.nvme_reset_ctrl()
 
     def test_format_ns(self):
@@ -142,10 +141,10 @@ class TestNVMeFormatCmd(TestNVMe):
                                               self.ncap,
                                               self.lba_format_list[i],
                                               metadata_size)
-            assert_equal(err, 0)
-            assert_equal(self.attach_ns(self.ctrl_id, self.default_nsid), 0)
+            self.assertEqual(err, 0)
+            self.assertEqual(self.attach_ns(self.ctrl_id, self.default_nsid), 0)
             self.run_ns_io(self.default_nsid, self.lbads_list[i])
             time.sleep(5)
-            assert_equal(self.detach_ns(self.ctrl_id, self.default_nsid), 0)
-            assert_equal(self.delete_and_validate_ns(self.default_nsid), 0)
+            self.assertEqual(self.detach_ns(self.ctrl_id, self.default_nsid), 0)
+            self.assertEqual(self.delete_and_validate_ns(self.default_nsid), 0)
             self.nvme_reset_ctrl()

--- a/tests/nvme_fw_log_test.py
+++ b/tests/nvme_fw_log_test.py
@@ -28,7 +28,6 @@ NVMe Firmware Log Testcase :-
 
 import subprocess
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -38,18 +37,18 @@ class TestNVMeFwLogCmd(TestNVMe):
     Represents NVMe Firmware Log test.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeFwLogCmd. """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeSimpleTestTemplate.
 
             - Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def get_fw_log(self):
         """ Wrapper for executing nvme fw-log.
@@ -71,4 +70,4 @@ class TestNVMeFwLogCmd(TestNVMe):
 
     def test_fw_log(self):
         """ Testcase main """
-        assert_equal(self.get_fw_log(), 0)
+        self.assertEqual(self.get_fw_log(), 0)

--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -36,7 +36,6 @@ Test the Mandatory features with get features command:-
 
 import subprocess
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -51,9 +50,9 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
               - vector_list_len : numer of the interrupt vectors.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeGetMandatoryFeatures """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
         self.feature_id_list = ["0x01", "0x02", "0x04", "0x05", "0x07",
                                 "0x08", "0x09", "0x0A", "0x0B"]
@@ -66,12 +65,12 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
                                 encoding='utf-8')
         self.vector_list_len = len(proc.stdout.read().strip().split(" "))
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeGetMandatoryFeatures
 
             Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def get_mandatory_features(self, feature_id):
         """ Wrapper for NVMe get features command
@@ -91,7 +90,7 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
                                         encoding='utf-8')
                 feature_output = proc.communicate()[0]
                 print(feature_output)
-                assert_equal(proc.wait(), 0)
+                self.assertEqual(proc.wait(), 0)
         else:
             get_feat_cmd = "nvme get-feature " + self.ctrl + \
                            " --feature-id=" + str(feature_id) + " -H"
@@ -101,7 +100,7 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
                                     encoding='utf-8')
             feature_output = proc.communicate()[0]
             print(feature_output)
-            assert_equal(proc.wait(), 0)
+            self.assertEqual(proc.wait(), 0)
 
     def test_get_mandatory_features(self):
         """ Testcase main """

--- a/tests/nvme_get_lba_status_test.py
+++ b/tests/nvme_get_lba_status_test.py
@@ -14,7 +14,6 @@ NVMe LBA Status Log Testcase :-
 
 import subprocess
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -24,9 +23,9 @@ class TestNVMeGetLbaStatusCmd(TestNVMe):
     Represents Get LBA Status test.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeGetLbaStatusCmd. """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.start_lba = 0
         self.block_count = 0
         self.namespace = 1
@@ -35,13 +34,13 @@ class TestNVMeGetLbaStatusCmd(TestNVMe):
         self.range_len = 1
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeGetLbaStatusCmd.
 
             - Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def get_lba_status(self):
         """ Wrapper for executing nvme get-lba-status.
@@ -68,4 +67,4 @@ class TestNVMeGetLbaStatusCmd(TestNVMe):
 
     def test_get_lba_status(self):
         """ Testcase main """
-        assert_equal(self.get_lba_status(), 0)
+        self.assertEqual(self.get_lba_status(), 0)

--- a/tests/nvme_id_ctrl_test.py
+++ b/tests/nvme_id_ctrl_test.py
@@ -28,7 +28,6 @@ NVMe Identify ctrl Testcase:-
 
 """
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -38,20 +37,20 @@ class TestNVMeIdctrlCmd(TestNVMe):
     Represents Id ctrl testcase
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeIdctrlCmd. """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeIdctrlCmd
 
             Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def test_id_ctrl(self):
         """ Testcase main """
         vendor = True
-        assert_equal(self.get_id_ctrl(), 0)
-        assert_equal(self.get_id_ctrl(vendor), 0)
+        self.assertEqual(self.get_id_ctrl(), 0)
+        self.assertEqual(self.get_id_ctrl(vendor), 0)

--- a/tests/nvme_id_ns_test.py
+++ b/tests/nvme_id_ns_test.py
@@ -29,7 +29,6 @@ NVme Identify Namespace Testcase:-
 
 import subprocess
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -39,19 +38,19 @@ class TestNVMeIdentifyNamespace(TestNVMe):
     Represents Identify Namesepace testcase
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeIdentifyNamespace. """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
         self.ns_list = self.get_ns_list()
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeIdentifyNamespace
 
             - Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def get_id_ns(self, nsid):
         """
@@ -87,5 +86,5 @@ class TestNVMeIdentifyNamespace(TestNVMe):
 
     def test_id_ns(self):
         """ Testcase main """
-        assert_equal(self.get_id_ns(1), 0)
-        assert_equal(self.get_id_ns_all(), 0)
+        self.assertEqual(self.get_id_ns(1), 0)
+        self.assertEqual(self.get_id_ns_all(), 0)

--- a/tests/nvme_lba_status_log_test.py
+++ b/tests/nvme_lba_status_log_test.py
@@ -14,7 +14,6 @@ NVMe LBA Status Log Testcase :-
 
 import subprocess
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -24,18 +23,18 @@ class TestNVMeLbaStatLogCmd(TestNVMe):
     Represents LBA Status Log test.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeLbaStatLogCmd. """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeLbaStatLogCmd.
 
             - Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def get_lba_stat_log(self):
         """ Wrapper for executing nvme lba-status-log.
@@ -57,4 +56,4 @@ class TestNVMeLbaStatLogCmd(TestNVMe):
 
     def test_lba_stat_log(self):
         """ Testcase main """
-        assert_equal(self.get_lba_stat_log(), 0)
+        self.assertEqual(self.get_lba_stat_log(), 0)

--- a/tests/nvme_read_write_test.py
+++ b/tests/nvme_read_write_test.py
@@ -30,7 +30,6 @@ NVMe Read/Write Testcae:-
 
 import filecmp
 
-from nose.tools import assert_equal
 from nvme_test_io import TestNVMeIO
 
 
@@ -45,9 +44,9 @@ class TestNVMeReadWriteTest(TestNVMeIO):
               - test_log_dir : directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeReadWriteTest """
-        TestNVMeIO.__init__(self)
+        super().setUp()
         self.start_block = 1023
         self.test_log_dir = self.log_dir + "/" + self.__class__.__name__
         self.setup_log_dir(self.__class__.__name__)
@@ -56,9 +55,9 @@ class TestNVMeReadWriteTest(TestNVMeIO):
         self.create_data_file(self.write_file, self.data_size, "15")
         open(self.read_file, 'a').close()
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeReadWriteTest """
-        TestNVMeIO.__del__(self)
+        super().tearDown()
 
     def read_validate(self):
         """ Validate the data file read
@@ -71,6 +70,6 @@ class TestNVMeReadWriteTest(TestNVMeIO):
 
     def test_nvme_write(self):
         """ Testcaes main  """
-        assert_equal(self.nvme_write(), 0)
-        assert_equal(self.nvme_read(), 0)
-        assert_equal(self.read_validate(), 0)
+        self.assertEqual(self.nvme_write(), 0)
+        self.assertEqual(self.nvme_read(), 0)
+        self.assertEqual(self.read_validate(), 0)

--- a/tests/nvme_simple_template_test.py
+++ b/tests/nvme_simple_template_test.py
@@ -29,19 +29,19 @@ class TestNVMeSimpleTestTemplate(TestNVMe):
 
     """ Represents Simple NVMe test """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeSimpleTestTemplate. """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
         # Add this test specific variables here
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeSimpleTestTemplate
 
             Call super class's destructor.
         """
         # Add this test specific cleanup code here
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def simple_template_test(self):
         """ Wrapper for this test specific functions

--- a/tests/nvme_smart_log_test.py
+++ b/tests/nvme_smart_log_test.py
@@ -27,7 +27,6 @@ NVMe Smart Log Verification Testcase:-
 
 """
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -39,18 +38,18 @@ class TestNVMeSmartLogCmd(TestNVMe):
         - Attributes:
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeSmartLogCmd """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """
         Post Section for TestNVMeSmartLogCmd
 
             - Call super class's destructor.
         """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def get_smart_log_ctrl(self):
         """ Wrapper for executing smart-log on controller.
@@ -84,7 +83,7 @@ class TestNVMeSmartLogCmd(TestNVMe):
 
     def test_smart_log(self):
         """ Testcase main """
-        assert_equal(self.get_smart_log_ctrl(), 0)
+        self.assertEqual(self.get_smart_log_ctrl(), 0)
         smlp = self.supp_check_id_ctrl("lpa")
         if smlp & 0x1 == True:
-            assert_equal(self.get_smart_log_all_ns(), 0)
+            self.assertEqual(self.get_smart_log_all_ns(), 0)

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -31,13 +31,12 @@ import stat
 import subprocess
 import sys
 import time
+import unittest
 
-from nose import tools
-from nose.tools import assert_equal
 from nvme_test_logger import TestNVMeLogger
 
 
-class TestNVMe(object):
+class TestNVMe(unittest.TestCase):
 
     """
     Represents a testcase, each testcase shuold inherit this
@@ -53,24 +52,23 @@ class TestNVMe(object):
             - clear_log_dir : default log directory.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMe. """
         # common code used in various testcases.
         self.ctrl = "XXX"
         self.ns1 = "XXX"
         self.test_log_dir = "XXX"
         self.default_nsid = 0x1
-        self.config_file = 'config.json'
+        self.config_file = 'tests/config.json'
 
         self.load_config()
         self.validate_pci_device()
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMe. """
         if self.clear_log_dir is True:
             shutil.rmtree(self.log_dir, ignore_errors=True)
 
-    @tools.nottest
     def validate_pci_device(self):
         """ Validate underlaying device belogs to pci subsystem.
             - Args:
@@ -81,9 +79,8 @@ class TestNVMe(object):
         x1, x2, dev = self.ctrl.split('/')
         cmd = cmd = "find /sys/devices -name \\*" + dev + " | grep -i pci"
         err = subprocess.call(cmd, shell=True)
-        assert_equal(err, 0, "ERROR : Only NVMe PCI subsystem is supported")
+        self.assertEqual(err, 0, "ERROR : Only NVMe PCI subsystem is supported")
 
-    @tools.nottest
     def load_config(self):
         """ Load Basic test configuration.
             - Args:
@@ -104,7 +101,6 @@ class TestNVMe(object):
             if not os.path.exists(self.log_dir):
                 os.makedirs(self.log_dir)
 
-    @tools.nottest
     def setup_log_dir(self, test_name):
         """ Set up the log directory for a testcase
             Args:
@@ -118,14 +114,12 @@ class TestNVMe(object):
         sys.stdout = TestNVMeLogger(self.test_log_dir + "/" + "stdout.log")
         sys.stderr = TestNVMeLogger(self.test_log_dir + "/" + "stderr.log")
 
-    @tools.nottest
     def exec_cmd(self, cmd):
         """ Wrapper for executing a shell command and return the result. """
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                                 encoding='utf-8')
         return proc.wait()
 
-    @tools.nottest
     def nvme_reset_ctrl(self):
         """ Wrapper for nvme reset command.
             - Args:
@@ -138,7 +132,7 @@ class TestNVMe(object):
                               shell=True,
                               stdout=subprocess.PIPE,
                               encoding='utf-8')
-        assert_equal(err, 0, "ERROR : nvme reset failed")
+        self.assertEqual(err, 0, "ERROR : nvme reset failed")
         time.sleep(5)
         rescan_cmd = "echo 1 > /sys/bus/pci/rescan"
         proc = subprocess.Popen(rescan_cmd,
@@ -147,9 +141,8 @@ class TestNVMe(object):
                                 stderr=subprocess.PIPE,
                                 encoding='utf-8')
         time.sleep(5)
-        assert_equal(proc.wait(), 0, "ERROR : pci rescan failed")
+        self.assertEqual(proc.wait(), 0, "ERROR : pci rescan failed")
 
-    @tools.nottest
     def get_ctrl_id(self):
         """ Wrapper for extracting the controller id.
             - Args:
@@ -163,12 +156,11 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : nvme list-ctrl failed")
+        self.assertEqual(err, 0, "ERROR : nvme list-ctrl failed")
         line = proc.stdout.readline()
         ctrl_id = line.split(":")[1].strip()
         return ctrl_id
 
-    @tools.nottest
     def get_ns_list(self):
         """ Wrapper for extrating the namespace list.
             - Args:
@@ -182,13 +174,12 @@ class TestNVMe(object):
                                 shell=True,
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
-        assert_equal(proc.wait(), 0, "ERROR : nvme list namespace failed")
+        self.assertEqual(proc.wait(), 0, "ERROR : nvme list namespace failed")
         for line in proc.stdout:
             ns_list.append(line.split('x')[-1])
 
         return ns_list
 
-    @tools.nottest
     def get_max_ns(self):
         """ Wrapper for extracting maximum number of namspaces supported.
             - Args:
@@ -204,7 +195,7 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : reading maximum namespace count failed")
+        self.assertEqual(err, 0, "ERROR : reading maximum namespace count failed")
 
         for line in proc.stdout:
             if pattern.match(line):
@@ -213,7 +204,6 @@ class TestNVMe(object):
         print(max_ns)
         return int(max_ns)
 
-    @tools.nottest
     def get_ncap(self):
         """ Wrapper for extracting capacity.
             - Args:
@@ -229,7 +219,7 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : reading nvm capacity failed")
+        self.assertEqual(err, 0, "ERROR : reading nvm capacity failed")
 
         for line in proc.stdout:
             if pattern.match(line):
@@ -238,7 +228,6 @@ class TestNVMe(object):
         print(ncap)
         return int(ncap)
 
-    @tools.nottest
     def get_format(self):
         """ Wrapper for extracting format.
             - Args:
@@ -254,7 +243,7 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : reading nvm capacity failed")
+        self.assertEqual(err, 0, "ERROR : reading nvm capacity failed")
 
         for line in proc.stdout:
             if "in use" in line:
@@ -262,7 +251,6 @@ class TestNVMe(object):
         print(nvm_format)
         return int(nvm_format)
 
-    @tools.nottest
     def delete_all_ns(self):
         """ Wrapper for deleting all the namespaces.
             - Args:
@@ -271,16 +259,15 @@ class TestNVMe(object):
                 - None
         """
         delete_ns_cmd = "nvme delete-ns " + self.ctrl + " -n 0xFFFFFFFF"
-        assert_equal(self.exec_cmd(delete_ns_cmd), 0)
+        self.assertEqual(self.exec_cmd(delete_ns_cmd), 0)
         list_ns_cmd = "nvme list-ns " + self.ctrl + " --all | wc -l"
         proc = subprocess.Popen(list_ns_cmd,
                                 shell=True,
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         output = proc.stdout.read().strip()
-        assert_equal(output, '0', "ERROR : deleting all namespace failed")
+        self.assertEqual(output, '0', "ERROR : deleting all namespace failed")
 
-    @tools.nottest
     def create_ns(self, nsze, ncap, flbas, dps):
         """ Wrapper for creating a namespace.
             - Args:
@@ -296,7 +283,6 @@ class TestNVMe(object):
                         " --flbas=" + str(flbas) + " --dps=" + str(dps)
         return self.exec_cmd(create_ns_cmd)
 
-    @tools.nottest
     def create_and_validate_ns(self, nsid, nsze, ncap, flbas, dps):
         """ Wrapper for creating and validating a namespace.
             - Args:
@@ -318,7 +304,6 @@ class TestNVMe(object):
                                   encoding='utf-8')
         return err
 
-    @tools.nottest
     def attach_ns(self, ctrl_id, ns_id):
         """ Wrapper for attaching the namespace.
             - Args:
@@ -343,7 +328,6 @@ class TestNVMe(object):
             err = 0 if stat.S_ISBLK(os.stat(self.ns1).st_mode) else 1
         return err
 
-    @tools.nottest
     def detach_ns(self, ctrl_id, nsid):
         """ Wrapper for detaching the namespace.
             - Args:
@@ -360,7 +344,6 @@ class TestNVMe(object):
                                stdout=subprocess.PIPE,
                                encoding='utf-8')
 
-    @tools.nottest
     def delete_and_validate_ns(self, nsid):
         """ Wrapper for deleting and validating that namespace is deleted.
             - Args:
@@ -374,7 +357,7 @@ class TestNVMe(object):
                               shell=True,
                               stdout=subprocess.PIPE,
                               encoding='utf-8')
-        assert_equal(err, 0, "ERROR : delete namespace failed")
+        self.assertEqual(err, 0, "ERROR : delete namespace failed")
         return err
 
     def get_smart_log(self, nsid):
@@ -391,7 +374,7 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : nvme smart log failed")
+        self.assertEqual(err, 0, "ERROR : nvme smart log failed")
 
         for line in proc.stdout:
             if "data_units_read" in line:
@@ -430,7 +413,7 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : nvme id controller failed")
+        self.assertEqual(err, 0, "ERROR : nvme id controller failed")
         return err
 
     def get_error_log(self):
@@ -447,7 +430,7 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : nvme error log failed")
+        self.assertEqual(err, 0, "ERROR : nvme error log failed")
         line = proc.stdout.readline()
         err_log_entry_count = int(line.split(" ")[5].strip().split(":")[1])
         entry_count = 0
@@ -472,14 +455,14 @@ class TestNVMe(object):
         run_io = subprocess.Popen(io_cmd, shell=True, stdout=subprocess.PIPE,
                                   encoding='utf-8')
         run_io_result = run_io.communicate()[1]
-        assert_equal(run_io_result, None)
+        self.assertEqual(run_io_result, None)
         io_cmd = "dd if=/dev/zero of=" + ns_path + " bs=" + \
                  str(block_size) + " count=10 > /dev/null 2>&1"
         print(io_cmd)
         run_io = subprocess.Popen(io_cmd, shell=True, stdout=subprocess.PIPE,
                                   encoding='utf-8')
         run_io_result = run_io.communicate()[1]
-        assert_equal(run_io_result, None)
+        self.assertEqual(run_io_result, None)
 
     def supp_check_id_ctrl(self, key):
         """ Wrapper for support check.
@@ -495,8 +478,8 @@ class TestNVMe(object):
                                 stdout=subprocess.PIPE,
                                 encoding='utf-8')
         err = proc.wait()
-        assert_equal(err, 0, "ERROR : nvme Identify controller Data \
-                     structure failed")
+        self.assertEqual(err, 0, "ERROR : nvme Identify controller Data \
+                         structure failed")
         for line in proc.stdout:
             if key in line:
                 key = line.replace(",", "", 1)

--- a/tests/nvme_test_io.py
+++ b/tests/nvme_test_io.py
@@ -23,7 +23,6 @@
 
 import os
 
-from nose import tools
 from nvme_test import TestNVMe
 
 
@@ -40,9 +39,9 @@ class TestNVMeIO(TestNVMe):
               - read_file : data file to use in nvme read command.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeIO """
-        TestNVMe.__init__(self)
+        super().setUp()
         # common code used in various testcases.
         self.data_size = 512
         self.start_block = 0
@@ -50,11 +49,10 @@ class TestNVMeIO(TestNVMe):
         self.write_file = "write_file.txt"
         self.read_file = "read_file.txt"
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeIO """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
-    @tools.nottest
     def create_data_file(self, pathname, data_size, pattern):
         """ Creates data file with specific pattern
             - Args:
@@ -72,7 +70,6 @@ class TestNVMeIO(TestNVMe):
         os.fsync(data_file.fileno())
         data_file.close()
 
-    @tools.nottest
     def nvme_write(self):
         """ Wrapper for nvme write operation
             - Args:
@@ -86,7 +83,6 @@ class TestNVMeIO(TestNVMe):
                     str(self.data_size) + " --data=" + self.write_file
         return self.exec_cmd(write_cmd)
 
-    @tools.nottest
     def nvme_read(self):
         """ Wrapper for nvme read operation
             - Args:

--- a/tests/nvme_test_logger.py
+++ b/tests/nvme_test_logger.py
@@ -26,7 +26,7 @@ Logger for NVMe Test Framwwork:-
 import sys
 
 
-class TestNVMeLogger(object):
+class TestNVMeLogger():
     """ Represents Logger for NVMe Testframework.  """
 
     def __init__(self, log_file_path):

--- a/tests/nvme_verify_test.py
+++ b/tests/nvme_verify_test.py
@@ -13,7 +13,6 @@ NVMe Verify Testcase:-
 
 """
 
-from nose.tools import assert_equal
 from nvme_test import TestNVMe
 
 
@@ -26,17 +25,17 @@ class TestNVMeVerify(TestNVMe):
               - test_log_dir : directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeVerify """
-        TestNVMe.__init__(self)
+        super().setUp()
         self.start_block = 0
         self.block_count = 0
         self.namespace = 1
         self.setup_log_dir(self.__class__.__name__)
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeVerify """
-        TestNVMe.__del__(self)
+        super().tearDown()
 
     def verify(self):
         """ Wrapper for nvme verify
@@ -53,4 +52,4 @@ class TestNVMeVerify(TestNVMe):
 
     def test_verify(self):
         """ Testcase main """
-        assert_equal(self.verify(), 0)
+        self.assertEqual(self.verify(), 0)

--- a/tests/nvme_writeuncor_test.py
+++ b/tests/nvme_writeuncor_test.py
@@ -30,7 +30,6 @@ NVMe Write Compare Testcae:-
 
 """
 
-from nose.tools import assert_equal, assert_not_equal
 from nvme_test_io import TestNVMeIO
 
 
@@ -43,9 +42,9 @@ class TestNVMeUncor(TestNVMeIO):
               - test_log_dir : directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Constructor TestNVMeUncor """
-        TestNVMeIO.__init__(self)
+        super().setUp()
         self.start_block = 1023
         self.setup_log_dir(self.__class__.__name__)
         self.write_file = self.test_log_dir + "/" + self.write_file
@@ -53,9 +52,9 @@ class TestNVMeUncor(TestNVMeIO):
         self.create_data_file(self.write_file, self.data_size, "15")
         open(self.read_file, 'a').close()
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeUncor """
-        TestNVMeIO.__del__(self)
+        super().tearDown()
 
     def write_uncor(self):
         """ Wrapper for nvme write uncorrectable
@@ -71,8 +70,8 @@ class TestNVMeUncor(TestNVMeIO):
 
     def test_write_uncor(self):
         """ Testcase main """
-        assert_equal(self.nvme_read(), 0)
-        assert_equal(self.write_uncor(), 0)
-        assert_not_equal(self.nvme_read(), 0)
-        assert_equal(self.nvme_write(), 0)
-        assert_equal(self.nvme_read(), 0)
+        self.assertEqual(self.nvme_read(), 0)
+        self.assertEqual(self.write_uncor(), 0)
+        self.assertNotEqual(self.nvme_read(), 0)
+        self.assertEqual(self.nvme_write(), 0)
+        self.assertEqual(self.nvme_read(), 0)

--- a/tests/nvme_writezeros_test.py
+++ b/tests/nvme_writezeros_test.py
@@ -31,7 +31,6 @@ NVMe Write Zeros:-
 
 import filecmp
 
-from nose.tools import assert_equal
 from nvme_test_io import TestNVMeIO
 
 
@@ -48,9 +47,9 @@ class TestNVMeWriteZeros(TestNVMeIO):
               - test_log_dir : directory for logs, temp files.
     """
 
-    def __init__(self):
+    def setUp(self):
         """ Pre Section for TestNVMeWriteZeros """
-        TestNVMeIO.__init__(self)
+        super().setUp()
         self.start_block = 1023
         self.block_count = 0
         self.setup_log_dir(self.__class__.__name__)
@@ -61,9 +60,9 @@ class TestNVMeWriteZeros(TestNVMeIO):
         self.create_data_file(self.zero_file, self.data_size, '\0')
         open(self.read_file, 'a').close()
 
-    def __del__(self):
+    def tearDown(self):
         """ Post Section for TestNVMeWriteZeros """
-        TestNVMeIO.__del__(self)
+        super().tearDown()
 
     def write_zeroes(self):
         """ Wrapper for nvme write-zeroe
@@ -98,9 +97,9 @@ class TestNVMeWriteZeros(TestNVMeIO):
 
     def test_write_zeros(self):
         """ Testcae main """
-        assert_equal(self.nvme_write(), 0)
-        assert_equal(self.nvme_read(), 0)
-        assert_equal(self.validate_write_read(), 0)
-        assert_equal(self.write_zeroes(), 0)
-        assert_equal(self.nvme_read(), 0)
-        assert_equal(self.validate_zeroes(), 0)
+        self.assertEqual(self.nvme_write(), 0)
+        self.assertEqual(self.nvme_read(), 0)
+        self.assertEqual(self.validate_write_read(), 0)
+        self.assertEqual(self.write_zeroes(), 0)
+        self.assertEqual(self.nvme_read(), 0)
+        self.assertEqual(self.validate_zeroes(), 0)


### PR DESCRIPTION
The test are still using nose which has been superseeded by
nose2. Update the tests to use the nose2 and unittest.

To minimize errors in most of the porting is done using sed, e.g
's/TestNVMeIO.__init__(self)/super().setUp()/g'.

While at it also update the build system and move the test files to
the build dir. This avoids in tree exectution of the Python files
which leaves the __pycache__ dir in the source tree.

This also fixes the problem, that the config file is not found when
'meson test -C .build' is used. We have the prober dir structure for
Python and nose2 to find all resources in the build root. Furthermore,
when running the tests the output is captured in the nvmetests
dir. This dir is also created under the build root dir.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1563