### PR TITLE
nvme: Set default rae value for nvme_get_nsid_log users

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -351,7 +351,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_get_log_smart(fd, cfg.namespace_id, true, &smart_log);
+	err = nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
 	if (!err)
 		nvme_show_smart_log(&smart_log, cfg.namespace_id, devicename,
 				    flags);
@@ -824,7 +824,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 		goto close_fd;
 	}
 
-	err = nvme_get_log_error(fd, cfg.log_entries, true, err_log);
+	err = nvme_get_log_error(fd, cfg.log_entries, false, err_log);
 	if (!err)
 		nvme_show_error_log(err_log, cfg.log_entries, devicename, flags);
 	else if (err > 0)
@@ -873,7 +873,7 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	err = nvme_get_log_fw_slot(fd, true, &fw_log);
+	err = nvme_get_log_fw_slot(fd, false, &fw_log);
 	if (!err)
 		nvme_show_fw_log(&fw_log, devicename, flags);
 	else if (err > 0)
@@ -1406,7 +1406,7 @@ static int get_resv_notif_log(int argc, char **argv,
 	if (flags < 0)
 		goto close_fd;
 
-	err = nvme_get_log_reservation(fd, true, &resv);
+	err = nvme_get_log_reservation(fd, false, &resv);
 	if (!err)
 		nvme_show_resv_notif_log(&resv, devicename, flags);
 	else if (err > 0)

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -42,7 +42,7 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 	if (fd < 0)
 		return fd;
 
-	nvme_get_log_smart(fd, cfg.namespace_id, true, &smart_log);
+	nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
 	nvme_show_smart_log(&smart_log, cfg.namespace_id, devicename, NORMAL);
 
 	printf("DW0[0-1]  Defect Cnt                    : %u\n", pvsc_smart->defect_cnt);

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -1759,7 +1759,7 @@ static void GetGenericLogs(int fd, const char *dir)
     }
 
     /* get fw slot info log */
-    if (nvme_get_log_fw_slot(fd, 1, &fw_log) == 0) {
+    if (nvme_get_log_fw_slot(fd, false, &fw_log) == 0) {
         WriteData((__u8*)&fw_log, sizeof(fw_log), dir,
                   "firmware_slot_info_log.bin", "firmware log");
     }

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -848,7 +848,7 @@ static int temp_stats(int argc, char **argv, struct command *cmd, struct plugin 
 	if(strcmp(cfg.output_format,"json"))
 		printf("Seagate Temperature Stats Information :\n");
 	/*STEP-1 : Get Current Temperature from SMART */
-	err = nvme_get_log_smart(fd, 0xffffffff, true, &smart_log);
+	err = nvme_get_log_smart(fd, 0xffffffff, false, &smart_log);
 	if (!err) {
 		temperature = ((smart_log.temperature[1] << 8) | smart_log.temperature[0]);
 		temperature = temperature ? temperature - 273 : 0;

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -34,7 +34,7 @@ static int getHealthValue(int argc, char **argv, struct command *cmd, struct plu
 		printf("\nDevice not found \n");;
 		return -1;
 	}
-	result = nvme_get_log_smart(fd, 0xffffffff, true, &smart_log);
+	result = nvme_get_log_smart(fd, 0xffffffff, false, &smart_log);
 	if (!result) {
 		printf("Transcend NVME heath value: ");
 		percent_used =smart_log.percent_used;

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -302,7 +302,7 @@ static int vt_add_entry_to_log(const int fd, const char *path, const struct vtvi
 		return -1;
 	}
 
-	ret = nvme_get_log_smart(fd, NVME_NSID_ALL, true, &smart.raw_smart);
+	ret = nvme_get_log_smart(fd, NVME_NSID_ALL, false, &smart.raw_smart);
 	if (ret) {
 		printf("Cannot read device SMART log\n");
 		return -1;
@@ -354,7 +354,7 @@ static int vt_update_vtview_log_header(const int fd, const char *path, const str
 		return -1;
 	}
 
-	ret = nvme_get_log_fw_slot(fd, true, &header.raw_fw);
+	ret = nvme_get_log_fw_slot(fd, false, &header.raw_fw);
 	if (ret) {
 		printf("Cannot read device firmware log\n");
 		return -1;

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -7370,7 +7370,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *command,
 	}
 
 	/* get data units written from the smart log page */
-	ret = nvme_get_log_smart(fd, cfg.namespace_id, true, &smart_log);
+	ret = nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
 	if (!ret) {
 		data_units_written = int128_to_double(smart_log.data_units_written);
 	}
@@ -8838,7 +8838,7 @@ static int wdc_do_drive_essentials(nvme_root_t r, int fd, char *dir, char *key)
 
 	/* Get FW Slot log page  */
 	memset(&fw_log, 0, sizeof (struct nvme_firmware_slot));
-	ret = nvme_get_log_fw_slot(fd, true, &fw_log);
+	ret = nvme_get_log_fw_slot(fd, false, &fw_log);
 	if (ret) {
 		fprintf(stderr, "ERROR : WDC : nvme_fw_log() failed, ret = %d\n", ret);
 	} else {


### PR DESCRIPTION
libnvme 1.0 hard codes the rae value for all nvme_get_nsid_log to
false. The upcoming 1.1 release will pass the rae value through
to the kernel. This is causing a behavior change. To be on the safe
side set all rae=true to false.

At least for nvme_get_log_error and nvme_get_log_smart this seems also
what the spec recommends.

Reported-by: Jeremy Kerr <jk@codeconstruct.com.au>
Signed-off-by: Daniel Wagner <dwagner@suse.de>

See #https://github.com/linux-nvme/libnvme/issues/437