### PR TITLE
nvme-print-json: Add Generic device name to list ouptut

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2507,6 +2507,7 @@ static void json_detail_list(nvme_root_t r)
 					uint64_t nuse = nvme_ns_get_lba_util(n) * lba;
 
 					json_object_add_value_string(jns, "NameSpace", nvme_ns_get_name(n));
+					json_object_add_value_string(jns, "Generic", nvme_ns_get_generic_name(n));
 					json_object_add_value_int(jns, "NSID", nvme_ns_get_nsid(n));
 					json_object_add_value_uint64(jns, "UsedBytes", nuse);
 					json_object_add_value_uint64(jns, "MaximumLBA", nvme_ns_get_lba_count(n));
@@ -2539,6 +2540,7 @@ static void json_detail_list(nvme_root_t r)
 				uint64_t nuse = nvme_ns_get_lba_util(n) * lba;
 
 				json_object_add_value_string(jns, "NameSpace", nvme_ns_get_name(n));
+				json_object_add_value_string(jns, "Generic", nvme_ns_get_generic_name(n));
 				json_object_add_value_int(jns, "NSID", nvme_ns_get_nsid(n));
 				json_object_add_value_uint64(jns, "UsedBytes", nuse);
 				json_object_add_value_uint64(jns, "MaximumLBA", nvme_ns_get_lba_count(n));
@@ -2565,15 +2567,18 @@ static struct json_object *json_list_item(nvme_ns_t n)
 {
 	struct json_object *jdevice = json_create_object();
 	char devname[128] = { 0 };
+	char genname[128] = { 0 };
 
 	int lba = nvme_ns_get_lba_size(n);
 	uint64_t nsze = nvme_ns_get_lba_count(n) * lba;
 	uint64_t nuse = nvme_ns_get_lba_util(n) * lba;
 
 	nvme_dev_full_path(n, devname, sizeof(devname));
+	nvme_generic_full_path(n, genname, sizeof(genname));
 
 	json_object_add_value_int(jdevice, "NameSpace", nvme_ns_get_nsid(n));
 	json_object_add_value_string(jdevice, "DevicePath", devname);
+	json_object_add_value_string(jdevice, "Generic", genname);
 	json_object_add_value_string(jdevice, "Firmware", nvme_ns_get_firmware(n));
 	json_object_add_value_string(jdevice, "ModelNumber", nvme_ns_get_model(n));
 	json_object_add_value_string(jdevice, "SerialNumber", nvme_ns_get_serial(n));

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5108,7 +5108,7 @@ void nvme_dev_full_path(nvme_ns_t n, char *path, size_t len)
 	snprintf(path, len, "%s", nvme_ns_get_name(n));
 }
 
-static void nvme_generic_full_path(nvme_ns_t n, char *path, size_t len)
+void nvme_generic_full_path(nvme_ns_t n, char *path, size_t len)
 {
 	int head_instance;
 	int instance;

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -149,6 +149,7 @@ const char *nvme_feature_to_string(enum nvme_features_id feature);
 const char *nvme_register_to_string(int reg);
 
 void nvme_dev_full_path(nvme_ns_t n, char *path, size_t len);
+void nvme_generic_full_path(nvme_ns_t n, char *path, size_t len);
 char *zone_type_to_string(__u8 cond);
 char *zone_state_to_string(__u8 state);
 const char *nvme_pel_event_to_string(int type);


### PR DESCRIPTION
The Generic device name is missing in the 'list' output.

see https://lore.kernel.org/linux-nvme/7f958c6d-d6e6-2346-a680-875c7fafe7e5@grimberg.me/