### PR TITLE
nvme-print: sanitize supported-log-pages output

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2447,13 +2447,13 @@ void json_support_log(struct nvme_supported_log_pages *support_log)
 		support = le32_to_cpu(support_log->lid_support[lid]);
 		if (support & 0x1) {
 			valid_attrs = json_create_object();
-			sprintf(key, "lid_0x%x ", lid);
-			json_object_add_value_uint(valid_attrs, key, support);
+			sprintf(key, "LID_0x%x", lid);
+			json_object_add_value_string(valid_attrs, key, nvme_log_to_string(lid));
 			json_array_add_value_object(valid, valid_attrs);
 		}
 	}
 
-	json_object_add_value_object(root, "supported_logs", valid);
+	json_object_add_value_object(root, "Supported_Logs", valid);
 	json_print_object(root, NULL);
 	printf("\n");
 	json_free_object(root);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4077,12 +4077,9 @@ void nvme_show_supported_log(struct nvme_supported_log_pages *support_log,
 	for (lid = 0; lid < 256; lid++) {
 		support = le32_to_cpu(support_log->lid_support[lid]);
 		if (support & 0x1) {
-			printf("LID 0x%x (%s), supports 0x%x\n", lid, nvme_log_to_string(lid),
-				support);
+			printf("LID 0x%x - %s\n", lid, nvme_log_to_string(lid));
 			if (human)
 				nvme_show_support_log_human(support, lid);
-			else
-				printf("\n");
 		}
 	}
 }

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -155,5 +155,6 @@ char *zone_state_to_string(__u8 state);
 const char *nvme_pel_event_to_string(int type);
 const char *get_sanitize_log_sstat_status_str(__u16 status);
 const char *nvme_ana_state_to_string(enum nvme_ana_state state);
+const char *nvme_log_to_string(__u8 lid);
 
 #endif


### PR DESCRIPTION
The current nvme supported-log-pages output is a little cryptic as seen below:

Support Log Pages Details for nvme1n1:
LID 0x0 (Supported Log Pages), supports 0x3

LID 0x1 (Error Information), supports 0x3
...

So sanitize this output to make it more meaningful with better formatting. These changes apply to the verbose and json outputs too. With these changes, the sanitized normal output shows up as follows:

Support Log Pages Details for nvme1n1:
LID 0x0 - Supported Log Pages
LID 0x1 - Error Information
...

And the sanitized verbose output would show up as:

Support Log Pages Details for nvme1n1:
LID 0x0 - Supported Log Pages
  LSUPP is supported
  IOS is supported
LID 0x1 - Error Information
  LSUPP is supported
  IOS is supported
...

And finally the sanitized json output would look as:

{
  "Supported_Logs":[
    {
      "LID_0x0":"Supported Log Pages"
    },
    {
      "LID_0x1":"Error Information"
    },
...