### PR TITLE
build: use latest container instead fixed version

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -14,7 +14,7 @@ jobs:
     name: build AppImage
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.36
+      image: ghcr.io/igaw/linux-nvme/debian:latest
     steps:
      - uses: actions/checkout@v3
      - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         compiler: [gcc, clang]
         buildtype: [debug, release]
     container:
-      image: ghcr.io/igaw/linux-nvme/debian.python:0.36
+      image: ghcr.io/igaw/linux-nvme/debian.python:latest
     steps:
       - uses: actions/checkout@v3
       - name: build
@@ -46,7 +46,7 @@ jobs:
       - name: compile and run unit tests
         uses: mosteo-actions/docker-run@v1
         with:
-          image: ghcr.io/igaw/linux-nvme/ubuntu-cross-${{ matrix.arch }}:0.36
+          image: ghcr.io/igaw/linux-nvme/ubuntu-cross-${{ matrix.arch }}:latest
           guest-dir: /build
           host-dir: ${{ github.workspace }}
           command: |
@@ -65,7 +65,7 @@ jobs:
     name: fallback shared libraries
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.36
+      image: ghcr.io/igaw/linux-nvme/debian:latest
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
     name: muon minimal static
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian:0.36
+      image: ghcr.io/igaw/linux-nvme/debian:latest
     steps:
       - uses: actions/checkout@v3
       - name: build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     name: code coverage
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/igaw/linux-nvme/debian.python:0.36
+      image: ghcr.io/igaw/linux-nvme/debian.python:latest
     steps:
       - uses: actions/checkout@v3
       - name: build


### PR DESCRIPTION
We control the build containers so there is little risk that these randomly break. So let's go with the latest version and avoid updating the build files all the time.