### PR TITLE
nvme-print: fix counter while looping through uuid_list

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2378,8 +2378,8 @@ static void json_nvme_id_uuid_list(const struct nvme_id_uuid_list *uuid_list)
 
 	root = json_create_object();
 	entries = json_create_array();
-	/* The 0th entry is reserved */
-	for (i = 1; i < NVME_ID_UUID_LIST_MAX; i++) {
+
+	for (i = 0; i < NVME_ID_UUID_LIST_MAX; i++) {
 		__u8 uuid[NVME_UUID_LEN];
 		struct json_object *entry = json_create_object();
 

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3207,8 +3207,8 @@ static void stdout_id_uuid_list(const struct nvme_id_uuid_list *uuid_list)
 {
 	int i, human = stdout_print_ops.flags & VERBOSE;
 
-	/* The 0th entry is reserved */
 	printf("NVME Identify UUID:\n");
+
 	for (i = 0; i < NVME_ID_UUID_LIST_MAX; i++) {
 		__u8 uuid[NVME_UUID_LEN];
 		char *association = "";


### PR DESCRIPTION
While iterating through the uuid_list in json_nvme_id_uuid_list() as part of the 'id-uuid' json output, it always misses out displaying the first uuid entry here due to wrongly initialized counter value. Fix it.

And while we are at it, remove the respective comment in stdout_id_uuid_list() as well where this counter is already properly initiatlized.