### PR TITLE
plugins/memblaze: fix "smart-log-add" display "wear-leveling" issue.

### DIFF
--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -107,7 +107,7 @@ static __u64 raw_2_u64(const __u8 *buf, size_t len)
     return le64_to_cpu(val);
 }
 
-static void get_memblaze_new_smart_info(struct nvme_p4_smart_log *smart, int index, u8 *nm_val, u8 *raw_val)
+static void get_memblaze_new_smart_info(struct nvme_p4_smart_log *smart, int index, __u8 *nm_val, __u8 *raw_val)
 {
     memcpy(nm_val, smart->itemArr[index].nmVal, NM_SIZE);
     memcpy(raw_val, smart->itemArr[index].rawVal, RAW_SIZE);
@@ -117,8 +117,8 @@ static void show_memblaze_smart_log_new(struct nvme_memblaze_smart_log *s,
     unsigned int nsid, const char *devname)
 {
     struct nvme_p4_smart_log *smart = (struct nvme_p4_smart_log *)s;
-    u8 *nm = malloc(NM_SIZE * sizeof(u8));
-    u8 *raw = malloc(RAW_SIZE * sizeof(u8));
+    __u8 *nm = malloc(NM_SIZE * sizeof(__u8));
+    __u8 *raw = malloc(RAW_SIZE * sizeof(__u8));
 
     if (!nm) {
         if (raw)
@@ -141,7 +141,7 @@ static void show_memblaze_smart_log_new(struct nvme_memblaze_smart_log *s,
 
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_WEARLEVELING_COUNT, nm, raw);
     printf("%-31s : %3d%%       %s%u%s%u%s%u\n", "wear_leveling", *nm,
-        "min: ", *(u16 *)raw, ", max: ", *(u16 *)(raw+2), ", avg: ", *(u16 *)(raw+4));
+        "min: ", *(__u16 *)raw, ", max: ", *(__u16 *)(raw+2), ", avg: ", *(__u16 *)(raw+4));
 
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_E2E_DECTECTION_COUNT, nm, raw);
     printf("%-31s: %3d%%       %"PRIu64"\n", "end_to_end_error_detection_count", *nm, int48_to_long(raw));
@@ -182,15 +182,15 @@ static void show_memblaze_smart_log_new(struct nvme_memblaze_smart_log *s,
 
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_TEMPT_SINCE_BORN, nm, raw);
     printf("%-32s: %3d%%       %s%u%s%u%s%u\n", "tempt_since_born",  *nm,
-        "max: ", *(u16 *)raw, ", min: ", *(u16 *)(raw+2), ", curr: ", *(u16 *)(raw+4));
+        "max: ", *(__u16 *)raw, ", min: ", *(__u16 *)(raw+2), ", curr: ", *(__u16 *)(raw+4));
 
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_POWER_CONSUMPTION, nm, raw);
     printf("%-32s: %3d%%       %s%u%s%u%s%u\n", "power_consumption",  *nm,
-        "max: ", *(u16 *)raw, ", min: ", *(u16 *)(raw+2), ", curr: ", *(u16 *)(raw+4));
+        "max: ", *(__u16 *)raw, ", min: ", *(__u16 *)(raw+2), ", curr: ", *(__u16 *)(raw+4));
 
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_TEMPT_SINCE_BOOTUP, nm, raw);
-    printf("%-32s: %3d%%       %s%u%s%u%s%u\n", "tempt_since_bootup",  *nm, "max: ", *(u16 *)raw,
-        ", min: ", *(u16 *)(raw+2), ", curr: ", *(u16 *)(raw+4));
+    printf("%-32s: %3d%%       %s%u%s%u%s%u\n", "tempt_since_bootup",  *nm, "max: ", *(__u16 *)raw,
+        ", min: ", *(__u16 *)(raw+2), ", curr: ", *(__u16 *)(raw+4));
 
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_READ_FAIL, nm, raw);
     printf("%-32s: %3d%%       %"PRIu64"\n", "read_fail_count", *nm, int48_to_long(raw));
