### PR TITLE
nvmf-autoconnect: restart service to avoid dropping AEN

### DIFF
--- a/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
+++ b/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
@@ -15,18 +15,18 @@ ENV{NVME_HOST_IFACE}=="", ENV{NVME_HOST_IFACE}="none"
 ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_AEN}=="0x70f002",\
   ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
   ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", ENV{NVME_HOST_IFACE}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}\t--host-iface=$env{NVME_HOST_IFACE}.service"
+  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}\t--host-iface=$env{NVME_HOST_IFACE}.service"
 
 # nvme-fc transport generated events (old-style for compatibility)
 ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
   ENV{NVMEFC_HOST_TRADDR}=="*",  ENV{NVMEFC_TRADDR}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=none\t--transport=fc\t--traddr=$env{NVMEFC_TRADDR}\t--trsvcid=none\t--host-traddr=$env{NVMEFC_HOST_TRADDR}.service"
+  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device=none\t--transport=fc\t--traddr=$env{NVMEFC_TRADDR}\t--trsvcid=none\t--host-traddr=$env{NVMEFC_HOST_TRADDR}.service"
 
 # A discovery controller just (re)connected, re-read the discovery log change to
 # check if there were any changes since it was last connected.
 ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_EVENT}=="rediscover", ATTR{cntrltype}=="discovery", \
   ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
   ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", ENV{NVME_HOST_IFACE}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block start nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}\t--host-iface=$env{NVME_HOST_IFACE}.service"
+  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}\t--host-iface=$env{NVME_HOST_IFACE}.service"
 
 LABEL="autoconnect_end"


### PR DESCRIPTION
If another discovery log page change AEN is received while the autoconnect service is already running for a previous AEN, the autoconnect service is not being relaunched. For example, if some of the entries in the log page are not reachable, attempting to connect to them may take a long time before timing out, so AENs received while waiting for the connections have no effect. The AEN is effectively dropped: we ignore the new discovery log entries and worse, the controller won't send more AENs because it's waiting for the log page to be fetched in response to the previous AEN.

Use `systemctl restart` instead of `systemctl start` to ensure `nvme connect-all` is run in response to each AEN. If a previous instance of the service is already running, it will be interrupted and the new log page will be fetched.

tcpdumps without this change show the AER being resubmitted in response to each AEN (by the kernel), but if the AEN is received while the `nvmf-connect` service is still running, no Get Log Page commands are sent. And so the controller doesn't send an AEN when the discovery log page changes in the future.
With this change, the AER is resubmitted and the discovery log page is refetched in response to every AEN. `dmesg` logs show the service being stopped, the NVMe connection that is timing out being cancelled, and the service starting again to re-fetch the log page:
```
May 12 12:27:24 init72-6 systemd[1]: Stopping NVMf auto-connect scan upon nvme discovery controller Events...
May 12 12:27:24 init72-6 kernel: nvme nvme4: failed to connect socket: -512
May 12 12:27:24 init72-6 systemd[1]: nvmf-connect@--device\x3dnvme0\t--transport\x3dtcp\t--traddr\x3d192.168.1.62\t--trsvcid\x3d4420\t--host-traddr\x3dnone\t--host-iface\x3dnone.service: Succeeded.
May 12 12:27:24 init72-6 systemd[1]: Stopped NVMf auto-connect scan upon nvme discovery controller Events.
May 12 12:27:24 init72-6 systemd[1]: Started NVMf auto-connect scan upon nvme discovery controller Events.
```