### PR TITLE
nvme: Fix format command to skip to reread NSID all block device

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5814,7 +5814,7 @@ static int format(int argc, char **argv, struct command *cmd, struct plugin *plu
 					err = -errno;
 					goto close_dev;
 				}
-			} else {
+			} else if (cfg.namespace_id != NVME_NSID_ALL) {
 				block_size = 1 << ns.lbaf[cfg.lbaf].ds;
 
 				/*


### PR DESCRIPTION
Since if NSID all specified NS data is not identified so the reread failed.