### PR TITLE
doc: --storage-tag-check doesn't take any arguments

### DIFF
--- a/Documentation/nvme-compare.txt
+++ b/Documentation/nvme-compare.txt
@@ -27,7 +27,7 @@ SYNOPSIS
 			[--dry-run | -w]
 			[--latency | -t]
 			[--storage-tag<storage-tag> | -g <storage-tag>]
-			[--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+			[--storage-tag-check | -C]
 			[--force]
 
 DESCRIPTION
@@ -141,13 +141,13 @@ metadata is passes.
 --latency::
 	Print out the latency the IOCTL took (in us).
 
---storage-tag=<storage-tag>::
 -g <storage-tag>::
+--storage-tag=<storage-tag>::
 	Variable Sized Expected Logical Block Storage Tag(ELBST).
 
---storage-tag-check=<storage-tag-check>::
--C <storage-tag-check>::
-	This bit specifies the Storage Tag field shall be checked as part of end-to-end
+-C::
+--storage-tag-check::
+	This flag enables Storage Tag field checking as part of end-to-end
 	data protection processing.
 
 --force::

--- a/Documentation/nvme-read.txt
+++ b/Documentation/nvme-read.txt
@@ -27,7 +27,7 @@ SYNOPSIS
 			[--dry-run | -w]
 			[--latency | -t]
 			[--storage-tag<storage-tag> | -g <storage-tag>]
-			[--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+			[--storage-tag-check | -C ]
 			[--force]
 
 DESCRIPTION
@@ -131,18 +131,18 @@ metadata is passes.
 --latency::
 	Print out the latency the IOCTL took (in us).
 
---storage-tag=<storage-tag>::
 -g <storage-tag>::
+--storage-tag=<storage-tag>::
 	Variable Sized Expected Logical Block Storage Tag(ELBST).
 
---storage-tag-check=<storage-tag-check>::
--C <storage-tag-check>::
-	This bit specifies the Storage Tag field shall be checked as part of end-to-end
+-C::
+--storage-tag-check::
+	This flag enables Storage Tag field checking as part of end-to-end
 	data protection processing.
 
 --force::
-    Ignore namespace is currently busy and performed the operation
-    even though.
+	Ignore namespace is currently busy and performed the operation
+	even though.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-verify.txt
+++ b/Documentation/nvme-verify.txt
@@ -18,7 +18,7 @@ SYNOPSIS
             [--app-tag-mask=<appmask> | -m <appmask>]
             [--app-tag=<apptag> | -a <apptag>]
             [--storage-tag<storage-tag> | -S <storage-tag>]
-            [--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+            [--storage-tag-check | -C]
 
 DESCRIPTION
 -----------
@@ -75,13 +75,13 @@ metadata is passes.
 -a <apptag>::
 	Optional application tag when used with protection information.
 
---storage-tag=<storage-tag>::
 -S <storage-tag>::
+--storage-tag=<storage-tag>::
 	Variable Sized Expected Logical Block Storage Tag(ELBST).
 
---storage-tag-check=<storage-tag-check>::
--C <storage-tag-check>::
-	This bit specifies the Storage Tag field shall be checked as part of Verify operation.
+-C::
+--storage-tag-check::
+	This flag enables Storage Tag field checking as part of Verify operation.
 
 EXAMPLES
 --------

--- a/Documentation/nvme-write.txt
+++ b/Documentation/nvme-write.txt
@@ -27,7 +27,7 @@ SYNOPSIS
 			[--dry-run | -w]
 			[--latency | -t]
 			[--storage-tag<storage-tag> | -g <storage-tag>]
-			[--storage-tag-check<storage-tag-check> | -C <storage-tag-check>]
+			[--storage-tag-check | -C]
 			[--force]
 
 DESCRIPTION
@@ -139,13 +139,13 @@ metadata is passes.
 --latency::
 	Print out the latency the IOCTL took (in us).
 
---storage-tag=<storage-tag>::
 -g <storage-tag>::
+--storage-tag=<storage-tag>::
 	Variable Sized Expected Logical Block Storage Tag(ELBST).
 
---storage-tag-check=<storage-tag-check>::
--C <storage-tag-check>::
-	This bit specifies the Storage Tag field shall be checked as part of end-to-end
+-C::
+--storage-tag-check::
+	This flag enables Storage Tag field checking as part of end-to-end
 	data protection processing.
 
 --force::


### PR DESCRIPTION
Update the documentation on --storage-tag-check. This command line option is a boolean flag and doesn't take any arguments.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1807