### PR TITLE
json: fix seg. fault converting NULL to JSON string

### DIFF
--- a/util/json.h
+++ b/util/json.h
@@ -28,16 +28,18 @@
 	json_object_object_add(o, k, util_json_object_new_double(v))
 #define json_object_add_value_float(o, k, v) \
 	json_object_object_add(o, k, json_object_new_double(v))
-#define json_object_add_value_string(o, k, v) \
-	json_object_object_add(o, k, json_object_new_string(v))
+static inline int json_object_add_value_string(struct json_object *o, const char *k, const char *v) {
+	return json_object_object_add(o, k, v ? json_object_new_string(v) : NULL);
+}
 #define json_object_add_value_array(o, k, v) \
 	json_object_object_add(o, k, v)
 #define json_object_add_value_object(o, k, v) \
 	json_object_object_add(o, k, v)
 #define json_array_add_value_object(o, k) \
 	json_object_array_add(o, k)
-#define json_array_add_value_string(o, v) \
-	json_object_array_add(o, json_object_new_string(v))
+static inline int json_array_add_value_string(struct json_object *o, const char *v) {
+	return json_object_array_add(o, v ? json_object_new_string(v) : NULL);
+}
 #define json_print_object(o, u)						\
 	printf("%s", json_object_to_json_string_ext(o,			\
 		JSON_C_TO_STRING_PRETTY |				\


### PR DESCRIPTION
The function `json_object_new_string()` seg. faults when passed a `NULL` pointer. This can happen, for example, when parameters returned by a controller (e.g. Firmware, Model Number, Serial Number, etc.) are undefined and therefore `NULL`. 

This causes the following command to crash:
`nvme list -v -o json`

Note that I had to convert the macros (`#define`) to `static inline` functions. This is to prevent the compiler from generating a lot of `condition always true` warnings for the case where `v` (the pointer that we're checking for `NULL`) is a static string (and hence never `NULL`).