### PR TITLE
udev-rules: set ctrl_loss_tmo to -1 for ONTAP NVMe/TCP

### DIFF
--- a/nvmf-autoconnect/udev-rules/71-nvmf-iopolicy-netapp.rules.in
+++ b/nvmf-autoconnect/udev-rules/71-nvmf-iopolicy-netapp.rules.in
@@ -1,3 +1,6 @@
 # Enable round-robin for NetApp ONTAP and NetApp E-Series
 ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{subsystype}=="nvm", ATTR{model}=="NetApp ONTAP Controller", ATTR{iopolicy}="round-robin"
 ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{subsystype}=="nvm", ATTR{model}=="NetApp E-Series", ATTR{iopolicy}="round-robin"
+
+# Set ctrl_loss_tmo to -1 for NetApp ONTAP NVMe/TCP
+ACTION!="remove", SUBSYSTEM=="nvme", KERNEL=="nvme*", ATTR{transport}=="tcp", ATTR{model}=="NetApp ONTAP Controller", ATTR{ctrl_loss_tmo}="-1"


### PR DESCRIPTION
Setting ctrl_loss_tmo to -1 for ONTAP NVMe/TCP controllers would enable indefinite reconnect attempts during a path loss and help avoid purging the path on the host, which otherwise may lead to mounted fs read-only behavior. So add a rule towards enabling the same.