### PR TITLE
doc: remove invalid hostkey info for --dhchap-secret

### DIFF
--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -107,9 +107,6 @@ OPTIONS
 --dhchap-secret=<secret>::
 	NVMe In-band authentication secret; needs to be in ASCII format as
 	specified in NVMe 2.0 section 8.13.5.8 'Secret representation'.
-	If this option is not specified, the default is read from
-	@SYSCONFDIR@/nvme/hostkey. If that does not exist no in-band authentication
-	is attempted.
 
 -C <secret>::
 --dhchap-ctrl-secret=<secret>::


### PR DESCRIPTION
There is no code which reads in the secret from the mentioned file. This was done in the early stages of the implementation. But it is not considered good practice to store secrets as plain text in /etc, thus this feature was removed later. Instead the connect command is able to use the kernel keystore for this.

Fixes: #2120