### PR TITLE
nvme: Check timestamp format result and increase string size

### DIFF
--- a/Documentation/cmd-plugins.txt
+++ b/Documentation/cmd-plugins.txt
@@ -65,7 +65,7 @@ linknvme:nvme-transcend-badblock[1]::
 	Retrieve Transcend NVMe device's bad blocks
 
 linknvme:nvme-transcend-healthvalue[1]::
-	Use NVMe SMART table to analyse the health value of Transcend device
+	Use NVMe SMART table to analyze the health value of Transcend device
 
 linknvme:nvme-virtium-show-identify[1]::
 	Show a complete detail of identify device information in json format

--- a/Documentation/cmds-main.txt
+++ b/Documentation/cmds-main.txt
@@ -44,7 +44,7 @@ linknvme:nvme-smart-log[1]::
 	Retrieve Smart Log
 
 linknvme:nvme-ana-log[1]::
-	Retreive ANA(Asymmetric Namespace Access) Log
+	Retrieve ANA(Asymmetric Namespace Access) Log
 
 linknvme:nvme-endurance-log[1]::
 	Retrieve endurance Log
@@ -236,7 +236,7 @@ linknvme:nvme-nvm-id-ns-lba-format[1]::
 	NVMe Identify Namespace NVM Command Set for the specified LBA Format index
 
 linknvme:nvme-persistent-event-log[1]::
-	Retrieve Presistent Event Log
+	Retrieve Persistent Event Log
 
 linknvme:nvme-predictable-lat-log[1]::
 	Retrieve Predictable Latency per Nvmset Log

--- a/Documentation/nvme-attach-ns.txt
+++ b/Documentation/nvme-attach-ns.txt
@@ -26,11 +26,11 @@ OPTIONS
 -c <ctrl-list,>::
 -controllers=<ctrl-list,>::
 	The comma separated list of controller identifiers to attach
-	the namesapce too.
+	the namespace too.
 
 EXAMPLES
 --------
-	Attach namspace to the controller:
+	Attach namespace to the controller:
 
 		# nvme attach-ns /dev/nvme1  -n 0x2 -c 0x21
 

--- a/Documentation/nvme-compare.txt
+++ b/Documentation/nvme-compare.txt
@@ -55,10 +55,10 @@ OPTIONS
 
 -y <metasize>::
 --metadata-size=<metasize>::
-	Size of metadata to be trasnferred in bytes.
+	Size of metadata to be transferred in bytes.
 
 -r <reftag>::
---ref-tag=<regtag>::
+--ref-tag=<reftag>::
 	Reference Tag for Protection Information
 
 -d <data-file>::
@@ -106,8 +106,8 @@ metadata is passes.
 --dir-type=<type>::
 	Optional directive type. The nvme-cli only enforces the value
 	be in the defined range for the directive type, though the NVMe
-	specifcation (1.3a) defines only one directive, 01h, for write
-	stream idenfiers.
+	specification (1.3a) defines only one directive, 01h, for write
+	stream identifiers.
 
 -S <spec>::
 --dir-spec=<spec>::
@@ -146,7 +146,7 @@ metadata is passes.
 	data protection processing.
 
 --force::
-    Ignore namespace is currently busy and perfome the operation
+    Ignore namespace is currently busy and performed the operation
     even though.
 
 EXAMPLES

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -43,7 +43,7 @@ connect-all commands to run. If no @SYSCONFDIR@/nvme/discovery.conf file
 exists, the command will quit with an error.
 
 Otherwise a specific Discovery Controller should be specified using the
---transport, --traddr and if necessary the --trsvcid and a Diѕcovery
+--transport, --traddr and if necessary the --trsvcid and a Discovery
 request will be sent to the specified Discovery Controller.
 
 See the documentation for the nvme-discover(1) command for further

--- a/Documentation/nvme-copy.txt
+++ b/Documentation/nvme-copy.txt
@@ -88,8 +88,8 @@ OPTIONS
 -T <type>::
 	Optional directive type. The nvme-cli only enforces the value
 	be in the defined range for the directive type, though the NVMe
-	specifcation (1.3a) defines only one directive, 01h, for write
-	stream idenfiers.
+	specification (1.3a) defines only one directive, 01h, for write
+	stream identifiers.
 
 --dir-spec=<spec>::
 -S <spec>::

--- a/Documentation/nvme-create-ns.txt
+++ b/Documentation/nvme-create-ns.txt
@@ -53,7 +53,7 @@ OPTIONS
 
 -a::
 --anagrp-id::
-	ANA Gorup Identifier. If this value is 0h specifies
+	ANA Group Identifier. If this value is 0h specifies
 	that the controller determines the value to use
 
 -i <nvmsetid>::

--- a/Documentation/nvme-device-self-test.txt
+++ b/Documentation/nvme-device-self-test.txt
@@ -24,7 +24,7 @@ OPTIONS
 -------
 -n <NUM>::
 --namespace-id=<NUM>::
-	Indicate the namespace in which the device self-test has to becarried out
+	Indicate the namespace in which the device self-test has to be carried out
 
 -s <NUM>::
 --self-test-code=<NUM>::

--- a/Documentation/nvme-dim.txt
+++ b/Documentation/nvme-dim.txt
@@ -21,7 +21,7 @@ deregister.
 
 The DIM command is used to explicitly register with Discovery Controllers (DC),
 especially with Central Discovery Controllers (CDC). CDCs maintain a database (DB)
-of all the Hosts and Storage Susbsystems in a network. The register task is used
+of all the Hosts and Storage Subsystems in a network. The register task is used
 to add a host to the CDC's DB. The deregister task is used to remove a host from
 the CDC's DB.
 

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -46,7 +46,7 @@ Discovery commands to run.  If no @SYSCONFDIR@/nvme/discovery.conf file
 exists, the command will quit with an error.
 
 Otherwise, a specific Discovery Controller should be specified using the
