### PR TITLE
build: Install missing s390 library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -274,7 +274,7 @@ jobs:
           EOF
           sudo apt update
       - name: install s390x compiler
-        run: sudo apt install gcc-s390x-linux-gnu pkg-config qemu-user-static
+        run: sudo apt install gcc-s390x-linux-gnu libgcc-s1:s390x pkg-config qemu-user-static
       - name: install libraries
         run: sudo apt install libjson-c-dev:s390x
       - uses: actions/checkout@v3


### PR DESCRIPTION
libjson-c-dev:s390x depends on the libgcc-s1 library.