### PR TITLE
Change default fallback behavior

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -22,8 +22,14 @@ jobs:
           python-version: '3.x'
       - uses: BSFishy/meson-build@v1.0.3
         with:
-          setup-options: --werror --buildtype=release --prefix=/usr
+          setup-options: >
+            --werror
+            --buildtype=release
+            --prefix=/usr
+            --force-fallback-for=libnvme
+            -Dlibnvme:werror=false
           action: install
+          meson-version: 0.61.2
       - name: build AppImage
         uses: AppImageCrafters/build-appimage@v1.3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           setup-options: >
             --werror
             --buildtype=debug
+            --force-fallback-for=libnvme
             -Dlibnvme:werror=false
           meson-version: 0.61.2
       - uses: bsfishy/meson-build@v1.0.3
@@ -58,6 +59,7 @@ jobs:
           setup-options: >
             --werror
             --buildtype=release
+            --force-fallback-for=libnvme
             -Dlibnvme:werror=false
           meson-version: 0.61.2
       - uses: bsfishy/meson-build@v1.0.3
@@ -90,6 +92,7 @@ jobs:
             --werror
             --buildtype=release
             --cross-file=.github/cross/clang.txt
+            --force-fallback-for=libnvme
             -Dlibnvme:werror=false
             -Dopenssl:werror=false
           meson-version: 0.61.2
@@ -200,6 +203,7 @@ jobs:
             --werror
             --buildtype=release
             --cross-file=.github/cross/ubuntu-armhf.txt
+            --force-fallback-for=libnvme
             -Dlibnvme:python=disabled
             -Dopenssl:werror=false
           meson-version: 0.61.2
@@ -242,6 +246,7 @@ jobs:
             --werror
             --buildtype=release
             --cross-file=.github/cross/ubuntu-ppc64le.txt
+            --force-fallback-for=libnvme
             -Dlibnvme:werror=false
             -Dlibnvme:python=disabled
             -Dopenssl:werror=false
@@ -285,6 +290,7 @@ jobs:
             --werror
             --buildtype=release
             --cross-file=.github/cross/ubuntu-s390x.txt
+            --force-fallback-for=libnvme
             -Dlibnvme:werror=false
             -Dlibnvme:python=disabled
             -Dopenssl:werror=false
