### PR TITLE
update build.sh script for muon builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -183,8 +183,10 @@ tools_build_muon() {
 }
 
 config_muon_default() {
-    CC="${CC}" CFLAGS="${CFLAGS} -static"               \
-        ninja="${SAMU}" "${MUON}" setup                 \
+    CC="${CC}" CFLAGS="${CFLAGS}" ninja="${SAMU}"       \
+        "${MUON}" setup                                 \
+        -Ddefault_library=static                        \
+        -Dc_link_args="-static"                         \
         -Dwrap_mode=forcefallback                       \
         -Dlibnvme:json-c=disabled                       \
         -Dlibnvme:python=disabled                       \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,6 +59,7 @@ CONFIG=${1:-"default"}
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
 BUILDDIR="$(pwd)/.build-ci"
+TOOLDIR="$(pwd)/.build-tools"
 
 fn_exists() { declare -F "$1" > /dev/null; }
 
@@ -136,37 +137,47 @@ install_meson_appimage() {
 }
 
 tools_build_samurai() {
-    mkdir -p "${BUILDDIR}"/build-tools
-    git clone --depth 1 https://github.com/michaelforney/samurai.git \
-        "${BUILDDIR}/build-tools/samurai"
-    pushd "${BUILDDIR}/build-tools/samurai" || exit 1
+    if [ ! -d "${TOOLDIR}"/samurai ]; then
+        git clone --depth 1 https://github.com/michaelforney/samurai.git \
+            "${TOOLDIR}/samurai"
+    fi
 
+    if [[ -f "${TOOLDIR}/samurai/samu" ]]; then
+        return
+    fi
+
+    pushd "${TOOLDIR}/samurai" || exit 1
     CC="${CC}" make
-    SAMU="${BUILDDIR}/build-tools/samurai/samu"
-
     popd || exit 1
 }
 
 tools_build_muon() {
-    mkdir -p "${BUILDDIR}"/build-tools
-    git clone --depth 1 https://git.sr.ht/~lattis/muon \
-        "${BUILDDIR}/build-tools/muon"
-    pushd "${BUILDDIR}/build-tools/muon" || exit 1
+    if [ ! -d "${TOOLDIR}/muon" ]; then
+        git clone --depth 1 https://git.sr.ht/~lattis/muon \
+            "${TOOLDIR}/muon"
+    fi
+
+    if [[ -f "${TOOLDIR}/build-muon/muon" ]]; then
+        return
+    fi
+
+    pushd "${TOOLDIR}/muon" || exit 1
 
     CC="${CC}" CFLAGS="${CFLAGS} -std=c99" ninja="${SAMU}" ./bootstrap.sh stage1
 
     CC="${CC}" ninja="${SAMU}" stage1/muon setup        \
-        -Dprefix="${BUILDDIR}/build-tools"              \
+        -Dprefix="${TOOLDIR}"                           \
         -Dlibcurl=enabled                               \
         -Dlibarchive=enabled                            \
         -Dlibpkgconf=enabled                            \
         -Ddocs=disabled                                 \
         -Dsamurai=disabled                              \
-        "${BUILDDIR}/build-tools/.build-muon"
-    "${SAMU}" -C "${BUILDDIR}/build-tools/.build-muon"
+        "${TOOLDIR}/build-muon"
+    "${SAMU}" -C "${TOOLDIR}/build-muon"
     MUON="${BUILDDIR}/build-tools/.build-muon/muon"
 
-    # "${MUON}" -C "${BUILDDIR}/build-tools/.build-muon" test
+    # "${TOOLDIR}/build-muon/muon" \
+    #    -C "${TOOLDIR}/build-muon" test
 
     popd || exit 1
 }
@@ -192,21 +203,24 @@ test_muon() {
     ldd "${BUILDDIR}/nvme" 2>&1 | grep 'not a dynamic executable' || exit 1
 }
 
-rm -rf "${BUILDDIR}"
-
 if [[ "${BUILDTOOL}" == "muon" ]]; then
-    if ! which samu ; then
+    SAMU="$(which samu 2> /dev/null)" || true
+    if [[ -z "${SAMU}" ]]; then
         tools_build_samurai
-    else
-        SAMU="$(which samu)"
+        SAMU="${TOOLDIR}/samurai/samu"
     fi
 
-    if ! which muon ; then
+    MUON="$(which muon 2> /dev/null)" || true
+    if [[ -z "${MUON}" ]]; then
         tools_build_muon
-    else
-        MUON="$(which muon)"
+        MUON="${TOOLDIR}/build-muon/muon"
     fi
 fi
+
+echo "samu: ${SAMU}"
+echo "muon: ${MUON}"
+
+rm -rf "${BUILDDIR}"
 
 config_"${BUILDTOOL}"_"${CONFIG}"
 fn_exists "build_${BUILDTOOL}_${CONFIG}" && "build_${BUILDTOOL}_${CONFIG}" || build_"${BUILDTOOL}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -167,9 +167,6 @@ tools_build_muon() {
 
     CC="${CC}" ninja="${SAMU}" stage1/muon setup        \
         -Dprefix="${TOOLDIR}"                           \
-        -Dlibcurl=enabled                               \
-        -Dlibarchive=enabled                            \
-        -Dlibpkgconf=enabled                            \
         -Ddocs=disabled                                 \
         -Dsamurai=disabled                              \
         "${TOOLDIR}/build-muon"
@@ -183,6 +180,8 @@ tools_build_muon() {
 }
 
 config_muon_default() {
+    # wrap_mode=forcefallback depends on git being available
+
     CC="${CC}" CFLAGS="${CFLAGS}" ninja="${SAMU}"       \
         "${MUON}" setup                                 \
         -Ddefault_library=static                        \


### PR DESCRIPTION
A few improvements for the build.sh script for muon

- do not rebuild samurai/muon every time.
- drop dependency on `libcurl`, `libarchive` and `libpkgconfig`. The `wrap` feature of muon is using `git` directly to fetch `libnvme`.