### PR TITLE
RFC: xnvme backend support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,7 @@ libnvme_dep = dependency('libnvme', version: '>=1.3', required: true,
                          fallback : ['libnvme', 'libnvme_dep'])
 libnvme_mi_dep = dependency('libnvme-mi', required: true,
                          fallback : ['libnvme', 'libnvme_mi_dep'])
+libxnvme_dep = dependency('xnvme', version: '>=0.2.0', required: true)
 
 # Check for libjson-c availability
 if get_option('json-c').disabled()
@@ -268,7 +269,7 @@ subdir('Documentation')
 executable(
   'nvme',
   sources,
-  dependencies: [ libnvme_dep, libnvme_mi_dep, json_c_dep,
+  dependencies: [ libxnvme_dep, libnvme_dep, libnvme_mi_dep, json_c_dep,
                   libhugetlbfs_dep ],
   link_args: '-ldl',
   include_directories: incdir,

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -20,8 +20,8 @@
  */
 #define do_admin_op(op, d, ...) ({					\
 	int __rc;							\
-	if (d->type == NVME_DEV_DIRECT)					\
-		__rc = nvme_ ## op(d->direct.fd, __VA_ARGS__);		\
+	if (d->type == NVME_DEV_DIRECT || d->type == NVME_DEV_XNVME)	\
+		__rc = nvme_ ## op(&d->direct.hnd, __VA_ARGS__);		\
 	else if (d->type == NVME_DEV_MI)				\
 		__rc = nvme_mi_admin_ ## op (d->mi.ctrl, __VA_ARGS__);	\
 	else								\
@@ -38,8 +38,8 @@
  */
 #define do_admin_args_op(op, d, args) ({				\
 	int __rc;							\
-	if (d->type == NVME_DEV_DIRECT) {				\
-		args->fd = d->direct.fd;				\
+	if (d->type == NVME_DEV_DIRECT || d->type == NVME_DEV_XNVME) {	\
+		args->hnd = &d->direct.hnd;					\
 		args->timeout = NVME_DEFAULT_IOCTL_TIMEOUT;		\
 		__rc = nvme_ ## op(args);				\
 	} else if (d->type == NVME_DEV_MI)				\
@@ -411,7 +411,7 @@ int nvme_cli_security_receive(struct nvme_dev *dev,
 {
 	/* Cannot use do_admin_args_op here because the API have different suffix*/
 	if (dev->type == NVME_DEV_DIRECT) {
-		args->fd = dev->direct.fd;
+		args->hnd = dev_fd(dev);
 		args->timeout = NVME_DEFAULT_IOCTL_TIMEOUT;
 		return nvme_security_receive(args);
 	}

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -95,7 +95,7 @@ enum dera_device_status
 	DEVICE_STAUTS__OVER_TEMPRATURE = 0x09,
 };
 
-static int nvme_dera_get_device_status(int fd, enum dera_device_status *result)
+static int nvme_dera_get_device_status(struct dev_handle *hnd, enum dera_device_status *result)
 {
 	int err = 0;
 
@@ -107,7 +107,7 @@ static int nvme_dera_get_device_status(int fd, enum dera_device_status *result)
 		.cdw12 = 0x104, 
 	};
 
-	err = nvme_submit_admin_passthru(fd, &cmd, NULL);
+	err = nvme_submit_admin_passthru(hnd, &cmd, NULL);
 	if (!err && result) {
 		*result = cmd.result;
 	}

--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -72,7 +72,7 @@ static int fdp_configs(int argc, char **argv, struct command *cmd,
 		goto out;
 	}
 
-	err = nvme_get_log_fdp_configurations(dev->direct.fd, cfg.egid, 0,
+	err = nvme_get_log_fdp_configurations(dev_fd(dev), cfg.egid, 0,
 			sizeof(hdr), &hdr);
 	if (err) {
 		nvme_show_status(errno);
@@ -85,7 +85,7 @@ static int fdp_configs(int argc, char **argv, struct command *cmd,
 		goto out;
 	}
 
-	err = nvme_get_log_fdp_configurations(dev->direct.fd, cfg.egid, 0,
+	err = nvme_get_log_fdp_configurations(dev_fd(dev), cfg.egid, 0,
 			hdr.size, log);
 	if (err) {
 		nvme_show_status(errno);
@@ -144,7 +144,7 @@ static int fdp_usage(int argc, char **argv, struct command *cmd, struct plugin *
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	err = nvme_get_log_reclaim_unit_handle_usage(dev->direct.fd, cfg.egid,
+	err = nvme_get_log_reclaim_unit_handle_usage(dev_fd(dev), cfg.egid,
 			0, sizeof(hdr), &hdr);
 	if (err) {
 		nvme_show_status(err);
@@ -158,7 +158,7 @@ static int fdp_usage(int argc, char **argv, struct command *cmd, struct plugin *
 		goto out;
 	}
 
-	err = nvme_get_log_reclaim_unit_handle_usage(dev->direct.fd, cfg.egid,
+	err = nvme_get_log_reclaim_unit_handle_usage(dev_fd(dev), cfg.egid,
 			0, len, log);
 	if (err) {
 		nvme_show_status(err);
@@ -217,7 +217,7 @@ static int fdp_stats(int argc, char **argv, struct command *cmd, struct plugin *
 
 	memset(&stats, 0x0, sizeof(stats));
 
-	err = nvme_get_log_fdp_stats(dev->direct.fd, cfg.egid, 0, sizeof(stats), &stats);
+	err = nvme_get_log_fdp_stats(dev_fd(dev), cfg.egid, 0, sizeof(stats), &stats);
 	if (err) {
 		nvme_show_status(err);
 		goto out;
@@ -278,7 +278,7 @@ static int fdp_events(int argc, char **argv, struct command *cmd, struct plugin 
 
 	memset(&events, 0x0, sizeof(events));
 
-	err = nvme_get_log_fdp_events(dev->direct.fd, cfg.egid,
+	err = nvme_get_log_fdp_events(dev_fd(dev), cfg.egid,
 			cfg.host_events, 0, sizeof(events), &events);
 	if (err) {
 		nvme_show_status(err);
@@ -511,8 +511,8 @@ static int fdp_set_events(int argc, char **argv, struct command *cmd, struct plu
 	}
 
 	struct nvme_set_features_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.fid		= NVME_FEAT_FID_FDP_EVENTS,
 		.nsid		= cfg.namespace_id,
 		.cdw11		= (nev << 16) | cfg.ph,

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -69,10 +69,14 @@ static int huawei_get_nvme_info(int fd, struct huawei_list_item *item, const cha
 	int err;
 	int len;
 	struct stat nvme_stat_info;
+	struct dev_handle hnd;
+
+	hnd.fd = fd;
+	hnd.dev_type = NVME_DEV_DIRECT;
 
 	memset(item, 0, sizeof(*item));
 
-	err = nvme_identify_ctrl(fd, &item->ctrl);
+	err = nvme_identify_ctrl(&hnd, &item->ctrl);
 	if (err)
 		return err;
 
@@ -84,8 +88,8 @@ static int huawei_get_nvme_info(int fd, struct huawei_list_item *item, const cha
 	}
 
 	item->huawei_device = true;
-	err = nvme_get_nsid(fd, &item->nsid);
-	err = nvme_identify_ns(fd, item->nsid, &item->ns);
+	err = nvme_get_nsid(&hnd, &item->nsid);
+	err = nvme_identify_ns(&hnd, item->nsid, &item->ns);
 	if (err)
 		return err;
 

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -138,7 +138,7 @@ static unsigned char setfilecontent(char *filenamea, unsigned char *buffer,
 	return true;
 }
 
-static int nvme_vucmd(int fd, unsigned char opcode, unsigned int cdw12,
+static int nvme_vucmd(struct dev_handle *hnd, unsigned char opcode, unsigned int cdw12,
 		      unsigned int cdw13, unsigned int cdw14,
 		      unsigned int cdw15, char *data, int data_len)
 {
@@ -153,7 +153,7 @@ static int nvme_vucmd(int fd, unsigned char opcode, unsigned int cdw12,
 	cmd.nsid = 0;
 	cmd.addr = (__u64)(__u64)(uintptr_t)data;
 	cmd.data_len = data_len;
-	return nvme_submit_admin_passthru(fd, &cmd, NULL);
+	return nvme_submit_admin_passthru(hnd, &cmd, NULL);
 }
 
 static int innogrit_vsc_geteventlog(int argc, char **argv,

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -342,14 +342,14 @@ static void show_memblaze_smart_log_old(struct nvme_memblaze_smart_log *smart,
     }
 }
 
-static int show_memblaze_smart_log(int fd, __u32 nsid, const char *devname,
+static int show_memblaze_smart_log(struct dev_handle *hnd, __u32 nsid, const char *devname,
     struct nvme_memblaze_smart_log *smart)
 {
     struct nvme_id_ctrl ctrl;
     char fw_ver[10];
     int err = 0;
 
-    err = nvme_identify_ctrl(fd, &ctrl);
+    err = nvme_identify_ctrl(hnd, &ctrl);
     if (err)
         return err;
 
@@ -477,8 +477,8 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *cmd
 	    return err;
 
     struct nvme_get_features_args args = {
+	    .hnd                = dev_fd(dev),
 	    .args_size		= sizeof(args),
-	    .fd			= dev_fd(dev),
 	    .fid		= feature_id,
 	    .nsid		= 0,
 	    .sel		= 0,
@@ -535,8 +535,8 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *cmd
 	    return err;
 
     struct nvme_set_features_args args = {
+	    .hnd                = dev_fd(dev),
 	    .args_size		= sizeof(args),
-	    .fd			= dev_fd(dev),
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -612,8 +612,8 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *cmd, s
     cfg.value = (param1 << MB_FEAT_HIGH_LATENCY_VALUE_SHIFT) | param2;
 
     struct nvme_set_features_args args = {
+	    .hnd                = dev_fd(dev),
 	    .args_size		= sizeof(args),
-	    .fd			= dev_fd(dev),
 	    .fid		= cfg.feature_id,
 	    .nsid		= 0,
 	    .cdw11		= cfg.value,
@@ -772,7 +772,8 @@ static int mb_high_latency_log_print(int argc, char **argv, struct command *cmd,
     return err;
 }
 
-static int memblaze_fw_commit(int fd, int select)
+
+static int memblaze_fw_commit(struct dev_handle *hnd, int select)
 {
 	struct nvme_passthru_cmd cmd = {
 		.opcode		= nvme_admin_fw_commit,
@@ -780,7 +781,7 @@ static int memblaze_fw_commit(int fd, int select)
 		.cdw12      = select,
 	};
 
-	return nvme_submit_admin_passthru(fd, &cmd, NULL);
+	return nvme_submit_admin_passthru(hnd, &cmd, NULL);
 }
 
 static int mb_selective_download(int argc, char **argv, struct command *cmd, struct plugin *plugin)
@@ -879,8 +880,8 @@ static int mb_selective_download(int argc, char **argv, struct command *cmd, str
 		xfer = min(xfer, fw_size);
 
 		struct nvme_fw_download_args args = {
+			.hnd            = dev_fd(dev),
 			.args_size	= sizeof(args),
-			.fd		= dev_fd(dev),
 			.offset		= offset,
 			.data_len	= xfer,
 			.data		= fw_buf,
@@ -1084,8 +1085,8 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *cmd, 
         return err;
 
     struct nvme_set_features_args args = {
+	.hnd            = dev_fd(dev),
         .args_size      = sizeof(args),
-        .fd             = dev_fd(dev),
         .fid            = cfg.feature_id,
         .nsid           = 0,
         .cdw11          = cfg.value,
@@ -1161,8 +1162,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 		option = cfg.enable;
 
 	struct nvme_get_features_args args_get = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args_get),
-		.fd		= dev_fd(dev),
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -1175,8 +1176,8 @@ static int mb_set_lat_stats(int argc, char **argv,
 	};
 
 	struct nvme_set_features_args args_set = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args_set),
-		.fd		= dev_fd(dev),
 		.fid		= fid,
 		.nsid		= nsid,
 		.cdw11		= option,

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -340,7 +340,7 @@ static void ocp_print_C0_log_json(void *data)
 	json_free_object(root);
 }
 
-static int get_c0_log_page(int fd, char *format)
+static int get_c0_log_page(struct dev_handle *hnd, char *format)
 {
 	__u8 *data;
 	int i;
@@ -360,7 +360,7 @@ static int get_c0_log_page(int fd, char *format)
 	}
 	memset(data, 0, sizeof(__u8) * C0_SMART_CLOUD_ATTR_LEN);
 
-	ret = nvme_get_log_simple(fd, C0_SMART_CLOUD_ATTR_OPCODE,
+	ret = nvme_get_log_simple(hnd, C0_SMART_CLOUD_ATTR_OPCODE,
 		C0_SMART_CLOUD_ATTR_LEN, data);
 
 	if (strcmp(format, "json"))
@@ -837,8 +837,8 @@ static int eol_plp_failure_mode_get(struct nvme_dev *dev, const __u32 nsid,
 	int err;
 
 	struct nvme_get_features_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.fid		= fid,
 		.nsid		= nsid,
 		.sel		= sel,
@@ -884,19 +884,19 @@ static int eol_plp_failure_mode_set(struct nvme_dev *dev, const __u32 nsid,
 
 
 	struct nvme_set_features_args args = {
-		.args_size = sizeof(args),
-		.fd = dev_fd(dev),
-		.fid = fid,
-		.nsid = nsid,
-		.cdw11 = mode << 30,
-		.cdw12 = 0,
-		.save = save,
-		.uuidx = uuid_index,
-		.cdw15 = 0,
-		.data_len = 0,
-		.data = NULL,
-		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
-		.result = &result,
+		.hnd            = dev_fd(dev),
+		.args_size	= sizeof(args),
+		.fid		= fid,
+		.nsid		= nsid,
+		.cdw11		= mode << 30,
+		.cdw12		= 0,
+		.save		= save,
+		.uuidx		= 0,
+		.cdw15		= 0,
+		.data_len	= 0,
+		.data		= NULL,
+		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result		= &result,
 	};
 
 	err = nvme_set_features(&args);

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -121,7 +121,7 @@ struct nvme_additional_smart_log {
 	struct nvme_additional_smart_log_item    grown_bb; //grown bad block
 };
 
-int nvme_query_cap(int fd, __u32 nsid, __u32 data_len, void *data)
+int nvme_query_cap(struct dev_handle *hnd, __u32 nsid, __u32 data_len, void *data)
 {
 	 int rc = 0;
 	 struct nvme_passthru_cmd cmd = {
@@ -131,10 +131,10 @@ int nvme_query_cap(int fd, __u32 nsid, __u32 data_len, void *data)
         .data_len        = data_len,
         };
 
-	 rc = ioctl(fd, SFX_GET_FREESPACE, data);
-	 return rc == 0 ? 0 : nvme_submit_admin_passthru(fd, &cmd, NULL);
+	 rc = ioctl(hnd->fd, SFX_GET_FREESPACE, data);
+	 return rc == 0 ? 0 : nvme_submit_admin_passthru(hnd, &cmd, NULL);
 }
-int nvme_change_cap(int fd, __u32 nsid, __u64 capacity)
+int nvme_change_cap(struct dev_handle *hnd, __u32 nsid, __u64 capacity)
 {
 	struct nvme_passthru_cmd cmd = {
 	.opcode		 = nvme_admin_change_cap,
@@ -143,10 +143,10 @@ int nvme_change_cap(int fd, __u32 nsid, __u64 capacity)
 	.cdw11		 = (capacity >> 32),
 	};
 
-	return nvme_submit_admin_passthru(fd, &cmd, NULL);
+	return nvme_submit_admin_passthru(hnd, &cmd, NULL);
 }
 
-int nvme_sfx_set_features(int fd, __u32 nsid, __u32 fid, __u32 value)
+int nvme_sfx_set_features(struct dev_handle *hnd, __u32 nsid, __u32 fid, __u32 value)
 {
 	struct nvme_passthru_cmd cmd = {
 	.opcode		 = nvme_admin_sfx_set_features,
@@ -155,10 +155,10 @@ int nvme_sfx_set_features(int fd, __u32 nsid, __u32 fid, __u32 value)
 	.cdw11		 = value,
 	};
 
-	return nvme_submit_admin_passthru(fd, &cmd, NULL);
+	return nvme_submit_admin_passthru(hnd, &cmd, NULL);
 }
 
-int nvme_sfx_get_features(int fd, __u32 nsid, __u32 fid, __u32 *result)
+int nvme_sfx_get_features(struct dev_handle *hnd, __u32 nsid, __u32 fid, __u32 *result)
 {
 	int err = 0;
 	struct nvme_passthru_cmd cmd = {
@@ -167,7 +167,7 @@ int nvme_sfx_get_features(int fd, __u32 nsid, __u32 fid, __u32 *result)
 	.cdw10		 = fid,
 	};
 
-	err = nvme_submit_admin_passthru(fd, &cmd, NULL);
+	err = nvme_submit_admin_passthru(hnd, &cmd, NULL);
 	if (!err && result) {
 		*result = cmd.result;
 	}
@@ -667,7 +667,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	return err;
 }
 
-int sfx_nvme_get_log(int fd, __u32 nsid, __u8 log_id, __u32 data_len, void *data)
+int sfx_nvme_get_log(struct dev_handle *hnd, __u32 nsid, __u8 log_id, __u32 data_len, void *data)
 {
 	struct nvme_passthru_cmd cmd = {
 		.opcode		   = nvme_admin_get_log_page,
@@ -681,7 +681,7 @@ int sfx_nvme_get_log(int fd, __u32 nsid, __u8 log_id, __u32 data_len, void *data
 	cmd.cdw10 = log_id | (numdl << 16);
 	cmd.cdw11 = numdu;
 
-	return nvme_submit_admin_passthru(fd, &cmd, NULL);
+	return nvme_submit_admin_passthru(hnd, &cmd, NULL);
 }
 
 /**
@@ -693,14 +693,14 @@ int sfx_nvme_get_log(int fd, __u32 nsid, __u8 log_id, __u32 data_len, void *data
  *
  * @return -1 fail ; 0 success
  */
-static int get_bb_table(int fd, __u32 nsid, unsigned char *buf, __u64 size)
+static int get_bb_table(struct dev_handle *hnd, __u32 nsid, unsigned char *buf, __u64 size)
 {
-	if (fd < 0 || !buf || size != 256*4096*sizeof(unsigned char)) {
+	if (hnd->fd < 0 || !buf || size != 256*4096*sizeof(unsigned char)) {
 		fprintf(stderr, "Invalid Param \r\n");
 		return EINVAL;
 	}
 
-	return sfx_nvme_get_log(fd, nsid, SFX_LOG_BBT, size, (void *)buf);
+	return sfx_nvme_get_log(hnd, nsid, SFX_LOG_BBT, size, (void *)buf);
 }
 
 /**
@@ -855,7 +855,7 @@ static int query_cap_info(int argc, char **argv, struct command *cmd, struct plu
 	return err;
 }
 
-static int change_sanity_check(int fd, __u64 trg_in_4k, int *shrink)
+static int change_sanity_check(struct dev_handle *hnd, __u64 trg_in_4k, int *shrink)
 {
 	struct sfx_freespace_ctx freespace_ctx = { 0 };
 	struct sysinfo s_info;
@@ -864,7 +864,7 @@ static int change_sanity_check(int fd, __u64 trg_in_4k, int *shrink)
 	__u64 provisoned_cap_4k = 0;
 	int extend = 0;
 
-	if (nvme_query_cap(fd, 0xffffffff, sizeof(freespace_ctx), &freespace_ctx)) {
+	if (nvme_query_cap(hnd, 0xffffffff, sizeof(freespace_ctx), &freespace_ctx)) {
 	    return -1;
 	}
 
@@ -999,7 +999,7 @@ static int change_cap(int argc, char **argv, struct command *cmd, struct plugin 
 		nvme_show_status(err);
 	else {
 		printf("ScaleFlux change-capacity: success\n");
-		ioctl(dev_fd(dev), BLKRRPART);
+		ioctl(dev_fd(dev)->fd, BLKRRPART);
 	}
 	dev_close(dev);
 	return err;
@@ -1022,14 +1022,14 @@ static int sfx_verify_chr(int fd)
 	return 0;
 }
 
-static int sfx_clean_card(int fd)
+static int sfx_clean_card(struct dev_handle *hnd)
 {
 	int ret;
 
-	ret = sfx_verify_chr(fd);
+	ret = sfx_verify_chr(hnd->fd);
 	if (ret)
 		return ret;
-	ret = ioctl(fd, NVME_IOCTL_CLR_CARD);
+	ret = ioctl(hnd->fd, NVME_IOCTL_CLR_CARD);
 	if (ret)
 		perror("Ioctl Fail.");
 	else

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1544,8 +1544,8 @@ static int clear_fw_activate_history(int argc, char **argv, struct command *cmd,
 	} else {
 
 		struct nvme_set_features_args args = {
+		.hnd         = dev_fd(dev),
 		.args_size  = sizeof(args),
-		.fd         = dev_fd(dev),
 		.fid        = 0xC1,
 		.nsid       = 0,
 		.cdw11      = 0x80000000,
@@ -1620,7 +1620,7 @@ static int vs_clr_pcie_correctable_errs(int argc, char **argv, struct command *c
 	} else {
 		struct nvme_set_features_args args = {
 		.args_size  = sizeof(args),
-		.fd         = dev_fd(dev),
+		.hnd        = dev_fd(dev),
 		.fid        = 0xC3,
 		.nsid       = 0,
 		.cdw11      = 0x80000000,
@@ -1736,7 +1736,7 @@ static int get_host_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		struct nvme_get_log_args args = {
 			.args_size  = sizeof(args),
-			.fd     = dev_fd(dev),
+			.hnd	    = dev_fd(dev),
 			.lid        = cfg.log_id,
 			.nsid       = cfg.namespace_id,
 			.lpo        = offset,
@@ -1853,7 +1853,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *cmd, struct plug
 
 		struct nvme_get_log_args args = {
 			.args_size  = sizeof(args),
-			.fd     = dev_fd(dev),
+			.hnd        = dev_fd(dev),
 			.lid        = log_id,
 			.nsid       = cfg.namespace_id,
 			.lpo        = offset,
@@ -1983,7 +1983,7 @@ static int vs_internal_log(int argc, char **argv, struct command *cmd, struct pl
 
 		struct nvme_get_log_args args = {
 			.args_size  = sizeof(args),
-			.fd     = dev_fd(dev),
+			.hnd        = dev_fd(dev),
 			.lid        = log_id,
 			.nsid       = cfg.namespace_id,
 			.lpo        = offset,

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -234,8 +234,8 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 	}
 
 	struct nvme_get_features_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.fid		= cfg.feature_id,
 		.nsid		= cfg.namespace_id,
 		.sel		= cfg.sel,
@@ -360,8 +360,8 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 	}
 
 	struct nvme_set_features_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.fid		= cfg.feature_id,
 		.nsid		= cfg.namespace_id,
 		.cdw11		= cfg.value,

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -102,8 +102,8 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 		.lpo = 0,
 		.result = NULL,
 		.log = &gc_log,
+		.hnd = dev_fd(dev),
 		.args_size = sizeof(args),
-		.fd = dev_fd(dev),
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = solidigm_vu_gc_log_id,
 		.len = sizeof(gc_log),
@@ -131,7 +131,6 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *c
 	}
 
 	/* Redundant close() to make static code analysis happy */
-	close(dev->direct.fd);
 	dev_close(dev);
 	return err;
 }

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -238,8 +238,8 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 		.lpo = 0,
 		.result = NULL,
 		.log = &smart_log_payload,
+		.hnd = dev_fd(dev),
 		.args_size = sizeof(args),
-		.fd = dev_fd(dev),
 		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
 		.lid = solidigm_vu_smart_log_id,
 		.len = sizeof(smart_log_payload),
@@ -268,7 +268,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *cmd
 	}
 
 	/* Redundant close() to make static code analysis happy */
-	close(dev->direct.fd);
+	close(dev_fd(dev)->fd);
 	dev_close(dev);
 	return err;
 }

--- a/plugins/solidigm/solidigm-telemetry.c
+++ b/plugins/solidigm/solidigm-telemetry.c
@@ -173,7 +173,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *cmd, struc
 close_fd:
 	if (!cfg.is_input_file) {
 		/* Redundant close() to make static code analysis happy */
-		close(dev->direct.fd);
+		close(dev_fd(dev)->fd);
 		dev_close(dev);
 	}
 ret:

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -257,7 +257,7 @@ static void vt_process_string(char *str, const size_t size)
 	}
 }
 
-static int vt_add_entry_to_log(const int fd, const char *path, const struct vtview_save_log_settings *cfg)
+static int vt_add_entry_to_log(struct dev_handle *hnd, const char *path, const struct vtview_save_log_settings *cfg)
 {
 	struct vtview_smart_log_entry smart;
 	const char *filename;
@@ -272,26 +272,26 @@ static int vt_add_entry_to_log(const int fd, const char *path, const struct vtvi
 		filename = cfg->output_file;
 
 	smart.time_stamp = time(NULL);
-	ret = nvme_get_nsid(fd, &nsid);
+	ret = nvme_get_nsid(hnd, &nsid);
 
 	if (ret < 0) {
 		printf("Cannot read namespace-id\n");
 		return -1;
 	}
 
-	ret = nvme_identify_ns(fd, nsid, &smart.raw_ns);
+	ret = nvme_identify_ns(hnd, nsid, &smart.raw_ns);
 	if (ret) {
 		printf("Cannot read namespace identify\n");
 		return -1;
 	}
 
-	ret = nvme_identify_ctrl(fd, &smart.raw_ctrl);
+	ret = nvme_identify_ctrl(hnd, &smart.raw_ctrl);
 	if (ret) {
 		printf("Cannot read device identify controller\n");
 		return -1;
 	}
 
-	ret = nvme_get_log_smart(fd, NVME_NSID_ALL, false, &smart.raw_smart);
+	ret = nvme_get_log_smart(hnd, NVME_NSID_ALL, false, &smart.raw_smart);
 	if (ret) {
 		printf("Cannot read device SMART log\n");
 		return -1;
@@ -304,7 +304,7 @@ static int vt_add_entry_to_log(const int fd, const char *path, const struct vtvi
 	return (ret);
 }
 
-static int vt_update_vtview_log_header(const int fd, const char *path, const struct vtview_save_log_settings *cfg)
+static int vt_update_vtview_log_header(struct dev_handle *hnd, const char *path, const struct vtview_save_log_settings *cfg)
 {
 	struct vtview_log_header header;
 	const char *filename;
@@ -337,13 +337,13 @@ static int vt_update_vtview_log_header(const int fd, const char *path, const str
 	printf("Log file: %s\n", filename);
 	header.time_stamp = time(NULL);
 
-	ret = nvme_identify_ctrl(fd, &header.raw_ctrl);
+	ret = nvme_identify_ctrl(hnd, &header.raw_ctrl);
 	if (ret) {
 		printf("Cannot read identify device\n");
 		return -1;
 	}
 
-	ret = nvme_get_log_fw_slot(fd, false, &header.raw_fw);
+	ret = nvme_get_log_fw_slot(hnd, false, &header.raw_fw);
 	if (ret) {
 		printf("Cannot read device firmware log\n");
 		return -1;

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -272,8 +272,8 @@ static int zns_mgmt_send(int argc, char **argv, struct command *cmd, struct plug
 	}
 
 	struct nvme_zns_mgmt_send_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= zsa,
@@ -305,14 +305,14 @@ ret:
 	return err;
 }
 
-static int get_zdes_bytes(int fd, __u32 nsid)
+static int get_zdes_bytes(struct dev_handle *hnd, __u32 nsid)
 {
 	struct nvme_zns_id_ns ns;
 	struct nvme_id_ns id_ns;
 	__u8 lbaf;
 	int err;
 
-	err = nvme_identify_ns(fd, nsid, &id_ns);
+	err = nvme_identify_ns(hnd, nsid, &id_ns);
 	if (err > 0) {
 		nvme_show_status(err);
 		return -1;
@@ -321,7 +321,7 @@ static int get_zdes_bytes(int fd, __u32 nsid)
 		return -1;
 	}
 
-	err = nvme_zns_identify_ns(fd, nsid,  &ns);
+	err = nvme_zns_identify_ns(hnd, nsid,  &ns);
 	if (err > 0) {
 		nvme_show_status(err);
 		return -1;
@@ -437,8 +437,8 @@ static int zone_mgmt_send(int argc, char **argv, struct command *cmd, struct plu
 	}
 
 	struct nvme_zns_mgmt_send_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= cfg.zsa,
@@ -527,8 +527,8 @@ static int open_zone(int argc, char **argv, struct command *cmd, struct plugin *
 	}
 
 	struct nvme_zns_mgmt_send_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= NVME_ZNS_ZSA_OPEN,
@@ -641,8 +641,8 @@ static int set_zone_desc(int argc, char **argv, struct command *cmd, struct plug
 	}
 
 	struct nvme_zns_mgmt_send_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zsa		= NVME_ZNS_ZSA_SET_DESC_EXT,
@@ -708,8 +708,8 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *cmd, struct pl
 	}
 
 	struct nvme_zns_mgmt_send_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.lba,
 		.zsa		= NVME_ZNS_ZSA_ZRWA_FLUSH,
@@ -801,8 +801,8 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *cmd, struct plu
 	}
 
 	struct nvme_zns_mgmt_recv_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.slba		= cfg.zslba,
 		.zra		= cfg.zra,
@@ -1186,8 +1186,8 @@ static int zone_append(int argc, char **argv, struct command *cmd, struct plugin
 		control |= NVME_IO_ZNS_APPEND_PIREMAP;
 
 	struct nvme_zns_append_args args = {
+		.hnd            = dev_fd(dev),
 		.args_size	= sizeof(args),
-		.fd		= dev_fd(dev),
 		.nsid		= cfg.namespace_id,
 		.zslba		= cfg.zslba,
 		.nlb		= nblocks,


### PR DESCRIPTION
Extended “struct nvme_dev” with the following device-handle types:

* struct dev_handle
* enum nvme_dev_type

The  ‘dev_handle' contains ‘struct xnvme_dev*’, file-descripter and ‘nvme_dev_type’ to manage library-side dispatch.

Adding  ‘open_dev_xnvme(struct nvme_dev **devp, char *devname)’ function to open xNVMe library device handle and same being passed to ‘libnvme’ through ‘struct dev_handle’.

This xnvme plugin can work on different platform such as linux, freebsd and even windows. As well as this can work with different driver on linux(kernel and userspace driver such as SPDK)

Note: this will require libnvme changes, which can be found here
https://github.com/linux-nvme/libnvme/pull/600