### PR TITLE
nvme: restric hmac options for gen-tls-key

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -8566,7 +8566,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 	err = argconfig_parse(argc, argv, desc, opts);
 	if (err)
 		return err;
-	if (cfg.hmac < 1 || cfg.hmac > 3) {
+	if (cfg.hmac < 1 || cfg.hmac > 2) {
 		nvme_show_error("Invalid HMAC identifier %u", cfg.hmac);
 		return -EINVAL;
 	}


### PR DESCRIPTION
During nvme gen-tls-key generation, the permitted hmac options is 1 for SHA-256 & 2 for SHA-384 respectively for the retained key. But nvme-cli mistakenly permits an additional option 3 too which defaults to SHA-256 itself. Rectify this.