### PR TITLE
 nvme: allocate aligned payloads for all nvme commands

### DIFF
--- a/nvme-print.h
+++ b/nvme-print.h
@@ -8,8 +8,8 @@
 #include <ccan/list/list.h>
 
 typedef struct nvme_effects_log_node {
+	struct nvme_cmd_effects_log effects; /* needs to be first member because of alignment requirement. */
 	enum nvme_csi csi;
-	struct nvme_cmd_effects_log effects;
 	struct list_node node;
 } nvme_effects_log_node_t;
 

--- a/nvme.c
+++ b/nvme.c
@@ -183,7 +183,20 @@ static const char space[51] = {[0 ... 49] = ' ', '\0'};
 
 static void *mmap_registers(nvme_root_t r, struct nvme_dev *dev);
 
-static void *__nvme_alloc(size_t len, bool *huge)
+#define ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
+
+static void *nvme_alloc(size_t len)
+{
+	size_t _len = ROUND_UP(len, 0x1000);
+	void *p;
+
+	if (posix_memalign((void *)&p, getpagesize(), _len))
+		return NULL;
+
+	memset(p, 0, _len);
+	return p;
+}
+
 static void *__nvme_alloc_huge(size_t len, bool *huge)
 {
 	void *p;

--- a/nvme.c
+++ b/nvme.c
@@ -5037,10 +5037,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	} else if (cfg.xfer % 4096)
 		cfg.xfer = 4096;
 
