### PR TITLE
json_discovery_log: avoid buffer overrun

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -350,9 +350,9 @@ static void json_discovery_log(struct nvmf_discovery_log *log, int numrec)
 		struct nvmf_disc_log_entry *e = &log->entries[i];
 		struct json_object *entry = json_create_object();
 
-		nvme_strip_spaces(e->trsvcid, NVMF_TRSVCID_SIZE);
-		nvme_strip_spaces(e->subnqn, NVMF_NQN_SIZE);
-		nvme_strip_spaces(e->traddr, NVMF_TRADDR_SIZE);
+		space_strip_len(NVMF_TRSVCID_SIZE, e->trsvcid);
+		space_strip_len(NVMF_NQN_SIZE, e->subnqn);
+		space_strip_len(NVMF_TRADDR_SIZE, e->traddr);
 
 		json_object_add_value_string(entry, "trtype",
 					     nvmf_trtype_str(e->trtype));

--- a/nvme.h
+++ b/nvme.h
@@ -114,12 +114,6 @@ const char *nvme_strerror(int errnum);
 unsigned long long elapsed_utime(struct timeval start_time,
 					struct timeval end_time);
 
-static inline void nvme_strip_spaces(char *s, int l)
-{
-        while (l && (s[l] == '\0' || s[l] == ' '))
-                s[l--] = '\0';
-}
-
 /* nvme-print.c */
 const char *nvme_select_to_string(int sel);
 


### PR DESCRIPTION
`nvme_strip_spaces()` has an off-by-one error and starts stripping spaces at the byte AFTER the end of the buffer. Use `space_strip_len()` instead, which doesn't have this bug and is already used in `print_discovery_log()`.