### PR TITLE
nvme-wrap: do_admin_args_op should not clear args timeout

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -40,7 +40,6 @@
 	int __rc;							\
 	if (d->type == NVME_DEV_DIRECT) {				\
 		args->fd = d->direct.fd;				\
-		args->timeout = NVME_DEFAULT_IOCTL_TIMEOUT;		\
 		__rc = nvme_ ## op(args);				\
 	} else if (d->type == NVME_DEV_MI)				\
 		__rc = nvme_mi_admin_ ## op (d->mi.ctrl, args);		\


### PR DESCRIPTION
if set with NVME_DEFAULT_IOCTL_TIMEOUT, timeout parameter always ignored


Reported-by: Daseul Lee <daseul.lee@samsung.com>