### PR TITLE
build: Delete libcurl, libarchive and libpkgconf from tools_build_muon

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -157,9 +157,6 @@ tools_build_muon() {
 
     CC="${CC}" ninja="${SAMU}" stage1/muon setup        \
         -Dprefix="${BUILDDIR}/build-tools"              \
-        -Dlibcurl=enabled                               \
-        -Dlibarchive=enabled                            \
-        -Dlibpkgconf=enabled                            \
         -Ddocs=disabled                                 \
         -Dsamurai=disabled                              \
         "${BUILDDIR}/build-tools/.build-muon"


### PR DESCRIPTION
Since build failed by dependency on CentOS 7, CentOS 8 and Ubuntu 23.10. Also build completed by the deletion and nvme binary created and works.