### PR TITLE
create-ns: align the namespaces to 1Mib boundaries when using SI suffixes

### DIFF
--- a/Documentation/nvme-create-ns.txt
+++ b/Documentation/nvme-create-ns.txt
@@ -98,13 +98,15 @@ OPTIONS
 
 -S::
 --nsze-si::
-	The namespace size (NSZE) in standard SI units.
+	The namespace size (NSZE) in standard SI units (aligned on 1Mib boundaries,
+	unless the controller recommends a smaller value).
 	The value SI suffixed is divided by the namespace LBA size to set as NSZE.
 	If the value not suffixed it is set as same with the nsze option.
 
 -C::
 --ncap-si::
-	The namespace capacity (NCAP) in standard SI units.
+	The namespace capacity (NCAP) in standard SI units (aligned on 1Mib boundaries,
+	unless the controller recommends a smaller value).
 	The value SI suffixed is divided by the namespace LBA size to set as NCAP.
 	If the value not suffixed it is set as same with the ncap option.
 


### PR DESCRIPTION
Some controllers refuse to create namespaces with a size not aligned to a 1 megabyte boundary, this happens when using the -S and -C options.

$ nvme create-ns /dev/nvme0 -S 80M -C 80M -f 0
NVMe status: Invalid Field in Command: A reserved coded value or an unsupported value in a defined field(0x2)

Fix this problem by modifying parse_lba_num_si() to align the values to 1 Megabyte boundaries.