### PR TITLE
udev-rule: apply round-robin iopolicy on i/o subsystems alone

### DIFF
--- a/nvmf-autoconnect/udev-rules/71-nvmf-iopolicy-netapp.rules.in
+++ b/nvmf-autoconnect/udev-rules/71-nvmf-iopolicy-netapp.rules.in
@@ -1,3 +1,3 @@
 # Enable round-robin for NetApp ONTAP and NetApp E-Series
-ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{model}=="NetApp ONTAP Controller", ATTR{iopolicy}="round-robin"
-ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{model}=="NetApp E-Series", ATTR{iopolicy}="round-robin"
+ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{subsystype}=="nvm", ATTR{model}=="NetApp ONTAP Controller", ATTR{iopolicy}="round-robin"
+ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{subsystype}=="nvm", ATTR{model}=="NetApp E-Series", ATTR{iopolicy}="round-robin"


### PR DESCRIPTION
The current 71-nvmf-iopolicy-netapp.rules.in sets the round-robin iopolicy not just on nvme i/o subsystems, but on discovery subsystems too. Update this rule to have this applied to i/o subsystems alone.


Cc: Clayton Skaggs <claytons@netapp.com>