### PR TITLE
Make unique discovery controllers persistent as default

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -227,6 +227,8 @@ static nvme_ctrl_t __create_discover_ctrl(nvme_root_t r, nvme_host_t h,
 		return NULL;
 
 	nvme_ctrl_set_discovery_ctrl(c, true);
+	nvme_ctrl_set_unique_discovery_ctrl(c,
+		     strcmp(trcfg->subsysnqn, NVME_DISC_SUBSYS_NAME));
 	tmo = set_discovery_kato(cfg);
 
 	errno = 0;
@@ -251,7 +253,7 @@ static nvme_ctrl_t create_discover_ctrl(nvme_root_t r, nvme_host_t h,
 	if (!c)
 		return NULL;
 
-	if (!persistent)
+	if (nvme_ctrl_is_unique_discovery_ctrl(c))
 		return c;
 
 	/* Find out the name of discovery controller */

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = f83b2c4c4738287e5bfd1b8bec691a228d997924
+revision = a04a8c73ab3476d5c8ebca46400367a0438a649d
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
This implemention changes the default behavior considerable:

- Try to use unique discovery controllers per default.
- Avoid connecting to already connected or 'duplicates' controllers during discovery
- Make unique discovery controllers persistent per default

The first two are backwards compatible, that means if the user isn't really using '--persistent' as command line option, the outcome should be the same. The last change is a bit daunting IMO. Is this really what the TP8013 mandates?

Fixes #1670 