### PR TITLE
nvme: Output zero padded hostid in resv-report command

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5913,7 +5913,7 @@ void nvme_show_resv_report(struct nvme_resv_status *status, int bytes,
 				le64_to_cpu(status->regctl_eds[i].rkey));
 			printf("  hostid     : ");
 			for (j = 0; j < 16; j++)
-				printf("%x",
+				printf("%02x",
 					status->regctl_eds[i].hostid[j]);
 			printf("\n");
 		}


### PR DESCRIPTION
The resv-report command is missing to print the zeros in hostid for the terminal output. Update the printf format specifier accordingly.

The JSON output does this correctly.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1757 