### PR TITLE
fabrics: Avoid out of bounds string chomping

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -149,10 +149,5 @@ int uuid_from_systemd(char *uuid);
 unsigned long long elapsed_utime(struct timeval start_time,
 					struct timeval end_time);
 
-static inline void nvme_strip_spaces(char *s, int l)
-{
-        while (l && (s[l] == '\0' || s[l] == ' '))
-                s[l--] = '\0';
-}
 __u16 get_feat_buf_len(unsigned short feature);
 #endif /* _NVME_H */


### PR DESCRIPTION
First move nvme_strip_chomp() to fabrics.c as it is the only
user. Also rename it to strchomp as there is nothing nvme specific.

While at it, fix the implementation of the function to handle
all the corner cases by using strnlen() to figure out the
max length of the string. After we terminate it properly,
we can start chopping off any trailing whitespace.

Also make sure that all call sides of strchomp to use the correct max
lenght of the string to avoid out of bounds access.

Also we don't need space_strip_len() to tell use what the max size of
the string is. We know it at compile time.

Signed-off-by: Daniel Wagner <dwagner@suse.de>