### PR TITLE
build: Add action build back

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,15 @@ jobs:
           python-version: '3.x'
       - uses: bsfishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=debug
             -Dlibnvme:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -47,11 +51,15 @@ jobs:
           python-version: '3.x'
       - uses: bsfishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=release
             -Dlibnvme:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -72,13 +80,17 @@ jobs:
           python-version: '3.x'
       - uses: bsfishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=release
             --cross-file=.github/cross/clang.txt
             -Dlibnvme:werror=false
             -Dopenssl:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -99,7 +111,7 @@ jobs:
           python-version: '3.x'
       - uses: BSFishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=release
@@ -107,6 +119,10 @@ jobs:
             --default-library=shared
             -Dlibnvme:werror=false
             -Dopenssl:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -127,7 +143,7 @@ jobs:
           python-version: '3.x'
       - uses: BSFishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=release
@@ -135,6 +151,10 @@ jobs:
             --default-library=static
             -Dlibnvme:werror=false
             -Dopenssl:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -164,13 +184,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: BSFishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=release
             --cross-file=.github/cross/ubuntu-armhf.txt
             -Dlibnvme:python=false
             -Dopenssl:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -200,7 +224,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: BSFishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=release
@@ -208,6 +232,10 @@ jobs:
             -Dlibnvme:werror=false
             -Dlibnvme:python=false
             -Dopenssl:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -237,7 +265,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: BSFishy/meson-build@v1.0.3
         with:
-          action: test
+          action: build
           setup-options: >
             --werror
             --buildtype=release
@@ -245,6 +273,10 @@ jobs:
             -Dlibnvme:werror=false
             -Dlibnvme:python=false
             -Dopenssl:werror=false
+          meson-version: 0.61.2
+      - uses: bsfishy/meson-build@v1.0.3
+        with:
+          action: test
           meson-version: 0.61.2
       - uses: actions/upload-artifact@v3
         if: failure()
@@ -295,4 +327,8 @@ jobs:
               -Djson-c=disabled          \
               build
           samu -C build
+      - name: test
+        run: |
+          export PATH=$(pwd)/build-tools/muon/build:$PATH
+
           muon -C build test

--- a/nvme.c
+++ b/nvme.c
@@ -4338,7 +4338,7 @@ static void abort_self_test(struct nvme_dev_self_test_args *args)
 {
 	int err;
 
-	args->stc = NVME_ST_CODE_ABORT,
+	args->stc = NVME_DST_STC_ABORT;
 
 	err = nvme_dev_self_test(args);
 	if (!err) {

--- a/plugins/inspur/inspur-nvme.c
+++ b/plugins/inspur/inspur-nvme.c
@@ -222,7 +222,9 @@ static int nvme_get_vendor_log(int argc, char **argv, struct command *cmd, struc
         return err;
 
     memset(local_mem, 0, BYTE_OF_4K);
-    err = nvme_get_log_simple(dev_fd(dev), VENDOR_SMART_LOG_PAGE, sizeof(r1_cli_vendor_log_t), local_mem);
+    err = nvme_get_log_simple(dev_fd(dev),
+                              (enum nvme_cmd_get_log_lid)VENDOR_SMART_LOG_PAGE,
+                              sizeof(r1_cli_vendor_log_t), local_mem);
     if (!err) {
         show_r1_vendor_log((r1_cli_vendor_log_t *)local_mem);
         show_r1_media_err_log((r1_cli_vendor_log_t *)local_mem);

--- a/plugins/solidigm/solidigm-latency-tracking.c
+++ b/plugins/solidigm/solidigm-latency-tracking.c
@@ -285,7 +285,6 @@ static int latency_tracking_is_enable(struct latency_tracker *lt, __u32 * enable
 		.nsid		= 0,
 		.sel		= 0,
 		.cdw11		= 0,
-		.uuidx		= 0,
 		.data_len	= LATENCY_TRACKING_FID_DATA_LEN,
 		.data		= NULL,
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
@@ -317,7 +316,6 @@ static int latency_tracking_enable(struct latency_tracker *lt)
 		.cdw11		= lt->cfg.enable,
 		.cdw12		= 0,
 		.save		= 0,
-		.uuidx		= 0,
 		.cdw15		= 0,
 		.data_len	= LATENCY_TRACKING_FID_DATA_LEN,
 		.data		= NULL,
@@ -369,7 +367,6 @@ static int latency_tracker_get_log(struct latency_tracker *lt)
 		.csi	= NVME_CSI_NVM,
 		.lsi	= NVME_LOG_LSI_NONE,
 		.lsp	= lt->cfg.type,
-		.uuidx	= NVME_UUID_NONE,
 		.rae	= false,
 		.ot	= false,
 	};


### PR DESCRIPTION
The test target is only the building the minimal dependencies, thus not the complete code base build. Add the build step back.

I noticed that most builds didn't fail though they should have fail  any PR which depends on a libnvme change which is not available.

We hit some clang build failures which we need to fix alongside.