### PR TITLE
plugins: minor fixes

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -7,6 +7,6 @@ sources += files([
 ])
 
 if get_option('buildtype') == 'debug'
-    add_project_arguments('-DCCAN_LIST_DEBUG=1',  language : ['c', 'cpp'])
-    add_project_arguments('-DCCAN_STR_DEBUG=1',  language : ['c', 'cpp'])
+    add_project_arguments('-DCCAN_LIST_DEBUG=1',  language : ['c'])
+    add_project_arguments('-DCCAN_STR_DEBUG=1',  language : ['c'])
 endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 ################################################################################
 project(
-    'nvme-cli', ['c', 'cpp'],
+    'nvme-cli', ['c'],
     meson_version: '>= 0.47.0',
     license: 'GPL-2.0-only',
     version: '2.1.1',

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -429,7 +429,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
         return ret;
 }
 
-static int ocp_print_C3_log_normal(int fd, struct ssd_latency_monitor_log *log_data)
+static int ocp_print_C3_log_normal(struct ssd_latency_monitor_log *log_data)
 {
         printf("-Latency Monitor/C3 Log Page Data- \n");
         printf("  Controller   :  %s\n", devicename);
@@ -725,7 +725,7 @@ static int get_c3_log_page(int fd, char *format)
 
                 switch (fmt) {
                 case NORMAL:
-                        ocp_print_C3_log_normal(fd, log_data);
+                        ocp_print_C3_log_normal(log_data);
                         break;
                 case JSON:
                         ocp_print_C3_log_json(log_data);

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -86,7 +86,7 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 	if (flags == -EINVAL) {
 		fprintf(stderr, "Invalid output format '%s'\n", cfg.output_format);
 		close(fd);
-		return fd;
+		return flags;
 	}
 
 	garbage_control_collection_log_t gc_log;

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -228,7 +228,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	if (flags == -EINVAL) {
 		fprintf(stderr, "Invalid output format '%s'\n", cfg.output_format);
 		close(fd);
-		return fd;
+		return flags;
 	}
 
 	err = nvme_get_log_simple(fd, solidigm_vu_smart_log_id, sizeof(smart_log_payload), &smart_log_payload);

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -4156,7 +4156,7 @@ static void wdc_print_latency_monitor_log_json(struct wdc_ssd_latency_monitor_lo
 	json_free_object(root);
 }
 
-static void wdc_print_error_rec_log_normal(int fd, struct wdc_ocp_c1_error_recovery_log *log_data)
+static void wdc_print_error_rec_log_normal(struct wdc_ocp_c1_error_recovery_log *log_data)
 {
 	int j;
 	printf("Error Recovery/C1 Log Page Data \n");
@@ -4210,7 +4210,7 @@ static void wdc_print_error_rec_log_json(struct wdc_ocp_c1_error_recovery_log *l
 	json_free_object(root);
 }
 
-static void wdc_print_dev_cap_log_normal(int fd, struct wdc_ocp_C4_dev_cap_log *log_data)
+static void wdc_print_dev_cap_log_normal(struct wdc_ocp_C4_dev_cap_log *log_data)
 {
 	int j;
 	printf("Device Capabilities/C4 Log Page Data \n");
@@ -4271,7 +4271,7 @@ static void wdc_print_dev_cap_log_json(struct wdc_ocp_C4_dev_cap_log *log_data)
 	json_free_object(root);
 }
 
-static void wdc_print_unsupported_reqs_log_normal(int fd, struct wdc_ocp_C5_unsupported_reqs *log_data)
+static void wdc_print_unsupported_reqs_log_normal(struct wdc_ocp_C5_unsupported_reqs *log_data)
 {
 	int j;
 	printf("Unsupported Requirements/C5 Log Page Data \n");
@@ -6392,7 +6392,7 @@ static int wdc_print_latency_monitor_log(int fd, struct wdc_ssd_latency_monitor_
 	return 0;
 }
 
-static int wdc_print_error_rec_log(int fd, struct wdc_ocp_c1_error_recovery_log *log_data, int fmt)
+static int wdc_print_error_rec_log(struct wdc_ocp_c1_error_recovery_log *log_data, int fmt)
 {
 	if (!log_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid C1 log data buffer\n");
@@ -6400,7 +6400,7 @@ static int wdc_print_error_rec_log(int fd, struct wdc_ocp_c1_error_recovery_log 
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_error_rec_log_normal(fd, log_data);
+		wdc_print_error_rec_log_normal(log_data);
 		break;
 	case JSON:
 		wdc_print_error_rec_log_json(log_data);
@@ -6409,7 +6409,7 @@ static int wdc_print_error_rec_log(int fd, struct wdc_ocp_c1_error_recovery_log 
 	return 0;
 }
 
-static int wdc_print_dev_cap_log(int fd, struct wdc_ocp_C4_dev_cap_log *log_data, int fmt)
+static int wdc_print_dev_cap_log(struct wdc_ocp_C4_dev_cap_log *log_data, int fmt)
 {
 	if (!log_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid C4 log data buffer\n");
@@ -6417,7 +6417,7 @@ static int wdc_print_dev_cap_log(int fd, struct wdc_ocp_C4_dev_cap_log *log_data
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_dev_cap_log_normal(fd, log_data);
+		wdc_print_dev_cap_log_normal(log_data);
 		break;
 	case JSON:
 		wdc_print_dev_cap_log_json(log_data);
@@ -6426,7 +6426,7 @@ static int wdc_print_dev_cap_log(int fd, struct wdc_ocp_C4_dev_cap_log *log_data
 	return 0;
 }
 
-static int wdc_print_unsupported_reqs_log(int fd, struct wdc_ocp_C5_unsupported_reqs *log_data, int fmt)
+static int wdc_print_unsupported_reqs_log(struct wdc_ocp_C5_unsupported_reqs *log_data, int fmt)
 {
 	if (!log_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid C5 log data buffer\n");
@@ -6434,7 +6434,7 @@ static int wdc_print_unsupported_reqs_log(int fd, struct wdc_ocp_C5_unsupported_
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_unsupported_reqs_log_normal(fd, log_data);
+		wdc_print_unsupported_reqs_log_normal(log_data);
 		break;
 	case JSON:
 		wdc_print_unsupported_reqs_log_json(log_data);
@@ -6838,7 +6838,7 @@ static int wdc_get_ocp_c1_log_page(nvme_root_t r, int fd, char *format)
 		}
 
 		/* parse the data */
-		wdc_print_error_rec_log(fd, log_data, fmt);
+		wdc_print_error_rec_log(log_data, fmt);
 	} else {
 		fprintf(stderr, "ERROR : WDC : Unable to read error recovery (C1) data from buffer\n");
 	}
@@ -6907,7 +6907,7 @@ static int wdc_get_ocp_c4_log_page(nvme_root_t r, int fd, char *format)
 		}
 
 		/* parse the data */
-		wdc_print_dev_cap_log(fd, log_data, fmt);
+		wdc_print_dev_cap_log(log_data, fmt);
 	} else {
 		fprintf(stderr, "ERROR : WDC : Unable to read device capabilities (C4) data from buffer\n");
 	}
@@ -6976,7 +6976,7 @@ static int wdc_get_ocp_c5_log_page(nvme_root_t r, int fd, char *format)
 		}
 
 		/* parse the data */
-		wdc_print_unsupported_reqs_log(fd, log_data, fmt);
+		wdc_print_unsupported_reqs_log(log_data, fmt);
 	} else {
 		fprintf(stderr, "ERROR : WDC : Unable to read unsupported requirements (C5) data from buffer\n");
 	}

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -8731,7 +8731,6 @@ static int wdc_do_drive_essentials(nvme_root_t r, int fd, char *dir, char *key)
 	memset(tarFiles,0,sizeof(tarFiles));
 	memset(tarCmd,0,sizeof(tarCmd));
 	memset(&timeInfo,0,sizeof(timeInfo));
-	memset(&vuLogInput, 0, sizeof(vuLogInput));
 
 	if (wdc_get_serial_and_fw_rev(fd, (char *)idSerialNo, (char *)idFwRev))
 	{

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -3498,8 +3498,7 @@ static int wdc_crash_dump(int fd, char *file, int type)
 	if (ret)
 		fprintf(stderr, "ERROR : WDC : failed to generate file name\n");
 	else
-		ret = wdc_do_crash_dump(fd, f, type);	\
-	close(fd);
+		ret = wdc_do_crash_dump(fd, f, type);
 	return ret;
 }
 


### PR DESCRIPTION
This series is a set of minor fixes for various plugins: a couple of fixes in error paths, plus removing some unused `fd` arguments for display functions.

[this is in preparation for a RFC change to the way we're passing the nvme devices around]