### PR TITLE
bash-nvme-completion.sh: a better fix for "readonly" with bash 5.x

### DIFF
--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -55,6 +55,7 @@ typeset -Ar _plugin_subcmds=(
 	[nvidia]="id-ctrl"
 	[ymtc]="smart-log-add"
 )
+readonly _plugin_subcmds
 
 # Associative array mapping plugins to coresponding option completions
 typeset -Ar _plugin_funcs=(
@@ -75,6 +76,7 @@ typeset -Ar _plugin_funcs=(
 	[nvidia]="plugin_nvidia_opts"
 	[ymtc]="plugin_ymtc_opts"
 )
+readonly _plugin_funcs
 
 # Top level commands
 _cmds="list list-subsys id-ctrl id-ns \


### PR DESCRIPTION
As a follow-up for #1574

The error with one-line "readonly" with assignment on bash 5.x was fixed by 25fd8c707b106ca0763402566ad657ef710bf09e. This commit restores "readonly" functionality and adds some uniformity.