### PR TITLE
plugins/ocp: Fix printing order of various Latency Monitor Log buckets

### DIFF
--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -117,7 +117,6 @@ static int ocp_print_C3_log_normal(struct nvme_dev *dev,
 {
 	char ts_buf[128];
 	int i, j;
-	int pos = 0;
 
 	printf("-Latency Monitor/C3 Log Page Data-\n");
 	printf("  Controller   :  %s\n", dev->name);
@@ -141,6 +140,8 @@ static int ocp_print_C3_log_normal(struct nvme_dev *dev,
 	printf("  Active Threshold D                 %d ms\n",
 	       C3_ACTIVE_THRESHOLD_INCREMENT *
 	       le16_to_cpu(log_data->active_threshold_d+1));
+	printf("  Active Latency Configuration       0x%x \n",
+	       le16_to_cpu(log_data->active_latency_config));
 	printf("  Active Latency Minimum Window      %d ms\n",
 	       C3_MINIMUM_WINDOW_INCREMENT *
 	       le16_to_cpu(log_data->active_latency_min_window));
@@ -178,14 +179,6 @@ static int ocp_print_C3_log_normal(struct nvme_dev *dev,
 
 	printf("                                                            Read                           Write                 Deallocate/Trim\n");
 	for (i = 0; i < C3_BUCKET_NUM; i++) {
-		printf("  Active Latency Mode: Bucket %d      %27d     %27d     %27d\n",
-		       i,
-		       log_data->active_latency_config & (1 << pos),
-		       log_data->active_latency_config & (1 << pos),
-		       log_data->active_latency_config & (1 << pos));
-	}
-
-	for (i = 0; i < C3_BUCKET_NUM; i++) {
 		printf("  Active Bucket Counter: Bucket %d    %27d     %27d     %27d\n",
 		       i,
 		       le32_to_cpu(log_data->active_bucket_counter[i][READ]),
@@ -196,10 +189,10 @@ static int ocp_print_C3_log_normal(struct nvme_dev *dev,
 	for (i = 0; i < C3_BUCKET_NUM; i++) {
 		printf("  Active Latency Time Stamp: Bucket %d    ", i);
 		for (j = 2; j >= 0; j--) {
-			if (le64_to_cpu(log_data->active_latency_timestamp[i][j]) == -1) {
+			if (le64_to_cpu(log_data->active_latency_timestamp[3-i][j]) == -1) {
 				printf("                    N/A         ");
 			} else {
-				convert_ts(le64_to_cpu(log_data->active_latency_timestamp[i][j]), ts_buf);
+				convert_ts(le64_to_cpu(log_data->active_latency_timestamp[3-i][j]), ts_buf);
 				printf("%s     ", ts_buf);
 			}
 		}
@@ -209,9 +202,9 @@ static int ocp_print_C3_log_normal(struct nvme_dev *dev,
 	for (i = 0; i < C3_BUCKET_NUM; i++) {
 		printf("  Active Measured Latency: Bucket %d  %27d ms  %27d ms  %27d ms\n",
 		       i,
-		       le16_to_cpu(log_data->active_measured_latency[i][READ-1]),
-		       le16_to_cpu(log_data->active_measured_latency[i][WRITE-1]),
-		       le16_to_cpu(log_data->active_measured_latency[i][TRIM-1]));
+		       le16_to_cpu(log_data->active_measured_latency[3-i][READ-1]),
+		       le16_to_cpu(log_data->active_measured_latency[3-i][WRITE-1]),
+		       le16_to_cpu(log_data->active_measured_latency[3-i][TRIM-1]));
 	}
 
 	printf("\n");
@@ -226,10 +219,10 @@ static int ocp_print_C3_log_normal(struct nvme_dev *dev,
 	for (i = 0; i < C3_BUCKET_NUM; i++) {
 		printf("  Static Latency Time Stamp: Bucket %d    ", i);
 		for (j = 2; j >= 0; j--) {
-			if (le64_to_cpu(log_data->static_latency_timestamp[i][j]) == -1) {
+			if (le64_to_cpu(log_data->static_latency_timestamp[3-i][j]) == -1) {
 				printf("                    N/A         ");
 			} else {
-				convert_ts(le64_to_cpu(log_data->static_latency_timestamp[i][j]), ts_buf);
+				convert_ts(le64_to_cpu(log_data->static_latency_timestamp[3-i][j]), ts_buf);
 				printf("%s     ", ts_buf);
 			}
 		}
@@ -239,9 +232,9 @@ static int ocp_print_C3_log_normal(struct nvme_dev *dev,
 	for (i = 0; i < C3_BUCKET_NUM; i++) {
 		printf("  Static Measured Latency: Bucket %d  %27d ms  %27d ms  %27d ms\n",
 		       i,
-		       le16_to_cpu(log_data->static_measured_latency[i][READ-1]),
-		       le16_to_cpu(log_data->static_measured_latency[i][WRITE-1]),
-		       le16_to_cpu(log_data->static_measured_latency[i][TRIM-1]));
+		       le16_to_cpu(log_data->static_measured_latency[3-i][READ-1]),
+		       le16_to_cpu(log_data->static_measured_latency[3-i][WRITE-1]),
+		       le16_to_cpu(log_data->static_measured_latency[3-i][TRIM-1]));
 	}
 
 	return 0;
@@ -253,7 +246,6 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
 	char ts_buf[128];
 	char buf[128];
 	int i, j;
-	int pos = 0;
 	char *operation[3] = {"Trim", "Write", "Read"};
 
 	root = json_create_object();
@@ -278,19 +270,8 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
 	json_object_add_value_uint(root, "Active Threshold D",
 		C3_ACTIVE_THRESHOLD_INCREMENT *
 		le16_to_cpu(log_data->active_threshold_d + 1));
-
-	for (i = 0; i < C3_BUCKET_NUM; i++) {
-		struct json_object *bucket;
-
-		bucket = json_create_object();
-		sprintf(buf, "Active Latency Mode: Bucket %d", i);
-		for (j = 2; j >= 0; j--) {
-			json_object_add_value_uint(bucket, operation[j],
-						   log_data->active_latency_config & (1 << pos));
-		}
-		json_object_add_value_object(root, buf, bucket);
-	}
-
+	json_object_add_value_uint(root, "Active Latency Configuration",
+		le16_to_cpu(log_data->active_latency_config));
 	json_object_add_value_uint(root, "Active Latency Minimum Window",
 		C3_MINIMUM_WINDOW_INCREMENT *
 		le16_to_cpu(log_data->active_latency_min_window));
@@ -313,10 +294,10 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
 		bucket = json_create_object();
 		sprintf(buf, "Active Latency Time Stamp: Bucket %d", i);
 		for (j = 2; j >= 0; j--) {
-			if (le64_to_cpu(log_data->active_latency_timestamp[i][j]) == -1) {
+			if (le64_to_cpu(log_data->active_latency_timestamp[3-i][j]) == -1) {
 				json_object_add_value_string(bucket, operation[j], "NA");
 			} else {
-				convert_ts(le64_to_cpu(log_data->active_latency_timestamp[i][j]), ts_buf);
+				convert_ts(le64_to_cpu(log_data->active_latency_timestamp[3-i][j]), ts_buf);
 				json_object_add_value_string(bucket, operation[j], ts_buf);
 			}
 		}
@@ -330,7 +311,7 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
 		sprintf(buf, "Active Measured Latency: Bucket %d", i);
 		for (j = 2; j >= 0; j--) {
 			json_object_add_value_uint(bucket, operation[j],
-				le16_to_cpu(log_data->active_measured_latency[i][j]));
+				le16_to_cpu(log_data->active_measured_latency[3-i][j]));
 		}
 		json_object_add_value_object(root, buf, bucket);
 	}
@@ -356,10 +337,10 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
 		bucket = json_create_object();
 		sprintf(buf, "Static Latency Time Stamp: Bucket %d", i);
 		for (j = 2; j >= 0; j--) {
-			if (le64_to_cpu(log_data->static_latency_timestamp[i][j]) == -1) {
+			if (le64_to_cpu(log_data->static_latency_timestamp[3-i][j]) == -1) {
 				json_object_add_value_string(bucket, operation[j], "NA");
 			} else {
-				convert_ts(le64_to_cpu(log_data->static_latency_timestamp[i][j]), ts_buf);
+				convert_ts(le64_to_cpu(log_data->static_latency_timestamp[3-i][j]), ts_buf);
 				json_object_add_value_string(bucket, operation[j], ts_buf);
 			}
 		}
@@ -373,7 +354,7 @@ static void ocp_print_C3_log_json(struct ssd_latency_monitor_log *log_data)
 		sprintf(buf, "Static Measured Latency: Bucket %d", i);
 		for (j = 2; j >= 0; j--) {
 			json_object_add_value_uint(bucket, operation[j],
-				le16_to_cpu(log_data->static_measured_latency[i][j]));
+				le16_to_cpu(log_data->static_measured_latency[3-i][j]));
 		}
 		json_object_add_value_object(root, buf, bucket);
 	}


### PR DESCRIPTION
Several buckets were being printed out in an incorrect order (so bucket 3 was being labelled as bucket 0, bucket 2 was labelled as bucket 1, 1 was labelled as 2, etc.).

The tables with these affected buckets were the : Active Latency Timestamp table, Active Measured Latency table, Static Latency Timestamp table, and Static Measure Latency table.

Also changed active latency configuration to just print out the hex value, rather than creating another table.