### PR TITLE
tests: Add tests for controller reset

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -28,6 +28,7 @@ tests = [
   'nvme_verify_test.py',
   'nvme_lba_status_log_test.py',
   'nvme_get_lba_status_test.py',
+  'nvme_ctrl_reset_test.py',
 ]
 
 runtests = find_program('nose2', required : false)

--- a/tests/nvme_ctrl_reset_test.py
+++ b/tests/nvme_ctrl_reset_test.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli
+#
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved.
+#
+# Author: Arunpandian J <arun.j@samsung.com>
+
+"""
+NVMe controller reset Testcase:-
+
+    1. Execute nvme controller reset.
+
+"""
+
+from nvme_test import TestNVMe
+
+
+class TestNVMeCtrlReset(TestNVMe):
+
+    """
+    Represents NVMe Controller reset testcase.
+        - Attributes:
+              - test_log_dir :  directory for logs, temp files.
+    """
+
+    def setUp(self):
+        """ Pre Section for TestNVMeCtrlReset """
+        super().setUp()
+        self.setup_log_dir(self.__class__.__name__)
+
+    def tearDown(self):
+        """ Post Section for TestNVMeCtrlReset """
+        super().tearDown()
+
+    def ctrl_reset(self):
+        """ Wrapper for nvme controller reset
+            - Args:
+                - None
+            - Returns:
+                - return code for nvme controller reset.
+        """
+        ctrl_reset_cmd = "nvme reset " + self.ctrl
+        return self.exec_cmd(ctrl_reset_cmd)
+
+    def test_ctrl_reset(self):
+        """ Testcase main """
+        self.assertEqual(self.ctrl_reset(), 0)


### PR DESCRIPTION
test added for controller reset and updated test list in meson.build with newly added
test nvme_ctrl_reset_test.

Signed-off-by: Arunpandian J <arun.j@samsung.com>