### PR TITLE
nvme: Fix get-feature command sel parameter check to allow value 8

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4800,7 +4800,7 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 		}
 	}
 
-	if (cfg.sel > 7) {
+	if (cfg.sel > 8) {
 		nvme_show_error("invalid 'select' param:%d", cfg.sel);
 		err = -EINVAL;
 		goto close_dev;


### PR DESCRIPTION
The parameter was changed to use value 8 also by the change 30b89e5ef.
  Note: The value is used only for the command functionality to limit feature
        output changed from default but not passed to the driver.

Fixes: 63dcb68c6 ("nvme: Fix parameter limit range")