### PR TITLE
build: Upload latest AppImage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -31,3 +31,7 @@ jobs:
         with:
           name: AppImage
           path: '*.AppImage*'
+      - uses: pyTooling/Actions/releaser@r0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: '*.AppImage'


### PR DESCRIPTION
We have to upload the AppImage as release to be able set a link.

Signed-off-by: Daniel Wagner <dwagner@suse.de>