### PR TITLE
create-ns: fix create-ns fail when -b 4096 while id-ns return nlbaf=1…

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2438,7 +2438,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 			}
 			goto close_fd;
 		}
-		for (i = 0; i < ns.nlbaf; ++i) {
+		for (i = 0; i <= ns.nlbaf; ++i) {
 			if ((1 << ns.lbaf[i].ds) == cfg.bs && ns.lbaf[i].ms == 0) {
 				cfg.flbas = i;
 				break;


### PR DESCRIPTION
… and 0 for 512, 1 for 4096

Fail case:
sudo nvme create-ns /dev/nvme0 --nsze=1875366486   --ncap=937684566  --block-size=4096  --timeout=120000
   FLBAS corresponding to block size 4096 not found
   Please correct block size, or specify FLBAS directly

Signed-off-by: Wei Hou <wei.hou@scaleflux.com>