### PR TITLE
Makefile: add 'make uninstall'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ endif
 install dist: ${BUILD-DIR}
 	cd ${BUILD-DIR} && meson $@
 
+.PHONY: uninstall
+uninstall:
+	cd ${BUILD-DIR} && meson --internal uninstall
+
 .PHONY: test
 test: ${BUILD-DIR}
 	ninja -C ${BUILD-DIR} $@


### PR DESCRIPTION
This PR adds ``make uninstall``.

Example output is provided below, showing how ``make uninstall`` behaves after ``make install``.
Equivalent PR provided for **libnvme**: https://github.com/linux-nvme/libnvme/pull/501

**Install**


```
safl@debtop:~/git/nvme-cli$ make && sudo make install
meson .build
The Meson build system
Version: 0.60.0
Source dir: /home/safl/git/nvme-cli
Build dir: /home/safl/git/nvme-cli/.build
Build type: native build
Project name: nvme-cli
Project version: 2.1.2
C compiler for the host machine: cc (gcc 10.2.1 "cc (Debian 10.2.1-6) 10.2.1 20210110")
C linker for the host machine: cc ld.bfd 2.35.2
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (0.29.2)
Run-time dependency libnvme found: YES 1.1
Run-time dependency libnvme-mi found: YES 1.1
Run-time dependency uuid found: YES 2.36.1
Run-time dependency json-c found: YES 0.15
Run-time dependency zlib found: YES 1.2.11
Has header "hugetlbfs.h" : NO 
Checking if "__builtin_type_compatible_p" : compiles: YES 
Checking if "typeof" : compiles: YES 
Checking if "byteswap.h" : compiles: YES 
Checking if "bswap64" : links: YES 
Checking if "isblank" : links: YES 
Checking if "sys/random.h" : compiles: YES 
Configuring config.h using configuration
Configuring nvme.spec using configuration
Configuring discovery.conf using configuration
Configuring 70-nvmf-autoconnect.conf using configuration
Configuring nvmefc-boot-connections.service using configuration
Configuring nvmf-autoconnect.service using configuration
Configuring nvmf-connect.target using configuration
Configuring nvmf-connect@.service using configuration
Configuring 70-nvmf-autoconnect.rules using configuration
Configuring 71-nvmf-iopolicy-netapp.rules using configuration
Program nose2 found: NO
Program python3 found: YES (/usr/bin/python3)
WARNING: Broken python installation detected. Python files installed by Meson might not be found by python interpreter.
 This warning can be avoided by setting "python.platlibdir" option.
WARNING: Broken python installation detected. Python files installed by Meson might not be found by python interpreter.
 This warning can be avoided by setting "python.purelibdir" option.
Program mypy found: YES (/usr/local/bin/mypy)
Program flake8 found: YES (/usr/local/bin/flake8)
Program autopep8 found: NO
Program isort found: YES (/usr/local/bin/isort)
Message: autopep8 or isort not found. Python formating disabled
Build targets in project: 3

Found ninja-1.10.2.git.kitware.jobserver-1 at /usr/local/bin/ninja
Configuration located in: .build
-------------------------------------------------------
ninja -C .build
ninja: Entering directory `.build'
[49/49] Linking target nvme
cd .build && meson install
ninja: Entering directory `/home/safl/git/nvme-cli/.build'
ninja: no work to do.
Installing nvme to /usr/sbin
Installing /home/safl/git/nvme-cli/completions/bash-nvme-completion.sh to /usr/share/bash-completion/completions
Installing /home/safl/git/nvme-cli/completions/_nvme to /usr/share/zsh/site-functions
Installing /home/safl/git/nvme-cli/.build/70-nvmf-autoconnect.conf to /usr/lib/dracut/dracut.conf.d
Installing /home/safl/git/nvme-cli/.build/nvmefc-boot-connections.service to /usr/lib/systemd/system
Installing /home/safl/git/nvme-cli/.build/nvmf-autoconnect.service to /usr/lib/systemd/system
Installing /home/safl/git/nvme-cli/.build/nvmf-connect.target to /usr/lib/systemd/system
Installing /home/safl/git/nvme-cli/.build/nvmf-connect@.service to /usr/lib/systemd/system
Installing /home/safl/git/nvme-cli/.build/70-nvmf-autoconnect.rules to /usr/lib/udev/rules.d
Installing /home/safl/git/nvme-cli/.build/71-nvmf-iopolicy-netapp.rules to /usr/lib/udev/rules.d
Installing /home/safl/git/nvme-cli/.build/discovery.conf to /etc/nvme
```

**Uninstall**

```
safl@debtop:~/git/nvme-cli$ sudo make uninstall
cd .build && meson --internal uninstall
Deleted: /usr/sbin/nvme
Deleted: /usr/share/bash-completion/completions/nvme
Deleted: /usr/share/zsh/site-functions/_nvme
Deleted: /usr/lib/dracut/dracut.conf.d/70-nvmf-autoconnect.conf
Deleted: /usr/lib/systemd/system/nvmefc-boot-connections.service
Deleted: /usr/lib/systemd/system/nvmf-autoconnect.service
Deleted: /usr/lib/systemd/system/nvmf-connect.target
Deleted: /usr/lib/systemd/system/nvmf-connect@.service
Deleted: /usr/lib/udev/rules.d/70-nvmf-autoconnect.rules
Deleted: /usr/lib/udev/rules.d/71-nvmf-iopolicy-netapp.rules
Deleted: /etc/nvme/discovery.conf

Uninstall finished.

Deleted: 11
Failed: 0

Remember that files created by custom scripts have not been removed.
```