### PR TITLE
MI: Add (and use) `nvme_cli_*` wrappers for more admin functions

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -133,6 +133,196 @@ int nvme_cli_sanitize_nvm(struct nvme_dev *dev, struct nvme_sanitize_nvm_args *a
 	return do_admin_args_op(sanitize_nvm, dev, args);
 }
 
+int nvme_cli_get_log(struct nvme_dev *dev, struct nvme_get_log_args *args)
+{
+	return do_admin_args_op(get_log, dev, args);
+}
+
+int nvme_cli_get_nsid_log(struct nvme_dev *dev, bool rae,
+			  enum nvme_cmd_get_log_lid lid,
+			  __u32 nsid, __u32 len, void *log)
+{
+	return do_admin_op(get_nsid_log, dev, rae, lid, nsid, len, log);
+}
+
+int nvme_cli_get_log_simple(struct nvme_dev *dev,
+			    enum nvme_cmd_get_log_lid lid,
+			    __u32 len, void *log)
+{
+	return do_admin_op(get_log_simple, dev, lid, len, log);
+}
+
+int nvme_cli_get_log_supported_log_pages(struct nvme_dev *dev, bool rae,
+					 struct nvme_supported_log_pages *log)
+{
+	return do_admin_op(get_log_supported_log_pages, dev, rae, log);
+}
+
+int nvme_cli_get_log_error(struct nvme_dev *dev, unsigned int nr_entries,
+			   bool rae, struct nvme_error_log_page *err_log)
+{
+	return do_admin_op(get_log_error, dev, nr_entries, rae, err_log);
+}
+
+int nvme_cli_get_log_smart(struct nvme_dev *dev, __u32 nsid, bool rae,
+			   struct nvme_smart_log *smart_log)
+{
+	return do_admin_op(get_log_smart, dev, nsid, rae, smart_log);
+}
+
+int nvme_cli_get_log_fw_slot(struct nvme_dev *dev, bool rae,
+			     struct nvme_firmware_slot *fw_log)
+{
+	return do_admin_op(get_log_fw_slot, dev, rae, fw_log);
+}
+
+int nvme_cli_get_log_changed_ns_list(struct nvme_dev *dev, bool rae,
+				     struct nvme_ns_list *ns_log)
+{
+	return do_admin_op(get_log_changed_ns_list, dev, rae, ns_log);
+}
+
+int nvme_cli_get_log_cmd_effects(struct nvme_dev *dev, enum nvme_csi csi,
+				 struct nvme_cmd_effects_log *effects_log)
+{
+	return do_admin_op(get_log_cmd_effects, dev, csi, effects_log);
+}
+
+int nvme_cli_get_log_device_self_test(struct nvme_dev *dev,
+				      struct nvme_self_test_log *log)
+{
+	return do_admin_op(get_log_device_self_test, dev, log);
+}
+
+int nvme_cli_get_log_create_telemetry_host(struct nvme_dev *dev,
+					   struct nvme_telemetry_log *log)
+{
+	return do_admin_op(get_log_create_telemetry_host, dev, log);
+}
+
+int nvme_cli_get_log_telemetry_host(struct nvme_dev *dev, __u64 offset,
+				    __u32 len, void *log)
+{
+	return do_admin_op(get_log_telemetry_host, dev, offset, len, log);
+}
+
+int nvme_cli_get_log_telemetry_ctrl(struct nvme_dev *dev, bool rae,
+				    __u64 offset, __u32 len, void *log)
+{
+	return do_admin_op(get_log_telemetry_ctrl, dev, rae, offset, len, log);
+}
+
+int nvme_cli_get_log_endurance_group(struct nvme_dev *dev, __u16 endgid,
+				     struct nvme_endurance_group_log *log)
+{
+	return do_admin_op(get_log_endurance_group, dev, endgid, log);
+}
+
+int nvme_cli_get_log_predictable_lat_nvmset(struct nvme_dev *dev,
+					    __u16 nvmsetid,
+					    struct nvme_nvmset_predictable_lat_log *log)
+{
+	return do_admin_op(get_log_predictable_lat_nvmset, dev, nvmsetid, log);
+}
+
+int nvme_cli_get_log_predictable_lat_event(struct nvme_dev *dev, bool rae,
+					   __u32 offset, __u32 len, void *log)
+{
+	return do_admin_op(get_log_predictable_lat_event, dev, rae, offset,
+			   len, log);
+}
+
+int nvme_cli_get_log_ana(struct nvme_dev *dev,
+			 enum nvme_log_ana_lsp lsp, bool rae,
+			 __u64 offset, __u32 len, void *log)
+{
+	return do_admin_op(get_log_ana, dev, lsp, rae, offset, len, log);
+}
+
+int nvme_cli_get_log_ana_groups(struct nvme_dev *dev, bool rae, __u32 len,
+				struct nvme_ana_group_desc *log)
+{
+	return do_admin_op(get_log_ana_groups, dev, rae, len, log);
+}
+
+int nvme_cli_get_log_lba_status(struct nvme_dev *dev, bool rae,
+				__u64 offset, __u32 len, void *log)
+{
+	return do_admin_op(get_log_lba_status, dev, rae, offset, len, log);
+}
+
+int nvme_cli_get_log_endurance_grp_evt(struct nvme_dev *dev, bool rae,
+				       __u32 offset, __u32 len, void *log)
+{
+	return do_admin_op(get_log_endurance_grp_evt, dev, rae, offset, len,
+			   log);
+}
+
+int nvme_cli_get_log_fid_supported_effects(struct nvme_dev *dev, bool rae,
+					   struct nvme_fid_supported_effects_log *log)
+{
+	return do_admin_op(get_log_fid_supported_effects, dev, rae, log);
+}
+
+int nvme_cli_get_log_mi_cmd_supported_effects(struct nvme_dev *dev, bool rae,
+					      struct nvme_mi_cmd_supported_effects_log *log)
+{
+	return do_admin_op(get_log_mi_cmd_supported_effects, dev, rae, log);
+}
+
+int nvme_cli_get_log_boot_partition(struct nvme_dev *dev, bool rae, __u8 lsp,
+				    __u32 len,
+				    struct nvme_boot_partition *part)
+{
+	return do_admin_op(get_log_boot_partition, dev, rae, lsp, len, part);
+}
+
+int nvme_cli_get_log_discovery(struct nvme_dev *dev, bool rae,
+			       __u32 offset, __u32 len, void *log)
+{
+	return do_admin_op(get_log_discovery, dev, rae, offset, len, log);
+}
+
+int nvme_cli_get_log_media_unit_stat(struct nvme_dev *dev, __u16 domid,
+				     struct nvme_media_unit_stat_log *mus)
+{
+	return do_admin_op(get_log_media_unit_stat, dev, domid, mus);
+}
+
+int nvme_cli_get_log_support_cap_config_list(struct nvme_dev *dev,
+					     __u16 domid,
+					     struct nvme_supported_cap_config_list_log *cap)
+{
+	return do_admin_op(get_log_support_cap_config_list, dev, domid, cap);
+}
+
+int nvme_cli_get_log_reservation(struct nvme_dev *dev, bool rae,
+				 struct nvme_resv_notification_log *log)
+{
+	return do_admin_op(get_log_reservation, dev, rae, log);
+}
+
+int nvme_cli_get_log_sanitize(struct nvme_dev *dev, bool rae,
+			      struct nvme_sanitize_log_page *log)
+{
+	return do_admin_op(get_log_sanitize, dev, rae, log);
+}
+
+int nvme_cli_get_log_zns_changed_zones(struct nvme_dev *dev, __u32 nsid,
+				       bool rae,
+				       struct nvme_zns_changed_zone_log *log)
+{
+	return do_admin_op(get_log_zns_changed_zones, dev, nsid, rae, log);
+}
+
+int nvme_cli_get_log_persistent_event(struct nvme_dev *dev,
+				      enum nvme_pevent_log_action action,
+				      __u32 size, void *pevent_log)
+{
+	return do_admin_op(get_log_persistent_event, dev, action, size,
+			   pevent_log);
+}
+
 /* The MI & direct interfaces don't have an exactly-matching API for
  * ns_mgmt_create, as we don't support a timeout for MI.
  */

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -58,6 +58,30 @@ int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl)
 	return do_admin_op(identify_ctrl, dev, ctrl);
 }
 
