### PR TITLE
wrapper: Call library version of nvme_init_copy_range_f1

### DIFF
--- a/wrapper.c
+++ b/wrapper.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * This file is part of nvme-cli
  *

--- a/wrapper.c
+++ b/wrapper.c
@@ -9,21 +9,34 @@
 
 #include <libnvme.h>
 
-const char * __attribute__((weak)) nvme_get_version(enum nvme_version type)
-{
-	const char *(*libnvme_get_version)(enum nvme_version type);
+#define PROTO(args...) args
+#define ARGS(args...) args
 
-	libnvme_get_version = dlsym(RTLD_NEXT, "nvme_get_version");
-
-	if (libnvme_get_version)
-		return libnvme_get_version(type);
-
-	return "n/a";
+#define VOID_FN(name, proto, args)				\
+void __attribute__((weak)) name(proto)				\
+{								\
+	void (*fn)(proto);					\
+	fn = dlsym(RTLD_NEXT, #name);				\
+	if (fn)							\
+		fn(args);					\
 }
 
-void __attribute__((weak))
-nvme_init_copy_range_f1(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
-		        __u64 *slbas, __u64 *eilbrts, __u32 *elbatms,
-			__u32 *elbats, __u16 nr)
-{
+#define FN(name, rtype, proto, args, fallback)			\
+rtype __attribute__((weak)) name(proto)				\
+{								\
+	rtype (*fn)(proto);					\
+	fn = dlsym(RTLD_NEXT, #name);				\
+	if (fn)							\
+		return fn(args);				\
+	return fallback;					\
 }
+
+FN(nvme_get_version,
+	const char *, PROTO(enum nvme_version type),
+	ARGS(type), "n/a")
+
+VOID_FN(nvme_init_copy_range_f1,
+	PROTO(struct nvme_copy_range_f1 *copy, __u16 *nlbs,
+	      __u64 *slbas, __u64 *eilbrts, __u32 *elbatms,
+	      __u32 *elbats, __u16 nr),
+	ARGS(copy, nlbs, slbas, eilbrts, elbatms, elbats, nr))


### PR DESCRIPTION
The wrapper needs to call the library version of the function.

While at it, introduce preprocessor helpers to reduce the amount
boilerplate code.

Fixes: 7ccb7d29afa0 ("wrapper: Add weak nvme_init_copy_range_f1 symbol")
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1628