### PR TITLE
nvme: Add wait for device self test

### DIFF
--- a/Documentation/nvme-device-self-test.txt
+++ b/Documentation/nvme-device-self-test.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme device-self-test' <device> [--namespace-id=<NUM> | -n <NUM>]
-			[--self-test-code=<NUM> | -s <NUM>] 
+			[--self-test-code=<NUM> | -s <NUM>]  [--wait | -w]
 
 DESCRIPTION
 -----------
@@ -33,6 +33,10 @@ OPTIONS
          2h: Start a extended device self-test operation
          eh: Start a vendor specific device self-test operation
          fh: abort the device self-test operation
+
+-w::
+--wait::
+	Wait for the device self test to complete before exiting
 
 
 EXAMPLES


### PR DESCRIPTION
Add a wait command line option to device-self-test which makes nvme-cli staying in forground and reports progress. This make it possible to wait for the end of the test.

Signed-off-by: Keith Busch <kbusch@kernel.org>
[dwagner: make termination condition handling the end of self test]
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #https://github.com/linux-nvme/nvme-cli/issues/1759