### PR TITLE
Add MI support to `nvme-cli`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,8 @@ conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 # Check for libnvme availability
 libnvme_dep = dependency('libnvme', version: '>=1.1', required: true,
                          fallback : ['libnvme', 'libnvme_dep'])
+libnvme_mi_dep = dependency('libnvme-mi', required: true,
+                         fallback : ['libnvme', 'libnvme_mi_dep'])
 
 # Check for libuuid availability
 libuuid_dep = dependency('uuid', required: true,
@@ -258,7 +260,7 @@ subdir('Documentation')
 executable(
   'nvme',
   sources,
-  dependencies: [ libnvme_dep, libuuid_dep, json_c_dep, libz_dep,
+  dependencies: [ libnvme_dep, libnvme_mi_dep, libuuid_dep, json_c_dep, libz_dep,
                   libhugetlbfs_dep ],
   link_args: '-ldl',
   include_directories: incdir,

--- a/meson.build
+++ b/meson.build
@@ -247,6 +247,7 @@ sources = [
   'nvme-models.c',
   'nvme-print.c',
   'nvme-rpmb.c',
+  'nvme-wrap.c',
   'plugin.c',
   'wrapper.c',
 ]

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -891,7 +891,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *p
 		return err;
 	
 	/* before parsing  commands, check if controller supports any RPMB targets */
-	err = nvme_identify_ctrl(dev->fd, &ctrl);
+	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
 	if (err)
 		goto out;
 	
@@ -960,14 +960,15 @@ int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *p
 	
 	switch (cfg.opt) {
 		case RPMB_REQ_READ_WRITE_CNTR:
-			err = rpmb_read_write_counter(dev->fd, cfg.target,
+			err = rpmb_read_write_counter(dev_fd(dev), cfg.target,
 						      &write_cntr);
 			if (err == 0)
 				printf("Write Counter is: %u\n", write_cntr);
 			break;
 	
 		case RPMB_REQ_AUTH_DCB_READ:
-			write_cntr = rpmb_read_config_block(dev->fd, &msg_buf);
+			write_cntr = rpmb_read_config_block(dev_fd(dev),
+							    &msg_buf);
 			if (msg_buf == NULL) {
 				fprintf(stderr, "failed read config blk\n");
 				goto out;
@@ -999,7 +1000,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *p
 					msg_size);
 				break;
 			}
-			err = rpmb_auth_data_read(dev->fd, cfg.target,
+			err = rpmb_auth_data_read(dev_fd(dev), cfg.target,
 						  cfg.address, &msg_buf,
 						  cfg.blocks,
 						  (regs.access_size + 1));
@@ -1020,7 +1021,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *p
 			} else if ((cfg.blocks * 512) < msg_size) {
 				msg_size = cfg.blocks * 512;
 			}
-			err = rpmb_auth_data_write(dev->fd, cfg.target,
+			err = rpmb_auth_data_write(dev_fd(dev), cfg.target,
 						   cfg.address,
 						  ((regs.access_size + 1) * 512),
 						   msg_buf, msg_size,
@@ -1032,12 +1033,12 @@ int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *p
 			break;
 
 		case RPMB_REQ_AUTH_DCB_WRITE:
-			err = rpmb_write_config_block(dev->fd, msg_buf,
+			err = rpmb_write_config_block(dev_fd(dev), msg_buf,
 						      key_buf, key_size);
 			break;
 	
 		case RPMB_REQ_AUTH_KEY_PROGRAM:
-			err = rpmb_program_auth_key(dev->fd, cfg.target,
+			err = rpmb_program_auth_key(dev_fd(dev), cfg.target,
 						    key_buf, key_size);
 			break;
 		default:

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Definitions for the NVM Express interface: libnvme/libnvme-mi device
+ * wrappers.
+ */
+
+#include <errno.h>
+
+#include <libnvme.h>
+#include <libnvme-mi.h>
+
+#include "nvme.h"
+#include "nvme-wrap.h"
+
+/*
+ * Helper for libnvme functions that pass the fd/ep separately. These just
+ * pass the correct handle to the direct/MI function.
+ * @op: the name of the libnvme function, without the nvme_/nvme_mi prefix
+ * @d: device handle: struct nvme_dev
+ */
+#define do_admin_op(op, d, ...) ({					\
+	int __rc;							\
+	if (d->type == NVME_DEV_DIRECT)					\
+		__rc = nvme_ ## op(d->direct.fd, __VA_ARGS__);		\
+	else if (d->type == NVME_DEV_MI)				\
+		__rc = nvme_mi_admin_ ## op (d->mi.ctrl, __VA_ARGS__);	\
+	else								\
+		__rc = -ENODEV;						\
+	__rc; })
+
+/*
+ * Helper for libnvme functions use the 'struct _args' pattern. These need
+ * the fd and timeout set for the direct interface, and pass the ep as
+ * an argument for the MI interface
+ * @op: the name of the libnvme function, without the nvme_/nvme_mi prefix
+ * @d: device handle: struct nvme_dev
+ * @args: op-specific args struct
+ */
+#define do_admin_args_op(op, d, args) ({				\
+	int __rc;							\
+	if (d->type == NVME_DEV_DIRECT) {				\
+		args->fd = d->direct.fd;				\
+		args->timeout = NVME_DEFAULT_IOCTL_TIMEOUT;		\
+		__rc = nvme_ ## op(args);				\
+	} else if (d->type == NVME_DEV_MI)				\
+		__rc = nvme_mi_admin_ ## op (d->mi.ctrl, args);		\
+	else								\
+		__rc = -ENODEV;						\
+	__rc; })
+
+int nvme_cli_identify(struct nvme_dev *dev, struct nvme_identify_args *args)
+{
+	return do_admin_args_op(identify, dev, args);
+}
+
+int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl)
+{
+	return do_admin_op(identify_ctrl, dev, ctrl);
+}
+

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Definitions for the NVM Express interface: libnvme/libnvme-mi device
+ * wrappers.
+ */
+
+#ifndef _NVME_WRAP_H
+#define _NVME_WRAP_H
+
+#include "nvme.h"
+
+int nvme_cli_identify(struct nvme_dev *dev, struct nvme_identify_args *args);
+int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl);
+
+#endif /* _NVME_WRAP_H */

--- a/nvme.c
+++ b/nvme.c
@@ -79,8 +79,8 @@ struct feat_cfg {
 	bool  human_readable;
 };
 
-struct nvme_dev _nvme_dev;
-struct nvme_dev *nvme_dev = &_nvme_dev;
+static struct nvme_dev _nvme_dev;
+static struct nvme_dev *nvme_dev = &_nvme_dev;
 
 static const char nvme_version_string[] = NVME_VERSION;
 

--- a/nvme.c
+++ b/nvme.c
@@ -61,6 +61,7 @@
 #include "nvme-print.h"
 #include "plugin.h"
 #include "util/base64.h"
+#include "nvme-wrap.h"
 
 #include "util/argconfig.h"
 #include "fabrics.h"
@@ -504,7 +505,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	if (flags < 0)
 		goto close_fd;
 
-	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
+	err = nvme_cli_identify_ctrl(dev, &ctrl);
 	if (err) {
 		fprintf(stderr, "ERROR : nvme_identify_ctrl() failed: %s\n",
 			nvme_strerror(errno));
@@ -917,7 +918,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 		goto close_dev;
 	}
 
-	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
+	err = nvme_cli_identify_ctrl(dev, &ctrl);
 	if (err < 0) {
 		perror("identify controller");
 		goto close_dev;
@@ -1166,7 +1167,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 		goto close_dev;
 	}
 
-	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
+	err = nvme_cli_identify_ctrl(dev, &ctrl);
 	if (err < 0) {
 		fprintf(stderr, "identify controller: %s\n",
 			nvme_strerror(errno));
@@ -1389,7 +1390,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 		goto close_dev;
 	}
 
-	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
+	err = nvme_cli_identify_ctrl(dev, &ctrl);
 	if (err < 0) {
 		fprintf(stderr, "identify controller: %s\n",
 			nvme_strerror(errno));
@@ -2191,7 +2192,6 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	struct nvme_identify_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 		.data		= &ns_list,
 		.nsid		= cfg.namespace_id - 1.
@@ -2205,7 +2205,7 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 		args.csi = cfg.csi;
 	}
 
-	err = nvme_identify(&args);
+	err = nvme_cli_identify(dev, &args);
 
 	if (!err)
 		nvme_show_list_ns(&ns_list, flags);
@@ -2866,7 +2866,7 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
+	err = nvme_cli_identify_ctrl(dev, &ctrl);
 	if (!err)
 		nvme_show_id_ctrl(&ctrl, flags, vs);
 	else if (err > 0)
@@ -4883,7 +4883,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		}
 	}
 
