### PR TITLE
Fix printing of u32 values

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3031,8 +3031,8 @@ void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, enum nvme_print_flags flags,
 	if (human)
 		nvme_show_id_ctrl_cctemp(ctrl->cctemp);
 	printf("mtfa      : %d\n", le16_to_cpu(ctrl->mtfa));
-	printf("hmpre     : %d\n", le32_to_cpu(ctrl->hmpre));
-	printf("hmmin     : %d\n", le32_to_cpu(ctrl->hmmin));
+	printf("hmpre     : %u\n", le32_to_cpu(ctrl->hmpre));
+	printf("hmmin     : %u\n", le32_to_cpu(ctrl->hmmin));
 	printf("tnvmcap   : %s\n",
 		uint128_t_to_l10n_string(le128_to_cpu(ctrl->tnvmcap)));
 	if (human)
@@ -3081,7 +3081,7 @@ void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, enum nvme_print_flags flags,
 	if (human)
 		nvme_show_id_ctrl_cqes(ctrl->cqes);
 	printf("maxcmd    : %d\n", le16_to_cpu(ctrl->maxcmd));
-	printf("nn        : %d\n", le32_to_cpu(ctrl->nn));
+	printf("nn        : %u\n", le32_to_cpu(ctrl->nn));
 	printf("oncs      : %#x\n", le16_to_cpu(ctrl->oncs));
 	if (human)
 		nvme_show_id_ctrl_oncs(ctrl->oncs);

--- a/util/json.h
+++ b/util/json.h
@@ -13,7 +13,7 @@
 #define json_free_object(o) json_object_put(o)
 #define json_free_array(a) json_object_put(a)
 #define json_object_add_value_uint(o, k, v) \
-	json_object_object_add(o, k, json_object_new_int(v))
+	json_object_object_add(o, k, json_object_new_uint64(v))
 #define json_object_add_value_int(o, k, v) \
 	json_object_object_add(o, k, json_object_new_int(v))
 #ifndef CONFIG_JSONC_14


### PR DESCRIPTION
Fields `HMPRE`, `HMMIN`, and `NN` in the Identify Controller data structure are 32-bit unsigned values but are being printed as signed integers. Print them using `%u` so large values are not displayed as negative ones. Also make JSON `uint` objects use `uint64` instead of `int64` internally so `u32` values are stored accurately.

Before (on a device which reports `NN` = 0xFFFFEFFF):
```
$ ./.build/nvme id-ctrl /dev/nvme0 | grep nn
nn        : -4097
$ ./.build/nvme id-ctrl /dev/nvme0 -o json | grep nn
  "nn":-4097,
```
After:
```
$ ./.build/nvme id-ctrl /dev/nvme0 | grep nn
nn        : 4294963199
$ ./.build/nvme id-ctrl /dev/nvme0 -o json | grep nn
  "nn":4294963199,
```