### PR TITLE
util: Fix le128_to_cpu on big-endian

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -52,6 +52,7 @@ endif
 test_uint128 = executable(
     'test-uint128',
     ['test-uint128.c', '../util/types.c'],
+    include_directories: [incdir, '..'],
     dependencies: [libuuid_dep],
 )
 

--- a/util/types.c
+++ b/util/types.c
@@ -4,20 +4,25 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <ccan/endian/endian.h>
+
 #include "types.h"
 
 nvme_uint128_t le128_to_cpu(__u8 *data)
 {
 	nvme_uint128_t u;
 
-	memcpy(u.bytes, data, 16);
+	if (HAVE_BIG_ENDIAN) {
+		nvme_uint128_t tmp;
+		memcpy(tmp.bytes, data, 16);
+		u.words[0] = le32_to_cpu(tmp.words[3]);
+		u.words[1] = le32_to_cpu(tmp.words[2]);
+		u.words[2] = le32_to_cpu(tmp.words[1]);
+		u.words[3] = le32_to_cpu(tmp.words[0]);
+	} else {
+		memcpy(u.bytes, data, 16);
+	}
 
-#if HAVE_BIG_ENDIAN
-	u.words[0] = le32_to_cpu(u.words[3]);
-	u.words[1] = le32_to_cpu(u.words[2]);
-	u.words[2] = le32_to_cpu(u.words[1]);
-	u.words[3] = le32_to_cpu(u.words[0]);
-#endif
 	return u;
 }
 


### PR DESCRIPTION
We currently have a bug when converting from le128, as we'll overwrite words that we later need to read.

Also, use an if rather than #ifdef, so the BE case can be compiled. Turns out we need the ccan headers for this.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>