### PR TITLE
log: high latency timestamp issue

### DIFF
--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -707,7 +707,7 @@ static int glp_high_latency(FILE *fdi, char *buf, int buflen, int print)
         }
         else  //  sort
         {
-            timestamp = logEntry->timestampH - 1;
+            timestamp = logEntry->timestampH;
             timestamp = timestamp << 32;
             timestamp += logEntry->timestampL;
             tt = timestamp / 1000;


### PR DESCRIPTION
1. The old nvme-cli set-feature uses 32bit to represent timestamp, but the spec definition is 48bit.
2. memblaze made a slight correction to allow for overflow.
3. Now this correction is no longer needed.