### PR TITLE
solidgm: fix initialization warning

### DIFF
--- a/plugins/solidigm/solidigm-telemetry.c
+++ b/plugins/solidigm/solidigm-telemetry.c
@@ -113,7 +113,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *cmd, struc
 
 	if (cfg.cfg_file) {
 		char *conf_str = 0;
-		size_t length;
+		size_t length = 0;
 
 		err = read_file2buffer(cfg.cfg_file, &conf_str, &length);
 		if (err) {


### PR DESCRIPTION
Seeing the below warning while compiling nvme-cli:

ninja: Entering directory `.build'
[27/51] Compiling C object nvme.p/plugins_solidigm_solidigm-telemetry.c.o ../plugins/solidigm/solidigm-telemetry.c: In function ‘solidigm_get_telemetry_log’: ../plugins/solidigm/solidigm-telemetry.c:126:22: warning: ‘length’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   tl.configuration = json_tokener_parse_ex(jstok, conf_str, length);
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[51/51] Linking target nvme

Fix this by initializing the 'length' variable to zero.

Signed-off-by: Martin George <marting@netapp.com>