### PR TITLE
Check that cfg.len is dw-aligned before the get_log_page function to prevent it from mismatching numd in the get_log_page function

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2257,7 +2257,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		cfg.log_id = (cfg.aen >> 16) & 0xff;
 	}
 
-	if (!cfg.log_len || cfg.log_len &0x3) {
+	if (!cfg.log_len || cfg.log_len & 0x3) {
 		fprintf(stderr, "non-zero or non-dw alignment log-len is required param\n");
 		err = -EINVAL;
 		goto close_dev;

--- a/nvme.c
+++ b/nvme.c
@@ -2257,7 +2257,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		cfg.log_id = (cfg.aen >> 16) & 0xff;
 	}
 
-	if (!cfg.log_len || cfg.log_len & 0x3) {
+	if (!cfg.log_len || cfg.log_len &0x3) {
 		fprintf(stderr, "non-zero or non-dw alignment log-len is required param\n");
 		err = -EINVAL;
 		goto close_dev;

--- a/nvme.c
+++ b/nvme.c
@@ -2257,8 +2257,8 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		cfg.log_id = (cfg.aen >> 16) & 0xff;
 	}
 
-	if (!cfg.log_len) {
-		fprintf(stderr, "non-zero log-len is required param\n");
+	if (!cfg.log_len || cfg.log_len & 0x3) {
+		fprintf(stderr, "non-zero or non-dw alignment log-len is required param\n");
 		err = -EINVAL;
 		goto close_dev;
 	}


### PR DESCRIPTION
Check the cfg.len in the get_log function to prevent the buffer of malloc from being less than the get log length