### PR TITLE
get-log: use chunked read

### DIFF
--- a/Documentation/nvme-get-log.txt
+++ b/Documentation/nvme-get-log.txt
@@ -19,6 +19,7 @@ SYNOPSIS
 	      [--rae | -r]
 	      [--csi=<command_set_identifier> | -y <command_set_identifier>]
 	      [--ot=<offset_type> | -O <offset_type>]
+		    [--xfer-len=<length> | -x <length>]
 
 DESCRIPTION
 -----------
@@ -94,6 +95,11 @@ OPTIONS
 	data structures in the log page to be returned.
 	The default is byte offset. If the option is specified
 	the index mode is used.
+
+-x <length>::
+--xfer-len <length>:
+	Specify the read chunk size. The length argument is expected to be
+	a multiple of 4096. The default size is 4096.
 
 EXAMPLES
 --------

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -158,6 +158,12 @@ int nvme_cli_get_log(struct nvme_dev *dev, struct nvme_get_log_args *args)
 	return do_admin_args_op(get_log, dev, args);
 }
 
+int nvme_cli_get_log_page(struct nvme_dev *dev, __u32 xfer_len,
+			  struct nvme_get_log_args *args)
+{
+	return do_admin_op(get_log_page, dev, xfer_len, args);
+}
+
 int nvme_cli_get_nsid_log(struct nvme_dev *dev, bool rae,
 			  enum nvme_cmd_get_log_lid lid,
 			  __u32 nsid, __u32 len, void *log)

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -51,6 +51,9 @@ int nvme_cli_get_features(struct nvme_dev *dev,
 
 
 int nvme_cli_get_log(struct nvme_dev *dev, struct nvme_get_log_args *args);
+int nvme_cli_get_log_page(struct nvme_dev *dev,
+                          __u32 xfer_len,
+                          struct nvme_get_log_args *args);
 
 int nvme_cli_get_nsid_log(struct nvme_dev *dev, bool rae,
 			  enum nvme_cmd_get_log_lid lid,

--- a/nvme.c
+++ b/nvme.c
@@ -2179,19 +2179,19 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	}
 
 	if (!cfg.log_len) {
-		perror("non-zero log-len is required param\n");
+		fprintf(stderr, "non-zero log-len is required param\n");
 		err = -EINVAL;
 		goto close_dev;
 	}
 
 	if (cfg.lsp > 128) {
-		perror("invalid lsp param\n");
+		fprintf(stderr, "invalid lsp param\n");
 		err = -EINVAL;
 		goto close_dev;
 	}
 
 	if (cfg.uuid_index > 128) {
-		perror("invalid uuid index param\n");
+		fprintf(stderr, "invalid uuid index param\n");
 		err = -EINVAL;
 		goto close_dev;
 	}

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 94dd6d027e482749d8a915aae5fd52ef7323c054
+revision = 7ea5ab7fb502c7e8ac68ce595bcb14f99d2187d5
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
nvme: Use chunked read in get_log()

Large transfer might not work because we exhaust resource limits, so
chunk the read into 4k (default).

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: #1818 
Depends: #https://github.com/linux-nvme/libnvme/pull/579