### PR TITLE
show-regs: Fix to return normal value

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5384,6 +5384,8 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 	if (err < 0) {
 		nvme_show_error("Invalid output format");
 		goto free_tree;
+	} else {
+		err = 0 ;
 	}
 
 	if (cfg.human_readable)


### PR DESCRIPTION
If the output format is not normal, the value of err will be non-zero.
If bar is returned the mmap_registers function, it does not return as 0.

Reviewed-by: Steven Seungcheol Lee <sc108.lee@samsung.com>