### PR TITLE
Fix utf-8 encoded number strings

### DIFF
--- a/unit/test-uint128.c
+++ b/unit/test-uint128.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <locale.h>
 
 #include "../util/types.h"
 
@@ -27,25 +28,36 @@ static void check_str(nvme_uint128_t val, const char *exp, const char *res)
 }
 
 struct tostr_test {
+	const char *locale;
 	nvme_uint128_t val;
 	const char *exp;
 };
 
 static struct tostr_test tostr_tests[] = {
-	{ U128(0, 0, 0, 0), "0" },
-	{ U128(0, 0, 0, 1), "1" },
-	{ U128(0, 0, 0, 10), "10" },
-	{ U128(4, 3, 2, 1), "316912650112397582603894390785" },
+	{ NULL, U128(0, 0, 0, 0),"0" },
+	{ NULL, U128(0, 0, 0, 1), "1" },
+	{ NULL, U128(0, 0, 0, 10), "10" },
+	{ NULL, U128(4, 3, 2, 1), "316912650112397582603894390785" },
 	{
+		NULL,
 		U128(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff),
 		"340282366920938463463374607431768211455"
 	},
+	{ "fr_FR.utf-8", U128(0, 0, 0, 1000), "1\u202f000" },
 };
 
 void tostr_test(struct tostr_test *test)
 {
 	char *str;
-	str = uint128_t_to_string(test->val);
+
+	if (!setlocale(LC_NUMERIC, test->locale))
+		return;
+
+	if (test->locale)
+		str = uint128_t_to_l10n_string(test->val);
+	else
+		str = uint128_t_to_string(test->val);
+
 	check_str(test->val, test->exp, str);
 }
 

--- a/util/types.c
+++ b/util/types.c
@@ -67,20 +67,21 @@ static char *__uint128_t_to_string(nvme_uint128_t val, bool l10n)
 	int idx = 60;
 	__u64 div, rem;
 	char *sep = NULL;
-	int i, len = 0;
+	int i, len = 0, cl = 0;
 
 	if (l10n) {
 		sep = localeconv()->thousands_sep;
 		len = strlen(sep);
+		cl = 1;
 	}
 
 	/* terminate at the end, and build up from the ones */
 	str[--idx] = '\0';
 
 	do {
-		if (len && !((sizeof(str) - idx) % (3 + len))) {
+		if (len && !((sizeof(str) - idx) % (3 + cl))) {
 			for (i = 0; i < len; i++)
-				str[--idx] = sep[i];
+				str[--idx] = sep[len - i - 1];
 		}
 
 		rem = val.words[0];


### PR DESCRIPTION
The separator char can be an utf-8 encoded symbol thus the length of the string is necessarly one.

Fix: #2061 