### PR TITLE
print-stdout: print Host Behavior Support correctly

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3282,7 +3282,7 @@ static void stdout_zns_changed(struct nvme_zns_changed_zone_log *log)
 static void stdout_zns_report_zone_attributes(__u8 za, __u8 zai)
 {
 	const char *const recommended_limit[4] = {"","1","2","3"};
-	printf("Attrs: Zone Descriptor Extension is %sVaild\n", 
+	printf("Attrs: Zone Descriptor Extension is %sVaild\n",
 		(za & NVME_ZNS_ZA_ZDEV)? "" : "Not ");
 	if(za & NVME_ZNS_ZA_RZR) {
 		printf("       Reset Zone Recommended with Reset Recommended Limit%s\n",
@@ -4474,8 +4474,16 @@ static void stdout_feature_show_fields(enum nvme_features_id fid,
 		stdout_lba_status_info(result);
 		break;
 	case NVME_FEAT_FID_HOST_BEHAVIOR:
-		if (buf)
-			printf("\tHost Behavior Support: %s\n", (buf[0] & 0x1) ? "True" : "False");
+		if (buf) {
+			struct nvme_feat_host_behavior *host_behavior =
+				(struct nvme_feat_host_behavior *)buf;
+			printf("\tAdvanced Command Retry Enable (ACRE): %s\n",
+			       host_behavior->acre ? "True" : "False");
+			printf("\tExtended Telemetry Data Area 4 Supported (ETDAS): %s\n",
+			       host_behavior->etdas ? "True" : "False");
+			printf("\tLBA Format Extension Enable (LBAFEE): %s\n",
+			       host_behavior->lbafee ? "True" : "False");
+		}
 		break;
 	case NVME_FEAT_FID_SANITIZE:
 		printf("\tNo-Deallocate Response Mode (NODRM) : %u\n", result & 0x1);

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 0d3b74ff193211f329ae3c13756557cc612bfd76
+revision = 93aecc45b3453406e9b80e45012ae37a2ad1c5e4
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
In nvme-cli 1.16, printing the Host Behavior Support feature logged the values of the 3 fields ACRE, ETDAS, and LBAFEE. This appears to have regressed in nvme-cli 2.0, and now only the value of ACRE is printed, without any description. Log all 3 fields with proper descriptions. Drop "Host Behavior Support" from their names, as it's redundant with the feature name.

This depends on https://github.com/linux-nvme/libnvme/pull/736

nvme-cli 1.16 output:
```
$ nvme get-feature /dev/nvme1 --feature-id 0x16 --human-readable
get-feature:0x16 (Host Behavior), Current value:00000000
	Host Behavior Support Advanced Command Retry Enable (ACRE): False
	Host Behavior Support Extended Telemetry Data Area 4 Supported (ETDAS): False
	Host Behavior Support LBA Format Extension Enable (LBAFEE): False
```
nvme-cli 2.x output:
```
$ nvme get-feature /dev/nvme1 --feature-id 0x16 ---human-readable
get-feature:0x16 (Host Behavior), Current value:00000000
	Host Behavior Support: False
```
New output:
```
$ nvme get-feature /dev/nvme1 --feature-id 0x16 --human-readable
get-feature:0x16 (Host Behavior), Current value:00000000
	Advanced Command Retry Enable (ACRE): False
	Extended Telemetry Data Area 4 Supported (ETDAS): False
	LBA Format Extension Enable (LBAFEE): False
```