### PR TITLE
plugins/ocp: OCP 2.0 field updates for SMART cloud log

### DIFF
--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -91,7 +91,8 @@ typedef enum {
 	SCAO_NUSE	= 152,	/* NUSE - Namespace utilization */
 	SCAO_PSC	= 160,	/* PLP start count */
 	SCAO_EEST	= 176,	/* Endurance estimate */
-	SCAO_PLRC	= 192,  /* PCIe Link Retraining Count */
+	SCAO_PLRC	= 192,	/* PCIe Link Retraining Count */
+	SCAO_PSCC	= 200,	/* Power State Change Count */
 	SCAO_LPV	= 494,	/* Log page version */
 	SCAO_LPG	= 496,	/* Log page GUID */
 } SMART_CLOUD_ATTRIBUTE_OFFSETS;
@@ -220,15 +221,17 @@ static void ocp_print_C0_log_normal(void *data)
 		printf("  Errata Version Field                          %d\n",
 		       (__u8)log_data[SCAO_EVF]);
 		printf("  Point Version Field                           %"PRIu16"\n",
-		       (uint16_t)log_data[SCAO_PVF]);
+		       le16_to_cpu(*(uint16_t *)&log_data[SCAO_PVF]));
 		printf("  Minor Version Field                           %"PRIu16"\n",
-		       (uint16_t)log_data[SCAO_MIVF]);
+		       le16_to_cpu(*(uint16_t *)&log_data[SCAO_MIVF]));
 		printf("  Major Version Field                           %d\n",
 		       (__u8)log_data[SCAO_MAVF]);
 		printf("  NVMe Errata Version				%d\n",
 		       (__u8)log_data[SCAO_NEV]);
 		printf("  PCIe Link Retraining Count			%"PRIu64"\n",
 		       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PLRC]));
+		printf("  Power State Change Count			%"PRIu64"\n",
+		       le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
 	}
 	printf("\n");
 }
@@ -317,15 +320,17 @@ static void ocp_print_C0_log_json(void *data)
 		json_object_add_value_uint(root, "Errata Version Field",
 					   (__u8)log_data[SCAO_EVF]);
 		json_object_add_value_uint(root, "Point Version Field",
-					   (uint16_t)log_data[SCAO_PVF]);
+					   le16_to_cpu(*(uint16_t *)&log_data[SCAO_PVF]));
 		json_object_add_value_uint(root, "Minor Version Field",
-					   (uint16_t)log_data[SCAO_MIVF]);
+					   le16_to_cpu(*(uint16_t *)&log_data[SCAO_MIVF]));
 		json_object_add_value_uint(root, "Major Version Field",
 					   (__u8)log_data[SCAO_MAVF]);
 		json_object_add_value_uint(root, "NVMe Errata Version",
 					   (__u8)log_data[SCAO_NEV]);
 		json_object_add_value_uint(root, "PCIe Link Retraining Count",
 					   (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PLRC]));
+		json_object_add_value_uint(root, "Power State Change Count",
+					   le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
 	}
 	json_print_object(root, NULL);
 	printf("\n");


### PR DESCRIPTION
- Add power state change field. This is an OCP 2.0 field.
- Parse full two bytes for point version and minor version fields. Although this should have no functional effect (since versions fields should be zero for 2.0) this should be correct (and if version ever increments past 255 we won't have a bug!)

Screenshots from OCP 2.0:
https://www.opencompute.org/documents/datacenter-nvme-ssd-specification-v2-0r21-pdf

![image](https://user-images.githubusercontent.com/110949503/222297029-807c0969-bd5b-4591-8a29-85efb7a604f7.png)

![image](https://user-images.githubusercontent.com/110949503/222297135-6bff267d-902a-462a-92ad-86d55907d560.png)
