### PR TITLE
nvme-print: Print PCI physical slot number with -v switch

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2526,6 +2526,7 @@ static void json_detail_list(nvme_root_t r)
 				json_object_add_value_string(jctrl, "Firmware", nvme_ctrl_get_firmware(c));
 				json_object_add_value_string(jctrl, "Transport", nvme_ctrl_get_transport(c));
 				json_object_add_value_string(jctrl, "Address", nvme_ctrl_get_address(c));
+				json_object_add_value_string(jctrl, "Slot", nvme_ctrl_get_phy_slot(c));
 
 				nvme_ctrl_for_each_ns(c, n) {
 					struct json_object *jns = json_create_object();

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4462,23 +4462,24 @@ static void stdout_detailed_list(nvme_root_t r)
 	}
 	printf("\n");
 
-	printf("%-8s %-20s %-40s %-8s %-6s %-14s %-12s %-16s\n", "Device",
-		"SN", "MN", "FR", "TxPort", "Address", "Subsystem", "Namespaces");
-	printf("%-.8s %-.20s %-.40s %-.8s %-.6s %-.14s %-.12s %-.16s\n", dash, dash,
-		dash, dash, dash, dash, dash, dash);
+	printf("%-8s %-20s %-40s %-8s %-6s %-14s %-6s %-12s %-16s\n", "Device",
+		"SN", "MN", "FR", "TxPort", "Address", "Slot", "Subsystem", "Namespaces");
+	printf("%-.8s %-.20s %-.40s %-.8s %-.6s %-.14s %-.6s %-.12s %-.16s\n", dash,
+		dash, dash, dash, dash, dash, dash, dash, dash);
 
 	nvme_for_each_host(r, h) {
 		nvme_for_each_subsystem(h, s) {
 			nvme_subsystem_for_each_ctrl(s, c) {
 				bool first = true;
 
-				printf("%-8s %-20s %-40s %-8s %-6s %-14s %-12s ",
+				printf("%-8s %-20s %-40s %-8s %-6s %-14s %-6s %-12s ",
 				       nvme_ctrl_get_name(c),
 				       nvme_ctrl_get_serial(c),
 				       nvme_ctrl_get_model(c),
 				       nvme_ctrl_get_firmware(c),
 				       nvme_ctrl_get_transport(c),
 				       nvme_ctrl_get_address(c),
+				       nvme_ctrl_get_phy_slot(c),
 				       nvme_subsystem_get_name(s));
 
 				nvme_ctrl_for_each_ns(c, n) {

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = ef27cf88b1aeed3ba778740f5f71dbd98a79073d
+revision = 42ac4535963556610a5bba8d1277c5a398a6ed5a
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
https://github.com/linux-nvme/libnvme/pull/657 adds PCI physical slot information to the controller.

This PR prints the Slot number in detailed/verbose output on stdout. JSON object is also updated to include the Slot number in detailed list.