### PR TITLE
Drop libuuid dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,11 +49,6 @@ libnvme_dep = dependency('libnvme', version: '>=1.1', required: true,
 libnvme_mi_dep = dependency('libnvme-mi', required: true,
                          fallback : ['libnvme', 'libnvme_mi_dep'])
 
-# Check for libuuid availability
-libuuid_dep = dependency('uuid', required: true,
-                         fallback : ['uuid', 'uuid_dep'])
-conf.set('CONFIG_LIBUUID', libuuid_dep.found(), description: 'Is libuuid available?')
-
 # Check for libjson-c availability
 json_c_dep = dependency('json-c', required: true, version: '>=0.13',
                         fallback : ['json-c', 'json_c_dep'])
@@ -261,7 +256,7 @@ subdir('Documentation')
 executable(
   'nvme',
   sources,
-  dependencies: [ libnvme_dep, libnvme_mi_dep, libuuid_dep, json_c_dep, libz_dep,
+  dependencies: [ libnvme_dep, libnvme_mi_dep, json_c_dep, libz_dep,
                   libhugetlbfs_dep ],
   link_args: '-ldl',
   include_directories: incdir,

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -22,7 +22,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
-#include <uuid/uuid.h>
 
 #include "common.h"
 #include "nvme.h"
@@ -68,7 +67,7 @@ struct ontapdevice_info {
 	unsigned		nsid;
 	struct nvme_id_ctrl	ctrl;
 	struct nvme_id_ns	ns;
-	uuid_t			uuid;
+	unsigned char		uuid[NVME_UUID_LEN];
 	unsigned char		log_data[ONTAP_C2_LOG_SIZE];
 	char			dev[265];
 };
@@ -334,7 +333,7 @@ static void netapp_ontapdevices_print(struct ontapdevice_info *devices,
 	for (i = 0; i < count; i++) {
 
 		netapp_get_ns_size(size, &lba, &devices[i].ns);
-		uuid_unparse_lower(devices[i].uuid, uuid_str);
+		nvme_uuid_to_string(devices[i].uuid, uuid_str);
 		netapp_get_ontap_labels(vsname, nspath, devices[i].log_data);
 
 		if (format == NJSON) {

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = b483bbd5f8069a79c7a638fc8049f54185acd2b9
+revision = 7aab6de685df525ab9dda6c0d3d1fecab91bc5d2
 
 [provide]
 libnvme = libnvme_dep

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -59,7 +59,7 @@ test_uint128 = executable(
     'test-uint128',
     ['test-uint128.c', '../util/types.c'],
     include_directories: [incdir, '..'],
-    dependencies: [libuuid_dep],
+    dependencies: [libnvme_dep],
 )
 
 test('uint128', test_uint128)

--- a/util/types.c
+++ b/util/types.c
@@ -78,12 +78,11 @@ char *uint128_t_to_string(nvme_uint128_t val)
 	return str + idx;
 }
 
-const char *util_uuid_to_string(uuid_t uuid)
+const char *util_uuid_to_string(unsigned char uuid[NVME_UUID_LEN])
 {
-	/* large enough to hold uuid str (37) + null-termination byte */
-	static char uuid_str[40];
+	static char uuid_str[NVME_UUID_LEN_STRING];
 
-	uuid_unparse_lower(uuid, uuid_str);
+	nvme_uuid_to_string(uuid, uuid_str);
 
 	return uuid_str;
 }

--- a/util/types.h
+++ b/util/types.h
@@ -8,6 +8,8 @@
 #include <uuid/uuid.h>
 #include <linux/types.h>
 
+#include <libnvme.h>
+
 #define ABSOLUTE_ZERO_CELSIUS -273
 
 static inline long kelvin_to_celsius(long t)
@@ -28,7 +30,7 @@ long double int128_to_double(__u8 *data);
 uint64_t int48_to_long(__u8 *data);
 
 char *uint128_t_to_string(nvme_uint128_t val);
-const char *util_uuid_to_string(uuid_t uuid);
+const char *util_uuid_to_string(unsigned char uuid[NVME_UUID_LEN]);
 const char *util_fw_to_string(char *c);
 
 #endif /* _MISC_H */


### PR DESCRIPTION
libnvme drop libuuid dependency and provides the one function nvme-cli needs (`nvme_uuid_to_string`)
