### PR TITLE
nvme-print-stdout: List only ctrls which are part of ns

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4674,6 +4674,7 @@ static bool stdout_detailed_ns(const char *name, void *arg)
 	struct htable_ns_iter it;
 	struct strset ctrls;
 	nvme_ctrl_t c;
+	nvme_path_t p;
 	nvme_ns_t n;
 	bool first;
 
@@ -4693,8 +4694,10 @@ static bool stdout_detailed_ns(const char *name, void *arg)
 			return true;
 		}
 
-		nvme_subsystem_for_each_ctrl(nvme_ns_get_subsystem(n), c)
+		nvme_namespace_for_each_path(n, p) {
+			c = nvme_path_get_ctrl(p);
 			strset_add(&ctrls, nvme_ctrl_get_name(c));
+		}
 	}
 
 	first = true;


### PR DESCRIPTION
We should only list the controllers which are associated with the current namespace. Previously we added all controllers of the subsystem to the list.

Fixes: a660c506906d ("nvme-print-stdout: Support subsys reachable from several hosts")