### PR TITLE
nvme: Add helper function to parse 16-bit comma separated list

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5795,7 +5795,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 		goto ret;
 	}
 
-	nb = argconfig_parse_comma_sep_array(cfg.nlbs, (int *)nlbs, ARRAY_SIZE(nlbs));
+	nb = argconfig_parse_comma_sep_array_short(cfg.nlbs, nlbs, ARRAY_SIZE(nlbs));
 	ns = argconfig_parse_comma_sep_array_long(cfg.slbas, slbas, ARRAY_SIZE(slbas));
 	
 	if (cfg.format == 0)

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -488,6 +488,51 @@ int argconfig_parse_comma_sep_array(char *string, int *val,
 	}
 }
 
+int argconfig_parse_comma_sep_array_short(char *string, unsigned short *val,
+					  unsigned max_length)
+{
+	int ret = 0;
+	unsigned long v;
+	char *tmp;
+	char *p;
+
+	if (!string || !strlen(string))
+		return 0;
+
+	tmp = strtok(string, ",");
+	if (!tmp)
+		return 0;
+
+	v = strtoul(tmp, &p, 0);
+	if (*p != 0)
+		return -1;
+	if (v > UINT16_MAX) {
+		fprintf(stderr, "%s out of range\n", tmp);
+		return -1;
+	}
+	val[ret] = v;
+	ret++;
+
+	while (1) {
+		tmp = strtok(NULL, ",");
+		if (tmp == NULL)
+			return ret;
+
+		if (ret >= max_length)
+			return -1;
+
+		v = strtoul(tmp, &p, 0);
+		if (*p != 0)
+			return -1;
+		if (v > UINT16_MAX) {
+			fprintf(stderr, "%s out of range\n", tmp);
+			return -1;
+		}
+		val[ret] = v;
+		ret++;
+	}
+}
+
 int argconfig_parse_comma_sep_array_long(char *string,
 					      unsigned long long *val,
 					      unsigned max_length)

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -126,6 +126,8 @@ int argconfig_parse_subopt_string(char *string, char **options,
 				  size_t max_options);
 int argconfig_parse_comma_sep_array(char *string, int *ret,
 					 unsigned max_length);
+int argconfig_parse_comma_sep_array_short(char *string, unsigned short *ret,
+					  unsigned max_length);
 int argconfig_parse_comma_sep_array_long(char *string,
 					      unsigned long long *ret,
 					      unsigned max_length);


### PR DESCRIPTION
In copy command, nlbs is declared as __u16. While parsing command line argument,
it is typecast to integer pointer. So nlbs[1], nlbs[3], nlbs[5], ... are stored
as zero after getting parsed. Therefore it is passing wrong value to controller.
Hence, adding a helper function to parse the 16-bit comma separated list

Signed-off-by: Francis Pravin Antony Michael Raj <francis.michael@solidigm.com>
Signed-off-by: Jonathan Derrick <jonathan.derrick@solidigm.com>