### PR TITLE
nvme: fix io_mgmt args parse error

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2042,7 +2042,7 @@ static int io_mgmt_send(int argc, char **argv, struct command *cmd, struct plugi
 
 	OPT_ARGS(opts) = {
 		OPT_UINT("namespace-id",  'n', &cfg.namespace_id,   namespace_id_desired),
-		OPT_UINT("mos",           's', &cfg.mos,            mos),
+		OPT_SHRT("mos",           's', &cfg.mos,            mos),
 		OPT_BYTE("mo",            'm', &cfg.mo,             mo),
 		OPT_FILE("data",          'd', &cfg.file,           data),
 		OPT_UINT("data-len",      'l', &cfg.data_len,       buf_len),
@@ -2138,7 +2138,7 @@ static int io_mgmt_recv(int argc, char **argv, struct command *cmd, struct plugi
 
 	OPT_ARGS(opts) = {
 		OPT_UINT("namespace-id",  'n', &cfg.namespace_id,   namespace_id_desired),
-		OPT_UINT("mos",           's', &cfg.mos,            mos),
+		OPT_SHRT("mos",           's', &cfg.mos,            mos),
 		OPT_BYTE("mo",            'm', &cfg.mo,             mo),
 		OPT_FILE("data",          'd', &cfg.file,           data),
 		OPT_UINT("data-len",      'l', &cfg.data_len,       buf_len),

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = c90eeff5f5bfab597a6152d979aa7049524dd79f
+revision = ef27cf88b1aeed3ba778740f5f71dbd98a79073d
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Since mos defined __u16, it should be parsed with OPT_SHRT if mos given right after mo, it cause parse error
mo always set as 0



Reported-by: Youngjin Jung <yj4369.jung@samsung.com>