### PR TITLE
plugins/wdc: Add type case for feature id

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -8997,7 +8997,7 @@ static int wdc_do_drive_essentials(nvme_root_t r, struct nvme_dev *dev,
 		if (deFeatureIdList[listIdx].featureId == FID_LBA_RANGE_TYPE)
 			continue;
 		ret = nvme_get_features_data(dev_fd(dev),
-					     deFeatureIdList[listIdx].featureId,
+					     (enum nvme_features_id)deFeatureIdList[listIdx].featureId,
 					     WDC_DE_GLOBAL_NSID,
 					     sizeof(featureIdBuff),
 					     &featureIdBuff, &result);


### PR DESCRIPTION
clang reports

../plugins/wdc/wdc-nvme.c:9000:36: warning: implicit conversion from enumeration type 'NVME_FEATURE_IDENTIFIERS' (aka 'enum _NVME_FEATURE_IDENTIFIERS') to different enumeration type 'enum nvme_features_id' [-Wenum-conversion]
                                             deFeatureIdList[listIdx].featureId,
                                             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~

Add type case to avoid the warning. Ideally, the plugin would not introduce their own enum value.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: https://github.com/linux-nvme/nvme-cli/issues/1665