### PR TITLE
ci: Add auto review bot

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,26 @@
+reviewers:
+  # The default reviewers
+  defaults:
+    - default-reviewers # group
+
+  # Reviewer groups each of which has a list of GitHub usernames
+  groups:
+    default-reviewers:
+      - igaw
+      - hreinecke
+    ocp-reviewers:
+      - arthurshau
+
+files:
+  # Keys are glob expressions.
+  # You can assign groups defined above as well as GitHub usernames.
+  '**':
+    - default-reviewers
+  'plugins/ocp/**':
+    - ocp-reviewers
+
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - DO NOT REVIEW
+  enable_group_assignment: false

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,16 @@
+name: Auto Request Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml # Config file location override


### PR DESCRIPTION
Arthur has asked  to be added as reviewer to the OCP plugin changes. 
Let's setup an auto review bot. We might also want to hook up this for the other
plugins in the future.

Signed-off-by: Daniel Wagner <dwagner@suse.de>