### PR TITLE
nvme: Masks SSTAT in sanize-log output

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -6502,7 +6502,7 @@ void nvme_show_sanitize_log(struct nvme_sanitize_log_page *sanitize,
 		printf("\n");
 
 	printf("Sanitize Status                        (SSTAT) :  %#x\n",
-		le16_to_cpu(sanitize->sstat));
+		le16_to_cpu(sanitize->sstat) & NVME_SANITIZE_SSTAT_STATUS_MASK);
 	if (human)
 		nvme_show_sanitize_log_sstat(le16_to_cpu(sanitize->sstat));
 


### PR DESCRIPTION
The sanitize->sstat needs to be mask. We do this for the JSON output
but not for the normal shell output.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: https://github.com/linux-nvme/nvme-cli/issues/752