### PR TITLE
Added average latency field to solidigm latency-tracking-log.

### DIFF
--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -66,17 +66,14 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 
 	struct config {
 		char	*output_format;
-		int	raw_binary;
 	};
 
 	struct config cfg = {
 		.output_format	= "normal",
-		.raw_binary	= 0
 	};
 
 	OPT_ARGS(opts) = {
 		OPT_FMT("output-format",   'o', &cfg.output_format,  output_format),
-		OPT_FLAG("raw-binary",     'b', &cfg.raw_binary,     "Dump output in binary format"),
 		OPT_END()
 	};
 
@@ -90,10 +87,6 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 		fprintf(stderr, "Invalid output format '%s'\n", cfg.output_format);
 		close(fd);
 		return fd;
-	}
-	
-	if (cfg.raw_binary)	{
-		flags = BINARY;
 	}
 
 	garbage_control_collection_log_t gc_log;

--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -13,7 +13,7 @@
 
 #include "cmd.h"
 
-#define SOLIDIGM_PLUGIN_VERSION "0.3"
+#define SOLIDIGM_PLUGIN_VERSION "0.4"
 
 PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_VERSION),
 	COMMAND_LIST(

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -206,19 +206,16 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	struct config {
 		__u32	namespace_id;
 		char	*output_format;
-		int	raw_binary;
 	};
 
 	struct config cfg = {
 		.namespace_id	= NVME_NSID_ALL,
 		.output_format	= "normal",
-		.raw_binary	= 0
 	};
 
 	OPT_ARGS(opts) = {
 		OPT_UINT("namespace-id",   'n', &cfg.namespace_id,   "(optional) desired namespace"),
 		OPT_FMT("output-format",   'o', &cfg.output_format,  output_format),
-		OPT_FLAG("raw-binary",     'b', &cfg.raw_binary,     "Dump output in binary format"),
 		OPT_END()
 	};
 
@@ -232,9 +229,6 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 		fprintf(stderr, "Invalid output format '%s'\n", cfg.output_format);
 		close(fd);
 		return fd;
-	}
-	if (cfg.raw_binary)	{
-		flags = BINARY;
 	}
 
 	err = nvme_get_log_simple(fd, solidigm_vu_smart_log_id, sizeof(smart_log_payload), &smart_log_payload);


### PR DESCRIPTION
Removed -b flag option from solidigm plug-in, in favor of "-o binary".