### PR TITLE
util/json.h: Add json_object_get_uint64 fallback implementation

### DIFF
--- a/plugins/solidigm/solidigm-telemetry/data-area.c
+++ b/plugins/solidigm/solidigm-telemetry/data-area.c
@@ -40,7 +40,7 @@ static bool telemetry_log_get_value(const struct telemetry_log *tl,
 		char err_msg[MAX_WARNING_SIZE];
 
 		snprintf(err_msg, MAX_WARNING_SIZE,
-			"Value offset greater than binary size (%u > %lu).",
+			"Value offset greater than binary size (%u > %zu).",
 			 offset_byte, tl->log_size);
 		*val_obj = json_object_new_string(err_msg);
 

--- a/util/json.c
+++ b/util/json.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #include <stdio.h>
+#include <errno.h>
 
 #include "json.h"
 #include "types.h"
@@ -39,4 +40,21 @@ struct json_object *util_json_object_new_uint128(nvme_uint128_t  val)
 	struct json_object *obj;
 	obj = json_object_new_string(uint128_t_to_string(val));
 	return obj;
+}
+
+uint64_t util_json_object_get_uint64(struct json_object *obj)
+{
+	uint64_t val = 0;
+
+	if (json_object_is_type(obj, json_type_string)) {
+		char *end = NULL;
+		const char *buf;
+
+		buf = json_object_get_string(obj);
+		val = strtoull(buf, &end, 10);
+		if ((val == 0 && errno != 0) || (end == buf))
+			return 0;
+	}
+
+	return val;
 }

--- a/util/json.h
+++ b/util/json.h
@@ -17,6 +17,7 @@
 	json_object_object_add(o, k, json_object_new_int(v))
 #ifndef CONFIG_JSONC_14
 #define json_object_new_uint64(v) util_json_object_new_uint64(v)
+#define json_object_get_uint64(v) util_json_object_get_uint64(v)
 #endif
 #define json_object_add_value_uint64(o, k, v) \
 	json_object_object_add(o, k, json_object_new_uint64(v))
@@ -44,5 +45,7 @@
 struct json_object *util_json_object_new_double(long double d);
 struct json_object *util_json_object_new_uint64(uint64_t i);
 struct json_object *util_json_object_new_uint128(nvme_uint128_t val);
+struct json_object *util_json_object_new_uint128(nvme_uint128_t val);
 
+uint64_t util_json_object_get_uint64(struct json_object *obj);
 #endif


### PR DESCRIPTION
We need the definition of json_object_get_uint64 in case json-c doesn't provide it.

Signed-off-by: Daniel Wagner <dwagner@suse.de>