### PR TITLE
fabrics: fix 'persistent' handling during connect-all with JSON file

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -642,6 +642,9 @@ static int discover_from_json_config_file(nvme_root_t r, nvme_host_t h,
 			else
 				subsysnqn = NVME_DISC_SUBSYS_NAME;
 
+			if (nvme_ctrl_is_persistent(c))
+				persistent = true;
+
 			memcpy(&cfg, defcfg, sizeof(cfg));
 
 			struct tr_config trcfg = {

--- a/libnvme-wrap.c
+++ b/libnvme-wrap.c
@@ -48,3 +48,9 @@ FN(nvme_get_feature_length2,
 	      __u32 *len),
 	ARGS(fid, cdw11, dir, len),
 	-EEXIST)
+
+FN(nvme_ctrl_is_persistent,
+	bool,
+	PROTO(nvme_ctrl_t c),
+	ARGS(c),
+	false)


### PR DESCRIPTION
Enable 'persistent' flag during nvme connect-all if set in the config JSON file.

Signed-off-by: Martin George <marting@netapp.com>