### PR TITLE
Support admin_passthru over nvme-mi

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -355,6 +355,19 @@ int nvme_cli_fw_commit(struct nvme_dev *dev,
 	return do_admin_args_op(fw_commit, dev, args);
 }
 
+int nvme_cli_admin_passthru(struct nvme_dev *dev, __u8 opcode, __u8 flags,
+			    __u16 rsvd, __u32 nsid, __u32 cdw2, __u32 cdw3,
+			    __u32 cdw10, __u32 cdw11, __u32 cdw12, __u32 cdw13,
+			    __u32 cdw14, __u32 cdw15, __u32 data_len,
+			    void *data, __u32 metadata_len, void *metadata,
+			    __u32 timeout_ms, __u32 *result)
+{
+	return do_admin_op(admin_passthru, dev, opcode, flags, rsvd, nsid,
+			   cdw2, cdw3, cdw10, cdw11, cdw12, cdw13, cdw14, cdw15,
+			   data_len, data, metadata_len, metadata, timeout_ms,
+			   result);
+}
+
 /* The MI & direct interfaces don't have an exactly-matching API for
  * ns_mgmt_create, as we don't support a timeout for MI.
  */

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -125,6 +125,13 @@ int nvme_cli_fw_download(struct nvme_dev *dev,
 int nvme_cli_fw_commit(struct nvme_dev *dev,
 			 struct nvme_fw_commit_args *args);
 
+int nvme_cli_admin_passthru(struct nvme_dev *dev, __u8 opcode, __u8 flags,
+			    __u16 rsvd, __u32 nsid, __u32 cdw2, __u32 cdw3,
+			    __u32 cdw10, __u32 cdw11, __u32 cdw12, __u32 cdw13,
+			    __u32 cdw14, __u32 cdw15, __u32 data_len,
+			    void *data, __u32 metadata_len, void *metadata,
+			    __u32 timeout_ms, __u32 *result);
+
 int nvme_cli_get_feature_length2(int fid, __u32 cdw11, enum nvme_data_tfr dir,
 				__u32 *len);
 

--- a/nvme.c
+++ b/nvme.c
@@ -7750,7 +7750,7 @@ static int passthru(int argc, char **argv, bool admin,
 	gettimeofday(&start_time, NULL);
 
 	if (admin)
-		err = nvme_admin_passthru(dev_fd(dev), cfg.opcode, cfg.flags,
+		err = nvme_cli_admin_passthru(dev, cfg.opcode, cfg.flags,
 					  cfg.rsvd,
 					  cfg.namespace_id, cfg.cdw2,
 					  cfg.cdw3, cfg.cdw10,

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = b25dc6102bc000ff4c8061e6448cfb4c034eaed6
+revision = 70aca88bc4a497e86e0b8b28d82ebb4db691ed39
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Bump libnvme version and support admin_passthru over nvme-mi.

Test Identify Controller command on:
- In-band
```
./nvme admin-passthru --opcode 0x06 --cdw10=0x01 --data-len=4096 --read /dev/nvme0
Admin Command Identify is Success and result: 0x00000000
       0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0000: 4d 14 4d 14 53 33 35 42 4e 58 30 4b 38 31 33 38 "M.M.S35BNX0K8138"
0010: 38 30 20 20 20 20 20 20 53 41 4d 53 55 4e 47 20 "80......SAMSUNG."
0020: 4d 5a 56 4b 57 35 31 32 48 4d 4a 50 2d 30 30 30 "MZVKW512HMJP-000"
0030: 4c 37 20 20 20 20 20 20 20 20 20 20 20 20 20 20 "L7.............."
0040: 36 4c 36 51 43 58 41 37 02 38 25 00 00 00 02 00 "6L6QCXA7.8%....."
0050: 00 02 01 00 a0 86 01 00 40 4b 4c 00 00 00 00 00 "........@KL....."
...
```

- nvme-mi:
```
./nvme admin-passthru --opcode 0x06 --cdw10=0x01 --data-len=4096 --read mctp:1,16:0
Admin Command Identify is Success and result: 0x00000000
       0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0000: 4d 14 4d 14 53 36 48 52 4e 41 30 54 35 31 30 33 "M.M.S6HRNA0T5103"
0010: 31 34 20 20 20 20 20 20 4d 5a 57 4c 52 33 54 38 "14......MZWLR3T8"
0020: 48 42 4c 53 2d 30 30 41 47 47 20 20 20 20 20 20 "HBLS-00AGG......"
0030: 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 "................"
0040: 4d 50 4b 39 41 50 35 54 00 38 25 00 02 08 00 00 "MPK9AP5T.8%....."
0050: 00 03 01 00 80 ba 8c 01 40 6f 40 01 00 23 00 00 "........@o@..#.."
...
```