### PR TITLE
nvme: fix rnlpt to_string() values.

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -610,10 +610,10 @@ void nvme_show_lba_status_log(void *lba_status, __u32 size,
 static const char *resv_notif_to_string(__u8 type)
 {
 	switch (type) {
-	case 0x1: return "Empty Log Page";
-	case 0x2: return "Registration Preempted";
-	case 0x3: return "Reservation Released";
-	case 0x4: return "Reservation Preempted";
+	case 0x0: return "Empty Log Page";
+	case 0x1: return "Registration Preempted";
+	case 0x2: return "Reservation Released";
+	case 0x3: return "Reservation Preempted";
 	default:  return "Reserved";
 	}
 }


### PR DESCRIPTION
"Reservation Notification Log Page Type" values do not start from 0x1 but from 0x0.

See Page 238:
https://nvmexpress.org/wp-content/uploads/NVM-Express-Base-Specification-2.0c-2022.10.04-Ratified.pdf
