### PR TITLE
docs: Document nvme-id-ns behavior when nsid is 0xFFFFFFFF

### DIFF
--- a/Documentation/nvme-id-ns.txt
+++ b/Documentation/nvme-id-ns.txt
@@ -35,7 +35,10 @@ OPTIONS
 --namespace-id=<nsid>::
 	Retrieve the identify namespace structure for the given nsid. This
 	is required for the character devices, or overrides the block nsid
-	if given.
+	if given. If the controller supports namespace management capability
+	and 0xFFFFFFFF is given, then the controller returns the identify
+	namespace structure that specifies common capabilities across
+	namespaces for the controller.
 
 --force::
 	Request controller return the identify namespace structure even


### PR DESCRIPTION
as documented in NVM Command Set Specification Revision 1.0b,
chapter 4.1.5.1 - NVM Command Set Identify Namespace Data Structure (CNS 00h).