### PR TITLE
fabrics: only look for matching ctrl on same host

### DIFF
--- a/fabrics.h
+++ b/fabrics.h
@@ -11,7 +11,7 @@ struct tr_config {
 	const char *trsvcid;
 };
 
-extern nvme_ctrl_t lookup_ctrl(nvme_root_t r, struct tr_config *trcfg);
+extern nvme_ctrl_t lookup_ctrl(nvme_host_t h, struct tr_config *trcfg);
 extern int nvmf_discover(const char *desc, int argc, char **argv, bool connect);
 extern int nvmf_connect(const char *desc, int argc, char **argv);
 extern int nvmf_disconnect(const char *desc, int argc, char **argv);

--- a/nbft.c
+++ b/nbft.c
@@ -144,7 +144,7 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 				};
 
 				/* Already connected ? */
-				cl = lookup_ctrl(r, &trcfg);
+				cl = lookup_ctrl(h, &trcfg);
 				if (cl && nvme_ctrl_get_name(cl))
 					continue;
 
@@ -170,7 +170,7 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 					nvme_free_ctrl(c);
 
 					trcfg.host_traddr = NULL;
-					cl = lookup_ctrl(r, &trcfg);
+					cl = lookup_ctrl(h, &trcfg);
 					if (cl && nvme_ctrl_get_name(cl))
 						continue;
 


### PR DESCRIPTION
With the `lookup_ctrl()` check to prevent duplicate connections, identical connections from different hosts are no longer possible. Fix `lookup_ctrl()` to only look for matching controllers on the same host that is being connected.
This restores the ability for multiple hosts on the same machine to connect to the same transport addresses on the same subsystem.

Fixes: 07d6b91 ("fabrics: Do not attempt to reconnect to already connected ctrls")

Previous behavior: `nvme connect` and `nvme connect-all` won't make another connection to the same address from a different host NQN because the address is considered already connected
```
$ nvme connect --transport tcp --traddr 192.168.2.182 --nqn nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d --hostnqn hostnqn1
$ nvme list-subsys
nvme-subsys0 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme0 tcp traddr=192.168.2.182,trsvcid=4420 live
$ nvme connect --transport tcp --traddr 192.168.2.182 --nqn nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d --hostnqn hostnqn2
already connected
$ nvme list-subsys
nvme-subsys0 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme0 tcp traddr=192.168.2.182,trsvcid=4420 live
$ cat /sys/class/nvme/*/hostnqn
hostnqn1
```
```
$ nvme connect-all --transport tcp --traddr 192.168.2.182 --hostnqn hostnqn1
$ nvme list-subsys
nvme-subsys1 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme2 tcp traddr=192.168.4.182,trsvcid=4420 live
 +- nvme1 tcp traddr=192.168.2.182,trsvcid=4420 live
$ nvme connect-all --transport tcp --traddr 192.168.2.182 --hostnqn hostnqn2
$ nvme list-subsys
nvme-subsys1 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme2 tcp traddr=192.168.4.182,trsvcid=4420 live
 +- nvme1 tcp traddr=192.168.2.182,trsvcid=4420 live
$ cat /sys/class/nvme/*/hostnqn
hostnqn1
hostnqn1
```

With this change, the connection from a different host NQN succeeds. Creating multiple connections from the same host NQN still fails:
```
$ nvme connect --transport tcp --traddr 192.168.2.182 --nqn nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d --hostnqn hostnqn1
$ nvme connect --transport tcp --traddr 192.168.2.182 --nqn nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d --hostnqn hostnqn2
$ nvme list-subsys
nvme-subsys0 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme1 tcp traddr=192.168.2.182,trsvcid=4420 live
nvme-subsys0 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme0 tcp traddr=192.168.2.182,trsvcid=4420 live
$ cat /sys/class/nvme/*/hostnqn
hostnqn1
hostnqn2
$ nvme connect --transport tcp --traddr 192.168.2.182 --nqn nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d --hostnqn hostnqn1
already connected
$ nvme connect --transport tcp --traddr 192.168.2.182 --nqn nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d --hostnqn hostnqn2
already connected
```
```
$ nvme connect-all --transport tcp --traddr 192.168.2.182 --hostnqn hostnqn1
$ nvme connect-all --transport tcp --traddr 192.168.2.182 --hostnqn hostnqn2
$ nvme list-subsys
nvme-subsys1 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme4 tcp traddr=192.168.4.182,trsvcid=4420 live
 +- nvme3 tcp traddr=192.168.2.182,trsvcid=4420 live
nvme-subsys1 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme2 tcp traddr=192.168.4.182,trsvcid=4420 live
 +- nvme1 tcp traddr=192.168.2.182,trsvcid=4420 live
$ cat /sys/class/nvme/*/hostnqn
hostnqn1
hostnqn1
hostnqn2
hostnqn2
$ nvme connect-all --transport tcp --traddr 192.168.2.182 --hostnqn hostnqn1
$ nvme connect-all --transport tcp --traddr 192.168.2.182 --hostnqn hostnqn2
$ nvme list-subsys
nvme-subsys1 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme4 tcp traddr=192.168.4.182,trsvcid=4420 live
 +- nvme3 tcp traddr=192.168.2.182,trsvcid=4420 live
nvme-subsys1 - NQN=nqn.2010-06.com.purestorage:flasharray.49d21803c4201f6d
\
 +- nvme2 tcp traddr=192.168.4.182,trsvcid=4420 live
 +- nvme1 tcp traddr=192.168.2.182,trsvcid=4420 live
```