-	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
+	err = nvme_cli_identify_ctrl(dev, &ctrl);
 	if (err) {
 		fprintf(stderr, "identify-ctrl: %s\n", nvme_strerror(errno));
 		goto close_dev;

--- a/nvme.c
+++ b/nvme.c
@@ -79,9 +79,6 @@ struct feat_cfg {
 	bool  human_readable;
 };
 
-static struct nvme_dev _nvme_dev;
-static struct nvme_dev *nvme_dev = &_nvme_dev;
-
 static const char nvme_version_string[] = NVME_VERSION;
 
 static struct plugin builtin = {
@@ -208,18 +205,21 @@ static ssize_t getrandom_bytes(void *buf, size_t buflen)
 #endif
 }
 
-static bool is_chardev(void)
+static bool is_chardev(struct nvme_dev *dev)
 {
-	return S_ISCHR(nvme_dev->stat.st_mode);
+	return S_ISCHR(dev->stat.st_mode);
 }
 
-static bool is_blkdev(void)
+static bool is_blkdev(struct nvme_dev *dev)
 {
-	return S_ISBLK(nvme_dev->stat.st_mode);
+	return S_ISBLK(dev->stat.st_mode);
 }
 
 static int open_dev(struct nvme_dev **devp, char *dev, int flags)
 {
+	static struct nvme_dev _nvme_dev;
+	static struct nvme_dev *nvme_dev = &_nvme_dev;
+
 	int err, fd;
 
 	/* Temporary: we use the global nvme_dev pointer for the nvme device.
@@ -239,7 +239,7 @@ static int open_dev(struct nvme_dev **devp, char *dev, int flags)
 		close(fd);
 		goto perror;
 	}
-	if (!is_chardev() && !is_blkdev()) {
+	if (!is_chardev(nvme_dev) && !is_blkdev(nvme_dev)) {
 		fprintf(stderr, "%s is not a block or character device\n", dev);
 		close(fd);
 		return -ENODEV;
@@ -369,7 +369,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	err = nvme_get_log_smart(dev->fd, cfg.namespace_id, false, &smart_log);
 	if (!err)
 		nvme_show_smart_log(&smart_log, cfg.namespace_id,
-				    nvme_dev->name, flags);
+				    dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -441,7 +441,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 
 	err = nvme_get_log_ana(dev->fd, lsp, true, 0, ana_log_len, ana_log);
 	if (!err) {
-		nvme_show_ana_log(ana_log, nvme_dev->name, flags, ana_log_len);
+		nvme_show_ana_log(ana_log, dev->name, flags, ana_log_len);
 	} else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -599,7 +599,7 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 					   &endurance_log);
 	if (!err)
 		nvme_show_endurance_log(&endurance_log, cfg.group_id,
-					nvme_dev->name, flags);
+					dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -768,7 +768,7 @@ static int get_supported_log_pages(int argc, char **argv, struct command *cmd,
 
 	err = nvme_get_log_supported_log_pages(dev->fd, false, &supports);
 	if (!err)
-		nvme_show_supported_log(&supports, nvme_dev->name, flags);
+		nvme_show_supported_log(&supports, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -849,7 +849,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	err = nvme_get_log_error(dev->fd, cfg.log_entries, false, err_log);
 	if (!err)
 		nvme_show_error_log(err_log, cfg.log_entries,
-				    nvme_dev->name, flags);
+				    dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -899,7 +899,7 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 
 	err = nvme_get_log_fw_slot(dev->fd, false, &fw_log);
 	if (!err)
-		nvme_show_fw_log(&fw_log, nvme_dev->name, flags);
+		nvme_show_fw_log(&fw_log, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -950,7 +950,7 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 	err = nvme_get_log_changed_ns_list(dev->fd, true, &changed_ns_list_log);
 	if (!err)
 		nvme_show_changed_ns_list_log(&changed_ns_list_log,
-					      nvme_dev->name, flags);
+					      dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1008,7 +1008,7 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 						  &plpns_log);
 	if (!err)
 		nvme_show_predictable_latency_per_nvmset(&plpns_log,
-			cfg.nvmset_id, nvme_dev->name, flags);
+			cfg.nvmset_id, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1099,7 +1099,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 						 pea_log);
 	if (!err)
 		nvme_show_predictable_latency_event_agg_log(pea_log, cfg.log_entries,
-			log_size, nvme_dev->name, flags);
+			log_size, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1227,7 +1227,7 @@ static int get_persistent_event_log(int argc, char **argv,
 		}
 
 		nvme_show_persistent_event_log(pevent_log_info, cfg.action,
-			cfg.log_len, nvme_dev->name, flags);
+			cfg.log_len, dev->name, flags);
 	} else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1323,7 +1323,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 					     endurance_log);
 	if (!err)
 		nvme_show_endurance_group_event_agg_log(endurance_log, cfg.log_entries,
-			log_size, nvme_dev->name, flags);
+			log_size, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1392,7 +1392,7 @@ static int get_lba_status_log(int argc, char **argv,
 
 	err = nvme_get_log_lba_status(dev->fd, cfg.rae, 0, lslplen, lab_status);
 	if (!err)
-		nvme_show_lba_status_log(lab_status, lslplen, nvme_dev->name, flags);
+		nvme_show_lba_status_log(lab_status, lslplen, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1442,7 +1442,7 @@ static int get_resv_notif_log(int argc, char **argv,
 
 	err = nvme_get_log_reservation(dev->fd, false, &resv);
 	if (!err)
-		nvme_show_resv_notif_log(&resv, nvme_dev->name, flags);
+		nvme_show_resv_notif_log(&resv, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1540,7 +1540,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 					  sizeof(boot) + bpsz,
 					  (struct nvme_boot_partition *)bp_log);
 	if (!err)
-		nvme_show_boot_part_log(&bp_log, nvme_dev->name, flags,
+		nvme_show_boot_part_log(&bp_log, dev->name, flags,
 					sizeof(boot) + bpsz);
 	else if (err > 0)
 		nvme_show_status(err);
@@ -1799,7 +1799,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	if (!err) {
 		if (!cfg.raw_binary) {
 			printf("Device:%s log-id:%d namespace-id:%#x\n",
-				nvme_dev->name, cfg.log_id,
+				dev->name, cfg.log_id,
 				cfg.namespace_id);
 			d(log, cfg.log_len, 16, 1);
 		} else
@@ -1863,7 +1863,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 
 	err = nvme_get_log_sanitize(dev->fd, cfg.rae, &sanitize_log);
 	if (!err)
-		nvme_show_sanitize_log(&sanitize_log, nvme_dev->name, flags);
+		nvme_show_sanitize_log(&sanitize_log, dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1914,7 +1914,7 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 	err = nvme_get_log_fid_supported_effects(dev->fd, false, &fid_support_log);
 	if (!err)
 		nvme_show_fid_support_effects_log(&fid_support_log,
-						  nvme_dev->name, flags);
+						  dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -1965,7 +1965,7 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 	err = nvme_get_log_mi_cmd_supported_effects(dev->fd, false, &mi_cmd_support_log);
 	if (!err)
 		nvme_show_mi_cmd_support_effects_log(&mi_cmd_support_log,
-						     nvme_dev->name, flags);
+						     dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -3468,7 +3468,7 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 		goto close_fd;
 	}
 	err = 0;
-	printf("%s: namespace-id:%d\n", nvme_dev->name, nsid);
+	printf("%s: namespace-id:%d\n", dev->name, nsid);
 
 close_fd:
 	dev_close(dev);
@@ -3779,7 +3779,7 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 	err = nvme_get_log_device_self_test(dev->fd, &log);
 	if (!err)
 		nvme_show_self_test_log(&log, cfg.dst_entries, 0,
-					nvme_dev->name, flags);
+					dev->name, flags);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
@@ -4872,9 +4872,9 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 
 	if (!cfg.force) {
 		fprintf(stderr, "You are about to format %s, namespace %#x%s.\n",
-			nvme_dev->name, cfg.namespace_id,
+			dev->name, cfg.namespace_id,
 			cfg.namespace_id == NVME_NSID_ALL ? "(ALL namespaces)" : "");
-		nvme_show_relatives(nvme_dev->name);
+		nvme_show_relatives(dev->name);
 		fprintf(stderr, "WARNING: Format may irrevocably delete this device's data.\n"
 			"You have 10 seconds to press Ctrl-C to cancel this operation.\n\n"
 			"Use the force [--force] option to suppress this warning.\n");
@@ -4903,7 +4903,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	else {
 		printf("Success formatting namespace:%x\n", cfg.namespace_id);
 		if (cfg.lbaf != prev_lbaf){
-			if (is_chardev()) {
+			if (is_chardev(dev)) {
 				if (ioctl(dev->fd, NVME_IOCTL_RESCAN) < 0) {
 					fprintf(stderr, "failed to rescan namespaces\n");
 					err = -errno;
@@ -4933,7 +4933,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 				}
 			}
 		}
-		if (cfg.reset && is_chardev())
+		if (cfg.reset && is_chardev(dev))
 			nvme_ctrl_reset(dev->fd);
 	}
 

--- a/nvme.c
+++ b/nvme.c
@@ -207,12 +207,12 @@ static ssize_t getrandom_bytes(void *buf, size_t buflen)
 
 static bool is_chardev(struct nvme_dev *dev)
 {
-	return S_ISCHR(dev->stat.st_mode);
+	return S_ISCHR(dev->direct.stat.st_mode);
 }
 
 static bool is_blkdev(struct nvme_dev *dev)
 {
-	return S_ISBLK(dev->stat.st_mode);
+	return S_ISBLK(dev->direct.stat.st_mode);
 }
 
 static int open_dev(struct nvme_dev **devp, char *devstr, int flags)
@@ -223,15 +223,17 @@ static int open_dev(struct nvme_dev **devp, char *devstr, int flags)
 	dev = calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
+
+	dev->type = NVME_DEV_DIRECT;
 	dev->name = basename(devstr);
 	err = open(devstr, flags);
 	if (err < 0) {
 		perror(devstr);
 		goto err_free;
 	}
-	dev->fd = err;
+	dev->direct.fd = err;
 
-	err = fstat(dev_fd(dev), &dev->stat);
+	err = fstat(dev_fd(dev), &dev->direct.stat);
 	if (err < 0) {
 		perror(devstr);
 		goto err_close;

--- a/nvme.c
+++ b/nvme.c
@@ -215,39 +215,41 @@ static bool is_blkdev(struct nvme_dev *dev)
 	return S_ISBLK(dev->stat.st_mode);
 }
 
-static int open_dev(struct nvme_dev **devp, char *dev, int flags)
+static int open_dev(struct nvme_dev **devp, char *devstr, int flags)
 {
-	static struct nvme_dev _nvme_dev;
-	static struct nvme_dev *nvme_dev = &_nvme_dev;
+	struct nvme_dev *dev;
+	int err;
 
-	int err, fd;
+	dev = calloc(1, sizeof(*dev));
+	if (!dev)
+		return -1;
 
-	/* Temporary: we use the global nvme_dev pointer for the nvme device.
-	 * This keeps the global in sync with the returned device. Later, we'll
-	 * remove the global entirely and allocate here instead.
-	 */
-	*devp = nvme_dev;
-
-	nvme_dev->name = basename(dev);
-	err = open(dev, flags);
-	if (err < 0)
-		goto perror;
-	fd = err;
-
-	err = fstat(fd, &nvme_dev->stat);
+	dev->name = basename(devstr);
+	err = open(devstr, flags);
 	if (err < 0) {
-		close(fd);
-		goto perror;
+		perror(devstr);
+		goto err_free;
 	}
-	if (!is_chardev(nvme_dev) && !is_blkdev(nvme_dev)) {
-		fprintf(stderr, "%s is not a block or character device\n", dev);
-		close(fd);
-		return -ENODEV;
+	dev->fd = err;
+
+	err = fstat(dev->fd, &dev->stat);
+	if (err < 0) {
+		perror(devstr);
+		goto err_close;
 	}
-	nvme_dev->fd = fd;
+	if (!is_chardev(dev) && !is_blkdev(dev)) {
+		fprintf(stderr, "%s is not a block or character device\n",
+			devstr);
+		err = -ENODEV;
+		goto err_close;
+	}
+	*devp = dev;
 	return 0;
-perror:
-	perror(dev);
+
+err_close:
+	close(dev->fd);
+err_free:
+	free(dev);
 	return err;
 }
 
@@ -316,6 +318,7 @@ enum nvme_print_flags validate_output_format(const char *format)
 void dev_close(struct nvme_dev *dev)
 {
 	close(dev->fd);
+	free(dev);
 }
 
 static int get_smart_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)

--- a/nvme.h
+++ b/nvme.h
@@ -37,14 +37,21 @@ enum nvme_print_flags {
 
 #define SYS_NVME "/sys/class/nvme"
 
-void register_extension(struct plugin *plugin);
-int parse_and_open(int argc, char **argv, const char *desc,
-	const struct argconfig_commandline_options *clo);
-
 struct nvme_dev {
+	int fd;
 	struct stat stat;
 	const char *name;
 };
+
+void register_extension(struct plugin *plugin);
+
+/*
+ * parse_and_open - parses arguments and opens the NVMe device, populating @dev
+ */
+int parse_and_open(struct nvme_dev **dev, int argc, char **argv, const char *desc,
+	const struct argconfig_commandline_options *clo);
+
+void dev_close(struct nvme_dev *dev);
 
 extern struct nvme_dev *nvme_dev;
 extern const char *output_format;

--- a/nvme.h
+++ b/nvme.h
@@ -24,6 +24,8 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 
+#include <libnvme-mi.h>
+
 #include "plugin.h"
 #include "util/json.h"
 #include "util/argconfig.h"
@@ -40,6 +42,7 @@ enum nvme_print_flags {
 
 enum nvme_dev_type {
 	NVME_DEV_DIRECT,
+	NVME_DEV_MI,
 };
 
 struct nvme_dev {
@@ -49,6 +52,11 @@ struct nvme_dev {
 			int fd;
 			struct stat stat;
 		} direct;
+		struct {
+			nvme_root_t root;
+			nvme_mi_ep_t ep;
+			nvme_mi_ctrl_t ctrl;
+		} mi;
 	};
 
 	const char *name;
@@ -65,6 +73,16 @@ static inline int __dev_fd(struct nvme_dev *dev, const char *func, int line)
 		return -1;
 	}
 	return dev->direct.fd;
+}
+
+static inline nvme_mi_ep_t dev_mi_ep(struct nvme_dev *dev)
+{
+	if (dev->type != NVME_DEV_MI) {
+		fprintf(stderr,
+			"warning: not a MI transport!\n");
+		return NULL;
+	}
+	return dev->mi.ep;
 }
 
 void register_extension(struct plugin *plugin);

--- a/nvme.h
+++ b/nvme.h
@@ -53,7 +53,6 @@ int parse_and_open(struct nvme_dev **dev, int argc, char **argv, const char *des
 
 void dev_close(struct nvme_dev *dev);
 
-extern struct nvme_dev *nvme_dev;
 extern const char *output_format;
 
 enum nvme_print_flags validate_output_format(const char *format);

--- a/nvme.h
+++ b/nvme.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <endian.h>
 #include <sys/time.h>
+#include <sys/stat.h>
 
 #include "plugin.h"
 #include "util/json.h"
@@ -40,7 +41,12 @@ void register_extension(struct plugin *plugin);
 int parse_and_open(int argc, char **argv, const char *desc,
 	const struct argconfig_commandline_options *clo);
 
-extern const char *devicename;
+struct nvme_dev {
+	struct stat stat;
+	const char *name;
+};
+
+extern struct nvme_dev *nvme_dev;
 extern const char *output_format;
 
 enum nvme_print_flags validate_output_format(const char *format);

--- a/nvme.h
+++ b/nvme.h
@@ -43,6 +43,11 @@ struct nvme_dev {
 	const char *name;
 };
 
+static inline int dev_fd(struct nvme_dev *dev)
+{
+	return dev->fd;
+}
+
 void register_extension(struct plugin *plugin);
 
 /*

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -131,7 +131,7 @@ static int get_status(int argc, char **argv, struct command *cmd, struct plugin 
 	if (err < 0)
 		return err;
 	
-	err = nvme_get_log_simple(dev->fd, 0xc0, sizeof(log), &log);
+	err = nvme_get_log_simple(dev_fd(dev), 0xc0, sizeof(log), &log);
 	if (err) {
 		goto exit;
 	}
@@ -154,7 +154,7 @@ static int get_status(int argc, char **argv, struct command *cmd, struct plugin 
 		"Runtime Low",
 	};
 
-	err = nvme_dera_get_device_status(dev->fd, &state);
+	err = nvme_dera_get_device_status(dev_fd(dev), &state);
 	if (!err){
 		if (state > 0 && state < 4){
 			printf("device_status                       : %s %d%% completed\n", dev_status[state], log.rebuild_percent);

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -43,7 +43,7 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 	if (err < 0)
 		return err;
 
-	nvme_get_log_smart(dev->fd, cfg.namespace_id, false, &smart_log);
+	nvme_get_log_smart(dev_fd(dev), cfg.namespace_id, false, &smart_log);
 	nvme_show_smart_log(&smart_log, cfg.namespace_id, dev->name, NORMAL);
 
 	printf("DW0[0-1]  Defect Cnt                    : %u\n", pvsc_smart->defect_cnt);
@@ -213,7 +213,7 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 		icount++;
 
 		memset(data, 0, 4096);
-		ret = nvme_vucmd(dev->fd, NVME_VSC_GET_EVENT_LOG, 0, 0,
+		ret = nvme_vucmd(dev_fd(dev), NVME_VSC_GET_EVENT_LOG, 0, 0,
 				 (SRB_SIGNATURE >> 32),
 				 (SRB_SIGNATURE & 0xFFFFFFFF),
 				 (char *)data, 4096);
@@ -281,8 +281,9 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 
 	if (cfg.clean_flg == 1) {
 		printf("Clean eventlog\n");
-		nvme_vucmd(dev->fd, NVME_VSC_CLEAN_EVENT_LOG, 0, 0, (SRB_SIGNATURE >> 32),
-			(SRB_SIGNATURE & 0xFFFFFFFF), (char *)NULL, 0);
+		nvme_vucmd(dev_fd(dev), NVME_VSC_CLEAN_EVENT_LOG, 0, 0,
+			   (SRB_SIGNATURE >> 32),
+			   (SRB_SIGNATURE & 0xFFFFFFFF), (char *)NULL, 0);
 	}
 
 	dev_close(dev);
@@ -322,7 +323,7 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 
 	ipackindex = 0;
 	memset(data, 0, 4096);
-	if (nvme_vucmd(dev->fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00,
+	if (nvme_vucmd(dev_fd(dev), NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00,
 		       (SRB_SIGNATURE >> 32), (SRB_SIGNATURE & 0xFFFFFFFF),
 		       (char *)data, 4096) == 0) {
 		memcpy(&cdumpinfo, &data[3072], sizeof(cdumpinfo));
@@ -345,7 +346,8 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 
 	if (busevsc == false) {
 		memset(data, 0, 4096);
-		ret = nvme_get_nsid_log(dev->fd, true, 0x07, NVME_NSID_ALL,
+		ret = nvme_get_nsid_log(dev_fd(dev), true, 0x07,
+					NVME_NSID_ALL,
 					4096, data);
 		if (ret != 0)
 			return ret;
@@ -369,13 +371,14 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 		for (icur = 0; icur < itotal; icur += 4096) {
 			memset(data, 0, 4096);
 			if (busevsc)
-				ret = nvme_vucmd(dev->fd, NVME_VSC_GET,
+				ret = nvme_vucmd(dev_fd(dev), NVME_VSC_GET,
 						 VSC_FN_GET_CDUMP, 0x00,
 						 (SRB_SIGNATURE >> 32),
 						 (SRB_SIGNATURE & 0xFFFFFFFF),
 						 (char *)data, 4096);
 			else
-				ret = nvme_get_nsid_log(dev->fd, true, 0x07,
+				ret = nvme_get_nsid_log(dev_fd(dev), true,
+							0x07,
 							NVME_NSID_ALL, 4096, data);
 			if (ret != 0)
 				return ret;
@@ -392,13 +395,14 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 		if (ipackindex != ipackcount) {
 			memset(data, 0, 4096);
 			if (busevsc)
-				ret = nvme_vucmd(dev->fd, NVME_VSC_GET,
+				ret = nvme_vucmd(dev_fd(dev), NVME_VSC_GET,
 						 VSC_FN_GET_CDUMP, 0x00,
 						 (SRB_SIGNATURE >> 32),
 						 (SRB_SIGNATURE & 0xFFFFFFFF),
 						 (char *)data, 4096);
 			else
-				ret = nvme_get_nsid_log(dev->fd, true, 0x07,
+				ret = nvme_get_nsid_log(dev_fd(dev), true,
+							0x07,
 							NVME_NSID_ALL, 4096,
 							data);
 			if (ret != 0)

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -44,8 +44,7 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 		return err;
 
 	nvme_get_log_smart(dev->fd, cfg.namespace_id, false, &smart_log);
-	nvme_show_smart_log(&smart_log, cfg.namespace_id,
-			    nvme_dev->name, NORMAL);
+	nvme_show_smart_log(&smart_log, cfg.namespace_id, dev->name, NORMAL);
 
 	printf("DW0[0-1]  Defect Cnt                    : %u\n", pvsc_smart->defect_cnt);
 	printf("DW0[2-3]  Slc Spb Cnt                   : %u\n", pvsc_smart->slc_spb_cnt);

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -20,10 +20,11 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 					 struct plugin *plugin)
 {
 	struct nvme_smart_log smart_log = { 0 };
-	int fd, i, iindex;
 	struct vsc_smart_log *pvsc_smart = (struct vsc_smart_log *)smart_log.rsvd232;
 	const char *desc = "Retrieve additional SMART log for the given device ";
 	const char *namespace = "(optional) desired namespace";
+	struct nvme_dev *dev;
+	int err, i, iindex;
 
 	struct config {
 		__u32 namespace_id;
@@ -38,11 +39,11 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
+	nvme_get_log_smart(dev->fd, cfg.namespace_id, false, &smart_log);
 	nvme_show_smart_log(&smart_log, cfg.namespace_id,
 			    nvme_dev->name, NORMAL);
 
@@ -164,9 +165,10 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 	unsigned int isize, icheck_stopvalue, iend;
 	unsigned char bSortLog = false, bget_nextlog = true;
 	struct evlg_flush_hdr *pevlog = (struct evlg_flush_hdr *)data;
-	int fd, ret = -1;
 	const char *desc = "Recrieve event log for the given device ";
 	const char *clean_opt = "(optional) 1 for clean event log";
+	struct nvme_dev *dev;
+	int ret = -1;
 
 	struct config {
 		__u32 clean_flg;
@@ -181,9 +183,9 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	ret = parse_and_open(&dev, argc, argv, desc, opts);
+	if (ret < 0)
+		return ret;
 
 
 	if (getcwd(currentdir, 128) == NULL)
@@ -212,8 +214,10 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 		icount++;
 
 		memset(data, 0, 4096);
-		ret = nvme_vucmd(fd, NVME_VSC_GET_EVENT_LOG, 0, 0, (SRB_SIGNATURE >> 32),
-			(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096);
+		ret = nvme_vucmd(dev->fd, NVME_VSC_GET_EVENT_LOG, 0, 0,
+				 (SRB_SIGNATURE >> 32),
+				 (SRB_SIGNATURE & 0xFFFFFFFF),
+				 (char *)data, 4096);
 		if (ret == -1)
 			return ret;
 
@@ -278,9 +282,11 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 
 	if (cfg.clean_flg == 1) {
 		printf("Clean eventlog\n");
-		nvme_vucmd(fd, NVME_VSC_CLEAN_EVENT_LOG, 0, 0, (SRB_SIGNATURE >> 32),
+		nvme_vucmd(dev->fd, NVME_VSC_CLEAN_EVENT_LOG, 0, 0, (SRB_SIGNATURE >> 32),
 			(SRB_SIGNATURE & 0xFFFFFFFF), (char *)NULL, 0);
 	}
+
+	dev_close(dev);
 
 	return ret;
 }
@@ -297,16 +303,17 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 	unsigned char busevsc = false;
 	unsigned int ipackcount, ipackindex;
 	char fwvera[32];
-	int fd, ret = -1;
 	const char *desc = "Recrieve cdump data for the given device ";
+	struct nvme_dev *dev;
+	int ret = -1;
 
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	ret = parse_and_open(&dev, argc, argv, desc, opts);
+	if (ret < 0)
+		return ret;
 
 	if (getcwd(currentdir, 128) == NULL)
 		return -1;
@@ -316,8 +323,9 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 
 	ipackindex = 0;
 	memset(data, 0, 4096);
-	if (nvme_vucmd(fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00, (SRB_SIGNATURE >> 32),
-		(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096) == 0) {
+	if (nvme_vucmd(dev->fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00,
+		       (SRB_SIGNATURE >> 32), (SRB_SIGNATURE & 0xFFFFFFFF),
+		       (char *)data, 4096) == 0) {
 		memcpy(&cdumpinfo, &data[3072], sizeof(cdumpinfo));
 		if (cdumpinfo.sig == 0x5a5b5c5d) {
 			busevsc = true;
@@ -338,7 +346,8 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 
 	if (busevsc == false) {
 		memset(data, 0, 4096);
-		ret = nvme_get_nsid_log(fd, true, 0x07, NVME_NSID_ALL, 4096, data);
+		ret = nvme_get_nsid_log(dev->fd, true, 0x07, NVME_NSID_ALL,
+					4096, data);
 		if (ret != 0)
 			return ret;
 
@@ -361,10 +370,14 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 		for (icur = 0; icur < itotal; icur += 4096) {
 			memset(data, 0, 4096);
 			if (busevsc)
-				ret = nvme_vucmd(fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00, (SRB_SIGNATURE >> 32),
-					(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096);
+				ret = nvme_vucmd(dev->fd, NVME_VSC_GET,
+						 VSC_FN_GET_CDUMP, 0x00,
+						 (SRB_SIGNATURE >> 32),
+						 (SRB_SIGNATURE & 0xFFFFFFFF),
+						 (char *)data, 4096);
 			else
-				ret = nvme_get_nsid_log(fd, true, 0x07, NVME_NSID_ALL, 4096, data);
+				ret = nvme_get_nsid_log(dev->fd, true, 0x07,
+							NVME_NSID_ALL, 4096, data);
 			if (ret != 0)
 				return ret;
 
@@ -380,10 +393,15 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 		if (ipackindex != ipackcount) {
 			memset(data, 0, 4096);
 			if (busevsc)
-				ret = nvme_vucmd(fd, NVME_VSC_GET, VSC_FN_GET_CDUMP, 0x00, (SRB_SIGNATURE >> 32),
-					(SRB_SIGNATURE & 0xFFFFFFFF), (char *)data, 4096);
+				ret = nvme_vucmd(dev->fd, NVME_VSC_GET,
+						 VSC_FN_GET_CDUMP, 0x00,
+						 (SRB_SIGNATURE >> 32),
+						 (SRB_SIGNATURE & 0xFFFFFFFF),
+						 (char *)data, 4096);
 			else
-				ret = nvme_get_nsid_log(fd, true, 0x07, NVME_NSID_ALL, 4096, data);
+				ret = nvme_get_nsid_log(dev->fd, true, 0x07,
+							NVME_NSID_ALL, 4096,
+							data);
 			if (ret != 0)
 				return ret;
 
@@ -399,5 +417,6 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 	}
 
 	printf("\n");
+	dev_close(dev);
 	return ret;
 }

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -43,7 +43,8 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 		return fd;
 
 	nvme_get_log_smart(fd, cfg.namespace_id, false, &smart_log);
-	nvme_show_smart_log(&smart_log, cfg.namespace_id, devicename, NORMAL);
+	nvme_show_smart_log(&smart_log, cfg.namespace_id,
+			    nvme_dev->name, NORMAL);
 
 	printf("DW0[0-1]  Defect Cnt                    : %u\n", pvsc_smart->defect_cnt);
 	printf("DW0[2-3]  Slc Spb Cnt                   : %u\n", pvsc_smart->slc_spb_cnt);

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -372,10 +372,10 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (!err) {
 		if (cfg.json)
 			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id,
-						 nvme_dev->name);
+						 dev->name);
 		else if (!cfg.raw_binary)
 			show_intel_smart_log(&smart_log, cfg.namespace_id,
-					     nvme_dev->name);
+					     dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -370,9 +370,11 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	err = nvme_get_log_simple(fd, 0xca, sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (cfg.json)
-			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id, devicename);
+			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id,
+						 nvme_dev->name);
 		else if (!cfg.raw_binary)
-			show_intel_smart_log(&smart_log, cfg.namespace_id, devicename);
+			show_intel_smart_log(&smart_log, cfg.namespace_id,
+					     nvme_dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -344,7 +344,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	const char *json= "Dump output in json format";
 
 	struct nvme_additional_smart_log smart_log;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	struct config {
 		__u32 namespace_id;
@@ -363,11 +364,11 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_log_simple(fd, 0xca, sizeof(smart_log), &smart_log);
+	err = nvme_get_log_simple(dev->fd, 0xca, sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (cfg.json)
 			show_intel_smart_log_jsn(&smart_log, cfg.namespace_id,
@@ -380,7 +381,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	}
 	else if (err > 0)
 		nvme_show_status(err);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -388,9 +389,9 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 {
 	const char *desc = "Get Intel Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
-
+	struct nvme_dev *dev;
 	char log[512];
-	int err, fd;
+	int err;
 
 	struct config {
 		bool  raw_binary;
@@ -404,11 +405,11 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_log_simple(fd, 0xdd, sizeof(log), log);
+	err = nvme_get_log_simple(dev->fd, 0xdd, sizeof(log), log);
 	if (!err) {
 		if (!cfg.raw_binary)
 			printf("Intel Marketing Name Log:\n%s\n", log);
@@ -416,7 +417,7 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 			d_raw((unsigned char *)&log, sizeof(log));
 	} else if (err > 0)
 		nvme_show_status(err);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -449,7 +450,8 @@ static void show_temp_stats(struct intel_temp_stats *stats)
 static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	struct intel_temp_stats stats;
-	int err, fd;
+	struct nvme_dev *dev;
+	int err;
 
 	const char *desc = "Get Temperature Statistics log and show it.";
 	const char *raw = "dump output in binary format";
@@ -465,11 +467,11 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_log_simple(fd, 0xc5, sizeof(stats), &stats);
+	err = nvme_get_log_simple(dev->fd, 0xc5, sizeof(stats), &stats);
 	if (!err) {
 		if (!cfg.raw_binary)
 			show_temp_stats(&stats);
@@ -477,7 +479,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 			d_raw((unsigned char *)&stats, sizeof(stats));
 	} else if (err > 0)
 		nvme_show_status(err);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -1026,9 +1028,9 @@ static void show_lat_stats(int write)
 
 static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-
-	int err, fd;
 	__u8 data[NAND_LAT_STATS_LEN];
+	struct nvme_dev *dev;
+	int err;
 
 	const char *desc = "Get Intel Latency Statistics log and show it.";
 	const char *raw = "Dump output in binary format";
@@ -1051,14 +1053,14 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
 	/* For optate, latency stats are deleted every time their LID is pulled.
 	 * Therefore, we query the longest lat_stats log page first.
 	 */
-	err = nvme_get_log_simple(fd, cfg.write ? 0xc2 : 0xc1,
+	err = nvme_get_log_simple(dev->fd, cfg.write ? 0xc2 : 0xc1,
 			   sizeof(data), &data);
 
 	media_version[0] = (data[1] << 8) | data[0];
@@ -1073,7 +1075,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 
 		struct nvme_get_features_args args = {
 			.args_size	= sizeof(args),
-			.fd		= fd,
+			.fd		= dev->fd,
 			.fid		= 0xf7,
 			.nsid		= 0,
 			.sel		= 0,
@@ -1125,7 +1127,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	}
 
 close_fd:
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -1340,13 +1342,14 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 {
 	__u8 buf[0x2000];
 	char f[0x100];
-	int err, fd, output, i, j, count = 0, core_num = 1;
+	int err, output, i, j, count = 0, core_num = 1;
 	struct nvme_passthru_cmd cmd;
 	struct intel_cd_log cdlog;
 	struct intel_vu_log *intel = malloc(sizeof(struct intel_vu_log));
 	struct intel_vu_nlog *intel_nlog = (struct intel_vu_nlog *)buf;
 	struct intel_assert_dump *ad = (struct intel_assert_dump *) intel->reserved;
 	struct intel_event_header *ehdr = (struct intel_event_header *)intel->reserved;
+	struct nvme_dev *dev;
 
 	const char *desc = "Get Intel Firmware Log and save it.";
 	const char *log = "Log type: 0, 1, or 2 for nlog, event log, and assert log, respectively.";
@@ -1382,10 +1385,10 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0) {
 		free(intel);
-		return fd;
+		return err;
 	}
 
 	if (cfg.log > 2 || cfg.core > 4 || cfg.lnum > 255) {
@@ -1394,7 +1397,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 	}
 
 	if (!cfg.file) {
-		err = setup_file(f, cfg.file, fd, cfg.log);
+		err = setup_file(f, cfg.file, dev->fd, cfg.log);
 		if (err)
 			goto out_free;
 		cfg.file = f;
@@ -1412,7 +1415,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 		goto out_free;
 	}
 
-	err = read_header(&cmd, buf, fd, cdlog.u.entireDword, cfg.namespace_id);
+	err = read_header(&cmd, buf, dev->fd, cdlog.u.entireDword, cfg.namespace_id);
 	if (err)
 		goto out;
 	memcpy(intel, buf, sizeof(*intel));
@@ -1421,7 +1424,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 	if ((intel->ver.major < 1 && intel->ver.minor < 1) ||
 	    (intel->ver.major <= 1 && intel->ver.minor <= 1 && cfg.log == 0)) {
 		cmd.addr = (unsigned long)(void *)buf;
-		err = get_internal_log_old(buf, output, fd, &cmd);
+		err = get_internal_log_old(buf, output, dev->fd, &cmd);
 		goto out;
 	}
 
@@ -1465,7 +1468,8 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				cmd.cdw10 = 0x400;
 				cmd.data_len = min(0x400, ad[i].assertsize) * 4;
 				err = read_entire_cmd(&cmd, ad[i].assertsize,
-						      0x400, output, fd, buf);
+						      0x400, output, dev->fd,
+						      buf);
 				if (err)
 					goto out;
 
@@ -1474,8 +1478,9 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				if (count > 1)
 					cdlog.u.fields.selectNlog = i;
 
-				err = read_header(&cmd, buf, fd, cdlog.u.entireDword,
-						cfg.namespace_id);
+				err = read_header(&cmd, buf, dev->fd,
+						  cdlog.u.entireDword,
+						  cfg.namespace_id);
 				if (err)
 					goto out;
 				err = write_header(buf, output, sizeof(*intel_nlog));
@@ -1487,7 +1492,8 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				cmd.cdw10 = 0x400;
 				cmd.data_len = min(0x1000, intel_nlog->nlogbytesize);
 				err = read_entire_cmd(&cmd, intel_nlog->nlogbytesize / 4,
-						      0x400, output, fd, buf);
+						      0x400, output, dev->fd,
+						      buf);
 				if (err)
 					goto out;
 			} else if (cfg.log == 1) {
@@ -1495,7 +1501,8 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 				cmd.cdw10 = 0x400;
 				cmd.data_len = 0x400;
 				err = read_entire_cmd(&cmd, ehdr->edumps[j].coresize,
-						      0x400, output, fd, buf);
+						      0x400, output, dev->fd,
+						      buf);
 				if (err)
 					goto out;
 			}
