### PR TITLE
Device self-test changes

### DIFF
--- a/Documentation/nvme-device-self-test.txt
+++ b/Documentation/nvme-device-self-test.txt
@@ -28,16 +28,19 @@ OPTIONS
 
 -s <NUM>::
 --self-test-code=<NUM>::
-        This field specifies the action taken by the device self-test command : 
+        This field specifies the action taken by the device self-test command :
+         0h: Show current state of device self-test operation
          1h: Start a short device self-test operation
          2h: Start a extended device self-test operation
          eh: Start a vendor specific device self-test operation
-         fh: abort the device self-test operation
+         fh: Abort the device self-test operation
+	Default is 0h.
 
 -w::
 --wait::
 	Wait for the device self test to complete before exiting
-
+	The device self-test is aborted by SIGINT signal interrupt for the wait
+	The option is ignored if the abort self-test code option specified.
 
 EXAMPLES
 --------

--- a/nvme.c
+++ b/nvme.c
@@ -152,6 +152,8 @@ static const char *timeout = "timeout value, in milliseconds";
 static const char *uuid_index = "UUID index";
 static const char *uuid_index_specify = "specify uuid index";
 static const char *verbose = "Increase output verbosity";
+static const char dash[51] = {[0 ... 49] = '=', '\0'};
+static const char space[51] = {[0 ... 49] = ' ', '\0'};
 
 static void *mmap_registers(nvme_root_t r, struct nvme_dev *dev);
 
@@ -4180,9 +4182,6 @@ static int sleep_self_test(unsigned int seconds)
 
 	return 0;
 }
-
-static const char dash[51] = {[0 ... 49] = '=', '\0'};
-static const char space[51] = {[0 ... 49] = ' ', '\0'};
 
 static int wait_self_test(struct nvme_dev *dev)
 {

--- a/nvme.c
+++ b/nvme.c
@@ -4246,7 +4246,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 
 	struct config cfg = {
 		.namespace_id	= NVME_NSID_ALL,
-		.stc		= 0,
+		.stc		= NVME_ST_CODE_RESERVED,
 		.wait		= false,
 	};
 
@@ -4261,7 +4261,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 	if (err)
 		goto ret;
 
-	if (cfg.stc == 0) {
+	if (cfg.stc == NVME_ST_CODE_RESERVED) {
 		struct nvme_self_test_log log;
 		err = nvme_cli_get_log_device_self_test(dev, &log);
 		if (err) {
@@ -4295,9 +4295,9 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 	if (!err) {
 		if (cfg.stc == 0xf)
 			printf("Aborting device self-test operation\n");
-		else if (cfg.stc == 0x2)
+		else if (cfg.stc == NVME_ST_CODE_EXTENDED)
 			printf("Extended Device self-test started\n");
-		else if (cfg.stc == 0x1)
+		else if (cfg.stc == NVME_ST_CODE_SHORT)
 			printf("Short Device self-test started\n");
 
 		if (cfg.wait)

--- a/nvme.c
+++ b/nvme.c
@@ -4248,7 +4248,7 @@ static void abort_self_test(struct nvme_dev_self_test_args *args)
 {
 	int err;
 
-	args->stc = 0xf,
+	args->stc = NVME_ST_CODE_ABORT,
 
 	err = nvme_dev_self_test(args);
 	if (!err) {
@@ -4330,14 +4330,14 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 	};
 	err = nvme_dev_self_test(&args);
 	if (!err) {
-		if (cfg.stc == 0xf)
+		if (cfg.stc == NVME_ST_CODE_ABORT)
 			printf("Aborting device self-test operation\n");
 		else if (cfg.stc == NVME_ST_CODE_EXTENDED)
 			printf("Extended Device self-test started\n");
 		else if (cfg.stc == NVME_ST_CODE_SHORT)
 			printf("Short Device self-test started\n");
 
-		if (cfg.wait && cfg.stc != 0xf)
+		if (cfg.wait && cfg.stc != NVME_ST_CODE_ABORT)
 			err = wait_self_test(dev);
 	} else if (err > 0) {
 		nvme_show_status(err);

--- a/nvme.c
+++ b/nvme.c
@@ -4265,13 +4265,13 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 		" which provides the necessary log to determine the state of the device";
 	const char *namespace_id = "Indicate the namespace in which the device self-test"\
 		" has to be carried out";
-	const char * self_test_code = "This field specifies the action taken by the device self-test command : "\
-		"\n0h Show current state of device self-test operation\n"\
-		"\n1h Start a short device self-test operation\n"\
+	const char * self_test_code = "This field specifies the action taken by the device self-test command :\n"\
+		"0h Show current state of device self-test operation\n"\
+		"1h Start a short device self-test operation\n"\
 		"2h Start a extended device self-test operation\n"\
 		"eh Start a vendor specific device self-test operation\n"\
-		"fh abort the device self-test operation";
-	const char *wait = "wait for the test to finish";
+		"fh Abort the device self-test operation";
+	const char *wait = "Wait for the test to finish";
 	struct nvme_dev *dev;
 	int err;
 

--- a/nvme.c
+++ b/nvme.c
@@ -4300,7 +4300,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 		else if (cfg.stc == NVME_ST_CODE_SHORT)
 			printf("Short Device self-test started\n");
 
-		if (cfg.wait)
+		if (cfg.wait && cfg.stc != 0xf)
 			err = wait_self_test(dev);
 	} else if (err > 0) {
 		nvme_show_status(err);

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 662799b5961ac1f4739825181480a32e1effa669
+revision = 2684cad62e2de02a139f053bbf804097a4ee5596
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Still thinking and trying to add changes below also etc.
1. Add device self-test SIGINT signal handling for wait option to abort
2. Use abort self-test code definition value instead hard-code value
3. Update device-self-test command documentation