### PR TITLE
nvme: call nvme_get_smart_log() with false

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -452,7 +452,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	if (cfg.human_readable)
 		flags |= VERBOSE;
 
-	err = nvme_cli_get_log_smart(dev, cfg.namespace_id, true,
+	err = nvme_cli_get_log_smart(dev, cfg.namespace_id, false,
 				 &smart_log);
 	if (!err)
 		nvme_show_smart_log(&smart_log, cfg.namespace_id,


### PR DESCRIPTION
Changing this to `true` resulted in my Western Digital 970 EVO Pro NVMe SSDs returning all zeros for smartlog information. Reverts change made in cc73f65.

Resolves #1729.

Signed-off-by: nick black <dankamongmen@gmail.com>