### PR TITLE
build: use prebuild containers for builds

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -13,24 +13,14 @@ jobs:
   build-appimage:
     name: build AppImage
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/igaw/linux-nvme/debian:0.36
     steps:
-      - uses: actions/checkout@v3
-      - name: install dependencies
-        run: sudo apt-get install libjson-c-dev libssl-dev libdbus-1-dev libhugetlbfs-dev
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - uses: BSFishy/meson-build@v1.0.3
-        with:
-          setup-options: >
-            --werror
-            --buildtype=release
-            --prefix=/usr
-            --force-fallback-for=libnvme
-            -Dlibnvme:werror=false
-          action: install
-          meson-version: 0.61.2
-      - name: build AppImage
+     - uses: actions/checkout@v3
+     - name: build
+        run: |
+          scripts/build.sh appimage
+     - name: build AppImage
         uses: AppImageCrafters/build-appimage@v1.3
         with:
           recipe: .github/AppImageBuilder.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,9 @@ jobs:
         compiler: [gcc, clang]
         buildtype: [debug, release]
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.30
+      image: ghcr.io/igaw/linux-nvme/debian.python:0.36
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
       - name: build
         run: |
           scripts/build.sh -b ${{ matrix.buildtype }} -c ${{ matrix.compiler }}
@@ -40,33 +37,22 @@ jobs:
       matrix:
         include:
           - arch: armhf
-            port: armhf
-            compiler: gcc-arm-linux-gnueabihf
-            packages:
           - arch: s390x
-            port: s390x
-            compiler: gcc-s390x-linux-gnu
-            packages: libgcc-s1:s390x
           - arch: ppc64le
-            port: ppc64el
-            compiler: gcc-powerpc64le-linux-gnu
-            packges:
     steps:
       - uses: actions/checkout@v3
-      - name: set up arm architecture
-        run: |
-          export release=$(lsb_release -c -s)
-          sudo dpkg --add-architecture ${{ matrix.port }}
-          sudo sed -i -e 's/deb http/deb [arch=amd64] http/g' /etc/apt/sources.list
-          sudo dd of=/etc/apt/sources.list.d/${{ matrix.arch }}.list <<EOF
-          deb [arch=${{ matrix.port }}] http://ports.ubuntu.com/ $release main universe restricted"
-          deb [arch=${{ matrix.port }}] http://ports.ubuntu.com/ $release-updates main universe restricted"
-          EOF
-          sudo apt update
-          sudo apt install -y meson pkg-config qemu-user-static ${{ matrix.compiler}} libjson-c-dev:${{ matrix.port }} ${{ matrix.packages }}
-      - name: build
-        run: |
-          scripts/build.sh -b release -c gcc -t ${{ matrix.arch }} cross
+      - name: enable foreign arch
+        uses: dbhi/qus/action@main
+      - name: compile and run unit tests
+        uses: mosteo-actions/docker-run@v1
+        with:
+          image: ghcr.io/igaw/linux-nvme/ubuntu-cross-${{ matrix.arch }}:0.36
+          guest-dir: /build
+          host-dir: ${{ github.workspace }}
+          command: |
+            scripts/build.sh -b release -c gcc -t ${{ matrix.arch }} cross
+          params: "--platform linux/amd64"
+          pull-params: "--platform linux/amd64"
       - uses: actions/upload-artifact@v3
         name: upload logs
         if: failure()
@@ -79,13 +65,10 @@ jobs:
     name: fallback shared libraries
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.30
+      image: ghcr.io/igaw/linux-nvme/debian:0.36
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
       - name: build
         run: |
           scripts/build.sh -b release -c gcc fallback
@@ -100,7 +83,7 @@ jobs:
     name: muon minimal static
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.30
+      image: ghcr.io/igaw/linux-nvme/debian:0.36
     steps:
       - uses: actions/checkout@v3
       - name: build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,21 @@
+---
+name: coverage
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  code-coverage:
+    name: code coverage
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/igaw/linux-nvme/debian.python:0.36
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: |
+          scripts/build.sh coverage
+      - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: false

--- a/meson.build
+++ b/meson.build
@@ -157,6 +157,11 @@ conf.set10(
     ),
     description: 'Is sys/random.h(getrandom) include-able?'
 )
+conf.set10(
+    'HAVE_ATTRIBUTE_UNUSED',
+    cc.get_id() == 'clang',
+    description: 'Is compiler warning about unused static line function?'
+)
 
 if cc.has_function_attribute('fallthrough')
   conf.set('fallthrough', '__attribute__((__fallthrough__))')


### PR DESCRIPTION
The builds keep failing because the install step fails. Use prebuild containers which contain all the dependencies.

While at it, also add a coverage build.