### PR TITLE
nvme: Use correct metadata buffer size

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -7657,7 +7657,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		.storage_tag	= cfg.storage_tag,
 		.data_len	= buffer_size,
 		.data		= buffer,
-		.metadata_len	= cfg.metadata_size,
+		.metadata_len	= mbuffer_size,
 		.metadata	= mbuffer,
 		.timeout	= NVME_DEFAULT_IOCTL_TIMEOUT,
 		.result		= NULL,


### PR DESCRIPTION
The submit_io command is using the metadata buffer size provided by the user. But this size argument might be updated and the correct length for the mbuffer is mbuffer_size. Thus use this value and not the initial length.

Fixes: 18de3a6d61a7 ("Convert to libnvme")

Fixes: #1967 