### PR TITLE
Implement support for version 1 TLS identifiers as specified in TP8018

### DIFF
--- a/Documentation/nvme-check-tls-key.txt
+++ b/Documentation/nvme-check-tls-key.txt
@@ -13,13 +13,17 @@ SYNOPSIS
 			[--hostnqn=<nqn> | -n <nqn>]
 			[--subsysnqn=<nqn> | -c <nqn>]
 			[--keydata=<key> | -d <key>]
-			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
+			[--output-format=<fmt> | -o <fmt>]
+			[--version=<vers> | -V <vers>]
+			[--insert | -i ]
+			[--verbose | -v]
 
 DESCRIPTION
 -----------
 Checks if the key is a valid NVMe TLS PSK in the PSK interchange format
-'NVMeTLSkey-1:01:<base64-encoded data>:', and stores the derived 'retained'
-TLS key in the keyring if the subsystem NQN is specified.
+'NVMeTLSkey-1:01:<base64-encoded data>:'. If '--insert' is specified the
+the derived 'retained' TLS key is stored in the keyring, otherwise the
+TLS identity of the key is printed out.
 
 OPTIONS
 -------
@@ -46,6 +50,14 @@ OPTIONS
 -d <key>::
 --keydata=<key>::
 	Key to be checked.
+
+-V <vers>::
+--version=<vers>::
+	NVMe TLS key identity version to be used.
+
+-i:
+--insert:
+	Insert the derived 'retained' key in the keyring.
 
 -o <fmt>::
 --output-format=<fmt>::

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -13,6 +13,7 @@ SYNOPSIS
 			[--hostnqn=<nqn> | -n <nqn>]
 			[--subsysnqn=<nqn> | -c <nqn>]
 			[--hmac=<hmac-id> | -h <hmac-id>]
+			[--version=<vers> | -V <vers>]
 			[--secret=<secret> | -s <secret>]
 			[--insert | -i]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
@@ -24,10 +25,12 @@ The resulting key is either printed in the PSK interchange format
 'NVMeTLSkey-1:01:<base64 encoded data>:',
 inserted as a 'retained' key into the specified keyring, or both.
 When the PSK should be inserted into the keyring a 'retained' key
-is derived from the secret key material, and the resulting 'retained'
+is derived from the secret key material. The resulting 'retained'
 key is stored with the identity
 'NVMe0R0<hmac> <host NQN> <subsystem NQN>'
-in the keyring.
+(for version '0') or
+'NVMe1R0<hmac> <host NQN> <subsystem NQN> <PSK hash>'
+(for version '1') in the keyring.
 The 'retained' key is derived from the secret key material,
 the specified subsystem NQN, and the host NQN.
 Once the 'retained' key is stored in the keyring the original
@@ -60,6 +63,12 @@ OPTIONS
 	Select a HMAC algorithm to use. Possible values are:
 	1 - SHA-256 (default)
 	2 - SHA-384
+
+-V <vers>::
+--version=<vers>::
+	Select the TLS identity to use. Possible values are:
+	0 - Original NVMe TLS 1.0c identity
+	1 - NVMe TLS 2.0 (TP8018) identity
 
 -s <secret>::
 --secret=<secret>::

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -22,8 +22,9 @@ DESCRIPTION
 -----------
 Generate a base64-encoded NVMe TLS pre-shared key (PSK).
 The resulting key is either printed in the PSK interchange format
-'NVMeTLSkey-1:01:<base64 encoded data>:',
-inserted as a 'retained' key into the specified keyring, or both.
+'NVMeTLSkey-1:01:<base64 encoded data>:' or inserted as a
+'retained' key into the specified keyring if the '--insert' option
+is given.
 When the PSK should be inserted into the keyring a 'retained' key
 is derived from the secret key material. The resulting 'retained'
 key is stored with the identity

--- a/nvme.c
+++ b/nvme.c
@@ -8644,6 +8644,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 	const char *secret =
 	    "Optional secret (in hexadecimal characters) to be used for the TLS key.";
 	const char *hmac = "HMAC function to use for the retained key (1 = SHA-256, 2 = SHA-384).";
+	const char *version = "TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0";
 	const char *hostnqn = "Host NQN for the retained key.";
 	const char *subsysnqn = "Subsystem NQN for the retained key.";
 	const char *keyring = "Keyring for the retained key.";
@@ -8664,6 +8665,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		char		*subsysnqn;
 		char		*secret;
 		unsigned int	hmac;
+		unsigned int	version;
 		bool		insert;
 	};
 
@@ -8674,6 +8676,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		.subsysnqn	= NULL,
 		.secret		= NULL,
 		.hmac		= 1,
+		.version	= 0,
 		.insert		= false,
 	};
 
@@ -8684,6 +8687,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		  OPT_STR("subsysnqn",	'c', &cfg.subsysnqn,	subsysnqn),
 		  OPT_STR("secret",	's', &cfg.secret,	secret),
 		  OPT_UINT("hmac",	'm', &cfg.hmac,		hmac),
+		  OPT_UINT("version",	'V', &cfg.version,	version),
 		  OPT_FLAG("insert",	'i', &cfg.insert,	insert));
 
 	err = argconfig_parse(argc, argv, desc, opts);
@@ -8691,6 +8695,10 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		return err;
 	if (cfg.hmac < 1 || cfg.hmac > 3) {
 		nvme_show_error("Invalid HMAC identifier %u", cfg.hmac);
+		return -EINVAL;
+	}
+	if (cfg.version > 1) {
+		nvme_show_error("Invalid TLS identity version %u", cfg.version);
 		return -EINVAL;
 	}
 	if (cfg.insert && !cfg.subsysnqn) {
@@ -8740,8 +8748,9 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 			}
 		}
 
-		tls_key = nvme_insert_tls_key(cfg.keyring, cfg.keytype, cfg.hostnqn, cfg.subsysnqn,
-					      cfg.hmac, raw_secret, key_len);
+		tls_key = nvme_insert_tls_key_versioned(cfg.keyring, cfg.keytype,
+					cfg.hostnqn, cfg.subsysnqn, cfg.hmac,
+					cfg.version, raw_secret, key_len);
 		if (tls_key < 0) {
 			nvme_show_error("Failed to insert key, error %d", errno);
 			return -errno;

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 93aecc45b3453406e9b80e45012ae37a2ad1c5e4
+revision = 4fe9e40ef30fa53d7b3b80392ca1fbc44b98e113
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
TP8018 specifies a new TLS identifier, where the original TLS identifer is suffixed with a PSK hash. This allows to differentiate between keys with different key material and with that enables key rotation.