### PR TITLE
build: Enable Azure Pipeline again

### DIFF
--- a/.github/azure-pipelines.yml
+++ b/.github/azure-pipelines.yml
@@ -6,7 +6,8 @@
 #   - nvme/012
 #   - nvme/013
 
-trigger: none # Disable CI triggers.
+trigger:
+  - master
 
 jobs:
   - job: blktests


### PR DESCRIPTION
Let's give it another try to use the addition tests. The Azure Pipeline Agent extension seems to work now.

Signed-off-by: Daniel Wagner <dwagner@suse.de>