### PR TITLE
wdc:  OCP Log page updates and fixes

### DIFF
--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.0.3"
+#define WDC_PLUGIN_VERSION   "2.1.1"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
Add support for Version 1 Error Recovery log page
Fix fw-activate-history timestamp json data
Update OCP log page capabiliites for SN550, SN650,
  and SN655

Signed-off-by: Jeff Lien <jeff.lien@wdc.com>