@@ -1513,14 +1520,13 @@ out:
 	close(output);
 out_free:
 	free(intel);
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
 static int enable_lat_stats_tracking(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	int err, fd;
 	const char *desc = (
 			"Enable/Disable Intel Latency Statistics Tracking.\n"
 			"No argument prints current status.");
@@ -1533,8 +1539,10 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	const __u32 cdw12 = 0x0;
 	const __u32 data_len = 32;
 	const __u32 save = 0;
-	__u32 result;
+	struct nvme_dev *dev;
 	void *buf = NULL;
+	__u32 result;
+	int err;
 
 	struct config {
 		bool enable, disable;
@@ -1551,7 +1559,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		{NULL}
 	};
 
-	fd = parse_and_open(argc, argv, desc, command_line_options);
+	err = parse_and_open(&dev, argc, argv, desc, command_line_options);
 
 	enum Option {
 		None = -1,
@@ -1566,12 +1574,12 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	else if (cfg.enable || cfg.disable)
 		option = cfg.enable;
 
-	if (fd < 0)
-		return fd;
+	if (err < 0)
+		return err;
 
 	struct nvme_get_features_args args_get = {
 		.args_size	= sizeof(args_get),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1585,7 +1593,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 
 	struct nvme_set_features_args args_set = {
 		.args_size	= sizeof(args_set),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,
@@ -1608,7 +1616,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 				fid, result);
 		} else {
 			printf("Could not read feature id 0xE2.\n");
-			close(fd);
+			dev_close(dev);
 			return err;
 		}
 		break;
@@ -1629,14 +1637,13 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		printf("%d not supported.\n", option);
 		return EINVAL;
 	}
-	close(fd);
-	return fd;
+	dev_close(dev);
+	return err;
 }
 
 static int set_lat_stats_thresholds(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	int err, fd, num;
 	const char *desc = "Write Intel Bucket Thresholds for Latency Statistics Tracking";
 	const char *bucket_thresholds = "Bucket Threshold List, comma separated list: 0, 10, 20 ...";
 	const char *write = "Set write bucket Thresholds for latency tracking (read default)";
@@ -1645,7 +1652,9 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 	const __u8 fid = 0xf7;
 	const __u32 cdw12 = 0x0;
 	const __u32 save = 0;
+	struct nvme_dev *dev;
 	__u32 result;
+	int err, num;
 
 	struct config {
 		bool write;
@@ -1664,21 +1673,21 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
+	err = parse_and_open(&dev, argc, argv, desc, opts);
 
-	if (fd < 0)
-		return fd;
+	if (err < 0)
+		return err;
 
 	/* Query maj and minor version first to figure out the amount of
 	 * valid buckets a user is allowed to modify. Read or write doesn't
 	 * matter
 	 */
-	err = nvme_get_log_simple(fd, 0xc2,
+	err = nvme_get_log_simple(dev->fd, 0xc2,
 			   sizeof(media_version), media_version);
 	if (err) {
 		fprintf(stderr, "Querying media version failed. ");
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (media_version[0] == 1000) {
@@ -1688,13 +1697,13 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 						      sizeof(thresholds));
 		if (num == -1) {
 			fprintf(stderr, "ERROR: Bucket list is malformed\n");
-			goto close_fd;
+			goto close_dev;
 
 		}
 
 		struct nvme_set_features_args args = {
 			.args_size	= sizeof(args),
-			.fd		= fd,
+			.fd		= dev->fd,
 			.fid		= fid,
 			.nsid		= nsid,
 			.cdw11		= cfg.write ? 0x1 : 0x0,
@@ -1719,8 +1728,8 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 		fprintf(stderr, "Unsupported command\n");
 	}
 
-close_fd:
-	close(fd);
+close_dev:
+	dev_close(dev);
 	return err;
 }
 

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -483,8 +483,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 	if (!err) {
 		if (!cfg.raw_binary)
 			err = show_memblaze_smart_log(dev->fd, cfg.namespace_id,
-						      nvme_dev->name,
-						      &smart_log);
+						      dev->name, &smart_log);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -481,7 +481,9 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 		sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
-			err = show_memblaze_smart_log(fd, cfg.namespace_id, devicename, &smart_log);
+			err = show_memblaze_smart_log(fd, cfg.namespace_id,
+						      nvme_dev->name,
+						      &smart_log);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -478,11 +478,12 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 	if (err < 0)
 		return err;
 
-	err = nvme_get_nsid_log(dev->fd, false, 0xca, cfg.namespace_id,
-		sizeof(smart_log), &smart_log);
+	err = nvme_get_nsid_log(dev_fd(dev), false, 0xca, cfg.namespace_id,
+				sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
-			err = show_memblaze_smart_log(dev->fd, cfg.namespace_id,
+			err = show_memblaze_smart_log(dev_fd(dev),
+						      cfg.namespace_id,
 						      dev->name, &smart_log);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
@@ -522,7 +523,7 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
 
     struct nvme_get_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= dev->fd,
+	    .fd			= dev_fd(dev),
 	    .fid		= feature_id,
 	    .nsid		= 0,
 	    .sel		= 0,
@@ -580,7 +581,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
 
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= dev->fd,
+	    .fd			= dev_fd(dev),
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -657,7 +658,7 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
 
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= dev->fd,
+	    .fd			= dev_fd(dev),
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -798,12 +799,12 @@ static int mb_high_latency_log_print(int argc, char **argv, struct command *cmd,
     fdi = fopen(FID_C3_LOG_FILENAME, "w+");
 
     glp_high_latency_show_bar(fdi, DO_PRINT_FLAG);
-    err = nvme_get_log_simple(dev->fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG,
+    err = nvme_get_log_simple(dev_fd(dev), GLP_ID_VU_GET_HIGH_LATENCY_LOG,
 			      sizeof(buf), &buf);
 
     while (1) {
         if (!glp_high_latency(fdi, buf, LOG_PAGE_SIZE, DO_PRINT_FLAG)) break;
-        err = nvme_get_log_simple(dev->fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG,
+        err = nvme_get_log_simple(dev_fd(dev), GLP_ID_VU_GET_HIGH_LATENCY_LOG,
 				  sizeof(buf), &buf);
         if ( err) {
 	    nvme_show_status(err);
@@ -925,7 +926,7 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 
 		struct nvme_fw_download_args args = {
 			.args_size	= sizeof(args),
-			.fd		= dev->fd,
+			.fd		= dev_fd(dev),
 			.offset		= offset,
 			.data_len	= xfer,
 			.data		= fw_buf,
@@ -945,7 +946,7 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 		offset += xfer;
 	}
 
-	err = memblaze_fw_commit(dev->fd, selectNo);
+	err = memblaze_fw_commit(dev_fd(dev), selectNo);
 
 	if(err == 0x10B || err == 0x20B) {
 		err = 0;
@@ -1088,7 +1089,7 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, st
     if (err < 0)
 	    return err;
 
-    err = nvme_get_log_simple(dev->fd, cfg.write ? 0xc2 : 0xc1,
+    err = nvme_get_log_simple(dev_fd(dev), cfg.write ? 0xc2 : 0xc1,
 			      sizeof(stats), &stats);
     if (!err)
         io_latency_histogram(cfg.write ? f2 : f1, stats, DO_PRINT_FLAG,
@@ -1134,7 +1135,7 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
 
     struct nvme_set_features_args args = {
         .args_size      = sizeof(args),
-        .fd             = dev->fd,
+        .fd             = dev_fd(dev),
         .fid            = cfg.feature_id,
         .nsid           = 0,
         .cdw11          = cfg.value,
@@ -1225,7 +1226,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 
 	struct nvme_get_features_args args_get = {
 		.args_size	= sizeof(args_get),
-		.fd		= dev->fd,
+		.fd		= dev_fd(dev),
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1239,7 +1240,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 
 	struct nvme_set_features_args args_set = {
 		.args_size	= sizeof(args_set),
-		.fd		= dev->fd,
+		.fd		= dev_fd(dev),
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -453,15 +453,16 @@ int parse_params(char *str, int number, ...)
 static int mb_get_additional_smart_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	struct nvme_memblaze_smart_log smart_log;
-	int err, fd;
 	char *desc = "Get Memblaze vendor specific additional smart log (optionally, "\
 		      "for the specified namespace), and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
+	struct nvme_dev *dev;
 	struct config {
 		__u32 namespace_id;
 		bool  raw_binary;
 	};
+	int err;
 
 	struct config cfg = {
 		.namespace_id = NVME_NSID_ALL,
@@ -473,15 +474,15 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
-	err = nvme_get_nsid_log(fd, false, 0xca, cfg.namespace_id,
+	err = nvme_get_nsid_log(dev->fd, false, 0xca, cfg.namespace_id,
 		sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
-			err = show_memblaze_smart_log(fd, cfg.namespace_id,
+			err = show_memblaze_smart_log(dev->fd, cfg.namespace_id,
 						      nvme_dev->name,
 						      &smart_log);
 		else
@@ -490,7 +491,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 	if (err > 0)
 		nvme_show_status(err);
 
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -507,20 +508,22 @@ static char *mb_feature_to_string(int feature)
 static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
     const char *desc = "Get Memblaze power management ststus\n	(value 0 - 25w, 1 - 20w, 2 - 15w)";
-    int err, fd;
     __u32 result;
     __u32 feature_id = MB_FEAT_POWER_MGMT;
+    struct nvme_dev *dev;
+    int err;
 
     OPT_ARGS(opts) = {
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     struct nvme_get_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= fd,
+	    .fd			= dev->fd,
 	    .fid		= feature_id,
 	    .nsid		= 0,
 	    .sel		= 0,
@@ -541,7 +544,7 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
             nvme_select_to_string(0), result);
     } else if (err > 0)
 	    nvme_show_status(err);
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -550,8 +553,9 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     const char *desc = "Set Memblaze power management status\n	(value 0 - 25w, 1 - 20w, 2 - 15w)";
     const char *value = "new value of feature (required)";
     const char *save = "specifies that the controller shall save the attribute";
-    int err, fd;
+    struct nvme_dev *dev;
     __u32 result;
+    int err;
 
     struct config {
         __u32 feature_id;
@@ -571,12 +575,13 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= fd,
+	    .fd			= dev->fd,
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -599,7 +604,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     } else if (err > 0)
 	nvme_show_status(err);
 
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -613,9 +618,10 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
                        "	p1 value: 0 is disable, 1 is enable\n"\
                        "	p2 value: 1 .. 5000 ms";
     const char *param = "input parameters";
-    int err, fd;
-    __u32 result;
     int param1 = 0, param2 = 0;
+    struct nvme_dev *dev;
+    __u32 result;
+    int err;
 
     struct config {
         __u32 feature_id;
@@ -634,24 +640,25 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     if (parse_params(cfg.param, 2, &param1, &param2)) {
         printf("setfeature: invalid formats %s\n", cfg.param);
-        close(fd);
+        dev_close(dev);
         return EINVAL;
     }
     if ((param1 == 1) && (param2 < P2MIN || param2 > P2MAX)) {
         printf("setfeature: invalid high io latency threshold %d\n", param2);
-        close(fd);
+        dev_close(dev);
         return EINVAL;
     }
     cfg.value = (param1 << MB_FEAT_HIGH_LATENCY_VALUE_SHIFT) | param2;
 
     struct nvme_set_features_args args = {
 	    .args_size		= sizeof(args),
-	    .fd			= fd,
+	    .fd			= dev->fd,
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -674,7 +681,7 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
     } else if (err > 0)
 	nvme_show_status(err);
 
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -776,25 +783,29 @@ static int glp_high_latency(FILE *fdi, char *buf, int buflen, int print)
 static int mb_high_latency_log_print(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
     const char *desc = "Get Memblaze high latency log";
-    int err, fd;
     char buf[LOG_PAGE_SIZE];
+    struct nvme_dev *dev;
     FILE *fdi = NULL;
+    int err;
 
     OPT_ARGS(opts) = {
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
     fdi = fopen(FID_C3_LOG_FILENAME, "w+");
 
     glp_high_latency_show_bar(fdi, DO_PRINT_FLAG);
-    err = nvme_get_log_simple(fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG, sizeof(buf), &buf);
+    err = nvme_get_log_simple(dev->fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG,
+			      sizeof(buf), &buf);
 
     while (1) {
         if (!glp_high_latency(fdi, buf, LOG_PAGE_SIZE, DO_PRINT_FLAG)) break;
-        err = nvme_get_log_simple(fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG, sizeof(buf), &buf);
+        err = nvme_get_log_simple(dev->fd, GLP_ID_VU_GET_HIGH_LATENCY_LOG,
+				  sizeof(buf), &buf);
         if ( err) {
 	    nvme_show_status(err);
             break;
@@ -802,7 +813,7 @@ static int mb_high_latency_log_print(int argc, char **argv, struct command *cmd,
     }
 
     if (NULL != fdi) fclose(fdi);
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -831,7 +842,8 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 	const char *select = "FW Select (e.g., --select=OOB, EEP, ALL)";
 	int xfer = 4096;
 	void *fw_buf;
-	int fd, selectNo,fw_fd,fw_size,err,offset = 0;
+	int selectNo,fw_fd,fw_size,err,offset = 0;
+	struct nvme_dev *dev;
 	struct stat sb;
 	int i;
 
@@ -851,9 +863,9 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0)
-		return fd;
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err < 0)
+		return err;
 
 	if (strlen(cfg.select) != 3) {
 		fprintf(stderr, "Invalid select flag\n");
@@ -914,7 +926,7 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 
 		struct nvme_fw_download_args args = {
 			.args_size	= sizeof(args),
-			.fd		= fd,
+			.fd		= dev->fd,
 			.offset		= offset,
 			.data_len	= xfer,
 			.data		= fw_buf,
@@ -934,7 +946,7 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 		offset += xfer;
 	}
 
-	err = memblaze_fw_commit(fd,selectNo);
+	err = memblaze_fw_commit(dev->fd, selectNo);
 
 	if(err == 0x10B || err == 0x20B) {
 		err = 0;
@@ -946,7 +958,7 @@ out_free:
 out_close:
 	close(fw_fd);
 out:
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 
@@ -1053,10 +1065,10 @@ int io_latency_histogram(char *file, char *buf, int print, int logid)
 static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
     char stats[LOG_PAGE_SIZE];
-    int err = 0;
-    int fd;
     char f1[] = FID_C1_LOG_FILENAME;
     char f2[] = FID_C2_LOG_FILENAME;
+    struct nvme_dev *dev;
+    int err;
 
     const char *desc = "Get Latency Statistics log and show it.";
     const char *write = "Get write statistics (read default)";
@@ -1073,17 +1085,19 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, st
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0) return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+	    return err;
 
-    err = nvme_get_log_simple(fd, cfg.write ? 0xc2 : 0xc1, sizeof(stats), &stats);
+    err = nvme_get_log_simple(dev->fd, cfg.write ? 0xc2 : 0xc1,
+			      sizeof(stats), &stats);
     if (!err)
         io_latency_histogram(cfg.write ? f2 : f1, stats, DO_PRINT_FLAG,
          cfg.write ? GLP_ID_VU_GET_WRITE_LATENCY_HISTOGRAM : GLP_ID_VU_GET_READ_LATENCY_HISTOGRAM);
     else
 	nvme_show_status(err);
 
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
@@ -1091,8 +1105,9 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, st
 #define FID        0x68
 static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-    int err, fd;
     char *desc = "Clear Memblaze devices error log.";
+    struct nvme_dev *dev;
+    int err;
 
     //const char *value = "new value of feature (required)";
     //const char *save = "specifies that the controller shall save the attribute";
@@ -1114,13 +1129,13 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
         OPT_END()
     };
 
-    fd = parse_and_open(argc, argv, desc, opts);
-    if (fd < 0)
-        return fd;
+    err = parse_and_open(&dev, argc, argv, desc, opts);
+    if (err < 0)
+        return err;
 
     struct nvme_set_features_args args = {
         .args_size      = sizeof(args),
-        .fd             = fd,
+        .fd             = dev->fd,
         .fid            = cfg.feature_id,
         .nsid           = 0,
         .cdw11          = cfg.value,
@@ -1156,14 +1171,13 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
 		printf("NVMe Status:%s(%x)\n", nvme_status_to_string(err), err);
 	};
 */
-    close(fd);
+    dev_close(dev);
     return err;
 }
 
 static int mb_set_lat_stats(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
-	int err, fd;
 	const char *desc = (
 			"Enable/Disable Latency Statistics Tracking.\n"
 			"No argument prints current status.");
@@ -1176,8 +1190,10 @@ static int mb_set_lat_stats(int argc, char **argv,
 	const __u32 cdw12 = 0x0;
 	const __u32 data_len = 32;
 	const __u32 save = 0;
-	__u32 result;
+	struct nvme_dev *dev;
 	void *buf = NULL;
+	__u32 result;
+	int err;
 
 	struct config {
 		bool enable, disable;
@@ -1194,7 +1210,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 		{NULL}
 	};
 
-	fd = parse_and_open(argc, argv, desc, command_line_options);
+	err = parse_and_open(&dev, argc, argv, desc, command_line_options);
 
 	enum Option {
 		None = -1,
@@ -1210,7 +1226,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 
 	struct nvme_get_features_args args_get = {
 		.args_size	= sizeof(args_get),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1224,7 +1240,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 
 	struct nvme_set_features_args args_set = {
 		.args_size	= sizeof(args_set),
-		.fd		= fd,
+		.fd		= dev->fd,
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,
@@ -1238,8 +1254,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 		.result		= &result,
 	};
 
-	if (fd < 0)
-		return fd;
+	if (err < 0)
+		return err;
 	switch (option) {
 	case None:
 		err = nvme_get_features(&args_get);
@@ -1249,7 +1265,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 				fid, result);
 		} else {
 			printf("Could not read feature id 0xE2.\n");
-			close(fd);
+			dev_close(dev);
 			return err;
 		}
 		break;
@@ -1270,7 +1286,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 		printf("%d not supported.\n", option);
 		err = EINVAL;
 	}
-	close(fd);
+	dev_close(dev);
 	return err;
 }
 

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -429,10 +429,11 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
         return ret;
 }
 
-static int ocp_print_C3_log_normal(struct ssd_latency_monitor_log *log_data)
+static int ocp_print_C3_log_normal(struct nvme_dev *dev,
+				   struct ssd_latency_monitor_log *log_data)
 {
         printf("-Latency Monitor/C3 Log Page Data- \n");
-        printf("  Controller   :  %s\n", nvme_dev->name);
+        printf("  Controller   :  %s\n", dev->name);
         int i, j;
         int pos = 0;
         char       ts_buf[128];
@@ -662,7 +663,7 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
         json_free_object(root);
 }
 
-static int get_c3_log_page(int fd, char *format)
+static int get_c3_log_page(struct nvme_dev *dev, char *format)
 {
         int ret = 0;
         int fmt = -1;
@@ -682,7 +683,7 @@ static int get_c3_log_page(int fd, char *format)
         }
         memset(data, 0, sizeof (__u8) * C3_LATENCY_MON_LOG_BUF_LEN);
 
-        ret = nvme_get_log_simple(fd, C3_LATENCY_MON_OPCODE,
+        ret = nvme_get_log_simple(dev->fd, C3_LATENCY_MON_OPCODE,
                         C3_LATENCY_MON_LOG_BUF_LEN, data);
 
         if (strcmp(format, "json"))
@@ -725,7 +726,7 @@ static int get_c3_log_page(int fd, char *format)
 
                 switch (fmt) {
                 case NORMAL:
-                        ocp_print_C3_log_normal(log_data);
+                        ocp_print_C3_log_normal(dev, log_data);
                         break;
                 case JSON:
                         ocp_print_C3_log_json(log_data);
@@ -766,7 +767,7 @@ static int ocp_latency_monitor_log(int argc, char **argv, struct command *comman
         if (ret < 0)
                 return ret;
 
-        ret = get_c3_log_page(dev->fd, cfg.output_format);
+        ret = get_c3_log_page(dev, cfg.output_format);
         if (ret)
                 fprintf(stderr,
                         "ERROR : OCP : Failure reading the C3 Log Page, ret = %d\n",

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -401,7 +401,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
                 struct plugin *plugin)
 {
         const char *desc = "Retrieve latency monitor log data.";
-        int fd;
+	struct nvme_dev *dev;
         int ret = 0;
 
         struct config {
@@ -417,15 +417,15 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
                 OPT_END()
         };
 
-        fd = parse_and_open(argc, argv, desc, opts);
-        if (fd < 0)
-                return fd;
+        ret = parse_and_open(&dev, argc, argv, desc, opts);
+        if (ret < 0)
+                return ret;
 
-        ret = get_c0_log_page(fd, cfg.output_format);
+        ret = get_c0_log_page(dev->fd, cfg.output_format);
         if (ret)
                 fprintf(stderr, "ERROR : OCP : Failure reading the C0 Log Page, ret = %d\n",
                         ret);
-        close(fd);
+        dev_close(dev);
         return ret;
 }
 
@@ -745,7 +745,7 @@ static int ocp_latency_monitor_log(int argc, char **argv, struct command *comman
                 struct plugin *plugin)
 {
         const char *desc = "Retrieve latency monitor log data.";
-        int fd;
+	struct nvme_dev *dev;
         int ret = 0;
 
         struct config {
@@ -762,15 +762,15 @@ static int ocp_latency_monitor_log(int argc, char **argv, struct command *comman
                 OPT_END()
         };
 
-        fd = parse_and_open(argc, argv, desc, opts);
-        if (fd < 0)
-                return fd;
+        ret = parse_and_open(&dev, argc, argv, desc, opts);
+        if (ret < 0)
+                return ret;
 
-        ret = get_c3_log_page(fd, cfg.output_format);
+        ret = get_c3_log_page(dev->fd, cfg.output_format);
         if (ret)
                 fprintf(stderr,
                         "ERROR : OCP : Failure reading the C3 Log Page, ret = %d\n",
                         ret);
-        close(fd);
+        dev_close(dev);
         return ret;
 }

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -421,7 +421,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
         if (ret < 0)
                 return ret;
 
-        ret = get_c0_log_page(dev->fd, cfg.output_format);
+        ret = get_c0_log_page(dev_fd(dev), cfg.output_format);
         if (ret)
                 fprintf(stderr, "ERROR : OCP : Failure reading the C0 Log Page, ret = %d\n",
                         ret);
@@ -683,8 +683,8 @@ static int get_c3_log_page(struct nvme_dev *dev, char *format)
         }
         memset(data, 0, sizeof (__u8) * C3_LATENCY_MON_LOG_BUF_LEN);
 
-        ret = nvme_get_log_simple(dev->fd, C3_LATENCY_MON_OPCODE,
-                        C3_LATENCY_MON_LOG_BUF_LEN, data);
+        ret = nvme_get_log_simple(dev_fd(dev), C3_LATENCY_MON_OPCODE,
+                                  C3_LATENCY_MON_LOG_BUF_LEN, data);
 
         if (strcmp(format, "json"))
                 fprintf(stderr,

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -432,7 +432,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
 static int ocp_print_C3_log_normal(struct ssd_latency_monitor_log *log_data)
 {
         printf("-Latency Monitor/C3 Log Page Data- \n");
-        printf("  Controller   :  %s\n", devicename);
+        printf("  Controller   :  %s\n", nvme_dev->name);
         int i, j;
         int pos = 0;
         char       ts_buf[128];

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -431,9 +431,11 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 		sizeof(smart_log), (void *)&smart_log);
 	if (!err) {
 		if (cfg.json)
-			show_sfx_smart_log_jsn(&smart_log, cfg.namespace_id, devicename);
+			show_sfx_smart_log_jsn(&smart_log, cfg.namespace_id,
+					       nvme_dev->name);
 		else if (!cfg.raw_binary)
-			show_sfx_smart_log(&smart_log, cfg.namespace_id, devicename);
+			show_sfx_smart_log(&smart_log, cfg.namespace_id,
+					   nvme_dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -432,10 +432,10 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (!err) {
 		if (cfg.json)
 			show_sfx_smart_log_jsn(&smart_log, cfg.namespace_id,
-					       nvme_dev->name);
+					       dev->name);
 		else if (!cfg.raw_binary)
 			show_sfx_smart_log(&smart_log, cfg.namespace_id,
-					   nvme_dev->name);
+					   dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1119,7 +1119,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s log-id:%d namespace-id:%#x\n",
-			       devicename, cfg.log_id,
+			       nvme_dev->name, cfg.log_id,
 			       cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
@@ -1239,7 +1239,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s namespace-id:%#x\n",
-			       devicename, cfg.namespace_id);
+			       nvme_dev->name, cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
 

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1128,7 +1128,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s log-id:%d namespace-id:%#x\n",
-			       nvme_dev->name, cfg.log_id,
+			       dev->name, cfg.log_id,
 			       cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
@@ -1249,7 +1249,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		if (!cfg.raw_binary) {
 			printf("Device:%s namespace-id:%#x\n",
-			       nvme_dev->name, cfg.namespace_id);
+			       dev->name, cfg.namespace_id);
 			printf("Data Block 1 Last Block:%d Data Block 2 Last Block:%d Data Block 3 Last Block:%d\n",
 			       tele_log.tele_data_area1, tele_log.tele_data_area2, tele_log.tele_data_area3);
 

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -144,7 +144,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 		   sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
-			show_shannon_smart_log(&smart_log, cfg.namespace_id, devicename);
+			show_shannon_smart_log(&smart_log, cfg.namespace_id,
+					       nvme_dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -146,7 +146,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	if (!err) {
 		if (!cfg.raw_binary)
 			show_shannon_smart_log(&smart_log, cfg.namespace_id,
-					       nvme_dev->name);
+					       dev->name);
 		else
 			d_raw((unsigned char *)&smart_log, sizeof(smart_log));
 	}

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -141,8 +141,8 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err < 0)
 		return err;
-	err = nvme_get_nsid_log(dev->fd, false, 0xca, cfg.namespace_id,
-		   sizeof(smart_log), &smart_log);
+	err = nvme_get_nsid_log(dev_fd(dev), false, 0xca, cfg.namespace_id,
+				sizeof(smart_log), &smart_log);
 	if (!err) {
 		if (!cfg.raw_binary)
 			show_shannon_smart_log(&smart_log, cfg.namespace_id,
@@ -235,7 +235,7 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 
 	struct nvme_get_features_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev->fd,
+		.fd		= dev_fd(dev),
 		.fid		= cfg.feature_id,
 		.nsid		= cfg.namespace_id,
 		.sel		= cfg.sel,
@@ -361,7 +361,7 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 
 	struct nvme_set_features_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev->fd,
+		.fd		= dev_fd(dev),
 		.fid		= cfg.feature_id,
 		.nsid		= cfg.namespace_id,
 		.cdw11		= cfg.value,

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -93,7 +93,7 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 	garbage_control_collection_log_t gc_log;
 	const int solidigm_vu_gc_log_id = 0xfd;
 
-	err = nvme_get_log_simple(dev->fd, solidigm_vu_gc_log_id,
+	err = nvme_get_log_simple(dev_fd(dev), solidigm_vu_gc_log_id,
 				  sizeof(gc_log), &gc_log);
 	if (!err) {
 		if (flags & BINARY)	{

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -97,9 +97,9 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 		if (flags & BINARY)	{
 			d_raw((unsigned char *)&gc_log, sizeof(gc_log));
 		} else if (flags & JSON) {
-			vu_gc_log_show_json(&gc_log, devicename);
+			vu_gc_log_show_json(&gc_log, nvme_dev->name);
 		} else {
-			vu_gc_log_show(&gc_log, devicename);
+			vu_gc_log_show(&gc_log, nvme_dev->name);
 		}
 	}
 	else if (err > 0) {

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -99,9 +99,9 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 		if (flags & BINARY)	{
 			d_raw((unsigned char *)&gc_log, sizeof(gc_log));
 		} else if (flags & JSON) {
-			vu_gc_log_show_json(&gc_log, nvme_dev->name);
+			vu_gc_log_show_json(&gc_log, dev->name);
 		} else {
-			vu_gc_log_show(&gc_log, nvme_dev->name);
+			vu_gc_log_show(&gc_log, dev->name);
 		}
 	}
 	else if (err > 0) {

--- a/plugins/solidigm/solidigm-latency-tracking.c
+++ b/plugins/solidigm/solidigm-latency-tracking.c
@@ -412,7 +412,7 @@ int solidigm_get_latency_tracking_log(int argc, char **argv, struct command *cmd
 	if (err < 0)
 		return err;
 
-	lt.fd = dev->fd;
+	lt.fd = dev_fd(dev);
 
 	lt.print_flags = validate_output_format(lt.cfg.output_format);
 	if (lt.print_flags == -EINVAL) {

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -231,7 +231,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 		return flags;
 	}
 
-	err = nvme_get_log_simple(dev->fd, solidigm_vu_smart_log_id,
+	err = nvme_get_log_simple(dev_fd(dev), solidigm_vu_smart_log_id,
 				  sizeof(smart_log_payload), &smart_log_payload);
 	if (!err) {
 		if (flags & JSON) {

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -234,11 +234,14 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	err = nvme_get_log_simple(fd, solidigm_vu_smart_log_id, sizeof(smart_log_payload), &smart_log_payload);
 	if (!err) {
 		if (flags & JSON) {
-			vu_smart_log_show_json(&smart_log_payload, cfg.namespace_id, devicename);
+			vu_smart_log_show_json(&smart_log_payload,
+					       cfg.namespace_id,
+					       nvme_dev->name);
 		} else if (flags & BINARY) {
 			d_raw((unsigned char *)&smart_log_payload, sizeof(smart_log_payload));
 		} else {
-			vu_smart_log_show(&smart_log_payload, cfg.namespace_id, devicename);
+			vu_smart_log_show(&smart_log_payload, cfg.namespace_id,
+					  nvme_dev->name);
 		}
 	} else if (err > 0) {
 		nvme_show_status(err);

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -236,13 +236,12 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	if (!err) {
 		if (flags & JSON) {
 			vu_smart_log_show_json(&smart_log_payload,
-					       cfg.namespace_id,
-					       nvme_dev->name);
+					       cfg.namespace_id, dev->name);
 		} else if (flags & BINARY) {
 			d_raw((unsigned char *)&smart_log_payload, sizeof(smart_log_payload));
 		} else {
 			vu_smart_log_show(&smart_log_payload, cfg.namespace_id,
-					  nvme_dev->name);
+					  dev->name);
 		}
 	} else if (err > 0) {
 		nvme_show_status(err);

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -388,11 +388,12 @@ static int nvme_get_vendor_log(struct nvme_dev *dev, __u32 namespace_id,
 	}
 
 	/* Check device supported */
-	err = nvme_get_sct_status(dev->fd, MASK_0 | MASK_1);
+	err = nvme_get_sct_status(dev_fd(dev), MASK_0 | MASK_1);
 	if (err) {
 		goto end;
 	}
-	err = nvme_get_nsid_log(dev->fd, false, log_page, namespace_id, log_len, log);
+	err = nvme_get_nsid_log(dev_fd(dev), false, log_page, namespace_id,
+				log_len, log);
 	if (err) {
 		fprintf(stderr, "%s: couldn't get log 0x%x\n", __func__,
 			log_page);
@@ -516,7 +517,7 @@ static int internal_log(int argc, char **argv, struct command *cmd, struct plugi
 	else
 		printf("Getting current log\n");
 
-	err = nvme_get_internal_log_file(dev->fd, cfg.output_file,
+	err = nvme_get_internal_log_file(dev_fd(dev), cfg.output_file,
 					 !cfg.prev_log);
 	if (err < 0)
 		fprintf(stderr, "%s: couldn't get fw log \n", __func__);
@@ -551,13 +552,13 @@ static int clear_correctable_errors(int argc, char **argv, struct command *cmd,
 	}
 
 	/* Check device supported */
-	err = nvme_get_sct_status(dev->fd, MASK_0 | MASK_1);
+	err = nvme_get_sct_status(dev_fd(dev), MASK_0 | MASK_1);
 	if (err)
 		goto end;
 
 	struct nvme_set_features_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev->fd,
+		.fd		= dev_fd(dev),
 		.fid		= feature_id,
 		.nsid		= namespace_id,
 		.cdw11		= value,

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -419,8 +419,9 @@ static int nvme_get_vendor_log(int fd, __u32 namespace_id, int log_page,
 		}
 	} else {
 		if (log_page == 0xc0)
-			default_show_vendor_log_c0(fd, namespace_id, devicename,
-					(struct nvme_xdn_smart_log_c0 *)log);
+			default_show_vendor_log_c0(fd, namespace_id,
+						   nvme_dev->name,
+						   (struct nvme_xdn_smart_log_c0 *)log);
 		else
 			d(log, log_len,16,1);
 	}

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -21,20 +21,20 @@ static int getHealthValue(int argc, char **argv, struct command *cmd, struct plu
 {
 	struct nvme_smart_log smart_log;
 	char *desc = "Get nvme health percentage.";
- 	int result=0, fd;
 	int  percent_used = 0, healthvalue=0;
-	 
+	struct nvme_dev *dev;
+	int result;
+
 	OPT_ARGS(opts) = {
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	 
-	if (fd < 0) {
+	result = parse_and_open(&dev, argc, argv, desc, opts);
+	if (result < 0) {
 		printf("\nDevice not found \n");;
 		return -1;
 	}
-	result = nvme_get_log_smart(fd, 0xffffffff, false, &smart_log);
+	result = nvme_get_log_smart(dev->fd, 0xffffffff, false, &smart_log);
 	if (!result) {
 		printf("Transcend NVME heath value: ");
 		percent_used =smart_log.percent_used;
@@ -50,7 +50,7 @@ static int getHealthValue(int argc, char **argv, struct command *cmd, struct plu
 		}
 			 
 	}
-	close(fd);
+	dev_close(dev);
 	return result;
 }
 
@@ -59,15 +59,16 @@ static int getBadblock(int argc, char **argv, struct command *cmd, struct plugin
 {
 
 	char *desc = "Get nvme bad block number.";
- 	int result=0, fd;
+	struct nvme_dev *dev;
+	int result;
  
 	OPT_ARGS(opts) = {
 		 
 		OPT_END()
 	};
 
-	fd = parse_and_open(argc, argv, desc, opts);
-	if (fd < 0) {
+	result = parse_and_open(&dev, argc, argv, desc, opts);
+	if (result < 0) {
 		printf("\nDevice not found \n");;
 		return -1;
 	}
@@ -79,11 +80,11 @@ static int getBadblock(int argc, char **argv, struct command *cmd, struct plugin
 	nvmecmd.cdw12=DW12_BAD_BLOCK;
 	nvmecmd.addr = (__u64)(uintptr_t)data;
 	nvmecmd.data_len = 0x1;
-	result = nvme_submit_admin_passthru(fd, &nvmecmd, NULL);
+	result = nvme_submit_admin_passthru(dev->fd, &nvmecmd, NULL);
 	if(!result) {
 		int badblock  = data[0];
 		printf("Transcend NVME badblock count: %d\n",badblock);
 	}
-	close(fd);
+	dev_close(dev);
 	return result;
 }

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -34,7 +34,7 @@ static int getHealthValue(int argc, char **argv, struct command *cmd, struct plu
 		printf("\nDevice not found \n");;
 		return -1;
 	}
-	result = nvme_get_log_smart(dev->fd, 0xffffffff, false, &smart_log);
+	result = nvme_get_log_smart(dev_fd(dev), 0xffffffff, false, &smart_log);
 	if (!result) {
 		printf("Transcend NVME heath value: ");
 		percent_used =smart_log.percent_used;
@@ -80,7 +80,7 @@ static int getBadblock(int argc, char **argv, struct command *cmd, struct plugin
 	nvmecmd.cdw12=DW12_BAD_BLOCK;
 	nvmecmd.addr = (__u64)(uintptr_t)data;
 	nvmecmd.data_len = 0x1;
-	result = nvme_submit_admin_passthru(dev->fd, &nvmecmd, NULL);
+	result = nvme_submit_admin_passthru(dev_fd(dev), &nvmecmd, NULL);
 	if(!result) {
 		int badblock  = data[0];
 		printf("Transcend NVME badblock count: %d\n",badblock);

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -986,7 +986,7 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 	printf("Running for %lf hour(s)\n", cfg.run_time_hrs);
 	printf("Logging SMART data for every %lf hour(s)\n", cfg.log_record_frequency_hrs);
 
-	ret = vt_update_vtview_log_header(dev->fd, path, &cfg);
+	ret = vt_update_vtview_log_header(dev_fd(dev), path, &cfg);
 	if (ret) {
 		err = EINVAL;
 		dev_close(dev);
@@ -1009,7 +1009,7 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 		if(cur_time >= end_time)
 			break;
 
-		ret = vt_add_entry_to_log(dev->fd, path, &cfg);
+		ret = vt_add_entry_to_log(dev_fd(dev), path, &cfg);
 		if (ret) {
 			printf("Cannot update driver log\n");
 			break;
@@ -1044,7 +1044,7 @@ static int vt_show_identify(int argc, char **argv, struct command *cmd, struct p
 		return err;
 	}
 
-	ret = nvme_identify_ctrl(dev->fd, &ctrl);
+	ret = nvme_identify_ctrl(dev_fd(dev), &ctrl);
 	if (ret) {
 		printf("Cannot read identify device\n");
 		dev_close(dev);

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10507,7 +10507,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
    	if (fmt == NORMAL) {
 		/* print the temperature stats */
 		printf("Temperature Stats for NVME device:%s namespace-id:%x\n",
-					nvme_dev->name, WDC_DE_GLOBAL_NSID);
+					dev->name, WDC_DE_GLOBAL_NSID);
 
 		printf("Current Composite Temperature           : %d °C\n", temperature);
 		printf("WCTEMP                                  : %"PRIu16" °C\n", id_ctrl.wctemp - 273);
@@ -10582,7 +10582,7 @@ static int wdc_capabilities(int argc, char **argv,
     capabilities = wdc_get_drive_capabilities(r, dev);
 
     /* print command and supported status */
-    printf("WDC Plugin Capabilities for NVME device:%s\n", nvme_dev->name);
+    printf("WDC Plugin Capabilities for NVME device:%s\n", dev->name);
     printf("cap-diag                      : %s\n", 
             capabilities & WDC_DRIVE_CAP_CAP_DIAG ? "Supported" : "Not Supported");
     printf("drive-log                     : %s\n", 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1297,7 +1297,7 @@ static int wdc_get_pci_ids(nvme_root_t r, uint32_t *device_id,
 	nvme_ns_t n = NULL;
 	int fd, ret;
 
-	c = nvme_scan_ctrl(r, devicename);
+	c = nvme_scan_ctrl(r, nvme_dev->name);
 	if (c) {
 		snprintf(vid, sizeof(vid), "%s/device/vendor",
 			nvme_ctrl_get_sysfs_dir(c));
@@ -1305,9 +1305,9 @@ static int wdc_get_pci_ids(nvme_root_t r, uint32_t *device_id,
 			nvme_ctrl_get_sysfs_dir(c));
 		nvme_free_ctrl(c);
 	} else {
-		n = nvme_scan_namespace(devicename);
+		n = nvme_scan_namespace(nvme_dev->name);
 		if (!n) {
-			fprintf(stderr, "Unable to find %s\n", devicename);
+			fprintf(stderr, "Unable to find %s\n", nvme_dev->name);
 			return -1;
 		}
 
@@ -4012,7 +4012,7 @@ static int wdc_convert_ts(time_t time, char *ts_buf)
 static int wdc_print_latency_monitor_log_normal(int fd, struct wdc_ssd_latency_monitor_log *log_data)
 {
 	printf("Latency Monitor/C3 Log Page Data \n");
-	printf("  Controller   :  %s\n", devicename);
+	printf("  Controller   :  %s\n", nvme_dev->name);
 	int err = -1, i, j;
 	struct nvme_id_ctrl ctrl;
 	char       ts_buf[128];
@@ -4453,7 +4453,7 @@ static void wdc_print_bd_ca_log_normal(void *data)
 	if (bd_data->field_id == 0x00) {
 		raw = (__u64*)&bd_data->raw_value[0];
 		printf("Additional Smart Log for NVME device:%s namespace-id:%x\n",
-			devicename, WDC_DE_GLOBAL_NSID);
+			nvme_dev->name, WDC_DE_GLOBAL_NSID);
 		printf("key                               normalized raw\n");
         printf("program_fail_count              : %3"PRIu8"%%       %"PRIu64"\n",
 				bd_data->normalized_value, le64_to_cpu(*raw & 0x00FFFFFFFFFFFFFF));
@@ -10446,7 +10446,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
    	if (fmt == NORMAL) {
 		/* print the temperature stats */
 		printf("Temperature Stats for NVME device:%s namespace-id:%x\n",
-					devicename, WDC_DE_GLOBAL_NSID);
+					nvme_dev->name, WDC_DE_GLOBAL_NSID);
 
 		printf("Current Composite Temperature           : %d °C\n", temperature);
 		printf("WCTEMP                                  : %"PRIu16" °C\n", id_ctrl.wctemp - 273);
@@ -10520,7 +10520,7 @@ static int wdc_capabilities(int argc, char **argv,
     capabilities = wdc_get_drive_capabilities(r, fd);
 
     /* print command and supported status */
-    printf("WDC Plugin Capabilities for NVME device:%s\n", devicename);
+    printf("WDC Plugin Capabilities for NVME device:%s\n", nvme_dev->name);
     printf("cap-diag                      : %s\n", 
             capabilities & WDC_DRIVE_CAP_CAP_DIAG ? "Supported" : "Not Supported");
     printf("drive-log                     : %s\n", 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -4481,7 +4481,7 @@ static void wdc_print_fb_ca_log_json(struct wdc_ssd_ca_perf_stats *perf)
 	json_free_object(root);
 }
 
-static void wdc_print_bd_ca_log_normal(void *data)
+static void wdc_print_bd_ca_log_normal(struct nvme_dev *dev, void *data)
 {
 	struct wdc_bd_ca_log_format *bd_data = (struct wdc_bd_ca_log_format *)data;
 	__u64 *raw;
@@ -4492,7 +4492,7 @@ static void wdc_print_bd_ca_log_normal(void *data)
 	if (bd_data->field_id == 0x00) {
 		raw = (__u64*)&bd_data->raw_value[0];
 		printf("Additional Smart Log for NVME device:%s namespace-id:%x\n",
-			nvme_dev->name, WDC_DE_GLOBAL_NSID);
+			dev->name, WDC_DE_GLOBAL_NSID);
 		printf("key                               normalized raw\n");
         printf("program_fail_count              : %3"PRIu8"%%       %"PRIu64"\n",
 				bd_data->normalized_value, le64_to_cpu(*raw & 0x00FFFFFFFFFFFFFF));
@@ -6501,7 +6501,7 @@ static int wdc_print_fb_ca_log(struct wdc_ssd_ca_perf_stats *perf, int fmt)
 	return 0;
 }
 
-static int wdc_print_bd_ca_log(void *bd_data, int fmt)
+static int wdc_print_bd_ca_log(struct nvme_dev *dev, void *bd_data, int fmt)
 {
 	if (!bd_data) {
 		fprintf(stderr, "ERROR : WDC : Invalid buffer to read data\n");
@@ -6509,7 +6509,7 @@ static int wdc_print_bd_ca_log(void *bd_data, int fmt)
 	}
 	switch (fmt) {
 	case NORMAL:
-		wdc_print_bd_ca_log_normal(bd_data);
+		wdc_print_bd_ca_log_normal(dev, bd_data);
 		break;
 	case JSON:
 		wdc_print_bd_ca_log_json(bd_data);
@@ -6665,7 +6665,7 @@ static int wdc_get_ca_log_page(nvme_root_t r, struct nvme_dev *dev, char *format
 
 			if (ret == 0) {
 				/* parse the data */
-				ret = wdc_print_bd_ca_log(data, fmt);
+				ret = wdc_print_bd_ca_log(dev, data, fmt);
 			} else {
 				fprintf(stderr, "ERROR : WDC : Unable to read CA Log Page data\n");
 				ret = -1;

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -40,7 +40,7 @@ static int show_ymtc_smart_log(struct nvme_dev *dev, __u32 nsid,
         free(nm);
         return -1;
     }
-    err = nvme_identify_ctrl(dev->fd, &ctrl);
+    err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
     if (err) {
         free(nm);
         free(raw);
@@ -145,7 +145,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
     if (err < 0)
         return err;
 
-    err = nvme_get_nsid_log(dev->fd, false, 0xca, cfg.namespace_id,
+    err = nvme_get_nsid_log(dev_fd(dev), false, 0xca, cfg.namespace_id,
 			    sizeof(smart_log), &smart_log);
     if (!err) {
         if (!cfg.raw_binary)

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -147,7 +147,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 			    sizeof(smart_log), &smart_log);
     if (!err) {
         if (!cfg.raw_binary)
-            err = show_ymtc_smart_log(fd, cfg.namespace_id, devicename, &smart_log);
+            err = show_ymtc_smart_log(fd, cfg.namespace_id, nvme_dev->name, &smart_log);
         else
             d_raw((unsigned char *)&smart_log, sizeof(smart_log));
     }

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -21,8 +21,8 @@ static void get_ymtc_smart_info(struct nvme_ymtc_smart_log *smart, int index, u8
     memcpy(raw_val, smart->itemArr[index].rawVal, RAW_SIZE);
 }
 
-static int show_ymtc_smart_log(int fd, __u32 nsid, const char *devname,
-    struct nvme_ymtc_smart_log *smart)
+static int show_ymtc_smart_log(struct nvme_dev *dev, __u32 nsid,
+			       struct nvme_ymtc_smart_log *smart)
 {
     struct nvme_id_ctrl ctrl;
     char fw_ver[10];
@@ -40,7 +40,7 @@ static int show_ymtc_smart_log(int fd, __u32 nsid, const char *devname,
         free(nm);
         return -1;
     }
-    err = nvme_identify_ctrl(fd, &ctrl);
+    err = nvme_identify_ctrl(dev->fd, &ctrl);
     if (err) {
         free(nm);
         free(raw);
@@ -52,7 +52,8 @@ static int show_ymtc_smart_log(int fd, __u32 nsid, const char *devname,
         ctrl.fr[4], ctrl.fr[5], ctrl.fr[6]);
 
     /* Table Title */
-    printf("Additional Smart Log for NVME device:%s namespace-id:%x\n", devname, nsid);
+    printf("Additional Smart Log for NVME device:%s namespace-id:%x\n",
+	   dev->name, nsid);
     /* Clumn Name*/
     printf("key                               normalized raw\n");
     /* 00 SI_VD_PROGRAM_FAIL */
@@ -148,7 +149,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 			    sizeof(smart_log), &smart_log);
     if (!err) {
         if (!cfg.raw_binary)
-            err = show_ymtc_smart_log(dev->fd, cfg.namespace_id, nvme_dev->name, &smart_log);
+            err = show_ymtc_smart_log(dev, cfg.namespace_id, &smart_log);
         else
             d_raw((unsigned char *)&smart_log, sizeof(smart_log));
     }

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -4,3 +4,4 @@ revision = 47e3562a7d9b4bb871f374058c52c654fb4735e9
 
 [provide]
 libnvme = libnvme_dep
+libnvme-mi = libnvme_mi_dep


### PR DESCRIPTION
This series adds MI channel support for `nvme-cli`, by adding a new format of device specifier:

    nvme id-ctrl mctp:1,9

We do this by introducing a new struct to contain the "transport" to the device. For the existing ioctl-based cases, this has the device fd. When using the MI transport, this contains the MI endpoint (`nvme_mi_ep_t`):

```c
enum nvme_dev_type {
	NVME_DEV_DIRECT,
	NVME_DEV_MI,
};

struct nvme_dev {
	enum nvme_dev_type type;
	union {
		struct {
			int fd;
			struct stat stat;
		} direct;
		struct {
			nvme_root_t root;
			nvme_mi_ep_t ep;
			nvme_mi_ctrl_t ctrl;
		} mi;
	};

	const char *name;
};
```

.. and then the majority of the changes involve passing this struct to each of the command implementations, rather than the fd.

This change is on top of my `fixes` PR: https://github.com/linux-nvme/nvme-cli/pull/1608 , so currently includes those commits too. I'd suggest merging that one first to keep the changes distinct.

Of course, any questions/comments/etc are more than welcome!

