### PR TITLE
Add warning fixes and enable cross compilation targets in github workflows

### DIFF
--- a/.github/cross/ubuntu-armhf.txt
+++ b/.github/cross/ubuntu-armhf.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = '/usr/bin/arm-linux-gnueabihf-gcc'
+ar = '/usr/arm-linux-gnueabihf/bin/ar'
+strip = '/usr/arm-linux-gnueabihf/bin/strip'
+pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
+ld = '/usr/bin/arm-linux/gnueabihf-ld'
+
+[properties]
+root = '/usr/arm-linux-gnueabihf'
+has_function_printf = true
+skip_sanity_check = true
+
+[host_machine]
+system = 'linux'
+cpu_family = 'arm'
+cpu = 'armv7'
+endian = 'little'

--- a/.github/cross/ubuntu-ppc64le.txt
+++ b/.github/cross/ubuntu-ppc64le.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = '/usr/bin/powerpc64le-linux-gnu-gcc'
+ar = '/usr/powerpc64le-linux-gnu/bin/ar'
+strip = '/usr/powerpc64le-linux-gnu/bin/strip'
+pkgconfig = '/usr/bin/powerpc64le-linux-gnu-pkg-config'
+ld = '/usr/bin/powerpc64le-linux-gnu-ld'
+
+[properties]
+root = '/usr/powerpc64le-linux-gnu'
+has_function_printf = true
+skip_sanity_check = true
+
+[host_machine]
+system = 'linux'
+cpu_family = 'ppc64'
+cpu = ''
+endian = 'little'

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -28,6 +28,66 @@ jobs:
           setup-options: --werror
           action: build
 
+  build-cross-armhf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up arm architecture
+        run: |
+          export release=$(lsb_release -c -s)
+          sudo dpkg --add-architecture armhf
+          sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
+          sudo dd of=/etc/apt/sources.list.d/armhf.list <<EOF
+          deb [arch=armhf] http://ports.ubuntu.com/ $release main universe restricted"
+          deb [arch=armhf] http://ports.ubuntu.com/ $release-updates main universe restricted"
+          EOF
+          sudo apt update
+      - name: install armhf compiler
+        run: sudo apt install gcc-arm-linux-gnueabihf pkg-config
+      - name: install libraries
+        run: sudo apt install uuid-dev:armhf libjson-c-dev:armhf
+      - uses: actions/checkout@v3
+      - uses: BSFishy/meson-build@v1.0.3
+        with:
+          # suppress python for now; the python headers currently assume native
+          setup-options: --werror --cross-file=.github/cross/ubuntu-armhf.txt -Dlibnvme:python=false
+          options: --verbose
+          action: build
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Linux_Meson_Testlog
+          path: build/meson-logs/testlog.txt
+
+  build-cross-ppc64le:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up ppc64le architecture
+        run: |
+          export release=$(lsb_release -c -s)
+          sudo dpkg --add-architecture ppc64el
+          sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
+          sudo dd of=/etc/apt/sources.list.d/ppc64el.list <<EOF
+          deb [arch=ppc64el] http://ports.ubuntu.com/ $release main universe restricted"
+          deb [arch=ppc64el] http://ports.ubuntu.com/ $release-updates main universe restricted"
+          EOF
+          sudo apt update
+      - name: install powerpc64le compiler
+        run: sudo apt install gcc-powerpc64le-linux-gnu pkg-config
+      - name: install libraries
+        run: sudo apt install uuid-dev:ppc64el libjson-c-dev:ppc64el
+      - uses: actions/checkout@v3
+      - uses: BSFishy/meson-build@v1.0.3
+        with:
+          # suppress python for now; the python headers currently assume native
+          setup-options: --werror --cross-file=.github/cross/ubuntu-ppc64le.txt -Dlibnvme:python=false
+          options: --verbose
+          action: build
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Linux_Meson_Testlog
+          path: build/meson-logs/testlog.txt
+
   build-fallback:
     runs-on: ubuntu-latest
     steps:

--- a/nvme.c
+++ b/nvme.c
@@ -5982,7 +5982,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	if (cfg.format == 0)
 		nrts = argconfig_parse_comma_sep_array(cfg.eilbrts, (int *)eilbrts.f0, ARRAY_SIZE(eilbrts.f0));
 	else if (cfg.format == 1)
-		nrts = argconfig_parse_comma_sep_array_long(cfg.eilbrts, (__u64 *)eilbrts.f1, ARRAY_SIZE(eilbrts.f1));
+		nrts = argconfig_parse_comma_sep_array_long(cfg.eilbrts, (unsigned long long *)eilbrts.f1, ARRAY_SIZE(eilbrts.f1));
 	else {
 		fprintf(stderr, "invalid format\n");
 		err = -EINVAL;

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -611,7 +611,8 @@ static void show_lat_stats_myrtle(struct sfx_lat_stats_myrtle *stats, int write)
 	for (i = 0; i < 64; i++)
 		printf("Bucket %2d: %u\n", i, stats->bucket_19[i]);
 
-	printf("\nAverage latency statistics %lld\n", stats->average);
+	printf("\nAverage latency statistics %" PRIu64 "\n",
+	       (uint64_t)stats->average);
 }
 
 

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1388,7 +1388,8 @@ static void print_stx_vs_fw_activate_history(stx_fw_activ_history_log_page fwAct
 			ts = *localtime(&t);
 			strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &ts);
 			printf(" %-20s   ", buf);
-			printf("%-5lld   ", fwActivHis.fwActHisEnt[i].powCycleCnt);
+			printf("%-5" PRId64 "   ",
+			       (uint64_t)fwActivHis.fwActHisEnt[i].powCycleCnt);
 
 			memset(prev_fw, 0, sizeof(prev_fw));
 			memcpy(prev_fw, fwActivHis.fwActHisEnt[i].previousFW, sizeof(fwActivHis.fwActHisEnt[i].previousFW));


### PR DESCRIPTION
This change adds a couple of cross-compilation targets for nvme-cli: armhf and powerpc64.

In order to do this though, we have to fix a couple of warnings for printf-specifiers and casts on those arches.