### PR TITLE
build: require meson 0.50.0+

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 ################################################################################
 project(
     'nvme-cli', ['c'],
-    meson_version: '>= 0.48.0',
+    meson_version: '>= 0.50.0',
     license: 'GPL-2.0-only',
     version: '2.2.1',
     default_options: [


### PR DESCRIPTION
The Meson buildspec uses features introduced in Meson 0.50.0, but only specifies 0.48.0. Eliminates a Meson warning.

Signed-off-by: nick black <dankamongmen@gmail.com>