### PR TITLE
Revert "nvme: Masks SSTAT in sanize-log output"

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -4423,7 +4423,7 @@ void nvme_show_sanitize_log(struct nvme_sanitize_log_page *sanitize,
 		printf("\n");
 
 	printf("Sanitize Status                        (SSTAT) :  %#x\n",
-		le16_to_cpu(sanitize->sstat) & NVME_SANITIZE_SSTAT_STATUS_MASK);
+		le16_to_cpu(sanitize->sstat));
 	if (human)
 		nvme_show_sanitize_log_sstat(le16_to_cpu(sanitize->sstat));
 


### PR DESCRIPTION
The NVME_SANITIZE_SSTAT_STATUS_MASK macro is used to mask the 3 least significant bits (representing the status of the most recent sanitize operation) of the SSTAT field.

The SSTAT field is 16 bits wide and contains other information too, such as the Global Data Erased bit and the number of completed passes.

Revert this commit so nvme-cli will print the entire SSTAT field

See NVME Base Specification, page 236
https://nvmexpress.org/wp-content/uploads/NVM-Express-Base-Specification-2_0-2021.06.02-Ratified-5.pdf

This reverts commit 7092ff55c5d9017231a68fa4dbb9a37b42d61d61.