+int nvme_cli_identify_ns(struct nvme_dev *dev, __u32 nsid,
+			 struct nvme_id_ns *ns)
+{
+	return do_admin_op(identify_ns, dev, nsid, ns);
+}
+
+int nvme_cli_identify_allocated_ns(struct nvme_dev *dev, __u32 nsid,
+			 struct nvme_id_ns *ns)
+{
+	return do_admin_op(identify_allocated_ns, dev, nsid, ns);
+}
+
+int nvme_cli_identify_active_ns_list(struct nvme_dev *dev, __u32 nsid,
+				     struct nvme_ns_list *list)
+{
+	return do_admin_op(identify_active_ns_list, dev, nsid, list);
+}
+
+int nvme_cli_identify_allocated_ns_list(struct nvme_dev *dev, __u32 nsid,
+					struct nvme_ns_list *list)
+{
+	return do_admin_op(identify_allocated_ns_list, dev, nsid, list);
+}
+
 int nvme_cli_get_features(struct nvme_dev *dev,
 			  struct nvme_get_features_args *args)
 {

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -106,6 +106,22 @@ int nvme_cli_ns_mgmt_delete(struct nvme_dev *dev, __u32 nsid)
 	return do_admin_op(ns_mgmt_delete, dev, nsid);
 }
 
