### PR TITLE
tree: Modify label name close_fd to close_dev

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -532,7 +532,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	err = flags = validate_output_format(cfg.output_format);
 	if (err < 0) {
 		nvme_show_error("Invalid output format");
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.raw_binary)
@@ -550,7 +550,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 		nvme_show_status(err);
 	else
 		nvme_show_error("smart log: %s", nvme_strerror(errno));
-close_fd:
+close_dev:
 	dev_close(dev);
 ret:
 	return err;
@@ -593,14 +593,14 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	err = flags = validate_output_format(cfg.output_format);
 	if (err < 0) {
 		nvme_show_error("Invalid output format");
-		goto close_fd;
+		goto close_dev;
 	}
 
 	err = nvme_cli_identify_ctrl(dev, &ctrl);
 	if (err) {
 		nvme_show_error("ERROR : nvme_identify_ctrl() failed: %s",
 			nvme_strerror(errno));
-		goto close_fd;
+		goto close_dev;
 	}
 
 	ana_log_len = sizeof(struct nvme_ana_log) +
@@ -611,7 +611,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	ana_log = malloc(ana_log_len);
 	if (!ana_log) {
 		err = -ENOMEM;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	lsp = cfg.groups ? NVME_LOG_ANA_LSP_RGO_GROUPS_ONLY :
@@ -625,7 +625,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 	else
 		nvme_show_error("ana-log: %s", nvme_strerror(errno));
 	free(ana_log);
-close_fd:
+close_dev:
 	dev_close(dev);
 ret:
 	return err;
@@ -4166,12 +4166,12 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 	if (err < 0) {
 		nvme_show_error("get namespace ID: %s", nvme_strerror(errno));
 		err = errno;
-		goto close_fd;
+		goto close_dev;
 	}
 	err = 0;
 	printf("%s: namespace-id:%d\n", dev->name, nsid);
 
-close_fd:
+close_dev:
 	dev_close(dev);
 ret:
 	return err;

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1065,7 +1065,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 	media_version[1] = (data[3] << 8) | data[2];
 
 	if (err)
-		goto close_fd;
+		goto close_dev;
 
 	if (media_version[0] == 1000) {
 		__u32 thresholds[OPTANE_V1000_BUCKET_LEN] = {0};
@@ -1088,7 +1088,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 		if (err) {
 			fprintf(stderr, "Quering thresholds failed. ");
 			nvme_show_status(err);
-			goto close_fd;
+			goto close_dev;
 		}
 
 		/* Update bucket thresholds to be printed */
@@ -1124,7 +1124,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *cmd, struct 
 			      sizeof(stats));
 	}
 
-close_fd:
+close_dev:
 	dev_close(dev);
 	return err;
 }

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -9451,7 +9451,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 	    cfg.log_id != NVME_LOG_LID_TELEMETRY_CTRL) {
 		fprintf(stderr, "ERROR: WDC: Invalid Log ID. It must be 7 (Host) or 8 (Controller)\n");
 		ret = -1;
-		goto close_fd;
+		goto close_dev;
 	}
 
 	if (cfg.file) {
@@ -9462,7 +9462,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 		if (verify_file < 0) {
 			fprintf(stderr, "ERROR: WDC: open: %s\n", strerror(errno));
 			ret = -1;
-			goto close_fd;
+			goto close_dev;
 		}
 		close(verify_file);
 		strncpy(f, cfg.file, PATH_MAX - 1);
@@ -9480,12 +9480,12 @@ static int wdc_reason_identifier(int argc, char **argv,
 		if (wdc_get_serial_name(dev, f, PATH_MAX, fileSuffix) == -1) {
 			fprintf(stderr, "ERROR: WDC: failed to generate file name\n");
 			ret = -1;
-			goto close_fd;
+			goto close_dev;
 		}
 		if (strlen(f) > PATH_MAX - 5) {
 			fprintf(stderr, "ERROR: WDC: file name overflow\n");
 			ret = -1;
-			goto close_fd;
+			goto close_dev;
 		}
 		strcat(f, ".bin");
 	}
@@ -9502,7 +9502,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 
 	nvme_show_status(ret);
 
-close_fd:
+close_dev:
 	dev_close(dev);
 	nvme_free_tree(r);
 	return ret;

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -137,7 +137,7 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
 
 	err = flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	err = nvme_zns_identify_ctrl(dev_fd(dev), &ctrl);
 	if (!err)
@@ -146,7 +146,7 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
 		nvme_show_status(err);
 	else
 		perror("zns identify controller");
-close_fd:
+close_dev:
 	dev_close(dev);
 	return err;
 }
@@ -190,7 +190,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 
 	flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 	if (cfg.vendor_specific)
 		flags |= VS;
 	if (cfg.human_readable)
@@ -200,14 +200,14 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
 		if (err < 0) {
 			perror("get-namespace-id");
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
 	err = nvme_identify_ns(dev_fd(dev), cfg.namespace_id, &id_ns);
 	if (err) {
 		nvme_show_status(err);
-		goto close_fd;
+		goto close_dev;
 	}
 
 	err = nvme_zns_identify_ns(dev_fd(dev), cfg.namespace_id, &ns);
@@ -217,7 +217,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 		nvme_show_status(err);
 	else
 		perror("zns identify namespace");
-close_fd:
+close_dev:
 	dev_close(dev);
 	return err;
 }
@@ -1258,13 +1258,13 @@ static int changed_zone_list(int argc, char **argv, struct command *cmd, struct 
 
 	flags = validate_output_format(cfg.output_format);
 	if (flags < 0)
-		goto close_fd;
+		goto close_dev;
 
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
 		if (err < 0) {
 			perror("get-namespace-id");
-			goto close_fd;
+			goto close_dev;
 		}
 	}
 
@@ -1277,7 +1277,7 @@ static int changed_zone_list(int argc, char **argv, struct command *cmd, struct 
 	else
 		perror("zns changed-zone-list");
 
-close_fd:
+close_dev:
 	dev_close(dev);
 	return err;
 }


### PR DESCRIPTION
Use same label name for same purpose
it was missing modification of 11542bbdb1c1ad7b1f425925ce474c7ce06162d0