### PR TITLE
nvme-print: sanitize supported-log-pages output

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4077,12 +4077,9 @@ void nvme_show_supported_log(struct nvme_supported_log_pages *support_log,
 	for (lid = 0; lid < 256; lid++) {
 		support = le32_to_cpu(support_log->lid_support[lid]);
 		if (support & 0x1) {
-			printf("LID 0x%x (%s), supports 0x%x\n", lid, nvme_log_to_string(lid),
-				support);
+			printf("LID 0x%x - %s\n", lid, nvme_log_to_string(lid));
 			if (human)
 				nvme_show_support_log_human(support, lid);
-			else
-				printf("\n");
 		}
 	}
 }


### PR DESCRIPTION
The current nvme supported-log-pages output is a little cryptic as seen below:

Support Log Pages Details for nvme1n1:
LID 0x0 (Supported Log Pages), supports 0x3

LID 0x1 (Error Information), supports 0x3
...

So sanitize this output to make it more meaningful with better formatting. This should apply to the verbose output as well. With these changes, the sanitized normal output should show up as follows:

Support Log Pages Details for nvme1n1:
LID 0x0 - Supported Log Pages
LID 0x1 - Error Information
...

And the sanitized verbose output would show up as:

Support Log Pages Details for nvme1n1:
LID 0x0 - Supported Log Pages
  LSUPP is supported
  IOS is supported
LID 0x1 - Error Information
  LSUPP is supported
  IOS is supported
...