### PR TITLE
util: Cleanup argconfig parse function

### DIFF
--- a/nvme-print-json.h
+++ b/nvme-print-json.h
@@ -78,6 +78,7 @@ void json_predictable_latency_event_agg_log(
 void json_predictable_latency_per_nvmset(
 	struct nvme_nvmset_predictable_lat_log *plpns_log,
 	__u16 nvmset_id);
+void json_output_status(int status);
 
 /* fabrics.c */
 void json_discovery_log(struct nvmf_discovery_log *log, int numrec);
@@ -136,6 +137,7 @@ void json_connect_msg(nvme_ctrl_t c);
 #define json_persistent_event_log(pevent_log_info, size)
 #define json_predictable_latency_event_agg_log(pea_log, log_entries)
 #define json_predictable_latency_per_nvmset(plpns_log, nvmset_id)
+#define json_output_status(status)
 
 /* fabrics.c */
 #define json_discovery_log(log, numrec)

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1744,6 +1744,9 @@ void nvme_show_status(int status)
 	int val;
 	int type;
 
+	if (argconfig_output_format_json(false))
+		return json_output_status(status);
+
 	/*
 	 * Callers should be checking for negative values first, but provide a
 	 * sensible fallback anyway

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -285,6 +285,16 @@ static int argconfig_parse_type(struct argconfig_commandline_options *s, struct 
 	return ret;
 }
 
+bool argconfig_output_format_json(bool set)
+{
+	static bool output_format_json = false;
+
+	if (set)
+		output_format_json = true;
+
+	return output_format_json;
+}
+
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		    struct argconfig_commandline_options *options)
 {
@@ -298,8 +308,8 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 	for (s = options; s->option; s++)
 		options_count++;
 
-	long_opts = calloc(1, sizeof(struct option) * (options_count + 2));
-	short_opts = calloc(1, sizeof(*short_opts) * (options_count * 3 + 4));
+	long_opts = calloc(1, sizeof(struct option) * (options_count + 3));
+	short_opts = calloc(1, sizeof(*short_opts) * (options_count * 3 + 5));
 
 	if (!long_opts || !short_opts) {
 		fprintf(stderr, "failed to allocate memory for opts: %s\n", strerror(errno));
@@ -325,10 +335,14 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 	}
 
 	long_opts[option_index].name = "help";
-	long_opts[option_index].val = 'h';
+	long_opts[option_index++].val = 'h';
+
+	long_opts[option_index].name = "json";
+	long_opts[option_index].val = 'j';
 
 	short_opts[short_index++] = '?';
-	short_opts[short_index] = 'h';
+	short_opts[short_index++] = 'h';
+	short_opts[short_index] = 'j';
 
 	optind = 0;
 	while ((c = getopt_long_only(argc, argv, short_opts, long_opts, &option_index)) != -1) {
@@ -338,6 +352,8 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 				ret = -EINVAL;
 				break;
 			}
+			if (c == 'j')
+				argconfig_output_format_json(true);
 			for (option_index = 0; option_index < options_count; option_index++) {
 				if (c == options[option_index].short_option)
 					break;

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -137,4 +137,5 @@ void argconfig_register_help_func(argconfig_help_func * f);
 void print_word_wrapped(const char *s, int indent, int start, FILE *stream);
 bool argconfig_parse_seen(struct argconfig_commandline_options *options,
 			  const char *option);
+bool argconfig_output_format_json(bool set);
 #endif


### PR DESCRIPTION
1. Split to parse config type function
2. Change if else statement to switch case statement
3. Use calloc instead of malloc
4. Delete unused while 0 statement
5. Add argconfig error common function
