### PR TITLE
util: Set errno to 0 before strtol/stroul call

### DIFF
--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -164,6 +164,8 @@ static int argconfig_parse_type(struct argconfig_commandline_options *s, struct 
 	char *endptr;
 	int ret = 0;
 
+	errno = 0;    /* To distinguish success/failure after strtol/stroul call */
+
 	switch (s->config_type) {
 	case CFG_STRING:
 		*((char **)value) = optarg;


### PR DESCRIPTION
In order to be able to distinguish between success/failure case when calling strtol/stroul we set errno explicitly to 0.

Fixes: #2030 