### PR TITLE
build: Initialize sysconfdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project(
       'buildtype=debug',
       'prefix=/usr/local',
       'warning_level=1',
+      'sysconfdir=etc',
     ]
 )
 
@@ -20,7 +21,7 @@ prefixdir  = get_option('prefix')
 datadir    = join_paths(prefixdir, get_option('datadir'))
 mandir     = join_paths(prefixdir, get_option('mandir'))
 sbindir    = join_paths(prefixdir, get_option('sbindir'))
-sysconfdir = prefixdir + get_option('sysconfdir')
+sysconfdir = join_paths(prefixdir, get_option('sysconfdir'))
 
 udevrulesdir   = join_paths(prefixdir, get_option('udevrulesdir'))
 dracutrulesdir = join_paths(prefixdir, get_option('dracutrulesdir'))


### PR DESCRIPTION
The default sysconfdir needs to be initialize so that Meson and muon expand to the same final result using join_paths().

Fixes: 432a49732bf7 ("build: Use prefixdir directly on sysconfdir")

See https://github.com/linux-nvme/libnvme/issues/588