### PR TITLE
build: Do not use json-c fallback for muon minimal build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,8 +351,10 @@ jobs:
           muon setup                    \
              -Dprefix=${ROOT_PATH}      \
              -Dwrap_mode=forcefallback  \
+             -Dlibnvme:json-c=disabled  \
              -Dlibnvme:python=disabled  \
              -Dlibnvme:openssl=disabled \
+             -Djson-c=disabled          \
              .build
           samu -C .build
           muon -C .build install

--- a/nbft.c
+++ b/nbft.c
@@ -18,6 +18,7 @@ static void print_connect_msg(nvme_ctrl_t c)
 
 static void json_connect_msg(nvme_ctrl_t c)
 {
+#ifdef CONFIG_JSONC
 	struct json_object *root;
 
 	root = json_create_object();
@@ -26,6 +27,7 @@ static void json_connect_msg(nvme_ctrl_t c)
 	json_print_object(root, NULL);
 	printf("\n");
 	json_free_object(root);
+#endif
 }
 
 int nbft_filter(const struct dirent *dent)

--- a/nbft.c
+++ b/nbft.c
@@ -10,6 +10,8 @@
 #include "libnvme.h"
 #include "fabrics.h"
 
+#include "util/types.h"
+
 #define NBFT_SYSFS_FILENAME	"NBFT*"
 
 static void print_connect_msg(nvme_ctrl_t c)

--- a/nbft.c
+++ b/nbft.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <fnmatch.h>
+#include <stdlib.h>
 
 #include "nvme.h"
 #include "nbft.h"

--- a/nvme-print-json.h
+++ b/nvme-print-json.h
@@ -142,10 +142,11 @@ void json_connect_msg(nvme_ctrl_t c);
 #define json_persistent_event_log(pevent_log_info, size)
 #define json_predictable_latency_event_agg_log(pea_log, log_entries)
 #define json_predictable_latency_per_nvmset(plpns_log, nvmset_id)
+#define json_output_error(msg, ap)
+#define json_output_result(msg, ap)
 #define json_output_status(status)
-#define json_output_error(const char *msg, va_list ap)
-#define json_output_perror(const char *msg)
-#define json_output_result(const char *msg, va_list ap)
+#define json_output_message(error, msg, ap)
+#define json_output_perror(msg)
 
 /* fabrics.c */
 #define json_discovery_log(log, numrec)


### PR DESCRIPTION
Configure the muon minimal build without using the json-c fallback. This ensures that the case where json-c is not available is also compile tested.

Fixes #1947