### PR TITLE
Implement support for version 1 TLS identifiers as specified in TP8018 (version 2)

### DIFF
--- a/Documentation/nvme-check-tls-key.txt
+++ b/Documentation/nvme-check-tls-key.txt
@@ -13,13 +13,17 @@ SYNOPSIS
 			[--hostnqn=<nqn> | -n <nqn>]
 			[--subsysnqn=<nqn> | -c <nqn>]
 			[--keydata=<key> | -d <key>]
-			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
+			[--output-format=<fmt> | -o <fmt>]
+			[--identity=<id-vers> | -I <id-vers>]
+			[--insert | -i ]
+			[--verbose | -v]
 
 DESCRIPTION
 -----------
 Checks if the key is a valid NVMe TLS PSK in the PSK interchange format
-'NVMeTLSkey-1:01:<base64-encoded data>:', and stores the derived 'retained'
-TLS key in the keyring if the subsystem NQN is specified.
+'NVMeTLSkey-1:01:<base64-encoded data>:'. If '--insert' is specified the
+the derived 'retained' TLS key is stored in the keyring, otherwise the
+TLS identity of the key is printed out.
 
 OPTIONS
 -------
@@ -46,6 +50,16 @@ OPTIONS
 -d <key>::
 --keydata=<key>::
 	Key to be checked.
+
+-I <id-vers>::
+--identity=<id-vers>::
+	NVMe TLS key identity version to be used; '0' for the default
+	identity, and '1' for the TLS identity suffixed by the PSK hash
+	as specified in TP8018.
+
+-i:
+--insert:
+	Insert the derived 'retained' key in the keyring.
 
 -o <fmt>::
 --output-format=<fmt>::

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -13,6 +13,7 @@ SYNOPSIS
 			[--hostnqn=<nqn> | -n <nqn>]
 			[--subsysnqn=<nqn> | -c <nqn>]
 			[--hmac=<hmac-id> | -h <hmac-id>]
+			[--identity=<id-vers> | -I <id-vers>]
 			[--secret=<secret> | -s <secret>]
 			[--insert | -i]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
@@ -24,10 +25,12 @@ The resulting key is either printed in the PSK interchange format
 'NVMeTLSkey-1:01:<base64 encoded data>:',
 inserted as a 'retained' key into the specified keyring, or both.
 When the PSK should be inserted into the keyring a 'retained' key
-is derived from the secret key material, and the resulting 'retained'
+is derived from the secret key material. The resulting 'retained'
 key is stored with the identity
 'NVMe0R0<hmac> <host NQN> <subsystem NQN>'
-in the keyring.
+(for identity version '0') or
+'NVMe1R0<hmac> <host NQN> <subsystem NQN> <PSK hash>'
+(for identity version '1') in the keyring.
 The 'retained' key is derived from the secret key material,
 the specified subsystem NQN, and the host NQN.
 Once the 'retained' key is stored in the keyring the original
@@ -60,6 +63,12 @@ OPTIONS
 	Select a HMAC algorithm to use. Possible values are:
 	1 - SHA-256 (default)
 	2 - SHA-384
+
+-I <vers>::
+--identity=<id-vers>::
+	Select the TLS identity to use. Possible values are:
+	0 - Original NVMe TLS 1.0c identity
+	1 - NVMe TLS 2.0 (TP8018) identity
 
 -s <secret>::
 --secret=<secret>::

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -22,8 +22,9 @@ DESCRIPTION
 -----------
 Generate a base64-encoded NVMe TLS pre-shared key (PSK).
 The resulting key is either printed in the PSK interchange format
-'NVMeTLSkey-1:01:<base64 encoded data>:',
-inserted as a 'retained' key into the specified keyring, or both.
+'NVMeTLSkey-1:01:<base64 encoded data>:' or inserted as a
+'retained' key into the specified keyring if the '--insert' option
+is given.
 When the PSK should be inserted into the keyring a 'retained' key
 is derived from the secret key material. The resulting 'retained'
 key is stored with the identity

