### PR TITLE
print: print csi and opcode in error log (TP4113)

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -3790,9 +3790,12 @@ void nvme_show_error_log(struct nvme_error_log_page *err_log, int entries,
 		printf("vs		: %d\n", err_log[i].vs);
 		printf("trtype		: %s\n",
 			nvme_trtype_to_string(err_log[i].trtype));
+		printf("csi		: %d\n", err_log[i].csi);
+		printf("opcode		: %#x\n", err_log[i].opcode);
 		printf("cs		: %#"PRIx64"\n",
 		       le64_to_cpu(err_log[i].cs));
 		printf("trtype_spec_info: %#x\n", err_log[i].trtype_spec_info);
+		printf("log_page_version: %d\n", err_log[i].log_page_version);
 		printf(".................\n");
 	}
 }

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 7ea5ab7fb502c7e8ac68ce595bcb14f99d2187d5
+revision = 629b04525a5d5d076db2908c533324bd910ec6c6
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Print newly added fields in the error information log page to show which command is errored by opcode. This commit is based on TP4113.

---
This needs (https://github.com/linux-nvme/libnvme/pull/598) to be accepted :)