### PR TITLE
doc: Update examples in nvme-list-subsys.txt

### DIFF
--- a/Documentation/nvme-list-subsys.txt
+++ b/Documentation/nvme-list-subsys.txt
@@ -30,12 +30,12 @@ EXAMPLES
 root@host# nvme list-subsys
 nvme-subsys0 - NQN=nvmf-test
 \
- +- nvme0 rdma traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.1
- +- nvme1 rdma traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.2
+ +- nvme0 rdma traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1
+ +- nvme1 rdma traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2
 nvme-subsys1 - NQN=nvmf-test2
 \
- +- nvme2 rdma traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.2
- +- nvme3 rdma traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.1
+ +- nvme2 rdma traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2
+ +- nvme3 rdma traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1
 
 [verse]
 root@host# nvme list-subsys -o json
@@ -50,12 +50,12 @@ root@host# nvme list-subsys -o json
         {
           "Name" : "nvme0",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.1"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1"
         },
         {
           "Name" : "nvme1",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.2"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2"
         }
       ]
     },
@@ -68,12 +68,12 @@ root@host# nvme list-subsys -o json
         {
           "Name" : "nvme2",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.2"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2"
         },
         {
           "Name" : "nvme3",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3 trsvcid=4420 host_traddr=1.1.1.1"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1"
         }
       ]
     }


### PR DESCRIPTION
The examples show the output from nvme-cli 1.x. The address field shows the attributes separated by spaces. The corresponding code in libnvme doesn't do this. Instead the exact output from sysfs, e.g.

  # cat /sys/class/nvme/nvme0/address
  traddr=192.168.201.101,trsvcid=4420

Update the example in the nvme list-subsys documentation.

Signed-off-by: Daniel Wagner <dwagnwer@suse.de>