---transport, --traddr, and if necessary the --trsvcid flags. A Diѕcovery
+--transport, --traddr, and if necessary the --trsvcid flags. A Discovery
 request will then be sent to the specified Discovery Controller.
 
 BACKGROUND
@@ -150,7 +150,7 @@ OPTIONS
 
 -k <#>::
 --keep-alive-tmo=<#>::
-	Overrides the default dealy (in seconds) for keep alive.
+	Overrides the default timeout (in seconds) for keep alive.
 	This option will be ignored for the discovery, and it is only
 	implemented for completeness.
 
@@ -210,7 +210,7 @@ OPTIONS
               'binary'. Only one output format can be used at a time.
 
 --force::
-	Disable the built-in persitent discover connection rules.
+	Disable the built-in persistent discover connection rules.
 	Combined with --persistent flag, always create new
 	persistent discovery connection.
 

--- a/Documentation/nvme-fid-support-effects-log.txt
+++ b/Documentation/nvme-fid-support-effects-log.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 For the NVMe device given, sends an FID Support and Effects log and
-provides the result and returned logstructure.
+provides the result and returned log structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/Documentation/nvme-fw-commit.txt
+++ b/Documentation/nvme-fw-commit.txt
@@ -72,7 +72,7 @@ BPINFO.ABPID.
 
 --bpid=<boot-partid>::
 -b <boot-partid>::
-	Specifiies the Boot partition that shall be used for the Commit Action,
+	Specifies the Boot partition that shall be used for the Commit Action,
 	if applicable (default: 0)
 
 EXAMPLES

--- a/Documentation/nvme-fw-download.txt
+++ b/Documentation/nvme-fw-download.txt
@@ -37,7 +37,7 @@ the Firmware Commit command (nvme fw-commit <args>).
 OPTIONS
 -------
 -f <firmware-file>::
---fw=<firmeware-file>::
+--fw=<firmware-file>::
 	Required argument. This specifies the path to the device's
 	firmware file on your system that will be read by the program
 	and sent to the device.

--- a/Documentation/nvme-id-domain.txt
+++ b/Documentation/nvme-id-domain.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-For the NVMe device given, send an identify command and return the domian list
+For the NVMe device given, send an identify command and return the domain list
 data structure.
 
 The <device> parameter is mandatory and may be either the NVMe character

--- a/Documentation/nvme-list-ns.txt
+++ b/Documentation/nvme-list-ns.txt
@@ -34,7 +34,7 @@ OPTIONS
 -y <command_set_identifier>::
 --csi=<command_set_identifier>::
 	If this value is given, retrieve the identify list structure associated
-	with the speicified I/O command set.
+	with the specified I/O command set.
 
 -a::
 --all::

--- a/Documentation/nvme-list.txt
+++ b/Documentation/nvme-list.txt
@@ -25,7 +25,7 @@ OPTIONS
 -v::
 --verbose::
 	Increase the information in the output, showing nvme subsystems,
-	controllers and namespaces separately and how they're realted to each
+	controllers and namespaces separately and how they're related to each
 	other.
 
 ENVIRONMENT

--- a/Documentation/nvme-lockdown.txt
+++ b/Documentation/nvme-lockdown.txt
@@ -18,7 +18,7 @@ DESCRIPTION
 -----------
 The Lockdown command is used to control the Command and Feature Lockdown
 capability which configures the prohibition or allowance of execution of the
-specified commandor Set Features command targeting a specific Feature
+specified command or Set Features command targeting a specific Feature
 Identifier.
 
 OPTIONS
@@ -34,17 +34,17 @@ OPTIONS
 
 --prhbt=<prhbt>::
 -p <prhbt>::
-	Prohibit(PRHBT) bit specifies whether to prohibit or allow the command
+	Prohibit (PRHBT) bit specifies whether to prohibit or allow the command
 	opcode or Set Features Feature Identifier specified by this command.
 
 --scp=<scp>::
 -s <scp>::
-	Scope(SCP) field specifies the contents of the Opcode or Feature Identifier field.
+	Scope (SCP) field specifies the contents of the Opcode or Feature Identifier field.
 
 --uuid=<UUID_Index>::
 -U <UUID_Index>::
-	UUID Index - If this field is set to a non-zerovalue, then the value of
-	this field is the index of a UUID in the UUIDList that is used by the command.
+	UUID Index - If this field is set to a non-zero value, then the value of
+	this field is the index of a UUID in the UUID List that is used by the command.
 	If this field is cleared to 0h,then no UUID index is specified.
 
 EXAMPLES

