### PR TITLE
build: Update library paths for AppImage

### DIFF
--- a/.github/AppImageBuilder.yml
+++ b/.github/AppImageBuilder.yml
@@ -28,17 +28,15 @@ AppDir:
     include:
       - libjson-c5
       - libhugetlbfs0
+      - libssl3
   files:
     include:
-    - /lib64/libcrypto.so.3
-    - /lib64/libdbus-1.so.3
-    - /lib64/libjson-c.so.5
+      - libcrypt.so.3
+      - libdbus-1.so.3
+      - libjson-c.so.5
     exclude:
-    - usr/share/man
-    - usr/share/doc/*/README.*
-    - usr/share/doc/*/changelog.*
-    - usr/share/doc/*/NEWS.*
-    - usr/share/doc/*/TODO.*
+      - usr/share/man
+      - usr/share/doc
   test:
     fedora-30:
       image: appimagecrafters/tests-env:fedora-30

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: install dependencies
-        run: sudo apt-get install libjson-c-dev libdbus-1-dev libhugetlbfs-dev
+        run: sudo apt-get install libjson-c-dev libssl-dev libdbus-1-dev libhugetlbfs-dev
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
Ubuntu uses a multilib setup hence the libraries are not found in /lib64.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1804