### PR TITLE
zsh: move SPDX identifier

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -1,6 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-
 #compdef _nvme nvme
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 # zsh completions for the nvme command-line interface,
 # very loosely based on git and adb command completion


### PR DESCRIPTION
The zsh completion system requires compdef to be set in the first line of the completion definition. The SPDX identifier introduced breaks this requirement, so let's just move it a line down.