### PR TITLE
tree: fail on non-negative return values from parse_and_open

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -887,7 +887,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *cmd, struct plugin *p
 		unsigned int rpmbs;
 	} regs;
 	
-	if ((err = parse_and_open(&dev, argc, argv, desc, opts)) < 0)
+	if ((err = parse_and_open(&dev, argc, argv, desc, opts)))
 		return err;
 	
 	/* before parsing  commands, check if controller supports any RPMB targets */

--- a/nvme.c
+++ b/nvme.c
@@ -441,7 +441,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -498,7 +498,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -577,7 +577,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.file_name) {
@@ -675,7 +675,7 @@ static int get_endurance_log(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -756,7 +756,7 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -843,7 +843,7 @@ static int get_supported_log_pages(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -901,7 +901,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -975,7 +975,7 @@ static int get_fw_log(int argc, char **argv, struct command *cmd, struct plugin 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1025,7 +1025,7 @@ static int get_changed_ns_list_log(int argc, char **argv, struct command *cmd, s
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1083,7 +1083,7 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1150,7 +1150,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1241,7 +1241,7 @@ static int get_persistent_event_log(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1374,7 +1374,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1456,7 +1456,7 @@ static int get_lba_status_log(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1524,7 +1524,7 @@ static int get_resv_notif_log(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1582,7 +1582,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1688,7 +1688,7 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1744,7 +1744,7 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1837,7 +1837,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.aen) {
@@ -1940,7 +1940,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -1992,7 +1992,7 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2044,7 +2044,7 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2100,7 +2100,7 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2168,7 +2168,7 @@ static int list_ns(int argc, char **argv, struct command *cmd, struct plugin *pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2252,7 +2252,7 @@ static int id_ns_lba_format(int argc, char **argv, struct command *cmd, struct p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2305,7 +2305,7 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2369,7 +2369,7 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -2423,7 +2423,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -2559,7 +2559,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.flbas != 0xff && cfg.bs != 0x00) {
@@ -2847,7 +2847,7 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2903,7 +2903,7 @@ static int nvm_id_ctrl(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -2961,7 +2961,7 @@ static int nvm_id_ns(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3039,7 +3039,7 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *cmd, stru
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3102,7 +3102,7 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3184,7 +3184,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3261,7 +3261,7 @@ static int cmd_set_independent_id_ns(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3320,7 +3320,7 @@ static int id_ns_granularity(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3377,7 +3377,7 @@ static int id_nvmset(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3431,7 +3431,7 @@ static int id_uuid(int argc, char **argv, struct command *cmd, struct plugin *pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3479,7 +3479,7 @@ static int id_iocs(int argc, char **argv, struct command *cmd, struct plugin *pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = nvme_identify_iocs(dev_fd(dev), cfg.cntid, &iocs);
@@ -3523,7 +3523,7 @@ static int id_domain(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3558,7 +3558,7 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = nvme_get_nsid(dev_fd(dev), &nsid);
@@ -3620,7 +3620,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	struct nvme_virtual_mgmt_args args = {
@@ -3679,7 +3679,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3737,7 +3737,7 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -3804,7 +3804,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	struct nvme_dev_self_test_args args = {
@@ -3867,7 +3867,7 @@ static int self_test_log(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -4061,7 +4061,7 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -4136,7 +4136,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	fw_fd = open(cfg.fw, O_RDONLY);
@@ -4262,7 +4262,7 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.slot > 7) {
@@ -4343,7 +4343,7 @@ static int subsystem_reset(int argc, char **argv, struct command *cmd, struct pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = nvme_subsystem_reset(dev_fd(dev));
@@ -4371,7 +4371,7 @@ static int reset(int argc, char **argv, struct command *cmd, struct plugin *plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = nvme_ctrl_reset(dev_fd(dev));
@@ -4394,7 +4394,7 @@ static int ns_rescan(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = nvme_ns_rescan(dev_fd(dev));
@@ -4447,7 +4447,7 @@ static int sanitize(int argc, char **argv, struct command *cmd, struct plugin *p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	switch (cfg.sanact) {
@@ -4620,7 +4620,7 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	r = nvme_scan(NULL);
@@ -4681,7 +4681,7 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.offset == -1) {
@@ -4738,7 +4738,7 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.offset == -1) {
@@ -4844,7 +4844,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 		goto ret;
 
 	err = open_exclusive(&dev, argc, argv, cfg.force);
-	if (err < 0) {
+	if (err) {
 		if (errno == EBUSY) {
 			fprintf(stderr, "Failed to open %s.\n",
 		                basename(argv[optind]));
@@ -5102,7 +5102,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -5268,7 +5268,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.tl == 0) {
@@ -5410,7 +5410,7 @@ static int dir_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	switch (cfg.dtype) {
@@ -5545,7 +5545,7 @@ static int write_uncor(int argc, char **argv, struct command *cmd, struct plugin
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -5684,7 +5684,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.prinfo > 0xf) {
@@ -5819,7 +5819,7 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	nc = argconfig_parse_comma_sep_array(cfg.ctx_attrs, (int *)ctx_attrs, ARRAY_SIZE(ctx_attrs));
@@ -5973,7 +5973,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	nb = argconfig_parse_comma_sep_array_short(cfg.nlbs, nlbs, ARRAY_SIZE(nlbs));
@@ -6073,7 +6073,7 @@ static int flush(int argc, char **argv, struct command *cmd, struct plugin *plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -6143,7 +6143,7 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -6227,7 +6227,7 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -6319,7 +6319,7 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!cfg.namespace_id) {
@@ -6403,7 +6403,7 @@ static int resv_report(int argc, char **argv, struct command *cmd, struct plugin
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -6587,14 +6587,14 @@ static int submit_io(int opcode, char *command, const char *desc,
 
 	if (opcode != nvme_cmd_write) {
 		err = parse_and_open(&dev, argc, argv, desc, opts);
-		if (err < 0)
+		if (err)
 			goto ret;
 	} else {
 		err = argconfig_parse(argc, argv, desc, opts);
 		if (err)
 			goto ret;
 		err = open_exclusive(&dev, argc, argv, cfg.force);
-		if (err < 0) {
+		if (err) {
 			if (errno == EBUSY) {
 				fprintf(stderr, "Failed to open %s.\n",
 					basename(argv[optind]));
@@ -6917,7 +6917,7 @@ static int verify_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.prinfo > 0xf) {
@@ -7044,7 +7044,7 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.size) {
@@ -7145,7 +7145,7 @@ static int get_lba_status(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto err;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -7231,7 +7231,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.operation > 0xf) {
@@ -7324,7 +7324,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.human_readable)
@@ -7465,7 +7465,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	/* check for input argument limit */
@@ -7636,7 +7636,7 @@ static int passthru(int argc, char **argv, bool admin,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (cfg.opcode & 0x01)

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -128,7 +128,7 @@ static int get_status(int argc, char **argv, struct command *cmd, struct plugin 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 	
 	err = nvme_get_log_simple(dev_fd(dev), 0xc0, sizeof(log), &log);

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -40,7 +40,7 @@ static int innogrit_smart_log_additional(int argc, char **argv,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	nvme_get_log_smart(dev_fd(dev), cfg.namespace_id, false, &smart_log);
@@ -183,7 +183,7 @@ static int innogrit_vsc_geteventlog(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 
@@ -312,7 +312,7 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	if (getcwd(currentdir, 128) == NULL)

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -365,7 +365,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	err = nvme_get_log_simple(dev_fd(dev), 0xca, sizeof(smart_log),
@@ -407,7 +407,7 @@ static int get_market_log(int argc, char **argv, struct command *cmd, struct plu
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	err = nvme_get_log_simple(dev_fd(dev), 0xdd, sizeof(log), log);
@@ -469,7 +469,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *cmd, struct
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	err = nvme_get_log_simple(dev_fd(dev), 0xc5, sizeof(stats), &stats);
@@ -1055,7 +1055,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	/* For optate, latency stats are deleted every time their LID is pulled.
@@ -1387,7 +1387,7 @@ static int get_internal_log(int argc, char **argv, struct command *command,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		free(intel);
 		return err;
 	}
@@ -1579,7 +1579,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	else if (cfg.enable || cfg.disable)
 		option = cfg.enable;
 
-	if (err < 0)
+	if (err)
 		return err;
 
 	struct nvme_get_features_args args_get = {
@@ -1680,7 +1680,7 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 
-	if (err < 0)
+	if (err)
 		return err;
 
 	/* Query maj and minor version first to figure out the amount of

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -475,7 +475,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *cm
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	err = nvme_get_nsid_log(dev_fd(dev), false, 0xca, cfg.namespace_id,
@@ -518,7 +518,7 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
 	    return err;
 
     struct nvme_get_features_args args = {
@@ -576,7 +576,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
 	    return err;
 
     struct nvme_set_features_args args = {
@@ -641,7 +641,7 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
 	    return err;
 
     if (parse_params(cfg.param, 2, &param1, &param2)) {
@@ -793,7 +793,7 @@ static int mb_high_latency_log_print(int argc, char **argv, struct command *cmd,
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
 	    return err;
 
     fdi = fopen(FID_C3_LOG_FILENAME, "w+");
@@ -864,7 +864,7 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	if (strlen(cfg.select) != 3) {
@@ -1086,7 +1086,7 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *cmd, st
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
 	    return err;
 
     err = nvme_get_log_simple(dev_fd(dev), cfg.write ? 0xc2 : 0xc1,
@@ -1130,7 +1130,7 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
         return err;
 
     struct nvme_set_features_args args = {
@@ -1254,7 +1254,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 		.result		= &result,
 	};
 
-	if (err < 0)
+	if (err)
 		return err;
 	switch (option) {
 	case None:

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -461,7 +461,7 @@ static int micron_parse_options(struct nvme_dev **dev, int argc, char **argv,
     int idx = 0;
     int err = parse_and_open(dev, argc, argv, desc, opts);
 
-    if (err < 0) {
+    if (err) {
         perror("open");
         return -1;
     }
@@ -519,7 +519,7 @@ static int micron_selective_download(int argc, char **argv,
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
         return err;
 
     if (strlen(cfg.select) != 3) {
@@ -741,7 +741,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *cmd,
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0) {
+    if (err) {
         printf("\nDevice not found \n");;
         return -1;
     }
@@ -883,7 +883,7 @@ static int micron_pcie_stats(int argc, char **argv,
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0) {
+    if (err) {
         printf("\nDevice not found \n");;
         return -1;
     }
@@ -1518,7 +1518,7 @@ static int micron_nand_stats(int argc, char **argv,
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0) {
+    if (err) {
         printf("\nDevice not found \n");;
         return -1;
     }
@@ -1620,7 +1620,7 @@ static int micron_smart_ext_log(int argc, char **argv,
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0) {
+    if (err) {
         printf("\nDevice not found \n");;
         return -1;
     }
@@ -3123,7 +3123,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *cmd,
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
         return err;
 
     /* if telemetry type is specified, check for data area */

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -418,7 +418,7 @@ static int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
         };
 
         ret = parse_and_open(&dev, argc, argv, desc, opts);
-        if (ret < 0)
+        if (ret)
                 return ret;
 
         ret = get_c0_log_page(dev_fd(dev), cfg.output_format);
@@ -764,7 +764,7 @@ static int ocp_latency_monitor_log(int argc, char **argv, struct command *comman
         };
 
         ret = parse_and_open(&dev, argc, argv, desc, opts);
-        if (ret < 0)
+        if (ret)
                 return ret;
 
         ret = get_c3_log_page(dev, cfg.output_format);

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -424,7 +424,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	err = nvme_get_nsid_log(dev_fd(dev), false, 0xca, cfg.namespace_id,
@@ -638,7 +638,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	err = nvme_get_log_simple(dev_fd(dev), cfg.write ? 0xc3 : 0xc1,
@@ -778,7 +778,7 @@ static int sfx_get_bad_block(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	data_buf = malloc(buf_size);
@@ -835,7 +835,7 @@ static int query_cap_info(int argc, char **argv, struct command *cmd, struct plu
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	if (nvme_query_cap(dev_fd(dev), 0xffffffff, sizeof(ctx), &ctx)) {
@@ -970,7 +970,7 @@ static int change_cap(int argc, char **argv, struct command *cmd, struct plugin 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	cap_in_sec = IDEMA_CAP(cfg.capacity_in_gb);
@@ -1086,7 +1086,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *cmd, struct pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	if (!cfg.feature_id) {
@@ -1185,7 +1185,7 @@ static int sfx_get_feature(int argc, char **argv, struct command *cmd, struct pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	if (!cfg.feature_id) {

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -176,7 +176,7 @@ static int log_pages_supp(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 	err = nvme_get_log_simple(dev_fd(dev), 0xc5,
 				  sizeof(logPageMap), &logPageMap);
@@ -738,7 +738,7 @@ static int vs_smart_log(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		printf ("\nDevice not found \n");
 		return -1;
 	}
@@ -843,7 +843,7 @@ static int temp_stats(int argc, char **argv, struct command *cmd, struct plugin 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		printf ("\nDevice not found \n");;
 		return -1;
 	}
@@ -1017,7 +1017,7 @@ static int vs_pcie_error_log(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		printf ("\nDevice not found \n");;
 		return -1;
 	}
@@ -1063,7 +1063,7 @@ static int vs_clr_pcie_correctable_errs(int argc, char **argv, struct command *c
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		printf ("\nDevice not found \n");;
 		return -1;
 	}
@@ -1115,7 +1115,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	dump_fd = STDOUT_FILENO;
@@ -1236,7 +1236,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	dump_fd = STDOUT_FILENO;
@@ -1371,7 +1371,7 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	dump_fd = STDOUT_FILENO;

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -139,7 +139,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 	err = nvme_get_nsid_log(dev_fd(dev), false, 0xca, cfg.namespace_id,
 				sizeof(smart_log), &smart_log);
@@ -211,7 +211,7 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	if (cfg.sel > 7) {
@@ -324,7 +324,7 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	if (!cfg.feature_id) {

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -80,7 +80,7 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	enum nvme_print_flags flags = validate_output_format(cfg.output_format);

--- a/plugins/solidigm/solidigm-latency-tracking.c
+++ b/plugins/solidigm/solidigm-latency-tracking.c
@@ -409,7 +409,7 @@ int solidigm_get_latency_tracking_log(int argc, char **argv, struct command *cmd
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	lt.fd = dev_fd(dev);

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -221,7 +221,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	flags = validate_output_format(cfg.output_format);

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -460,7 +460,7 @@ static int vendor_log(int argc, char **argv, struct command *cmd, struct plugin 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		fprintf(stderr,"%s: failed to parse arguments\n", __func__);
 		return EINVAL;
 	}
@@ -507,7 +507,7 @@ static int internal_log(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		fprintf(stderr,"%s: failed to parse arguments\n", __func__);
 		return EINVAL;
 	}
@@ -546,7 +546,7 @@ static int clear_correctable_errors(int argc, char **argv, struct command *cmd,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		fprintf(stderr,"%s: failed to parse arguments\n", __func__);
 		return EINVAL;
 	}

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -30,7 +30,7 @@ static int getHealthValue(int argc, char **argv, struct command *cmd, struct plu
 	};
 
 	result = parse_and_open(&dev, argc, argv, desc, opts);
-	if (result < 0) {
+	if (result) {
 		printf("\nDevice not found \n");;
 		return -1;
 	}
@@ -68,7 +68,7 @@ static int getBadblock(int argc, char **argv, struct command *cmd, struct plugin
 	};
 
 	result = parse_and_open(&dev, argc, argv, desc, opts);
-	if (result < 0) {
+	if (result) {
 		printf("\nDevice not found \n");;
 		return -1;
 	}

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -976,7 +976,7 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv, struct command *cm
 	}
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		printf("Error parse and open (err = %d)\n", err);
 		return err;
 	}
@@ -1039,7 +1039,7 @@ static int vt_show_identify(int argc, char **argv, struct command *cmd, struct p
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0) {
+	if (err) {
 		printf("Error parse and open (err = %d)\n", err);
 		return err;
 	}

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -3022,7 +3022,7 @@ static int wdc_cap_diag(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -3341,7 +3341,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *command
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -3637,7 +3637,7 @@ static int wdc_drive_log(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -3691,7 +3691,7 @@ static int wdc_get_crash_dump(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -3742,7 +3742,7 @@ static int wdc_get_pfail_dump(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -3832,7 +3832,7 @@ static int wdc_purge(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -3894,7 +3894,7 @@ static int wdc_purge_monitor(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7170,7 +7170,7 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7291,7 +7291,7 @@ static int wdc_vs_cloud_log(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7362,7 +7362,7 @@ static int wdc_vs_hw_rev_log(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7453,7 +7453,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7565,7 +7565,7 @@ static int wdc_get_latency_monitor_log(int argc, char **argv, struct command *co
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7610,7 +7610,7 @@ static int wdc_get_error_recovery_log(int argc, char **argv, struct command *com
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7655,7 +7655,7 @@ static int wdc_get_dev_capabilities_log(int argc, char **argv, struct command *c
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7700,7 +7700,7 @@ static int wdc_get_unsupported_reqs_log(int argc, char **argv, struct command *c
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7777,7 +7777,7 @@ static int wdc_clear_pcie_correctable_errors(int argc, char **argv, struct comma
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7829,7 +7829,7 @@ static int wdc_drive_status(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -7944,7 +7944,7 @@ static int wdc_clear_assert_dump(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -8145,7 +8145,7 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *com
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -8268,7 +8268,7 @@ static int wdc_clear_fw_activate_history(int argc, char **argv, struct command *
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -8324,7 +8324,7 @@ static int wdc_vs_telemetry_controller_option(int argc, char **argv, struct comm
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -9128,7 +9128,7 @@ static int wdc_drive_essentials(int argc, char **argv, struct command *command,
 
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -9224,7 +9224,7 @@ static int wdc_drive_resize(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -9274,7 +9274,7 @@ static int wdc_namespace_resize(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	if ((cfg.op_option != 0x1) &&
@@ -9340,7 +9340,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
 
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -9475,7 +9475,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *command
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	ret = validate_output_format(cfg.output_format);
@@ -10157,7 +10157,7 @@ static int wdc_vs_nand_stats(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -10237,7 +10237,7 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *command,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 
@@ -10326,7 +10326,7 @@ static int wdc_vs_drive_info(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	fmt = validate_output_format(cfg.output_format);
@@ -10535,7 +10535,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	r = nvme_scan(NULL);
@@ -10641,7 +10641,7 @@ static int wdc_capabilities(int argc, char **argv,
     };
 
     ret = parse_and_open(&dev, argc, argv, desc, opts);
-    if (ret < 0)
+    if (ret)
         return ret;
 
     /* get capabilities */
@@ -10746,7 +10746,7 @@ static int wdc_cloud_ssd_plugin_version(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	/* get capabilities */
@@ -10793,7 +10793,7 @@ static int wdc_cloud_boot_SSD_version(int argc, char **argv,
 	};
 
 	ret = parse_and_open(&dev, argc, argv, desc, opts);
-	if (ret < 0)
+	if (ret)
 		return ret;
 
 	/* get capabilities */
@@ -10863,7 +10863,7 @@ static int wdc_enc_get_log(int argc, char **argv, struct command *command,
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	if (!wdc_enc_check_model(dev)) {

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -142,7 +142,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
     };
 
     err = parse_and_open(&dev, argc, argv, desc, opts);
-    if (err < 0)
+    if (err)
         return err;
 
     err = nvme_get_nsid_log(dev_fd(dev), false, 0xca, cfg.namespace_id,

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -137,7 +137,7 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	err = flags = validate_output_format(cfg.output_format);
@@ -190,7 +190,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	flags = validate_output_format(cfg.output_format);
@@ -256,7 +256,7 @@ static int zns_mgmt_send(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		goto ret;
 
 	err = asprintf(&command, "%s-%s", plugin->name, cmd->name);
@@ -376,7 +376,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *cmd, struct plu
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	if (!cfg.namespace_id) {
@@ -515,7 +515,7 @@ static int open_zone(int argc, char **argv, struct command *cmd, struct plugin *
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	if (!cfg.namespace_id) {
@@ -597,7 +597,7 @@ static int set_zone_desc(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	if (!cfg.namespace_id) {
@@ -696,7 +696,7 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *cmd, struct pl
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	if (!cfg.namespace_id) {
@@ -771,7 +771,7 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	flags = validate_output_format(cfg.output_format);
@@ -887,7 +887,7 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	flags = validate_output_format(cfg.output_format);
@@ -1082,7 +1082,7 @@ static int zone_append(int argc, char **argv, struct command *cmd, struct plugin
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	if (!cfg.data_size) {
@@ -1261,7 +1261,7 @@ static int changed_zone_list(int argc, char **argv, struct command *cmd, struct 
 	};
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return errno;
 
 	flags = validate_output_format(cfg.output_format);


### PR DESCRIPTION
Currently, we see a warning with specific compilers:

```
  ../nvme/nvme.c: In function 'ns_rescan':
  ../nvme/nvme.c:4389:19: warning: 'dev' may be used uninitialized in this function [-Wmaybe-uninitialized]
```

This is due to a theoretical failure path in `parse_and_open()`, where
`argconfig_parse()` returns a positive value - this would require the
global `errno` to be negative.

Even though the unintialised use of dev is only possible with negative
error (which shouldn't happen), we should still consider any non-zero
return value of `parse_and_open` a failure. This change fixes the
instances of:

    err = parse_and_open(...);
    if (err < 0)

changing to:

    err = parse_and_open(...);
    if (err)

... and also applies this to the single use of `open_exclusive()`.

The positive return values from `parse_and_open()` were removed in
11542bbd; beforehand, `parse_and_open()` would return a fd.

Fixes: 11542bbd ("tree: Combine NVMe file descriptor into struct nvme_dev")
Fixes: https://github.com/linux-nvme/nvme-cli/issues/1647

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>