### PR TITLE
build: Print option summary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -300,3 +300,19 @@ endforeach
 
 install_data(disc,
              install_dir: join_paths(sysconfdir, 'nvme'))
+
+################################################################################
+if meson.version().version_compare('>=0.53.0')
+    summary_dict = {
+        'prefixdir':         prefixdir,
+        'sysconfdir':        sysconfdir,
+        'sbindir':           sbindir,
+        'datadir':           datadir,
+        'mandir':            mandir,
+        'udevrulesdir':      udevrulesdir,
+        'dracutrulesdir':    dracutrulesdir,
+        'systemddir':        systemddir,
+        'build location':    meson.current_build_dir(),
+    }
+    summary(summary_dict)
+endif


### PR DESCRIPTION
At the end of the meson setup command, display the options so that we can quickly determine that we're configured the project properly


[dwagner: ported this from libnvme to nvme-cli]