### PR TITLE
nvme: Allow standard SI units for ns-create nsze and ncap input

### DIFF
--- a/Documentation/nvme-create-ns.txt
+++ b/Documentation/nvme-create-ns.txt
@@ -19,6 +19,9 @@ SYNOPSIS
 			[--lbstm=<lbstm> | -l <lbstm>]
 			[--block-size=<block-size> | -b <block-size>]
 			[--timeout=<timeout> | -t <timeout>]
+			[--nsze-si=<nsze-si> | -S <nsze-si>]
+			[--ncap-si=<ncap-si> | -C <ncap-si>]
+
 DESCRIPTION
 -----------
 For the NVMe device given, sends a namespace management command to create
@@ -75,10 +78,26 @@ OPTIONS
   values will be values will be scanned and the lowest numbered will be
   selected for the create-ns operation. Conflicts with --flbas argument.
 
+-S::
+--nsze-si::
+	The namespace size (NSZE) in standard SI units.
+	The value SI suffixed is divided by the namespace LBA size to set as NSZE.
+	If the value not suffixed it is set as same with the nsze option.
+
+-C::
+--ncap-si::
+	The namespace capacity (NCAP) in standard SI units.
+	The value SI suffixed is divided by the namespace LBA size to set as NCAP.
+	If the value not suffixed it is set as same with the ncap option.
 
 EXAMPLES
 --------
-No examples provided yet.
+* Create a namespace:
++
+------------
+# nvme create-ns /dev/nvme0 --nsze 11995709440 --ncap 1199570940 --flbas 0 --dps 0 --nmic 0
+# nvme create-ns /dev/nvme0 --nsze-si 6.14T --ncap 1199570940 --flbas 0 --dps 0 --nmic 0
+------------
 
 NVME
 ----

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -64,6 +64,15 @@ test_uint128 = executable(
 
 test('uint128', test_uint128)
 
+test_suffix_si_parse = executable(
+    'test-suffix-si-parse',
+    ['test-suffix-si-parse.c', '../util/suffix.c'],
+    include_directories: [incdir, '..'],
+    dependencies: [libnvme_dep],
+)
+
+test('suffix_si_parse', test_suffix_si_parse)
+
 python_module = import('python')
 
 python = python_module.find_installation('python3')

--- a/tests/test-suffix-si-parse.c
+++ b/tests/test-suffix-si-parse.c
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../util/suffix.h"
+#include "../util/types.h"
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+static int test_rc;
+
+static void check_num(const char *val, int lbas, __u64 exp, __u64 num)
+{
+	if (exp == num)
+		return;
+
+	printf("ERROR: printing {%s} (lbas %d), got '%llu', expected '%llu'\n",
+	       val, lbas, (unsigned long long)num, (unsigned long long)exp);
+
+	test_rc = 1;
+}
+
+struct tonum_test {
+	const char *val;
+	int lbas;
+	const __u64 exp;
+};
+
+static struct tonum_test tonum_tests[] = {
+	{ "11995709440", 512, 11995709440 },
+	{ "1199570940", 512, 1199570940 },
+	{ "6.14T", 512, 11992187500 },
+	{ "6.14T", 520, 11807692307 },
+	{ "6.14T", 4096, 1499023437 },
+	{ "6.14", 512, 0 },
+	{ "6.14#", 512, 0 },
+};
+
+void tonum_test(struct tonum_test *test)
+{
+	__u64 num;
+	bool suffixed;
+
+	num = suffix_si_parse(test->val, &suffixed);
+
+	if (suffixed)
+		num /= test->lbas;
+
+	check_num(test->val, test->lbas, test->exp, num);
+}
+
+int main(void)
+{
+	unsigned int i;
+
+	test_rc = 0;
+
+	for (i = 0; i < ARRAY_SIZE(tonum_tests); i++)
+		tonum_test(&tonum_tests[i]);
+
+	return test_rc ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/util/suffix.c
+++ b/util/suffix.c
@@ -69,6 +69,31 @@ const char *suffix_si_get(double *value)
 	return "";
 }
 
+uint64_t suffix_si_parse(const char *value, bool *suffixed)
+{
+	char *suffix;
+	double ret;
+	struct si_suffix *s;
+
+	errno = 0;
+	ret = strtod(value, &suffix);
+	if (errno)
+		return 0;
+
+	for (s = si_suffixes; s->magnitude != 0; s++) {
+		if (suffix[0] == s->suffix[0]) {
+			if (suffixed && suffix[0] != '\0')
+				*suffixed = true;
+			return ret *= s->magnitude;
+		}
+	}
+
+	if (suffix[0] != '\0')
+		errno = EINVAL;
+
+	return (uint64_t)ret;
+}
+
 static struct binary_suffix {
 	int shift;
 	const char *suffix;

--- a/util/suffix.h
+++ b/util/suffix.h
@@ -33,8 +33,10 @@
 #ifndef __ARGCONFIG_SUFFIX_H__
 
 #include <inttypes.h>
+#include <stdbool.h>
 
 const char *suffix_si_get(double *value);
+uint64_t suffix_si_parse(const char *value, bool *suffixed);
 const char *suffix_binary_get(long long *value);
 const char *suffix_dbinary_get(double *value);
 uint64_t suffix_binary_parse(const char *value);


### PR DESCRIPTION
This is proposed by the issue #1747.

Signed-off-by: Tokunori Ikegami <ikegami.t@gmail.com>