### PR TITLE
nvme: Update list secondary command

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -106,11 +106,11 @@ int nvme_cli_identify_primary_ctrl(struct nvme_dev *dev, __u32 nsid,
 	return do_admin_op(identify_primary_ctrl, dev, nsid, cap);
 }
 
-int nvme_cli_identify_secondary_ctrl_list(struct nvme_dev *dev, __u32 nsid,
+int nvme_cli_identify_secondary_ctrl_list(struct nvme_dev *dev,
 					  __u16 ctrl_id,
 					  struct nvme_secondary_ctrl_list *sc_list)
 {
-	return do_admin_op(identify_secondary_ctrl_list, dev, nsid, ctrl_id,
+	return do_admin_op(identify_secondary_ctrl_list, dev, ctrl_id,
 			   sc_list);
 }
 

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -28,7 +28,7 @@ int nvme_cli_identify_allocated_ns_list(struct nvme_dev *dev, __u32 nsid,
 					struct nvme_ns_list *list);
 int nvme_cli_identify_primary_ctrl(struct nvme_dev *dev, __u32 nsid,
 				   struct nvme_primary_ctrl_cap *cap);
-int nvme_cli_identify_secondary_ctrl_list(struct nvme_dev *dev, __u32 nsid,
+int nvme_cli_identify_secondary_ctrl_list(struct nvme_dev *dev,
 					  __u16 ctrl_id,
 					  struct nvme_secondary_ctrl_list *sc_list);
 int nvme_cli_ns_mgmt_delete(struct nvme_dev *dev, __u32 nsid);

--- a/nvme.c
+++ b/nvme.c
@@ -4314,21 +4314,18 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 
 	struct config {
 		__u16	cntid;
-		__u32	namespace_id;
 		__u32	num_entries;
 		char	*output_format;
 	};
 
 	struct config cfg = {
 		.cntid		= 0,
-		.namespace_id	= 0,
 		.num_entries	= ARRAY_SIZE(sc_list->sc_entry),
 		.output_format	= "normal",
 	};
 
 	OPT_ARGS(opts) = {
 		OPT_SHRT("cntid",        'c', &cfg.cntid,         controller),
-		OPT_UINT("namespace-id", 'n', &cfg.namespace_id,  namespace_id_optional),
 		OPT_UINT("num-entries",  'e', &cfg.num_entries,   num_entries),
 		OPT_FMT("output-format", 'o', &cfg.output_format, output_format),
 		OPT_END()
@@ -4356,7 +4353,7 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 		goto close_err;
 	}
 
-	err = nvme_cli_identify_secondary_ctrl_list(dev, cfg.namespace_id, cfg.cntid, sc_list);
+	err = nvme_cli_identify_secondary_ctrl_list(dev, cfg.cntid, sc_list);
 	if (!err)
 		nvme_show_list_secondary_ctrl(sc_list, cfg.num_entries, flags);
 	else if (err > 0)

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = f0043495c0ff3c7a4f6d0cbc534b1d8d5c418023
+revision = 27c3a37a3c2c7b4b568e394c9935348d61cfcefa
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
The nsid argument of the  nvme_{mi_admin}_identify_secondary_ctrl_list
command has been removed. Update the call side accordingly.

Signed-off-by: Daniel Wagner <dwagner@suse.de>

Fixes: https://github.com/linux-nvme/libnvme/issues/700
