### PR TITLE
nvme: fix /dev/spkd/ typo

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5120,7 +5120,7 @@ void nvme_generic_full_path(nvme_ns_t n, char *path, size_t len)
 	if (stat(path, &st) == 0)
 		return;
 
-	snprintf(path, len, "/dev/spkd/ng%dn%d", instance, head_instance);
+	snprintf(path, len, "/dev/spdk/ng%dn%d", instance, head_instance);
 	if (stat(path, &st) == 0)
 		return;
 	/*


### PR DESCRIPTION
SPDK NVMe character devices are located at /dev/spdk/ according to the documentation (https://spdk.io/doc/nvme.html#nvme_cuse). Fix the typo.

Fixes: 6c9f792f99aa8782b32635c44e3a573bbb36c830 ("nvme: Print full device path")
Cc: Daniel Wagner <dwagner@suse.de>