### PR TITLE
nvme: Add wrappers for firmware commands

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -323,6 +323,18 @@ int nvme_cli_get_log_persistent_event(struct nvme_dev *dev,
 			   pevent_log);
 }
 
+int nvme_cli_fw_download(struct nvme_dev *dev,
+			 struct nvme_fw_download_args *args)
+{
+	return do_admin_args_op(fw_download, dev, args);
+}
+
+int nvme_cli_fw_commit(struct nvme_dev *dev,
+			 struct nvme_fw_commit_args *args)
+{
+	return do_admin_args_op(fw_commit, dev, args);
+}
+
 /* The MI & direct interfaces don't have an exactly-matching API for
  * ns_mgmt_create, as we don't support a timeout for MI.
  */

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -112,4 +112,10 @@ int nvme_cli_get_log_zns_changed_zones(struct nvme_dev *dev, __u32 nsid,
 int nvme_cli_get_log_persistent_event(struct nvme_dev *dev,
 				      enum nvme_pevent_log_action action,
 				      __u32 size, void *pevent_log);
+
+int nvme_cli_fw_download(struct nvme_dev *dev,
+			 struct nvme_fw_download_args *args);
+
+int nvme_cli_fw_commit(struct nvme_dev *dev,
+			 struct nvme_fw_commit_args *args);
 #endif /* _NVME_WRAP_H */

--- a/nvme.c
+++ b/nvme.c
@@ -4186,14 +4186,13 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 
 		struct nvme_fw_download_args args = {
 			.args_size	= sizeof(args),
-			.fd		= dev_fd(dev),
 			.offset		= cfg.offset,
 			.data_len	= cfg.xfer,
 			.data		= fw_buf,
 			.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 			.result		= NULL,
 		};
-		err = nvme_fw_download(&args);
+		err = nvme_cli_fw_download(dev, &args);
 		if (err < 0) {
 			fprintf(stderr, "fw-download: %s\n", nvme_strerror(errno));
 			break;
@@ -4283,14 +4282,13 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 
 	struct nvme_fw_commit_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.slot		= cfg.slot,
 		.action		= cfg.action,
 		.bpid		= cfg.bpid,
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 		.result		= &result,
 	};
-	err = nvme_fw_commit(&args);
+	err = nvme_cli_fw_commit(dev, &args);
 	if (err < 0)
 		fprintf(stderr, "fw-commit: %s\n", nvme_strerror(errno));
 	else if (err != 0)

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 501347ffdf6321d42ceabf173792c95bd44dac0d
+revision = 677075a11e8c2755d5566174c8321812f886ab29
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
This change adds nvme_dev wrappers for the firmware download and firmware commit commands, allowing access over a MI channel.

We need a bump to libnvme for the underlying MI firmware calls.

Signed-off-by: Jeremy Kerr <jk@codeconstruct.com.au>