### PR TITLE
plugins/ocp: Add DSSD Power state feature(FID: C7h) 

### DIFF
--- a/Documentation/nvme-ocp-set-dssd-power-state-feature.txt
+++ b/Documentation/nvme-ocp-set-dssd-power-state-feature.txt
@@ -1,0 +1,42 @@
+set-dssd-power-state-feature(1)
+===============================
+
+NAME
+----
+nvme-ocp-set-dssd-power-state-feature - Set DSSD Power State
+
+SYNOPSIS
+--------
+[verse]
+'nvme ocp set-dssd-power-state-feature' <device> [--power-state=<fmt> | -p <fmt>] [--no-uuid | -n]
+                                                 [--save | -s]
+
+DESCRIPTION
+-----------
+For the NVMe device given, retrieves OCP DSSD Power state Feature
+
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0) or block device (ex: /dev/nvme0n1).
+
+This will only work on OCP compliant devices supporting this feature.
+Results for any other device are undefined.
+
+On success it returns 0, error code otherwise.
+
+OPTIONS
+-------
+-p <format>::
+--power-state=<format>::
+	DSSD Power State to set in watts.
+
+EXAMPLES
+--------
+* Has the program issue a set-dssd-power-state-feature command to set DSSD Power State to set in watts.
++
+------------
+# nvme ocp set-dssd-power-state-feature /dev/nvme0 -p <value> -s <value> -n <value>
+------------
+
+NVME
+----
+Part of the nvme-user suite.

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -237,6 +237,20 @@ _nvme () {
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp device-capability-log options" _device_capability_log
 				;;
+			(set-dssd-power-state-feature)
+				local _set_dssd_power_state_feature
+				_set_dssd_power_state_feature=(
+				/dev/nvme':supply a device to use (required)'
+				--power-state=':DSSD Power State to set in watts'
+				-p':alias for --power-state'
+				--save':Specifies that the controller shall save the attribute'
+				-s':alias for --save'
+				--no-uuid':Skip UUID index search'
+				-n':alias for --no-uuid'
+				)
+				_arguments '*:: :->subcmds'
+				_describe -t commands "nvme ocp set-dssd-power-state-feature options" _set_dssd_power_state_feature
+				;;
 			(*)
 				_files
 				;;
@@ -1993,6 +2007,7 @@ _nvme () {
 			clear-pcie-correctable-error-counters':Clear PCIe correctable error counters'
 			vs-fw-activate-history':Get firmware activation history log'
 			device-capability-log':Get Device capability log'
+			set-dssd-power-state-feature':Set DSSD Power State'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme ocp options" _ocp

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1348,6 +1348,9 @@ plugin_ocp_opts () {
 		"device-capability-log")
 		opts+=" --output-format= -o"
 			;;
+		"set-dssd-power-state-feature")
+		opts+=" --power-state= -p --no-uuid -n --save -s"
+			;;
 		"help")
 		opts+=$NO_OPTS
 			;;
@@ -1416,7 +1419,8 @@ _nvme_subcmds () {
 			set-latency-monitor-feature internal-log \
 			clear-fw-activate-history eol-plp-failure-mode \
 			clear-pcie-correctable-error-counters \
-			vs-fw-activate-history device-capability-log"
+			vs-fw-activate-history device-capability-log \
+			set-dssd-power-state-feature"
 	)
 
 	# Associative array mapping plugins to coresponding option completions

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -26,6 +26,7 @@ PLUGIN(NAME("ocp", "OCP cloud SSD extensions", NVME_VERSION),
 		ENTRY("unsupported-reqs-log", "Get Unsupported Requirements Log Page", ocp_unsupported_requirements_log)
 		ENTRY("error-recovery-log", "Retrieve Error Recovery Log Page", ocp_error_recovery_log)
 		ENTRY("device-capability-log", "Get Device capabilities Requirements Log Page", ocp_device_capabilities_log)
+		ENTRY("set-dssd-power-state-feature", "Get Device capabilities Requirements Log Page", set_dssd_power_state_feature)
 	)
 );
 


### PR DESCRIPTION
Added DSSD Power state feature(FID: C7h) in OCP plugin and related documentation, bash completion in respective directory.