--- a/nvme.c
+++ b/nvme.c
@@ -8780,10 +8780,12 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 {
 	const char *desc = "Check a TLS key for NVMe PSK Interchange format.\n";
 	const char *keydata = "TLS key (in PSK Interchange format) to be validated.";
+	const char *identity = "TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)";
 	const char *hostnqn = "Host NQN for the retained key.";
 	const char *subsysnqn = "Subsystem NQN for the retained key.";
 	const char *keyring = "Keyring for the retained key.";
 	const char *keytype = "Key type of the retained key.";
+	const char *insert = "Insert retained key into the keyring.";
 
 	unsigned char decoded_key[128];
 	unsigned int decoded_len;
@@ -8792,11 +8794,13 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 	int err = 0, hmac;
 	long tls_key;
 	struct config {
-		char	*keyring;
-		char	*keytype;
-		char	*hostnqn;
-		char	*subsysnqn;
-		char	*keydata;
+		char		*keyring;
+		char		*keytype;
+		char		*hostnqn;
+		char		*subsysnqn;
+		char		*keydata;
+		unsigned int	identity;
+		bool		insert;
 	};
 
 	struct config cfg = {
@@ -8805,6 +8809,8 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 		.hostnqn	= NULL,
 		.subsysnqn	= NULL,
 		.keydata	= NULL,
+		.identity	= 0,
+		.insert		= false,
 	};
 
 	NVME_ARGS(opts, cfg,
@@ -8812,7 +8818,9 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 		  OPT_STR("keytype",	't', &cfg.keytype,	keytype),
 		  OPT_STR("hostnqn",	'n', &cfg.hostnqn,	hostnqn),
 		  OPT_STR("subsysnqn",	'c', &cfg.subsysnqn,	subsysnqn),
-		  OPT_STR("keydata",	'd', &cfg.keydata,	keydata));
+		  OPT_STR("keydata",	'd', &cfg.keydata,	keydata),
+		  OPT_UINT("identity",	'I', &cfg.identity,	identity),
+		  OPT_FLAG("insert",	'i', &cfg.insert,	insert));
 
 	err = argconfig_parse(argc, argv, desc, opts);
 	if (err)
@@ -8820,6 +8828,11 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 
 	if (!cfg.keydata) {
 		nvme_show_error("No key data");
+		return -EINVAL;
+	}
+	if (cfg.identity > 1) {
+		nvme_show_error("Invalid TLS identity version %u",
+				cfg.identity);
 		return -EINVAL;
 	}
 
@@ -8845,6 +8858,18 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 		return -EINVAL;
 	}
 
+	if (cfg.subsysnqn) {
+		if (cfg.insert && !cfg.hostnqn) {
+			cfg.hostnqn = nvmf_hostnqn_from_file();
+			if (!cfg.hostnqn) {
+				nvme_show_error("Failed to read host NQN");
+				return -EINVAL;
+			}
+		}
+	} else if (cfg.insert || cfg.identity == 1) {
+		nvme_show_error("Need to specify a subsystem NQN");
+		return -EINVAL;
+	}
 	err = base64_decode(cfg.keydata + 16, strlen(cfg.keydata) - 17, decoded_key);
 	if (err < 0) {
 		nvme_show_error("Base64 decoding failed (%s, error %d)", cfg.keydata + 16, err);
@@ -8865,23 +8890,28 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 		nvme_show_error("CRC mismatch (key %08x, crc %08x)", key_crc, crc);
 		return -EINVAL;
 	}
