### PR TITLE
nvme: Use correct data buffer size

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -7672,7 +7672,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	} else if (err) {
 		nvme_show_status(err);
 	} else {
-		if (!(opcode & 1) && write(dfd, (void *)buffer, cfg.data_size) < 0) {
+		if (!(opcode & 1) && write(dfd, (void *)buffer, buffer_size) < 0) {
 			nvme_show_error("write: %s: failed to write buffer to output file",
 				strerror(errno));
 			err = -EINVAL;


### PR DESCRIPTION
The submit_io command is using the buffer size provided by the user. But this size argument might be updated and the correct length for the buffer is buffer_size. Thus use this value and not the initial length.

Fixes: #1967