--- a/Documentation/nvme-micron-clear-pcie-errors.txt
+++ b/Documentation/nvme-micron-clear-pcie-errors.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-This command clears corretable pcie errors for the specified Micron device.
+This command clears correctable pcie errors for the specified Micron device.
 
 The <device> parameter is mandatory and may be either the NVMe
 character device (ex: /dev/nvme0), or a namespace block device (ex:

--- a/Documentation/nvme-micron-internal-log.txt
+++ b/Documentation/nvme-micron-internal-log.txt
@@ -13,8 +13,8 @@ SYNOPSIS
 DESCRIPTION
 -----------
 For the given NVMe device, sends the Micron vendor specific device commands to retrieve
-various logs (in binary format) and compresses them and saves into speficied zip file.
-These vendor unique logs can be analysed with Micron Technical support team for any device
+various logs (in binary format) and compresses them and saves into specified zip file.
+These vendor unique logs can be analyzed with Micron Technical support team for any device
 specific issues
 
 The <device> parameter is mandatory and may be either the NVMe

--- a/Documentation/nvme-micron-temperature-stats.txt
+++ b/Documentation/nvme-micron-temperature-stats.txt
@@ -1,4 +1,4 @@
-nvme-micron-temperarature-stats(1)
+nvme-micron-temperature-stats(1)
 ==================================
 
 NAME

--- a/Documentation/nvme-pred-lat-event-agg-log.txt
+++ b/Documentation/nvme-pred-lat-event-agg-log.txt
@@ -22,7 +22,7 @@ The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
 
 On success, the returned Predictable Latency Event Aggregate Log
-Page structure may be returned in one ofseveral ways depending on
+Page structure may be returned in one of several ways depending on
 the option flags; the structure may parsed by the program and printed
 in a readable format or the raw buffer may be printed to stdout for
 another program to parse.
@@ -43,7 +43,7 @@ OPTIONS
 
 -b::
 --raw-binary::
-	Print the raw Predectible Latency Event Aggregate log buffer to stdout.
+	Print the raw Predictable Latency Event Aggregate log buffer to stdout.
 
 -o <format>::
 --output-format=<format>::
@@ -59,7 +59,7 @@ EXAMPLES
 ------------
 +
 
-* Print the raw Predectible Latency Event Aggregate log to a file:
+* Print the raw Predictable Latency Event Aggregate log to a file:
 +
 ------------
 # nvme pred-lat-event-agg-log /dev/nvme0 --raw-binary > pred_lat_agg_log.raw

--- a/Documentation/nvme-predictable-lat-log.txt
+++ b/Documentation/nvme-predictable-lat-log.txt
@@ -3,7 +3,7 @@ nvme-predictable-lat-log(1)
 
 NAME
 ----
-nvme-predictable-lat-log - Send Predectible latency per NVM set log page request,
+nvme-predictable-lat-log - Send Predictable latency per NVM set log page request,
 returns result and log
 
 SYNOPSIS
@@ -15,14 +15,14 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Retrieves the NVMe Predectible latency per NVM set log page from an NVMe device
+Retrieves the NVMe Predictable latency per NVM set log page from an NVMe device
 and provides the returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
 
-On success, the returned Predectible latency per NVM set log structure
-may be returned in one ofseveral ways depending on the option flags; the
+On success, the returned Predictable latency per NVM set log structure
+may be returned in one of several ways depending on the option flags; the
 structure may parsed by the program and printed in a readable format or
 the raw buffer may be printed to stdout for another program to parse.
 
@@ -30,14 +30,14 @@ OPTIONS
 -------
 -i <nvmset_id>::
 --nvmset-id=<nvmset_id>::
-    Retrieve the Predectible latency per NVM set log for the given nvmset id.
+    Retrieve the Predictable latency per NVM set log for the given nvmset id.
     This argument is mandatory and its success may depend on the device's
     statistics to provide this log For More details see NVM Express 1.4 Spec.
     Section 5.14.1.10. The default nvmset id to use is 1 for the device.
 
 -b::
 --raw-binary::
-	Print the raw Predectible latency per NVM set log buffer to stdout.
+	Print the raw Predictable latency per NVM set log buffer to stdout.
 
 -o <format>::
 --output-format=<format>::
@@ -46,14 +46,14 @@ OPTIONS
 
 EXAMPLES
 --------
-* Print the Predectible latency per NVM set log page in a human readable format:
+* Print the Predictable latency per NVM set log page in a human readable format:
 +
 ------------
 # nvme predictable-lat-log /dev/nvme0
 ------------
 +
 
-* Print the raw Predectible latency per NVM set log to a file:
+* Print the raw Predictable latency per NVM set log to a file:
 +
 ------------
 # nvme predictable-lat-log /dev/nvme0 --raw-binary > nvmset_log.raw

--- a/Documentation/nvme-primary-ctrl-caps.txt
+++ b/Documentation/nvme-primary-ctrl-caps.txt
@@ -45,7 +45,7 @@ EXAMPLES
 fields in a human readable format:
 +
 ------------
-# nvme primary-ctrl-caps /dev/nvme0 --human-readbale
+# nvme primary-ctrl-caps /dev/nvme0 --human-readable
 # nvme primary-ctrl-caps /dev/nvme0 -H
 ------------
 NVME

--- a/Documentation/nvme-read.txt
+++ b/Documentation/nvme-read.txt
@@ -95,8 +95,8 @@ metadata is passes.
 --dir-type=<type>::
 	Optional directive type. The nvme-cli only enforces the value
 	be in the defined range for the directive type, though the NVMe
-	specifcation (1.3a) defines only one directive, 01h, for write
-	stream idenfiers.
+	specification (1.3a) defines only one directive, 01h, for write
+	stream identifiers.
 
 -S <spec>::
 --dir-spec=<spec>::
@@ -136,7 +136,7 @@ metadata is passes.
 	data protection processing.
 
 --force::
-    Ignore namespace is currently busy and perfome the operation
+    Ignore namespace is currently busy and performed the operation
     even though.
 
 EXAMPLES

--- a/Documentation/nvme-rpmb.txt
+++ b/Documentation/nvme-rpmb.txt
@@ -41,7 +41,7 @@ OPTIONS
 			RPMB target given with --target or -t options. As per 
 			spec, this is one time action which can't be undone.
 
-	read-couter   - Read 'write counter' of specified RPMB target. The
+	read-counter  - Read 'write counter' of specified RPMB target. The
 			counter value read is printed onto STDOUT
 
 	read-config   - Read 512 bytes of device configuration block data of
@@ -59,7 +59,7 @@ OPTIONS
 			-o option should be given to read the amount of data
 			to be read in 512 byte blocks.
 
-	write-data    - Supports authenticated data writting to specified RPMB
+	write-data    - Supports authenticated data writing to specified RPMB
 			target (--target or -t option) at given offset
 			specified with --address or -o option, using key
 			specified using --keyfile or -k options. --blocks or
@@ -99,10 +99,10 @@ OPTIONS
 -o <offset>::
 --address=<offset>::
 	The address (in 512 byte sector offset from 0) to be used for data 
-	trasnfer commands (read or write) for a specified RPMB target.
+	transfer commands (read or write) for a specified RPMB target.
 -b::
 --blocks=<sectors>::
-	The size in 512 byte sectors to be used for data trasnfer commands
+	The size in 512 byte sectors to be used for data transfer commands
 	(read or write) for a specified RPMB target.
 
 EXAMPLES
@@ -113,7 +113,7 @@ EXAMPLES
 # nvme rpmb /dev/nvme0 --cmd=info
 -----------
 +
-* Program 'SecreteKey' as authentication key for target 1
+* Program 'SecretKey' as authentication key for target 1
 +
 ------------
 # nvme rpmb /dev/nvme0 --cmd=program-key -key='SecretKey' --target=1
@@ -134,7 +134,7 @@ EXAMPLES
 * Write 200 blocks of (512 bytes) from input.bin onto target 0
 +
 ------------
-# nvme rpmb /dev/nvme0 -c write-data -t 0 -f input.bin -b 200 -k 'SecreteKey'
+# nvme rpmb /dev/nvme0 -c write-data -t 0 -f input.bin -b 200 -k 'SecretKey'
 ------------
 +
 * Read 200 blocks of (512 bytes) from target 2, at offset 0x100 and save the

--- a/Documentation/nvme-sanitize.txt
+++ b/Documentation/nvme-sanitize.txt
@@ -28,7 +28,7 @@ On success it returns 0, error code otherwise.
 OPTIONS
 -------
 -d::
---no-delloc::
+--no-dealloc::
     No Deallocate After Sanitize:
     If set, then the controller shall not deallocate any logical
     blocks as a result of successfully completing the sanitize
@@ -80,7 +80,7 @@ OPTIONS
     sanitize operation.
 
 --force::
-    Ignore namespace is currently busy and perfome the operation
+    Ignore namespace is currently busy and performed the operation
     even though.
 
 EXAMPLES

--- a/Documentation/nvme-self-test-log.txt
+++ b/Documentation/nvme-self-test-log.txt
@@ -3,7 +3,7 @@ nvme-self-test-log(1)
 
 NAME
 ----
-nvme-self-test-log - Retrieve the log information initited by device-self-test and display it
+nvme-self-test-log - Retrieve the log information initiated by device-self-test and display it
 
 SYNOPSIS
 --------

--- a/Documentation/nvme-set-property.txt
+++ b/Documentation/nvme-set-property.txt
@@ -4,7 +4,7 @@ nvme-set-property(1)
 NAME
 ----
 nvme-set-property - Writes and shows the defined NVMe controller property 
-for NVMe ove Fabric
+for NVMe over Fabric
 
 SYNOPSIS
 --------
@@ -15,7 +15,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Writes and shows the defined NVMe controller property for NVMe ove Fabric.
+Writes and shows the defined NVMe controller property for NVMe over Fabric.
 
 OPTIONS
 -------

--- a/Documentation/nvme-supported-log-pages.txt
+++ b/Documentation/nvme-supported-log-pages.txt
@@ -13,13 +13,13 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Retrieves the NVMe supportd log pages details from an NVMe device and provides
+Retrieves the NVMe supported log pages details from an NVMe device and provides
 the returned structure.
 
 The <device> parameter is mandatory and should be the NVMe character
 device (ex: /dev/nvme0).
 
-On success, the returned supportd log pages log structure will be printed
+On success, the returned supported log pages log structure will be printed
 for each command that is supported.
 
 OPTIONS

--- a/Documentation/nvme-transcend-healthvalue.txt
+++ b/Documentation/nvme-transcend-healthvalue.txt
@@ -3,12 +3,12 @@ nvme-transcend-healthvalue(1)
 
 NAME
 ----
-nvme-transcend-healthvalue - Use NVMe SMART table to analyse the health value of Transcend device.
+nvme-transcend-healthvalue - Use NVMe SMART table to analyze the health value of Transcend device.
 
 SYNOPSIS
 --------
 [verse]
-'nvme transcned healthvalue' <device> 
+'nvme transcend healthvalue' <device>
 
 DESCRIPTION
 -----------
@@ -29,7 +29,7 @@ EXAMPLES
 * Print the Transcend Device health value in a human readable format:
 +
 ------------
-# nvme transcned healthvalue /dev/nvme0
+# nvme transcend healthvalue /dev/nvme0
 ------------
 
 NVME

--- a/Documentation/nvme-virtium-save-smart-to-vtview-log.txt
+++ b/Documentation/nvme-virtium-save-smart-to-vtview-log.txt
@@ -38,7 +38,7 @@ of the log file name.
 OPTIONS
 -------
 -r <NUM>::
---run-tim=<NUM>::
+--run-time=<NUM>::
 	(optional) Number of hours to log data (default = 20 hours)
 
 -f <NUM>::

--- a/Documentation/nvme-wdc-get-drive-status.txt
+++ b/Documentation/nvme-wdc-get-drive-status.txt
@@ -39,7 +39,7 @@ Output Explanation
 |The 2 possible states are :  Present or Not Present.
 
 |*Thermal Throttling Status*
-|The 3 possible states are :  Off, On, or Unavaiable.
+|The 3 possible states are :  Off, On, or Unavailable.
 
 |*Format Corrupt Reason*
 |The 3 possible states are :  Not Corrupted, Corrupt due to FW Assert, or Corrupt for Unknown Reason.

--- a/Documentation/nvme-wdc-namespace-resize.txt
+++ b/Documentation/nvme-wdc-namespace-resize.txt
@@ -40,12 +40,12 @@ OPTIONS
 
 EXAMPLES
 --------
-* Resizes namespace 1 to 50% of the orginal TNVMCAP reported value:
+* Resizes namespace 1 to 50% of the original TNVMCAP reported value:
 +
 ------------
 # nvme wdc namespace-resize /dev/nvme0 -n 1 -o 3
 ------------
-* Resizes namespace 2 to 7% of the orginal TNVMCAP reported value:
+* Resizes namespace 2 to 7% of the original TNVMCAP reported value:
 +
 ------------
 # nvme wdc namespace-resize /dev/nvme0 --namespace-id=2 --op-option=1

--- a/Documentation/nvme-wdc-vs-fw-activate-history.txt
+++ b/Documentation/nvme-wdc-vs-fw-activate-history.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-For the NVMe device given, read a Vendor Unique WDC log page that returns the firmware actiation
+For the NVMe device given, read a Vendor Unique WDC log page that returns the firmware activation
 history. 
 
 The <device> parameter is mandatory and must be the NVMe character device (ex: /dev/nvme0).
@@ -53,13 +53,13 @@ Firmware Activate History Log Page Data Output Explanation
 |The new firmware level running on the SSD after the activation took place.
 
 |*Slot Number*
-|The slot tht the firmware is being activated from. 
+|The slot that the firmware is being activated from.
 
 |*Commit Action Type*
 |The commit action type associated with the firmware activation event
 
 |*Result*
-|The result of the firmware activation event.  The ouput shall be in the format:
+|The result of the firmware activation event.  The output shall be in the format:
 Pass or Failed + error code
 |===
 

--- a/Documentation/nvme-write-uncor.txt
+++ b/Documentation/nvme-write-uncor.txt
@@ -8,7 +8,7 @@ nvme-write-uncor - Send an NVMe write uncorrectable command, return results
 SYNOPSIS
 --------
 [verse]
-'nvme-write-uncorr' <device> [--start-block=<slba> | -s <slba>]
+'nvme-write-uncor' <device> [--start-block=<slba> | -s <slba>]
 			[--block-count=<nlb> | -c <nlb>]
 			[--namespace-id=<nsid> | -n <nsid>]
 			[--force]
@@ -33,7 +33,7 @@ OPTIONS
 	Namespace ID use in the command.
 
 --force::
-    Ignore namespace is currently busy and perfome the operation
+    Ignore namespace is currently busy and performed the operation
     even though.
 
 EXAMPLES

--- a/Documentation/nvme-write-zeroes.txt
+++ b/Documentation/nvme-write-zeroes.txt
@@ -90,7 +90,7 @@ metadata is passes.
 	data protection processing.
 
 --force::
-    Ignore namespace is currently busy and perfome the operation
+    Ignore namespace is currently busy and performed the operation
     even though.
 
 EXAMPLES

--- a/Documentation/nvme-write.txt
+++ b/Documentation/nvme-write.txt
@@ -103,8 +103,8 @@ metadata is passes.
 --dir-type=<type>::
 	Optional directive type. The nvme-cli only enforces the value
 	be in the defined range for the directive type, though the NVMe
-	specifcation (1.3a) defines only one directive, 01h, for write
-	stream idenfiers.
+	specification (1.3a) defines only one directive, 01h, for write
+	stream identifiers.
 
 -S <spec>::
 --dir-spec=<spec>::
@@ -144,7 +144,7 @@ metadata is passes.
 	data protection processing.
 
 --force::
-    Ignore namespace is currently busy and perfome the operation
+    Ignore namespace is currently busy and performed the operation
     even though.
 
 EXAMPLES

--- a/Documentation/nvme-zns-id-ns.txt
+++ b/Documentation/nvme-zns-id-ns.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-For the NVMe device given, sends the zoned command set's identify namepsace
+For the NVMe device given, sends the zoned command set's identify namespace
 command and provides the result and returned structure.
 
 The <device> parameter is mandatory and may be either the NVMe character

--- a/Documentation/nvme-zns-set-zone-desc.txt
+++ b/Documentation/nvme-zns-set-zone-desc.txt
@@ -8,7 +8,7 @@ nvme-zns-set-zone-desc - Set extended descriptor data for a zone
 SYNOPSIS
 --------
 [verse]
-'nvme zns setzone-desc' <device> [--namespace-id=<NUM> | -n <NUM>]
+'nvme zns set-zone-desc' <device> [--namespace-id=<NUM> | -n <NUM>]
 				 [--start-lba=<IONUM>, -s <IONUM>]
 				 [--zrwaa | -r]
 				 [-data=<FILE>, -d <FILE>]
@@ -17,9 +17,9 @@ SYNOPSIS
 DESCRIPTION
 -----------
 For the NVMe device given, issues the Zone Management Send command with the
-Set Zone Descriptor Extenions action. The input will default to stdin.
+Set Zone Descriptor Extensions action. The input will default to stdin.
 Alternatively, the data may come from a file that can be specified. The data
-length will automatically be calculated from the zns identify namesapce.
+length will automatically be calculated from the zns identify namespace.
 
 OPTIONS
 -------

--- a/Documentation/nvme-zns-zone-append.txt
+++ b/Documentation/nvme-zns-zone-append.txt
@@ -27,7 +27,7 @@ The zone append command writes the logical blocks specified by the command to
 the medium from the data data buffer provided. Will use stdin by default
 if you don't provide a file.
 
-On sucess, the program will report the LBA that was assigned to the data for
+On success, the program will report the LBA that was assigned to the data for
 the append operation.
 
 OPTIONS

--- a/Documentation/nvme-zns-zrwa-flush-zone.txt
+++ b/Documentation/nvme-zns-zrwa-flush-zone.txt
@@ -39,7 +39,7 @@ OPTIONS
 
 EXAMPLES
 --------
-* flush the first zwra of first zone for zrwacg(15) on namespace 1:
+* flush the first zrwa of first zone for zrwacg(15) on namespace 1:
 +
 ------------
 # nvme zns zrwa-flush-zone /dev/nvme0 -n 1 -l 15

--- a/fabrics.c
+++ b/fabrics.c
@@ -661,7 +661,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topoplogy: %s\n",
+		fprintf(stderr, "Failed to scan topology: %s\n",
 			 nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
@@ -850,7 +850,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topoplogy: %s\n",
+		fprintf(stderr, "Failed to scan topology: %s\n",
 			 nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
@@ -946,7 +946,7 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topoplogy: %s\n",
+		fprintf(stderr, "Failed to scan topology: %s\n",
 			 nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
@@ -1033,7 +1033,7 @@ int nvmf_disconnect_all(const char *desc, int argc, char **argv)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topoplogy: %s\n",
+		fprintf(stderr, "Failed to scan topology: %s\n",
 			 nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
@@ -1104,7 +1104,7 @@ int nvmf_config(const char *desc, int argc, char **argv)
 	if (scan_tree) {
 		ret = nvme_scan_topology(r, NULL, NULL);
 		if (ret < 0) {
-			fprintf(stderr, "Failed to scan topoplogy: %s\n",
+			fprintf(stderr, "Failed to scan topology: %s\n",
 				nvme_strerror(errno));
 			nvme_free_tree(r);
 			return ret;
@@ -1243,7 +1243,7 @@ int nvmf_dim(const char *desc, int argc, char **argv)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topoplogy: %s\n",
+		fprintf(stderr, "Failed to scan topology: %s\n",
 			 nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6705,14 +6705,14 @@ static void nvme_show_auto_pst(struct nvme_feat_auto_pst *apst)
 static void nvme_show_timestamp(struct nvme_timestamp *ts)
 {
 	struct tm *tm;
-	char buffer[32];
+	char buffer[320];
 	time_t timestamp = int48_to_long(ts->timestamp) / 1000;
 
 	tm = localtime(&timestamp);
-	strftime(buffer, sizeof(buffer), "%c %Z", tm);
 
 	printf("\tThe timestamp is : %"PRIu64" (%s)\n",
-		int48_to_long(ts->timestamp), buffer);
+		int48_to_long(ts->timestamp),
+		strftime(buffer, sizeof(buffer), "%c %Z", tm) ? buffer : "-");
 	printf("\t%s\n", (ts->attr & 2) ?
 		"The Timestamp field was initialized with a "\
 			"Timestamp value using a Set Features command." :

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -87,8 +87,8 @@ const char *nvme_cmd_to_string(int admin, __u8 opcode)
 		case nvme_admin_directive_send:	return "Directive Send";
 		case nvme_admin_directive_recv:	return "Directive Receive";
 		case nvme_admin_virtual_mgmt:	return "Virtualization Management";
-		case nvme_admin_nvme_mi_send:	return "NVMEe-MI Send";
-		case nvme_admin_nvme_mi_recv:	return "NVMEe-MI Receive";
+		case nvme_admin_nvme_mi_send:	return "NVMe-MI Send";
+		case nvme_admin_nvme_mi_recv:	return "NVMe-MI Receive";
 		case nvme_admin_dbbuf:		return "Doorbell Buffer Config";
 		case nvme_admin_format_nvm:	return "Format NVM";
 		case nvme_admin_security_send:	return "Security Send";
@@ -4321,7 +4321,7 @@ void nvme_show_cmd_set_independent_id_ns(
 	if (flags & JSON)
 		return json_nvme_cmd_set_independent_id_ns(ns);
 
-	printf("NVME Identify Command Set Idependent Namespace %d:\n", nsid);
+	printf("NVME Identify Command Set Independent Namespace %d:\n", nsid);
 	printf("nsfeat  : %#x\n", ns->nsfeat);
 	if (human)
 		nvme_show_cmd_set_independent_id_ns_nsfeat(ns->nsfeat);
@@ -4408,7 +4408,7 @@ static void json_nvme_id_ns_descs(void *data)
 			nidt_name = "csi";
 			break;
 		default:
-			/* Skip unnkown types */
+			/* Skip unknown types */
 			len = cur->nidl;
 			break;
 		}
@@ -4493,7 +4493,7 @@ void nvme_show_id_ns_descs(void *data, unsigned nsid, enum nvme_print_flags flag
 			len += sizeof(csi);
 			break;
 		default:
-			/* Skip unnkown types */
+			/* Skip unknown types */
 			len = cur->nidl;
 			break;
 		}
@@ -4506,7 +4506,7 @@ static void print_psd_workload(__u8 apw)
 {
 	switch (apw & 0x7) {
 	case NVME_PSD_WORKLOAD_NP:
-		/* Unkown or not provided */
+		/* Unknown or not provided */
 		printf("-");
 		break;
 
@@ -4985,14 +4985,14 @@ static void show_nvme_id_ns_zoned_ozcs(__le16 ns_ozcs)
 				zrwasup ? "Yes" : "No");
 }
 
-static void nvme_show_zns_id_ns_recommandeded_limit(__le32 ns_rl, int human, 
+static void nvme_show_zns_id_ns_recommended_limit(__le32 ns_rl, int human,
 	const char *target_limit)
 {
-	unsigned int recommandeded_limit = le32_to_cpu(ns_rl);
-	if (!recommandeded_limit && human)
+	unsigned int recommended_limit = le32_to_cpu(ns_rl);
+	if (!recommended_limit && human)
 		printf("%s    : Not Reported\n", target_limit);
 	else
-		printf("%s    : %u\n", target_limit, recommandeded_limit);	
+		printf("%s    : %u\n", target_limit, recommended_limit);
 }
 
 static void nvme_show_zns_id_ns_zrwacap(__u8 zrwacap)
@@ -5056,14 +5056,14 @@ void nvme_show_zns_id_ns(struct nvme_zns_id_ns *ns,
 		printf("mor     : %#x\n", le32_to_cpu(ns->mor));
 	}
 
-	nvme_show_zns_id_ns_recommandeded_limit(ns->rrl,  human, "rrl ");
-	nvme_show_zns_id_ns_recommandeded_limit(ns->frl,  human, "frl ");
-	nvme_show_zns_id_ns_recommandeded_limit(ns->rrl1, human, "rrl1");
-	nvme_show_zns_id_ns_recommandeded_limit(ns->rrl2, human, "rrl2");
-	nvme_show_zns_id_ns_recommandeded_limit(ns->rrl3, human, "rrl3");
-	nvme_show_zns_id_ns_recommandeded_limit(ns->frl,  human, "frl1");
-	nvme_show_zns_id_ns_recommandeded_limit(ns->frl,  human, "frl2");
-	nvme_show_zns_id_ns_recommandeded_limit(ns->frl,  human, "frl3");
+	nvme_show_zns_id_ns_recommended_limit(ns->rrl,  human, "rrl ");
+	nvme_show_zns_id_ns_recommended_limit(ns->frl,  human, "frl ");
+	nvme_show_zns_id_ns_recommended_limit(ns->rrl1, human, "rrl1");
+	nvme_show_zns_id_ns_recommended_limit(ns->rrl2, human, "rrl2");
+	nvme_show_zns_id_ns_recommended_limit(ns->rrl3, human, "rrl3");
+	nvme_show_zns_id_ns_recommended_limit(ns->frl,  human, "frl1");
+	nvme_show_zns_id_ns_recommended_limit(ns->frl,  human, "frl2");
+	nvme_show_zns_id_ns_recommended_limit(ns->frl,  human, "frl3");
 
 	printf("numzrwa : %#x\n", le32_to_cpu(ns->numzrwa));
 	printf("zrwafg  : %u\n", le16_to_cpu(ns->zrwafg));
@@ -5240,16 +5240,16 @@ static void json_nvme_zns_report_zones(void *report, __u32 descs,
 
 static void nvme_show_zns_report_zone_attributes(__u8 za, __u8 zai)
 {
-	const char *const recommanded_limit[4] = {"","1","2","3"};
+	const char *const recommended_limit[4] = {"","1","2","3"};
 	printf("Attrs: Zone Descriptor Extension is %sVaild\n", 
 		(za & NVME_ZNS_ZA_ZDEV)? "" : "Not ");
 	if(za & NVME_ZNS_ZA_RZR) {
 		printf("       Reset Zone Recommended with Reset Recommended Limit%s\n",
-			recommanded_limit[(zai&0xd)>>2]);
+			recommended_limit[(zai&0xd)>>2]);
 	}
 	if (za & NVME_ZNS_ZA_FZR) {
 		printf("       Finish Zone Recommended with Finish Recommended Limit%s\n",
-			recommanded_limit[zai&0x3]);
+			recommended_limit[zai&0x3]);
 	}
 	if (za & NVME_ZNS_ZA_ZFC) {
 		printf("       Zone Finished by Controller\n");
@@ -5738,7 +5738,7 @@ void nvme_show_id_domain_list(struct nvme_id_domain_list *id_dom,
 	else if (flags & JSON)
 		return json_id_domain_list(id_dom);
 
-	printf("Number of Domain Entires: %u\n", id_dom->num);
+	printf("Number of Domain Entries: %u\n", id_dom->num);
 	for (i = 0; i < id_dom->num; i++) {
 		printf("Domain Id for Attr Entry[%u]: %u\n", i,
 			le16_to_cpu(id_dom->domain_attr[i].dom_id));
@@ -5746,7 +5746,7 @@ void nvme_show_id_domain_list(struct nvme_id_domain_list *id_dom,
 			int128_to_double(id_dom->domain_attr[i].dom_cap));
 		printf("Unallocated Domain Capacity for Attr Entry[%u]: %.0Lf\n", i,
 			int128_to_double(id_dom->domain_attr[i].unalloc_dom_cap));
-		printf("Max Endurange Group Domain Capacity for Attr Entry[%u]: %.0Lf\n", i,
+		printf("Max Endurance Group Domain Capacity for Attr Entry[%u]: %.0Lf\n", i,
 			int128_to_double(id_dom->domain_attr[i].max_egrp_dom_cap));
 	}
 }
@@ -6161,7 +6161,7 @@ void nvme_show_supported_log(struct nvme_supported_log_pages *support_log,
 	else if (flags & JSON)
 		return json_support_log(support_log);
 
-	printf("Support Log Pages Deatils for %s:\n", devname);
+	printf("Support Log Pages Details for %s:\n", devname);
 	for (lid = 0; lid < 256; lid++) {
 		support = le32_to_cpu(support_log->lid_support[lid]);
 		if (support & 0x1) {
@@ -6541,12 +6541,12 @@ const char *nvme_feature_to_string(enum nvme_features_id feature)
 	case NVME_FEAT_FID_HCTM:	return "Host Controlled Thermal Management";
 	case NVME_FEAT_FID_NOPSC:	return "Non-Operational Power State Config";
 	case NVME_FEAT_FID_RRL:		return "Read Recovery Level";
-	case NVME_FEAT_FID_PLM_CONFIG:	return "Predicatable Latency Mode Config";
-	case NVME_FEAT_FID_PLM_WINDOW:	return "Predicatable Latency Mode Window";
+	case NVME_FEAT_FID_PLM_CONFIG:	return "Predictable Latency Mode Config";
+	case NVME_FEAT_FID_PLM_WINDOW:	return "Predictable Latency Mode Window";
 	case NVME_FEAT_FID_LBA_STS_INTERVAL:	return "LBA Status Interval";
 	case NVME_FEAT_FID_HOST_BEHAVIOR:	return "Host Behavior";
 	case NVME_FEAT_FID_SANITIZE:	return "Sanitize";
-	case NVME_FEAT_FID_ENDURANCE_EVT_CFG:	return "Enduarance Event Group Configuration";
+	case NVME_FEAT_FID_ENDURANCE_EVT_CFG:	return "Endurance Event Group Configuration";
 	case NVME_FEAT_FID_IOCS_PROFILE:	return "I/O Command Set Profile";
 	case NVME_FEAT_FID_SPINUP_CONTROL:	return "Spinup Control";
 	case NVME_FEAT_FID_ENH_CTRL_METADATA:	return "Enhanced Controller Metadata";
@@ -6556,7 +6556,7 @@ const char *nvme_feature_to_string(enum nvme_features_id feature)
 	case NVME_FEAT_FID_HOST_ID:	return "Host Identifier";
 	case NVME_FEAT_FID_RESV_MASK:	return "Reservation Notification Mask";
 	case NVME_FEAT_FID_RESV_PERSIST:return "Reservation Persistence";
-	case NVME_FEAT_FID_WRITE_PROTECT:	return "Namespce Write Protect";
+	case NVME_FEAT_FID_WRITE_PROTECT:	return "Namespace Write Protect";
 	}
 	/*
 	 * We don't use the "default:" statement to let the compiler warning if
@@ -6794,7 +6794,7 @@ static void nvme_directive_show_fields(__u8 dtype, __u8 doper,
 				*(__u32 *) (field + 16));
 			printf("\tStream Granularity Size (in unit of SWS)   (SGS): %u\n",
 				*(__u16 *) (field + 20));
-			printf("\tNamespece Streams Allocated                (NSA): %u\n",
+			printf("\tNamespace Streams Allocated                (NSA): %u\n",
 				*(__u16 *) (field + 22));
 			printf("\tNamespace Streams Open                     (NSO): %u\n",
 				*(__u16 *) (field + 24));

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6710,7 +6710,7 @@ static void nvme_show_timestamp(struct nvme_timestamp *ts)
 
 	tm = localtime(&timestamp);
 
-	printf("\tThe timestamp is : %"PRIu64" (%s)\n",
+	printf("\tThe timestamp is : %'"PRIu64" (%s)\n",
 		int48_to_long(ts->timestamp),
 		strftime(buffer, sizeof(buffer), "%c %Z", tm) ? buffer : "-");
 	printf("\t%s\n", (ts->attr & 2) ?

--- a/nvme.c
+++ b/nvme.c
@@ -1158,7 +1158,7 @@ static int get_persistent_event_log(int argc, char **argv,
 	}
 
 	/*
-	 * if header aleady read with context establish action 0x1,
+	 * if header already read with context establish action 0x1,
 	 * action shall not be 0x1 again in the subsequent request,
 	 * until the current context is released by issuing action
 	 * with 0x2, otherwise throws command sequence error, make
@@ -1188,7 +1188,7 @@ static int get_persistent_event_log(int argc, char **argv,
 		pevent_collected = pevent_log_info;
 		if (pevent_collected->gen_number != pevent->gen_number) {
 			printf("Collected Persistent Event Log may be invalid, "\
-				"Re-read the log is reiquired\n");
+				"Re-read the log is required\n");
 			goto free;
 		}
 
@@ -2647,7 +2647,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	}
 	err = nvme_scan_topology(r, NULL, NULL);
 	if (err < 0) {
-		fprintf(stderr, "Failed to scan topoplogy: %s\n",
+		fprintf(stderr, "Failed to scan topology: %s\n",
 			 nvme_strerror(errno));
 		nvme_free_tree(r);
 		return err;
@@ -2988,7 +2988,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		"given device, returns properties of the specified namespace "\
 		"in either human-readable or binary format. Can also return "\
 		"binary vendor-specific namespace attributes.";
-	const char *force = "Return this namespace, even if not attaced (1.2 devices only)";
+	const char *force = "Return this namespace, even if not attached (1.2 devices only)";
 	const char *vendor_specific = "dump binary vendor fields";
 	const char *raw = "show identify in binary format";
 	const char *human_readable = "show identify in readable format";
@@ -3853,7 +3853,7 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 		"specified controller. Operating parameters are grouped "\
 		"and identified by Feature Identifiers; each Feature "\
 		"Identifier contains one or more attributes that may affect "\
-		"behaviour of the feature. Each Feature has three possible "\
+		"behavior of the feature. Each Feature has three possible "\
 		"settings: default, saveable, and current. If a Feature is "\
 		"saveable, it may be modified by set-feature. Default values "\
 		"are vendor-specific and not changeable. Use set-feature to "\
@@ -4541,7 +4541,7 @@ ret:
 static int set_property(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Writes and shows the defined NVMe controller property "\
-			   "for NVMe ove Fabric";
+			   "for NVMe over Fabric";
 	const char *offset = "the offset of the property";
 	const char *value = "the value of the property to be set";
 	int fd, err;
@@ -7274,7 +7274,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 	if (fd < 0)
 		goto ret;
 
-	/* check for input arguement limit */
+	/* check for input argument limit */
 	if (cfg.ifc > 3) {
 		fprintf(stderr, "invalid interface settings:%d\n", cfg.ifc);
 		err = -1;

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -160,7 +160,7 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 		"specified controller. Operating parameters are grouped "\
 		"and identified by Feature Identifiers; each Feature "\
 		"Identifier contains one or more attributes that may affect "\
-		"behaviour of the feature. Each Feature has three possible "\
+		"behavior of the feature. Each Feature has three possible "\
 		"settings: default, saveable, and current. If a Feature is "\
 		"saveable, it may be modified by set-feature. Default values "\
 		"are vendor-specific and not changeable. Use set-feature to "\


### PR DESCRIPTION
Since the default size is possible to be exceeded for a locale date and time.

Signed-off-by: Tokunori Ikegami <ikegami.t@gmail.com>