@@ -305,8 +305,8 @@ static void show_memblaze_smart_log_old(struct nvme_memblaze_smart_log *smart,
 
      if ( IS_PAPAYA(fw_ver_local) ) {
         struct nvme_p4_smart_log *s = (struct nvme_p4_smart_log *)smart;
-        u8 *nm = malloc(NM_SIZE * sizeof(u8));
-        u8 *raw = malloc(RAW_SIZE * sizeof(u8));
+        __u8 *nm = malloc(NM_SIZE * sizeof(__u8));
+        __u8 *raw = malloc(RAW_SIZE * sizeof(__u8));
 
 	if (!nm) {
             if (raw)
@@ -327,7 +327,7 @@ static void show_memblaze_smart_log_old(struct nvme_memblaze_smart_log *smart,
 
         get_memblaze_new_smart_info(s, WEARLEVELING_COUNT, nm, raw);
         printf("%-31s                                 : %3d%%       %s%u%s%u%s%u\n",
-			"wear_leveling", *nm, "min: ", *(u16 *)raw, ", max: ", *(u16 *)(raw+2), ", avg: ", *(u16 *)(raw+4));
+			"wear_leveling", *nm, "min: ", *(__u16 *)raw, ", max: ", *(__u16 *)(raw+2), ", avg: ", *(__u16 *)(raw+4));
 
         get_memblaze_new_smart_info(s, TOTAL_WRITE, nm, raw);
         printf("%-32s                                : %3d%%       %"PRIu64"\n",

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -184,7 +184,7 @@ static void show_memblaze_smart_log_new(struct nvme_memblaze_smart_log *s,
     /* 02 RAISIN_SI_VD_WEARLEVELING_COUNT */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_WEARLEVELING_COUNT, nm, raw);
     printf("%-31s : %3d%%       %s%u%s%u%s%u\n", STR02_01, *nm,
-        STR02_03, *raw, STR02_04, *(raw+2), STR02_05, *(raw+4));
+        STR02_03, *(u16 *)raw, STR02_04, *(u16 *)(raw+2), STR02_05, *(u16 *)(raw+4));
     /* 03 RAISIN_SI_VD_E2E_DECTECTION_COUNT */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_E2E_DECTECTION_COUNT, nm, raw);
     printf("%-31s: %3d%%       %"PRIu64"\n", STR03_01, *nm, int48_to_long(raw));
@@ -202,8 +202,8 @@ static void show_memblaze_smart_log_new(struct nvme_memblaze_smart_log *s,
     printf("%-32s: %3d%%       %"PRIu64"%s\n", STR07_01, *nm, int48_to_long(raw), STR07_02);
     /* 08 RAISIN_SI_VD_THERMAL_THROTTLE_STATUS */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_THERMAL_THROTTLE_STATUS, nm, raw);
-    printf("%-32s: %3d%%       %"PRIu64"%%%s%"PRIu64"\n", STR08_01, *nm,
-        int48_to_long(raw), STR08_02, int48_to_long(raw+1));
+    printf("%-32s: %3d%%       %u%%%s%"PRIu64"\n", STR08_01, *nm,
+        *raw, STR08_02, int48_to_long(raw+1));
     /* 09 RAISIN_SI_VD_RETRY_BUFF_OVERFLOW_COUNT */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_RETRY_BUFF_OVERFLOW_COUNT, nm, raw);
     printf("%-32s: %3d%%       %"PRIu64"\n", STR09_01, *nm, int48_to_long(raw));
@@ -225,15 +225,15 @@ static void show_memblaze_smart_log_new(struct nvme_memblaze_smart_log *s,
     /* 15 RAISIN_SI_VD_TEMPT_SINCE_BORN */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_TEMPT_SINCE_BORN, nm, raw);
     printf("%-32s: %3d%%       %s%u%s%u%s%u\n", STR15_01,  *nm,
-        STR15_03, *raw, STR15_04, *(raw+2), STR15_05, *(raw+4));
+        STR15_03, *(u16 *)raw, STR15_04, *(u16 *)(raw+2), STR15_05, *(u16 *)(raw+4));
     /* 16 RAISIN_SI_VD_POWER_CONSUMPTION */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_POWER_CONSUMPTION, nm, raw);
     printf("%-32s: %3d%%       %s%u%s%u%s%u\n", STR16_01,  *nm,
-        STR16_03, *raw, STR16_04, *(raw+2), STR16_05, *(raw+4));
+        STR16_03, *(u16 *)raw, STR16_04, *(u16 *)(raw+2), STR16_05, *(u16 *)(raw+4));
     /* 17 RAISIN_SI_VD_TEMPT_SINCE_BOOTUP */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_TEMPT_SINCE_BOOTUP, nm, raw);
-    printf("%-32s: %3d%%       %s%u%s%u%s%u\n", STR17_01,  *nm, STR17_03, *raw,
-        STR17_04, *(raw+2), STR17_05, *(raw+4));
+    printf("%-32s: %3d%%       %s%u%s%u%s%u\n", STR17_01,  *nm, STR17_03, *(u16 *)raw,
+        STR17_04, *(u16 *)(raw+2), STR17_05, *(u16 *)(raw+4));
     /* 18 RAISIN_SI_VD_POWER_LOSS_PROTECTION */
     /* 19 RAISIN_SI_VD_READ_FAIL */
     get_memblaze_new_smart_info(smart, RAISIN_SI_VD_READ_FAIL, nm, raw);
