### PR TITLE
fabrics: fix conditions in nvmf-autoconnect.service

### DIFF
--- a/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Connect NVMe-oF subsystems automatically during boot
-ConditionPathExists=|!@SYSCONFDIR@/nvme/config.json
-ConditionPathExists=|!@SYSCONFDIR@/nvme/discovery.conf
+ConditionPathExists=|@SYSCONFDIR@/nvme/config.json
+ConditionPathExists=|@SYSCONFDIR@/nvme/discovery.conf
 After=network-online.target
 Before=remote-fs-pre.target
 


### PR DESCRIPTION
The unit should be started if either config.json or discovery.conf exists. The current syntax would start it if either one does not exist. Fix it.

Fixes: eec7634 ("fabrics: Trigger auto connect if config.json exists")