### PR TITLE
Patches for TLS support

### DIFF
--- a/Documentation/nvme-check-tls-key.txt
+++ b/Documentation/nvme-check-tls-key.txt
@@ -8,18 +8,42 @@ nvme-check-tls-key - Check a generated NVMe TLS PSK
 SYNOPSIS
 --------
 [verse]
-'nvme check-tls-key' [--key=<key> ]
+'nvme check-tls-key' [--keyring=<name>  | -k <name> ]
+		     [--keytype=<type>  | -t <type> ]
+		     [--hostnqn=<nqn>   | -n <nqn>  ]
+		     [--subsysnqn=<nqn> | -c <nqn>  ]
+		     [--keydata=<key>   | -d <key>  ]
 
 DESCRIPTION
 -----------
 Checks if the key is a valid NVMe TLS PSK in the PSK interchange format
-NVMeTLSkey-1:01:VRLbtnN9AQb2WXW3c9+wEf/DRLz0QuLdbYvEhwtdWwNf9LrZ:
-
+'NVMeTLSkey-1:01:<base64-encoded data>:', and stores the derived 'retained'
+TLS key in the keyring if the subsystem NQN is specified.
 
 OPTIONS
 -------
--k <key>::
---key=<key>::
+-k <name>::
+--keyring=<name>::
+	Name of the keyring into which the 'retained' TLS key should be
+	stored. Default is '.nvme'.
+
+-t <type>::
+--keytype=<type>::
+	Type of the key for resulting TLS key.
+	Default is 'psk'.
+
+-n <nqn>::
+--hostnqn=<nqn>::
+	Host NVMe Qualified Name (NQN) to be used to derive the
+	'retained' TLS key
+
+-c <nqn>::
+--subsysnqn=<nqn>::
+	Subsystem NVMe Qualified Name (NQN) to be used to derive the
+	'retained' TLS key
+
+-d <key>::
+--keydata=<key>::
 	Key to be checked.
 
 EXAMPLES

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -23,13 +23,16 @@ SYNOPSIS
 		[--keep-alive-tmo=<sec>   | -k <sec>]
 		[--reconnect-delay=<#>    | -c <#>]
 		[--ctrl-loss-tmo=<#>	  | -l <#>]
-		[--hdr-digest             | -g]
-		[--data-digest            | -G]
 		[--nr-io-queues=<#>       | -i <#>]
 		[--nr-write-queues=<#>    | -W <#>]
 		[--nr-poll-queues=<#>     | -P <#>]
 		[--queue-size=<#>         | -Q <#>]
+		[--keyring=<#>                    ]
+		[--tls_key=<#>                    ]
+		[--hdr-digest             | -g]
+		[--data-digest            | -G]
 		[--persistent             | -p]
+		[--tls                        ]
 		[--quiet                  | -S]
 		[--dump-config            | -O]
 
@@ -145,14 +148,6 @@ OPTIONS
 --ctrl-loss-tmo=<#>::
 	Overrides the default controller loss timeout period (in seconds).
 
--g::
---hdr-digest::
-	Generates/verifies header digest (TCP).
-
--G::
---data-digest::
-	Generates/verifies data digest (TCP).
-
 -i <#>::
 --nr-io-queues=<#>::
 	Overrides the default number of I/O queues create by the driver.
@@ -173,10 +168,27 @@ OPTIONS
 	by the driver. This option will be ignored for discovery, but will be
 	passed on to the subsequent connect call.
 
+--keyring=<#>::
+	Keyring for TLS key lookup.
+
+--tls_key=<#>::
+	TLS key for the connection (TCP).
+
+-g::
+--hdr-digest::
+	Generates/verifies header digest (TCP).
+
+-G::
+--data-digest::
+	Generates/verifies data digest (TCP).
+
 -p::
 --persistent::
 	Don't remove the discovery controller after retrieving the discovery
 	log page.
+
+--tls::
+	Enable TLS encryption (TCP).
 
 -S::
 --quiet::

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -27,10 +27,12 @@ SYNOPSIS
 		[--keep-alive-tmo=<#>     | -k <#>]
 		[--reconnect-delay=<#>    | -c <#>]
 		[--ctrl-loss-tmo=<#>      | -l <#>]
+		[--tos=<#>                | -T <#>]
 		[--duplicate-connect      | -D]
 		[--disable-sqflow         | -d]
 		[--hdr-digest             | -g]
 		[--data-digest            | -G]
+		[--tls                        ]
 		[--dump-config            | -O]
 		[--output-format=<fmt>    | -o <fmt>]
 
@@ -150,6 +152,10 @@ OPTIONS
 --ctrl-loss-tmo=<#>::
 	Overrides the default controller loss timeout period (in seconds).
 
+-T <#>::
+--tos=<#>::
+	Type of service for the connection (TCP)
+
 -D::
 --duplicate-connect::
 	Allows duplicated connections between same transport host and subsystem
@@ -167,6 +173,9 @@ OPTIONS
 -G::
 --data-digest::
 	Generates/verifies data digest (TCP).
+
+--tls::
+	Enable TLS encryption (TCP).
 
 -O::
 --dump-config::

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -28,6 +28,8 @@ SYNOPSIS
 		[--reconnect-delay=<#>    | -c <#>]
 		[--ctrl-loss-tmo=<#>      | -l <#>]
 		[--tos=<#>                | -T <#>]
+		[--keyring=<#>                    ]
+		[--tls_key=<#>                    ]
 		[--duplicate-connect      | -D]
 		[--disable-sqflow         | -d]
 		[--hdr-digest             | -g]
@@ -155,6 +157,12 @@ OPTIONS
 -T <#>::
 --tos=<#>::
 	Type of service for the connection (TCP)
+
+--keyring=<#>::
+	Keyring for TLS key lookup.
+
+--tls_key=<#>::
+	TLS key for the connection (TCP).
 
 -D::
 --duplicate-connect::

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -23,14 +23,17 @@ SYNOPSIS
 		[--keep-alive-tmo=<sec>   | -k <sec>]
 		[--reconnect-delay=<#>	  | -c <#>]
 		[--ctrl-loss-tmo=<#>	  | -l <#>]
-		[--hdr-digest             | -g]
-		[--data-digest            | -G]
 		[--nr-io-queues=<#>       | -i <#>]
 		[--nr-write-queues=<#>    | -W <#>]
 		[--nr-poll-queues=<#>     | -P <#>]
 		[--queue-size=<#>         | -Q <#>]
+		[--keyring=<#>                    ]
+		[--tls_key=<#>                    ]
+		[--hdr-digest             | -g]
+		[--data-digest            | -G]
 		[--persistent             | -p]
 		[--quiet                  | -S]
+		[--tls                        ]
 		[--dump-config            | -O]
 		[--output-format=<fmt>    | -o <fmt>]
 		[--force]
@@ -165,14 +168,6 @@ OPTIONS
 --ctrl-loss-tmo=<#>::
 	Overrides the default controller loss timeout period (in seconds).
 
--g::
---hdr-digest::
-	Generates/verifies header digest (TCP).
-
--G::
---data-digest::
-	Generates/verifies data digest (TCP).
-
 -i <#>::
 --nr-io-queues=<#>::
 	Overrides the default number of I/O queues create by the driver.
@@ -194,10 +189,27 @@ OPTIONS
 	This option will be ignored for the discovery, and it is only
 	implemented for completeness.
 
+--keyring=<#>::
+	Keyring for TLS key lookup.
+
+--tls_key=<#>::
+	TLS key for the connection (TCP).
+
+-g::
+--hdr-digest::
+	Generates/verifies header digest (TCP).
+
+-G::
+--data-digest::
+	Generates/verifies data digest (TCP).
+
 -p::
 --persistent::
 	Don't remove the discovery controller after retrieving the discovery
 	log page.
+
+--tls::
+	Enable TLS encryption (TCP).
 
 -S::
 --quiet::

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -8,18 +8,52 @@ nvme-gen-tls-key - Generate a NVMe TLS PSK
 SYNOPSIS
 --------
 [verse]
-'nvme gen-tls-key' [--hmac=<hmac-id> | -h <hmac-id>]
+'nvme gen-tls-key' [--keyring=<name> | -k <name>]
+                      [--keytype=<type> | -t <type> ]
+		      [--hostnqn=<nqn> | -n <nqn>]
+		      [--subsysnqn=<nqn> | -c <nqn>]
+		      [--hmac=<hmac-id> | -h <hmac-id>]
 		      [--secret=<secret> | -s <secret> ]
+		      [--insert | -i ]
 
 DESCRIPTION
 -----------
-Generate a base64-encoded NVMe TLS pre-shared key (PSK) in
-the PSK interchange format
-NVMeTLSkey-1:01:VRLbtnN9AQb2WXW3c9+wEf/DRLz0QuLdbYvEhwtdWwNf9LrZ:
-and prints it to stdout.
+Generate a base64-encoded NVMe TLS pre-shared key (PSK).
+The resulting key is either printed in the PSK interchange format
+'NVMeTLSkey-1:01:<base64 encoded data>:',
+inserted as a 'retained' key into the specified keyring, or both.
+When the PSK should be inserted into the keyring a 'retained' key
+is derived from the secret key material, and the resulting 'retained'
+key is stored with the identity
+'NVMe0R0<hmac> <host NQN> <subsystem NQN>'
+in the keyring.
+The 'retained' key is derived from the secret key material,
+the specified subsystem NQN, and the host NQN.
+Once the 'retained' key is stored in the keyring the original
+secret key material cannot be retrieved.
 
 OPTIONS
 -------
+-k <name>::
+--keyring=<name>::
+	Name of the keyring into which the 'retained' TLS key should be
+	stored. Default is '.nvme'.
+
+-t <type>::
+--keytype=<type>::
+	Type of the key for resulting TLS key.
+	Default is 'psk'.
+
+-n <nqn>::
+--hostnqn=<nqn>::
+	Host NVMe Qualified Name (NQN) to be used to derive the
+	'retained' TLS key
+
+-c <nqn>::
+--subsysnqn=<nqn>::
+	Subsystem NVMe Qualified Name (NQN) to be used to derive the
+	'retained' TLS key
+
 -h <hmac-id>::
 --hmac=<hmac-id>::
 	Select a HMAC algorithm to use. Possible values are:
@@ -30,6 +64,11 @@ OPTIONS
 --secret=<secret>::
 	Secret value (in hexadecimal) to be used for the key. If none are
 	provided a random value is used.
+
+-i::
+--insert::
+	Insert the resulting TLS key into the keyring without printing out
+	the key in PSK interchange format.
 
 EXAMPLES
 --------

--- a/fabrics.c
+++ b/fabrics.c
@@ -75,6 +75,8 @@ static const char *nvmf_keep_alive_tmo	= "keep alive timeout period in seconds";
 static const char *nvmf_reconnect_delay	= "reconnect timeout period in seconds";
 static const char *nvmf_ctrl_loss_tmo	= "controller loss timeout period in seconds";
 static const char *nvmf_tos		= "type of service";
+static const char *nvmf_keyring		= "Keyring for TLS key lookup";
+static const char *nvmf_tls_key		= "TLS key to use";
 static const char *nvmf_dup_connect	= "allow duplicate connections between same transport host and subsystem port";
 static const char *nvmf_disable_sqflow	= "disable controller sq flow control (default false)";
 static const char *nvmf_hdr_digest	= "enable transport protocol header digest (TCP transport)";
@@ -100,6 +102,8 @@ static const char *nvmf_config_file	= "Use specified JSON configuration file or 
 	OPT_INT("reconnect-delay",    'c', &c.reconnect_delay,    nvmf_reconnect_delay),\
 	OPT_INT("ctrl-loss-tmo",      'l', &c.ctrl_loss_tmo,      nvmf_ctrl_loss_tmo),	\
 	OPT_INT("tos",                'T', &c.tos,                nvmf_tos),		\
+	OPT_INT("keyring",              0, &c.keyring,            nvmf_keyring),	\
+	OPT_INT("tls_key",              0, &c.tls_key,            nvmf_tls_key),	\
 	OPT_FLAG("duplicate-connect", 'D', &c.duplicate_connect,  nvmf_dup_connect),	\
 	OPT_FLAG("disable-sqflow",    'd', &c.disable_sqflow,     nvmf_disable_sqflow),	\
 	OPT_FLAG("hdr-digest",        'g', &c.hdr_digest,         nvmf_hdr_digest),	\

--- a/fabrics.c
+++ b/fabrics.c
@@ -79,17 +79,18 @@ static const char *nvmf_dup_connect	= "allow duplicate connections between same 
 static const char *nvmf_disable_sqflow	= "disable controller sq flow control (default false)";
 static const char *nvmf_hdr_digest	= "enable transport protocol header digest (TCP transport)";
 static const char *nvmf_data_digest	= "enable transport protocol data digest (TCP transport)";
+static const char *nvmf_tls		= "enable TLS";
 static const char *nvmf_config_file	= "Use specified JSON configuration file or 'none' to disable";
 
 #define NVMF_OPTS(c)									\
 	OPT_STRING("transport",       't', "STR", &transport,	nvmf_tport), \
+	OPT_STRING("nqn",             'n', "STR", &subsysnqn,	nvmf_nqn), \
 	OPT_STRING("traddr",          'a', "STR", &traddr,	nvmf_traddr), \
 	OPT_STRING("trsvcid",         's', "STR", &trsvcid,	nvmf_trsvcid), \
 	OPT_STRING("host-traddr",     'w', "STR", &c.host_traddr,	nvmf_htraddr), \
 	OPT_STRING("host-iface",      'f', "STR", &c.host_iface,	nvmf_hiface), \
 	OPT_STRING("hostnqn",         'q', "STR", &hostnqn,	nvmf_hostnqn), \
 	OPT_STRING("hostid",          'I', "STR", &hostid,	nvmf_hostid), \
-	OPT_STRING("nqn",             'n', "STR", &subsysnqn,	nvmf_nqn), \
 	OPT_STRING("dhchap-secret",   'S', "STR", &hostkey,     nvmf_hostkey), \
 	OPT_INT("nr-io-queues",       'i', &c.nr_io_queues,       nvmf_nr_io_queues),	\
 	OPT_INT("nr-write-queues",    'W', &c.nr_write_queues,    nvmf_nr_write_queues),\
@@ -102,7 +103,8 @@ static const char *nvmf_config_file	= "Use specified JSON configuration file or 
 	OPT_FLAG("duplicate-connect", 'D', &c.duplicate_connect,  nvmf_dup_connect),	\
 	OPT_FLAG("disable-sqflow",    'd', &c.disable_sqflow,     nvmf_disable_sqflow),	\
 	OPT_FLAG("hdr-digest",        'g', &c.hdr_digest,         nvmf_hdr_digest),	\
-	OPT_FLAG("data-digest",       'G', &c.data_digest,        nvmf_data_digest)	\
+	OPT_FLAG("data-digest",       'G', &c.data_digest,        nvmf_data_digest), \
+	OPT_FLAG("tls",                 0, &c.tls,                nvmf_tls)	\
 
 struct tr_config {
 	const char *subsysnqn;


### PR DESCRIPTION
These are the companion patches to https://github.com/linux-nvme/libnvme/pull/602
We just enable the fabrics options '--tls', '--keyring', and '--tls_key', the actual handling is done by libnvme.