### PR TITLE
fguid printed with wrong format

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4624,7 +4624,7 @@ void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, enum nvme_print_flags flags,
 	printf("cntrltype : %d\n", ctrl->cntrltype);
 	if (human)
 		nvme_show_id_ctrl_cntrltype(ctrl->cntrltype);
-	printf("fguid     : %-.*s\n", (int)sizeof(ctrl->fguid), ctrl->fguid);
+    printf("fguid     : %.0Lf\n", int128_to_double(ctrl->fguid));
 	printf("crdt1     : %u\n", le16_to_cpu(ctrl->crdt1));
 	printf("crdt2     : %u\n", le16_to_cpu(ctrl->crdt2));
 	printf("crdt3     : %u\n", le16_to_cpu(ctrl->crdt3));

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4624,7 +4624,7 @@ void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, enum nvme_print_flags flags,
 	printf("cntrltype : %d\n", ctrl->cntrltype);
 	if (human)
 		nvme_show_id_ctrl_cntrltype(ctrl->cntrltype);
-    printf("fguid     : %.0Lf\n", int128_to_double(ctrl->fguid));
+	printf("fguid     : %s\n", nvme_uuid_to_string(ctrl->fguid));
 	printf("crdt1     : %u\n", le16_to_cpu(ctrl->crdt1));
 	printf("crdt2     : %u\n", le16_to_cpu(ctrl->crdt2));
 	printf("crdt3     : %u\n", le16_to_cpu(ctrl->crdt3));


### PR DESCRIPTION
Signed-off-by: Pierre Labat <plabat@micron.com>

The fguid (__u8  fguid[16]) of the  Identify Controller Data Structure is made of non printable characters. From the nvme spec "This field uses the EUI-64 based 16-byte designator format". As a result when fguid is not zero, the printf output is garbled/spread on several lines because the format used is a string format (%-.*s).
fguid should be printed the same as other similar fields of the Identify Controller Data Structure (containing 16 non printable characters). So no garbling is occurring.
