### PR TITLE
rpmbuild: Do docs build to avoid error from missing .1, .html files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,5 @@ rpm:
 	meson ${BUILD-DIR} \
 		-Dudevrulesdir=$(shell rpm --eval '%{_udevrulesdir}') \
 		-Dsystemddir=$(shell rpm --eval '%{_unitdir}') \
-		-Ddocs=man
+		-Ddocs=man -Ddocs-build=true
 	rpmbuild -ba ${BUILD-DIR}/nvme.spec --define "_builddir ${BUILD-DIR}" -v


### PR DESCRIPTION
Program asciidoc found: YES (/usr/bin/asciidoc)
Documentation/meson.build:253:8: ERROR: File nvme-wdc-cloud-boot-SSD-version.1 does not exist.

Signed-off-by: Steven Seungcheol Lee <sc108.lee@samsung.com>