### PR TITLE
Add Support for Phy rx eom log

### DIFF
--- a/Documentation/nvme-phy-rx-eom-log.txt
+++ b/Documentation/nvme-phy-rx-eom-log.txt
@@ -1,0 +1,59 @@
+nvme-phy-rx-eom-log(1)
+======================
+
+NAME
+----
+nvme-phy-rx-eom-log - Retrieves a Physical Interface Receiver Eye Opening Measurement log page from an NVMe device
+
+SYNOPSIS
+--------
+[verse]
+'nvme phy-rx-eom-log' <device> [--lsp=<field> | -s <field>]
+                    [--controller=<id> | -c <id>]
+                    [--output-format=<fmt> | -o <fmt>]
+
+DESCRIPTION
+-----------
+Retrieves a Physical Interface Receiver Eye Opening Measurement log page from
+an NVMe device and provides the returned structure.
+
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
+
+On success it returns 0, error code otherwise.
+
+OPTIONS
+-------
+-s <field>::
+--lsp=<field>::
+	The log specified field configuring the controller's action to take
+	during processing of the command and the measurement quality.
+
+-c <id>::
+--controller=<id>::
+	Controller ID of the controller associated wit the PCIe port to be
+	measured.
+
+-o <format>::
+--output-format=<format>::
+    Set the reporting format to 'normal', 'json', or
+    'binary'. Only one output format can be used at a time.
+
+EXAMPLES
+--------
+* Start a best quality measurement and retrieve the log page header 
++
+------------
+# nvme phy-rx-eom-log /dev/nvme0 --lsp=10
+------------
+
+* Retrieve a finished best quality measurement on controller with ID 3
++
+------------
+# nvme phy-rx-eom-log /dev/nvme0 --lsp=2 --controller=3
+------------
+
+
+NVME
+----
+Part of the nvme-user suite

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -49,6 +49,7 @@ COMMAND_LIST(
 	ENTRY("lba-status-log", "Retrieve LBA Status Information Log, show it", get_lba_status_log)
 	ENTRY("resv-notif-log", "Retrieve Reservation Notification Log, show it", get_resv_notif_log)
 	ENTRY("boot-part-log", "Retrieve Boot Partition Log, show it", get_boot_part_log)
+	ENTRY("phy-rx-eom-log", "Retrieve Physical Interface Receiver Eye Opening Measurement, show it", get_phy_rx_eom_log)
 	ENTRY("get-feature", "Get feature and show the resulting value", get_feature)
 	ENTRY("device-self-test", "Perform the necessary tests to observe the performance", device_self_test)
 	ENTRY("self-test-log", "Retrieve the SELF-TEST Log, show it", self_test_log)

--- a/nvme-print-binary.c
+++ b/nvme-print-binary.c
@@ -63,6 +63,18 @@ static void binary_boot_part_log(void *bp_log, const char *devname,
 	d_raw((unsigned char *)bp_log, size);
 }
 
+static void binary_phy_rx_eom_log(struct nvme_phy_rx_eom_log *log,
+	__u16 controller)
+{
+	size_t len;
+	if (log->eomip == NVME_PHY_RX_EOM_COMPLETED)
+		len = log->hsize + log->dsize * log->nd;
+	else
+		len = log->hsize;
+
+	d_raw((unsigned char *)log, len);
+}
+
 static void binary_media_unit_stat_log(struct nvme_media_unit_stat_log *mus_log)
 {
 	 d_raw((unsigned char *)mus_log, sizeof(*mus_log));
@@ -288,6 +300,7 @@ static void binary_discovery_log(struct nvmf_discovery_log *log, int numrec)
 static struct print_ops binary_print_ops = {
 	.ana_log			= binary_ana_log,
 	.boot_part_log			= binary_boot_part_log,
+	.phy_rx_eom_log			= binary_phy_rx_eom_log,
 	.ctrl_list			= binary_list_ctrl,
 	.ctrl_registers			= binary_ctrl_registers,
 	.directive			= binary_directive,

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -735,7 +735,7 @@ static void stdout_media_unit_stat_log(struct nvme_media_unit_stat_log *mus_log)
 static void stdout_fdp_config_fdpa(uint8_t fdpa)
 {
 	__u8 valid = (fdpa >> 7) & 0x1;
-	__u8 rsvd = (fdpa >> 5) >> 0x3;
+	__u8 rsvd = (fdpa >> 5) & 0x3;
 	__u8 fdpvwc = (fdpa >> 4) & 0x1;
 	__u8 rgif = fdpa & 0xf;
 

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -258,6 +258,12 @@ void nvme_show_boot_part_log(void *bp_log, const char *devname,
 	nvme_print(boot_part_log, flags, bp_log, devname, size);
 }
 
+void nvme_show_phy_rx_eom_log(struct nvme_phy_rx_eom_log *log, __u16 controller,
+	enum nvme_print_flags flags)
+{
+	nvme_print(phy_rx_eom_log, flags, log, controller);
+}
+
 void nvme_show_media_unit_stat_log(struct nvme_media_unit_stat_log *mus_log,
 				   enum nvme_print_flags flags)
 {

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -23,6 +23,7 @@ struct print_ops {
 	/* libnvme types.h print functions */
 	void (*ana_log)(struct nvme_ana_log *ana_log, const char *devname, size_t len);
 	void (*boot_part_log)(void *bp_log, const char *devname, __u32 size);
+	void (*phy_rx_eom_log)(struct nvme_phy_rx_eom_log *log, __u16 controller);
 	void (*ctrl_list)(struct nvme_ctrl_list *ctrl_list);
 	void (*ctrl_registers)(void *bar, bool fabrics);
 	void (*directive)(__u8 type, __u8 oper, __u16 spec, __u32 nsid, __u32 result, void *buf, __u32 len);
@@ -166,6 +167,8 @@ void nvme_show_resv_notif_log(struct nvme_resv_notification_log *resv,
 	const char *devname, enum nvme_print_flags flags);
 void nvme_show_boot_part_log(void *bp_log, const char *devname,
 	__u32 size, enum nvme_print_flags flags);
+void nvme_show_phy_rx_eom_log(struct nvme_phy_rx_eom_log *log,
+	__u16 controller, enum nvme_print_flags flags);
 void nvme_show_fid_support_effects_log(struct nvme_fid_supported_effects_log *fid_log,
 	const char *devname, enum nvme_print_flags flags);
 void nvme_show_mi_cmd_support_effects_log(struct nvme_mi_cmd_supported_effects_log *mi_cmd_log,

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -302,6 +302,12 @@ int nvme_cli_get_log_boot_partition(struct nvme_dev *dev, bool rae, __u8 lsp,
 	return do_admin_op(get_log_boot_partition, dev, rae, lsp, len, part);
 }
 
+int nvme_cli_get_log_phy_rx_eom(struct nvme_dev *dev, __u8 lsp, __u16 controller,
+				__u32 len, struct nvme_phy_rx_eom_log *part)
+{
+	return do_admin_op(get_log_phy_rx_eom, dev, lsp, controller, len, part);
+}
+
 int nvme_cli_get_log_discovery(struct nvme_dev *dev, bool rae,
 			       __u32 offset, __u32 len, void *log)
 {

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -105,6 +105,8 @@ int nvme_cli_get_log_mi_cmd_supported_effects(struct nvme_dev *dev, bool rae,
 int nvme_cli_get_log_boot_partition(struct nvme_dev *dev, bool rae, __u8 lsp,
 				    __u32 len,
 				    struct nvme_boot_partition *part);
+int nvme_cli_get_log_phy_rx_eom(struct nvme_dev *dev, __u8 lsp, __u16 controller,
+				__u32 len, struct nvme_phy_rx_eom_log *part);
 int nvme_cli_get_log_discovery(struct nvme_dev *dev, bool rae,
 			       __u32 offset, __u32 len, void *log);
 int nvme_cli_get_log_media_unit_stat(struct nvme_dev *dev, __u16 domid,


### PR DESCRIPTION
This primarily introduces a new command `phy-rx-eom-log` for getting that log page and allowing the user to specify the lsi/lsp values for it. These changes depend on libnvme commit `e923016`.

One question I have is how to handle failing allocations in `nvme-print-json.c`. Currently these changes just silently fail to include the printable eye data in the json root, but if there's some way this error should be reported I can make that change.

The second commit addresses a very minor bug obscuring non-zero reserved fields for fdpa. I could split this out into its own PR if that would be preferred, otherwise it seemed simple enough to include here as a separate commit.