### PR TITLE
fabrics: fix invalid output format error during nvme connect

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -887,7 +887,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	int ret;
 	enum nvme_print_flags flags;
 	struct nvme_fabrics_config cfg = { 0 };
-	char *format = "";
+	char *format = "normal";
 
 
 	NVMF_ARGS(opts, cfg,


### PR DESCRIPTION
Nvme connect currently fails with an "Invalid output format" error if no output-format is specified to the nvme connect command. Fix this by initializing the format string.

Fixes: b6319a7 ("fabrics: Do not print device on connect per default")