### PR TITLE
solidigm: Add supported log pages log feature to Solidigm plugin

### DIFF
--- a/plugins/solidigm/meson.build
+++ b/plugins/solidigm/meson.build
@@ -3,6 +3,7 @@ sources += [
   'plugins/solidigm/solidigm-smart.c',
   'plugins/solidigm/solidigm-garbage-collection.c',
   'plugins/solidigm/solidigm-latency-tracking.c',
+  'plugins/solidigm/solidigm-log-page-dir.c',
   'plugins/solidigm/solidigm-telemetry.c',
 ]
 subdir('solidigm-telemetry')

--- a/plugins/solidigm/solidigm-log-page-dir.c
+++ b/plugins/solidigm/solidigm-log-page-dir.c
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2023 Solidigm.
+ *
+ * Author: karl.dedow@solidigm.com
+ */
+
+#include "solidigm-log-page-dir.h"
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "common.h"
+#include "nvme-print.h"
+
+#include "plugins/ocp/ocp-utils.h"
+
+struct __attribute__((packed)) supported_log_pages {
+	__u32 supported[256];
+};
+
+struct log_description {
+	int lid;
+	const char *description;
+};
+
+static const unsigned char ocp_uuid[NVME_UUID_LEN] = {
+	0xc1, 0x94, 0xd5, 0x5b, 0xe0, 0x94, 0x47, 0x94, 0xa2, 0x1d,
+	0x29, 0x99, 0x8f, 0x56, 0xbe, 0x6f };
+
+static const unsigned char solidigm_uuid[NVME_UUID_LEN] = { 
+	0x96, 0x19, 0x58, 0x6e, 0xc1, 0x1b, 0x43, 0xad, 0xaa, 0xaa,
+	0x65, 0x41, 0x87, 0xf6, 0xbb, 0xb2 
+};
+
+enum solidigm_uuid {
+	NO_UUID,
+	INVALID_UUID,
+	SOLIDIGM_UUID,
+	OCP_UUID,
+};
+
+static int get_uuid_index(struct nvme_id_uuid_list *uuid_list, const unsigned char *uuid)
+{
+	// Some Solidigm drives have swapped UUIDs, so check for that too..
+	unsigned char swapped_uuid[NVME_UUID_LEN] = { 0 };
+	for (int index = NVME_UUID_LEN - 1; index >= 0; index--)
+		swapped_uuid[NVME_UUID_LEN - index - 1] = uuid[index];
+
+	const unsigned char *uuids[2] = { uuid, swapped_uuid };
+
+	for (int index = 0; index < NVME_ID_UUID_LIST_MAX; index++) {
+		for (int count = 0; count < sizeof(uuids) / sizeof(unsigned char *); count++) {
+			if (!memcmp(uuids[count], &uuid_list->entry[index].uuid, NVME_UUID_LEN))
+				return index + 1;
+		}
+	}
+
+	return -1;
+}
+
+static enum solidigm_uuid get_uuid_enum(struct nvme_dev *dev, const int uuid_index)
+{
+	if (uuid_index == 0)
+		return NO_UUID;
+	
+	if (uuid_index < 0 || uuid_index > 127)
+		return INVALID_UUID;
+
+	struct nvme_id_uuid_list uuid_list;
+	int err = nvme_identify_uuid(dev_fd(dev), &uuid_list);
+
+	// If UUID list not supported, then the logs are assumed to be Solidigm (legacy)
+	if (err)
+		return INVALID_UUID;
+
+	int ocp_uuid_index = get_uuid_index(&uuid_list, ocp_uuid);
+
+	if (ocp_uuid_index == uuid_index)
+		return OCP_UUID;
+	
+	int solidigm_uuid_index = get_uuid_index(&uuid_list, solidigm_uuid);
+
+	if (solidigm_uuid_index == uuid_index)
+		return SOLIDIGM_UUID;
+	
+	return INVALID_UUID;
+}
+
+static const char *lid_desc_from_struct(const int lid, const int log_desc_size,
+					struct log_description *log_desc)
+{
+	for (int index = 0; index < log_desc_size; index++) {
+		if (lid == log_desc[index].lid)
+			return log_desc[index].description;
+	}
+
+	return "Unknown";
+}
+
+static const char *lid_to_desc(const int lid, const enum solidigm_uuid uuid)
+{
+	static struct log_description standard_log_descs[] = {
+		{ 0x00, "Supported Log Pages"},
+		{ 0x01, "Error Information"},
+		{ 0x02, "SMART / Health Information"},
+		{ 0x03, "Firmware Slot Information"},
+		{ 0x04, "Changed Namespace List"},
+		{ 0x05, "Commands Supported and Effects"},
+		{ 0x06, "Device Self Test"},
+		{ 0x07, "Telemetry Host-Initiated"},
+		{ 0x08, "Telemetry Controller-Initiated"},
+		{ 0x09, "Endurance Group Information"},
+		{ 0x0A, "Predictable Latency Per NVM Set"},
+		{ 0x0B, "Predictable Latency Event Aggregate"},
+		{ 0x0C, "Asymmetric Namespace Access"},
+		{ 0x0D, "Persistent Event Log"},
+		{ 0x0E, "Predictable Latency Event Aggregate"},
+		{ 0x0F, "Endurance Group Event Aggregate"},
+		{ 0x10, "Media Unit Status"},
+		{ 0x11, "Supported Capacity Configuration List"},
+		{ 0x12, "Feature Identifiers Supported and Effects"},
+		{ 0x13, "NVMe-MI Commands Supported and Effects"},
+		{ 0x14, "Command and Feature lockdown"},
+		{ 0x15, "Boot Partition"},
+		{ 0x16, "Rotational Media Information"},
+		{ 0x70, "Discovery"},
+		{ 0x80, "Reservation Notification"},
+		{ 0x81, "Sanitize Status"},
+	};
+	const int standard_log_size = sizeof(standard_log_descs) / sizeof(struct log_description);
+
+	static struct log_description ocp_log_descs[] = {
+		{ 0xC0, "OCP SMART / Health Information Extended" },
+		{ 0xC1, "OCP Error Recovery" },
+		{ 0xC2, "OCP Firmware Activation History" },
+		{ 0xC3, "OCP Latency Monitor" },
+		{ 0xC4, "OCP Device Capabilities" },
+		{ 0xC5, "OCP Unsupported Requirements" },
+	};
+	const int ocp_log_size = sizeof(ocp_log_descs) / sizeof(struct log_description);
+
+	static struct log_description solidigm_log_descs[] = {
+		{ 0xC1, "Read Commands Latency Statistics" },
+		{ 0xC2, "Write Commands Latency Statistics" },
+		{ 0xC4, "Endurance Manager Statistics" },
+		{ 0xC5, "Temperature Statistics" },
+		{ 0xCA, "SMART Attributes" },
+	};
+	const int solidigm_log_size = sizeof(solidigm_log_descs) / sizeof(struct log_description);
+
+	static struct log_description all_vu_log_descs[] = {
+		{ 0xC0, "OCP SMART / Health Information Extended" },
+		{ 0xC1, "OCP Error Recovery or Read Commands Latency Statistics" },
+		{ 0xC2, "OCP Firmware Activation History or Write Commands Latency Statistics" },
+		{ 0xC3, "OCP Latency Monitor" },
+		{ 0xC4, "OCP Device Capabilities or Endurance Manager Statistics" },
+		{ 0xC5, "OCP Unsupported Requirements or Temperature Statistics" },
+		{ 0xCA, "SMART Attributes" },
+	};
+	const int all_vu_log_size = sizeof(all_vu_log_descs) / sizeof(struct log_description);
+
+	// Standard logs are less than 0xC0
+	if (lid < 0xC0)
+		return lid_desc_from_struct(lid, standard_log_size, standard_log_descs);
+	else if (uuid == OCP_UUID)
+		return lid_desc_from_struct(lid, ocp_log_size, ocp_log_descs);
+	// Otherwise these are Solidigm logs.
+	else if (uuid == SOLIDIGM_UUID)
+		return lid_desc_from_struct(lid, solidigm_log_size, solidigm_log_descs);
+	else if (uuid == NO_UUID)
+		return lid_desc_from_struct(lid, all_vu_log_size, all_vu_log_descs);
+
+	return "Unknown";
+}
+
+static void solidigm_supported_log_pages_print(const struct supported_log_pages *supported,
+					       const enum solidigm_uuid uuid)
+{
+	printf("Log Page Directory Log:\n");
+	printf("  Supported:\n");
+
+	for (int lid = 0; lid < sizeof(supported->supported) / sizeof(__u32); lid++) {
+		if (supported->supported[lid] == 0)
+			continue;
+
+		printf("    Log Page:\n");
+		printf("      %-16s0x%02x\n", "LID:", le32_to_cpu(lid));
+		printf("      %-16s%s\n", "Description:", lid_to_desc(lid, uuid));
+	}
+
+	printf("\n");
+}
+
+static void solidigm_supported_log_pages_json(const struct supported_log_pages *supported,
+					      const enum solidigm_uuid uuid)
+{
+	struct json_object *root = json_create_object();
+	struct json_object *supported_arry = json_create_array();
+
+	for (int lid = 0; lid < sizeof(supported->supported) / sizeof(__u32); lid++) {
+		if (supported->supported[lid] == 0)
+			continue;
+
+		struct json_object *supported_obj = json_create_object();
+
+		json_object_add_value_uint(supported_obj, "lid", le32_to_cpu(lid));
+		json_object_add_value_string(supported_obj, "description",
+					     lid_to_desc(lid, uuid));
+
+		json_array_add_value_object(supported_arry, supported_obj);
+	}
+
+	json_object_add_value_array(root, "supported", supported_arry);
+
+	json_print_object(root, NULL);
+	json_free_object(root);
+
+	printf("\n");
+}
+
+int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *cmd,
+					struct plugin *plugin)
+{
+	const __u8 log_id = 0x00;
+	int uuid_index = 0;
+	enum solidigm_uuid uuid = INVALID_UUID;
+
+	const char *description = "Retrieves and parses supported log pages log.";
+	char *format = "normal";
+
+	OPT_ARGS(options) = {
+		OPT_INT("uuid-index", 'u', &uuid_index, "UUID index value : (integer)"),
+		OPT_FMT("output-format", 'o', &format, "output format : normal | json"),
+		OPT_END()
+	};
+
+	struct nvme_dev *dev = NULL;
+	int err = parse_and_open(&dev, argc, argv, description, options);
+
+	if (err)
+		return err;
+
+	struct supported_log_pages supported_data = { 0 };
+
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = &supported_data,
+		.args_size = sizeof(args),
+		.fd = dev_fd(dev),
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = log_id,
+		.len = sizeof(supported_data),
+		.nsid = NVME_NSID_ALL,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = 0,
+		.uuidx = uuid_index,
+		.rae = false,
+		.ot = false,
+	};
+
+	err = nvme_get_log(&args);
+
+	if (!err) {
+		uuid = get_uuid_enum(dev, uuid_index);
+
+		if (uuid == INVALID_UUID) {
+			fprintf(stderr, "Error: Invalid UUID value: %d.\n", uuid_index);
+			err = -EINVAL;
+		}
+	} else
+		nvme_show_status(err);
+	
+	
+	if (!err) {
+		const enum nvme_print_flags print_flag = validate_output_format(format);
+
+		if (print_flag == JSON)
+			solidigm_supported_log_pages_json(&supported_data, uuid);
+		else if (print_flag == NORMAL)
+			solidigm_supported_log_pages_print(&supported_data, uuid);
+		else {
+			fprintf(stderr, "Error: Invalid output format specified.\n");
+			err = -EINVAL;
+		}
+	}
+
+	dev_close(dev);
+	return err;
+}

