### PR TITLE
build: fix

### DIFF
--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "common.h"
 #include "nvme.h"

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -13,6 +13,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <time.h>
 
 #include "common.h"
 #include "nvme.h"

--- a/util/types.h
+++ b/util/types.h
@@ -5,7 +5,6 @@
 /* type conversion helpers */
 
 #include <stdint.h>
-#include <uuid/uuid.h>
 #include <linux/types.h>
 
 #include <libnvme.h>


### PR DESCRIPTION
when we tried updating to 2.2 in nixpkgs (see https://github.com/NixOS/nixpkgs/pull/198471) we saw a handful of compiler errors about `uuid.h` still being included and stuff from `time.h` not being declared.

maybe we're just "holding it wrong", but these changes seem necessary to be able to build this release.