### PR TITLE
docs: Fixed typos and add missing option

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -18,8 +18,9 @@ SYNOPSIS
 		[--hostnqn=<hostnqn>      | -q <hostnqn>]
 		[--hostid=<hostid>        | -I <hostid>]
 		[--raw=<filename>         | -r <filename>]
+		[--device=<device>        | -d <device>]
 		[--cfg-file=<cfg>         | -C <cfg>]
-		[--keep-alive-tmo=<#>     | -k <#>]
+		[--keep-alive-tmo=<sec>   | -k <sec>]
 		[--reconnect-delay=<#>    | -c <#>]
 		[--ctrl-loss-tmo=<#>	  | -l <#>]
 		[--hdr-digest             | -g]
@@ -113,6 +114,13 @@ OPTIONS
 	This field will take the output of the 'nvme connect-all' command
 	and dump it to a raw binary file. By default 'nvme connect-all' will
 	dump the output to stdout.
+
+-d <device>::
+--device=<device>::
+	This field takes a device as input. It must be a persistent device
+	associated with a Discovery Controller previously created by the
+	command "connect-all" or "discover". <device> follows the format
+	nvme*, eg. nvme0, nvme1.
 
 -C <cfg>::
 --config-file=<cfg>::

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -23,8 +23,8 @@ SYNOPSIS
 		[--keep-alive-tmo=<sec>   | -k <sec>]
 		[--reconnect-delay=<#>	  | -c <#>]
 		[--ctrl-loss-tmo=<#>	  | -l <#>]
-		[--hdr_digest             | -g]
-		[--data_digest            | -G]
+		[--hdr-digest             | -g]
+		[--data-digest            | -G]
 		[--nr-io-queues=<#>       | -i <#>]
 		[--nr-write-queues=<#>    | -W <#>]
 		[--nr-poll-queues=<#>     | -P <#>]
@@ -97,7 +97,7 @@ OPTIONS
 --traddr=<traddr>::
 	This field specifies the network address of the Discovery Controller.
 	For transports using IP addressing (e.g. rdma) this should be an
-	IP-based (ex. IPv4) address.
+	IP-based address (ex. IPv4).
 
 -s <trsvcid>::
 --trsvcid=<trsvcid>::
@@ -137,8 +137,10 @@ OPTIONS
 
 -d <device>::
 --device=<device>::
-	This field takes a device as input. Device is in the format of nvme*,
-	eg. nvme0, nvme1
+	This field takes a device as input. It must be a persistent device
+	associated with a Discovery Controller previously created by the
+	command "connect-all" or "discover". <device> follows the format
+	nvme*, eg. nvme0, nvme1.
 
 -C <cfg>::
 --config-file=<cfg>::
@@ -150,8 +152,8 @@ OPTIONS
 
 -k <#>::
 --keep-alive-tmo=<#>::
-	Overrides the default timeout (in seconds) for keep alive.
-	This option will be ignored for the discovery, and it is only
+	Overrides the default keep alive timeout (in seconds). This
+	option will be ignored for discovery, and it is only
 	implemented for completeness.
 
 -c <#>::
@@ -164,11 +166,11 @@ OPTIONS
 	Overrides the default controller loss timeout period (in seconds).
 
 -g::
---hdr_digest::
+--hdr-digest::
 	Generates/verifies header digest (TCP).
 
 -G::
---data_digest::
+--data-digest::
 	Generates/verifies data digest (TCP).
 
 -i <#>::
@@ -194,7 +196,8 @@ OPTIONS
 
 -p::
 --persistent::
-	Persistent discovery connection.
+	Don't remove the discovery controller after retrieving the discovery
+	log page.
 
 -S::
 --quiet::


### PR DESCRIPTION
For `nvme-discover` the options `--hdr-digest` and `--data-digest` were documented with an underscore instead of a hyphen (i.e. `--hdr_digest` and `--data_digest`).

For `nvme-connect-all` the option `--device` was missing.

I also made a few other changes for consistency between `nvme-discover` and `nvme-connect-all`.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>