### PR TITLE
fabrics: Move duplicate code to libnvme

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 9fd8a963393f0bb1b3328aa2c4abd151562d67ab
+revision = 18b3316c502f229a5339d2c283510ec8008ec3b9
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Removing duplicate code and moving to libnvme. This nvme-cli patch depends on libnvme commit 18b3316c502f229a5339d2c283510ec8008ec3b9.

Depends-on: https://github.com/linux-nvme/libnvme/pull/716

Some of the checks will fail until the above PR has been merged on libnvme.