### PR TITLE
fix freed memory dereference.

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -3168,7 +3168,6 @@ static int micron_internal_logs(int argc, char **argv, struct command *cmd,
     if (telemetry_option) {
         if ((ctrl.lpa & 0x8) != 0x8) {
            printf("telemetry option is not supported for specified drive\n");
-           dev_close(dev);
            goto out;
         }
         int logSize = 0; __u8 *buffer = NULL; const char *dir = ".";


### PR DESCRIPTION
dev_close() is already called after the jump to "out". Calling it 2 times against the same pointer is unsafe because it will dereference freed memory.

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>