+int nvme_cli_ns_attach(struct nvme_dev *dev, struct nvme_ns_attach_args *args)
+{
+	return do_admin_args_op(ns_attach, dev, args);
+}
+
+int nvme_cli_ns_attach_ctrls(struct nvme_dev *dev, __u32 nsid,
+			     struct nvme_ctrl_list *ctrlist)
+{
+	return do_admin_op(ns_attach_ctrls, dev, nsid, ctrlist);
+}
+
+int nvme_cli_ns_detach_ctrls(struct nvme_dev *dev, __u32 nsid,
+			     struct nvme_ctrl_list *ctrlist)
+{
+	return do_admin_op(ns_detach_ctrls, dev, nsid, ctrlist);
+}
 
 /* The MI & direct interfaces don't have an exactly-matching API for
  * ns_mgmt_create, as we don't support a timeout for MI.

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -123,6 +123,11 @@ int nvme_cli_ns_detach_ctrls(struct nvme_dev *dev, __u32 nsid,
 	return do_admin_op(ns_detach_ctrls, dev, nsid, ctrlist);
 }
 
+int nvme_cli_format_nvm(struct nvme_dev *dev, struct nvme_format_nvm_args *args)
+{
+	return do_admin_args_op(format_nvm, dev, args);
+}
+
 /* The MI & direct interfaces don't have an exactly-matching API for
  * ns_mgmt_create, as we don't support a timeout for MI.
  */

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -58,6 +58,19 @@ int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl)
 	return do_admin_op(identify_ctrl, dev, ctrl);
 }
 
+int nvme_cli_identify_ctrl_list(struct nvme_dev *dev, __u16 ctrl_id,
+				struct nvme_ctrl_list *list)
+{
+	return do_admin_op(identify_ctrl_list, dev, ctrl_id, list);
+}
+
+int nvme_cli_identify_nsid_ctrl_list(struct nvme_dev *dev, __u32 nsid,
+				     __u16 ctrl_id,
+				     struct nvme_ctrl_list *list)
+{
+	return do_admin_op(identify_nsid_ctrl_list, dev, nsid, ctrl_id, list);
+}
+
 int nvme_cli_identify_ns(struct nvme_dev *dev, __u32 nsid,
 			 struct nvme_id_ns *ns)
 {

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -128,6 +128,11 @@ int nvme_cli_format_nvm(struct nvme_dev *dev, struct nvme_format_nvm_args *args)
 	return do_admin_args_op(format_nvm, dev, args);
 }
 
+int nvme_cli_sanitize_nvm(struct nvme_dev *dev, struct nvme_sanitize_nvm_args *args)
+{
+	return do_admin_args_op(sanitize_nvm, dev, args);
+}
+
 /* The MI & direct interfaces don't have an exactly-matching API for
  * ns_mgmt_create, as we don't support a timeout for MI.
  */

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -88,3 +88,24 @@ int nvme_cli_get_features(struct nvme_dev *dev,
 	return do_admin_args_op(get_features, dev, args);
 }
 