--- a/plugins/solidigm/solidigm-log-page-dir.c
+++ b/plugins/solidigm/solidigm-log-page-dir.c
@@ -15,222 +15,230 @@
 
 #include "plugins/ocp/ocp-utils.h"
 
-struct __attribute__((packed)) supported_log_pages {
-	__u32 supported[256];
+static const int MIN_VENDOR_LID = 0xC0;
+
+struct lid_dir {
+	struct __attribute__((packed)) {
+		bool supported;
+		const char *str;
+	} lid[NVME_LOG_SUPPORTED_LOG_PAGES_MAX];
 };
 
-struct log_description {
-	int lid;
-	const char *description;
-};
-
-static const unsigned char ocp_uuid[NVME_UUID_LEN] = {
-	0xc1, 0x94, 0xd5, 0x5b, 0xe0, 0x94, 0x47, 0x94, 0xa2, 0x1d,
-	0x29, 0x99, 0x8f, 0x56, 0xbe, 0x6f };
-
-static const unsigned char solidigm_uuid[NVME_UUID_LEN] = { 
-	0x96, 0x19, 0x58, 0x6e, 0xc1, 0x1b, 0x43, 0xad, 0xaa, 0xaa,
-	0x65, 0x41, 0x87, 0xf6, 0xbb, 0xb2 
-};
-
-enum solidigm_uuid {
-	NO_UUID,
-	INVALID_UUID,
-	SOLIDIGM_UUID,
-	OCP_UUID,
-};
-
-static int get_uuid_index(struct nvme_id_uuid_list *uuid_list, const unsigned char *uuid)
+static void init_lid_dir(struct lid_dir *lid_dir)
 {
-	// Some Solidigm drives have swapped UUIDs, so check for that too..
-	unsigned char swapped_uuid[NVME_UUID_LEN] = { 0 };
-	for (int index = NVME_UUID_LEN - 1; index >= 0; index--)
-		swapped_uuid[NVME_UUID_LEN - index - 1] = uuid[index];
+	static const char *unknown_str = "Unknown";
 
-	const unsigned char *uuids[2] = { uuid, swapped_uuid };
+	for (int lid = 0; lid < NVME_LOG_SUPPORTED_LOG_PAGES_MAX; lid++) {
+		lid_dir->lid[lid].supported = false;
+		lid_dir->lid[lid].str = unknown_str;
+	}
+}
 
-	for (int index = 0; index < NVME_ID_UUID_LIST_MAX; index++) {
-		for (int count = 0; count < sizeof(uuids) / sizeof(unsigned char *); count++) {
-			if (!memcmp(uuids[count], &uuid_list->entry[index].uuid, NVME_UUID_LEN))
-				return index + 1;
+static bool is_invalid_uuid(const struct nvme_id_uuid_list_entry entry)
+{
+	static const unsigned char ALL_ZERO_UUID[NVME_UUID_LEN] = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 
+	};
+
+	return memcmp(ALL_ZERO_UUID, entry.uuid, NVME_UUID_LEN) == 0;
+}
+
+static bool is_solidigm_uuid(const struct nvme_id_uuid_list_entry entry)
+{
+	static const unsigned char SOLIDIGM_UUID[NVME_UUID_LEN] = {
+		0x96, 0x19, 0x58, 0x6e, 0xc1, 0x1b, 0x43, 0xad,
+		0xaa, 0xaa, 0x65, 0x41, 0x87, 0xf6, 0xbb, 0xb2
+	};
+
+	return memcmp(SOLIDIGM_UUID, entry.uuid, NVME_UUID_LEN) == 0;
+}
+
+static bool is_ocp_uuid(const struct nvme_id_uuid_list_entry entry)
+{
+	static const unsigned char OCP_UUID[NVME_UUID_LEN] = {
+		0xc1, 0x94, 0xd5, 0x5b, 0xe0, 0x94, 0x47, 0x94,
+		0xa2, 0x1d, 0x29, 0x99, 0x8f, 0x56, 0xbe, 0x6f
+	};
+
+	return memcmp(OCP_UUID, entry.uuid, NVME_UUID_LEN) == 0;
+}
+
+static int get_supported_log_pages_log(struct nvme_dev *dev, int uuid_index,
+				       struct nvme_supported_log_pages *supported)
+{
+	static const __u8 LID = 0x00;
+
+	memset(supported, 0, sizeof(*supported));
+	struct nvme_get_log_args args = {
+		.lpo = 0,
+		.result = NULL,
+		.log = supported,
+		.args_size = sizeof(args),
+		.fd = dev_fd(dev),
+		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.lid = LID,
+		.len = sizeof(*supported),
+		.nsid = NVME_NSID_ALL,
+		.csi = NVME_CSI_NVM,
+		.lsi = NVME_LOG_LSI_NONE,
+		.lsp = 0,
+		.uuidx = uuid_index,
+		.rae = false,
+		.ot = false,
+	};
+
+	return nvme_get_log(&args);
+}
+
+static struct lid_dir* get_standard_lids(struct nvme_supported_log_pages *supported)
+{
+	static struct lid_dir standard_dir = { 0 };
+
+	init_lid_dir(&standard_dir);
+	standard_dir.lid[0x00].str = "Supported Log Pages";
+	standard_dir.lid[0x01].str = "Error Information";
+	standard_dir.lid[0x02].str = "SMART / Health Information";
+	standard_dir.lid[0x03].str = "Firmware Slot Information";
+	standard_dir.lid[0x04].str = "Changed Namespace List";
+	standard_dir.lid[0x05].str = "Commands Supported and Effects";
+	standard_dir.lid[0x06].str = "Device Self Test";
+	standard_dir.lid[0x07].str = "Telemetry Host-Initiated";
+	standard_dir.lid[0x08].str = "Telemetry Controller-Initiated";
+	standard_dir.lid[0x09].str = "Endurance Group Information";
+	standard_dir.lid[0x0A].str = "Predictable Latency Per NVM Set";
+	standard_dir.lid[0x0B].str = "Predictable Latency Event Aggregate";
+	standard_dir.lid[0x0C].str = "Asymmetric Namespace Access";
+	standard_dir.lid[0x0D].str = "Persistent Event Log";
+	standard_dir.lid[0x0E].str = "Predictable Latency Event Aggregate";
+	standard_dir.lid[0x0F].str = "Endurance Group Event Aggregate";
+	standard_dir.lid[0x10].str = "Media Unit Status";
+	standard_dir.lid[0x11].str = "Supported Capacity Configuration List";
+	standard_dir.lid[0x12].str = "Feature Identifiers Supported and Effects";
+	standard_dir.lid[0x13].str = "NVMe-MI Commands Supported and Effects";
+	standard_dir.lid[0x14].str = "Command and Feature lockdown";
+	standard_dir.lid[0x15].str = "Boot Partition";
+	standard_dir.lid[0x16].str = "Rotational Media Information";
+	standard_dir.lid[0x70].str = "Discovery";
+	standard_dir.lid[0x80].str = "Reservation Notification";
+	standard_dir.lid[0x81].str = "Sanitize Status";
+
+	for (int lid = 0; lid < NVME_LOG_SUPPORTED_LOG_PAGES_MAX; lid++) {
+		if (!supported->lid_support[lid] || lid >= MIN_VENDOR_LID)
+			continue;
+
+		standard_dir.lid[lid].supported = true;
+	}
+
+	return &standard_dir;
+}
+
+static void update_vendor_lid_supported(struct nvme_supported_log_pages *supported,
+					struct lid_dir* lid_dir)
+{
+	for (int lid = 0; lid < NVME_LOG_SUPPORTED_LOG_PAGES_MAX; lid++) {
+		if (!supported->lid_support[lid]|| lid < MIN_VENDOR_LID)
+			continue;
+
+		lid_dir->lid[lid].supported = true;
+	}
+}
+
+static struct lid_dir* get_solidigm_lids(struct nvme_supported_log_pages *supported)
+{
+	static struct lid_dir solidigm_dir = { 0 };
+
+	init_lid_dir(&solidigm_dir);
+	solidigm_dir.lid[0xC1].str = "Read Commands Latency Statistics";
+	solidigm_dir.lid[0xC2].str = "Write Commands Latency Statistics";
+	solidigm_dir.lid[0xC4].str = "Endurance Manager Statistics";
+	solidigm_dir.lid[0xC5].str = "Temperature Statistics";
+	solidigm_dir.lid[0xCA].str = "SMART Attributes";
+
+	update_vendor_lid_supported(supported, &solidigm_dir);
+
+	return &solidigm_dir;
+}
+
+static struct lid_dir* get_ocp_lids(struct nvme_supported_log_pages *supported)
+{
+	static struct lid_dir ocp_dir = { 0 };
+
+	init_lid_dir(&ocp_dir);
+	ocp_dir.lid[0xC0].str = "OCP SMART / Health Information Extended";
+	ocp_dir.lid[0xC1].str = "OCP Error Recovery";
+	ocp_dir.lid[0xC2].str = "OCP Firmware Activation History";
+	ocp_dir.lid[0xC3].str = "OCP Latency Monitor";
+	ocp_dir.lid[0xC4].str = "OCP Device Capabilities";
+	ocp_dir.lid[0xC5].str = "OCP Unsupported Requirements";
+
+	update_vendor_lid_supported(supported, &ocp_dir);
+
+	return &ocp_dir;
+}
+
+static void supported_log_pages_normal(struct lid_dir *lid_dir[NVME_ID_UUID_LIST_MAX + 1])
+{
+	printf("Log Page Directory:\n");
+	printf("-----------------------------------------------------------------\n");
+	printf("| %-5s| %-42s| %-11s|\n", "LID", "Description", "UUID Index");
+	printf("-----------------------------------------------------------------\n");
+
+	for (int uuid_index = 0; uuid_index <= NVME_ID_UUID_LIST_MAX; uuid_index++) {
+		if (!lid_dir[uuid_index])
+			continue;
+
+		for (int lid = 0; lid < NVME_LOG_SUPPORTED_LOG_PAGES_MAX; lid++) {
+			if (!lid_dir[uuid_index]->lid[lid].supported)
+				continue;
+
+			printf("| 0x%-3.02x", le32_to_cpu(lid));
+			printf("| %-42s", lid_dir[uuid_index]->lid[lid].str);
+			printf("| %-11d|\n", le32_to_cpu(uuid_index));
 		}
 	}
 
-	return -1;
+	printf("-----------------------------------------------------------------\n");
 }
 
-static enum solidigm_uuid get_uuid_enum(struct nvme_dev *dev, const int uuid_index)
-{
-	if (uuid_index == 0)
-		return NO_UUID;
-	
-	if (uuid_index < 0 || uuid_index > 127)
-		return INVALID_UUID;
-
-	struct nvme_id_uuid_list uuid_list;
-	int err = nvme_identify_uuid(dev_fd(dev), &uuid_list);
-
-	// If UUID list not supported, then the logs are assumed to be Solidigm (legacy)
-	if (err)
-		return INVALID_UUID;
-
-	int ocp_uuid_index = get_uuid_index(&uuid_list, ocp_uuid);
-
-	if (ocp_uuid_index == uuid_index)
-		return OCP_UUID;
-	
-	int solidigm_uuid_index = get_uuid_index(&uuid_list, solidigm_uuid);
-
-	if (solidigm_uuid_index == uuid_index)
-		return SOLIDIGM_UUID;
-	
-	return INVALID_UUID;
-}
-
-static const char *lid_desc_from_struct(const int lid, const int log_desc_size,
-					struct log_description *log_desc)
-{
-	for (int index = 0; index < log_desc_size; index++) {
-		if (lid == log_desc[index].lid)
-			return log_desc[index].description;
-	}
-
-	return "Unknown";
-}
-
-static const char *lid_to_desc(const int lid, const enum solidigm_uuid uuid)
-{
-	static struct log_description standard_log_descs[] = {
-		{ 0x00, "Supported Log Pages"},
-		{ 0x01, "Error Information"},
-		{ 0x02, "SMART / Health Information"},
-		{ 0x03, "Firmware Slot Information"},
-		{ 0x04, "Changed Namespace List"},
-		{ 0x05, "Commands Supported and Effects"},
-		{ 0x06, "Device Self Test"},
-		{ 0x07, "Telemetry Host-Initiated"},
-		{ 0x08, "Telemetry Controller-Initiated"},
-		{ 0x09, "Endurance Group Information"},
-		{ 0x0A, "Predictable Latency Per NVM Set"},
-		{ 0x0B, "Predictable Latency Event Aggregate"},
-		{ 0x0C, "Asymmetric Namespace Access"},
-		{ 0x0D, "Persistent Event Log"},
-		{ 0x0E, "Predictable Latency Event Aggregate"},
-		{ 0x0F, "Endurance Group Event Aggregate"},
-		{ 0x10, "Media Unit Status"},
-		{ 0x11, "Supported Capacity Configuration List"},
-		{ 0x12, "Feature Identifiers Supported and Effects"},
-		{ 0x13, "NVMe-MI Commands Supported and Effects"},
-		{ 0x14, "Command and Feature lockdown"},
-		{ 0x15, "Boot Partition"},
-		{ 0x16, "Rotational Media Information"},
-		{ 0x70, "Discovery"},
-		{ 0x80, "Reservation Notification"},
-		{ 0x81, "Sanitize Status"},
-	};
-	const int standard_log_size = sizeof(standard_log_descs) / sizeof(struct log_description);
-
-	static struct log_description ocp_log_descs[] = {
-		{ 0xC0, "OCP SMART / Health Information Extended" },
-		{ 0xC1, "OCP Error Recovery" },
-		{ 0xC2, "OCP Firmware Activation History" },
-		{ 0xC3, "OCP Latency Monitor" },
-		{ 0xC4, "OCP Device Capabilities" },
-		{ 0xC5, "OCP Unsupported Requirements" },
-	};
-	const int ocp_log_size = sizeof(ocp_log_descs) / sizeof(struct log_description);
-
-	static struct log_description solidigm_log_descs[] = {
-		{ 0xC1, "Read Commands Latency Statistics" },
-		{ 0xC2, "Write Commands Latency Statistics" },
-		{ 0xC4, "Endurance Manager Statistics" },
-		{ 0xC5, "Temperature Statistics" },
-		{ 0xCA, "SMART Attributes" },
-	};
-	const int solidigm_log_size = sizeof(solidigm_log_descs) / sizeof(struct log_description);
-
-	static struct log_description all_vu_log_descs[] = {
-		{ 0xC0, "OCP SMART / Health Information Extended" },
-		{ 0xC1, "OCP Error Recovery or Read Commands Latency Statistics" },
-		{ 0xC2, "OCP Firmware Activation History or Write Commands Latency Statistics" },
-		{ 0xC3, "OCP Latency Monitor" },
-		{ 0xC4, "OCP Device Capabilities or Endurance Manager Statistics" },
-		{ 0xC5, "OCP Unsupported Requirements or Temperature Statistics" },
-		{ 0xCA, "SMART Attributes" },
-	};
-	const int all_vu_log_size = sizeof(all_vu_log_descs) / sizeof(struct log_description);
-
-	// Standard logs are less than 0xC0
-	if (lid < 0xC0)
-		return lid_desc_from_struct(lid, standard_log_size, standard_log_descs);
-	else if (uuid == OCP_UUID)
-		return lid_desc_from_struct(lid, ocp_log_size, ocp_log_descs);
-	// Otherwise these are Solidigm logs.
-	else if (uuid == SOLIDIGM_UUID)
-		return lid_desc_from_struct(lid, solidigm_log_size, solidigm_log_descs);
-	else if (uuid == NO_UUID)
-		return lid_desc_from_struct(lid, all_vu_log_size, all_vu_log_descs);
-
-	return "Unknown";
-}
-
-static void solidigm_supported_log_pages_print(const struct supported_log_pages *supported,
-					       const enum solidigm_uuid uuid)
-{
-	printf("Log Page Directory Log:\n");
-	printf("  Supported:\n");
-
-	for (int lid = 0; lid < sizeof(supported->supported) / sizeof(__u32); lid++) {
-		if (supported->supported[lid] == 0)
-			continue;
-
-		printf("    Log Page:\n");
-		printf("      %-16s0x%02x\n", "LID:", le32_to_cpu(lid));
-		printf("      %-16s%s\n", "Description:", lid_to_desc(lid, uuid));
-	}
-
-	printf("\n");
-}
-
-static void solidigm_supported_log_pages_json(const struct supported_log_pages *supported,
-					      const enum solidigm_uuid uuid)
+static void supported_log_pages_json(struct lid_dir *lid_dir[NVME_ID_UUID_LIST_MAX + 1])
 {
 	struct json_object *root = json_create_object();
 	struct json_object *supported_arry = json_create_array();
 
-	for (int lid = 0; lid < sizeof(supported->supported) / sizeof(__u32); lid++) {
-		if (supported->supported[lid] == 0)
+	for (int uuid_index = 0; uuid_index <= NVME_ID_UUID_LIST_MAX; uuid_index++) {
+		if (!lid_dir[uuid_index])
 			continue;
 
-		struct json_object *supported_obj = json_create_object();
+		for (int lid = 0; lid < NVME_LOG_SUPPORTED_LOG_PAGES_MAX; lid++) {
+			if (!lid_dir[uuid_index]->lid[lid].supported)
+				continue;
 
-		json_object_add_value_uint(supported_obj, "lid", le32_to_cpu(lid));
-		json_object_add_value_string(supported_obj, "description",
-					     lid_to_desc(lid, uuid));
+			struct json_object *lid_obj = json_create_object();
 
-		json_array_add_value_object(supported_arry, supported_obj);
+			json_object_add_value_uint(lid_obj, "lid", le32_to_cpu(lid));
+			json_object_add_value_string(lid_obj, "description",
+						     lid_dir[uuid_index]->lid[lid].str);
+			json_object_add_value_uint(lid_obj, "uuid index", le32_to_cpu(uuid_index));
+			json_array_add_value_object(supported_arry, lid_obj);
+		}
 	}
 
 	json_object_add_value_array(root, "supported", supported_arry);
 
 	json_print_object(root, NULL);
 	json_free_object(root);
-
 	printf("\n");
 }
 
 int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *cmd,
 					struct plugin *plugin)
 {
-	const __u8 log_id = 0x00;
-	int uuid_index = 0;
-	enum solidigm_uuid uuid = INVALID_UUID;
-
-	const char *description = "Retrieves and parses supported log pages log.";
+	const int NO_UUID_INDEX = 0;
+	const char *description = "Retrieves the list of supported log pages.";
 	char *format = "normal";
 
 	OPT_ARGS(options) = {
-		OPT_INT("uuid-index", 'u', &uuid_index, "UUID index value : (integer)"),
 		OPT_FMT("output-format", 'o', &format, "output format : normal | json"),
 		OPT_END()
 	};
@@ -241,49 +249,52 @@ int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *c
 	if (err)
 		return err;
 
-	struct supported_log_pages supported_data = { 0 };
-
-	struct nvme_get_log_args args = {
-		.lpo = 0,
-		.result = NULL,
-		.log = &supported_data,
-		.args_size = sizeof(args),
-		.fd = dev_fd(dev),
-		.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
-		.lid = log_id,
-		.len = sizeof(supported_data),
-		.nsid = NVME_NSID_ALL,
-		.csi = NVME_CSI_NVM,
-		.lsi = NVME_LOG_LSI_NONE,
-		.lsp = 0,
-		.uuidx = uuid_index,
-		.rae = false,
-		.ot = false,
-	};
-
-	err = nvme_get_log(&args);
+	struct lid_dir *lid_dirs[NVME_ID_UUID_LIST_MAX + 1] = { 0 };
+	struct nvme_id_uuid_list uuid_list = { 0 };
+	struct nvme_supported_log_pages supported = { 0 };
+	
+	err = get_supported_log_pages_log(dev, NO_UUID_INDEX, &supported);
 
 	if (!err) {
-		uuid = get_uuid_enum(dev, uuid_index);
+		lid_dirs[NO_UUID_INDEX] = get_standard_lids(&supported);
 
-		if (uuid == INVALID_UUID) {
-			fprintf(stderr, "Error: Invalid UUID value: %d.\n", uuid_index);
-			err = -EINVAL;
+		// Assume VU logs are the Solidigm log pages if UUID not supported.
+		if (nvme_identify_uuid(dev_fd(dev), &uuid_list)) {
+			struct lid_dir *solidigm_lid_dir = get_solidigm_lids(&supported);
+
+			// Transfer supported Solidigm lids to lid directory at UUID index 0
+			for (int lid = 0; lid < NVME_LOG_SUPPORTED_LOG_PAGES_MAX; lid++) {
+				if (solidigm_lid_dir->lid[lid].supported)
+					lid_dirs[NO_UUID_INDEX]->lid[lid] = solidigm_lid_dir->lid[lid];
+			}
 		}
-	} else
+		else {
+			for (int uuid_index = 1; uuid_index <= NVME_ID_UUID_LIST_MAX; uuid_index++) {
+				if (is_invalid_uuid(uuid_list.entry[uuid_index - 1]))
+					break;
+				else if (get_supported_log_pages_log(dev, uuid_index, &supported))
+					continue;
+				
+				if (is_solidigm_uuid(uuid_list.entry[uuid_index - 1]))
+					lid_dirs[uuid_index] = get_solidigm_lids(&supported);
+				else if (is_ocp_uuid(uuid_list.entry[uuid_index - 1]))
+					lid_dirs[uuid_index] = get_ocp_lids(&supported);
+			}
+		}
+	}
+	else
 		nvme_show_status(err);
-	
-	
+
 	if (!err) {
 		const enum nvme_print_flags print_flag = validate_output_format(format);
 
-		if (print_flag == JSON)
-			solidigm_supported_log_pages_json(&supported_data, uuid);
-		else if (print_flag == NORMAL)
-			solidigm_supported_log_pages_print(&supported_data, uuid);
-		else {
-			fprintf(stderr, "Error: Invalid output format specified.\n");
-			err = -EINVAL;
+		if (print_flag == NORMAL)
+			supported_log_pages_normal(lid_dirs);
+		else if (print_flag == JSON) {
+			supported_log_pages_json(lid_dirs);
+		} else {
+			fprintf(stderr, "Error: Invalid output format specified: %s.\n", format);
+			return -EINVAL;
 		}
 	}
 

--- a/plugins/solidigm/solidigm-log-page-dir.c
+++ b/plugins/solidigm/solidigm-log-page-dir.c
@@ -15,7 +15,8 @@
 
 #include "plugins/ocp/ocp-utils.h"
 
-static const int MIN_VENDOR_LID = 0xC0;
+#define MIN_VENDOR_LID 0xC0
+#define SOLIDIGM_MAX_UUID 2
 
 struct lid_dir {
 	struct __attribute__((packed)) {
@@ -177,14 +178,14 @@ static struct lid_dir* get_ocp_lids(struct nvme_supported_log_pages *supported)
 	return &ocp_dir;
 }
 
-static void supported_log_pages_normal(struct lid_dir *lid_dir[NVME_ID_UUID_LIST_MAX + 1])
+static void supported_log_pages_normal(struct lid_dir *lid_dir[SOLIDIGM_MAX_UUID + 1])
 {
 	printf("Log Page Directory:\n");
 	printf("-----------------------------------------------------------------\n");
 	printf("| %-5s| %-42s| %-11s|\n", "LID", "Description", "UUID Index");
 	printf("-----------------------------------------------------------------\n");
 
-	for (int uuid_index = 0; uuid_index <= NVME_ID_UUID_LIST_MAX; uuid_index++) {
+	for (int uuid_index = 0; uuid_index <= SOLIDIGM_MAX_UUID; uuid_index++) {
 		if (!lid_dir[uuid_index])
 			continue;
 
@@ -201,12 +202,12 @@ static void supported_log_pages_normal(struct lid_dir *lid_dir[NVME_ID_UUID_LIST
 	printf("-----------------------------------------------------------------\n");
 }
 
-static void supported_log_pages_json(struct lid_dir *lid_dir[NVME_ID_UUID_LIST_MAX + 1])
+static void supported_log_pages_json(struct lid_dir *lid_dir[SOLIDIGM_MAX_UUID + 1])
 {
 	struct json_object *root = json_create_object();
 	struct json_object *supported_arry = json_create_array();
 
-	for (int uuid_index = 0; uuid_index <= NVME_ID_UUID_LIST_MAX; uuid_index++) {
+	for (int uuid_index = 0; uuid_index <= SOLIDIGM_MAX_UUID; uuid_index++) {
 		if (!lid_dir[uuid_index])
 			continue;
 
@@ -249,7 +250,7 @@ int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *c
 	if (err)
 		return err;
 
-	struct lid_dir *lid_dirs[NVME_ID_UUID_LIST_MAX + 1] = { 0 };
+	struct lid_dir *lid_dirs[SOLIDIGM_MAX_UUID + 1] = { 0 };
 	struct nvme_id_uuid_list uuid_list = { 0 };
 	struct nvme_supported_log_pages supported = { 0 };
 	
@@ -269,7 +270,7 @@ int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *c
 			}
 		}
 		else {
-			for (int uuid_index = 1; uuid_index <= NVME_ID_UUID_LIST_MAX; uuid_index++) {
+			for (int uuid_index = 1; uuid_index <= SOLIDIGM_MAX_UUID; uuid_index++) {
 				if (is_invalid_uuid(uuid_list.entry[uuid_index - 1]))
 					break;
 				else if (get_supported_log_pages_log(dev, uuid_index, &supported))

--- a/plugins/solidigm/solidigm-log-page-dir.h
+++ b/plugins/solidigm/solidigm-log-page-dir.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2023 Solidigm.
+ *
+ * Authors: karl.dedow@solidigm.com
+ */
+
+#ifndef SOLIDIGM_LOG_PAGE_DIRECTORY_H
+#define SOLIDIGM_LOG_PAGE_DIRECTORY_H
+
+struct command;
+struct plugin;
+
+int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *cmd,
+					struct plugin *plugin);
+
+#endif

--- a/plugins/solidigm/solidigm-nvme.c
+++ b/plugins/solidigm/solidigm-nvme.c
@@ -14,6 +14,7 @@
 #include "solidigm-garbage-collection.h"
 #include "solidigm-latency-tracking.h"
 #include "solidigm-telemetry.h"
+#include "solidigm-log-page-dir.h"
 
 #include "plugins/ocp/ocp-clear-fw-update-history.h"
 #include "plugins/ocp/ocp-smart-extended-log.h"
@@ -51,9 +52,14 @@ static int smart_cloud(int argc, char **argv, struct command *cmd,
 	return ocp_smart_add_log(argc, argv, cmd, plugin);
 }
 
-
 static int fw_activation_history(int argc, char **argv, struct command *cmd,
 				 struct plugin *plugin)
 {
 	return ocp_fw_activation_history_log(argc, argv, cmd, plugin);
+}
+
+static int get_log_page_directory_log(int argc, char **argv, struct command *cmd,
+				      struct plugin *plugin)
+{
+	return solidigm_get_log_page_directory_log(argc, argv, cmd, plugin);
 }

--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -24,6 +24,7 @@ PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_V
 		ENTRY("parse-telemetry-log", "Parse Telemetry Log binary", get_telemetry_log)
 		ENTRY("clear-fw-activate-history", "Clear firmware update history log (redirects to ocp plug-in)", clear_fw_update_history)
 		ENTRY("vs-fw-activate-history", "Get firmware activation history log (redirects to ocp plug-in)", fw_activation_history)
+		ENTRY("log-page-directory", "Retrieve log page directory", get_log_page_directory_log)
 	)
 );
 


### PR DESCRIPTION
Added the log-page-directory command to the solidigm plugin as per OCP NVMe Cloud 2.0 nvme-cli requirements (UTIL-NM-7):
https://www.opencompute.org/documents/datacenter-nvme-ssd-specification-v2-0r21-pdf

The feature works by doing the following:

1. Retrieve the supported log pages log (LID=0x00) with UUID index (if specified)
2. If successful, then parse the contents (and add a description)

Parsing works by mapping the specified UUID index to a known solidigm GUID, then assigning a uuid enum. If the uuid enum is valid, then adding a description works the following way:

1. If standard log id (i.e. <0xC0), use the default log id -> description mapping
2. Otherwise, use the uuid enum to find the appropriate log id -> description mapping

**Example Output (nvme solidigm log-page-directory /dev/nvme0) :**
![image](https://user-images.githubusercontent.com/110949503/232936359-d78e60e5-369f-4d1f-b105-7402142bf747.png)

**Example Output(nvme solidigm log-page-directory /dev/nvme0 -u 2):**
![image](https://user-images.githubusercontent.com/110949503/232936410-0471e528-312e-40e5-876c-faf4e174d6a6.png) 

**Example JSON (nvme solidigm log-page-directory /dev/nvme0 -o json):**
![image](https://user-images.githubusercontent.com/110949503/232936879-9a717dd5-615a-41ec-9610-ed19bd6deeca.png)

**Example JSON (nvme solidigm log-page-directory /dev/nvme0 -o json -u 2) :**
![image](https://user-images.githubusercontent.com/110949503/232936960-56b2f56e-e106-43f8-85c6-78c455287541.png)
