### PR TITLE
Changed 'Kelvin' to 'kelvin', as recommended by the BIPM.

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2087,14 +2087,14 @@ static void nvme_show_id_ctrl_apsta(__u8 apsta)
 
 static void nvme_show_id_ctrl_wctemp(__le16 wctemp)
 {
-	printf(" [15:0] : %ld°C (%u kelvin)\tWarning Composite Temperature Threshold (WCTEMP)\n",
+	printf(" [15:0] : %ld °C (%u K)\tWarning Composite Temperature Threshold (WCTEMP)\n",
 	       kelvin_to_celsius(le16_to_cpu(wctemp)), le16_to_cpu(wctemp));
 	printf("\n");
 }
 
 static void nvme_show_id_ctrl_cctemp(__le16 cctemp)
 {
-	printf(" [15:0] : %ld°C (%u kelvin)\tCritical Composite Temperature Threshold (CCTEMP)\n",
+	printf(" [15:0] : %ld °C (%u K)\tCritical Composite Temperature Threshold (CCTEMP)\n",
 	       kelvin_to_celsius(le16_to_cpu(cctemp)), le16_to_cpu(cctemp));
 	printf("\n");
 }
@@ -2144,14 +2144,14 @@ static void nvme_show_id_ctrl_hctma(__le16 ctrl_hctma)
 
 static void nvme_show_id_ctrl_mntmt(__le16 mntmt)
 {
-	printf(" [15:0] : %ld°C (%u kelvin)\tMinimum Thermal Management Temperature (MNTMT)\n",
+	printf(" [15:0] : %ld °C (%u K)\tMinimum Thermal Management Temperature (MNTMT)\n",
 	       kelvin_to_celsius(le16_to_cpu(mntmt)), le16_to_cpu(mntmt));
 	printf("\n");
 }
 
 static void nvme_show_id_ctrl_mxtmt(__le16 mxtmt)
 {
-	printf(" [15:0] : %ld°C (%u kelvin)\tMaximum Thermal Management Temperature (MXTMT)\n",
+	printf(" [15:0] : %ld °C (%u K)\tMaximum Thermal Management Temperature (MXTMT)\n",
 	       kelvin_to_celsius(le16_to_cpu(mxtmt)), le16_to_cpu(mxtmt));
 	printf("\n");
 }
@@ -4156,7 +4156,7 @@ void nvme_show_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 		printf("      Persistent Mem. RO[5]          : %d\n", (smart->critical_warning & 0x20) >> 5);
 	}
 
-	printf("temperature				: %ld°C (%u kelvin)\n",
+	printf("temperature				: %ld °C (%u K)\n",
 		kelvin_to_celsius(temperature), temperature);
 	printf("available_spare				: %u%%\n",
 		smart->avail_spare);
@@ -4199,7 +4199,7 @@ void nvme_show_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 
 		if (temp == 0)
 			continue;
-		printf("Temperature Sensor %d           : %ld°C (%u kelvin)\n",
+		printf("Temperature Sensor %d           : %ld °C (%u K)\n",
 		       i + 1, kelvin_to_celsius(temp), temp);
 	}
 	printf("Thermal Management T1 Trans Count	: %u\n",
@@ -4899,7 +4899,7 @@ void nvme_feature_show_fields(enum nvme_features_id fid, unsigned int result, un
 		field = (result & 0x000f0000) >> 16;
 		printf("\tThreshold Temperature Select (TMPSEL): %u - %s\n",
 		       field, nvme_feature_temp_sel_to_string(field));
-		printf("\tTemperature Threshold         (TMPTH): %ld°C (%u kelvin)\n",
+		printf("\tTemperature Threshold         (TMPTH): %ld °C (%u K)\n",
 		       kelvin_to_celsius(result & 0x0000ffff), result & 0x0000ffff);
 		break;
 	case NVME_FEAT_FID_ERR_RECOVERY:
@@ -4965,9 +4965,9 @@ void nvme_feature_show_fields(enum nvme_features_id fid, unsigned int result, un
 		printf("\tKeep Alive Timeout (KATO) in milliseconds: %u\n", result);
 		break;
 	case NVME_FEAT_FID_HCTM:
-		printf("\tThermal Management Temperature 1 (TMT1) : %u kelvin (%ld°C)\n",
+		printf("\tThermal Management Temperature 1 (TMT1) : %u K (%ld °C)\n",
 		       result >> 16, kelvin_to_celsius(result >> 16));
-		printf("\tThermal Management Temperature 2 (TMT2) : %u kelvin (%ld°C)\n",
+		printf("\tThermal Management Temperature 2 (TMT2) : %u K (%ld °C)\n",
 		       result & 0x0000ffff, kelvin_to_celsius(result & 0x0000ffff));
 		break;
 	case NVME_FEAT_FID_NOPSC:

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -2087,14 +2087,14 @@ static void nvme_show_id_ctrl_apsta(__u8 apsta)
 
 static void nvme_show_id_ctrl_wctemp(__le16 wctemp)
 {
-	printf(" [15:0] : %ld°C (%u Kelvin)\tWarning Composite Temperature Threshold (WCTEMP)\n",
+	printf(" [15:0] : %ld°C (%u kelvin)\tWarning Composite Temperature Threshold (WCTEMP)\n",
 	       kelvin_to_celsius(le16_to_cpu(wctemp)), le16_to_cpu(wctemp));
 	printf("\n");
 }
 
 static void nvme_show_id_ctrl_cctemp(__le16 cctemp)
 {
-	printf(" [15:0] : %ld°C (%u Kelvin)\tCritical Composite Temperature Threshold (CCTEMP)\n",
+	printf(" [15:0] : %ld°C (%u kelvin)\tCritical Composite Temperature Threshold (CCTEMP)\n",
 	       kelvin_to_celsius(le16_to_cpu(cctemp)), le16_to_cpu(cctemp));
 	printf("\n");
 }
@@ -2144,14 +2144,14 @@ static void nvme_show_id_ctrl_hctma(__le16 ctrl_hctma)
 
 static void nvme_show_id_ctrl_mntmt(__le16 mntmt)
 {
-	printf(" [15:0] : %ld°C (%u Kelvin)\tMinimum Thermal Management Temperature (MNTMT)\n",
+	printf(" [15:0] : %ld°C (%u kelvin)\tMinimum Thermal Management Temperature (MNTMT)\n",
 	       kelvin_to_celsius(le16_to_cpu(mntmt)), le16_to_cpu(mntmt));
 	printf("\n");
 }
 
 static void nvme_show_id_ctrl_mxtmt(__le16 mxtmt)
 {
-	printf(" [15:0] : %ld°C (%u Kelvin)\tMaximum Thermal Management Temperature (MXTMT)\n",
+	printf(" [15:0] : %ld°C (%u kelvin)\tMaximum Thermal Management Temperature (MXTMT)\n",
 	       kelvin_to_celsius(le16_to_cpu(mxtmt)), le16_to_cpu(mxtmt));
 	printf("\n");
 }
@@ -4156,7 +4156,7 @@ void nvme_show_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 		printf("      Persistent Mem. RO[5]          : %d\n", (smart->critical_warning & 0x20) >> 5);
 	}
 
-	printf("temperature				: %ld°C (%u Kelvin)\n",
+	printf("temperature				: %ld°C (%u kelvin)\n",
 		kelvin_to_celsius(temperature), temperature);
 	printf("available_spare				: %u%%\n",
 		smart->avail_spare);
@@ -4199,7 +4199,7 @@ void nvme_show_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 
 		if (temp == 0)
 			continue;
-		printf("Temperature Sensor %d           : %ld°C (%u Kelvin)\n",
+		printf("Temperature Sensor %d           : %ld°C (%u kelvin)\n",
 		       i + 1, kelvin_to_celsius(temp), temp);
 	}
 	printf("Thermal Management T1 Trans Count	: %u\n",
@@ -4899,7 +4899,7 @@ void nvme_feature_show_fields(enum nvme_features_id fid, unsigned int result, un
 		field = (result & 0x000f0000) >> 16;
 		printf("\tThreshold Temperature Select (TMPSEL): %u - %s\n",
 		       field, nvme_feature_temp_sel_to_string(field));
-		printf("\tTemperature Threshold         (TMPTH): %ld°C (%u Kelvin)\n",
+		printf("\tTemperature Threshold         (TMPTH): %ld°C (%u kelvin)\n",
 		       kelvin_to_celsius(result & 0x0000ffff), result & 0x0000ffff);
 		break;
 	case NVME_FEAT_FID_ERR_RECOVERY:
@@ -4965,9 +4965,9 @@ void nvme_feature_show_fields(enum nvme_features_id fid, unsigned int result, un
 		printf("\tKeep Alive Timeout (KATO) in milliseconds: %u\n", result);
 		break;
 	case NVME_FEAT_FID_HCTM:
-		printf("\tThermal Management Temperature 1 (TMT1) : %u Kelvin (%ld°C)\n",
+		printf("\tThermal Management Temperature 1 (TMT1) : %u kelvin (%ld°C)\n",
 		       result >> 16, kelvin_to_celsius(result >> 16));
-		printf("\tThermal Management Temperature 2 (TMT2) : %u Kelvin (%ld°C)\n",
+		printf("\tThermal Management Temperature 2 (TMT2) : %u kelvin (%ld°C)\n",
 		       result & 0x0000ffff, kelvin_to_celsius(result & 0x0000ffff));
 		break;
 	case NVME_FEAT_FID_NOPSC:

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -226,17 +226,17 @@ static void show_memblaze_smart_log_old(struct nvme_memblaze_smart_log *smart,
     printf("Total thermal throttling minutes since power on			: %u\n",
         smart->items[THERMAL_THROTTLE].thermal_throttle.count);
 
-    printf("Maximum temperature in kelvin since last factory reset		: %u\n",
+    printf("Maximum temperature in kelvins since last factory reset		: %u\n",
         le16_to_cpu(smart->items[TEMPT_SINCE_RESET].temperature.max));
-    printf("Minimum temperature in kelvin since last factory reset		: %u\n",
+    printf("Minimum temperature in kelvins since last factory reset		: %u\n",
         le16_to_cpu(smart->items[TEMPT_SINCE_RESET].temperature.min));
     if (compare_fw_version(fw_ver, "0.09.0300") != 0) {
-        printf("Maximum temperature in kelvin since power on			: %u\n",
+        printf("Maximum temperature in kelvins since power on			: %u\n",
             le16_to_cpu(smart->items[TEMPT_SINCE_BOOTUP].temperature_p.max));
-        printf("Minimum temperature in kelvin since power on			: %u\n",
+        printf("Minimum temperature in kelvins since power on			: %u\n",
             le16_to_cpu(smart->items[TEMPT_SINCE_BOOTUP].temperature_p.min));
     }
-    printf("Current temperature in kelvin					: %u\n",
+    printf("Current temperature in kelvins					: %u\n",
         le16_to_cpu(smart->items[TEMPT_SINCE_RESET].temperature.curr));
 
     printf("Maximum power in watt since power on				: %u\n",

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -226,17 +226,17 @@ static void show_memblaze_smart_log_old(struct nvme_memblaze_smart_log *smart,
     printf("Total thermal throttling minutes since power on			: %u\n",
         smart->items[THERMAL_THROTTLE].thermal_throttle.count);
 
-    printf("Maximum temperature in Kelvin since last factory reset		: %u\n",
+    printf("Maximum temperature in kelvin since last factory reset		: %u\n",
         le16_to_cpu(smart->items[TEMPT_SINCE_RESET].temperature.max));
-    printf("Minimum temperature in Kelvin since last factory reset		: %u\n",
+    printf("Minimum temperature in kelvin since last factory reset		: %u\n",
         le16_to_cpu(smart->items[TEMPT_SINCE_RESET].temperature.min));
     if (compare_fw_version(fw_ver, "0.09.0300") != 0) {
-        printf("Maximum temperature in Kelvin since power on			: %u\n",
+        printf("Maximum temperature in kelvin since power on			: %u\n",
             le16_to_cpu(smart->items[TEMPT_SINCE_BOOTUP].temperature_p.max));
-        printf("Minimum temperature in Kelvin since power on			: %u\n",
+        printf("Minimum temperature in kelvin since power on			: %u\n",
             le16_to_cpu(smart->items[TEMPT_SINCE_BOOTUP].temperature_p.min));
     }
-    printf("Current temperature in Kelvin					: %u\n",
+    printf("Current temperature in kelvin					: %u\n",
         le16_to_cpu(smart->items[TEMPT_SINCE_RESET].temperature.curr));
 
     printf("Maximum power in watt since power on				: %u\n",

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10576,7 +10576,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 	if (ret != 0)
 		goto out;
 
-   	/* convert from kelvin to degrees Celsius */
+	/* convert from kelvins to degrees Celsius */
 	temperature = ((smart_log.temperature[1] << 8) | smart_log.temperature[0]) - 273;
 
 	/* retrieve HCTM Thermal Management Temperatures */

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10576,7 +10576,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 	if (ret != 0)
 		goto out;
 
-   	/* convert from Kelvin to degrees Celsius */
+   	/* convert from kelvin to degrees Celsius */
 	temperature = ((smart_log.temperature[1] << 8) | smart_log.temperature[0]) - 273;
 
 	/* retrieve HCTM Thermal Management Temperatures */


### PR DESCRIPTION
The BIPM recommends that SI units (even those named after scientists) start with a lowercase letter when spelled out.

**References**
* https://www.bipm.org/en/si-base-units/kelvin
* https://www.nist.gov/pml/owm/writing-si-metric-system-units
* https://english.stackexchange.com/questions/173906