### PR TITLE
libnvme-wrap: exit on VOID_FN lookup failure

### DIFF
--- a/libnvme-wrap.c
+++ b/libnvme-wrap.c
@@ -7,19 +7,24 @@
 
 #include <dlfcn.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include <libnvme.h>
+#include "nvme-print.h"
 
 #define PROTO(args...) args
 #define ARGS(args...) args
 
-#define VOID_FN(name, proto, args)				\
-void __attribute__((weak)) name(proto)				\
-{								\
-	void (*fn)(proto);					\
-	fn = dlsym(RTLD_NEXT, #name);				\
-	if (fn)							\
-		fn(args);					\
+#define VOID_FN(name, proto, args)					\
+void __attribute__((weak)) name(proto)					\
+{									\
+	void (*fn)(proto);						\
+	fn = dlsym(RTLD_NEXT, #name);					\
+	if (!fn) {							\
+		nvme_show_error("libnvme function " #name " not found");\
+		exit(EXIT_FAILURE);					\
+	}								\
+	fn(args);						 	\
 }
 
 #define FN(name, rtype, proto, args, defret)			\


### PR DESCRIPTION
libnvme-wrap provides fallbacks for missing libnvme functions. For functions that return a value, the FN() macro can be used to define a default return value if the function isn't found. This isn't possible for functions returning void,
so VOID_FN() currently is a no-op if the function can't be found. For nvme_init_copy_range_f1(), the only current VOID_FN() user, this will result in silently sending a Copy command with a zeroed range, which is not what the user requested. Instead, exit the process immediately if the function can't be found.

Here's an example with the `nvme_init_copy_range_f1` symbol removed from `libnvme.map`:
```
$ nvme copy /dev/nvme1n1 --format 1 --slbs 123 --blocks 456 --sdlba 789
libnvme function nvme_init_copy_range_f1 not found
$ echo $?
1
```
Previously this would issue the Copy command with the wrong range:
```
$ nvme copy /dev/nvme1n1 --format 1 --slbs 123 --blocks 456 --sdlba 789
NVMe Copy: success
```