### PR TITLE
util: Reimplement suffix_si_parse

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2809,10 +2809,10 @@ static int detach_ns(int argc, char **argv, struct command *cmd, struct plugin *
 static int parse_lba_num_si(struct nvme_dev *dev, const char *opt,
 			    const char *val, __u8 flbas, __u64 *num)
 {
-	bool suffixed = false;
 	struct nvme_id_ctrl ctrl;
 	__u32 nsid = 1;
 	struct nvme_id_ns ns;
+	char *endptr;
 	int err = -EINVAL;
 	int i;
 	int lbas;
@@ -2873,17 +2873,17 @@ static int parse_lba_num_si(struct nvme_dev *dev, const char *opt,
 	i = flbas & NVME_NS_FLBAS_LOWER_MASK;
 	lbas = (1 << ns.lbaf[i].ds) + ns.lbaf[i].ms;
 
-	*num = suffix_si_parse(val, &suffixed);
-
-	if (errno)
+	if (suffix_si_parse(val, &endptr, (uint64_t*)num)) {
 		fprintf(stderr,
 			"Expected long suffixed integer argument for '%s-si' but got '%s'!\n",
 			opt, val);
+		return -errno;
+	}
 
-	if (suffixed)
+	if (endptr[0] != '\0')
 		*num /= lbas;
 
-	return errno;
+	return 0;
 }
 
 static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *plugin)

--- a/unit/meson.build
+++ b/unit/meson.build
@@ -18,6 +18,15 @@ test_suffix_si_parse = executable(
 
 test('suffix_si_parse', test_suffix_si_parse)
 
+test_suffix_binary_parse = executable(
+    'test-suffix-binary-parse',
+    ['test-suffix-binary-parse.c', '../util/suffix.c'],
+    include_directories: [incdir, '..'],
+    dependencies: [libnvme_dep],
+)
+
+test('suffix_binary_parse', test_suffix_binary_parse)
+
 test_uint128_si = executable(
     'test-uint128-si',
     ['test-uint128-si.c', '../util/types.c', '../util/suffix.c'],

--- a/unit/test-suffix-binary-parse.c
+++ b/unit/test-suffix-binary-parse.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "../util/suffix.h"
+#include "../util/types.h"
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+static int test_rc;
+
+static void check_num(const char *val, __u64 exp, __u64 num)
+{
+	if (exp == num)
+		return;
+
+	printf("ERROR: printing {%s},  got '%llu', expected '%llu'\n",
+	       val, (unsigned long long)num, (unsigned long long)exp);
+
+	test_rc = 1;
+}
+
+struct tonum_test {
+	const char *val;
+	const uint64_t exp;
+	int ret;
+};
+
+static struct tonum_test tonum_tests[] = {
+	{ "1Ki", 1024, 0},
+	{ "34Gi", 36507222016, 0 },
+	{ "1234", 0, -EINVAL },
+	{ "34.9Ki", 0, -EINVAL},
+	{ "32Gii", 0, -EINVAL },
+};
+
+void tonum_test(struct tonum_test *test)
+{
+	char *endptr;
+	uint64_t num;
+	int ret;
+
+	ret = suffix_binary_parse(test->val, &endptr, &num);
+	if (ret != test->ret) {
+		printf("ERROR: converting {%s} failed\n", test->val);
+		test_rc = 1;
+		return;
+	}
+	if (ret)
+		return;
+
+	check_num(test->val, test->exp, num);
+}
+
+int main(void)
+{
+	unsigned int i;
+
+	test_rc = 0;
+
+	for (i = 0; i < ARRAY_SIZE(tonum_tests); i++)
+		tonum_test(&tonum_tests[i]);
+
+	return test_rc ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -293,8 +293,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 				goto out;
 			}
 		} else if (s->config_type == CFG_LONG_SUFFIX) {
-			*((uint64_t *)value_addr) = suffix_binary_parse(optarg);
-			if (errno) {
+			if (suffix_binary_parse(optarg, &endptr, (uint64_t*)&value_addr)) {
 				fprintf(stderr,
 					"Expected long suffixed integer argument for '%s' but got '%s'!\n",
 					long_opts[option_index].name, optarg);

--- a/util/suffix.c
+++ b/util/suffix.c
@@ -31,28 +31,31 @@
  */
 
 #include "suffix.h"
+#include "common.h"
 
 #include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
 #include <math.h>
+#include <float.h>
+#include <limits.h>
+#include <locale.h>
 
 static struct si_suffix {
 	long double magnitude;
+	unsigned int exponent;
 	const char *suffix;
 } si_suffixes[] = {
-	{1e30, "Q"},
-	{1e27, "R"},
-	{1e24, "Y"},
-	{1e21, "Z"},
-	{1e18, "E"},
-	{1e15, "P"},
-	{1e12, "T"},
-	{1e9, "G"},
-	{1e6, "M"},
-	{1e3, "k"},
-	{1e0, ""},
-	{0}
+	{1e30, 30, "Q"},
+	{1e27, 27, "R"},
+	{1e24, 24, "Y"},
+	{1e21, 21, "Z"},
+	{1e18, 18, "E"},
+	{1e15, 15, "P"},
+	{1e12, 12, "T"},
+	{1e9, 9, "G"},
+	{1e6, 6, "M"},
+	{1e3, 3, "k"},
 };
 
 const char *suffix_si_get(double *value)
@@ -65,36 +68,87 @@ const char *suffix_si_get(double *value)
 	return suffix;
 }
 
-uint64_t suffix_si_parse(const char *value, bool *suffixed)
+int suffix_si_parse(const char *str, char **endptr, uint64_t *val)
 {
-	char *suffix;
-	double ret;
-	struct si_suffix *s;
+	unsigned long long num, frac;
+	char *sep, *tmp;
+	int frac_len, len, i;
 
-	errno = 0;
-	ret = strtod(value, &suffix);
-	if (errno)
+	num = strtoull(str, endptr, 0);
+	if (str == *endptr ||
+	    ((num == ULLONG_MAX) && errno == ERANGE))
+		return -EINVAL;
+
+	/* simple number, no decimal point not suffix */
+	if ((*endptr)[0] == '\0') {
+		*val = num;
 		return 0;
-
-	for (s = si_suffixes; s->magnitude != 0; s++) {
-		if (suffix[0] == s->suffix[0]) {
-			if (suffixed && suffix[0] != '\0')
-				*suffixed = true;
-			return ret *= s->magnitude;
-		}
 	}
 
-	if (suffix[0] != '\0')
-		errno = EINVAL;
+	/* get rid of the decimal point */
+	sep = localeconv()->decimal_point;
+	if (sep)
+		len = strlen(sep);
+	else
+		len = 0;
 
-	return (uint64_t)ret;
+	for (i = 0; i < len; i++) {
+		if (((*endptr)[i] == '\0') || (*endptr)[i] != sep[i])
+			return -EINVAL;
+	}
+	*endptr += len;
+	tmp = *endptr;
+
+	/* extract the digits after decimal point */
+	frac = strtoull(tmp, endptr, 0);
+	if (tmp == *endptr ||
+	    ((frac == ULLONG_MAX) && errno == ERANGE))
+		return -EINVAL;
+
+	/* test that we have max one character as suffix */
+	if ((*endptr)[0] != '\0' && (*endptr)[1] != '\0')
+		return -EINVAL;
+
+	frac_len = *endptr - tmp;
+
+	for (i = 0; i < ARRAY_SIZE(si_suffixes); i++) {
+		struct si_suffix *s = &si_suffixes[i];
+
+		if ((*endptr)[0] != s->suffix[0])
+			continue;
+
+		/* we should check for overflow */
+		for (int j = 0; j < s->exponent; j++)
+			num *= 10;
+
+		if (s->exponent > frac_len) {
+			for (int j = 0; j < s->exponent - frac_len;  j++)
+				frac *= 10;
+		} else if (s->exponent < frac_len) {
+			for (int j = 0; j < frac_len - s->exponent;  j++)
+				frac /= 10;
+		} else {
+			frac = 0;
+		}
+
+		*val = num + frac;
+		return 0;
+	}
+
+	if ((*endptr)[0] != '\0')
+		return -EINVAL;
+
+	*val = num;
+	return 0;
 }
 
 const char *suffix_si_get_ld(long double *value)
 {
-	struct si_suffix *s;
+	int i;
 
-	for (s = si_suffixes; s->magnitude != 0; s++) {
+	for (i = 0; i < ARRAY_SIZE(si_suffixes); i++) {
+		struct si_suffix *s = &si_suffixes[i];
+
 		if (*value >= s->magnitude) {
 			*value /= s->magnitude;
 			return s->suffix;

--- a/util/suffix.h
+++ b/util/suffix.h
@@ -40,6 +40,6 @@ int suffix_si_parse(const char *str, char **endptr, uint64_t *val);
 const char *suffix_si_get_ld(long double *value);
 const char *suffix_binary_get(long long *value);
 const char *suffix_dbinary_get(double *value);
-uint64_t suffix_binary_parse(const char *value);
+int suffix_binary_parse(const char *str, char **endptr, uint64_t *val);
 
 #endif

--- a/util/suffix.h
+++ b/util/suffix.h
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 
 const char *suffix_si_get(double *value);
-uint64_t suffix_si_parse(const char *value, bool *suffixed);
+int suffix_si_parse(const char *str, char **endptr, uint64_t *val);
 const char *suffix_si_get_ld(long double *value);
 const char *suffix_binary_get(long long *value);
 const char *suffix_dbinary_get(double *value);


### PR DESCRIPTION
suffix_si_parse() has an very awkward interface with using errno and suffixed as return value. Let's just use the return code as status value and use an argument for returning the value and avoid setting the errno.

Furthermoe, this function should not know anything about LBAs, it just supposed to parse a string with a suffix. In order to support the previous use case we also return the endprt which allows to implement the nsze-si parse use case and the caller side (see documentation on create-ns).

Next problem is that suffix_is_parse uses double for calculation which tend to get inaccurate, e.g. 6.14T results in 61399999997. Instead let's do do all in pure integer arithmetic.

Also handle the decimal point according the locale settings.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1788 