### PR TITLE
print: Fix nvme_id_uuid_list

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5661,7 +5661,7 @@ void nvme_show_id_uuid_list(const struct nvme_id_uuid_list *uuid_list,
 
 	/* The 0th entry is reserved */
 	printf("NVME Identify UUID:\n");
-	for (i = 1; i < NVME_ID_UUID_LIST_MAX; i++) {
+	for (i = 0; i < NVME_ID_UUID_LIST_MAX; i++) {
 		uuid_t uuid;
 		char *association = "";
 		uint8_t identifier_association = uuid_list->entry[i].header & 0x3;
@@ -5685,7 +5685,7 @@ void nvme_show_id_uuid_list(const struct nvme_id_uuid_list *uuid_list,
 				break;
 			}
 		}
-		printf(" Entry[%3d]\n", i);
+		printf(" Entry[%3d]\n", i+1);
 		printf(".................\n");
 		printf("association  : 0x%x %s\n", identifier_association, association);
 		printf("UUID         : %s", nvme_uuid_to_string(uuid));


### PR DESCRIPTION
Signed-off-by: Jeff Lien <jeff.lien@wdc.com>

The previous code would skip the first entry in the list.  This fix will print all entries.   