### PR TITLE
fabrics: Make PDC behavior configurable

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -148,6 +148,14 @@ static inline int strcasecmp0(const char *s1, const char *s2)
 	return strcasecmp(s1, s2);
 }
 
+static bool is_persistent_discovery_ctrl(nvme_host_t h, nvme_ctrl_t c)
+{
+	if (nvme_host_is_pdc_enabled(h, DEFAULT_PDC_ENABLED))
+		return nvme_ctrl_is_unique_discovery_ctrl(c);
+
+	return false;
+}
+
 static bool disc_ctrl_config_match(nvme_ctrl_t c, struct tr_config *trcfg)
 {
 	if (!strcmp0(nvme_ctrl_get_transport(c), trcfg->transport) &&
@@ -675,7 +683,7 @@ static int discover_from_conf_file(nvme_root_t r, nvme_host_t h,
 			goto next;
 
 		__discover(c, &cfg, raw, connect, persistent, flags);
-		if (!(persistent || nvme_ctrl_is_unique_discovery_ctrl(c)))
+		if (!(persistent || is_persistent_discovery_ctrl(h, c)))
 			ret = nvme_disconnect_ctrl(c);
 		nvme_free_ctrl(c);
 
@@ -751,7 +759,7 @@ static int discover_from_json_config_file(nvme_root_t r, nvme_host_t h,
 				continue;
 
 			__discover(cn, &cfg, raw, connect, persistent, flags);
-			if (!(persistent || nvme_ctrl_is_unique_discovery_ctrl(cn)))
+			if (!(persistent || is_persistent_discovery_ctrl(h, cn)))
 				ret = nvme_disconnect_ctrl(cn);
 			nvme_free_ctrl(cn);
 		}
@@ -923,7 +931,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	}
 
 	ret = __discover(c, &cfg, raw, connect, persistent, flags);
-	if (!(persistent || nvme_ctrl_is_unique_discovery_ctrl(c)))
+	if (!(persistent || is_persistent_discovery_ctrl(h, c)))
 		nvme_disconnect_ctrl(c);
 	nvme_free_ctrl(c);
 

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,8 @@ conf.set('CONFIG_LIBHUGETLBFS', have_libhugetlbfs, description: 'Is libhugetlbfs
 # Set the nvme-cli version
 conf.set('NVME_VERSION', '"' + meson.project_version() + '"')
 
+conf.set10('DEFAULT_PDC_ENABLED', get_option('pdc-enabled'))
+
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(
     'HAVE_BUILTIN_TYPES_COMPATIBLE_P',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,4 +7,5 @@ option('htmldir', type : 'string', value : '', description : 'directory for HTML
 option('systemctl', type : 'string', value : '/usr/bin/systemctl', description : 'path to systemctl binary')
 option('nvme-tests', type : 'boolean', value : false, description: 'Run tests against real hardware')
 option('docs', type : 'combo', choices : ['false', 'html', 'man', 'all'], description : 'install documentation')
-option('docs-build', type : 'boolean', value : false,  description : 'build documentation')
+option('docs-build', type : 'boolean', value : false, description : 'build documentation')
+option('pdc-enabled', type: 'boolean', value : false, description : 'set default Persistent Discovery Controllers behavior')

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = a04a8c73ab3476d5c8ebca46400367a0438a649d
+revision = 568c5b80d1387a1491b09a8254fe039f0675d073
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
The persistent discovery controller is a behavior change which might break existing installation. Instead enabling it per default, introduce a compile time and a global configuration option to define the default settings.

Signed-off-by: Daniel Wagner <dwagner@suse.de>