### PR TITLE
udev: Add HOST_IFACE to udev rule

### DIFF
--- a/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
+++ b/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
@@ -4,16 +4,22 @@
 #   controller and connect to elements in the discovery log.
 #
 #
+ACTION!="change", GOTO="autoconnect_end"
+
+# For backwards compatibility. Make sure HOST_IFACE is not an empty string.
+ENV{NVME_HOST_IFACE}=="", ENV{NVME_HOST_IFACE}="none"
 
 # Events from persistent discovery controllers or nvme-fc transport events
 # NVME_AEN:
 #   type 0x2 (NOTICE) info 0xf0 (DISCOVERY_LOG_CHANGE) log-page-id 0x70 (DISCOVERY_LOG_PAGE)
 ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_AEN}=="0x70f002",\
   ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
-  ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}.service"
+  ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", ENV{NVME_HOST_IFACE}=="*", \
+  RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}\t--host-iface=$env{NVME_HOST_IFACE}.service"
 
 # nvme-fc transport generated events (old-style for compatibility)
 ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
   ENV{NVMEFC_HOST_TRADDR}=="*",  ENV{NVMEFC_TRADDR}=="*", \
   RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=none\t--transport=fc\t--traddr=$env{NVMEFC_TRADDR}\t--trsvcid=none\t--host-traddr=$env{NVMEFC_HOST_TRADDR}.service"
+
+LABEL="autoconnect_end"


### PR DESCRIPTION
The HOST_IFACE only applies to TCP connections. When provided, it forces TCP connections on a specific interface instead of letting the routing table decide. Some users may prefer to force connections on specific interfaces instead of configuring the routing table. This change makes sure that the HOST_IFACE used to set up the persistent connection to the discovery controller also gets applied to the I/O controller connections.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>