### PR TITLE
nvme-print: Unify number base format for nsid

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -5156,7 +5156,7 @@ void nvme_show_list_item(nvme_ns_t n)
 	nvme_dev_full_path(n, devname, sizeof(devname));
 	nvme_generic_full_path(n, genname, sizeof(genname));
 
-	printf("%-21s %-21s %-20s %-40s %-9d %-26s %-16s %-8s\n",
+	printf("%-21s %-21s %-20s %-40s %#-10x %-26s %-16s %-8s\n",
 		devname, genname, nvme_ns_get_serial(n),
 		nvme_ns_get_model(n), nvme_ns_get_nsid(n), usage, format,
 		nvme_ns_get_firmware(n));
@@ -5169,9 +5169,9 @@ static void nvme_show_simple_list(nvme_root_t r)
 	nvme_ctrl_t c;
 	nvme_ns_t n;
 
-	printf("%-21s %-21s %-20s %-40s %-9s %-26s %-16s %-8s\n",
+	printf("%-21s %-21s %-20s %-40s %-10s %-26s %-16s %-8s\n",
 	    "Node", "Generic", "SN", "Model", "Namespace", "Usage", "Format", "FW Rev");
-	printf("%-.21s %-.21s %-.20s %-.40s %-.9s %-.26s %-.16s %-.8s\n",
+	printf("%-.21s %-.21s %-.20s %-.40s %-.10s %-.26s %-.16s %-.8s\n",
 		dash, dash, dash, dash, dash, dash, dash, dash);
 
 	nvme_for_each_host(r, h) {
@@ -5206,7 +5206,7 @@ static void nvme_show_ns_details(nvme_ns_t n)
 	nvme_dev_full_path(n, devname, sizeof(devname));
 	nvme_generic_full_path(n, genname, sizeof(genname));
 
-	printf("%-12s %-12s %-8x %-26s %-16s ", devname,
+	printf("%-12s %-12s %#-10x %-26s %-16s ", devname,
 		genname, nvme_ns_get_nsid(n), usage, format);
 }
 
@@ -5276,9 +5276,9 @@ static void nvme_show_detailed_list(nvme_root_t r)
 	}
 	printf("\n");
 
-	printf("%-12s %-12s %-8s %-26s %-16s %-16s\n", "Device", "Generic",
+	printf("%-12s %-12s %-10s %-26s %-16s %-16s\n", "Device", "Generic",
 		"NSID", "Usage", "Format", "Controllers");
-	printf("%-.12s %-.12s %-.8s %-.26s %-.16s %-.16s\n", dash, dash, dash,
+	printf("%-.12s %-.12s %-.10s %-.26s %-.16s %-.16s\n", dash, dash, dash,
 		dash, dash, dash);
 
 	nvme_for_each_host(r, h) {


### PR DESCRIPTION
`nvme list` is one of the most frequently used subcommand to list up nvme devices in the system.  `nvme list -v` prints much more detail in it.  But, those two commands have different number base format which are decimal and hexadecimal without any prefix (e.g., 0x) or something.

nvme list -v shows hexadecimal nsid without `0x` which means it might be confused between decimal and hexadecimal.  To unify this, this patch expands NSID field width from 8 to 10 to cover `0x` two chracters as a prefix.  Chainging it to decimal format might cause issues for the existing systems looking at this value, so just put the prefix on it.