+int nvme_cli_ns_mgmt_delete(struct nvme_dev *dev, __u32 nsid)
+{
+	return do_admin_op(ns_mgmt_delete, dev, nsid);
+}
+
+
+/* The MI & direct interfaces don't have an exactly-matching API for
+ * ns_mgmt_create, as we don't support a timeout for MI.
+ */
+int nvme_cli_ns_mgmt_create(struct nvme_dev *dev, struct nvme_id_ns *ns,
+			__u32 *nsid, __u32 timeout, __u8 csi)
+{
+	if (dev->type == NVME_DEV_DIRECT)
+		return nvme_ns_mgmt_create(dev_fd(dev), ns, nsid, timeout, csi);
+	if (dev->type == NVME_DEV_MI)
+		return nvme_mi_admin_ns_mgmt_create(dev->mi.ctrl, ns,
+						    csi, nsid);
+
+	return -ENODEV;
+}
+

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -58,3 +58,9 @@ int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl)
 	return do_admin_op(identify_ctrl, dev, ctrl);
 }
 
+int nvme_cli_get_features(struct nvme_dev *dev,
+			  struct nvme_get_features_args *args)
+{
+	return do_admin_args_op(get_features, dev, args);
+}
+

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -11,6 +11,14 @@
 
 int nvme_cli_identify(struct nvme_dev *dev, struct nvme_identify_args *args);
 int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl);
+int nvme_cli_identify_ns(struct nvme_dev *dev, __u32 nsid,
+			 struct nvme_id_ns *ns);
+int nvme_cli_identify_allocated_ns(struct nvme_dev *dev, __u32 nsid,
+				   struct nvme_id_ns *ns);
+int nvme_cli_identify_active_ns_list(struct nvme_dev *dev, __u32 nsid,
+				     struct nvme_ns_list *list);
+int nvme_cli_identify_allocated_ns_list(struct nvme_dev *dev, __u32 nsid,
+					struct nvme_ns_list *list);
 
 int nvme_cli_get_features(struct nvme_dev *dev,
 			  struct nvme_get_features_args *args);

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -20,6 +20,10 @@ int nvme_cli_identify_active_ns_list(struct nvme_dev *dev, __u32 nsid,
 int nvme_cli_identify_allocated_ns_list(struct nvme_dev *dev, __u32 nsid,
 					struct nvme_ns_list *list);
 
+int nvme_cli_ns_mgmt_delete(struct nvme_dev *dev, __u32 nsid);
+int nvme_cli_ns_mgmt_create(struct nvme_dev *dev, struct nvme_id_ns *ns,
+			__u32 *nsid, __u32 timeout, __u8 csi);
+
 int nvme_cli_get_features(struct nvme_dev *dev,
 			  struct nvme_get_features_args *args);
 

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -12,4 +12,7 @@
 int nvme_cli_identify(struct nvme_dev *dev, struct nvme_identify_args *args);
 int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl);
 
+int nvme_cli_get_features(struct nvme_dev *dev,
+			  struct nvme_get_features_args *args);
+
 #endif /* _NVME_WRAP_H */

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -29,6 +29,13 @@ int nvme_cli_ns_mgmt_delete(struct nvme_dev *dev, __u32 nsid);
 int nvme_cli_ns_mgmt_create(struct nvme_dev *dev, struct nvme_id_ns *ns,
 			__u32 *nsid, __u32 timeout, __u8 csi);
 
