### PR TITLE
util: Fix le128_to_cpu on little-endian

### DIFF
--- a/util/types.c
+++ b/util/types.c
@@ -11,18 +11,12 @@
 nvme_uint128_t le128_to_cpu(__u8 *data)
 {
 	nvme_uint128_t u;
-
-	if (HAVE_BIG_ENDIAN) {
-		nvme_uint128_t tmp;
-		memcpy(tmp.bytes, data, 16);
-		u.words[0] = le32_to_cpu(tmp.words[3]);
-		u.words[1] = le32_to_cpu(tmp.words[2]);
-		u.words[2] = le32_to_cpu(tmp.words[1]);
-		u.words[3] = le32_to_cpu(tmp.words[0]);
-	} else {
-		memcpy(u.bytes, data, 16);
-	}
-
+	nvme_uint128_t tmp;
+	memcpy(tmp.bytes, data, 16);
+	u.words[0] = le32_to_cpu(tmp.words[3]);
+	u.words[1] = le32_to_cpu(tmp.words[2]);
+	u.words[2] = le32_to_cpu(tmp.words[1]);
+	u.words[3] = le32_to_cpu(tmp.words[0]);
 	return u;
 }
 


### PR DESCRIPTION
We need to swap the words order in little-endian machine too. For example:
```
uint128:  0x4000000030000000200000001

 0  1  2  3 |  4  5  6  7 | 8  9  a  b  | c  d  e  f
01 00 00 00 | 02 00 00 00 | 03 00 00 00 | 04 00 00 00

  w0(MSB)   |     w1      |    w2       |  w3(LSB)
04 00 00 00 | 03 00 00 00 | 02 00 00 00 | 01 00 00 00
```
Fix: https://github.com/linux-nvme/nvme-cli/issues/1702

Signed-off-by: Jinliang Wang <jinliangw@google.com>