### PR TITLE
fabrics: fix fc config JSON file handling

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -630,7 +630,7 @@ static int discover_from_json_config_file(nvme_root_t r, nvme_host_t h,
 					  enum nvme_print_flags flags,
 					  bool force)
 {
-	const char *transport, *traddr, *trsvcid, *subsysnqn;
+	const char *transport, *traddr, *host_traddr, *trsvcid, *subsysnqn;
 	nvme_subsystem_t s;
 	nvme_ctrl_t c, cn;
 	struct nvme_fabrics_config cfg;
@@ -640,9 +640,16 @@ static int discover_from_json_config_file(nvme_root_t r, nvme_host_t h,
 		nvme_subsystem_for_each_ctrl(s, c) {
 			transport = nvme_ctrl_get_transport(c);
 			traddr = nvme_ctrl_get_traddr(c);
+			host_traddr = nvme_ctrl_get_host_traddr(c);
 
 			if (!transport && !traddr)
 				continue;
+
+			/* ignore if no host_traddr for fc */
+			if (!strcmp(transport, "fc")) {
+				if (!host_traddr)
+					continue;
+			}
 
 			/* ignore none fabric transports */
 			if (strcmp(transport, "tcp") &&
@@ -668,7 +675,7 @@ static int discover_from_json_config_file(nvme_root_t r, nvme_host_t h,
 				.subsysnqn	= subsysnqn,
 				.transport	= transport,
 				.traddr		= traddr,
-				.host_traddr	= cfg.host_traddr,
+				.host_traddr	= host_traddr,
 				.host_iface	= cfg.host_iface,
 				.trsvcid	= trsvcid,
 			};


### PR DESCRIPTION
Unlike other nvme transports, nvme/fc connection requires a valid host_traddr in addition to traddr and transport type. Current fc config JSON handling is broken due to the host_traddr not getting updated even if explicitly listed in the JSON file, as shown below:

nvme connect-all -J /usr/local/etc/nvme/config.json Failed to write to /dev/nvme-fabrics: Invalid argument

And the below error is logged in the messages file for the same:

nvme_fabrics: missing parameter 'host_traddr=%s'

Fix this by ensuring the relevant host_traddr string is appropriately passed to the respective nvme controller structure.