### PR TITLE
Bash Completion fixes

### DIFF
--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -940,7 +940,7 @@ plugin_micron_opts () {
 	return 0
 }
 
-lugin_seagate_opts () {
+plugin_seagate_opts () {
     local opts=""
 	local compargs=""
 

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -5,7 +5,8 @@
 # Kelly Kaoudis kelly.n.kaoudis at intel.com, Aug. 2015
 
 # Constant to indicate command has no options
-readonly NO_OPTS=""
+NO_OPTS=""
+readonly NO_OPTS
 
 # Associative array of plugins and associated subcommands
 # Order here is same as PLUGIN_OBJS in Makefile


### PR DESCRIPTION
Fixed:
* error when completion file is sourced for the second time
* typo resulted in broken completion for seagate plugin
