### PR TITLE
RFC: Make device data non-global, contained within a `struct nvme_dev`

### DIFF
--- a/ccan/meson.build
+++ b/ccan/meson.build
@@ -7,6 +7,6 @@ sources += files([
 ])
 
 if get_option('buildtype') == 'debug'
-    add_project_arguments('-DCCAN_LIST_DEBUG=1',  language : ['c', 'cpp'])
-    add_project_arguments('-DCCAN_STR_DEBUG=1',  language : ['c', 'cpp'])
+    add_project_arguments('-DCCAN_LIST_DEBUG=1',  language : ['c'])
+    add_project_arguments('-DCCAN_STR_DEBUG=1',  language : ['c'])
 endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 ################################################################################
 project(
-    'nvme-cli', ['c', 'cpp'],
+    'nvme-cli', ['c'],
     meson_version: '>= 0.47.0',
     license: 'GPL-2.0-only',
     version: '2.1.1',

--- a/nvme.c
+++ b/nvme.c
@@ -79,8 +79,8 @@ struct feat_cfg {
 	bool  human_readable;
 };
 
-struct nvme_dev _nvme_dev;
-struct nvme_dev *nvme_dev = &_nvme_dev;
+static struct nvme_dev _nvme_dev;
+static struct nvme_dev *nvme_dev = &_nvme_dev;
 
 static const char nvme_version_string[] = NVME_VERSION;
 

--- a/nvme.c
+++ b/nvme.c
@@ -79,8 +79,8 @@ struct feat_cfg {
 	bool  human_readable;
 };
 
-static struct stat nvme_stat;
-const char *devicename;
+struct nvme_dev _nvme_dev;
+struct nvme_dev *nvme_dev = &_nvme_dev;
 
 static const char nvme_version_string[] = NVME_VERSION;
 
@@ -210,25 +210,25 @@ static ssize_t getrandom_bytes(void *buf, size_t buflen)
 
 static bool is_chardev(void)
 {
-	return S_ISCHR(nvme_stat.st_mode);
+	return S_ISCHR(nvme_dev->stat.st_mode);
 }
 
 static bool is_blkdev(void)
 {
-	return S_ISBLK(nvme_stat.st_mode);
+	return S_ISBLK(nvme_dev->stat.st_mode);
 }
 
 static int open_dev(char *dev, int flags)
 {
 	int err, fd;
 
-	devicename = basename(dev);
+	nvme_dev->name = basename(dev);
 	err = open(dev, flags);
 	if (err < 0)
 		goto perror;
 	fd = err;
 
-	err = fstat(fd, &nvme_stat);
+	err = fstat(fd, &nvme_dev->stat);
 	if (err < 0) {
 		close(fd);
 		goto perror;
@@ -353,8 +353,8 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 
 	err = nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
 	if (!err)
-		nvme_show_smart_log(&smart_log, cfg.namespace_id, devicename,
-				    flags);
+		nvme_show_smart_log(&smart_log, cfg.namespace_id,
+                                    nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -425,7 +425,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 
 	err = nvme_get_log_ana(fd, lsp, true, 0, ana_log_len, ana_log);
 	if (!err) {
-		nvme_show_ana_log(ana_log, devicename, flags, ana_log_len);
+		nvme_show_ana_log(ana_log, nvme_dev->name, flags, ana_log_len);
 	} else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -576,7 +576,8 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 
 	err = nvme_get_log_endurance_group(fd, cfg.group_id, &endurance_log);
 	if (!err)
-		nvme_show_endurance_log(&endurance_log, cfg.group_id, devicename, flags);
+		nvme_show_endurance_log(&endurance_log, cfg.group_id,
+                                        nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -664,7 +665,7 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 		int nvme_command_set_supported;
 		int other_command_sets_supported;
 		nvme_root = nvme_scan(NULL);
-		bar = mmap_registers(nvme_root, devicename);
+		bar = mmap_registers(nvme_root, nvme_dev->name);
 		nvme_free_tree(nvme_root);
 
 		if (!bar) {
@@ -742,7 +743,7 @@ static int get_supported_log_pages(int argc, char **argv, struct command *cmd,
 
 	err = nvme_get_log_supported_log_pages(fd, false, &supports);
 	if (!err)
-		nvme_show_supported_log(&supports, devicename, flags);
+		nvme_show_supported_log(&supports, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -821,7 +822,8 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 
 	err = nvme_get_log_error(fd, cfg.log_entries, false, err_log);
 	if (!err)
-		nvme_show_error_log(err_log, cfg.log_entries, devicename, flags);
+		nvme_show_error_log(err_log, cfg.log_entries,
+                                    nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -870,7 +872,7 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 
 	err = nvme_get_log_fw_slot(fd, false, &fw_log);
 	if (!err)
-		nvme_show_fw_log(&fw_log, devicename, flags);
+		nvme_show_fw_log(&fw_log, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -919,8 +921,8 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 
 	err = nvme_get_log_changed_ns_list(fd, true, &changed_ns_list_log);
 	if (!err)
-		nvme_show_changed_ns_list_log(&changed_ns_list_log, devicename,
-					      flags);
+		nvme_show_changed_ns_list_log(&changed_ns_list_log,
+                                              nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -976,7 +978,7 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 	err = nvme_get_log_predictable_lat_nvmset(fd, cfg.nvmset_id, &plpns_log);
 	if (!err)
 		nvme_show_predictable_latency_per_nvmset(&plpns_log,
-			cfg.nvmset_id, devicename, flags);
+			cfg.nvmset_id, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1065,7 +1067,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	err = nvme_get_log_predictable_lat_event(fd, cfg.rae, 0, log_size, pea_log);
 	if (!err)
 		nvme_show_predictable_latency_event_agg_log(pea_log, cfg.log_entries,
-			log_size, devicename, flags);
+			log_size, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1192,7 +1194,7 @@ static int get_persistent_event_log(int argc, char **argv,
 		}
 
 		nvme_show_persistent_event_log(pevent_log_info, cfg.action,
-			cfg.log_len, devicename, flags);
+			cfg.log_len, nvme_dev->name, flags);
 	} else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1286,7 +1288,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	err = nvme_get_log_endurance_grp_evt(fd, cfg.rae, 0, log_size, endurance_log);
 	if (!err)
 		nvme_show_endurance_group_event_agg_log(endurance_log, cfg.log_entries,
-			log_size, devicename, flags);
+			log_size, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1354,7 +1356,7 @@ static int get_lba_status_log(int argc, char **argv,
 
 	err = nvme_get_log_lba_status(fd, cfg.rae, 0, lslplen, lab_status);
 	if (!err)
-		nvme_show_lba_status_log(lab_status, lslplen, devicename, flags);
+		nvme_show_lba_status_log(lab_status, lslplen, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1403,7 +1405,7 @@ static int get_resv_notif_log(int argc, char **argv,
 
 	err = nvme_get_log_reservation(fd, false, &resv);
 	if (!err)
-		nvme_show_resv_notif_log(&resv, devicename, flags);
+		nvme_show_resv_notif_log(&resv, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1500,7 +1502,8 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 					  sizeof(boot) + bpsz,
 					  (struct nvme_boot_partition *)bp_log);
 	if (!err)
-		nvme_show_boot_part_log(&bp_log, devicename, flags, sizeof(boot) + bpsz);
+		nvme_show_boot_part_log(&bp_log, nvme_dev->name, flags,
+                                        sizeof(boot) + bpsz);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1757,7 +1760,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	if (!err) {
 		if (!cfg.raw_binary) {
 			printf("Device:%s log-id:%d namespace-id:%#x\n",
-				devicename, cfg.log_id,
+				nvme_dev->name, cfg.log_id,
 				cfg.namespace_id);
 			d(log, cfg.log_len, 16, 1);
 		} else
@@ -1820,7 +1823,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 
 	err = nvme_get_log_sanitize(fd, cfg.rae, &sanitize_log);
 	if (!err)
-		nvme_show_sanitize_log(&sanitize_log, devicename, flags);
+		nvme_show_sanitize_log(&sanitize_log, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1869,7 +1872,8 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 
 	err = nvme_get_log_fid_supported_effects(fd, false, &fid_support_log);
 	if (!err)
-		nvme_show_fid_support_effects_log(&fid_support_log, devicename, flags);
+		nvme_show_fid_support_effects_log(&fid_support_log,
+                                                  nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1918,7 +1922,8 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 
 	err = nvme_get_log_mi_cmd_supported_effects(fd, false, &mi_cmd_support_log);
 	if (!err)
-		nvme_show_mi_cmd_support_effects_log(&mi_cmd_support_log, devicename, flags);
+		nvme_show_mi_cmd_support_effects_log(&mi_cmd_support_log,
+                                                     nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -2524,6 +2529,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	const char *desc = "Retrieve information for subsystems";
 	const char *verbose = "Increase output verbosity";
 	nvme_scan_filter_t filter = NULL;
+        char *devname;
 	int err;
 	int nsid = NVME_NSID_ALL;
 
@@ -2547,9 +2553,9 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	if (err < 0)
 		goto ret;
 
-	devicename = NULL;
+	devname = NULL;
 	if (optind < argc)
-		devicename = basename(argv[optind++]);
+		devname = basename(argv[optind++]);
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
@@ -2563,29 +2569,29 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 
 	r = nvme_create_root(stderr, map_log_level(cfg.verbose, false));
 	if (!r) {
-		if (devicename)
+		if (devname)
 			fprintf(stderr,
 				"Failed to scan nvme subsystem for %s\n",
-				devicename);
+				devname);
 		else
 			fprintf(stderr, "Failed to scan nvme subsystem\n");
 		err = -errno;
 		goto ret;
 	}
 
-	if (devicename) {
+	if (devname) {
 		int subsys_num;
 
-		if (sscanf(devicename,"nvme%dn%d",
+		if (sscanf(devname,"nvme%dn%d",
 			   &subsys_num, &nsid) != 2) {
-			fprintf(stderr, "Invalid device name %s\n", devicename);
+			fprintf(stderr, "Invalid device name %s\n", devname);
 			err = -EINVAL;
 			goto ret;
 		}
 		filter = nvme_match_device_filter;
 	}
 
-	err = nvme_scan_topology(r, filter, (void *)devicename);
+	err = nvme_scan_topology(r, filter, (void *)devname);
 	if (err) {
 		fprintf(stderr, "Failed to scan topology: %s\n",
 			nvme_strerror(errno));
@@ -3404,7 +3410,7 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 		goto close_fd;
 	}
 	err = 0;
-	printf("%s: namespace-id:%d\n", devicename, nsid);
+	printf("%s: namespace-id:%d\n", nvme_dev->name, nsid);
 
 close_fd:
 	close(fd);
@@ -3710,7 +3716,7 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 	err = nvme_get_log_device_self_test(fd, &log);
 	if (!err)
 		nvme_show_self_test_log(&log, cfg.dst_entries, 0,
-			devicename, flags);
+                                        nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -4382,15 +4388,15 @@ static void *mmap_registers(nvme_root_t r, const char *dev)
 	void *membase;
 	int fd;
 
-	c = nvme_scan_ctrl(r, devicename);
+	c = nvme_scan_ctrl(r, nvme_dev->name);
 	if (c) {
 		snprintf(path, sizeof(path), "%s/device/resource0",
 			nvme_ctrl_get_sysfs_dir(c));
 		nvme_free_ctrl(c);
 	} else {
-		n = nvme_scan_namespace(devicename);
+		n = nvme_scan_namespace(nvme_dev->name);
 		if (!n) {
-			fprintf(stderr, "Unable to find %s\n", devicename);
+			fprintf(stderr, "Unable to find %s\n", nvme_dev->name);
 			return NULL;
 		}
 		snprintf(path, sizeof(path), "%s/device/device/resource0",
@@ -4401,13 +4407,13 @@ static void *mmap_registers(nvme_root_t r, const char *dev)
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
 		fprintf(stderr, "%s did not find a pci resource, open failed %s\n",
-				devicename, strerror(errno));
+				nvme_dev->name, strerror(errno));
 		return NULL;
 	}
 
 	membase = mmap(NULL, getpagesize(), PROT_READ, MAP_SHARED, fd, 0);
 	if (membase == MAP_FAILED) {
-		fprintf(stderr, "%s failed to map. ", devicename);
+		fprintf(stderr, "%s failed to map. ", nvme_dev->name);
 		fprintf(stderr, "Did your kernel enable CONFIG_IO_STRICT_DEVMEM?\n");
 		membase = NULL;
 	}
@@ -4458,7 +4464,7 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 
 	err = nvme_get_properties(fd, &bar);
 	if (err) {
-		bar = mmap_registers(r, devicename);
+		bar = mmap_registers(r, nvme_dev->name);
 		fabrics = false;
 		if (bar)
 			err = 0;
@@ -4793,9 +4799,9 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 
 	if (!cfg.force) {
 		fprintf(stderr, "You are about to format %s, namespace %#x%s.\n",
-			devicename, cfg.namespace_id,
+			nvme_dev->name, cfg.namespace_id,
 			cfg.namespace_id == NVME_NSID_ALL ? "(ALL namespaces)" : "");
-		nvme_show_relatives(devicename);
+		nvme_show_relatives(nvme_dev->name);
 		fprintf(stderr, "WARNING: Format may irrevocably delete this device's data.\n"
 			"You have 10 seconds to press Ctrl-C to cancel this operation.\n\n"
 			"Use the force [--force] option to suppress this warning.\n");

--- a/nvme.c
+++ b/nvme.c
@@ -218,9 +218,15 @@ static bool is_blkdev(void)
 	return S_ISBLK(nvme_dev->stat.st_mode);
 }
 
-static int open_dev(char *dev, int flags)
+static int open_dev(struct nvme_dev **devp, char *dev, int flags)
 {
 	int err, fd;
+
+        /* Temporary: we use the global nvme_dev pointer for the nvme device.
+         * This keeps the global in sync with the returned device. Later, we'll
+         * remove the global entirely and allocate here instead.
+         */
+        *devp = nvme_dev;
 
 	nvme_dev->name = basename(dev);
 	err = open(dev, flags);
@@ -238,7 +244,8 @@ static int open_dev(char *dev, int flags)
 		close(fd);
 		return -ENODEV;
 	}
-	return fd;
+        nvme_dev->fd = fd;
+	return 0;
 perror:
 	perror(dev);
 	return err;
@@ -254,7 +261,7 @@ static int check_arg_dev(int argc, char **argv)
 	return 0;
 }
 
-static int get_dev(int argc, char **argv, int flags)
+static int get_dev(struct nvme_dev **dev, int argc, char **argv, int flags)
 {
 	int ret;
 
@@ -262,11 +269,12 @@ static int get_dev(int argc, char **argv, int flags)
 	if (ret)
 		return ret;
 
-	return open_dev(argv[optind], flags);
+	return open_dev(dev, argv[optind], flags);
 }
 
-int parse_and_open(int argc, char **argv, const char *desc,
-	const struct argconfig_commandline_options *opts)
+int parse_and_open(struct nvme_dev **dev, int argc, char **argv,
+                   const char *desc,
+                   const struct argconfig_commandline_options *opts)
 {
 	int ret;
 
@@ -274,21 +282,22 @@ int parse_and_open(int argc, char **argv, const char *desc,
 	if (ret)
 		return ret;
 
-	ret = get_dev(argc, argv, O_RDONLY);
+	ret = get_dev(dev, argc, argv, O_RDONLY);
 	if (ret < 0)
 		argconfig_print_help(desc, opts);
 
 	return ret;
 }
 
-int open_exclusive(int argc, char **argv, int ignore_exclusive)
+int open_exclusive(struct nvme_dev **dev, int argc, char **argv,
+                   int ignore_exclusive)
 {
-    int flags = O_RDONLY;
+        int flags = O_RDONLY;
 
 	if (!ignore_exclusive)
 		flags |= O_EXCL;
 
-    return get_dev(argc, argv, flags);
+        return get_dev(dev, argc, argv, flags);
 }
 
 enum nvme_print_flags validate_output_format(const char *format)
@@ -304,6 +313,11 @@ enum nvme_print_flags validate_output_format(const char *format)
 	return -EINVAL;
 }
 
+void dev_close(struct nvme_dev *dev)
+{
+	close(dev->fd);
+}
+
 static int get_smart_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	struct nvme_smart_log smart_log;
@@ -314,7 +328,8 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	const char *raw = "output in binary format";
 	const char *human_readable = "show info in readable format";
 	enum nvme_print_flags flags;
-	int err = -1, fd;
+        struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u32	namespace_id;
@@ -339,8 +354,8 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -351,7 +366,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
+	err = nvme_get_log_smart(dev->fd, cfg.namespace_id, false, &smart_log);
 	if (!err)
 		nvme_show_smart_log(&smart_log, cfg.namespace_id,
                                     nvme_dev->name, flags);
@@ -360,7 +375,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	else
 		fprintf(stderr, "smart log: %s\n", nvme_strerror(errno));
 close_fd:
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -372,11 +387,12 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 			    "decoded format (default), json or binary.";
 	const char *groups = "Return ANA groups only.";
 	void *ana_log;
-	int err = -1, fd;
 	size_t ana_log_len;
 	struct nvme_id_ctrl ctrl;
 	enum nvme_print_flags flags;
 	enum nvme_log_ana_lsp lsp;
+        struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		bool	groups;
@@ -394,15 +410,15 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
 		goto close_fd;
 
-	err = nvme_identify_ctrl(fd, &ctrl);
+	err = nvme_identify_ctrl(dev->fd, &ctrl);
 	if (err) {
 		fprintf(stderr, "ERROR : nvme_identify_ctrl() failed: %s\n",
 			nvme_strerror(errno));
@@ -423,7 +439,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	lsp = cfg.groups ? NVME_LOG_ANA_LSP_RGO_GROUPS_ONLY :
 		NVME_LOG_ANA_LSP_RGO_NAMESPACES;
 
-	err = nvme_get_log_ana(fd, lsp, true, 0, ana_log_len, ana_log);
+	err = nvme_get_log_ana(dev->fd, lsp, true, 0, ana_log_len, ana_log);
 	if (!err) {
 		nvme_show_ana_log(ana_log, nvme_dev->name, flags, ana_log_len);
 	} else if (err > 0)
@@ -432,7 +448,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 		fprintf(stderr, "ana-log: %s", nvme_strerror(errno));
 	free(ana_log);
 close_fd:
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -446,10 +462,11 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 	const char *cgen = "Gather report generated by the controller.";
 	const char *dgen = "Pick which telemetry data area to report. Default is 3 to fetch areas 1-3. Valid options are 1, 2, 3, 4.";
 	struct nvme_telemetry_log *log;
-	int err = 0, fd, output;
+	int err = 0, output;
 	size_t total_size;
 	__u8 *data_ptr = NULL;
 	int data_written = 0, data_remaining = 0;
+        struct nvme_dev *dev;
 
 	struct config {
 		char	*file_name;
@@ -472,14 +489,14 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.file_name) {
 		fprintf(stderr, "Please provide an output file!\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	cfg.host_gen = !!cfg.host_gen;
@@ -488,15 +505,18 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 		fprintf(stderr, "Failed to open output file %s: %s!\n",
 				cfg.file_name, strerror(errno));
 		err = output;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.ctrl_init)
-		err = nvme_get_ctrl_telemetry(fd, true, &log, cfg.data_area, &total_size);
+		err = nvme_get_ctrl_telemetry(dev->fd, true, &log,
+                                              cfg.data_area, &total_size);
 	else if (cfg.host_gen)
-		err = nvme_get_new_host_telemetry(fd, &log, cfg.data_area, &total_size);
+		err = nvme_get_new_host_telemetry(dev->fd, &log,
+                                                  cfg.data_area, &total_size);
 	else
-		err = nvme_get_host_telemetry(fd, &log, cfg.data_area, &total_size);
+		err = nvme_get_host_telemetry(dev->fd, &log,
+                                              cfg.data_area, &total_size);
 
 	if (err < 0) {
 		fprintf(stderr, "get-telemetry-log: %s\n",
@@ -536,8 +556,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 
 close_output:
 	close(output);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -548,7 +568,8 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 	const char *desc = "Retrieves endurance groups log page and prints the log.";
 	const char *group_id = "The endurance group identifier";
 	enum nvme_print_flags flags;
-	int err, fd;
+        struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		char	*output_format;
@@ -566,15 +587,16 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
-	err = nvme_get_log_endurance_group(fd, cfg.group_id, &endurance_log);
+	err = nvme_get_log_endurance_group(dev->fd, cfg.group_id,
+                                           &endurance_log);
 	if (!err)
 		nvme_show_endurance_log(&endurance_log, cfg.group_id,
                                         nvme_dev->name, flags);
@@ -582,8 +604,8 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "endurance log: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -617,10 +639,11 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 	const char *csi = "";
 	struct list_head log_pages;
 	nvme_effects_log_node_t *node;
+        struct nvme_dev *dev;
 
 	void *bar = NULL;
 
-	int err = -1, fd;
+	int err = -1;
 	enum nvme_print_flags flags;
 
 	struct config {
@@ -645,13 +668,13 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 	if (cfg.human_readable)
@@ -669,7 +692,7 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 		nvme_free_tree(nvme_root);
 
 		if (!bar) {
-			goto close_fd;
+			goto close_dev;
 		}
 		cap = mmio_read64(bar + NVME_REG_CAP);
 		munmap(bar, getpagesize());
@@ -678,15 +701,15 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 		other_command_sets_supported = NVME_CAP_CSS(cap) & NVME_CAP_CSS_CSI;
 
 		if (nvme_command_set_supported)
-			err = collect_effects_log(fd, NVME_CSI_NVM,
+			err = collect_effects_log(dev->fd, NVME_CSI_NVM,
 						  &log_pages, flags);
 
 		if (!err && other_command_sets_supported)
-			err = collect_effects_log(fd, NVME_CSI_ZNS,
+			err = collect_effects_log(dev->fd, NVME_CSI_ZNS,
 						  &log_pages, flags);
 
 	} else {
-		err = collect_effects_log(fd, cfg.csi, &log_pages, flags);
+		err = collect_effects_log(dev->fd, cfg.csi, &log_pages, flags);
 	}
 
 	if (!err)
@@ -696,10 +719,12 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 	else
 		perror("effects log page");
 
-close_fd:
-	while ((node = list_pop(&log_pages, nvme_effects_log_node_t, node)))
+close_dev:
+	while ((node = list_pop(&log_pages, nvme_effects_log_node_t, node))) {
 		free(node);
-	close(fd);
+	}
+
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -710,9 +735,9 @@ static int get_supported_log_pages(int argc, char **argv, struct command *cmd,
 	const char *desc = "Retrieve supported logs and print the table.";
 	const char *verbose = "Increase output verbosity";
 	struct nvme_supported_log_pages supports;
-
-	int err = -1, fd;
 	enum nvme_print_flags flags;
+        struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		char	*output_format;
@@ -730,18 +755,18 @@ static int get_supported_log_pages(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
-	err = nvme_get_log_supported_log_pages(fd, false, &supports);
+	err = nvme_get_log_supported_log_pages(dev->fd, false, &supports);
 	if (!err)
 		nvme_show_supported_log(&supports, nvme_dev->name, flags);
 	else if (err > 0)
@@ -750,8 +775,8 @@ static int get_supported_log_pages(int argc, char **argv, struct command *cmd,
 		fprintf(stderr, "supported log pages: %s",
 			nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -766,7 +791,8 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	struct nvme_error_log_page *err_log;
 	struct nvme_id_ctrl ctrl;
 	enum nvme_print_flags flags;
-	int err = -1, fd;
+        struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u32	log_entries;
@@ -787,40 +813,40 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
 	if (!cfg.log_entries) {
 		fprintf(stderr, "non-zero log-entries is required param\n");
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ctrl(fd, &ctrl);
+	err = nvme_identify_ctrl(dev->fd, &ctrl);
 	if (err < 0) {
 		perror("identify controller");
-		goto close_fd;
+		goto close_dev;
 	} else if (err) {
 		fprintf(stderr, "could not identify controller\n");
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	cfg.log_entries = min(cfg.log_entries, ctrl.elpe + 1);
 	err_log = calloc(cfg.log_entries, sizeof(struct nvme_error_log_page));
 	if (!err_log) {
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_get_log_error(fd, cfg.log_entries, false, err_log);
+	err = nvme_get_log_error(dev->fd, cfg.log_entries, false, err_log);
 	if (!err)
 		nvme_show_error_log(err_log, cfg.log_entries,
                                     nvme_dev->name, flags);
@@ -829,8 +855,8 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	else
 		perror("error log");
 	free(err_log);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -842,7 +868,8 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 	const char *raw = "use binary output";
 	struct nvme_firmware_slot fw_log;
 	enum nvme_print_flags flags;
-	int err, fd;
+        struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		char	*output_format;
@@ -860,25 +887,25 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	err = nvme_get_log_fw_slot(fd, false, &fw_log);
+	err = nvme_get_log_fw_slot(dev->fd, false, &fw_log);
 	if (!err)
 		nvme_show_fw_log(&fw_log, nvme_dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "fw log: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -891,7 +918,8 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 	const char *raw = "output in binary format";
 	struct nvme_ns_list changed_ns_list_log;
 	enum nvme_print_flags flags;
-	int err, fd;
+        struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		char	*output_format;
@@ -909,17 +937,17 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	err = nvme_get_log_changed_ns_list(fd, true, &changed_ns_list_log);
+	err = nvme_get_log_changed_ns_list(dev->fd, true, &changed_ns_list_log);
 	if (!err)
 		nvme_show_changed_ns_list_log(&changed_ns_list_log,
                                               nvme_dev->name, flags);
@@ -928,8 +956,8 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 	else
 		fprintf(stderr, "changed ns list log: %s\n",
 			nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -944,7 +972,8 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 	const char *raw = "use binary output";
 	struct nvme_nvmset_predictable_lat_log plpns_log;
 	enum nvme_print_flags flags;
-	int err, fd;
+        struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u16	nvmset_id;
@@ -965,17 +994,18 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	err = nvme_get_log_predictable_lat_nvmset(fd, cfg.nvmset_id, &plpns_log);
+	err = nvme_get_log_predictable_lat_nvmset(dev->fd, cfg.nvmset_id,
+                                                  &plpns_log);
 	if (!err)
 		nvme_show_predictable_latency_per_nvmset(&plpns_log,
 			cfg.nvmset_id, nvme_dev->name, flags);
@@ -985,8 +1015,8 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 		fprintf(stderr, "predictable latency per nvm set: %s\n",
 			nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1004,9 +1034,10 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	const char *raw = "use binary output";
 	enum nvme_print_flags flags;
 	struct nvme_id_ctrl ctrl;
+        struct nvme_dev *dev;
 	__u32 log_size;
 	void *pea_log;
-	int err, fd;
+	int err;
 
 	struct config {
 		__u64	log_entries;
@@ -1030,30 +1061,30 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
 	if (!cfg.log_entries) {
 		fprintf(stderr, "non-zero log-entries is required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ctrl(fd, &ctrl);
+	err = nvme_identify_ctrl(dev->fd, &ctrl);
 	if (err < 0) {
 		fprintf(stderr, "identify controller: %s\n",
 			nvme_strerror(errno));
-		goto close_fd;
+		goto close_dev;
 	} else if (err) {
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	}
 
 	cfg.log_entries = min(cfg.log_entries, le32_to_cpu(ctrl.nsetidmax));
@@ -1061,10 +1092,11 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	pea_log = calloc(log_size, 1);
 	if (!pea_log) {
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_get_log_predictable_lat_event(fd, cfg.rae, 0, log_size, pea_log);
+	err = nvme_get_log_predictable_lat_event(dev->fd, cfg.rae, 0, log_size,
+                                                 pea_log);
 	if (!err)
 		nvme_show_predictable_latency_event_agg_log(pea_log, cfg.log_entries,
 			log_size, nvme_dev->name, flags);
@@ -1075,8 +1107,8 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 			nvme_strerror(errno));
 	free(pea_log);
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1094,8 +1126,9 @@ static int get_persistent_event_log(int argc, char **argv,
 	struct nvme_persistent_event_log *pevent, *pevent_collected;
 	enum nvme_print_flags flags;
 	void *pevent_log_info;
-	int err, fd;
+        struct nvme_dev *dev;
 	bool huge;
+	int err;
 
 	struct config {
 		__u8	action;
@@ -1119,23 +1152,23 @@ static int get_persistent_event_log(int argc, char **argv,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
 	pevent = calloc(sizeof(*pevent), 1);
 	if (!pevent) {
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_get_log_persistent_event(fd, cfg.action,
+	err = nvme_get_log_persistent_event(dev->fd, cfg.action,
 			sizeof(*pevent), pevent);
 	if (err < 0) {
 		fprintf(stderr, "persistent event log: %s\n",
@@ -1173,10 +1206,10 @@ static int get_persistent_event_log(int argc, char **argv,
 		err = -ENOMEM;
 		goto free_pevent;
 	}
-	err = nvme_get_log_persistent_event(fd, cfg.action,
+	err = nvme_get_log_persistent_event(dev->fd, cfg.action,
 		cfg.log_len, pevent_log_info);
 	if (!err) {
-		err = nvme_get_log_persistent_event(fd, cfg.action,
+		err = nvme_get_log_persistent_event(dev->fd, cfg.action,
 				sizeof(*pevent), pevent);
 		if (err < 0) {
 			fprintf(stderr, "persistent event log: %s\n",
@@ -1205,8 +1238,8 @@ free:
 	nvme_free(pevent_log_info, huge);
 free_pevent:
 	free(pevent);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1225,8 +1258,9 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	void *endurance_log;
 	struct nvme_id_ctrl ctrl;
 	enum nvme_print_flags flags;
-	int err, fd;
+        struct nvme_dev *dev;
 	__u32 log_size;
+	int err;
 
 	struct config {
 		__u64	log_entries;
@@ -1250,31 +1284,31 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
 	if (!cfg.log_entries) {
 		fprintf(stderr, "non-zero log-entries is required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ctrl(fd, &ctrl);
+	err = nvme_identify_ctrl(dev->fd, &ctrl);
 	if (err < 0) {
 		fprintf(stderr, "identify controller: %s\n",
 			nvme_strerror(errno));
-		goto close_fd;
+		goto close_dev;
 	} else if (err) {
 		fprintf(stderr, "could not identify controller\n");
 		err = -ENODEV;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	cfg.log_entries = min(cfg.log_entries, le16_to_cpu(ctrl.endgidmax));
@@ -1282,10 +1316,11 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	endurance_log = calloc(log_size, 1);
 	if (!endurance_log) {
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_get_log_endurance_grp_evt(fd, cfg.rae, 0, log_size, endurance_log);
+	err = nvme_get_log_endurance_grp_evt(dev->fd, cfg.rae, 0, log_size,
+                                             endurance_log);
 	if (!err)
 		nvme_show_endurance_group_event_agg_log(endurance_log, cfg.log_entries,
 			log_size, nvme_dev->name, flags);
@@ -1296,8 +1331,8 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 			nvme_strerror(errno));
 	free(endurance_log);
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1311,8 +1346,9 @@ static int get_lba_status_log(int argc, char **argv,
 	const char *rae = "Retain an Asynchronous Event";
 	void *lab_status;
 	enum nvme_print_flags flags;
-	int err, fd;
+        struct nvme_dev *dev;
 	__u32 lslplen;
+	int err;
 
 	struct config {
 		bool	rae;
@@ -1330,31 +1366,31 @@ static int get_lba_status_log(int argc, char **argv,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
-	err = nvme_get_log_lba_status(fd, true, 0, sizeof(__u32), &lslplen);
+	err = nvme_get_log_lba_status(dev->fd, true, 0, sizeof(__u32), &lslplen);
 	if (err < 0) {
 		fprintf(stderr, "lba status log page: %s\n",
 			nvme_strerror(errno));
-		goto close_fd;
+		goto close_dev;
 	} else if (err) {
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	}
 
 	lab_status = calloc(lslplen, 1);
 	if (!lab_status) {
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_get_log_lba_status(fd, cfg.rae, 0, lslplen, lab_status);
+	err = nvme_get_log_lba_status(dev->fd, cfg.rae, 0, lslplen, lab_status);
 	if (!err)
 		nvme_show_lba_status_log(lab_status, lslplen, nvme_dev->name, flags);
 	else if (err > 0)
@@ -1364,8 +1400,8 @@ static int get_lba_status_log(int argc, char **argv,
 			nvme_strerror(errno));
 	free(lab_status);
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1380,7 +1416,8 @@ static int get_resv_notif_log(int argc, char **argv,
 		"json or binary.";
 	struct nvme_resv_notification_log resv;
 	enum nvme_print_flags flags;
-	int err, fd;
+        struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		char	*output_format;
@@ -1395,15 +1432,15 @@ static int get_resv_notif_log(int argc, char **argv,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
-	err = nvme_get_log_reservation(fd, false, &resv);
+	err = nvme_get_log_reservation(dev->fd, false, &resv);
 	if (!err)
 		nvme_show_resv_notif_log(&resv, nvme_dev->name, flags);
 	else if (err > 0)
@@ -1412,8 +1449,8 @@ static int get_resv_notif_log(int argc, char **argv,
 		fprintf(stderr, "resv notifi log: %s\n",
 			nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 
@@ -1430,7 +1467,8 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 	struct nvme_boot_partition boot;
 	__u8 *bp_log;
 	enum nvme_print_flags flags;
-	int err = -1, fd = 0, output = 0;
+	int err = -1, output = 0;
+        struct nvme_dev *dev;
 	__u32 bpsz = 0;
 
 	struct config {
@@ -1452,24 +1490,24 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (!cfg.file_name) {
 		fprintf(stderr, "Please provide an output file!\n");
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.lsp > 128) {
 		fprintf(stderr, "invalid lsp param: %u\n", cfg.lsp);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	output = open(cfg.file_name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
@@ -1477,10 +1515,10 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 		fprintf(stderr, "Failed to open output file %s: %s!\n",
 				cfg.file_name, strerror(errno));
 		err = output;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_get_log_boot_partition(fd, false, cfg.lsp,
+	err = nvme_get_log_boot_partition(dev->fd, false, cfg.lsp,
 					  sizeof(boot), &boot);
 	if (err < 0) {
 		fprintf(stderr, "boot partition log: %s\n",
@@ -1498,7 +1536,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 		goto close_output;
 	}
 
-	err = nvme_get_log_boot_partition(fd, false, cfg.lsp,
+	err = nvme_get_log_boot_partition(dev->fd, false, cfg.lsp,
 					  sizeof(boot) + bpsz,
 					  (struct nvme_boot_partition *)bp_log);
 	if (!err)
@@ -1522,8 +1560,8 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 
 close_output:
 	close(output);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1535,9 +1573,9 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *cmd,
 	const char *domainid = "Domain Identifier";
 	const char *raw = "use binary output";
 	struct nvme_media_unit_stat_log mus;
-
-	int err = -1, fd;
 	enum nvme_print_flags flags;
+        struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u16	domainid;
@@ -1558,18 +1596,18 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	err = nvme_get_log_media_unit_stat(fd, cfg.domainid, &mus);
+	err = nvme_get_log_media_unit_stat(dev->fd, cfg.domainid, &mus);
 	if (!err)
 		nvme_show_media_unit_stat_log(&mus, flags);
 	else if (err > 0)
@@ -1578,8 +1616,8 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *cmd,
 		fprintf(stderr, "media unit status log: %s\n",
 			nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1591,9 +1629,9 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *cmd,
 	const char *domainid = "Domain Identifier";
 	const char *raw = "use binary output";
 	struct nvme_supported_cap_config_list_log cap_log;
-
-	int err = -1, fd;
 	enum nvme_print_flags flags;
+        struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u16	domainid;
@@ -1614,18 +1652,18 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	err = nvme_get_log_support_cap_config_list(fd, cfg.domainid, &cap_log);
+	err = nvme_get_log_support_cap_config_list(dev->fd, cfg.domainid, &cap_log);
 	if (!err)
 		nvme_show_supported_cap_config_log(&cap_log, flags);
 	else if (err > 0)
@@ -1633,8 +1671,8 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *cmd,
 	else
 		perror("supported capacity configuration list log");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1656,8 +1694,9 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *uuid_index = "UUID index";
 	const char *csi = "command set identifier";
 	const char *offset_type = "offset type";
-	int err, fd;
+	struct nvme_dev *dev;
 	unsigned char *log;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -1705,8 +1744,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.aen) {
@@ -1717,31 +1756,31 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	if (!cfg.log_len) {
 		perror("non-zero log-len is required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.lsp > 128) {
 		perror("invalid lsp param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.uuid_index > 128) {
 		perror("invalid uuid index param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	log = malloc(cfg.log_len);
 	if (!log) {
 		perror("could not alloc buffer for log\n");
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_get_log_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.lid		= cfg.log_id,
 		.nsid		= cfg.namespace_id,
 		.lpo		= cfg.lpo,
@@ -1771,8 +1810,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		fprintf(stderr, "log page: %s\n", nvme_strerror(errno));
 	free(log);
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1785,7 +1824,8 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	const char *human_readable = "show log in readable format";
 	struct nvme_sanitize_log_page sanitize_log;
 	enum nvme_print_flags flags;
-	int fd, err;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		bool	rae;
@@ -1809,19 +1849,19 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_get_log_sanitize(fd, cfg.rae, &sanitize_log);
+	err = nvme_get_log_sanitize(dev->fd, cfg.rae, &sanitize_log);
 	if (!err)
 		nvme_show_sanitize_log(&sanitize_log, nvme_dev->name, flags);
 	else if (err > 0)
@@ -1829,8 +1869,8 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	else
 		fprintf(stderr, "sanitize status log: %s\n",
 			nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1842,7 +1882,8 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 	const char *human_readable = "show log in readable format";
 	struct nvme_fid_supported_effects_log fid_support_log;
 	enum nvme_print_flags flags;
-	int fd, err = -1;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		char	*output_format;
@@ -1860,17 +1901,17 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_get_log_fid_supported_effects(fd, false, &fid_support_log);
+	err = nvme_get_log_fid_supported_effects(dev->fd, false, &fid_support_log);
 	if (!err)
 		nvme_show_fid_support_effects_log(&fid_support_log,
                                                   nvme_dev->name, flags);
@@ -1879,8 +1920,8 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 	else
 		fprintf(stderr, "fid support effects log: %s\n",
 			nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1892,7 +1933,8 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 	const char *human_readable = "show log in readable format";
 	struct nvme_mi_cmd_supported_effects_log mi_cmd_support_log;
 	enum nvme_print_flags flags;
-	int fd, err = -1;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		char	*output_format;
@@ -1910,17 +1952,17 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_get_log_mi_cmd_supported_effects(fd, false, &mi_cmd_support_log);
+	err = nvme_get_log_mi_cmd_supported_effects(dev->fd, false, &mi_cmd_support_log);
 	if (!err)
 		nvme_show_mi_cmd_support_effects_log(&mi_cmd_support_log,
                                                      nvme_dev->name, flags);
@@ -1929,8 +1971,8 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 	else
 		fprintf(stderr, "mi command support effects log: %s\n",
 			nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -1941,9 +1983,10 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 		"given device is part of, or optionally controllers attached to a specific namespace.";
 	const char *controller = "controller to display";
 	const char *namespace_id = "optional namespace attached to controller";
-	int err, fd;
 	struct nvme_ctrl_list *cntlist;
 	enum nvme_print_flags flags;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u16	cntid;
@@ -1964,24 +2007,24 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (posix_memalign((void *)&cntlist, getpagesize(), 0x1000)) {
 		fprintf(stderr, "can not allocate controller list payload\n");
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.namespace_id == NVME_NSID_NONE)
-                 err = nvme_identify_ctrl_list(fd, cfg.cntid, cntlist);
+                 err = nvme_identify_ctrl_list(dev->fd, cfg.cntid, cntlist);
         else
-                 err = nvme_identify_nsid_ctrl_list(fd, cfg.namespace_id,
+                 err = nvme_identify_nsid_ctrl_list(dev->fd, cfg.namespace_id,
 					   cfg.cntid, cntlist);
 	if (!err)
 		nvme_show_list_ctrl(cntlist, flags);
@@ -1992,8 +2035,8 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 			nvme_strerror(errno));
 
 	free(cntlist);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -2006,9 +2049,10 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 	const char *csi = "I/O command set identifier";
 	const char *all = "show all namespaces in the subsystem, whether attached or inactive";
 	struct nvme_identify_args args = { 0 };
-	int err, fd;
 	struct nvme_ns_list ns_list;
 	enum nvme_print_flags flags;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -2032,26 +2076,26 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (flags != JSON && flags != NORMAL) {
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (!cfg.namespace_id) {
 		err = -EINVAL;
 		fprintf(stderr, "invalid nsid parameter\n");
-		goto close_fd;
+		goto close_dev;
 	}
 
 	args.args_size = sizeof(args);
-	args.fd = fd;
+	args.fd = dev->fd;
 	args.timeout = NVME_DEFAULT_IOCTL_TIMEOUT;
 	args.data = &ns_list;
 	args.nsid = cfg.namespace_id - 1;
@@ -2073,8 +2117,8 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 	else
 		fprintf(stderr, "id namespace list: %s",
 			nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -2090,7 +2134,8 @@ static int id_ns_lba_format(int argc, char **argv, struct command *cmd, struct p
 	const char *verbose = "Increase output verbosity";
 	enum nvme_print_flags flags;
 	struct nvme_id_ns ns;
-	int err = -1, fd;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u16	lba_format_index;
@@ -2114,18 +2159,18 @@ static int id_ns_lba_format(int argc, char **argv, struct command *cmd, struct p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
-	err = nvme_identify_ns_csi_user_data_format(fd, cfg.lba_format_index,
+	err = nvme_identify_ns_csi_user_data_format(dev->fd, cfg.lba_format_index,
 										cfg.uuid_index, NVME_CSI_NVM, &ns);
 	if (!err)
 		nvme_show_id_ns(&ns, 0, cfg.lba_format_index, true, flags);
@@ -2133,8 +2178,8 @@ static int id_ns_lba_format(int argc, char **argv, struct command *cmd, struct p
 		nvme_show_status(err);
 	else
 		perror("identify namespace for specific LBA format");
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return nvme_status_to_errno(err, false);
 }
@@ -2145,9 +2190,10 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *cmd,
 	const char *desc = "Show endurance group list information for the given endurance "\
 		"group id";
 	const char *endurance_grp_id = "Endurance Group ID";
-	int err = -1, fd;
 	struct nvme_id_endurance_group_list *endgrp_list;
 	enum nvme_print_flags flags;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u16	endgrp_id;
@@ -2165,25 +2211,25 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (flags != JSON && flags != NORMAL) {
 		err = -EINVAL;
 		fprintf(stderr, "invalid output format\n");
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (posix_memalign((void *)&endgrp_list, getpagesize(), 0x1000)) {
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_endurance_group_list(fd, cfg.endgrp_id, endgrp_list);
+	err = nvme_identify_endurance_group_list(dev->fd, cfg.endgrp_id, endgrp_list);
 	if (!err)
 		nvme_show_endurance_group_list(endgrp_list, flags);
 	else if (err > 0)
@@ -2193,8 +2239,8 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *cmd,
 			nvme_strerror(errno));
 
 	free(endgrp_list);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -2209,7 +2255,8 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		"the namespace is not already inactive, once deleted.";
 	const char *namespace_id = "namespace to delete";
 	const char *timeout = "timeout value, in milliseconds";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -2227,20 +2274,20 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n",
 				nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
-	err = nvme_ns_mgmt_delete(fd, cfg.namespace_id);
+	err = nvme_ns_mgmt_delete(dev->fd, cfg.namespace_id);
 	if (!err)
 		printf("%s: Success, deleted nsid:%d\n", cmd->name,
 								cfg.namespace_id);
@@ -2249,16 +2296,17 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	else
 		fprintf(stderr, "delete namespace: %s\n", nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
 
 static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, struct command *cmd)
 {
-	int err, num, fd, i, list[2048];
 	struct nvme_ctrl_list cntlist;
+	int err, num, i, list[2048];
+	struct nvme_dev *dev;
 	__u16 ctrlist[2048];
 
 	const char *namespace_id = "namespace to attach";
@@ -2280,15 +2328,15 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
 		fprintf(stderr, "%s: namespace-id parameter required\n",
 						cmd->name);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	num = argconfig_parse_comma_sep_array(cfg.cntlist, list, 2047);
@@ -2300,7 +2348,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 		fprintf(stderr, "%s: controller id list is malformed\n",
 						cmd->name);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	for (i = 0; i < num; i++)
@@ -2309,9 +2357,9 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	nvme_init_ctrl_list(&cntlist, num, ctrlist);
 
 	if (attach)
-		err = nvme_ns_attach_ctrls(fd, cfg.namespace_id, &cntlist);
+		err = nvme_ns_attach_ctrls(dev->fd, cfg.namespace_id, &cntlist);
 	else
-		err = nvme_ns_detach_ctrls(fd, cfg.namespace_id, &cntlist);
+		err = nvme_ns_detach_ctrls(dev->fd, cfg.namespace_id, &cntlist);
 
 	if (!err)
 		printf("%s: Success, nsid:%d\n", cmd->name, cfg.namespace_id);
@@ -2320,8 +2368,8 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	else
 		perror(attach ? "attach namespace" : "detach namespace");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -2366,8 +2414,9 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	const char *bs = "target block size, specify only if \'FLBAS\' "\
 		"value not entered";
 
-	int err = 0, fd, i;
 	struct nvme_id_ns ns;
+	struct nvme_dev *dev;
+	int err = 0, i;
 	__u32 nsid;
 
 	struct config {
@@ -2413,15 +2462,15 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.flbas != 0xff && cfg.bs != 0x00) {
 		fprintf(stderr,
 			"Invalid specification of both FLBAS and Block Size, please specify only one\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.bs) {
 		if ((cfg.bs & (~cfg.bs + 1)) != cfg.bs) {
@@ -2429,9 +2478,9 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 				"Invalid value for block size (%"PRIu64"). Block size must be a power of two\n",
 				(uint64_t)cfg.bs);
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
-		err = nvme_identify_ns(fd, NVME_NSID_ALL, &ns);
+		err = nvme_identify_ns(dev->fd, NVME_NSID_ALL, &ns);
 		if (err) {
 			if (err < 0)
 				fprintf(stderr, "identify-namespace: %s",
@@ -2440,7 +2489,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 				fprintf(stderr, "identify failed\n");
 				nvme_show_status(err);
 			}
-			goto close_fd;
+			goto close_dev;
 		}
 		for (i = 0; i <= ns.nlbaf; ++i) {
 			if ((1 << ns.lbaf[i].ds) == cfg.bs && ns.lbaf[i].ms == 0) {
@@ -2458,7 +2507,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 			"Please correct block size, or specify FLBAS directly\n");
 
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_id_ns ns2 = {
@@ -2472,7 +2521,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		.lbstm = cpu_to_le64(cfg.lbstm),
 	};
 
-	err = nvme_ns_mgmt_create(fd, &ns2, &nsid, cfg.timeout, cfg.csi);
+	err = nvme_ns_mgmt_create(dev->fd, &ns2, &nsid, cfg.timeout, cfg.csi);
 	if (!err)
 		printf("%s: Success, created nsid:%d\n", cmd->name, nsid);
 	else if (err > 0)
@@ -2480,8 +2529,8 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	else
 		fprintf(stderr, "create namespace: %s\n", nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -2677,7 +2726,8 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	const char *human_readable = "show identify in readable format";
 	enum nvme_print_flags flags;
 	struct nvme_id_ctrl ctrl;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		bool	vendor_specific;
@@ -2701,13 +2751,13 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 	if (cfg.vendor_specific)
@@ -2715,15 +2765,15 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_identify_ctrl(fd, &ctrl);
+	err = nvme_identify_ctrl(dev->fd, &ctrl);
 	if (!err)
 		nvme_show_id_ctrl(&ctrl, flags, vs);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "identify controller: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -2741,7 +2791,8 @@ static int nvm_id_ctrl(int argc, char **argv, struct command *cmd,
 		"the specified controller in various formats.";
 	enum nvme_print_flags flags;
 	struct nvme_id_ctrl_nvm ctrl_nvm;
-	int fd, err = -1;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		char	*output_format;
@@ -2756,23 +2807,23 @@ static int nvm_id_ctrl(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
-	err = nvme_nvm_identify_ctrl(fd, &ctrl_nvm);
+	err = nvme_nvm_identify_ctrl(dev->fd, &ctrl_nvm);
 	if (!err)
 		nvme_show_id_ctrl_nvm(&ctrl_nvm, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "nvm identify controller: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -2789,7 +2840,8 @@ static int nvm_id_ns(int argc, char **argv, struct command *cmd,
 	enum nvme_print_flags flags;
 	struct nvme_nvm_id_ns id_ns;
 	struct nvme_id_ns ns;
-	int fd, err = -1;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u32	namespace_id;
@@ -2813,32 +2865,32 @@ static int nvm_id_ns(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			perror("get-namespace-id");
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
-	err = nvme_identify_ns(fd, cfg.namespace_id, &ns);
+	err = nvme_identify_ns(dev->fd, cfg.namespace_id, &ns);
 	if (err) {
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ns_csi(fd, cfg.namespace_id, cfg.uuid_index,
+	err = nvme_identify_ns_csi(dev->fd, cfg.namespace_id, cfg.uuid_index,
 							NVME_CSI_NVM, &id_ns);
 	if (!err)
 		nvme_show_nvm_id_ns(&id_ns, cfg.namespace_id, &ns, 0, false, flags);
@@ -2846,8 +2898,8 @@ static int nvm_id_ns(int argc, char **argv, struct command *cmd,
 		nvme_show_status(err);
 	else
 		perror("nvm identify namespace");
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return nvme_status_to_errno(err, false);
 }
@@ -2865,7 +2917,8 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *cmd, stru
 	enum nvme_print_flags flags;
 	struct nvme_id_ns ns;
 	struct nvme_nvm_id_ns nvm_ns;
-	int err = -1, fd;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u16	lba_format_index;
@@ -2889,23 +2942,23 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *cmd, stru
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
-	err = nvme_identify_ns(fd, NVME_NSID_ALL, &ns);
+	err = nvme_identify_ns(dev->fd, NVME_NSID_ALL, &ns);
 	if (err) {
 		ns.nlbaf = NVME_FEAT_LBA_RANGE_MAX - 1;
 		ns.nulbaf = 0;
 	}
-	err = nvme_identify_iocs_ns_csi_user_data_format(fd, cfg.lba_format_index,
+	err = nvme_identify_iocs_ns_csi_user_data_format(dev->fd, cfg.lba_format_index,
 										cfg.uuid_index, NVME_CSI_NVM, &nvm_ns);
 	if (!err)
 		nvme_show_nvm_id_ns(&nvm_ns, 0, &ns, cfg.lba_format_index, true,
@@ -2914,8 +2967,8 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *cmd, stru
 		nvme_show_status(err);
 	else
 		perror("NVM identify namespace for specific LBA format");
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return nvme_status_to_errno(err, false);
 }
@@ -2928,8 +2981,9 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *raw = "show descriptors in binary format";
 	const char *namespace_id = "identifier of desired namespace";
 	enum nvme_print_flags flags;
-	int err, fd;
+	struct nvme_dev *dev;
 	void *nsdescs;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -2950,30 +3004,30 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
 	if (posix_memalign(&nsdescs, getpagesize(), 0x1000)) {
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ns_descs(fd, cfg.namespace_id, nsdescs);
+	err = nvme_identify_ns_descs(dev->fd, cfg.namespace_id, nsdescs);
 	if (!err)
 		nvme_show_id_ns_descs(nsdescs, cfg.namespace_id, flags);
 	else if (err > 0)
@@ -2981,8 +3035,8 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 	else
 		fprintf(stderr, "identify namespace: %s\n", nvme_strerror(errno));
 	free(nsdescs);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3001,7 +3055,8 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 
 	enum nvme_print_flags flags;
 	struct nvme_id_ns ns;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -3031,13 +3086,13 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 	if (cfg.vendor_specific)
@@ -3046,17 +3101,17 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		flags |= VERBOSE;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
 	if (cfg.force)
-		err = nvme_identify_allocated_ns(fd, cfg.namespace_id, &ns);
+		err = nvme_identify_allocated_ns(dev->fd, cfg.namespace_id, &ns);
 	else
-		err = nvme_identify_ns(fd, cfg.namespace_id, &ns);
+		err = nvme_identify_ns(dev->fd, cfg.namespace_id, &ns);
 
 	if (!err)
 		nvme_show_id_ns(&ns, cfg.namespace_id, 0, false, flags);
@@ -3064,8 +3119,8 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "identify namespace: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3082,7 +3137,8 @@ static int cmd_set_independent_id_ns(int argc, char **argv,
 
 	enum nvme_print_flags flags;
 	struct nvme_id_independent_id_ns ns;
-	int err = -1, fd;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u32	namespace_id;
@@ -3106,35 +3162,35 @@ static int cmd_set_independent_id_ns(int argc, char **argv,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
 	if (!cfg.namespace_id) {
-		err = cfg.namespace_id = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = cfg.namespace_id = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			perror("get-namespace-id");
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
-	err = nvme_identify_independent_identify_ns(fd, cfg.namespace_id, &ns);
+	err = nvme_identify_independent_identify_ns(dev->fd, cfg.namespace_id, &ns);
 	if (!err)
 		nvme_show_cmd_set_independent_id_ns(&ns, cfg.namespace_id, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "I/O command set independent identify namespace: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3147,7 +3203,8 @@ static int id_ns_granularity(int argc, char **argv, struct command *cmd, struct 
 
 	struct nvme_id_ns_granularity_list *granularity_list;
 	enum nvme_print_flags flags;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		char	*output_format;
@@ -3162,21 +3219,21 @@ static int id_ns_granularity(int argc, char **argv, struct command *cmd, struct 
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (posix_memalign((void *)&granularity_list, getpagesize(), NVME_IDENTIFY_DATA_SIZE)) {
 		fprintf(stderr, "can not allocate granularity list payload\n");
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ns_granularity(fd, granularity_list);
+	err = nvme_identify_ns_granularity(dev->fd, granularity_list);
 	if (!err)
 		nvme_show_id_ns_granularity_list(granularity_list, flags);
 	else if (err > 0)
@@ -3184,8 +3241,8 @@ static int id_ns_granularity(int argc, char **argv, struct command *cmd, struct 
 	else
 		fprintf(stderr, "identify namespace granularity: %s\n", nvme_strerror(errno));
 	free(granularity_list);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3200,7 +3257,8 @@ static int id_nvmset(int argc, char **argv, struct command *cmd, struct plugin *
 
 	struct nvme_id_nvmset_list nvmset;
 	enum nvme_print_flags flags;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u16	nvmset_id;
@@ -3218,15 +3276,15 @@ static int id_nvmset(int argc, char **argv, struct command *cmd, struct plugin *
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
-	err = nvme_identify_nvmset_list(fd, cfg.nvmset_id, &nvmset);
+	err = nvme_identify_nvmset_list(dev->fd, cfg.nvmset_id, &nvmset);
 	if (!err)
 		nvme_show_id_nvmset(&nvmset, cfg.nvmset_id, flags);
 	else if (err > 0)
@@ -3234,8 +3292,8 @@ static int id_nvmset(int argc, char **argv, struct command *cmd, struct plugin *
 	else
 		fprintf(stderr, "identify nvm set list: %s\n", nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3250,7 +3308,8 @@ static int id_uuid(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	struct nvme_id_uuid_list uuid_list;
 	enum nvme_print_flags flags;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		char	*output_format;
@@ -3271,27 +3330,27 @@ static int id_uuid(int argc, char **argv, struct command *cmd, struct plugin *pl
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_identify_uuid(fd, &uuid_list);
+	err = nvme_identify_uuid(dev->fd, &uuid_list);
 	if (!err)
 		nvme_show_id_uuid_list(&uuid_list, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "identify UUID list: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;;
 }
@@ -3303,7 +3362,8 @@ static int id_iocs(int argc, char **argv, struct command *cmd, struct plugin *pl
 		"in either human-readable or binary format.";
 	const char *controller_id = "identifier of desired controller";
 	struct nvme_id_iocs iocs;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u16	cntid;
@@ -3318,13 +3378,11 @@ static int id_iocs(int argc, char **argv, struct command *cmd, struct plugin *pl
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
-		err = fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
-	}
 
-	err = nvme_identify_iocs(fd, cfg.cntid, &iocs);
+	err = nvme_identify_iocs(dev->fd, cfg.cntid, &iocs);
 	if (!err) {
 		printf("NVMe Identify I/O Command Set:\n");
 		nvme_show_id_iocs(&iocs);
@@ -3333,7 +3391,7 @@ static int id_iocs(int argc, char **argv, struct command *cmd, struct plugin *pl
 	else
 		fprintf(stderr, "NVMe Identify I/O Command Set: %s\n", nvme_strerror(errno));
 
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3345,7 +3403,8 @@ static int id_domain(int argc, char **argv, struct command *cmd, struct plugin *
 	const char *domain_id = "identifier of desired domain";
 	struct nvme_id_domain_list id_domain;
 	enum nvme_print_flags flags;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u16	dom_id;
@@ -3363,17 +3422,15 @@ static int id_domain(int argc, char **argv, struct command *cmd, struct plugin *
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
-		err = fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
-	}
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
-	err = nvme_identify_domain_list(fd, cfg.dom_id, &id_domain);
+	err = nvme_identify_domain_list(dev->fd, cfg.dom_id, &id_domain);
 	if (!err) {
 		printf("NVMe Identify command for Domain List is successful:\n");
 		printf("NVMe Identify Domain List:\n");
@@ -3383,8 +3440,8 @@ static int id_domain(int argc, char **argv, struct command *cmd, struct plugin *
 	else
 		fprintf(stderr, "NVMe Identify Domain List: %s\n", nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3392,18 +3449,19 @@ ret:
 static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Get namespace ID of a the block device.";
-	int err = 0, fd;
+	struct nvme_dev *dev;
 	unsigned int nsid;
+	int err = 0;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
-	err = nvme_get_nsid(fd, &nsid);
+	err = nvme_get_nsid(dev->fd, &nsid);
 	if (err < 0) {
 		fprintf(stderr, "get namespace ID: %s\n", nvme_strerror(errno));
 		err = errno;
@@ -3413,7 +3471,7 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 	printf("%s: namespace-id:%d\n", nvme_dev->name, nsid);
 
 close_fd:
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3435,8 +3493,9 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 		"8h: Secondary Assign\n"\
 		"9h: Secondary Online";
 	const char *nr = "Number of Controller Resources(NR)";
-	int fd, err;
+	struct nvme_dev *dev;
 	__u32 result;
+	int err;
 
 	struct config {
 		__u16	cntlid;
@@ -3460,13 +3519,13 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	struct nvme_virtual_mgmt_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.act		= cfg.act,
 		.rt		= cfg.rt,
 		.cntlid		= cfg.cntlid,
@@ -3483,7 +3542,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 	} else
 		fprintf(stderr, "virt-mgmt: %s\n", nvme_strerror(errno));
 
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3496,9 +3555,9 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *cmd, struct 
 		"decoded format (default), json or binary.";
 	const char *human_readable = "show info in readable format";
 	struct nvme_primary_ctrl_cap caps;
-
-	int err, fd;
 	enum nvme_print_flags flags;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u16	cntlid;
@@ -3519,25 +3578,25 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *cmd, struct 
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_identify_primary_ctrl(fd, cfg.cntlid, &caps);
+	err = nvme_identify_primary_ctrl(dev->fd, cfg.cntlid, &caps);
 	if (!err)
 		nvme_show_primary_ctrl_cap(&caps, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "identify primary controller capabilities: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3552,7 +3611,8 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 
 	struct nvme_secondary_ctrl_list *sc_list;
 	enum nvme_print_flags flags;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u16	cntid;
@@ -3576,27 +3636,28 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_err;
 
 	if (!cfg.num_entries) {
 		fprintf(stderr, "non-zero num-entries is required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_err;
 	}
 
 	if (posix_memalign((void *)&sc_list, getpagesize(), sizeof(*sc_list))) {
 		fprintf(stderr, "can not allocate controller list payload\n");
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_err;
 	}
 
-	err = nvme_identify_secondary_ctrl_list(fd, cfg.namespace_id, cfg.cntid, sc_list);
+	err = nvme_identify_secondary_ctrl_list(dev->fd, cfg.namespace_id,
+						cfg.cntid, sc_list);
 	if (!err)
 		nvme_show_list_secondary_ctrl(sc_list, cfg.num_entries, flags);
 	else if (err > 0)
@@ -3606,8 +3667,8 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 
 	free(sc_list);
 
-close_fd:
-	close(fd);
+close_err:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3623,7 +3684,8 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 		"2h Start a extended device self-test operation\n"\
 		"eh Start a vendor specific device self-test operation\n"\
 		"fh abort the device self-test operation\n";
-	int fd, err;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -3641,13 +3703,13 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	struct nvme_dev_self_test_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.stc		= cfg.stc,
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
@@ -3666,7 +3728,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 	} else
 		fprintf(stderr, "Device self-test: %s\n", nvme_strerror(errno));
 
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3682,7 +3744,8 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 
 	struct nvme_self_test_log log;
 	enum nvme_print_flags flags;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u8	dst_entries;
@@ -3703,17 +3766,17 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
-	err = nvme_get_log_device_self_test(fd, &log);
+	err = nvme_get_log_device_self_test(dev->fd, &log);
 	if (!err)
 		nvme_show_self_test_log(&log, cfg.dst_entries, 0,
                                         nvme_dev->name, flags);
@@ -3721,8 +3784,8 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 		nvme_show_status(err);
 	else
 		fprintf(stderr, "self test log: %s\n", nvme_strerror(errno));
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -3871,8 +3934,8 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 	const char *cdw11 = "dword 11 for interrupt vector config";
 	const char *human_readable = "show feature in readable format";
 	const char *uuid_index = "specify uuid index";
+	struct nvme_dev *dev;
 	int err;
-	int fd;
 
 	struct feat_cfg cfg = {
 		.feature_id	= 0,
@@ -3897,16 +3960,16 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			if (errno != ENOTTY) {
 				fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-				goto close_fd;
+				goto close_dev;
 			}
 			cfg.namespace_id = NVME_NSID_ALL;
 		}
@@ -3915,19 +3978,19 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 	if (cfg.sel > 8) {
 		fprintf(stderr, "invalid 'select' param:%d\n", cfg.sel);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.uuid_index > 128) {
 		fprintf(stderr, "invalid uuid index param: %u\n", cfg.uuid_index);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = get_feature_ids(fd, cfg);
+	err = get_feature_ids(dev->fd, cfg);
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 
 ret:
 	return err;
@@ -3946,10 +4009,11 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	const char *fw = "firmware file (required)";
 	const char *xfer = "transfer chunksize limit";
 	const char *offset = "starting dword offset, default 0";
-	int err, fd, fw_fd = -1;
 	unsigned int fw_size;
-	struct stat sb;
+	struct nvme_dev *dev;
 	void *fw_buf, *buf;
+	int err, fw_fd = -1;
+	struct stat sb;
 	bool huge;
 
 	struct config {
@@ -3971,8 +4035,8 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	fw_fd = open(cfg.fw, O_RDONLY);
@@ -3981,7 +4045,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 		fprintf(stderr, "Failed to open firmware file %s: %s\n",
 				cfg.fw, strerror(errno));
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	err = fstat(fw_fd, &sb);
@@ -4022,7 +4086,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 
 		struct nvme_fw_download_args args = {
 			.args_size	= sizeof(args),
-			.fd		= fd,
+			.fd		= dev->fd,
 			.offset		= cfg.offset,
 			.data_len	= cfg.xfer,
 			.data		= fw_buf,
@@ -4048,8 +4112,8 @@ free:
 	nvme_free(buf, huge);
 close_fw_fd:
 	close(fw_fd);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4074,8 +4138,9 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 	const char *slot = "[0-7]: firmware slot for commit action";
 	const char *action = "[0-7]: commit action";
 	const char *bpid = "[0,1]: boot partition identifier, if applicable (default: 0)";
-	int err, fd;
+	struct nvme_dev *dev;
 	__u32 result;
+	int err;
 
 	struct config {
 		__u8	slot;
@@ -4096,29 +4161,29 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.slot > 7) {
 		fprintf(stderr, "invalid slot:%d\n", cfg.slot);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.action > 7 || cfg.action == 4 || cfg.action == 5) {
 		fprintf(stderr, "invalid action:%d\n", cfg.action);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.bpid > 1) {
 		fprintf(stderr, "invalid boot partition id:%d\n", cfg.bpid);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_fw_commit_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.slot		= cfg.slot,
 		.action		= cfg.action,
 		.bpid		= cfg.bpid,
@@ -4161,8 +4226,8 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 				"sequence due to processing a command from an Admin SQ on a controller");
 	}
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4170,17 +4235,18 @@ ret:
 static int subsystem_reset(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Resets the NVMe subsystem\n";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
-	err = nvme_subsystem_reset(fd);
+	err = nvme_subsystem_reset(dev->fd);
 	if (err < 0) {
 		if (errno == ENOTTY)
 			fprintf(stderr,
@@ -4189,7 +4255,7 @@ static int subsystem_reset(int argc, char **argv, struct command *cmd, struct pl
 			fprintf(stderr, "Subsystem-reset: %s\n", nvme_strerror(errno));
 	}
 
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4197,21 +4263,22 @@ ret:
 static int reset(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Resets the NVMe controller\n";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
-	err = nvme_ctrl_reset(fd);
+	err = nvme_ctrl_reset(dev->fd);
 	if (err < 0)
 		fprintf(stderr, "Reset: %s\n", nvme_strerror(errno));
 
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4219,21 +4286,22 @@ ret:
 static int ns_rescan(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Rescans the NVMe namespaces\n";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
-	err = nvme_ns_rescan(fd);
+	err = nvme_ns_rescan(dev->fd);
 	if (err < 0)
 		fprintf(stderr, "Namespace Rescan");
 
-	close(fd);
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4247,7 +4315,8 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *ause_desc = "Allow unrestricted sanitize exit.";
 	const char *sanact_desc = "Sanitize action.";
 	const char *ovrpat_desc = "Overwrite pattern.";
-	int fd, err;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		bool	no_dealloc;
@@ -4277,8 +4346,8 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	switch (cfg.sanact) {
@@ -4290,14 +4359,14 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	default:
 		fprintf(stderr, "Invalid Sanitize Action\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.sanact == NVME_SANITIZE_SANACT_EXIT_FAILURE) {
 	       if (cfg.ause || cfg.no_dealloc) {
 			fprintf(stderr, "SANACT is Exit Failure Mode\n");
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 	       }
 	}
 
@@ -4305,19 +4374,19 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 		if (cfg.owpass > 16) {
 			fprintf(stderr, "OWPASS out of range [0-16]\n");
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 	} else {
 		if (cfg.owpass || cfg.oipbp || cfg.ovrpat) {
 			fprintf(stderr, "SANACT is not Overwrite\n");
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
 	struct nvme_sanitize_nvm_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.sanact		= cfg.sanact,
 		.ause		= cfg.ause,
 		.owpass		= cfg.owpass,
@@ -4333,8 +4402,8 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	else if (err > 0)
 		nvme_show_status(err);
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4430,10 +4499,11 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 					"output_format == normal";
 
 	enum nvme_print_flags flags;
-	nvme_root_t r;
+	struct nvme_dev *dev;
 	bool fabrics = true;
-	int fd, err;
+	nvme_root_t r;
 	void *bar;
+	int err;
 
 	struct config {
 		char	*output_format;
@@ -4451,18 +4521,18 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	r = nvme_scan(NULL);
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_get_properties(fd, &bar);
+	err = nvme_get_properties(dev->fd, &bar);
 	if (err) {
 		bar = mmap_registers(r, nvme_dev->name);
 		fabrics = false;
@@ -4470,15 +4540,15 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 			err = 0;
 	}
 	if (!bar)
-		goto close_fd;
+		goto close_dev;
 
 	nvme_show_ctrl_registers(bar, fabrics, flags);
 	if (fabrics)
 		free(bar);
 	else
 		munmap(bar, getpagesize());
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 	nvme_free_tree(r);
 ret:
 	return err;
@@ -4492,8 +4562,9 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 	const char *offset = "offset of the requested property";
 	const char *human_readable = "show property in readable format";
 
-	int fd, err;
+	struct nvme_dev *dev;
 	__u64 value;
+	int err;
 
 	struct config {
 		int	offset;
@@ -4511,19 +4582,19 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.offset == -1) {
 		fprintf(stderr, "offset required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_get_property_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.offset		= cfg.offset,
 		.value		= &value,
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
@@ -4537,8 +4608,8 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 		nvme_show_status(err);
 	}
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4549,7 +4620,8 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 			   "for NVMe over Fabric";
 	const char *offset = "the offset of the property";
 	const char *value = "the value of the property to be set";
-	int fd, err;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		int	offset;
@@ -4567,24 +4639,24 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.offset == -1) {
 		fprintf(stderr, "offset required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.value == -1) {
 		fprintf(stderr, "value required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_set_property_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.offset		= cfg.offset,
 		.value		= cfg.value,
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
@@ -4600,8 +4672,8 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 		nvme_show_status(err);
 	}
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4624,9 +4696,10 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 	struct nvme_id_ns ns;
 	struct nvme_id_ctrl ctrl;
-	int err, fd, i;
-	int block_size;
+	struct nvme_dev *dev;
 	__u8 prev_lbaf = 0;
+	int block_size;
+	int err, i;
 
 	struct config {
 		__u32	namespace_id;
@@ -4672,8 +4745,8 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	if (err)
 		goto ret;
 
-	err = fd = open_exclusive(argc, argv, cfg.force);
-	if (fd < 0) {
+	err = open_exclusive(&dev, argc, argv, cfg.force);
+	if (err < 0) {
 		if (errno == EBUSY) {
 			fprintf(stderr, "Failed to open %s.\n",
 		                basename(argv[optind]));
@@ -4692,7 +4765,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		fprintf(stderr,
 			"Invalid specification of both LBAF and Block Size, please specify only one\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.bs) {
 		if ((cfg.bs & (~cfg.bs + 1)) != cfg.bs) {
@@ -4700,14 +4773,14 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 				"Invalid value for block size (%"PRIu64"), must be a power of two\n",
 				       (uint64_t) cfg.bs);
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
-	err = nvme_identify_ctrl(fd, &ctrl);
+	err = nvme_identify_ctrl(dev->fd, &ctrl);
 	if (err) {
 		fprintf(stderr, "identify-ctrl: %s\n", nvme_strerror(errno));
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if ((ctrl.fna & 1) == 1) {
@@ -4718,10 +4791,10 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		 */
 		cfg.namespace_id = NVME_NSID_ALL;
 	} else if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
@@ -4731,11 +4804,11 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 			"specify a namespace to format or use '-n 0xffffffff' "
 			"to format all namespaces on this controller.\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.namespace_id != NVME_NSID_ALL) {
-		err = nvme_identify_ns(fd, cfg.namespace_id, &ns);
+		err = nvme_identify_ns(dev->fd, cfg.namespace_id, &ns);
 		if (err) {
 			if (err < 0)
 				fprintf(stderr, "identify-namespace: %s\n", nvme_strerror(errno));
@@ -4743,7 +4816,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 				fprintf(stderr, "identify failed\n");
 				nvme_show_status(err);
 			}
-			goto close_fd;
+			goto close_dev;
 		}
 		nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &prev_lbaf);
 
@@ -4762,7 +4835,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 				fprintf(stderr,
 					"Please correct block size, or specify LBAF directly\n");
 				err = -EINVAL;
-				goto close_fd;
+				goto close_dev;
 			}
 		} else  if (cfg.lbaf == 0xff)
 			cfg.lbaf = prev_lbaf;
@@ -4774,27 +4847,27 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	if (cfg.ses > 7) {
 		fprintf(stderr, "invalid secure erase settings:%d\n", cfg.ses);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.lbaf > 63) {
 		fprintf(stderr, "invalid lbaf:%d\n", cfg.lbaf);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.pi > 7) {
 		fprintf(stderr, "invalid pi:%d\n", cfg.pi);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.pil > 1) {
 		fprintf(stderr, "invalid pil:%d\n", cfg.pil);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.ms > 1) {
 		fprintf(stderr, "invalid ms:%d\n", cfg.ms);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (!cfg.force) {
@@ -4811,7 +4884,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 
 	struct nvme_format_nvm_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.lbafu		= (cfg.lbaf & NVME_NS_FLBAS_HIGHER_MASK) >> 4,
 		.lbaf		= cfg.lbaf & NVME_NS_FLBAS_LOWER_MASK,
@@ -4831,10 +4904,10 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		printf("Success formatting namespace:%x\n", cfg.namespace_id);
 		if (cfg.lbaf != prev_lbaf){
 			if (is_chardev()) {
-				if(ioctl(fd, NVME_IOCTL_RESCAN) < 0){
+				if(ioctl(dev->fd, NVME_IOCTL_RESCAN) < 0){
 					fprintf(stderr, "failed to rescan namespaces\n");
 					err = -errno;
-					goto close_fd;
+					goto close_dev;
 				}
 			} else {
 				block_size = 1 << ns.lbaf[cfg.lbaf].ds;
@@ -4846,26 +4919,26 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 				 * to the given one because blkdev will not
 				 * update by itself without re-opening fd.
 				 */
-				if (ioctl(fd, BLKBSZSET, &block_size) < 0) {
+				if (ioctl(dev->fd, BLKBSZSET, &block_size) < 0) {
 					fprintf(stderr, "failed to set block size to %d\n",
 							block_size);
 					err = -errno;
-					goto close_fd;
+					goto close_dev;
 				}
 
-				if(ioctl(fd, BLKRRPART) < 0) {
+				if(ioctl(dev->fd, BLKRRPART) < 0) {
 					fprintf(stderr, "failed to re-read partition table\n");
 					err = -errno;
-					goto close_fd;
+					goto close_dev;
 				}
 			}
 		}
 		if (cfg.reset && is_chardev())
-			nvme_ctrl_reset(fd);
+			nvme_ctrl_reset(dev->fd);
 	}
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -4892,10 +4965,11 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	const char *cdw12 = "feature cdw12, if used";
 	const char *save = "specifies that the controller shall save the attribute";
 	const char *uuid_index = "specify uuid index";
+	struct nvme_dev *dev;
 	int err;
 	__u32 result;
 	void *buf = NULL;
-	int fd, ffd = STDIN_FILENO;
+	int ffd = STDIN_FILENO;
 
 	struct config {
 		__u32	namespace_id;
@@ -4930,16 +5004,16 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			if (errno != ENOTTY) {
 				fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-				goto close_fd;
+				goto close_dev;
 			}
 
 			cfg.namespace_id = NVME_NSID_ALL;
@@ -4949,13 +5023,13 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	if (!cfg.feature_id) {
 		fprintf(stderr, "feature-id required param\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.uuid_index > 128) {
 		fprintf(stderr, "invalid uuid index param: %u\n", cfg.uuid_index);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (!cfg.data_len)
@@ -4966,7 +5040,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
 			fprintf(stderr, "can not allocate feature payload\n");
 			err = -ENOMEM;
-			goto close_fd;
+			goto close_dev;
 		}
 		memset(buf, 0, cfg.data_len);
 	}
@@ -5003,7 +5077,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 
 	struct nvme_set_features_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= cfg.feature_id,
 		.nsid		= cfg.namespace_id,
 		.cdw11		= cfg.value,
@@ -5043,8 +5117,8 @@ close_ffd:
 		close(ffd);
 free:
 	free(buf);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -5063,7 +5137,8 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *tl = "transfer length (cf. SPC-4)";
 	const char *namespace_id = "desired namespace";
 	const char *nssf = "NVMe Security Specific Field";
-	int err, fd, sec_fd = STDIN_FILENO;
+	int err, sec_fd = STDIN_FILENO;
+	struct nvme_dev *dev;
 	void *sec_buf;
 	unsigned int sec_size;
 
@@ -5095,14 +5170,14 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.tl == 0) {
 		fprintf(stderr, "--tl unspecified or zero\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 	if ((cfg.tl & 3) != 0)
 		fprintf(stderr, "WARNING: --tl not dword aligned; unaligned bytes may be truncated\n");
@@ -5116,7 +5191,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 			fprintf(stderr, "Failed to open %s: %s\n",
 					cfg.file, strerror(errno));
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 
 		err = fstat(sec_fd, &sb);
@@ -5146,7 +5221,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	struct nvme_security_send_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.nssf		= cfg.nssf,
 		.spsp0		= cfg.spsp & 0xff,
@@ -5170,8 +5245,8 @@ free:
 	free(sec_buf);
 close_sec_fd:
 	close(sec_fd);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -5190,11 +5265,12 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *ttype = "target directive type to be enabled/disabled";
 	const char *human_readable = "show directive in readable format";
 	const char *input = "write/send file (default stdin)";
-	int err, fd;
+	struct nvme_dev *dev;
 	__u32 result;
 	__u32 dw12 = 0;
 	void *buf = NULL;
 	int ffd = STDIN_FILENO;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -5236,8 +5312,8 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	switch (cfg.dtype) {
@@ -5247,14 +5323,14 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 			if (!cfg.ttype) {
 				fprintf(stderr, "target-dir required param\n");
 				err = -EINVAL;
-				goto close_fd;
+				goto close_dev;
 			}
 			dw12 = cfg.ttype << 8 | cfg.endir;
 			break;
 		default:
 			fprintf(stderr, "invalid directive operations for Identify Directives\n");
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 		break;
 	case NVME_DIRECTIVE_DTYPE_STREAMS:
@@ -5265,20 +5341,20 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		default:
 			fprintf(stderr, "invalid directive operations for Streams Directives\n");
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 		break;
 	default:
 		fprintf(stderr, "invalid directive type\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 
 	if (cfg.data_len) {
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
 			err = -ENOMEM;
-			goto close_fd;
+			goto close_dev;
 		}
 		memset(buf, 0, cfg.data_len);
 	}
@@ -5304,7 +5380,7 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	struct nvme_directive_send_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.dspec		= cfg.dspec,
 		.doper		= cfg.doper,
@@ -5336,20 +5412,21 @@ close_ffd:
 	close(ffd);
 free:
 	free(buf);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
 
 static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err, fd;
 	const char *desc = "The Write Uncorrectable command is used to set a "\
 			"range of logical blocks to invalid.";
 	const char *namespace_id = "desired namespace";
 	const char *start_block = "64-bit LBA of first block to access";
 	const char *block_count = "number of blocks (zeroes based) on device to access";
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -5370,21 +5447,21 @@ static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
 	struct nvme_io_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.start_block,
 		.nlb		= cfg.block_count,
@@ -5399,8 +5476,8 @@ static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin
 	else
 		printf("NVME Write Uncorrectable Success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -5440,11 +5517,12 @@ static int invalid_tags(__u64 storage_tag, __u64 ref_tag, __u8 sts, __u8 pif)
 
 static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err, fd;
 	__u16 control = 0;
 	__u8 lba_index, sts = 0, pif = 0;
 	struct nvme_id_ns ns;
+	struct nvme_dev *dev;
 	struct nvme_nvm_id_ns nvm_ns;
+	int err;
 
 	const char *desc = "The Write Zeroes command is used to set a "\
 			"range of logical blocks to zero.";
@@ -5508,13 +5586,13 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.prinfo > 0xf) {
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	control |= (cfg.prinfo << 10);
@@ -5527,23 +5605,23 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	if (cfg.storage_tag_check)
 		control |= NVME_IO_STC;
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
-	err = nvme_identify_ns(fd, cfg.namespace_id, &ns);
+	err = nvme_identify_ns(dev->fd, cfg.namespace_id, &ns);
 	if (err) {
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	} else if (err < 0) {
 		fprintf(stderr, "identify namespace: %s\n", nvme_strerror(errno));
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ns_csi(fd, cfg.namespace_id, 0, NVME_CSI_NVM, &nvm_ns);
+	err = nvme_identify_ns_csi(dev->fd, cfg.namespace_id, 0, NVME_CSI_NVM, &nvm_ns);
 	if (!err) {
 		nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &lba_index);
 		sts = nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_STS_MASK;
@@ -5552,12 +5630,12 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 
 	if (invalid_tags(cfg.storage_tag, cfg.ref_tag, sts, pif)) {
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_io_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.start_block,
 		.nlb		= cfg.block_count,
@@ -5579,8 +5657,8 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	else
 		printf("NVME Write Zeroes Success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -5600,12 +5678,13 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	const char *idr = "Attribute Integral Dataset for Read";
 	const char *cdw11 = "All the command DWORD 11 attributes. Use instead of specifying individual attributes";
 
-	int err, fd;
 	uint16_t nr, nc, nb, ns;
 	__u32 ctx_attrs[256] = {0,};
 	__u32 nlbs[256] = {0,};
 	__u64 slbas[256] = {0,};
 	struct nvme_dsm_range dsm[256];
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -5641,8 +5720,8 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	nc = argconfig_parse_comma_sep_array(cfg.ctx_attrs, (int *)ctx_attrs, ARRAY_SIZE(ctx_attrs));
@@ -5652,14 +5731,14 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	if (!nr || nr > 256) {
 		fprintf(stderr, "No range definition provided\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 	if (!cfg.cdw11)
@@ -5668,7 +5747,7 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	nvme_init_dsm_range(dsm, ctx_attrs, nlbs, slbas, nr);
 	struct nvme_dsm_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.attrs		= cfg.cdw11,
 		.nr_ranges	= nr,
@@ -5684,8 +5763,8 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	else
 		printf("NVMe DSM: success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -5715,10 +5794,11 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	const char *d_dspec = "directive specific (write part)";
 	const char *d_format = "source range entry format";
 
-	int err, fd;
 	uint16_t nr, nb, ns, nrts, natms, nats;
 	__u16 nlbs[128] = { 0 };
 	unsigned long long slbas[128] = {0,};
+	struct nvme_dev *dev;
+	int err;
 
 	union {
 		__u32 f0[128];
@@ -5794,11 +5874,9 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
-		err = fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
-	}
 
 	nb = argconfig_parse_comma_sep_array(cfg.nlbs, (int *)nlbs, ARRAY_SIZE(nlbs));
 	ns = argconfig_parse_comma_sep_array_long(cfg.slbas, slbas, ARRAY_SIZE(slbas));
@@ -5810,7 +5888,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	else {
 		fprintf(stderr, "invalid format\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	natms = argconfig_parse_comma_sep_array(cfg.elbatms, (int *)elbatms, ARRAY_SIZE(elbatms));
@@ -5820,14 +5898,14 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	if (!nr || nr > 128 || (cfg.format == 1 && nr > 101)) {
 		fprintf(stderr, "invalid range\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
@@ -5840,7 +5918,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 
 	struct nvme_copy_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.copy		= copy.f0,
 		.sdlba		= cfg.sdlba,
@@ -5866,8 +5944,8 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	else
 		printf("NVMe Copy: success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -5880,7 +5958,8 @@ static int flush(int argc, char **argv, struct command *cmd, struct plugin *plug
 		"flushed by the controller, from any namespace, depending on controller and "\
 		"associated namespace status.";
 	const char *namespace_id = "identifier of desired namespace";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -5895,27 +5974,27 @@ static int flush(int argc, char **argv, struct command *cmd, struct plugin *plug
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
-	err = nvme_flush(fd, cfg.namespace_id);
+	err = nvme_flush(dev->fd, cfg.namespace_id);
 	if (err < 0)
 		fprintf(stderr, "flush: %s\n", nvme_strerror(errno));
 	else if (err != 0)
 		nvme_show_status(err);
 	else
 		printf("NVMe Flush: success\n");
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -5934,7 +6013,8 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	const char *rtype = "reservation type";
 	const char *racqa = "reservation acquire action";
 	const char *iekey = "ignore existing res. key";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -5964,26 +6044,26 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 	if (cfg.racqa > 7) {
 		fprintf(stderr, "invalid racqa:%d\n", cfg.racqa);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_resv_acquire_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.rtype		= cfg.rtype,
 		.racqa		= cfg.racqa,
@@ -6001,8 +6081,8 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	else
 		printf("NVME Reservation Acquire success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -6018,7 +6098,8 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 	const char *nrkey = "new reservation key";
 	const char *rrega = "reservation registration action";
 	const char *cptpl = "change persistence through power loss setting";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -6047,32 +6128,32 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 	if (cfg.cptpl > 3) {
 		fprintf(stderr, "invalid cptpl:%d\n", cfg.cptpl);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.rrega > 7) {
 		fprintf(stderr, "invalid rrega:%d\n", cfg.rrega);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_resv_register_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.rrega		= cfg.rrega,
 		.cptpl		= cfg.cptpl,
@@ -6090,8 +6171,8 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 	else
 		printf("NVME Reservation  success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -6111,7 +6192,8 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 	const char *iekey = "ignore existing res. key";
 	const char *rtype = "reservation type";
 	const char *rrela = "reservation release action";
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -6138,26 +6220,26 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 	if (cfg.rrela > 7) {
 		fprintf(stderr, "invalid rrela:%d\n", cfg.rrela);
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_resv_release_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.rtype		= cfg.rtype,
 		.rrela		= cfg.rrela,
@@ -6174,8 +6256,8 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 	else
 		printf("NVME Reservation Release success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -6194,7 +6276,8 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 
 	struct nvme_resv_status *status;
 	enum nvme_print_flags flags;
-	int err, fd, size;
+	struct nvme_dev *dev;
+	int err, size;
 
 	struct config {
 		__u32	namespace_id;
@@ -6221,21 +6304,21 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.raw_binary)
 		flags = BINARY;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
@@ -6249,13 +6332,13 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 	if (posix_memalign((void **)&status, getpagesize(), size)) {
 		fprintf(stderr, "No memory for resv report:%d\n", size);
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 	memset(status, 0, size);
 
 	struct nvme_resv_report_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.eds		= cfg.eds,
 		.len		= size,
@@ -6271,8 +6354,8 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 	else
 		fprintf(stderr, "reservation report: %s\n", nvme_strerror(errno));
 	free(status);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -6291,7 +6374,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	struct timeval start_time, end_time;
 	void *buffer, *mbuffer = NULL;
 	int err = 0;
-	int dfd, mfd, fd;
+	int dfd, mfd;
 	int flags = opcode & 1 ? O_RDONLY : O_WRONLY | O_CREAT;
 	int mode = S_IRUSR | S_IWUSR |S_IRGRP | S_IWGRP| S_IROTH;
 	__u16 control = 0;
@@ -6302,6 +6385,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	struct nvme_id_ns ns;
 	struct nvme_nvm_id_ns nvm_ns;
 	__u8 lba_index, ms = 0, sts = 0, pif = 0;
+	struct nvme_dev *dev;
 
 	const char *namespace_id = "Identifier of desired namespace";
 	const char *start_block = "64-bit addr of first block to access";
@@ -6404,14 +6488,14 @@ static int submit_io(int opcode, char *command, const char *desc,
 	};
 
 	if (opcode != nvme_cmd_write) {
-		err = fd = parse_and_open(argc, argv, desc, opts);
-		if (fd < 0)
+		err = parse_and_open(&dev, argc, argv, desc, opts);
+		if (err < 0)
 			goto ret;
 	} else {
 		err = argconfig_parse(argc, argv, desc, opts);
 		if (err)
 			goto ret;
-		err = fd = open_exclusive(argc, argv, cfg.force);
+		err = open_exclusive(&dev, argc, argv, cfg.force);
 		if (err < 0) {
 			if (errno == EBUSY) {
 				fprintf(stderr, "Failed to open %s.\n",
@@ -6429,17 +6513,17 @@ static int submit_io(int opcode, char *command, const char *desc,
 	}
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
 	dfd = mfd = opcode & 1 ? STDIN_FILENO : STDOUT_FILENO;
 	if (cfg.prinfo > 0xf) {
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	dsmgmt = cfg.dsmgmt;
@@ -6455,7 +6539,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 			fprintf(stderr, "Invalid directive type, %x\n",
 				cfg.dtype);
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 		control |= cfg.dtype << 4;
 		dsmgmt |= ((__u32)cfg.dspec) << 16;
@@ -6466,7 +6550,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		if (dfd < 0) {
 			perror(cfg.data);
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
@@ -6485,7 +6569,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		goto close_mfd;
 	}
 
-	if (nvme_get_logical_block_size(fd, cfg.namespace_id,
+	if (nvme_get_logical_block_size(dev->fd, cfg.namespace_id,
 					&logical_block_size) < 0)
 			goto close_mfd;
 
@@ -6504,7 +6588,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	}
 
 	if (cfg.metadata_size) {
-		err = nvme_identify_ns(fd, cfg.namespace_id, &ns);
+		err = nvme_identify_ns(dev->fd, cfg.namespace_id, &ns);
 		if (err > 0) {
 			nvme_show_status(err);
 			goto free_buffer;
@@ -6516,7 +6600,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 		nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &lba_index);
 		ms = ns.lbaf[lba_index].ms;
 
-		err = nvme_identify_ns_csi(fd, 1, 0, NVME_CSI_NVM, &nvm_ns);
+		err = nvme_identify_ns_csi(dev->fd, 1, 0, NVME_CSI_NVM, &nvm_ns);
 		if (!err) {
 			sts = nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_STS_MASK;
 			pif = (nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_PIF_MASK) >> 7; 
@@ -6585,7 +6669,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 
 	struct nvme_io_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.start_block,
 		.nlb		= cfg.block_count,
@@ -6638,8 +6722,8 @@ close_mfd:
 		close(mfd);
 close_dfd:
 	close(dfd);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -6669,11 +6753,12 @@ static int write_cmd(int argc, char **argv, struct command *cmd, struct plugin *
 
 static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err, fd;
 	__u16 control = 0;
 	__u8 lba_index, sts = 0, pif = 0;
 	struct nvme_id_ns ns;
 	struct nvme_nvm_id_ns nvm_ns;
+	struct nvme_dev *dev;
+	int err;
 
 	const char *desc = "Verify specified logical blocks on the given device.";
 	const char *namespace_id = "desired namespace";
@@ -6732,13 +6817,13 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.prinfo > 0xf) {
 		err = EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	control |= (cfg.prinfo << 10);
@@ -6750,23 +6835,23 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		control |= NVME_IO_STC;
 
 	if (!cfg.namespace_id) {
-		err = nvme_get_nsid(fd, &cfg.namespace_id);
+		err = nvme_get_nsid(dev->fd, &cfg.namespace_id);
 		if (err < 0) {
 			fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
-	err = nvme_identify_ns(fd, cfg.namespace_id, &ns);
+	err = nvme_identify_ns(dev->fd, cfg.namespace_id, &ns);
 	if (err) {
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	} else if (err < 0) {
 		fprintf(stderr, "identify namespace: %s\n", nvme_strerror(errno));
-		goto close_fd;
+		goto close_dev;
 	}
 
-	err = nvme_identify_ns_csi(fd, cfg.namespace_id, 0, NVME_CSI_NVM, &nvm_ns);
+	err = nvme_identify_ns_csi(dev->fd, cfg.namespace_id, 0, NVME_CSI_NVM, &nvm_ns);
 	if (!err) {
 		nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &lba_index);
 		sts = nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_STS_MASK;
@@ -6775,12 +6860,12 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 
 	if (invalid_tags(cfg.storage_tag, cfg.ref_tag, sts, pif)) {
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_io_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.start_block,
 		.nlb		= cfg.block_count,
@@ -6802,8 +6887,8 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 	else
 		printf("NVME Verify Success\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -6823,8 +6908,9 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 	const char *raw = "dump output in binary format";
 	const char *namespace_id = "desired namespace";
 	const char *nssf = "NVMe Security Specific Field";
-	int err, fd;
+	struct nvme_dev *dev;
 	void *sec_buf = NULL;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -6857,8 +6943,8 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.size) {
@@ -6866,13 +6952,13 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 			fprintf(stderr, "No memory for security size:%d\n",
 								cfg.size);
 			err = -ENOMEM;
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
 	struct nvme_security_receive_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.nssf		= cfg.nssf,
 		.spsp0		= cfg.spsp & 0xff,
@@ -6899,8 +6985,8 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	free(sec_buf);
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -6923,8 +7009,9 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 
 	enum nvme_print_flags flags;
 	unsigned long buf_len;
-	int err, fd;
+	struct nvme_dev *dev;
 	void *buf;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -6957,30 +7044,30 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto err;
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (!cfg.atype) {
 		fprintf(stderr, "action type (--action) has to be given\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	buf_len = (cfg.mndw + 1) * 4;
 	buf = calloc(1, buf_len);
 	if (!buf) {
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_get_lba_status_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.slba,
 		.mndw		= cfg.mndw,
@@ -6998,8 +7085,8 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 	else
 		fprintf(stderr, "get lba status: %s\n", nvme_strerror(errno));
 	free(buf);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 err:
 	return err;
 }
@@ -7017,7 +7104,8 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 	const char *cap_upper = "Most significant 32 bits of the capacity in bytes of the "\
 		"Endurance Group or NVM Set to be created";
 
-	int err = -1, fd;
+	struct nvme_dev *dev;
+	int err = -1;
 	__u32 result;
 
 	struct config {
@@ -7042,19 +7130,19 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.operation > 0xf) {
 		fprintf(stderr, "invalid operation field: %u\n", cfg.operation);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_capacity_mgmt_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.op		= cfg.operation,
 		.element_id	= cfg.element_id,
 		.cdw11		= cfg.dw11,
@@ -7075,8 +7163,8 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 	else if (err < 0)
 		fprintf(stderr, "capacity management: %s\n", nvme_strerror(errno));
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -7095,10 +7183,11 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 	const char *human_readable = "show directive in readable format";
 
 	enum nvme_print_flags flags = NORMAL;
-	int err, fd;
+	struct nvme_dev *dev;
 	__u32 result;
 	__u32 dw12 = 0;
 	void *buf = NULL;
+	int err;
 
 	struct config {
 		__u32	namespace_id;
@@ -7134,8 +7223,8 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.human_readable)
@@ -7153,7 +7242,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 		default:
 			fprintf(stderr, "invalid directive operations for Identify Directives\n");
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 		break;
 	case NVME_DIRECTIVE_DTYPE_STREAMS:
@@ -7172,26 +7261,26 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 		default:
 			fprintf(stderr, "invalid directive operations for Streams Directives\n");
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 		break;
 	default:
 		fprintf(stderr, "invalid directive type\n");
 		err = -EINVAL;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.data_len) {
 		if (posix_memalign(&buf, getpagesize(), cfg.data_len)) {
 			err = -ENOMEM;
-			goto close_fd;
+			goto close_dev;
 		}
 		memset(buf, 0, cfg.data_len);
 	}
 
 	struct nvme_directive_recv_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.nsid		= cfg.namespace_id,
 		.dspec		= cfg.dspec,
 		.doper		= cfg.doper,
@@ -7213,8 +7302,8 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 		fprintf(stderr, "dir-receive: %s\n", nvme_strerror(errno));
 
 	free(buf);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -7247,7 +7336,8 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 		"List that is used by the command.If this field is cleared to 0h,"\
 		"then no UUID index is specified";
 
-	int fd, err = -1;
+	struct nvme_dev *dev;
+	int err = -1;
 
 	struct config {
 		__u8	ofi;
@@ -7274,35 +7364,35 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	/* check for input argument limit */
 	if (cfg.ifc > 3) {
 		fprintf(stderr, "invalid interface settings:%d\n", cfg.ifc);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.prhbt > 1) {
 		fprintf(stderr, "invalid prohibit settings:%d\n", cfg.prhbt);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.scp > 15) {
 		fprintf(stderr, "invalid scope settings:%d\n", cfg.scp);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 	if (cfg.uuid > 127) {
 		fprintf(stderr, "invalid UUID index settings:%d\n", cfg.uuid);
 		err = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	struct nvme_lockdown_args args = {
 		.args_size	= sizeof(args),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.scp		= cfg.scp,
 		.prhbt		= cfg.prhbt,
 		.ifc		= cfg.ifc,
@@ -7319,8 +7409,8 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 	else
 		printf("Lockdown Command is Successful\n");
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }
@@ -7356,7 +7446,8 @@ static int passthru(int argc, char **argv, bool admin,
 	int flags;
 	int mode = S_IRUSR | S_IWUSR |S_IRGRP | S_IWGRP| S_IROTH;
 	void *data = NULL, *mdata = NULL;
-	int err = 0, dfd, mfd, fd;
+	int err = 0, dfd, mfd;
+	struct nvme_dev *dev;
 	__u32 result;
 	bool huge = false;
 	const char *cmd_name = NULL;
@@ -7444,8 +7535,8 @@ static int passthru(int argc, char **argv, bool admin,
 		OPT_END()
 	};
 
-	err = fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
 		goto ret;
 
 	if (cfg.opcode & 0x01)
@@ -7469,7 +7560,7 @@ static int passthru(int argc, char **argv, bool admin,
 		if (dfd < 0) {
 			perror(cfg.input_file);
 			err = -EINVAL;
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
@@ -7546,13 +7637,13 @@ static int passthru(int argc, char **argv, bool admin,
 	gettimeofday(&start_time, NULL);
 
 	if (admin)
-		err = nvme_admin_passthru(fd, cfg.opcode, cfg.flags, cfg.rsvd,
+		err = nvme_admin_passthru(dev->fd, cfg.opcode, cfg.flags, cfg.rsvd,
 				cfg.namespace_id, cfg.cdw2, cfg.cdw3, cfg.cdw10,
 				cfg.cdw11, cfg.cdw12, cfg.cdw13, cfg.cdw14,
 				cfg.cdw15, cfg.data_len, data, cfg.metadata_len,
 				mdata, cfg.timeout, &result);
 	else
-		err = nvme_io_passthru(fd, cfg.opcode, cfg.flags, cfg.rsvd,
+		err = nvme_io_passthru(dev->fd, cfg.opcode, cfg.flags, cfg.rsvd,
 				cfg.namespace_id, cfg.cdw2, cfg.cdw3, cfg.cdw10,
 				cfg.cdw11, cfg.cdw12, cfg.cdw13, cfg.cdw14,
 				cfg.cdw15, cfg.data_len, data, cfg.metadata_len,
@@ -7597,8 +7688,8 @@ close_dfd:
 close_mfd:
 	if (strlen(cfg.metadata))
 		close(mfd);
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 ret:
 	return err;
 }

--- a/nvme.h
+++ b/nvme.h
@@ -37,14 +37,21 @@ enum nvme_print_flags {
 
 #define SYS_NVME "/sys/class/nvme"
 
-void register_extension(struct plugin *plugin);
-int parse_and_open(int argc, char **argv, const char *desc,
-	const struct argconfig_commandline_options *clo);
-
 struct nvme_dev {
+	int fd;
 	struct stat stat;
 	const char *name;
 };
+
+void register_extension(struct plugin *plugin);
+
+/*
+ * parse_and_open - parses arguments and opens the NVMe device, populating @dev
+ */
+int parse_and_open(struct nvme_dev **dev, int argc, char **argv, const char *desc,
+	const struct argconfig_commandline_options *clo);
+
+void dev_close(struct nvme_dev *dev);
 
 extern struct nvme_dev *nvme_dev;
 extern const char *output_format;

--- a/nvme.h
+++ b/nvme.h
@@ -53,7 +53,6 @@ int parse_and_open(struct nvme_dev **dev, int argc, char **argv, const char *des
 
 void dev_close(struct nvme_dev *dev);
 
-extern struct nvme_dev *nvme_dev;
 extern const char *output_format;
 
 enum nvme_print_flags validate_output_format(const char *format);

--- a/nvme.h
+++ b/nvme.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <endian.h>
 #include <sys/time.h>
+#include <sys/stat.h>
 
 #include "plugin.h"
 #include "util/json.h"
@@ -40,7 +41,12 @@ void register_extension(struct plugin *plugin);
 int parse_and_open(int argc, char **argv, const char *desc,
 	const struct argconfig_commandline_options *clo);
 
-extern const char *devicename;
+struct nvme_dev {
+	struct stat stat;
+	const char *name;
+};
+
+extern struct nvme_dev *nvme_dev;
 extern const char *output_format;
 
 enum nvme_print_flags validate_output_format(const char *format);

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -43,7 +43,8 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 		return fd;
 
 	nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
-	nvme_show_smart_log(&smart_log, cfg.namespace_id, devicename, NORMAL);
+	nvme_show_smart_log(&smart_log, cfg.namespace_id,
+                            nvme_dev->name, NORMAL);
 
 	printf("DW0[0-1]  Defect Cnt                    : %u\n", pvsc_smart->defect_cnt);
 	printf("DW0[2-3]  Slc Spb Cnt                   : %u\n", pvsc_smart->slc_spb_cnt);

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -45,7 +45,7 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 
 	nvme_get_log_smart(dev->fd, cfg.namespace_id, false, &smart_log);
 	nvme_show_smart_log(&smart_log, cfg.namespace_id,
-                            nvme_dev->name, NORMAL);
+                            dev->name, NORMAL);
 
 	printf("DW0[0-1]  Defect Cnt                    : %u\n", pvsc_smart->defect_cnt);
 	printf("DW0[2-3]  Slc Spb Cnt                   : %u\n", pvsc_smart->slc_spb_cnt);

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -20,10 +20,11 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 					 struct plugin *plugin)
 {
 	struct nvme_smart_log smart_log = { 0 };
-	int fd, i, iindex;
 	struct vsc_smart_log *pvsc_smart = (struct vsc_smart_log *)smart_log.rsvd232;
 	const char *desc = "Retrieve additional SMART log for the given device ";
 	const char *namespace = "(optional) desired namespace";
+	struct nvme_dev *dev;
+	int err, i, iindex;
 
 	struct config {
 		__u32 namespace_id;
@@ -38,11 +39,11 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
+	nvme_get_log_smart(dev->fd, cfg.namespace_id, false, &smart_log);
 	nvme_show_smart_log(&smart_log, cfg.namespace_id,
                             nvme_dev->name, NORMAL);
 
@@ -164,9 +165,10 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 	unsigned int isize, icheck_stopvalue, iend;
 	unsigned char bSortLog = false, bget_nextlog = true;
 	struct evlg_flush_hdr *pevlog = (struct evlg_flush_hdr *)data;
-	int fd, ret = -1;
 	const char *desc = "Recrieve event log for the given device ";
 	const char *clean_opt = "(optional) 1 for clean event log";
+	struct nvme_dev *dev;
+	int ret = -1;
 
 	struct config {
 		__u32 clean_flg;
@@ -181,9 +183,9 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	ret = parse_and_open(&dev, argc, argv, desc, opts);
+	if (ret < 0)
+		return ret;
 
 
 	if (getcwd(currentdir, 128) == NULL)
@@ -212,8 +214,10 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 		icount++;
 
 		memset(data, 0, 4096);
-		ret = nvme_vucmd(fd, NVME_VSC_GET_EVENT_LOG, 0, 0, (SRB_SIGNATURE >> 32),
-			(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096);
+		ret = nvme_vucmd(dev->fd, NVME_VSC_GET_EVENT_LOG, 0, 0,
+				 (SRB_SIGNATURE >> 32),
+				 (SRB_SIGNATURE & 0xFFFFFFFF),
+				 (char *)data, 4096);
 		if (ret == -1)
 			return ret;
 
@@ -278,9 +282,11 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 
 	if (cfg.clean_flg == 1) {
 		printf("Clean eventlog\n");
-		nvme_vucmd(fd, NVME_VSC_CLEAN_EVENT_LOG, 0, 0, (SRB_SIGNATURE >> 32),
+		nvme_vucmd(dev->fd, NVME_VSC_CLEAN_EVENT_LOG, 0, 0, (SRB_SIGNATURE >> 32),
 			(SRB_SIGNATURE & 0xFFFFFFFF), (char *)NULL, 0);
 	}
+
+	dev_close(dev);
 
 	return ret;
 }
@@ -297,16 +303,17 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 	unsigned char busevsc = false;
 	unsigned int ipackcount, ipackindex;
 	char fwvera[32];
-	int fd, ret = -1;
 	const char *desc = "Recrieve cdump data for the given device ";
+	struct nvme_dev *dev;
+	int ret = -1;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	ret = parse_and_open(&dev, argc, argv, desc, opts);
+	if (ret < 0)
+		return ret;
 
 	if (getcwd(currentdir, 128) == NULL)
 		return -1;
@@ -316,8 +323,9 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 
 	ipackindex = 0;
 	memset(data, 0, 4096);
-	if (nvme_vucmd(fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00, (SRB_SIGNATURE >> 32),
-		(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096) == 0) {
+	if (nvme_vucmd(dev->fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00,
+		       (SRB_SIGNATURE >> 32), (SRB_SIGNATURE & 0xFFFFFFFF),
+		       (char *)data, 4096) == 0) {
 		memcpy(&cdumpinfo, &data[3072], sizeof(cdumpinfo));
 		if (cdumpinfo.sig == 0x5a5b5c5d) {
 			busevsc = true;
@@ -338,7 +346,8 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 
 	if (busevsc == false) {
 		memset(data, 0, 4096);
-		ret = nvme_get_nsid_log(fd, true, 0x07, NVME_NSID_ALL, 4096, data);
+		ret = nvme_get_nsid_log(dev->fd, true, 0x07, NVME_NSID_ALL,
+					4096, data);
 		if (ret != 0)
 			return ret;
 
@@ -361,10 +370,14 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 		for (icur = 0; icur < itotal; icur += 4096) {
 			memset(data, 0, 4096);
 			if (busevsc)
-				ret = nvme_vucmd(fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00, (SRB_SIGNATURE >> 32),
-					(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096);
+				ret = nvme_vucmd(dev->fd, NVME_VSC_GET,
+						 VSC_FN_GET_CDUMP, 0x00,
+						 (SRB_SIGNATURE >> 32),
+						 (SRB_SIGNATURE & 0xFFFFFFFF),
+						 (char *)data, 4096);
 			else
-				ret = nvme_get_nsid_log(fd, true, 0x07, NVME_NSID_ALL, 4096, data);
+				ret = nvme_get_nsid_log(dev->fd, true, 0x07,
+							NVME_NSID_ALL, 4096, data);
 			if (ret != 0)
 				return ret;
 
@@ -380,10 +393,15 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 		if (ipackindex != ipackcount) {
 			memset(data, 0, 4096);
 			if (busevsc)
-				ret = nvme_vucmd(fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00, (SRB_SIGNATURE >> 32),
-					(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096);
+				ret = nvme_vucmd(dev->fd, NVME_VSC_GET,
+						 VSC_FN_GET_CDUMP, 0x00,
+						 (SRB_SIGNATURE >> 32),
+						 (SRB_SIGNATURE & 0xFFFFFFFF),
+						 (char *)data, 4096);
 			else
-				ret = nvme_get_nsid_log(fd, true, 0x07, NVME_NSID_ALL, 4096, data);
+				ret = nvme_get_nsid_log(dev->fd, true, 0x07,
+							NVME_NSID_ALL, 4096,
+							data);
 			if (ret != 0)
 				return ret;
 
@@ -399,5 +417,6 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 	}
 
 	printf("\n");
+	dev_close(dev);
 	return ret;
 }

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -344,7 +344,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	const char *json= "Dump output in json format";
 
 	struct nvme_additional_smart_log smart_log;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32 namespace_id;
@@ -363,11 +364,11 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_log_simple(fd, 0xca, sizeof(smart_log), &smart_log);
+	err = nvme_get_log_simple(dev->fd, 0xca, sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (cfg.json)
 			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id,
@@ -380,7 +381,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	}
 	else if (err > 0)
 		nvme_show_status(err);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -388,9 +389,9 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 {
 	const char *desc = "Get Intel Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
-
+	struct nvme_dev *dev;
 	char log[512];
-	int err, fd;
+	int err;
 
 	struct config {
 		bool  raw_binary;
@@ -404,11 +405,11 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_log_simple(fd, 0xdd, sizeof(log), log);
+	err = nvme_get_log_simple(dev->fd, 0xdd, sizeof(log), log);
 	if (!err) {
 		if (!cfg.raw_binary)
 			printf("Intel Marketing Name Log:\n%s\n", log);
@@ -416,7 +417,7 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 			d_raw((unsigned char *)&log, sizeof(log));
 	} else if (err > 0)
 		nvme_show_status(err);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -449,7 +450,8 @@ static void show_temp_stats(struct intel_temp_stats *stats)
 static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	struct intel_temp_stats stats;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	const char *desc = "Get Temperature Statistics log and show it.";
 	const char *raw = "dump output in binary format";
@@ -465,11 +467,11 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_log_simple(fd, 0xc5, sizeof(stats), &stats);
+	err = nvme_get_log_simple(dev->fd, 0xc5, sizeof(stats), &stats);
 	if (!err) {
 		if (!cfg.raw_binary)
 			show_temp_stats(&stats);
@@ -477,7 +479,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 			d_raw((unsigned char *)&stats, sizeof(stats));
 	} else if (err > 0)
 		nvme_show_status(err);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -1026,9 +1028,9 @@ static void show_lat_stats(int write)
 
 static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-
-	int err, fd;
 	__u8 data[NAND_LAT_STATS_LEN];
+	struct nvme_dev *dev;
+	int err;
 
 	const char *desc = "Get Intel Latency Statistics log and show it.";
 	const char *raw = "Dump output in binary format";
@@ -1051,14 +1053,14 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
 	/* For optate, latency stats are deleted every time their LID is pulled.
 	 * Therefore, we query the longest lat_stats log page first.
 	 */
-	err = nvme_get_log_simple(fd, cfg.write ? 0xc2 : 0xc1,
+	err = nvme_get_log_simple(dev->fd, cfg.write ? 0xc2 : 0xc1,
 			   sizeof(data), &data);
 
 	media_version[0] = (data[1] << 8) | data[0];
@@ -1073,7 +1075,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 
 		struct nvme_get_features_args args = {
 			.args_size	= sizeof(args),
-			.fd		= fd,
+			.fd		= dev->fd,
 			.fid		= 0xf7,
 			.nsid		= 0,
 			.sel		= 0,
@@ -1125,7 +1127,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	}
 
 close_fd:
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -1340,13 +1342,14 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 {
 	__u8 buf[0x2000];
 	char f[0x100];
-	int err, fd, output, i, j, count = 0, core_num = 1;
+	int err, output, i, j, count = 0, core_num = 1;
 	struct nvme_passthru_cmd cmd;
 	struct intel_cd_log cdlog;
 	struct intel_vu_log *intel = malloc(sizeof(struct intel_vu_log));
 	struct intel_vu_nlog *intel_nlog = (struct intel_vu_nlog *)buf;
 	struct intel_assert_dump *ad = (struct intel_assert_dump *) intel->reserved;
 	struct intel_event_header *ehdr = (struct intel_event_header *)intel->reserved;
+	struct nvme_dev *dev;
 
 	const char *desc = "Get Intel Firmware Log and save it.";
 	const char *log = "Log type: 0, 1, or 2 for nlog, event log, and assert log, respectively.";
@@ -1382,10 +1385,10 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0) {
 		free(intel);
-		return fd;
+		return err;
 	}
 
 	if (cfg.log > 2 || cfg.core > 4 || cfg.lnum > 255) {
@@ -1394,7 +1397,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 	}
 
 	if (!cfg.file) {
-		err = setup_file(f, cfg.file, fd, cfg.log);
+		err = setup_file(f, cfg.file, dev->fd, cfg.log);
 		if (err)
 			goto out_free;
 		cfg.file = f;
@@ -1412,7 +1415,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 		goto out_free;
 	}
 
-	err = read_header(&cmd, buf, fd, cdlog.u.entireDword, cfg.namespace_id);
+	err = read_header(&cmd, buf, dev->fd, cdlog.u.entireDword, cfg.namespace_id);
 	if (err)
 		goto out;
 	memcpy(intel, buf, sizeof(*intel));
@@ -1421,7 +1424,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 	if ((intel->ver.major < 1 && intel->ver.minor < 1) ||
 	    (intel->ver.major <= 1 && intel->ver.minor <= 1 && cfg.log == 0)) {
 		cmd.addr = (unsigned long)(void *)buf;
-		err = get_internal_log_old(buf, output, fd, &cmd);
+		err = get_internal_log_old(buf, output, dev->fd, &cmd);
 		goto out;
 	}
 
@@ -1465,7 +1468,8 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				cmd.cdw10 = 0x400;
 				cmd.data_len = min(0x400, ad[i].assertsize) * 4;
 				err = read_entire_cmd(&cmd, ad[i].assertsize,
-						      0x400, output, fd, buf);
+						      0x400, output, dev->fd,
+						      buf);
 				if (err)
 					goto out;
 
@@ -1474,8 +1478,9 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				if (count > 1)
 					cdlog.u.fields.selectNlog = i;
 
-				err = read_header(&cmd, buf, fd, cdlog.u.entireDword,
-						cfg.namespace_id);
+				err = read_header(&cmd, buf, dev->fd,
+						  cdlog.u.entireDword,
+						  cfg.namespace_id);
 				if (err)
 					goto out;
 				err = write_header(buf, output, sizeof(*intel_nlog));
@@ -1487,7 +1492,8 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				cmd.cdw10 = 0x400;
 				cmd.data_len = min(0x1000, intel_nlog->nlogbytesize);
 				err = read_entire_cmd(&cmd, intel_nlog->nlogbytesize / 4,
-						      0x400, output, fd, buf);
+						      0x400, output, dev->fd,
+						      buf);
 				if (err)
 					goto out;
 			} else if (cfg.log == 1) {
@@ -1495,7 +1501,8 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				cmd.cdw10 = 0x400;
 				cmd.data_len = 0x400;
 				err = read_entire_cmd(&cmd, ehdr->edumps[j].coresize,
-						      0x400, output, fd, buf);
+						      0x400, output, dev->fd,
+						      buf);
 				if (err)
 					goto out;
 			}
@@ -1513,14 +1520,13 @@ out:
 	close(output);
 out_free:
 	free(intel);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
 static int enable_lat_stats_tracking(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	int err, fd;
 	const char *desc = (
 			"Enable/Disable Intel Latency Statistics Tracking.\n"
 			"No argument prints current status.");
@@ -1533,8 +1539,10 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	const __u32 cdw12 = 0x0;
 	const __u32 data_len = 32;
 	const __u32 save = 0;
-	__u32 result;
+	struct nvme_dev *dev;
 	void *buf = NULL;
+	__u32 result;
+	int err;
 
 	struct config {
 		bool enable, disable;
@@ -1551,7 +1559,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		{NULL}
 	};
 
-	fd = parse_and_open(argc, argv, desc, command_line_options);
+	err = parse_and_open(&dev, argc, argv, desc, command_line_options);
 
 	enum Option {
 		None = -1,
@@ -1566,12 +1574,12 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	else if (cfg.enable || cfg.disable)
 		option = cfg.enable;
 
-	if (fd < 0)
-		return fd;
+	if (err < 0)
+		return err;
 
 	struct nvme_get_features_args args_get = {
 		.args_size	= sizeof(args_get),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1585,7 +1593,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 
 	struct nvme_set_features_args args_set = {
 		.args_size	= sizeof(args_set),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,
@@ -1608,7 +1616,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 				fid, result);
 		} else {
 			printf("Could not read feature id 0xE2.\n");
-			close(fd);
+			dev_close(dev);
 			return err;
 		}
 		break;
@@ -1629,14 +1637,13 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		printf("%d not supported.\n", option);
 		return EINVAL;
 	}
-	close(fd);
-	return fd;
+	dev_close(dev);
+	return err;
 }
 
 static int set_lat_stats_thresholds(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	int err, fd, num;
 	const char *desc = "Write Intel Bucket Thresholds for Latency Statistics Tracking";
 	const char *bucket_thresholds = "Bucket Threshold List, comma separated list: 0, 10, 20 ...";
 	const char *write = "Set write bucket Thresholds for latency tracking (read default)";
@@ -1645,7 +1652,9 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 	const __u8 fid = 0xf7;
 	const __u32 cdw12 = 0x0;
 	const __u32 save = 0;
+	struct nvme_dev *dev;
 	__u32 result;
+	int err, num;
 
 	struct config {
 		bool write;
@@ -1664,21 +1673,21 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
+	err = parse_and_open(&dev, argc, argv, desc, opts);
 
-	if (fd < 0)
-		return fd;
+	if (err < 0)
+		return err;
 
 	/* Query maj and minor version first to figure out the amount of
 	 * valid buckets a user is allowed to modify. Read or write doesn't
 	 * matter
 	 */
-	err = nvme_get_log_simple(fd, 0xc2,
+	err = nvme_get_log_simple(dev->fd, 0xc2,
 			   sizeof(media_version), media_version);
 	if (err) {
 		fprintf(stderr, "Querying media version failed. ");
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (media_version[0] == 1000) {
@@ -1688,13 +1697,13 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 						      sizeof(thresholds));
 		if (num == -1) {
 			fprintf(stderr, "ERROR: Bucket list is malformed\n");
-			goto close_fd;
+			goto close_dev;
 
 		}
 
 		struct nvme_set_features_args args = {
 			.args_size	= sizeof(args),
-			.fd		= fd,
+			.fd		= dev->fd,
 			.fid		= fid,
 			.nsid		= nsid,
 			.cdw11		= cfg.write ? 0x1 : 0x0,
@@ -1719,8 +1728,8 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 		fprintf(stderr, "Unsupported command\n");
 	}
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 	return err;
 }
 

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -372,10 +372,10 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (!err) {
 		if (cfg.json)
 			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id,
-                                                 nvme_dev->name);
+                                                 dev->name);
 		else if (!cfg.raw_binary)
 			show_intel_smart_log(&smart_log, cfg.namespace_id,
-                                             nvme_dev->name);
+                                             dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -370,9 +370,11 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	err = nvme_get_log_simple(fd, 0xca, sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (cfg.json)
-			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id, devicename);
+			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id,
+                                                 nvme_dev->name);
 		else if (!cfg.raw_binary)
-			show_intel_smart_log(&smart_log, cfg.namespace_id, devicename);
+			show_intel_smart_log(&smart_log, cfg.namespace_id,
+                                             nvme_dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -481,7 +481,9 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 		sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
-			err = show_memblaze_smart_log(fd, cfg.namespace_id, devicename, &smart_log);
+			err = show_memblaze_smart_log(fd, cfg.namespace_id,
+                                                      nvme_dev->name,
+                                                      &smart_log);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -453,15 +453,16 @@ int parse_params(char *str, int number, ...)
 static int mb_get_additional_smart_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	struct nvme_memblaze_smart_log smart_log;
-	int err, fd;
 	char *desc = "Get Memblaze vendor specific additional smart log (optionally, "\
 		      "for the specified namespace), and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
+	struct nvme_dev *dev;
 	struct config {
 		__u32 namespace_id;
 		bool  raw_binary;
 	};
+	int err;
 
 	struct config cfg = {
 		.namespace_id = NVME_NSID_ALL,
@@ -473,15 +474,15 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_nsid_log(fd, false, 0xca, cfg.namespace_id,
+	err = nvme_get_nsid_log(dev->fd, false, 0xca, cfg.namespace_id,
 		sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
-			err = show_memblaze_smart_log(fd, cfg.namespace_id,
+			err = show_memblaze_smart_log(dev->fd, cfg.namespace_id,
                                                       nvme_dev->name,
                                                       &smart_log);
 		else
@@ -490,7 +491,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 	if (err > 0)
 		nvme_show_status(err);
 
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -507,20 +508,22 @@ static char *mb_feature_to_string(int feature)
 static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
     const char *desc = "Get Memblaze power management ststus\n	(value 0 - 25w, 1 - 20w, 2 - 15w)";
-    int err, fd;
     __u32 result;
     __u32 feature_id = MB_FEAT_POWER_MGMT;
+    struct nvme_dev *dev;
+    int err;
 
     OPT_ARGS(opts) = {
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     struct nvme_get_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= fd,
+	    .fd			= dev->fd,
 	    .fid		= feature_id,
 	    .nsid		= 0,
 	    .sel		= 0,
@@ -541,7 +544,7 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
             nvme_select_to_string(0), result);
     } else if (err > 0)
 	    nvme_show_status(err);
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -550,8 +553,9 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     const char *desc = "Set Memblaze power management status\n	(value 0 - 25w, 1 - 20w, 2 - 15w)";
     const char *value = "new value of feature (required)";
     const char *save = "specifies that the controller shall save the attribute";
-    int err, fd;
+    struct nvme_dev *dev;
     __u32 result;
+    int err;
 
     struct config {
         __u32 feature_id;
@@ -571,12 +575,13 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= fd,
+	    .fd			= dev->fd,
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -599,7 +604,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     } else if (err > 0)
 	nvme_show_status(err);
 
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -613,9 +618,10 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
                        "	p1 value: 0 is disable, 1 is enable\n"\
                        "	p2 value: 1 .. 5000 ms";
     const char *param = "input parameters";
-    int err, fd;
-    __u32 result;
     int param1 = 0, param2 = 0;
+    struct nvme_dev *dev;
+    __u32 result;
+    int err;
 
     struct config {
         __u32 feature_id;
@@ -634,24 +640,25 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     if (parse_params(cfg.param, 2, &param1, &param2)) {
         printf("setfeature: invalid formats %s\n", cfg.param);
-        close(fd);
+        dev_close(dev);
         return EINVAL;
     }
     if ((param1 == 1) && (param2 < P2MIN || param2 > P2MAX)) {
         printf("setfeature: invalid high io latency threshold %d\n", param2);
-        close(fd);
+        dev_close(dev);
         return EINVAL;
     }
     cfg.value = (param1 << MB_FEAT_HIGH_LATENCY_VALUE_SHIFT) | param2;
 
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= fd,
+	    .fd			= dev->fd,
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -674,7 +681,7 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
     } else if (err > 0)
 	nvme_show_status(err);
 
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -776,25 +783,29 @@ static int glp_high_latency(FILE *fdi, char *buf, int buflen, int print)
 static int mb_high_latency_log_print(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
     const char *desc = "Get Memblaze high latency log";
-    int err, fd;
     char buf[LOG_PAGE_SIZE];
+    struct nvme_dev *dev;
     FILE *fdi = NULL;
+    int err;
 
     OPT_ARGS(opts) = {
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     fdi = fopen(FID_C3_LOG_FILENAME, "w+");
 
     glp_high_latency_show_bar(fdi, DO_PRINT_FLAG);
-    err = nvme_get_log_simple(fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG, sizeof(buf), &buf);
+    err = nvme_get_log_simple(dev->fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG,
+			      sizeof(buf), &buf);
 
     while (1) {
         if (!glp_high_latency(fdi, buf, LOG_PAGE_SIZE, DO_PRINT_FLAG)) break;
-        err = nvme_get_log_simple(fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG, sizeof(buf), &buf);
+        err = nvme_get_log_simple(dev->fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG,
+				  sizeof(buf), &buf);
         if ( err) {
 	    nvme_show_status(err);
             break;
@@ -802,7 +813,7 @@ static int mb_high_latency_log_print(int argc, char **argv, struct command *cmd,
     }
 
     if (NULL != fdi) fclose(fdi);
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -831,7 +842,8 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 	const char *select = "FW Select (e.g., --select=OOB, EEP, ALL)";
 	int xfer = 4096;
 	void *fw_buf;
-	int fd, selectNo,fw_fd,fw_size,err,offset = 0;
+	int selectNo,fw_fd,fw_size,err,offset = 0;
+	struct nvme_dev *dev;
 	struct stat sb;
 	int i;
 
@@ -851,9 +863,9 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
 	if (strlen(cfg.select) != 3) {
 		fprintf(stderr, "Invalid select flag\n");
@@ -914,7 +926,7 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 
 		struct nvme_fw_download_args args = {
 			.args_size	= sizeof(args),
-			.fd		= fd,
+			.fd		= dev->fd,
 			.offset		= offset,
 			.data_len	= xfer,
 			.data		= fw_buf,
@@ -934,7 +946,7 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 		offset += xfer;
 	}
 
-	err = memblaze_fw_commit(fd,selectNo);
+	err = memblaze_fw_commit(dev->fd, selectNo);
 
 	if(err == 0x10B || err == 0x20B) {
 		err = 0;
@@ -946,7 +958,7 @@ out_free:
 out_close:
 	close(fw_fd);
 out:
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -1053,10 +1065,10 @@ int io_latency_histogram(char *file, char *buf, int print, int logid)
 static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
     char stats[LOG_PAGE_SIZE];
-    int err = 0;
-    int fd;
     char f1[] = FID_C1_LOG_FILENAME;
     char f2[] = FID_C2_LOG_FILENAME;
+    struct nvme_dev *dev;
+    int err;
 
     const char *desc = "Get Latency Statistics log and show it.";
     const char *write = "Get write statistics (read default)";
@@ -1073,17 +1085,19 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, st
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
-    err = nvme_get_log_simple(fd, cfg.write ? 0xc2 : 0xc1, sizeof(stats), &stats);
+    err = nvme_get_log_simple(dev->fd, cfg.write ? 0xc2 : 0xc1,
+			      sizeof(stats), &stats);
     if (!err)
         io_latency_histogram(cfg.write ? f2 : f1, stats, DO_PRINT_FLAG,
          cfg.write ? GLP_ID_VU_GET_WRITE_LATENCY_HISTOGRAM : GLP_ID_VU_GET_READ_LATENCY_HISTOGRAM);
     else
 	nvme_show_status(err);
 
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -1091,8 +1105,9 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, st
 #define FID        0x68
 static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-    int err, fd;
     char *desc = "Clear Memblaze devices error log.";
+    struct nvme_dev *dev;
+    int err;
 
     //const char *value = "new value of feature (required)";
     //const char *save = "specifies that the controller shall save the attribute";
@@ -1114,13 +1129,13 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0)
-        return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+        return err;
 
     struct nvme_set_features_args args = {
         .args_size      = sizeof(args),
-        .fd             = fd,
+        .fd             = dev->fd,
         .fid            = cfg.feature_id,
         .nsid           = 0,
         .cdw11          = cfg.value,
@@ -1156,14 +1171,13 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
 		printf("NVMe Status:%s(%x)\n", nvme_status_to_string(err), err);
 	};
 */
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
 static int mb_set_lat_stats(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	int err, fd;
 	const char *desc = (
 			"Enable/Disable Latency Statistics Tracking.\n"
 			"No argument prints current status.");
@@ -1176,8 +1190,10 @@ static int mb_set_lat_stats(int argc, char **argv,
 	const __u32 cdw12 = 0x0;
 	const __u32 data_len = 32;
 	const __u32 save = 0;
-	__u32 result;
+	struct nvme_dev *dev;
 	void *buf = NULL;
+	__u32 result;
+	int err;
 
 	struct config {
 		bool enable, disable;
@@ -1194,7 +1210,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 		{NULL}
 	};
 
-	fd = parse_and_open(argc, argv, desc, command_line_options);
+	err = parse_and_open(&dev, argc, argv, desc, command_line_options);
 
 	enum Option {
 		None = -1,
@@ -1210,7 +1226,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 
 	struct nvme_get_features_args args_get = {
 		.args_size	= sizeof(args_get),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1224,7 +1240,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 
 	struct nvme_set_features_args args_set = {
 		.args_size	= sizeof(args_set),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,
@@ -1238,8 +1254,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 		.result		= &result,
 	};
 
-	if (fd < 0)
-		return fd;
+	if (err < 0)
+		return err;
 	switch (option) {
 	case None:
 		err = nvme_get_features(&args_get);
@@ -1249,7 +1265,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 				fid, result);
 		} else {
 			printf("Could not read feature id 0xE2.\n");
-			close(fd);
+			dev_close(dev);
 			return err;
 		}
 		break;
@@ -1270,7 +1286,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 		printf("%d not supported.\n", option);
 		err = EINVAL;
 	}
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -483,8 +483,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 	if (!err) {
 		if (!cfg.raw_binary)
 			err = show_memblaze_smart_log(dev->fd, cfg.namespace_id,
-                                                      nvme_dev->name,
-                                                      &smart_log);
+						      dev->name, &smart_log);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -429,10 +429,11 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
         return ret;
 }
 
-static int ocp_print_C3_log_normal(struct ssd_latency_monitor_log *log_data)
+static int ocp_print_C3_log_normal(struct nvme_dev *dev,
+				   struct ssd_latency_monitor_log *log_data)
 {
         printf("-Latency Monitor/C3 Log Page Data- \n");
-        printf("  Controller   :  %s\n", nvme_dev->name);
+        printf("  Controller   :  %s\n", dev->name);
         int i, j;
         int pos = 0;
         char       ts_buf[128];
@@ -662,7 +663,7 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
         json_free_object(root);
 }
 
-static int get_c3_log_page(int fd, char *format)
+static int get_c3_log_page(struct nvme_dev *dev, char *format)
 {
         int ret = 0;
         int fmt = -1;
@@ -682,7 +683,7 @@ static int get_c3_log_page(int fd, char *format)
         }
         memset(data, 0, sizeof (__u8) * C3_LATENCY_MON_LOG_BUF_LEN);
 
-        ret = nvme_get_log_simple(fd, C3_LATENCY_MON_OPCODE,
+        ret = nvme_get_log_simple(dev->fd, C3_LATENCY_MON_OPCODE,
                         C3_LATENCY_MON_LOG_BUF_LEN, data);
 
         if (strcmp(format, "json"))
@@ -725,7 +726,7 @@ static int get_c3_log_page(int fd, char *format)
 
                 switch (fmt) {
                 case NORMAL:
-                        ocp_print_C3_log_normal(log_data);
+                        ocp_print_C3_log_normal(dev, log_data);
                         break;
                 case JSON:
                         ocp_print_C3_log_json(log_data);
@@ -766,7 +767,7 @@ static int ocp_latency_monitor_log(int argc, char **argv, struct command *comman
         if (ret < 0)
                 return ret;
 
-        ret = get_c3_log_page(dev->fd, cfg.output_format);
+        ret = get_c3_log_page(dev, cfg.output_format);
         if (ret)
                 fprintf(stderr,
                         "ERROR : OCP : Failure reading the C3 Log Page, ret = %d\n",

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -401,7 +401,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
                 struct plugin *plugin)
 {
         const char *desc = "Retrieve latency monitor log data.";
-        int fd;
+	struct nvme_dev *dev;
         int ret = 0;
 
         struct config {
@@ -417,15 +417,15 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
                 OPT_END()
         };
 
-        fd = parse_and_open(argc, argv, desc, opts);
-        if (fd < 0)
-                return fd;
+        ret = parse_and_open(&dev, argc, argv, desc, opts);
+        if (ret < 0)
+                return ret;
 
-        ret = get_c0_log_page(fd, cfg.output_format);
+        ret = get_c0_log_page(dev->fd, cfg.output_format);
         if (ret)
                 fprintf(stderr, "ERROR : OCP : Failure reading the C0 Log Page, ret = %d\n",
                         ret);
-        close(fd);
+        dev_close(dev);
         return ret;
 }
 
@@ -745,7 +745,7 @@ static int ocp_latency_monitor_log(int argc, char **argv, struct command *comman
                 struct plugin *plugin)
 {
         const char *desc = "Retrieve latency monitor log data.";
-        int fd;
+	struct nvme_dev *dev;
         int ret = 0;
 
         struct config {
@@ -762,15 +762,15 @@ static int ocp_latency_monitor_log(int argc, char **argv, struct command *comman
                 OPT_END()
         };
 
-        fd = parse_and_open(argc, argv, desc, opts);
-        if (fd < 0)
-                return fd;
+        ret = parse_and_open(&dev, argc, argv, desc, opts);
+        if (ret < 0)
+                return ret;
 
-        ret = get_c3_log_page(fd, cfg.output_format);
+        ret = get_c3_log_page(dev->fd, cfg.output_format);
         if (ret)
                 fprintf(stderr,
                         "ERROR : OCP : Failure reading the C3 Log Page, ret = %d\n",
                         ret);
-        close(fd);
+        dev_close(dev);
         return ret;
 }

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -432,7 +432,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
 static int ocp_print_C3_log_normal(struct ssd_latency_monitor_log *log_data)
 {
         printf("-Latency Monitor/C3 Log Page Data- \n");
-        printf("  Controller   :  %s\n", devicename);
+        printf("  Controller   :  %s\n", nvme_dev->name);
         int i, j;
         int pos = 0;
         char       ts_buf[128];

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -429,7 +429,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
         return ret;
 }
 
-static int ocp_print_C3_log_normal(int fd, struct ssd_latency_monitor_log *log_data)
+static int ocp_print_C3_log_normal(struct ssd_latency_monitor_log *log_data)
 {
         printf("-Latency Monitor/C3 Log Page Data- \n");
         printf("  Controller   :  %s\n", devicename);
@@ -725,7 +725,7 @@ static int get_c3_log_page(int fd, char *format)
 
                 switch (fmt) {
                 case NORMAL:
-                        ocp_print_C3_log_normal(fd, log_data);
+                        ocp_print_C3_log_normal(log_data);
                         break;
                 case JSON:
                         ocp_print_C3_log_json(log_data);

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -431,9 +431,11 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 		sizeof(smart_log), (void *)&smart_log);
 	if (!err) {
 		if (cfg.json)
-			show_sfx_smart_log_jsn(&smart_log, cfg.namespace_id, devicename);
+			show_sfx_smart_log_jsn(&smart_log, cfg.namespace_id,
+                                               nvme_dev->name);
 		else if (!cfg.raw_binary)
-			show_sfx_smart_log(&smart_log, cfg.namespace_id, devicename);
+			show_sfx_smart_log(&smart_log, cfg.namespace_id,
+                                           nvme_dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -432,10 +432,10 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (!err) {
 		if (cfg.json)
 			show_sfx_smart_log_jsn(&smart_log, cfg.namespace_id,
-                                               nvme_dev->name);
+                                               dev->name);
 		else if (!cfg.raw_binary)
 			show_sfx_smart_log(&smart_log, cfg.namespace_id,
-                                           nvme_dev->name);
+                                           dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1119,7 +1119,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s log-id:%d namespace-id:%#x\n",
-			       devicename, cfg.log_id,
+			       nvme_dev->name, cfg.log_id,
 			       cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
@@ -1239,7 +1239,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s namespace-id:%#x\n",
-			       devicename, cfg.namespace_id);
+			       nvme_dev->name, cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
 

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1128,7 +1128,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s log-id:%d namespace-id:%#x\n",
-			       nvme_dev->name, cfg.log_id,
+			       dev->name, cfg.log_id,
 			       cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
@@ -1249,7 +1249,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s namespace-id:%#x\n",
-			       nvme_dev->name, cfg.namespace_id);
+			       dev->name, cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
 

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -144,7 +144,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 		   sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
-			show_shannon_smart_log(&smart_log, cfg.namespace_id, devicename);
+			show_shannon_smart_log(&smart_log, cfg.namespace_id,
+                                               nvme_dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -146,7 +146,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (!err) {
 		if (!cfg.raw_binary)
 			show_shannon_smart_log(&smart_log, cfg.namespace_id,
-                                               nvme_dev->name);
+                                               dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -86,7 +86,7 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 	if (flags == -EINVAL) {
 		fprintf(stderr, "Invalid output format '%s'\n", cfg.output_format);
 		close(fd);
-		return fd;
+		return flags;
 	}
 
 	garbage_control_collection_log_t gc_log;

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -97,9 +97,9 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 		if (flags & BINARY)	{
 			d_raw((unsigned char *)&gc_log, sizeof(gc_log));
 		} else if (flags & JSON) {
-			vu_gc_log_show_json(&gc_log, devicename);
+			vu_gc_log_show_json(&gc_log, nvme_dev->name);
 		} else {
-			vu_gc_log_show(&gc_log, devicename);
+			vu_gc_log_show(&gc_log, nvme_dev->name);
 		}
 	}
 	else if (err > 0) {

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -99,9 +99,9 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 		if (flags & BINARY)	{
 			d_raw((unsigned char *)&gc_log, sizeof(gc_log));
 		} else if (flags & JSON) {
-			vu_gc_log_show_json(&gc_log, nvme_dev->name);
+			vu_gc_log_show_json(&gc_log, dev->name);
 		} else {
-			vu_gc_log_show(&gc_log, nvme_dev->name);
+			vu_gc_log_show(&gc_log, dev->name);
 		}
 	}
 	else if (err > 0) {

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -228,7 +228,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	if (flags == -EINVAL) {
 		fprintf(stderr, "Invalid output format '%s'\n", cfg.output_format);
 		close(fd);
-		return fd;
+		return flags;
 	}
 
 	err = nvme_get_log_simple(fd, solidigm_vu_smart_log_id, sizeof(smart_log_payload), &smart_log_payload);

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -237,12 +237,12 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 		if (flags & JSON) {
 			vu_smart_log_show_json(&smart_log_payload,
                                                cfg.namespace_id,
-                                               nvme_dev->name);
+                                               dev->name);
 		} else if (flags & BINARY) {
 			d_raw((unsigned char *)&smart_log_payload, sizeof(smart_log_payload));
 		} else {
 			vu_smart_log_show(&smart_log_payload, cfg.namespace_id,
-                                          nvme_dev->name);
+                                          dev->name);
 		}
 	} else if (err > 0) {
 		nvme_show_status(err);

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -234,11 +234,14 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	err = nvme_get_log_simple(fd, solidigm_vu_smart_log_id, sizeof(smart_log_payload), &smart_log_payload);
 	if (!err) {
 		if (flags & JSON) {
-			vu_smart_log_show_json(&smart_log_payload, cfg.namespace_id, devicename);
+			vu_smart_log_show_json(&smart_log_payload,
+                                               cfg.namespace_id,
+                                               nvme_dev->name);
 		} else if (flags & BINARY) {
 			d_raw((unsigned char *)&smart_log_payload, sizeof(smart_log_payload));
 		} else {
-			vu_smart_log_show(&smart_log_payload, cfg.namespace_id, devicename);
+			vu_smart_log_show(&smart_log_payload, cfg.namespace_id,
+                                          nvme_dev->name);
 		}
 	} else if (err > 0) {
 		nvme_show_status(err);

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -361,11 +361,11 @@ struct nvme_xdn_smart_log_c0 {
 	__u8 resv[512 - NR_SMART_ITEMS_C0];
 };
 
-static void default_show_vendor_log_c0(int fd, __u32 nsid, const char *devname,
+static void default_show_vendor_log_c0(struct nvme_dev *dev, __u32 nsid,
 		struct nvme_xdn_smart_log_c0 *smart)
 {
 	printf("Vendor Log Page Directory 0xC0 for NVME device:%s namespace-id:%x\n",
-		devname, nsid);
+		dev->name, nsid);
 	printf("Error Log          : %u \n", smart->items[ERROR_LOG_C0]);
 	printf("SMART Health Log   : %u \n", smart->items[SMART_HEALTH_LOG_C0]);
 	printf("Firmware Slot Info : %u \n", smart->items[FIRMWARE_SLOT_INFO_C0]);
@@ -375,8 +375,8 @@ static void default_show_vendor_log_c0(int fd, __u32 nsid, const char *devname,
 	printf("SMART Attributes   : %u \n", smart->items[SMART_ATTRIBUTES_C0]);
 }
 
-static int nvme_get_vendor_log(int fd, __u32 namespace_id, int log_page,
-				const char* const filename)
+static int nvme_get_vendor_log(struct nvme_dev *dev, __u32 namespace_id,
+			       int log_page, const char* const filename)
 {
 	int err;
 	void* log = NULL;
@@ -388,11 +388,11 @@ static int nvme_get_vendor_log(int fd, __u32 namespace_id, int log_page,
 	}
 
 	/* Check device supported */
-	err = nvme_get_sct_status(fd, MASK_0 | MASK_1);
+	err = nvme_get_sct_status(dev->fd, MASK_0 | MASK_1);
 	if (err) {
 		goto end;
 	}
-	err = nvme_get_nsid_log(fd, false, log_page, namespace_id, log_len, log);
+	err = nvme_get_nsid_log(dev->fd, false, log_page, namespace_id, log_len, log);
 	if (err) {
 		fprintf(stderr, "%s: couldn't get log 0x%x\n", __func__,
 			log_page);
@@ -419,9 +419,7 @@ static int nvme_get_vendor_log(int fd, __u32 namespace_id, int log_page,
 		}
 	} else {
 		if (log_page == 0xc0)
-			default_show_vendor_log_c0(fd, namespace_id,
-                                                   nvme_dev->name,
-					(struct nvme_xdn_smart_log_c0 *)log);
+			default_show_vendor_log_c0(dev, namespace_id, log);
 		else
 			d(log, log_len,16,1);
 	}
@@ -472,7 +470,7 @@ static int vendor_log(int argc, char **argv, struct command *cmd, struct plugin 
 		goto end;
 	}
 
-	err = nvme_get_vendor_log(dev->fd, cfg.namespace_id, cfg.log,
+	err = nvme_get_vendor_log(dev, cfg.namespace_id, cfg.log,
 				  cfg.output_file);
 	if (err)
 		fprintf(stderr, "%s: couldn't get vendor log 0x%x\n", __func__, cfg.log);

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -419,7 +419,8 @@ static int nvme_get_vendor_log(int fd, __u32 namespace_id, int log_page,
 		}
 	} else {
 		if (log_page == 0xc0)
-			default_show_vendor_log_c0(fd, namespace_id, devicename,
+			default_show_vendor_log_c0(fd, namespace_id,
+                                                   nvme_dev->name,
 					(struct nvme_xdn_smart_log_c0 *)log);
 		else
 			d(log, log_len,16,1);

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -21,20 +21,20 @@ static int getHealthValue(int argc, char **argv, struct command *cmd, struct plu
 {
 	struct nvme_smart_log smart_log;
 	char *desc = "Get nvme health percentage.";
- 	int result=0, fd;
 	int  percent_used = 0, healthvalue=0;
-	 
+	struct nvme_dev *dev;
+	int result;
+
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	 
-	if (fd < 0) {
+	result = parse_and_open(&dev, argc, argv, desc, opts);
+	if (result < 0) {
 		printf("\nDevice not found \n");;
 		return -1;
 	}
-	result = nvme_get_log_smart(fd, 0xffffffff, false, &smart_log);
+	result = nvme_get_log_smart(dev->fd, 0xffffffff, false, &smart_log);
 	if (!result) {
 		printf("Transcend NVME heath value: ");
 		percent_used =smart_log.percent_used;
@@ -50,7 +50,7 @@ static int getHealthValue(int argc, char **argv, struct command *cmd, struct plu
 		}
 			 
 	}
-	close(fd);
+	dev_close(dev);
 	return result;
 }
 
@@ -59,15 +59,16 @@ static int getBadblock(int argc, char **argv, struct command *cmd, struct plugin
 {
 
 	char *desc = "Get nvme bad block number.";
- 	int result=0, fd;
+	struct nvme_dev *dev;
+ 	int result;
  
 	OPT_ARGS(opts) = {
 		 
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
+	result = parse_and_open(&dev, argc, argv, desc, opts);
+	if (result < 0) {
 		printf("\nDevice not found \n");;
 		return -1;
 	}
@@ -79,11 +80,11 @@ static int getBadblock(int argc, char **argv, struct command *cmd, struct plugin
 	nvmecmd.cdw12=DW12_BAD_BLOCK;
 	nvmecmd.addr = (__u64)(uintptr_t)data;
 	nvmecmd.data_len = 0x1;
-	result = nvme_submit_admin_passthru(fd, &nvmecmd, NULL);
+	result = nvme_submit_admin_passthru(dev->fd, &nvmecmd, NULL);
 	if(!result) {
 		int badblock  = data[0];
 		printf("Transcend NVME badblock count: %d\n",badblock);
 	}
-	close(fd);
+	dev_close(dev);
 	return result;
 }

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -927,8 +927,7 @@ static void vt_parse_detail_identify(const struct nvme_id_ctrl *ctrl)
 
 static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err = 0;
-	int fd, ret;
+	int ret, err = 0;
 	long int total_time = 0;
 	long int freq_time = 0;
 	long int cur_time = 0;
@@ -949,6 +948,7 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 	const char *freq = "(optional) How often you want to log SMART data (0.25 = 15' , 0.5 = 30' , 1 = 1 hour, 2 = 2 hours, etc.). Default = 10 hours.";
 	const char *output_file = "(optional) Name of the log file (give it a name that easy for you to remember what the test is). You can leave it blank too, we will take care it for you.";
 	const char *test_name = "(optional) Name of the test you are doing. We use this as part of the name of the log file.";
+	struct nvme_dev *dev;
 
 	struct vtview_save_log_settings cfg = {
 		.run_time_hrs = 20,
@@ -975,10 +975,10 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 		strcpy(path, argv[1]);
 	}
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
-		printf("Error parse and open (fd = %d)\n", fd);
-		return (fd);
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0) {
+		printf("Error parse and open (err = %d)\n", err);
+		return err;
 	}
 
 	printf("Running...\n");
@@ -986,10 +986,10 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 	printf("Running for %lf hour(s)\n", cfg.run_time_hrs);
 	printf("Logging SMART data for every %lf hour(s)\n", cfg.log_record_frequency_hrs);
 
-	ret = vt_update_vtview_log_header(fd, path, &cfg);
+	ret = vt_update_vtview_log_header(dev->fd, path, &cfg);
 	if (ret) {
 		err = EINVAL;
-		close(fd);
+		dev_close(dev);
 		return (err);
 	}
 
@@ -1009,7 +1009,7 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 		if(cur_time >= end_time)
 			break;
 
-		ret = vt_add_entry_to_log(fd, path, &cfg);
+		ret = vt_add_entry_to_log(dev->fd, path, &cfg);
 		if (ret) {
 			printf("Cannot update driver log\n");
 			break;
@@ -1021,15 +1021,15 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 		fflush(stdout);
 	}
 
-	close (fd);
+	dev_close(dev);
 	return (err);
 }
 
 static int vt_show_identify(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	int err = 0;
-	int fd ,ret;
+	int ret, err = 0;
 	struct nvme_id_ctrl ctrl;
+	struct nvme_dev *dev;
 	char *desc = "Parse identify data to json format\n\n"
 		"Typical usages:\n\n"
 		"virtium show-identify /dev/yourDevice\n";
@@ -1038,16 +1038,16 @@ static int vt_show_identify(int argc, char **argv, struct command *cmd, struct p
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
-		printf("Error parse and open (fd = %d)\n", fd);
-		return (fd);
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0) {
+		printf("Error parse and open (err = %d)\n", err);
+		return (err);
 	}
 
-	ret = nvme_identify_ctrl(fd, &ctrl);
+	ret = nvme_identify_ctrl(dev->fd, &ctrl);
 	if (ret) {
 		printf("Cannot read identify device\n");
-		close (fd);
+		dev_close(dev);
 		return (-1);
 	}
 
@@ -1055,6 +1055,6 @@ static int vt_show_identify(int argc, char **argv, struct command *cmd, struct p
 	vt_process_string(ctrl.mn, sizeof(ctrl.mn));
 	vt_parse_detail_identify(&ctrl);
 
-	close(fd);
+	dev_close(dev);
 	return (err);
 }

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -4156,7 +4156,7 @@ static void wdc_print_latency_monitor_log_json(struct wdc_ssd_latency_monitor_lo
 	json_free_object(root);
 }
 
-static void wdc_print_error_rec_log_normal(int fd, struct wdc_ocp_c1_error_recovery_log *log_data)
+static void wdc_print_error_rec_log_normal(struct wdc_ocp_c1_error_recovery_log *log_data)
 {
 	int j;
 	printf("Error Recovery/C1 Log Page Data \n");
@@ -4210,7 +4210,7 @@ static void wdc_print_error_rec_log_json(struct wdc_ocp_c1_error_recovery_log *l
 	json_free_object(root);
 }
 
-static void wdc_print_dev_cap_log_normal(int fd, struct wdc_ocp_C4_dev_cap_log *log_data)
+static void wdc_print_dev_cap_log_normal(struct wdc_ocp_C4_dev_cap_log *log_data)
 {
 	int j;
 	printf("Device Capabilities/C4 Log Page Data \n");
@@ -4271,7 +4271,7 @@ static void wdc_print_dev_cap_log_json(struct wdc_ocp_C4_dev_cap_log *log_data)
 	json_free_object(root);
 }
 
-static void wdc_print_unsupported_reqs_log_normal(int fd, struct wdc_ocp_C5_unsupported_reqs *log_data)
+static void wdc_print_unsupported_reqs_log_normal(struct wdc_ocp_C5_unsupported_reqs *log_data)
 {
 	int j;
 	printf("Unsupported Requirements/C5 Log Page Data \n");
@@ -6392,7 +6392,7 @@ static int wdc_print_latency_monitor_log(int fd, struct wdc_ssd_latency_monitor_
 	return 0;
 }
 
-static int wdc_print_error_rec_log(int fd, struct wdc_ocp_c1_error_recovery_log *log_data, int fmt)
+static int wdc_print_error_rec_log(struct wdc_ocp_c1_error_recovery_log *log_data, int fmt)
 {
 	if (!log_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid C1 log data buffer\n");
@@ -6400,7 +6400,7 @@ static int wdc_print_error_rec_log(int fd, struct wdc_ocp_c1_error_recovery_log 
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_error_rec_log_normal(fd, log_data);
+		wdc_print_error_rec_log_normal(log_data);
 		break;
 	case JSON:
 		wdc_print_error_rec_log_json(log_data);
@@ -6409,7 +6409,7 @@ static int wdc_print_error_rec_log(int fd, struct wdc_ocp_c1_error_recovery_log 
 	return 0;
 }
 
-static int wdc_print_dev_cap_log(int fd, struct wdc_ocp_C4_dev_cap_log *log_data, int fmt)
+static int wdc_print_dev_cap_log(struct wdc_ocp_C4_dev_cap_log *log_data, int fmt)
 {
 	if (!log_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid C4 log data buffer\n");
@@ -6417,7 +6417,7 @@ static int wdc_print_dev_cap_log(int fd, struct wdc_ocp_C4_dev_cap_log *log_data
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_dev_cap_log_normal(fd, log_data);
+		wdc_print_dev_cap_log_normal(log_data);
 		break;
 	case JSON:
 		wdc_print_dev_cap_log_json(log_data);
@@ -6426,7 +6426,7 @@ static int wdc_print_dev_cap_log(int fd, struct wdc_ocp_C4_dev_cap_log *log_data
 	return 0;
 }
 
-static int wdc_print_unsupported_reqs_log(int fd, struct wdc_ocp_C5_unsupported_reqs *log_data, int fmt)
+static int wdc_print_unsupported_reqs_log(struct wdc_ocp_C5_unsupported_reqs *log_data, int fmt)
 {
 	if (!log_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid C5 log data buffer\n");
@@ -6434,7 +6434,7 @@ static int wdc_print_unsupported_reqs_log(int fd, struct wdc_ocp_C5_unsupported_
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_unsupported_reqs_log_normal(fd, log_data);
+		wdc_print_unsupported_reqs_log_normal(log_data);
 		break;
 	case JSON:
 		wdc_print_unsupported_reqs_log_json(log_data);
@@ -6838,7 +6838,7 @@ static int wdc_get_ocp_c1_log_page(nvme_root_t r, int fd, char *format)
 		}
 
 		/* parse the data */
-		wdc_print_error_rec_log(fd, log_data, fmt);
+		wdc_print_error_rec_log(log_data, fmt);
 	} else {
 		fprintf(stderr, "ERROR : WDC : Unable to read error recovery (C1) data from buffer\n");
 	}
@@ -6907,7 +6907,7 @@ static int wdc_get_ocp_c4_log_page(nvme_root_t r, int fd, char *format)
 		}
 
 		/* parse the data */
-		wdc_print_dev_cap_log(fd, log_data, fmt);
+		wdc_print_dev_cap_log(log_data, fmt);
 	} else {
 		fprintf(stderr, "ERROR : WDC : Unable to read device capabilities (C4) data from buffer\n");
 	}
@@ -6976,7 +6976,7 @@ static int wdc_get_ocp_c5_log_page(nvme_root_t r, int fd, char *format)
 		}
 
 		/* parse the data */
-		wdc_print_unsupported_reqs_log(fd, log_data, fmt);
+		wdc_print_unsupported_reqs_log(log_data, fmt);
 	} else {
 		fprintf(stderr, "ERROR : WDC : Unable to read unsupported requirements (C5) data from buffer\n");
 	}

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10507,7 +10507,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
    	if (fmt == NORMAL) {
 		/* print the temperature stats */
 		printf("Temperature Stats for NVME device:%s namespace-id:%x\n",
-					nvme_dev->name, WDC_DE_GLOBAL_NSID);
+					dev->name, WDC_DE_GLOBAL_NSID);
 
 		printf("Current Composite Temperature           : %d °C\n", temperature);
 		printf("WCTEMP                                  : %"PRIu16" °C\n", id_ctrl.wctemp - 273);
@@ -10582,7 +10582,7 @@ static int wdc_capabilities(int argc, char **argv,
     capabilities = wdc_get_drive_capabilities(r, dev);
 
     /* print command and supported status */
-    printf("WDC Plugin Capabilities for NVME device:%s\n", nvme_dev->name);
+    printf("WDC Plugin Capabilities for NVME device:%s\n", dev->name);
     printf("cap-diag                      : %s\n", 
             capabilities & WDC_DRIVE_CAP_CAP_DIAG ? "Supported" : "Not Supported");
     printf("drive-log                     : %s\n", 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1297,7 +1297,7 @@ static int wdc_get_pci_ids(nvme_root_t r, uint32_t *device_id,
 	nvme_ns_t n = NULL;
 	int fd, ret;
 
-	c = nvme_scan_ctrl(r, devicename);
+	c = nvme_scan_ctrl(r, nvme_dev->name);
 	if (c) {
 		snprintf(vid, sizeof(vid), "%s/device/vendor",
 			nvme_ctrl_get_sysfs_dir(c));
@@ -1305,9 +1305,9 @@ static int wdc_get_pci_ids(nvme_root_t r, uint32_t *device_id,
 			nvme_ctrl_get_sysfs_dir(c));
 		nvme_free_ctrl(c);
 	} else {
-		n = nvme_scan_namespace(devicename);
+		n = nvme_scan_namespace(nvme_dev->name);
 		if (!n) {
-			fprintf(stderr, "Unable to find %s\n", devicename);
+			fprintf(stderr, "Unable to find %s\n", nvme_dev->name);
 			return -1;
 		}
 
@@ -4012,7 +4012,7 @@ static int wdc_convert_ts(time_t time, char *ts_buf)
 static int wdc_print_latency_monitor_log_normal(int fd, struct wdc_ssd_latency_monitor_log *log_data)
 {
 	printf("Latency Monitor/C3 Log Page Data \n");
-	printf("  Controller   :  %s\n", devicename);
+	printf("  Controller   :  %s\n", nvme_dev->name);
 	int err = -1, i, j;
 	struct nvme_id_ctrl ctrl;
 	char       ts_buf[128];
@@ -4453,7 +4453,7 @@ static void wdc_print_bd_ca_log_normal(void *data)
 	if (bd_data->field_id == 0x00) {
 		raw = (__u64*)&bd_data->raw_value[0];
 		printf("Additional Smart Log for NVME device:%s namespace-id:%x\n",
-			devicename, WDC_DE_GLOBAL_NSID);
+			nvme_dev->name, WDC_DE_GLOBAL_NSID);
 		printf("key                               normalized raw\n");
         printf("program_fail_count              : %3"PRIu8"%%       %"PRIu64"\n",
 				bd_data->normalized_value, le64_to_cpu(*raw & 0x00FFFFFFFFFFFFFF));
@@ -10446,7 +10446,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
    	if (fmt == NORMAL) {
 		/* print the temperature stats */
 		printf("Temperature Stats for NVME device:%s namespace-id:%x\n",
-					devicename, WDC_DE_GLOBAL_NSID);
+					nvme_dev->name, WDC_DE_GLOBAL_NSID);
 
 		printf("Current Composite Temperature           : %d °C\n", temperature);
 		printf("WCTEMP                                  : %"PRIu16" °C\n", id_ctrl.wctemp - 273);
@@ -10520,7 +10520,7 @@ static int wdc_capabilities(int argc, char **argv,
     capabilities = wdc_get_drive_capabilities(r, fd);
 
     /* print command and supported status */
-    printf("WDC Plugin Capabilities for NVME device:%s\n", devicename);
+    printf("WDC Plugin Capabilities for NVME device:%s\n", nvme_dev->name);
     printf("cap-diag                      : %s\n", 
             capabilities & WDC_DRIVE_CAP_CAP_DIAG ? "Supported" : "Not Supported");
     printf("drive-log                     : %s\n", 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -8731,7 +8731,6 @@ static int wdc_do_drive_essentials(nvme_root_t r, int fd, char *dir, char *key)
 	memset(tarFiles,0,sizeof(tarFiles));
 	memset(tarCmd,0,sizeof(tarCmd));
 	memset(&timeInfo,0,sizeof(timeInfo));
-	memset(&vuLogInput, 0, sizeof(vuLogInput));
 
 	if (wdc_get_serial_and_fw_rev(fd, (char *)idSerialNo, (char *)idFwRev))
 	{

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -4481,7 +4481,7 @@ static void wdc_print_fb_ca_log_json(struct wdc_ssd_ca_perf_stats *perf)
 	json_free_object(root);
 }
 
-static void wdc_print_bd_ca_log_normal(void *data)
+static void wdc_print_bd_ca_log_normal(struct nvme_dev *dev, void *data)
 {
 	struct wdc_bd_ca_log_format *bd_data = (struct wdc_bd_ca_log_format *)data;
 	__u64 *raw;
@@ -4492,7 +4492,7 @@ static void wdc_print_bd_ca_log_normal(void *data)
 	if (bd_data->field_id == 0x00) {
 		raw = (__u64*)&bd_data->raw_value[0];
 		printf("Additional Smart Log for NVME device:%s namespace-id:%x\n",
-			nvme_dev->name, WDC_DE_GLOBAL_NSID);
+			dev->name, WDC_DE_GLOBAL_NSID);
 		printf("key                               normalized raw\n");
         printf("program_fail_count              : %3"PRIu8"%%       %"PRIu64"\n",
 				bd_data->normalized_value, le64_to_cpu(*raw & 0x00FFFFFFFFFFFFFF));
@@ -6501,7 +6501,7 @@ static int wdc_print_fb_ca_log(struct wdc_ssd_ca_perf_stats *perf, int fmt)
 	return 0;
 }
 
-static int wdc_print_bd_ca_log(void *bd_data, int fmt)
+static int wdc_print_bd_ca_log(struct nvme_dev *dev, void *bd_data, int fmt)
 {
 	if (!bd_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid buffer to read data\n");
@@ -6509,7 +6509,7 @@ static int wdc_print_bd_ca_log(void *bd_data, int fmt)
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_bd_ca_log_normal(bd_data);
+		wdc_print_bd_ca_log_normal(dev, bd_data);
 		break;
 	case JSON:
 		wdc_print_bd_ca_log_json(bd_data);
@@ -6665,7 +6665,7 @@ static int wdc_get_ca_log_page(nvme_root_t r, struct nvme_dev *dev, char *format
 
 			if (ret == 0) {
 				/* parse the data */
-				ret = wdc_print_bd_ca_log(data, fmt);
+				ret = wdc_print_bd_ca_log(dev, data, fmt);
 			} else {
 				fprintf(stderr, "ERROR : WDC : Unable to read CA Log Page data\n");
 				ret = -1;

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -3498,8 +3498,7 @@ static int wdc_crash_dump(int fd, char *file, int type)
 	if (ret)
 		fprintf(stderr, "ERROR : WDC : failed to generate file name\n");
 	else
-		ret = wdc_do_crash_dump(fd, f, type);	\
-	close(fd);
+		ret = wdc_do_crash_dump(fd, f, type);
 	return ret;
 }
 

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -147,7 +147,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 			    sizeof(smart_log), &smart_log);
     if (!err) {
         if (!cfg.raw_binary)
-            err = show_ymtc_smart_log(fd, cfg.namespace_id, devicename, &smart_log);
+            err = show_ymtc_smart_log(fd, cfg.namespace_id, nvme_dev->name, &smart_log);
         else
             d_raw((unsigned char *)&smart_log, sizeof(smart_log));
     }

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -21,8 +21,8 @@ static void get_ymtc_smart_info(struct nvme_ymtc_smart_log *smart, int index, u8
     memcpy(raw_val, smart->itemArr[index].rawVal, RAW_SIZE);
 }
 
-static int show_ymtc_smart_log(int fd, __u32 nsid, const char *devname,
-    struct nvme_ymtc_smart_log *smart)
+static int show_ymtc_smart_log(struct nvme_dev *dev, __u32 nsid,
+			       struct nvme_ymtc_smart_log *smart)
 {
     struct nvme_id_ctrl ctrl;
     char fw_ver[10];
@@ -40,7 +40,7 @@ static int show_ymtc_smart_log(int fd, __u32 nsid, const char *devname,
         free(nm);
         return -1;
     }
-    err = nvme_identify_ctrl(fd, &ctrl);
+    err = nvme_identify_ctrl(dev->fd, &ctrl);
     if (err) {
         free(nm);
         free(raw);
@@ -52,7 +52,8 @@ static int show_ymtc_smart_log(int fd, __u32 nsid, const char *devname,
         ctrl.fr[4], ctrl.fr[5], ctrl.fr[6]);
 
     /* Table Title */
-    printf("Additional Smart Log for NVME device:%s namespace-id:%x\n", devname, nsid);
+    printf("Additional Smart Log for NVME device:%s namespace-id:%x\n",
+	   dev->name, nsid);
     /* Clumn Name*/
     printf("key                               normalized raw\n");
     /* 00 SI_VD_PROGRAM_FAIL */
@@ -148,7 +149,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 			    sizeof(smart_log), &smart_log);
     if (!err) {
         if (!cfg.raw_binary)
-            err = show_ymtc_smart_log(dev->fd, cfg.namespace_id, nvme_dev->name, &smart_log);
+            err = show_ymtc_smart_log(dev, cfg.namespace_id, &smart_log);
         else
             d_raw((unsigned char *)&smart_log, sizeof(smart_log));
     }


### PR DESCRIPTION
This draft change is a bit of an experiment on the path of using `nvme-cli` to also handle NVMe-MI transports.

At present, we have a few bits of data that pertain to the nvme device handle:

 * a global `devicename` string
 * local `fd`s to pass to the libnvme API, and/or perform direct `ioctl()`s
 * a static `struct stat`

This series attempts to tidy that up a little, by moving these three into a single new struct (`struct nvme_dev`), which we allocate on `parse_and_open()`. The intention will be to later make this flexible enough to use a MI-specific handle (`nvme_mi_ep_t`) alongside the `fd`. 

This patchset is quite large, as almost every function in the core and plugins assumes direct access to the `fd`. However, the changes are mostly mechanical - replacing `int fd` with `struct nvme_dev` + `dev->fd`. 