### PR TITLE
Revert "udev: re-read the discovery log page when a discovery control…

### DIFF
--- a/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
+++ b/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
@@ -17,10 +17,3 @@ ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_AEN}=="0x70f002",\
 ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
   ENV{NVMEFC_HOST_TRADDR}=="*",  ENV{NVMEFC_TRADDR}=="*", \
   RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=none\t--transport=fc\t--traddr=$env{NVMEFC_TRADDR}\t--trsvcid=none\t--host-traddr=$env{NVMEFC_HOST_TRADDR}.service"
-
-# A discovery controller just (re)connected, re-read the discovery log change to
-# check if there were any changes since it was last connected.
-ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_EVENT}=="connected", ATTR{cntrltype}=="discovery", \
-  ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
-  ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}.service"


### PR DESCRIPTION
…ler reconnected"

This reverts commit f86faaaa2a1ff319bde188dc8988be1ec054d238.

Observing unwanted side-effects with nvme discovery. For e.g., running
a simple 'nvme discover' command ends up invoking connect-all as well,
creating namespaces on the host.

One can also see spurious discovery controllers in the 'nvme
list-subsys' output, despite having not created any persistent
discovery controllers at all.

Reported-by: Martin George <Martin.George@netapp.com>
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1631