### PR TITLE
fabrics: Pass ctrl key to connect logic

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -395,8 +395,13 @@ static int __discover(nvme_ctrl_t c, struct nvme_fabrics_config *defcfg,
 				set_discovery_kato(defcfg);
 
 			errno = 0;
-			child = nvmf_connect_disc_entry(h, e, defcfg,
-							&discover);
+			struct nvmf_connect_disc_entry2_args args = {
+				.args_size		= sizeof(args),
+				.defcfg			= defcfg,
+				.discover		= &discover,
+				.dhchap_ctrl_key	= nvmf_ctrlkey,
+			};
+			child = nvmf_connect_disc_entry2(h, e, &args);
 
 			defcfg->keep_alive_tmo = tmo;
 

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 6c5aedd78690b042250f3dc82b48b7302ea91dbd
+revision = 3db735c0b8082f15d766eec7d5de0dfca45b277f
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
The dhchap control key needs to be passed into libnvme via the new nvmf_connect_disc_entry2 in order to support the -S and -C options in the connect-all case.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/1618