-	if (cfg.subsysnqn) {
-		if (!cfg.hostnqn) {
-			cfg.hostnqn = nvmf_hostnqn_from_file();
-			if (!cfg.hostnqn) {
-				nvme_show_error("Failed to read host NQN");
-				return -EINVAL;
-			}
-		}
-
-		tls_key = nvme_insert_tls_key(cfg.keyring, cfg.keytype, cfg.hostnqn, cfg.subsysnqn,
-					      hmac, decoded_key, decoded_len);
+	if (cfg.insert) {
+		tls_key = nvme_insert_tls_key_versioned(cfg.keyring,
+					cfg.keytype, cfg.hostnqn,
+					cfg.subsysnqn, cfg.identity,
+					hmac, decoded_key, decoded_len);
 		if (tls_key < 0) {
 			nvme_show_error("Failed to insert key, error %d", errno);
 			return -errno;
 		}
 	} else {
-		printf("Key is valid (HMAC %d, length %d, CRC %08x)\n", hmac, decoded_len, crc);
+		char *tls_id;
+
+		tls_id = nvme_generate_tls_key_identity(cfg.hostnqn,
+					cfg.subsysnqn, cfg.identity,
+					hmac, decoded_key, decoded_len);
+		if (!tls_id) {
+			nvme_show_error("Failed to generated identity, error %d",
+					errno);
+			return -errno;
+		}
+		printf("%s\n", tls_id);
+		free(tls_id);
 	}
 	return 0;
 }

--- a/nvme.c
+++ b/nvme.c
@@ -8644,6 +8644,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 	const char *secret =
 	    "Optional secret (in hexadecimal characters) to be used for the TLS key.";
 	const char *hmac = "HMAC function to use for the retained key (1 = SHA-256, 2 = SHA-384).";
+	const char *identity = "TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0";
 	const char *hostnqn = "Host NQN for the retained key.";
 	const char *subsysnqn = "Subsystem NQN for the retained key.";
 	const char *keyring = "Keyring for the retained key.";
@@ -8664,6 +8665,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		char		*subsysnqn;
 		char		*secret;
 		unsigned int	hmac;
+		unsigned int	identity;
 		bool		insert;
 	};
 
@@ -8674,6 +8676,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		.subsysnqn	= NULL,
 		.secret		= NULL,
 		.hmac		= 1,
+		.identity	= 0,
 		.insert		= false,
 	};
 
@@ -8684,6 +8687,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		  OPT_STR("subsysnqn",	'c', &cfg.subsysnqn,	subsysnqn),
 		  OPT_STR("secret",	's', &cfg.secret,	secret),
 		  OPT_UINT("hmac",	'm', &cfg.hmac,		hmac),
+		  OPT_UINT("identity",	'I', &cfg.identity,	identity),
 		  OPT_FLAG("insert",	'i', &cfg.insert,	insert));
 
 	err = argconfig_parse(argc, argv, desc, opts);
@@ -8691,6 +8695,11 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		return err;
 	if (cfg.hmac < 1 || cfg.hmac > 3) {
 		nvme_show_error("Invalid HMAC identifier %u", cfg.hmac);
+		return -EINVAL;
+	}
+	if (cfg.identity > 1) {
+		nvme_show_error("Invalid TLS identity version %u",
+				cfg.identity);
 		return -EINVAL;
 	}
 	if (cfg.insert && !cfg.subsysnqn) {
@@ -8740,8 +8749,10 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 			}
 		}
 
-		tls_key = nvme_insert_tls_key(cfg.keyring, cfg.keytype, cfg.hostnqn, cfg.subsysnqn,
-					      cfg.hmac, raw_secret, key_len);
+		tls_key = nvme_insert_tls_key_versioned(cfg.keyring,
+					cfg.keytype, cfg.hostnqn,
+					cfg.subsysnqn, cfg.identity,
+					cfg.hmac, raw_secret, key_len);
 		if (tls_key < 0) {
 			nvme_show_error("Failed to insert key, error %d", errno);
 			return -errno;

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 93aecc45b3453406e9b80e45012ae37a2ad1c5e4
+revision = 4fe9e40ef30fa53d7b3b80392ca1fbc44b98e113
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
TP8018 specifies a new TLS identifier, where the original TLS identifer is suffixed with a PSK hash. This allows to differentiate between keys with different key material and with that enables key rotation.