+int nvme_cli_ns_attach(struct nvme_dev *dev, struct nvme_ns_attach_args *args);
+
+int nvme_cli_ns_attach_ctrls(struct nvme_dev *dev, __u32 nsid,
+			     struct nvme_ctrl_list *ctrlist);
+int nvme_cli_ns_detach_ctrls(struct nvme_dev *dev, __u32 nsid,
+			     struct nvme_ctrl_list *ctrlist);
+
 int nvme_cli_get_features(struct nvme_dev *dev,
 			  struct nvme_get_features_args *args);
 

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -43,4 +43,73 @@ int nvme_cli_sanitize_nvm(struct nvme_dev *dev,
 int nvme_cli_get_features(struct nvme_dev *dev,
 			  struct nvme_get_features_args *args);
 
+
+int nvme_cli_get_log(struct nvme_dev *dev, struct nvme_get_log_args *args);
+
+int nvme_cli_get_nsid_log(struct nvme_dev *dev, bool rae,
+			  enum nvme_cmd_get_log_lid lid,
+			  __u32 nsid, __u32 len, void *log);
+int nvme_cli_get_log_simple(struct nvme_dev *dev,
+			    enum nvme_cmd_get_log_lid lid,
+			    __u32 len, void *log);
+int nvme_cli_get_log_supported_log_pages(struct nvme_dev *dev, bool rae,
+					 struct nvme_supported_log_pages *log);
+int nvme_cli_get_log_error(struct nvme_dev *dev, unsigned int nr_entries,
+			   bool rae, struct nvme_error_log_page *err_log);
+int nvme_cli_get_log_smart(struct nvme_dev *dev, __u32 nsid, bool rae,
+			   struct nvme_smart_log *smart_log);
+int nvme_cli_get_log_fw_slot(struct nvme_dev *dev, bool rae,
+			     struct nvme_firmware_slot *fw_log);
+int nvme_cli_get_log_changed_ns_list(struct nvme_dev *dev, bool rae,
+				     struct nvme_ns_list *ns_log);
+int nvme_cli_get_log_cmd_effects(struct nvme_dev *dev, enum nvme_csi csi,
+				 struct nvme_cmd_effects_log *effects_log);
+int nvme_cli_get_log_device_self_test(struct nvme_dev *dev,
+				      struct nvme_self_test_log *log);
+int nvme_cli_get_log_create_telemetry_host(struct nvme_dev *dev,
+					   struct nvme_telemetry_log *log);
+int nvme_cli_get_log_telemetry_host(struct nvme_dev *dev, __u64 offset,
+				    __u32 len, void *log);
+int nvme_cli_get_log_telemetry_ctrl(struct nvme_dev *dev, bool rae,
+				    __u64 offset, __u32 len, void *log);
+int nvme_cli_get_log_endurance_group(struct nvme_dev *dev, __u16 endgid,
+				     struct nvme_endurance_group_log *log);
+int nvme_cli_get_log_predictable_lat_nvmset(struct nvme_dev *dev,
+					    __u16 nvmsetid,
+					    struct nvme_nvmset_predictable_lat_log *log);
+int nvme_cli_get_log_predictable_lat_event(struct nvme_dev *dev, bool rae,
+					   __u32 offset, __u32 len, void *log);
+int nvme_cli_get_log_ana(struct nvme_dev *dev,
+			 enum nvme_log_ana_lsp lsp, bool rae,
+			 __u64 offset, __u32 len, void *log);
+int nvme_cli_get_log_ana_groups(struct nvme_dev *dev, bool rae, __u32 len,
+				struct nvme_ana_group_desc *log);
+int nvme_cli_get_log_lba_status(struct nvme_dev *dev, bool rae,
+				__u64 offset, __u32 len, void *log);
+int nvme_cli_get_log_endurance_grp_evt(struct nvme_dev *dev, bool rae,
+				       __u32 offset, __u32 len, void *log);
+int nvme_cli_get_log_fid_supported_effects(struct nvme_dev *dev, bool rae,
+					   struct nvme_fid_supported_effects_log *log);
+int nvme_cli_get_log_mi_cmd_supported_effects(struct nvme_dev *dev, bool rae,
+					      struct nvme_mi_cmd_supported_effects_log *log);
+int nvme_cli_get_log_boot_partition(struct nvme_dev *dev, bool rae, __u8 lsp,
+				    __u32 len,
+				    struct nvme_boot_partition *part);
+int nvme_cli_get_log_discovery(struct nvme_dev *dev, bool rae,
+			       __u32 offset, __u32 len, void *log);
+int nvme_cli_get_log_media_unit_stat(struct nvme_dev *dev, __u16 domid,
+				     struct nvme_media_unit_stat_log *mus);
+int nvme_cli_get_log_support_cap_config_list(struct nvme_dev *dev,
+					     __u16 domid,
+					     struct nvme_supported_cap_config_list_log *cap);
+int nvme_cli_get_log_reservation(struct nvme_dev *dev, bool rae,
+				 struct nvme_resv_notification_log *log);
+int nvme_cli_get_log_sanitize(struct nvme_dev *dev, bool rae,
+			      struct nvme_sanitize_log_page *log);
+int nvme_cli_get_log_zns_changed_zones(struct nvme_dev *dev, __u32 nsid,
+				       bool rae,
+				       struct nvme_zns_changed_zone_log *log);
+int nvme_cli_get_log_persistent_event(struct nvme_dev *dev,
+				      enum nvme_pevent_log_action action,
+				      __u32 size, void *pevent_log);
 #endif /* _NVME_WRAP_H */

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -37,6 +37,8 @@ int nvme_cli_ns_detach_ctrls(struct nvme_dev *dev, __u32 nsid,
 			     struct nvme_ctrl_list *ctrlist);
 
 int nvme_cli_format_nvm(struct nvme_dev *dev, struct nvme_format_nvm_args *args);
+int nvme_cli_sanitize_nvm(struct nvme_dev *dev,
+			  struct nvme_sanitize_nvm_args *args);
 
 int nvme_cli_get_features(struct nvme_dev *dev,
 			  struct nvme_get_features_args *args);

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -36,6 +36,8 @@ int nvme_cli_ns_attach_ctrls(struct nvme_dev *dev, __u32 nsid,
 int nvme_cli_ns_detach_ctrls(struct nvme_dev *dev, __u32 nsid,
 			     struct nvme_ctrl_list *ctrlist);
 
+int nvme_cli_format_nvm(struct nvme_dev *dev, struct nvme_format_nvm_args *args);
+
 int nvme_cli_get_features(struct nvme_dev *dev,
 			  struct nvme_get_features_args *args);
 

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -11,6 +11,11 @@
 
 int nvme_cli_identify(struct nvme_dev *dev, struct nvme_identify_args *args);
 int nvme_cli_identify_ctrl(struct nvme_dev *dev, struct nvme_id_ctrl *ctrl);
+int nvme_cli_identify_ctrl_list(struct nvme_dev *dev, __u16 ctrl_id,
+				struct nvme_ctrl_list *list);
+int nvme_cli_identify_nsid_ctrl_list(struct nvme_dev *dev, __u32 nsid,
+				     __u16 ctrl_id,
+				     struct nvme_ctrl_list *list);
 int nvme_cli_identify_ns(struct nvme_dev *dev, __u32 nsid,
 			 struct nvme_id_ns *ns);
 int nvme_cli_identify_allocated_ns(struct nvme_dev *dev, __u32 nsid,

--- a/nvme.c
+++ b/nvme.c
@@ -2386,7 +2386,7 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		}
 	}
 
-	err = nvme_ns_mgmt_delete(dev_fd(dev), cfg.namespace_id);
+	err = nvme_cli_ns_mgmt_delete(dev, cfg.namespace_id);
 	if (!err)
 		printf("%s: Success, deleted nsid:%d\n", cmd->name,
 								cfg.namespace_id);
@@ -2622,8 +2622,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		.lbstm = cpu_to_le64(cfg.lbstm),
 	};
 
