### PR TITLE
build: Update libnvme version dependency to 1.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@ endif
 conf.set('SYSCONFDIR', '"@0@"'.format(sysconfdir))
 
 # Check for libnvme availability
-libnvme_dep = dependency('libnvme', version: '>=1.1', required: true,
+libnvme_dep = dependency('libnvme', version: '>=1.2', required: true,
                          fallback : ['libnvme', 'libnvme_dep'])
 libnvme_mi_dep = dependency('libnvme-mi', required: true,
                          fallback : ['libnvme', 'libnvme_mi_dep'])


### PR DESCRIPTION
With the drop of libuuid we need also the corresponding libnvme library which provides its own uuid types.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1717 