### PR TITLE
build: upload artifacts only for upstream repo

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -34,7 +34,7 @@ jobs:
     name: deploy AppImage
     runs-on: ubuntu-latest
     needs: build-appimage
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'linux-nvme/nvme-cli' }}
     steps:
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   code-coverage:
+    if: github.repository == 'linux-nvme/nvme-cli'
     name: code coverage
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linux-nvme/nvme-cli'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
There is no point trying to upload any artifacts to linux-nvme organization if it's a fork.