-	err = nvme_ns_mgmt_create(dev_fd(dev), &ns2, &nsid, cfg.timeout,
-				  cfg.csi);
+	err = nvme_cli_ns_mgmt_create(dev, &ns2, &nsid, cfg.timeout, cfg.csi);
 	if (!err)
 		printf("%s: Success, created nsid:%d\n", cmd->name, nsid);
 	else if (err > 0)

--- a/nvme.c
+++ b/nvme.c
@@ -4489,17 +4489,15 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	struct nvme_sanitize_nvm_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.sanact		= cfg.sanact,
 		.ause		= cfg.ause,
 		.owpass		= cfg.owpass,
 		.oipbp		= cfg.oipbp,
 		.nodas		= cfg.no_dealloc,
 		.ovrpat		= cfg.ovrpat,
-		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 		.result		= NULL,
 	};
-	err = nvme_sanitize_nvm(&args);
+	err = nvme_cli_sanitize_nvm(dev, &args);
 	if (err < 0)
 		fprintf(stderr, "sanitize: %s\n", nvme_strerror(errno));
 	else if (err > 0)

--- a/nvme.c
+++ b/nvme.c
@@ -2581,7 +2581,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 			err = -EINVAL;
 			goto close_dev;
 		}
-		err = nvme_identify_ns(dev_fd(dev), NVME_NSID_ALL, &ns);
+		err = nvme_cli_identify_ns(dev, NVME_NSID_ALL, &ns);
 		if (err) {
 			if (err < 0)
 				fprintf(stderr, "identify-namespace: %s",
@@ -2985,7 +2985,7 @@ static int nvm_id_ns(int argc, char **argv, struct command *cmd,
 		}
 	}
 
-	err = nvme_identify_ns(dev_fd(dev), cfg.namespace_id, &ns);
+	err = nvme_cli_identify_ns(dev, cfg.namespace_id, &ns);
 	if (err) {
 		nvme_show_status(err);
 		goto close_dev;
@@ -3055,7 +3055,7 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *cmd, stru
 	if (cfg.verbose)
 		flags |= VERBOSE;
 
-	err = nvme_identify_ns(dev_fd(dev), NVME_NSID_ALL, &ns);
+	err = nvme_cli_identify_ns(dev, NVME_NSID_ALL, &ns);
 	if (err) {
 		ns.nlbaf = NVME_FEAT_LBA_RANGE_MAX - 1;
 		ns.nulbaf = 0;
@@ -3212,10 +3212,10 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 	}
 
 	if (cfg.force)
-		err = nvme_identify_allocated_ns(dev_fd(dev),
-						 cfg.namespace_id, &ns);
+		err = nvme_cli_identify_allocated_ns(dev,
+						     cfg.namespace_id, &ns);
 	else
-		err = nvme_identify_ns(dev_fd(dev), cfg.namespace_id, &ns);
+		err = nvme_cli_identify_ns(dev, cfg.namespace_id, &ns);
 
 	if (!err)
 		nvme_show_id_ns(&ns, cfg.namespace_id, 0, false, flags);
@@ -4914,7 +4914,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 	}
 
 	if (cfg.namespace_id != NVME_NSID_ALL) {
-		err = nvme_identify_ns(dev_fd(dev), cfg.namespace_id, &ns);
+		err = nvme_cli_identify_ns(dev, cfg.namespace_id, &ns);
 		if (err) {
 			if (err < 0)
 				fprintf(stderr, "identify-namespace: %s\n", nvme_strerror(errno));
@@ -5718,7 +5718,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 		}
 	}
 
-	err = nvme_identify_ns(dev_fd(dev), cfg.namespace_id, &ns);
+	err = nvme_cli_identify_ns(dev, cfg.namespace_id, &ns);
 	if (err) {
 		nvme_show_status(err);
 		goto close_dev;
@@ -6695,7 +6695,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 	}
 
 	if (cfg.metadata_size) {
-		err = nvme_identify_ns(dev_fd(dev), cfg.namespace_id, &ns);
+		err = nvme_cli_identify_ns(dev, cfg.namespace_id, &ns);
 		if (err > 0) {
 			nvme_show_status(err);
 			goto free_buffer;
@@ -6950,7 +6950,7 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		}
 	}
 
-	err = nvme_identify_ns(dev_fd(dev), cfg.namespace_id, &ns);
+	err = nvme_cli_identify_ns(dev, cfg.namespace_id, &ns);
 	if (err) {
 		nvme_show_status(err);
 		goto close_dev;

--- a/nvme.c
+++ b/nvme.c
@@ -2454,11 +2454,11 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	nvme_init_ctrl_list(&cntlist, num, ctrlist);
 
 	if (attach)
-		err = nvme_ns_attach_ctrls(dev_fd(dev), cfg.namespace_id,
-					   &cntlist);
+		err = nvme_cli_ns_attach_ctrls(dev, cfg.namespace_id,
+					       &cntlist);
 	else
-		err = nvme_ns_detach_ctrls(dev_fd(dev), cfg.namespace_id,
-					   &cntlist);
+		err = nvme_cli_ns_detach_ctrls(dev, cfg.namespace_id,
+					       &cntlist);
 
 	if (!err)
 		printf("%s: Success, nsid:%d\n", cmd->name, cfg.namespace_id);

--- a/nvme.c
+++ b/nvme.c
@@ -2117,12 +2117,10 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 	}
 
 	if (cfg.namespace_id == NVME_NSID_NONE)
-		err = nvme_identify_ctrl_list(dev_fd(dev), cfg.cntid,
-					      cntlist);
+		err = nvme_cli_identify_ctrl_list(dev, cfg.cntid, cntlist);
 	else
-		err = nvme_identify_nsid_ctrl_list(dev_fd(dev),
-						   cfg.namespace_id,
-						   cfg.cntid, cntlist);
+		err = nvme_cli_identify_nsid_ctrl_list(dev, cfg.namespace_id,
+							cfg.cntid, cntlist);
 	if (!err)
 		nvme_show_list_ctrl(cntlist, flags);
 	else if (err > 0)

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 47e3562a7d9b4bb871f374058c52c654fb4735e9
+revision = 501347ffdf6321d42ceabf173792c95bd44dac0d
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Now that we have the MI transport & wrapper infrastructure merged, and the admin commands implemented in libnvme-mi, we can add more functionality to the wrapper code, and start using the `nvme_cli_` functions in nvme-cli.

As always, comments, queries, suggestions etc are most welcome.