### PR TITLE
plugins/solidigm: Fixes and clean-up of Telemetry parse code.

### DIFF
--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -13,7 +13,7 @@
 
 #include "cmd.h"
 
-#define SOLIDIGM_PLUGIN_VERSION "0.8"
+#define SOLIDIGM_PLUGIN_VERSION "0.10"
 
 PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_VERSION),
 	COMMAND_LIST(

--- a/plugins/solidigm/solidigm-telemetry.c
+++ b/plugins/solidigm/solidigm-telemetry.c
@@ -112,7 +112,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *cmd, struc
 	}
 
 	if (cfg.cfg_file) {
-		char *conf_str = 0;
+		char *conf_str = NULL;
 		size_t length = 0;
 
 		err = read_file2buffer(cfg.cfg_file, &conf_str, &length);
@@ -124,6 +124,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *cmd, struc
 		struct json_tokener * jstok = json_tokener_new();
 
 		tl.configuration = json_tokener_parse_ex(jstok, conf_str, length);
+		free(conf_str);
 		if (jstok->err != json_tokener_success)	{
 			SOLIDIGM_LOG_WARNING("Parsing error on JSON configuration file %s: %s (at offset %d)",
 					     cfg.cfg_file,
@@ -160,11 +161,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *cmd, struc
 			goto close_fd;
 		}
 	}
-	solidigm_telemetry_log_header_parse(&tl);
-	if (cfg.cfg_file)
-		solidigm_telemetry_log_data_areas_parse(&tl, cfg.data_area);
-	else
-		solidigm_telemetry_log_cod_parse(&tl);
+	solidigm_telemetry_log_data_areas_parse(&tl, cfg.data_area);
 
 	json_print_object(tl.root, NULL);
 	json_free_object(tl.root);

--- a/plugins/solidigm/solidigm-telemetry/cod.c
+++ b/plugins/solidigm/solidigm-telemetry/cod.c
@@ -51,10 +51,10 @@ const char *oemDataMapDesc[] = {
 	"All Time Current Max Wear Level", // 0x28
 	"Media Wear Remaining", // 0x29
 	"Total Non-Defrag Writes",  // 0x2A
-	"Number of sectors relocated in reaction to an error" //Uid 0x2B = 43
+	"Media Health Relocations" //Uid 0x2B = 43
 };
 
-static const char * getOemDataMapDescription(__u32 id)
+static const char *getOemDataMapDescription(uint32_t id)
 {
 	if (id < (sizeof(oemDataMapDesc) / sizeof(oemDataMapDesc[0]))) {
 		return oemDataMapDesc[id];
@@ -121,7 +121,7 @@ void solidigm_telemetry_log_cod_parse(struct telemetry_log *tl)
 	if  (!json_object_object_get_ex(reason_id, "OemDataMapOffset", &COD_offset))
 		return;
 
-	__u64 offset = json_object_get_int(COD_offset);
+	uint64_t offset = json_object_get_int(COD_offset);
 
 	if  (offset ==  0) {
 		return;
@@ -132,7 +132,7 @@ void solidigm_telemetry_log_cod_parse(struct telemetry_log *tl)
 		return;
 	}
 
-	const struct cod_map *data = (struct cod_map *) (((__u8 *)tl->log ) + offset);
+	const struct cod_map *data = (struct cod_map *) (((uint8_t *)tl->log) + offset);
 
 	uint32_t signature = be32_to_cpu(data->header.Signature);
 	if ( signature != OEMSIGNATURE){
@@ -147,10 +147,11 @@ void solidigm_telemetry_log_cod_parse(struct telemetry_log *tl)
 	struct json_object *cod = json_create_object();
 	json_object_object_add(tl->root, "cod", cod);
 
-	for (int i =0 ; i < data->header.EntryCount; i++) {
+	for (uint64_t i = 0; i < data->header.EntryCount; i++) {
 		if ((offset + sizeof(struct cod_header) + (i + 1) * sizeof(struct cod_item)) >
 		tl->log_size){
-			SOLIDIGM_LOG_WARNING("Warning: COD data out of bounds at item %d!", i);
+			SOLIDIGM_LOG_WARNING("Warning: COD data out of bounds at item %"PRIu64"!",
+					     i);
 			return;
 		}
 		struct cod_item item = data->items[i];

--- a/plugins/solidigm/solidigm-telemetry/data-area.h
+++ b/plugins/solidigm/solidigm-telemetry/data-area.h
@@ -4,8 +4,7 @@
  *
  * Author: leonardo.da.cunha@solidigm.com
  */
-#include "common.h"
 #include "telemetry-log.h"
 
-int solidigm_telemetry_log_data_areas_parse(const struct telemetry_log *tl,
+int solidigm_telemetry_log_data_areas_parse(struct telemetry_log *tl,
 					    enum nvme_telemetry_da last_da);

--- a/plugins/solidigm/solidigm-telemetry/header.c
+++ b/plugins/solidigm/solidigm-telemetry/header.c
@@ -137,8 +137,8 @@ static void solidigm_telemetry_log_reason_id_parse(const struct telemetry_log *t
 {
 	const struct reason_indentifier_1_0 *ri1_0 =
 		(struct reason_indentifier_1_0 *) tl->log->rsnident;
-	__u16 version_major = le16_to_cpu(ri1_0->versionMajor);
-	__u16 version_minor = le16_to_cpu(ri1_0->versionMinor);
+	uint16_t version_major = le16_to_cpu(ri1_0->versionMajor);
+	uint16_t version_minor = le16_to_cpu(ri1_0->versionMinor);
 
 	json_object_add_value_uint(reason_id, "versionMajor", version_major);
 	json_object_add_value_uint(reason_id, "versionMinor", version_minor);


### PR DESCRIPTION
Fixed parsing of 64 bit values.
Fixed COD field name.
Fixed compilation warnings when compiling for 32 bit. Added missing free().
Consolidated single entry function to telemetry parser. Consolidated use of integer types.