### PR TITLE
fix an error message in scaleflux plugin

### DIFF
--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -659,7 +659,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 			}
 		} else {
 			printf("ScaleFlux IO %s Command Latency Statistics Invalid Version Maj %d Min %d\n",
-				    write ? "Write" : "Read", stats.ver.maj, stats.ver.min);
+				    cfg.write ? "Write" : "Read", stats.ver.maj, stats.ver.min);
 		}
 	} else if (err > 0)
 		nvme_show_status(err);


### PR DESCRIPTION
"write" is a const string which cannot be null, we should check cfg.write instead

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>