### PR TITLE
nvme: fixup length calculation for 'nvme gen-tls-key --secret'

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -8718,7 +8718,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 				nvme_show_error("Invalid secret '%s'", cfg.secret);
 				return -EINVAL;
 			}
-			if (i >= key_len) {
+			if (i >= key_len * 2) {
 				fprintf(stderr, "Skipping excess secret bytes\n");
 				break;
 			}


### PR DESCRIPTION
The raw secret is passed in hex, so the length of the input is twice the size of the key.