### PR TITLE
fabrics: Ensure host-traddr/iface consistency for "connect-all"

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -908,6 +908,20 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 				 * on exit.
 				 */
 				persistent = true;
+				/*
+				 * When --host-traddr/--host-iface are not specified on the
+				 * command line, use the discovery controller's (c) host-
+				 * traddr/host-iface for the connections to controllers
+				 * returned in the Discovery Log Pages. This is essential
+				 * when invoking "connect-all" with --device to reuse an
+				 * existing persistent discovery controller (as is done
+				 * for the udev rules). This ensures that host-traddr/
+				 * host-iface are consistent with the discovery controller (c).
+				 */
+				if (!cfg.host_traddr)
+					cfg.host_traddr = (char *)nvme_ctrl_get_host_traddr(c);
+				if (!cfg.host_iface)
+					cfg.host_iface = (char *)nvme_ctrl_get_host_iface(c);
 			}
 		} else {
 			/*


### PR DESCRIPTION
Fix for: https://github.com/linux-nvme/nvme-cli/issues/1806

When using `nvme connect-all --device` without specifying the options `--host-traddr` and `--host-iface`, the children connections may not have the same `host-traddr` / `host-iface` as the connection to the discovery controller (DC).

This is specific to the `--device` option where one reuses a persistent connection to a discovery controller to update the discovery log pages (DLP) and connect to new controllers listed in the new DLP. If `--device` is used w/o also specifying `--host-traddr` and `--host-iface`, then the new connections may not use the same attributes that were used for the DC connection.

This patch checks if `--host-traddr` and `--host-iface` have been provided, and if not, it will use the DC's `--host-traddr` and `--host-iface` for the new connections made as a result of changes to the DLP.

Signed-off-by: Martin Belanger <martin.belanger@dell.com>