### PR TITLE
nvme: Change feature default NSID to 0 from all namespaces ID FFFFFFFFh

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -408,7 +408,7 @@ static int get_dev(struct nvme_dev **dev, int argc, char **argv, int flags)
 
 int parse_and_open(struct nvme_dev **dev, int argc, char **argv,
 		   const char *desc,
-		   const struct argconfig_commandline_options *opts)
+		   struct argconfig_commandline_options *opts)
 {
 	int ret;
 
@@ -4700,7 +4700,7 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 	if (err)
 		goto ret;
 
-	if (!cfg.namespace_id) {
+	if (!opts[1].seen) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
 		if (err < 0) {
 			if (errno != ENOTTY) {
@@ -5866,14 +5866,13 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	if (err)
 		goto ret;
 
-	if (!cfg.namespace_id) {
+	if (!opts[0].seen) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
 		if (err < 0) {
 			if (errno != ENOTTY) {
 				fprintf(stderr, "get-namespace-id: %s\n", nvme_strerror(errno));
 				goto close_dev;
 			}
-
 			cfg.namespace_id = NVME_NSID_ALL;
 		}
 	}

--- a/nvme.h
+++ b/nvme.h
@@ -96,7 +96,7 @@ void register_extension(struct plugin *plugin);
  * parse_and_open - parses arguments and opens the NVMe device, populating @dev
  */
 int parse_and_open(struct nvme_dev **dev, int argc, char **argv, const char *desc,
-	const struct argconfig_commandline_options *clo);
+	struct argconfig_commandline_options *clo);
 
 void dev_close(struct nvme_dev *dev);
 

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1558,7 +1558,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 		.disable = false,
 	};
 
-	const struct argconfig_commandline_options command_line_options[] = {
+	struct argconfig_commandline_options command_line_options[] = {
 		{"enable", 'e', "", CFG_FLAG, &cfg.enable, no_argument, enable_desc},
 		{"disable", 'd', "", CFG_FLAG, &cfg.disable, no_argument, disable_desc},
 		{NULL}

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -1140,7 +1140,7 @@ static int mb_set_lat_stats(int argc, char **argv,
 		.disable = false,
 	};
 
-	const struct argconfig_commandline_options command_line_options[] = {
+	struct argconfig_commandline_options command_line_options[] = {
 		{"enable", 'e', "", CFG_FLAG, &cfg.enable, no_argument, enable_desc},
 		{"disable", 'd', "", CFG_FLAG, &cfg.disable, no_argument, disable_desc},
 		{NULL}

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -455,7 +455,7 @@ exit_status:
  */
 static int micron_parse_options(struct nvme_dev **dev, int argc, char **argv,
 				const char *desc,
-				const struct argconfig_commandline_options *opts,
+				struct argconfig_commandline_options *opts,
 				eDriveModel *modelp)
 {
     int idx = 0;

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -158,12 +158,12 @@ int argconfig_parse_byte(const char *opt, const char *str, unsigned char *val)
 }
 
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
-		    const struct argconfig_commandline_options *options)
+		    struct argconfig_commandline_options *options)
 {
 	char *short_opts;
 	char *endptr;
 	struct option *long_opts;
-	const struct argconfig_commandline_options *s;
+	struct argconfig_commandline_options *s;
 	int c, option_index = 0, short_index = 0, options_count = 0;
 	void *value_addr;
 	int ret = -EINVAL;
@@ -198,6 +198,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 			long_opts[option_index].flag = NULL;
 			long_opts[option_index].val = 0;
 		}
+		s->seen = false;
 		option_index++;
 	}
 
@@ -232,6 +233,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		}
 
 		s = &options[option_index];
+		s->seen = true;
 		value_addr = (void *)(char *)s->default_value;
 		if (s->config_type == CFG_STRING) {
 			*((char **)value_addr) = optarg;

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -38,6 +38,7 @@
 #include <getopt.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 enum argconfig_types {
 	CFG_FLAG,
@@ -62,7 +63,7 @@ enum argconfig_types {
 };
 
 #define OPT_ARGS(n) \
-	const struct argconfig_commandline_options n[]
+	struct argconfig_commandline_options n[]
 
 #define OPT_END() { NULL }
 
@@ -109,6 +110,7 @@ struct argconfig_commandline_options {
 	void *default_value;
 	int argument_type;
 	const char *help;
+	bool seen;
 };
 
 #define CFG_MAX_SUBOPTS 500
@@ -119,7 +121,7 @@ void argconfig_append_usage(const char *str);
 void argconfig_print_help(const char *program_desc,
 			  const struct argconfig_commandline_options *options);
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
-		    const struct argconfig_commandline_options *options);
+		    struct argconfig_commandline_options *options);
 int argconfig_parse_subopt_string(char *string, char **options,
 				  size_t max_options);
 int argconfig_parse_comma_sep_array(char *string, int *ret,


### PR DESCRIPTION
Since some features requires the NSID as 0 but not able set previously.