### PR TITLE
json: Support uint64 types serialization for older json-c versions

### DIFF
--- a/util/json.c
+++ b/util/json.c
@@ -17,3 +17,18 @@ struct json_object *util_json_object_new_double(long double d)
 	return obj;
 
 }
+
+struct json_object *util_json_object_new_uint64(uint64_t i)
+{
+	struct json_object *obj;
+	char *str;
+
+	if (asprintf(&str, "%" PRIu64, i) < 0)
+		return NULL;
+
+	obj = json_object_new_string(str);
+
+	free(str);
+	return obj;
+
+}

--- a/util/json.h
+++ b/util/json.h
@@ -19,11 +19,7 @@
 	json_object_object_add(o, k, json_object_new_uint64(v))
 #else
 #define json_object_add_value_uint64(o, k, v) \
-	if ((v) > UINT_MAX) {						\
-		fprintf(stderr, "Value overflow in %s", k);		\
-		json_object_object_add(o, k, json_object_new_int(-1));	\
-	} else								\
-		json_object_object_add(o, k, json_object_new_int(v))
+	json_object_object_add(o, k, util_json_object_new_uint64(v))
 #endif
 #define json_object_add_value_double(o, k, v) \
 	json_object_object_add(o, k, util_json_object_new_double(v))
@@ -45,5 +41,6 @@
 		JSON_C_TO_STRING_NOSLASHESCAPE))
 
 struct json_object *util_json_object_new_double(long double d);
+struct json_object *util_json_object_new_uint64(uint64_t i);
 
 #endif


### PR DESCRIPTION
Notable json-c 0.13 is lacking support for serializing uint64_t
types. At this point of writing the 0.13 version is widely
deployed. Let's add our own version of the serialization function as
fallback.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes #1632