### PR TITLE
completion: add 'version' and 'help' to list

### DIFF
--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1477,7 +1477,7 @@ _nvme_subcmds () {
 		_cmds+=" $plugin"
 	done
 
-	cmds+=" version help"
+	_cmds+=" version help"
 
 	if [[ ${#words[*]} -lt 3 ]]; then
 		COMPREPLY+=( $(compgen -W "$_cmds" -- $cur ) )


### PR DESCRIPTION
The variable containing the commands is call _cmds and not cmds, thus the tab completion didn't work for 'version' and 'help'.

Fixes: #1950