### PR TITLE
nit: ocp: rename FW activation history command

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -217,15 +217,15 @@ _nvme () {
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp clear-pcie-correctable-error-counters options" _clear_pcie_correctable_error_counters
 				;;
-			(vs-fw-activate-history)
-				local _vs_fw_activate_history
-				_vs_fw_activate_history=(
+			(fw-activate-history)
+				local _fw_activate_history
+				_fw_activate_history=(
 				/dev/nvme':supply a device to use (required)'
 				--output-format=':Output format: normal|json'
 				-o':alias for --output-format'
 				)
 				_arguments '*:: :->subcmds'
-				_describe -t commands "nvme ocp vs-fw-activate-history options" _vs_fw_activate_history
+				_describe -t commands "nvme ocp fw-activate-history options" _fw_activate_history
 				;;
 			(device-capability-log)
 				local _device_capability_log

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1342,7 +1342,7 @@ plugin_ocp_opts () {
 		"clear-pcie-correctable-error-counters")
 		opts+=" --no-uuid -n"
 			;;
-		"vs-fw-activate-history")
+		"fw-activate-history")
 		opts+=" --output-format= -o"
 			;;
 		"device-capability-log")

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -22,7 +22,7 @@ PLUGIN(NAME("ocp", "OCP cloud SSD extensions", NVME_VERSION),
 		ENTRY("clear-fw-activate-history", "Clear firmware update history log", clear_fw_update_history)
 		ENTRY("eol-plp-failure-mode", "Define EOL or PLP circuitry failure mode.", eol_plp_failure_mode)
 		ENTRY("clear-pcie-correctable-error-counters", "Clear PCIe correctable error counters", clear_pcie_corectable_error_counters)
-		ENTRY("vs-fw-activate-history", "Get firmware activation history log", fw_activation_history_log)
+		ENTRY("fw-activate-history", "Get firmware activation history log", fw_activation_history_log)
 		ENTRY("unsupported-reqs-log", "Get Unsupported Requirements Log Page", ocp_unsupported_requirements_log)
 		ENTRY("error-recovery-log", "Retrieve Error Recovery Log Page", ocp_error_recovery_log)
 		ENTRY("device-capability-log", "Get Device capabilities Requirements Log Page", ocp_device_capabilities_log)


### PR DESCRIPTION
Get rid of the "vs-" prefix in the fw-activate-history command to bring it in line with the other command names