### PR TITLE
util: Add file stream parameter to print word wrapped

### DIFF
--- a/plugin.c
+++ b/plugin.c
@@ -77,12 +77,12 @@ void general_help(struct plugin *plugin)
 	usage(plugin);
 
 	printf("\n");
-	print_word_wrapped(prog->desc, 0, 0);
+	print_word_wrapped(prog->desc, 0, 0, stdout);
 	printf("\n");
 
 	if (plugin->desc) {
 		printf("\n");
-		print_word_wrapped(plugin->desc, 0, 0);
+		print_word_wrapped(plugin->desc, 0, 0, stdout);
 		printf("\n");
 	}
 

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -53,7 +53,7 @@ void argconfig_append_usage(const char *str)
 	append_usage_str = str;
 }
 
-void print_word_wrapped(const char *s, int indent, int start)
+void print_word_wrapped(const char *s, int indent, int start, FILE *stream)
 {
 	const int width = 76;
 	const char *c, *t;
@@ -61,7 +61,7 @@ void print_word_wrapped(const char *s, int indent, int start)
 	int last_line = indent;
 
 	while (start < indent) {
-		putc(' ', stderr);
+		putc(' ', stream);
 		start++;
 	}
 
@@ -78,14 +78,14 @@ void print_word_wrapped(const char *s, int indent, int start)
 				int i;
 new_line:
 				last_line = (int) (c-s) + start;
-				putc('\n', stderr);
+				putc('\n', stream);
 				for (i = 0; i < indent; i++)
-					putc(' ', stderr);
+					putc(' ', stream);
 				start = indent;
 				continue;
 			}
 		}
-		putc(*c, stderr);
+		putc(*c, stream);
 	}
 }
 
@@ -115,8 +115,8 @@ static void show_option(const struct argconfig_commandline_options *option)
 
 	fprintf(stderr, "%s", buffer);
 	if (option->help) {
-		print_word_wrapped("--- ", 40, b - buffer);
-		print_word_wrapped(option->help, 44, 44);
+		print_word_wrapped("--- ", 40, b - buffer, stderr);
+		print_word_wrapped(option->help, 44, 44, stderr);
 	}
 	fprintf(stderr, "\n");
 }
@@ -126,16 +126,16 @@ void argconfig_print_help(const char *program_desc,
 {
 	const struct argconfig_commandline_options *s;
 
-	printf("\033[1mUsage: %s\033[0m\n\n",
-	       append_usage_str);
+	fprintf(stderr, "\033[1mUsage: %s\033[0m\n\n",
+		append_usage_str);
 
-	print_word_wrapped(program_desc, 0, 0);
-	printf("\n");
+	print_word_wrapped(program_desc, 0, 0, stderr);
+	fprintf(stderr, "\n");
 
 	if (!options || !options->option)
 		return;
 
-	printf("\n\033[1mOptions:\033[0m\n");
+	fprintf(stderr, "\n\033[1mOptions:\033[0m\n");
 	for (s = options; (s != NULL) && (s->option != NULL); s++)
 		show_option(s);
 }

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <stdarg.h>
+#include <stdio.h>
 
 enum argconfig_types {
 	CFG_FLAG,
@@ -134,5 +135,5 @@ int argconfig_parse_comma_sep_array_long(char *string,
 int argconfig_parse_byte(const char *opt, const char *str, unsigned char *val);
 void argconfig_register_help_func(argconfig_help_func * f);
 
-void print_word_wrapped(const char *s, int indent, int start);
+void print_word_wrapped(const char *s, int indent, int start, FILE *stream);
 #endif


### PR DESCRIPTION
This is to allow to select stdout or stderr streams for print.

Signed-off-by: Tokunori Ikegami <ikegami.t@gmail.com>