### PR TITLE
nvme-mi: support ns-descs, primary-ctrl-caps, list-secondary

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -77,6 +77,12 @@ int nvme_cli_identify_ns(struct nvme_dev *dev, __u32 nsid,
 	return do_admin_op(identify_ns, dev, nsid, ns);
 }
 
+int nvme_cli_identify_ns_descs(struct nvme_dev *dev, __u32 nsid,
+			       struct nvme_ns_id_desc *descs)
+{
+	return do_admin_op(identify_ns_descs, dev, nsid, descs);
+}
+
 int nvme_cli_identify_allocated_ns(struct nvme_dev *dev, __u32 nsid,
 			 struct nvme_id_ns *ns)
 {
@@ -93,6 +99,20 @@ int nvme_cli_identify_allocated_ns_list(struct nvme_dev *dev, __u32 nsid,
 					struct nvme_ns_list *list)
 {
 	return do_admin_op(identify_allocated_ns_list, dev, nsid, list);
+}
+
+int nvme_cli_identify_primary_ctrl(struct nvme_dev *dev, __u32 nsid,
+				   struct nvme_primary_ctrl_cap *cap)
+{
+	return do_admin_op(identify_primary_ctrl, dev, nsid, cap);
+}
+
+int nvme_cli_identify_secondary_ctrl_list(struct nvme_dev *dev, __u32 nsid,
+					  __u16 ctrl_id,
+					  struct nvme_secondary_ctrl_list *sc_list)
+{
+	return do_admin_op(identify_secondary_ctrl_list, dev, nsid, ctrl_id,
+			   sc_list);
 }
 
 int nvme_cli_get_features(struct nvme_dev *dev,

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -18,13 +18,19 @@ int nvme_cli_identify_nsid_ctrl_list(struct nvme_dev *dev, __u32 nsid,
 				     struct nvme_ctrl_list *list);
 int nvme_cli_identify_ns(struct nvme_dev *dev, __u32 nsid,
 			 struct nvme_id_ns *ns);
+int nvme_cli_identify_ns_descs(struct nvme_dev *dev, __u32 nsid,
+			       struct nvme_ns_id_desc *descs);
 int nvme_cli_identify_allocated_ns(struct nvme_dev *dev, __u32 nsid,
 				   struct nvme_id_ns *ns);
 int nvme_cli_identify_active_ns_list(struct nvme_dev *dev, __u32 nsid,
 				     struct nvme_ns_list *list);
 int nvme_cli_identify_allocated_ns_list(struct nvme_dev *dev, __u32 nsid,
 					struct nvme_ns_list *list);
-
+int nvme_cli_identify_primary_ctrl(struct nvme_dev *dev, __u32 nsid,
+				   struct nvme_primary_ctrl_cap *cap);
+int nvme_cli_identify_secondary_ctrl_list(struct nvme_dev *dev, __u32 nsid,
+					  __u16 ctrl_id,
+					  struct nvme_secondary_ctrl_list *sc_list);
 int nvme_cli_ns_mgmt_delete(struct nvme_dev *dev, __u32 nsid);
 int nvme_cli_ns_mgmt_create(struct nvme_dev *dev, struct nvme_id_ns *ns,
 			__u32 *nsid, __u32 timeout, __u8 csi);

--- a/nvme.c
+++ b/nvme.c
@@ -3124,7 +3124,7 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 		goto close_dev;
 	}
 
-	err = nvme_identify_ns_descs(dev_fd(dev), cfg.namespace_id, nsdescs);
+	err = nvme_cli_identify_ns_descs(dev, cfg.namespace_id, nsdescs);
 	if (!err)
 		nvme_show_id_ns_descs(nsdescs, cfg.namespace_id, flags);
 	else if (err > 0)
@@ -3688,7 +3688,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *cmd, struct 
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_identify_primary_ctrl(dev_fd(dev), cfg.cntlid, &caps);
+	err = nvme_cli_identify_primary_ctrl(dev, cfg.cntlid, &caps);
 	if (!err)
 		nvme_show_primary_ctrl_cap(&caps, flags);
 	else if (err > 0)
@@ -3756,8 +3756,8 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 		goto close_err;
 	}
 
-	err = nvme_identify_secondary_ctrl_list(dev_fd(dev), cfg.namespace_id,
-						cfg.cntid, sc_list);
+	err = nvme_cli_identify_secondary_ctrl_list(dev, cfg.namespace_id,
+						    cfg.cntid, sc_list);
 	if (!err)
 		nvme_show_list_secondary_ctrl(sc_list, cfg.num_entries, flags);
 	else if (err > 0)
@@ -5621,7 +5621,7 @@ static int invalid_tags(__u64 storage_tag, __u64 ref_tag, __u8 sts, __u8 pif)
 
 	if (result)
 		fprintf(stderr, "Reference tag larger than allowed by PIF\n");
-	
+
 	return result;
 }
 
@@ -5736,7 +5736,7 @@ static int write_zeroes(int argc, char **argv, struct command *cmd, struct plugi
 	if (!err) {
 		nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &lba_index);
 		sts = nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_STS_MASK;
-		pif = (nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_PIF_MASK) >> 7; 
+		pif = (nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_PIF_MASK) >> 7;
 	}
 
 	if (invalid_tags(cfg.storage_tag, cfg.ref_tag, sts, pif)) {
@@ -5991,7 +5991,7 @@ static int copy(int argc, char **argv, struct command *cmd, struct plugin *plugi
 
 	nb = argconfig_parse_comma_sep_array_short(cfg.nlbs, nlbs, ARRAY_SIZE(nlbs));
 	ns = argconfig_parse_comma_sep_array_long(cfg.slbas, slbas, ARRAY_SIZE(slbas));
-	
+
 	if (cfg.format == 0)
 		nrts = argconfig_parse_comma_sep_array(cfg.eilbrts, (int *)eilbrts.f0, ARRAY_SIZE(eilbrts.f0));
 	else if (cfg.format == 1)
@@ -6715,7 +6715,7 @@ static int submit_io(int opcode, char *command, const char *desc,
 					   &nvm_ns);
 		if (!err) {
 			sts = nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_STS_MASK;
-			pif = (nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_PIF_MASK) >> 7; 
+			pif = (nvm_ns.elbaf[lba_index] & NVME_NVM_ELBAF_PIF_MASK) >> 7;
 		}
 
 		mbuffer_size = ((unsigned long long)cfg.block_count + 1) * ms;


### PR DESCRIPTION
Suppport ns-descs, primary-ctrl-caps and list-secondary subcommands though nvme-mi.

Signed-off-by: Jinliang Wang <jinliangw@google.com>

