### PR TITLE
nvme: validate storage tag size correctly

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -6358,7 +6358,7 @@ static int invalid_tags(__u64 storage_tag, __u64 ref_tag, __u8 sts, __u8 pif)
 			result = 1;
 		break;
 	case 1:
-		if (sts > 16 && ref_tag >= (1LL << (80 - sts)))
+		if (sts >= 16 && ref_tag >= (1LL << (80 - sts)))
 			result = 1;
 		break;
 	case 2:

--- a/nvme.c
+++ b/nvme.c
@@ -6362,7 +6362,7 @@ static int invalid_tags(__u64 storage_tag, __u64 ref_tag, __u8 sts, __u8 pif)
 			result = 1;
 		break;
 	case 2:
-		if (sts > 0 && ref_tag >= (1LL << (64 - sts)))
+		if (sts > 0 && ref_tag >= (1LL << (48 - sts)))
 			result = 1;
 		break;
 	default:


### PR DESCRIPTION
when pif =2, sts=48, ref tag value not zero, write cmd succees