### PR TITLE
nvme: do not include meta data for PRACT=1 and MD=8

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -7297,8 +7297,15 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 
 	nvme_id_ns_flbas_to_lbaf_inuse(ns->flbas, &lba_index);
 	ms = ns->lbaf[lba_index].ms;
-	if (ns->flbas & NVME_NS_FLBAS_META_EXT)
-		logical_block_size += ms;
+	if (ns->flbas & NVME_NS_FLBAS_META_EXT) {
+		/*
+		 * No meta data is transfered for PRACT=1 and MD=8:
+		 *   5.2.2.1 Protection Information and Write Commands
+		 *   5.2.2.2 Protection Informatio and Read Commands
+		 */
+		if (!(cfg.prinfo == 0x1 && ms == 8))
+			logical_block_size += ms;
+	}
 
 	buffer_size = ((long long)cfg.block_count + 1) * logical_block_size;
 	if (cfg.data_size < buffer_size)

--- a/nvme.c
+++ b/nvme.c
@@ -7306,11 +7306,16 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	else
 		buffer_size = cfg.data_size;
 
-	/* Get the required block count. Note this is a zeroes based value. */
-	nblocks = ((buffer_size + (logical_block_size - 1)) / logical_block_size) - 1;
+	if (argconfig_parse_seen(opts, "block-count")) {
+		/* Use the value provided */
+		nblocks = cfg.block_count;
+	} else {
+		/* Get the required block count. Note this is a zeroes based value. */
+		nblocks = ((buffer_size + (logical_block_size - 1)) / logical_block_size) - 1;
 
-	/* Update the data size based on the required block count */
-	buffer_size = (nblocks + 1) * logical_block_size;
+		/* Update the data size based on the required block count */
+		buffer_size = (nblocks + 1) * logical_block_size;
+	}
 
 	buffer = nvme_alloc_huge(buffer_size, &huge);
 	if (!buffer) {


### PR DESCRIPTION
No meta data is transfered for PRACT=1 and MD=8:
   5.2.2.1 Protection Information and Write Commands
   5.2.2.2 Protection Informatio and Read Commands

Fixes: #2016
