### PR TITLE
nvme: support security-recv and security-send over nvme-mi

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -393,3 +393,26 @@ int nvme_cli_get_feature_length2(int fid, __u32 cdw11, enum nvme_data_tfr dir,
 		return err;
 	return nvme_get_feature_length(fid, cdw11, len);
 }
+
+int nvme_cli_security_send(struct nvme_dev *dev,
+			   struct nvme_security_send_args* args)
+{
+	return do_admin_args_op(security_send, dev, args);
+}
+
+int nvme_cli_security_receive(struct nvme_dev *dev,
+			      struct nvme_security_receive_args* args)
+{
+	/* Cannot use do_admin_args_op here because the API have different suffix*/
+	if (dev->type == NVME_DEV_DIRECT) {
+		args->fd = dev->direct.fd;
+		args->timeout = NVME_DEFAULT_IOCTL_TIMEOUT;
+		return nvme_security_receive(args);
+	}
+
+	if (dev->type == NVME_DEV_MI)
+		return nvme_mi_admin_security_recv(dev->mi.ctrl, args);
+
+	return -ENODEV;
+}
+

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -135,4 +135,10 @@ int nvme_cli_admin_passthru(struct nvme_dev *dev, __u8 opcode, __u8 flags,
 int nvme_cli_get_feature_length2(int fid, __u32 cdw11, enum nvme_data_tfr dir,
 				__u32 *len);
 
+int nvme_cli_security_send(struct nvme_dev *dev,
+			   struct nvme_security_send_args* args);
+
+int nvme_cli_security_receive(struct nvme_dev *dev,
+			      struct nvme_security_receive_args* args);
+
 #endif /* _NVME_WRAP_H */

--- a/nvme.c
+++ b/nvme.c
@@ -5497,7 +5497,6 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	struct nvme_security_send_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.nssf		= cfg.nssf,
 		.spsp0		= cfg.spsp & 0xff,
@@ -5509,7 +5508,9 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 		.result		= NULL,
 	};
-	err = nvme_security_send(&args);
+
+	err = nvme_cli_security_send(dev, &args);
+
 	if (err < 0)
 		fprintf(stderr, "security-send: %s\n", nvme_strerror(errno));
 	else if (err != 0)
@@ -7177,7 +7178,6 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 
 	struct nvme_security_receive_args args = {
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.nssf		= cfg.nssf,
 		.spsp0		= cfg.spsp & 0xff,
@@ -7189,7 +7189,9 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 		.result		= NULL,
 	};
-	err = nvme_security_receive(&args);
+
+	err = nvme_cli_security_receive(dev, &args);
+
 	if (err < 0)
 		fprintf(stderr, "security receive: %s\n", nvme_strerror(errno));
 	else if (err != 0)


### PR DESCRIPTION
We cannot use nvme_cli_security_receive wrapper method as other commands because the API between inband and nvme-mi are not compatible.

Signed-off-by: Jinliang Wang <jinliangw@google.com>

Tested:
```
# ./nvme security-recv -n 0 --secp=1 --spsp=0x0001 --size=512 --al=512 mctp:1,16:0
NVME Security Receive Command Success
       0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0000: 00 00 00 b4 00 00 00 01 00 00 00 00 00 00 00 00 "................"
0010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "................"
0020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 "................"
0030: 00 01 10 0c 51 00 00 00 00 00 00 00 00 00 00 00 "....Q..........."
0040: 00 02 10 0c 09 00 00 00 00 00 00 00 00 00 00 00 "................"
0050: 00 03 10 1c 01 00 00 00 00 00 00 00 00 00 02 00 "................"
0060: 7f ff ff ff ff ff ff ff 00 00 00 00 00 00 00 00 "................"
0070: 02 01 10 0c 00 00 00 21 04 00 00 00 00 00 00 00 ".......!........"
0080: 02 02 10 0c 00 00 00 08 00 a0 00 00 00 00 00 01 "................"
0090: 02 03 10 10 10 00 00 02 01 00 04 00 21 00 00 00 "............!..."
00a0: 00 00 00 00 04 03 22 10 20 00 00 00 00 00 00 21 "......"........!"
00b0: 00 00 00 20 00 00 00 01 00 00 00 00 00 00 00 00 "................"
```