### PR TITLE
nvme: check if cfg.metadata is NULL before passing it to strlen()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -7792,7 +7792,7 @@ close_dfd:
 	if (strlen(cfg.input_file))
 		close(dfd);
 close_mfd:
-	if (strlen(cfg.metadata))
+	if (cfg.metadata && strlen(cfg.metadata))
 		close(mfd);
 close_dev:
 	dev_close(dev);


### PR DESCRIPTION
if cfg.metadata is NULL, passing it to strlen() will trigger a SIGSEGV.