### PR TITLE
cleanup: Move cleanup_nvme_dev from nvme.h

### DIFF
--- a/nvme.h
+++ b/nvme.h
@@ -30,7 +30,6 @@
 #include "util/json.h"
 #include "util/mem.h"
 #include "util/argconfig.h"
-#include "util/cleanup.h"
 
 enum nvme_print_flags {
 	NORMAL	= 0,
@@ -101,10 +100,6 @@ int parse_and_open(struct nvme_dev **dev, int argc, char **argv, const char *des
 	struct argconfig_commandline_options *clo);
 
 void dev_close(struct nvme_dev *dev);
-
-static inline DEFINE_CLEANUP_FUNC(
-	cleanup_nvme_dev, struct nvme_dev *, dev_close)
-#define _cleanup_nvme_dev_ __cleanup__(cleanup_nvme_dev)
 
 extern const char *output_format;
 

--- a/plugins/solidigm/solidigm-temp-stats.c
+++ b/plugins/solidigm/solidigm-temp-stats.c
@@ -6,6 +6,7 @@
  */
 
 #include <errno.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "nvme-print.h"

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -6,14 +6,12 @@
 #include <stdlib.h>
 
 #include "util/mem.h"
+#include "nvme.h"
 
 #define __cleanup__(fn) __attribute__((cleanup(fn)))
 
-#define DECLARE_CLEANUP_FUNC(name, type) \
-	void name(type *__p)
-
 #define DEFINE_CLEANUP_FUNC(name, type, free_fn)\
-DECLARE_CLEANUP_FUNC(name, type)		\
+void name(type *__p)				\
 {						\
 	if (*__p)				\
 		free_fn(*__p);			\
@@ -21,7 +19,7 @@ DECLARE_CLEANUP_FUNC(name, type)		\
 
 static inline void freep(void *p)
 {
-        free(*(void**) p);
+	free(*(void **)p);
 }
 #define _cleanup_free_ __cleanup__(freep)
 
@@ -33,5 +31,9 @@ static inline void close_file(int *f)
 		close(*f);
 }
 #define _cleanup_file_ __cleanup__(close_file)
+
+static inline DEFINE_CLEANUP_FUNC(
+	cleanup_nvme_dev, struct nvme_dev *, dev_close)
+#define _cleanup_nvme_dev_ __cleanup__(cleanup_nvme_dev)
 
 #endif


### PR DESCRIPTION
Also delete DECLARE_CLEANUP_FUNC to make DEFINE_CLEANUP_FUNC simple. For the solidigm-temp-stats.c compile warning by the change add include.