-	if (cfg.xfer < HUGE_MIN)
-		fw_buf = __nvme_alloc(fw_size, &huge);
-	else
-		fw_buf = nvme_alloc(fw_size, &huge);
+	fw_buf = nvme_alloc(fw_size, &huge);
 
 	if (!fw_buf) {
 		err = -ENOMEM;

--- a/nvme.h
+++ b/nvme.h
@@ -29,6 +29,7 @@
 #include "plugin.h"
 #include "util/json.h"
 #include "util/argconfig.h"
+#include "util/cleanup.h"
 
 enum nvme_print_flags {
 	NORMAL	= 0,
@@ -100,6 +101,13 @@ int parse_and_open(struct nvme_dev **dev, int argc, char **argv, const char *des
 
 void dev_close(struct nvme_dev *dev);
 
+static inline void cleanup_nvme_dev(struct nvme_dev **dev)
+{
+	if (*dev)
+		dev_close(*dev);
+}
+#define _cleanup_nvme_dev_ __cleanup__(cleanup_nvme_dev)
+
 extern const char *output_format;
 
 enum nvme_print_flags validate_output_format(const char *format);
@@ -109,6 +117,7 @@ int __id_ctrl(int argc, char **argv, struct command *cmd,
 extern int current_index;
 void *nvme_alloc_huge(size_t len, bool *huge);
 void nvme_free_huge(void *p, bool huge);
+
 const char *nvme_strerror(int errnum);
 
 unsigned long long elapsed_utime(struct timeval start_time,

--- a/nvme.h
+++ b/nvme.h
@@ -107,8 +107,8 @@ int __id_ctrl(int argc, char **argv, struct command *cmd,
 	struct plugin *plugin, void (*vs)(uint8_t *vs, struct json_object *root));
 
 extern int current_index;
-void *nvme_alloc(size_t len, bool *huge);
-void nvme_free(void *p, bool huge);
+void *nvme_alloc_huge(size_t len, bool *huge);
+void nvme_free_huge(void *p, bool huge);
 const char *nvme_strerror(int errnum);
 
 unsigned long long elapsed_utime(struct timeval start_time,

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -1799,7 +1799,7 @@ static void GetGenericLogs(int fd, const char *dir)
 	}
 
 	log_len = le64_to_cpu(pevent_log.tll);
-	pevent_log_info = nvme_alloc(log_len, &huge);
+	pevent_log_info = nvme_alloc_huge(log_len, &huge);
 	if (!pevent_log_info) {
 		perror("could not alloc buffer for persistent event log page (ignored)!\n");
 		return;
@@ -1809,7 +1809,7 @@ static void GetGenericLogs(int fd, const char *dir)
 	if (!err)
 		WriteData((__u8 *)pevent_log_info, log_len, dir,
 			  "persistent_event_log.bin", "persistent event log");
-	nvme_free(pevent_log_info, huge);
+	nvme_free_huge(pevent_log_info, huge);
 }
 
 static void GetNSIDDInfo(int fd, const char *dir, int nsid)

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1410,7 +1410,7 @@ static int nvme_dump_evtlog(struct nvme_dev *dev, __u32 namespace_id, __u32 stor
 	if (log_len % 4)
 		log_len = (log_len / 4 + 1) * 4;
 
-	pevent_log_info = nvme_alloc(single_len, &huge);
+	pevent_log_info = nvme_alloc_huge(single_len, &huge);
 	if (!pevent_log_info) {
 		err = -ENOMEM;
 		goto free_pevent;
@@ -1453,8 +1453,8 @@ static int nvme_dump_evtlog(struct nvme_dev *dev, __u32 namespace_id, __u32 stor
 	printf("\nDump-evtlog: Success\n");
 
 	if (parse) {
-		nvme_free(pevent_log_info, huge);
-		pevent_log_info = nvme_alloc(log_len, &huge);
+		nvme_free_huge(pevent_log_info, huge);
+		pevent_log_info = nvme_alloc_huge(log_len, &huge);
 		if (!pevent_log_info) {
 			fprintf(stderr, "Failed to alloc enough memory 0x%x to parse evtlog\n", log_len);
 			err = -ENOMEM;
@@ -1479,7 +1479,7 @@ static int nvme_dump_evtlog(struct nvme_dev *dev, __u32 namespace_id, __u32 stor
 close_fd:
 	fclose(fd);
 free:
-	nvme_free(pevent_log_info, huge);
+	nvme_free_huge(pevent_log_info, huge);
 free_pevent:
 	free(pevent);
 ret:

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10386,7 +10386,7 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *command,
 		goto out;
 	}
 
-	pcieStatsPtr = nvme_alloc(pcie_stats_size, &huge);
+	pcieStatsPtr = nvme_alloc_huge(pcie_stats_size, &huge);
 	if (!pcieStatsPtr) {
 		fprintf(stderr, "ERROR: WDC: PCIE Stats alloc: %s\n", strerror(errno));
 		ret = -1;
@@ -10417,7 +10417,7 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *command,
 		}
 	}
 
-	nvme_free(pcieStatsPtr, huge);
+	nvme_free_huge(pcieStatsPtr, huge);
 
 out:
 	nvme_free_tree(r);

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -949,7 +949,7 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 	log_len = sizeof(struct nvme_zone_report) + ((sizeof(struct nvme_zns_desc) * nr_zones_chunks) + (nr_zones_chunks * zdes));
 	report_size = log_len;
 
-	report = nvme_alloc(report_size, &huge);
+	report = nvme_alloc_huge(report_size, &huge);
 	if (!report) {
 		perror("alloc");
 		err = -ENOMEM;
@@ -997,7 +997,7 @@ static int report_zones(int argc, char **argv, struct command *cmd, struct plugi
 			ops->zns_finish_zone_list(total_nr_zones, zone_list);
 	}
 
-	nvme_free(report, huge);
+	nvme_free_huge(report, huge);
 
 free_buff:
 	free(buff);

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -16,10 +16,10 @@ DECLARE_CLEANUP_FUNC(name, type)		\
 
 DECLARE_CLEANUP_FUNC(cleanup_charp, char *);
 
-static inline void freep(void *p) {
+static inline void freep(void *p)
+{
         free(*(void**) p);
 }
-
 #define _cleanup_free_ __cleanup__(freep)
 
 #endif

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -16,4 +16,10 @@ DECLARE_CLEANUP_FUNC(name, type)		\
 
 DECLARE_CLEANUP_FUNC(cleanup_charp, char *);
 
+static inline void freep(void *p) {
+        free(*(void**) p);
+}
+
+#define _cleanup_free_ __cleanup__(freep)
+
 #endif

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -2,6 +2,9 @@
 #ifndef __CLEANUP_H
 #define __CLEANUP_H
 
+#include <unistd.h>
+#include <stdlib.h>
+
 #define __cleanup__(fn) __attribute__((cleanup(fn)))
 
 #define DECLARE_CLEANUP_FUNC(name, type) \
@@ -21,5 +24,12 @@ static inline void freep(void *p)
         free(*(void**) p);
 }
 #define _cleanup_free_ __cleanup__(freep)
+
+static inline void close_file(int *f)
+{
+	if (*f >= 0)
+		close(*f);
+}
+#define _cleanup_file_ __cleanup__(close_file)
 
 #endif


### PR DESCRIPTION
The kernel supports since v5.2 direct mapped DMA buffers to userspace.
Up to this point a bounce buffer was involved. Because the buffers are
now directly accessed by the device, the rules of alignment also apply
for the payloads.

Furthermore, ensure that the buffer is a multiple of 4k, because there
are devices on the market which will always transfer a multiple of 4k,
even if we ask for less, e.g 512 bytes. This avoid stack smashes.

Fixes: #https://github.com/linux-nvme/libnvme/issues/684