### PR TITLE
fabrics: Fix ordering for auto connect services

### DIFF
--- a/nvmf-autoconnect/systemd/nvmefc-boot-connections.service.in
+++ b/nvmf-autoconnect/systemd/nvmefc-boot-connections.service.in
@@ -1,6 +1,9 @@
 [Unit]
 Description=Auto-connect to subsystems on FC-NVME devices found during boot
 ConditionPathExists=/sys/class/fc/fc_udev_device/nvme_discovery
+DefaultDependencies=no
+After=systemd-udevd.service
+Before=local-fs-pre.target
 
 [Service]
 Type=oneshot

--- a/nvmf-autoconnect/systemd/nvmf-connect@.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-connect@.service.in
@@ -4,7 +4,9 @@
 
 [Unit]
 Description=NVMf auto-connect scan upon nvme discovery controller Events
-After=syslog.target
+DefaultDependencies=no
+After=systemd-udevd.service
+Before=local-fs-pre.target
 PartOf=nvmf-connect.target
 Requires=nvmf-connect.target
 


### PR DESCRIPTION
In order to be able to mount file systems via /etc/fstab we have to make sure that the corresponding auto connect services have been executed. Because the mounting of the local filesystem happens very early in the boot we have to carefully sort these service file into the boot process.

First, we have to disable the DefaultDependency as this will automatically add dependency on sysinit.target which is too late (after local mounts). Though without the default dependency we have to provide a Before and After conditions.

The Before is simple as we have a local-fs-pre target. The After is a bit tricky as there are no targets available.

Because the whole autoconnect machinery depends on udev events being delivered we place the service after systemd-udevd has been started.

Link: https://www.freedesktop.org/software/systemd/man/bootup.html
Reported-by: Maurizio Lombardi <mlombard@redhat.com>
Reported-by: Wen Xiong <wenxiong@linux.ibm.com>
Tested-by: Maurizio Lombardi <mlombard@redhat.com>
Tested-by: Wen Xiong <wenxiong@linux.ibm.com>

Fixes: #1394 