### PR TITLE
plugins/ocp: Add SMART cloud log to solidigm plugin

### DIFF
--- a/plugins/solidigm/solidigm-nvme.c
+++ b/plugins/solidigm/solidigm-nvme.c
@@ -14,7 +14,9 @@
 #include "solidigm-garbage-collection.h"
 #include "solidigm-latency-tracking.h"
 #include "solidigm-telemetry.h"
+
 #include "plugins/ocp/ocp-clear-fw-update-history.h"
+#include "plugins/ocp/ocp-smart-extended-log.h"
 
 static int get_additional_smart_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
@@ -37,7 +39,13 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 }
 
 static int clear_fw_update_history(int argc, char **argv, struct command *cmd,
-								   struct plugin *plugin)
+				   struct plugin *plugin)
 {
 	return ocp_clear_fw_update_history(argc, argv, cmd, plugin);
+}
+
+static int smart_cloud(int argc, char **argv, struct command *cmd,
+		       struct plugin *plugin)
+{
+	return ocp_smart_add_log(argc, argv, cmd, plugin);
 }

--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -18,6 +18,7 @@
 PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_VERSION),
 	COMMAND_LIST(
 		ENTRY("smart-log-add", "Retrieve Solidigm SMART Log", get_additional_smart_log)
+		ENTRY("vs-smart-add-log", "Get SMART / health extended log (redirects to ocp plug-in)", smart_cloud)
 		ENTRY("garbage-collect-log", "Retrieve Garbage Collection Log", get_garbage_collection_log)
 		ENTRY("latency-tracking-log", "Enable/Retrieve Latency tracking Log", get_latency_tracking_log)
 		ENTRY("parse-telemetry-log", "Parse Telemetry Log binary", get_telemetry_log)


### PR DESCRIPTION
Utilized existing SMART cloud implementation in OCP plugin to expose feature in the solidigm plugin (as per OCP 2.0 nvme-cli vendor plugin requirements)