### PR TITLE
nvme-print: fix segfault in supported-log-pages json output

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2441,7 +2441,7 @@ void json_support_log(struct nvme_supported_log_pages *support_log)
 	__u32 support;
 
 	root = json_create_object();
-	valid = json_create_object();
+	valid = json_create_array();
 
 	for (lid = 0; lid < 256; lid++) {
 		support = le32_to_cpu(support_log->lid_support[lid]);


### PR DESCRIPTION
nvme supported-log-pages -o json currently segfaults due to the wrong json object type as shown below:

nvme: json_object.c: json_object_array_add: Assertion `json_object_get_type(jso) == json_type_array' failed. Aborted (core dumped)

Fix this by passing the appropriate json type.