### PR TITLE
fw-download retry, progress and error-handling improvements

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4234,6 +4234,9 @@ static int fw_download_single(struct nvme_dev *dev, void *fw_buf,
 		fflush(stdout);
 	}
 
+	fprintf(stderr, "fw-download: failed on offset 0x%08x/0x%08x\n",
+		offset, fw_len);
+
 	if (err < 0)
 		fprintf(stderr, "fw-download: %s\n", nvme_strerror(errno));
 	else


### PR DESCRIPTION
As part of implementing firmware-download over MI transports, this series adds some reliability improvements to the fw-download subcommand:

 * reporting progress on individual data transfers, with a new `--progress` argument
 * retrying individual transfers where the controller does not indicate a Do Not Resend error
 * allowing the user to ignore Overlapping Range errors, if recovering from a previous transfer (`--ignore-ovr`)

As always, I'm happy to answer any queries or handle any comments / feedback.