@@ -372,7 +372,7 @@ static void show_memblaze_smart_log_old(struct nvme_memblaze_smart_log *smart,
         /* 02 RAISIN_SI_VD_WEARLEVELING_COUNT */
         get_memblaze_new_smart_info(s, WEARLEVELING_COUNT, nm, raw);
         printf("%-31s                                 : %3d%%       %s%u%s%u%s%u\n",
-			STR02_01, *nm, STR02_03, *raw, STR02_04, *(raw+2), STR02_05, *(raw+4));
+			STR02_01, *nm, STR02_03, *(u16 *)raw, STR02_04, *(u16 *)(raw+2), STR02_05, *(u16 *)(raw+4));
         /* 11 RAISIN_SI_VD_TOTAL_WRITE */
         get_memblaze_new_smart_info(s, TOTAL_WRITE, nm, raw);
         printf("%-32s                                : %3d%%       %"PRIu64"\n",

--- a/plugins/memblaze/memblaze-nvme.h
+++ b/plugins/memblaze/memblaze-nvme.h
@@ -6,12 +6,6 @@
 #define MEMBLAZE_NVME
 
 #include "cmd.h"
-#include "common.h"
-
-#include <ctype.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 
 PLUGIN(NAME("memblaze", "Memblaze vendor specific extensions", NVME_VERSION),
 	COMMAND_LIST(
@@ -30,4 +24,3 @@ PLUGIN(NAME("memblaze", "Memblaze vendor specific extensions", NVME_VERSION),
 #endif
 
 #include "define_cmd.h"
-

--- a/plugins/memblaze/memblaze-utils.h
+++ b/plugins/memblaze/memblaze-utils.h
@@ -9,9 +9,6 @@
 #define NM_SIZE                 2
 #define RAW_SIZE                7
 
-typedef unsigned char           u8;
-typedef unsigned short          u16;
-
 // Intel Format & new format
 /* Raisin Additional smart external ID */
 #define RAISIN_SI_VD_PROGRAM_FAIL_ID                        0xAB
@@ -136,18 +133,18 @@ struct nvme_memblaze_smart_log_item {
 
 struct nvme_memblaze_smart_log {
     struct nvme_memblaze_smart_log_item items[NR_SMART_ITEMS];
-    u8 resv[SMART_INFO_OLD_SIZE - sizeof(struct nvme_memblaze_smart_log_item) * NR_SMART_ITEMS];
+    __u8 resv[SMART_INFO_OLD_SIZE - sizeof(struct nvme_memblaze_smart_log_item) * NR_SMART_ITEMS];
 };
 
 // Intel Format & new format
 struct nvme_p4_smart_log_item
 {
     /* Item identifier */
-    u8 id[ID_SIZE];
+    __u8 id[ID_SIZE];
     /* Normalized value or percentage. In the range from 0 to 100. */
-    u8 nmVal[NM_SIZE];
+    __u8 nmVal[NM_SIZE];
     /* raw value */
-    u8 rawVal[RAW_SIZE];
+    __u8 rawVal[RAW_SIZE];
 };
 
 struct nvme_p4_smart_log
@@ -159,7 +156,7 @@ struct nvme_p4_smart_log
      * because micron's getlogpage request,the size of many commands have changed to 4k.
      * request size > user malloc size,casuing parameters that are closed in momery are dirty.
      */
-    u8 resv[SMART_INFO_NEW_SIZE - sizeof(struct nvme_p4_smart_log_item) * NR_SMART_ITEMS];
+    __u8 resv[SMART_INFO_NEW_SIZE - sizeof(struct nvme_p4_smart_log_item) * NR_SMART_ITEMS];
 };
 
 // base
@@ -222,4 +219,3 @@ struct nvme_p4_smart_log
     }
 
 #endif // __MEMBLAZE_UTILS_H__
-

--- a/plugins/memblaze/memblaze-utils.h
+++ b/plugins/memblaze/memblaze-utils.h
@@ -10,6 +10,7 @@
 #define RAW_SIZE                7
 
 typedef unsigned char           u8;
+typedef unsigned short          u16;
 
 // Intel Format & new format
 /* Raisin Additional smart external ID */


### PR DESCRIPTION
1. use "u16 *" instead of "u8 *" to fix the wear-leveling values as defined.
2. remove some useless code.
3. replace the string code style.