### PR TITLE
Not issue IDENTIFY command to get a LBA size

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -7446,8 +7446,8 @@ static int submit_io(int opcode, char *command, const char *desc,
 		goto close_mfd;
 	}
 
-	if (nvme_get_logical_block_size(dev_fd(dev), cfg.namespace_id,
-					&logical_block_size) < 0)
+	if (nvme_get_logical_block_size_attr(dev->name,
+				&logical_block_size) < 0)
 		goto close_mfd;
 
 	buffer_size = ((long long)cfg.block_count + 1) * logical_block_size;


### PR DESCRIPTION
Hello,

This patchset is to prevent `submit_io()` from issuing an admin command (IDENTIFY) to figure out a LBA size of the target namespace. `nvme-cli` is a command line utility that composed of many sub-commands which is pretty based on command-by-command unit.  Someone might not want for any admin commands to proceed before `nvme read` or `nvme write`.  Kernel already has initialized namespaces and store the `logical_block_size` in the sysfs and we can easily read from the attribute value rather than issuing a command.

Please review :)

Thanks,