### PR TITLE
Add support for libvnme status types

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3255,10 +3255,28 @@ void d_raw(unsigned char *buf, unsigned len)
 		putchar(*(buf+i));
 }
 
-void nvme_show_status(__u16 status)
+void nvme_show_status(int status)
 {
-	fprintf(stderr, "NVMe status: %s(%#x)\n",
-		nvme_status_to_string(status, false), status);
+        int val = nvme_status_get_value(status);
+        int type = nvme_status_get_type(status);
+
+        /* Callers should be checking for negative values first, but provide a
+         * sensible fallback anyway
+         */
+        if (status < 0) {
+                fprintf(stderr, "Error: %s\n", nvme_strerror(errno));
+                return;
+        }
+
+        switch (type) {
+        case NVME_STATUS_TYPE_NVME:
+                fprintf(stderr, "NVMe status: %s(%#x)\n",
+                        nvme_status_to_string(val, false), val);
+                break;
+        default:
+                fprintf(stderr, "Unknown status type %d, value %#x\n",
+                        type, val);
+        }
 }
 
 static void nvme_show_id_ctrl_cmic(__u8 cmic)

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3273,6 +3273,10 @@ void nvme_show_status(int status)
                 fprintf(stderr, "NVMe status: %s(%#x)\n",
                         nvme_status_to_string(val, false), val);
                 break;
+        case NVME_STATUS_TYPE_MI:
+                fprintf(stderr, "NVMe-MI status: %s(%#x)\n",
+                        nvme_mi_status_to_string(val), val);
+                break;
         default:
                 fprintf(stderr, "Unknown status type %d, value %#x\n",
                         type, val);

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -16,7 +16,7 @@ typedef struct nvme_effects_log_node {
 void d(unsigned char *buf, int len, int width, int group);
 void d_raw(unsigned char *buf, unsigned len);
 
-void nvme_show_status(__u16 status);
+void nvme_show_status(int status);
 void nvme_show_lba_status_info(__u32 result);
 void nvme_show_relatives(const char *name);
 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10984,7 +10984,7 @@ static int wdc_enc_submit_move_data(struct nvme_dev *dev, char *cmd, int len,
 #endif
 	nvme_cmd.result = 0;
 	err = nvme_submit_admin_passthru(dev_fd(dev), &nvme_cmd, NULL);
-	if (err == NVME_SC_INTERNAL) {
+	if (nvme_status_equals(err, NVME_STATUS_TYPE_NVME, NVME_SC_INTERNAL)) {
 		fprintf(stderr, "%s: WARNING : WDC : No log ID:x%x available\n",
 			__func__, log_id);
 	}


### PR DESCRIPTION
WIP: needs upstream libnvme changes first

This series adds support for the status type encoding proposed in https://github.com/linux-nvme/libnvme/pull/502

We first add decoding using the nvme_status_get_type() helper, and then add support for MI-specific status values through nvme_mi_status_to_string().