### PR TITLE
nvme-doc: Rectify man page for supported-log-pages

### DIFF
--- a/Documentation/nvme-supported-log-pages.1
+++ b/Documentation/nvme-supported-log-pages.1
@@ -33,7 +33,7 @@ nvme-supported-log-pages \- Send NVMe Supported Log pages request, returns resul
 .sp
 .nf
 \fInvme supported\-log\-pages\fR <device> [\-\-output\-format=<fmt> | \-o <fmt>]
-                            [\-\-human\-readable | \-H]
+                            [\-\-verbose | \-v]
 .fi
 .SH "DESCRIPTION"
 .sp
@@ -49,9 +49,9 @@ On success, the returned supported log pages log structure will be printed for e
 This option will set the reporting format to normal, json, or binary\&. Only one output format can be used at a time\&.
 .RE
 .PP
-\-H, \-\-human\-readable
+\-v, \-\-verbose
 .RS 4
-This option will parse and format many of the bit fields into a human\-readable format\&.
+Show detailed information including LSUPP and IOP support details\&.
 .RE
 .SH "EXAMPLES"
 .sp

--- a/Documentation/nvme-supported-log-pages.html
+++ b/Documentation/nvme-supported-log-pages.html
@@ -750,7 +750,7 @@ nvme-supported-log-pages(1) Manual Page
 <div class="sectionbody">
 <div class="verseblock">
 <pre class="content"><em>nvme supported-log-pages</em> &lt;device&gt; [--output-format=&lt;fmt&gt; | -o &lt;fmt&gt;]
-                            [--human-readable | -H]</pre>
+                            [--verbose | -v]</pre>
 <div class="attribution">
 </div></div>
 </div>
@@ -790,8 +790,7 @@ for each command that is supported.</p></div>
 </dt>
 <dd>
 <p>
-        This option will parse and format many of the bit fields into a
-        human-readable format.
+        Show detailed information including LSUPP and IOP support details.
 </p>
 </dd>
 </dl></div>

--- a/Documentation/nvme-supported-log-pages.txt
+++ b/Documentation/nvme-supported-log-pages.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme supported-log-pages' <device> [--output-format=<fmt> | -o <fmt>]
-                            [--human-readable | -H]
+                            [--verbose | -v]
 
 DESCRIPTION
 -----------
@@ -30,10 +30,9 @@ OPTIONS
 	This option will set the reporting format to normal, json, or binary.
 	Only one output format can be used at a time.
 
--H::
---human-readable::
-	This option will parse and format many of the bit fields into a
-	human-readable format.
+-v::
+--verbose::
+	Show detailed information including LSUPP and IOP support details.
 
 EXAMPLES
 --------


### PR DESCRIPTION
Instead of the human-readable option, one only has the verbose option available for the nvme supported-log-pages. So rectify the corresponding man page to reflect the same.