### PR TITLE
build: Give auto review bot write permission on pull request

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,3 +1,4 @@
+---
 name: Auto Request Review
 
 on:
@@ -8,9 +9,11 @@ jobs:
   auto-request-review:
     name: Auto Request Review
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          config: .github/reviewers.yml # Config file location override
+          config: .github/reviewers.yml  # Config file location override


### PR DESCRIPTION
Currently setting the reviewer from the bot fails with:
  Error: HttpError: Resource not accessible by integration

The GITHUB_TOKEN needs enough permission to update the PR.

Links: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
Signed-off-by: Daniel Wagner <dwagner@suse.de>