### PR TITLE
fabrics: prevent 'nvme connect' to well-known discovery NQN

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -966,6 +966,13 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 		}
 	}
 
+	if (!strcmp(subsysnqn, NVME_DISC_SUBSYS_NAME)) {
+		fprintf(stderr,
+			"avoiding connect to %s, use nvme discover instead\n",
+			NVME_DISC_SUBSYS_NAME);
+		return -EINVAL;
+	}
+
 	if (!strcmp(config_file, "none"))
 		config_file = NULL;
 


### PR DESCRIPTION
Using 'nvme connect' to connect to the well-known discovery NQN could result in a few problems with the current implementation:

1) It does not explicitly disconnect from the discovery subsystem after usage, thereby leading to a spurious discovery controller on the host.

2) Multiple 'nvme connect' invocations to the well-known discovery NQN would result in duplicate discovery controllers on the host.

All this is already handled in 'nvme discover'. So it would be better to avoid using 'nvme connect' to connect to the well-known discovery NQN in the first place, and use 'nvme discover' instead for the same.