### PR TITLE
Drop incomplete support for TP8013 and 8014 

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -143,9 +143,8 @@ static inline const char *adrfam_str(__u8 adrfam)
 }
 
 static const char * const subtypes[] = {
-	[NVME_NQN_DISC]		= "discovery subsystem referral",
+	[NVME_NQN_DISC]		= "discovery subsystem",
 	[NVME_NQN_NVME]		= "nvme subsystem",
-	[NVME_NQN_CURR]		= "current subsystem",
 };
 
 static inline const char *subtype_str(__u8 subtype)
@@ -1173,7 +1172,6 @@ retry:
 
 	switch (e->subtype) {
 	case NVME_NQN_DISC:
-	case NVME_NQN_CURR:
 		discover = true;
 	case NVME_NQN_NVME:
 		break;

--- a/fabrics.c
+++ b/fabrics.c
@@ -82,7 +82,6 @@ struct connect_args {
 	char *trsvcid;
 	char *host_traddr;
 	char *host_iface;
-	char *subsystype;
 	struct connect_args *next;
 	struct connect_args *tail;
 };
@@ -297,13 +296,6 @@ static bool ctrl_matches_connectargs(const char *name, struct connect_args *args
 	addr = nvme_get_ctrl_attr(path, "address");
 	cargs.subsysnqn = nvme_get_ctrl_attr(path, "subsysnqn");
 	cargs.transport = nvme_get_ctrl_attr(path, "transport");
-	cargs.subsystype = nvme_get_ctrl_attr(path, "subsystype");
-	if (!cargs.subsystype) {
-		if (!strcmp(cargs.subsysnqn, NVME_DISC_SUBSYS_NAME))
-			cargs.subsystype = strdup("discovery");
-		else
-			cargs.subsystype = strdup("nvm");
-	}
 
 	if (!addr || !cargs.subsysnqn || !cargs.transport) {
 		fprintf(stderr, "nvme_get_ctrl_attr failed\n");
@@ -315,7 +307,7 @@ static bool ctrl_matches_connectargs(const char *name, struct connect_args *args
 	cargs.host_traddr = parse_conn_arg(addr, ' ', conarg_host_traddr);
 	cargs.host_iface = parse_conn_arg(addr, ' ', conarg_host_iface);
 
-	if (!strcmp(cargs.subsystype, "discovery")) {
+	if (!strcmp(cargs.subsysnqn, NVME_DISC_SUBSYS_NAME)) {
 		char *kato_str = nvme_get_ctrl_attr(path, "kato"), *p;
 		unsigned int kato = 0;
 
@@ -424,7 +416,6 @@ static void destruct_connect_args(struct connect_args *cargs)
 	free(cargs->trsvcid);
 	free(cargs->host_traddr);
 	free(cargs->host_iface);
-	free(cargs->subsystype);
 }
 
 static void free_connect_args(struct connect_args *cargs)

--- a/linux/nvme.h
+++ b/linux/nvme.h
@@ -75,9 +75,8 @@ static inline uint64_t le64_to_cpu(__le64 x)
 #define NVME_NSID_ALL		0xffffffff
 
 enum nvme_subsys_type {
-	NVME_NQN_DISC	= 1,		/* Referral Discovery type target subsystem */
+	NVME_NQN_DISC	= 1,		/* Discovery type target subsystem */
 	NVME_NQN_NVME	= 2,		/* NVME type target subsystem */
-	NVME_NQN_CURR	= 3,		/* Current Discovery type target subsystem */
 };
 
 /* Address Family codes for Discovery Log Page entry ADRFAM field */


### PR DESCRIPTION
These two patches only introduce a bare minimum to support TP8013 and 80134. There many fixes and features needed to get this really working. As there is little interest in adding this to the 1.x branch, let's drop those changes again.
