### PR TITLE
util: Numbers without any suffix are also valid

### DIFF
--- a/unit/test-suffix-binary-parse.c
+++ b/unit/test-suffix-binary-parse.c
@@ -30,9 +30,9 @@ struct tonum_test {
 };
 
 static struct tonum_test tonum_tests[] = {
+	{ "1234", 1234, 0 },
 	{ "1Ki", 1024, 0},
 	{ "34Gi", 36507222016, 0 },
-	{ "1234", 0, -EINVAL },
 	{ "34.9Ki", 0, -EINVAL},
 	{ "32Gii", 0, -EINVAL },
 };

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -293,7 +293,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 				goto out;
 			}
 		} else if (s->config_type == CFG_LONG_SUFFIX) {
-			if (suffix_binary_parse(optarg, &endptr, (uint64_t*)&value_addr)) {
+			if (suffix_binary_parse(optarg, &endptr, (uint64_t*)value_addr)) {
 				fprintf(stderr,
 					"Expected long suffixed integer argument for '%s' but got '%s'!\n",
 					long_opts[option_index].name, optarg);

--- a/util/suffix.c
+++ b/util/suffix.c
@@ -217,6 +217,12 @@ int suffix_binary_parse(const char *str, char **endptr, uint64_t *val)
 		return 0;
 	}
 
+	/* simple number, no decimal point, no suffix */
+	if ((*endptr)[0] == '\0') {
+		*val = ret;
+		return 0;
+	}
+
 	for (i = 0; i < ARRAY_SIZE(binary_suffixes); i++) {
 		struct binary_suffix *s = &binary_suffixes[i];
 


### PR DESCRIPTION
suffix_binary_parse() is used to parse most of the numeric command lines. As it turns out the main use case to provide just numbers without any suffix. Fix the regression recently introduced when we made the parser also to check two characters suffixes.

Fixes: 1e5abd545622 ("util: Update suffix_binary_parse API")
Reported-by: Steven Seungcheol Lee <sc108.lee@samsung.com>
Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1801