### PR TITLE
build: Use prefixdir directly on sysconfdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ prefixdir  = get_option('prefix')
 datadir    = join_paths(prefixdir, get_option('datadir'))
 mandir     = join_paths(prefixdir, get_option('mandir'))
 sbindir    = join_paths(prefixdir, get_option('sbindir'))
-sysconfdir = join_paths(prefixdir, get_option('sysconfdir'))
+sysconfdir = prefixdir + get_option('sysconfdir')
 
 udevrulesdir   = join_paths(prefixdir, get_option('udevrulesdir'))
 dracutrulesdir = join_paths(prefixdir, get_option('dracutrulesdir'))


### PR DESCRIPTION
The sysconfdir is an explicit path '/etc' and the muon implementation of join_paths is dropping the prefixdir, thus we need to string concanate the syscondfir path instead of using the join_paths function.

Signed-off-by: Daniel Wagner <dwagner@suse.de>