@@ -301,50 +307,62 @@ jobs:
           path: |
             build/meson-logs/*.txt
 
-  build-minimal:
-    name: muon minimal
+  build-muon:
+    name: muon
     runs-on: ubuntu-latest
     steps:
+      - name: install dependencies
+        run: sudo apt install gcc make pkg-config libcurl4-openssl-dev libarchive-dev libpkgconf-dev
       - uses: actions/checkout@v3
-      - name: build muon and samurai build-tool
+      - name: build samurai
         run: |
-          mkdir build-tools
-          cd build-tools
-          git clone --depth 1 https://git.sr.ht/~lattis/muon
-          cd muon
+          cd ..
 
           export CC=gcc
-          export ninja=build/samu
+          export ROOT_PATH=$(pwd)/root
 
-          ./tools/bootstrap_ninja.sh build
-          ./bootstrap.sh build
+          git clone --depth 1 https://github.com/michaelforney/samurai.git
 
-          build/muon setup               \
-              -Dlibcurl=disabled         \
-              -Dlibarchive=disabled      \
+          cd samurai
+          make
+          make PREFIX=${ROOT_PATH} install
+      - name: build muon
+        run: |
+          cd ..
+
+          export CC=gcc
+          export ROOT_PATH=$(pwd)/root
+          export PATH=${ROOT_PATH}/bin:${PATH}
+
+
+          git clone https://git.sr.ht/~lattis/muon
+          git -C muon reset --hard 0.2.0
+
+          cd muon
+          ./bootstrap.sh stage1
+          stage1/muon setup              \
+              -Dprefix=${ROOT_PATH}      \
               -Ddocs=disabled            \
               -Dsamurai=disabled         \
-              build
-          build/samu -C build
-          build/muon -C build test
-      - name: fetch libnvme
-        run: |
-          cd subprojects
-          git clone https://github.com/linux-nvme/libnvme.git
-          libnvme_ref=$(sed -n "s/revision = \([0-9a-z]\+\)/\1/p" libnvme.wrap)
-          git -C libnvme checkout $libnvme_ref
+              .build
+          samu -C .build
+          .build/muon -C .build install
       - name: build
         run: |
-          export PATH=$(pwd)/build-tools/muon/build:$PATH
+          export ROOT_PATH=$(pwd)/../root
+          export PATH=${ROOT_PATH}/bin:${PATH}
 
-          muon setup                     \
-              -Dlibnvme:python=disabled  \
-              -Dlibnvme:json-c=disabled  \
-              -Djson-c=disabled          \
-              build
-          samu -C build
+          muon setup                    \
+             -Dprefix=${ROOT_PATH}      \
+             -Dwrap_mode=forcefallback  \
+             -Dlibnvme:python=disabled  \
+             -Dlibnvme:openssl=disabled \
+             .build
+          samu -C .build
+          muon -C .build install
       - name: test
         run: |
-          export PATH=$(pwd)/build-tools/muon/build:$PATH
+          export ROOT_PATH=$(pwd)/../root
+          export PATH=${ROOT_PATH}/bin:${PATH}
 
-          muon -C build test
+          muon -C .build test

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ project(
       'prefix=/usr/local',
       'warning_level=1',
       'sysconfdir=etc',
+      'wrap_mode=nofallback',
     ]
 )
 

--- a/meson.build
+++ b/meson.build
@@ -55,7 +55,7 @@ libnvme_mi_dep = dependency('libnvme-mi', required: true,
 if get_option('json-c').disabled()
     json_c_dep = dependency('', required: false)
 else
-    json_c_dep = dependency('json-c', required: true, version: '>=0.13',
+    json_c_dep = dependency('json-c', required: get_option('json-c'), version: '>=0.13',
                             fallback : ['json-c', 'json_c_dep'])
     if json_c_dep.version().version_compare('>=0.14')
         conf.set('CONFIG_JSONC_14', true, description: 'Is json-c at least 0.14?')

--- a/meson.build
+++ b/meson.build
@@ -70,12 +70,10 @@ conf.set('CONFIG_JSONC', json_c_dep.found(), description: 'Is json-c available?'
 if cc.has_header('hugetlbfs.h')
   libhugetlbfs_dep = cc.find_library('hugetlbfs',
                                      required : false)
-  have_libhugetlbfs = libhugetlbfs_dep.found()
 else
-  libhugetlbfs_dep = []
-  have_libhugetlbfs = false
+  libhugetlbfs_dep = dependency('', required: false)
 endif
-conf.set('CONFIG_LIBHUGETLBFS', have_libhugetlbfs, description: 'Is libhugetlbfs available?')
+conf.set('CONFIG_LIBHUGETLBFS', libhugetlbfs_dep.found(), description: 'Is libhugetlbfs available?')
 
 # Set the nvme-cli version
 conf.set('NVME_VERSION', '"' + meson.project_version() + '"')
@@ -304,7 +302,7 @@ install_data(disc,
 
 ################################################################################
 if meson.version().version_compare('>=0.53.0')
-    summary_dict = {
+    path_dict = {
         'prefixdir':         prefixdir,
         'sysconfdir':        sysconfdir,
         'sbindir':           sbindir,
@@ -315,5 +313,14 @@ if meson.version().version_compare('>=0.53.0')
         'systemddir':        systemddir,
         'build location':    meson.current_build_dir(),
     }
-    summary(summary_dict)
+    summary(path_dict, section: 'Paths')
+    dep_dict = {
+        'json-c':            json_c_dep.found(),
+        'libhugetlbfs':      libhugetlbfs_dep.found(),
+    }
+    summary(dep_dict, section: 'Dependencies')
+    conf_dict = {
+        'pdc enabled':       get_option('pdc-enabled')
+    }
+    summary(conf_dict, section: 'Configuration')
 endif

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = b26dfb6e49d9e6f6a42e6de9c49f1da733a34324
+revision = c90eeff5f5bfab597a6152d979aa7049524dd79f
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
meson's default setting for wrap mode is to attempt to download missing
dependencies. Disable this feature as the community is unhappy with
this default behavior.
