### PR TITLE
fabrics: fix connect error if hostid file does not exist

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -739,6 +739,8 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	}
 	if (!hostid)
 		hostid = hid = nvmf_hostid_from_file();
+	if (!hostid && hostnqn)
+		hostid = hid = nvmf_hostid_from_hostnqn(hostnqn);
 	nvmf_check_hostid_and_hostnqn(hostid, hostnqn);
 	h = nvme_lookup_host(r, hostnqn, hostid);
 	if (!h) {
@@ -960,6 +962,8 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	}
 	if (!hostid)
 		hostid = hid = nvmf_hostid_from_file();
+	if (!hostid && hostnqn)
+		hostid = hid = nvmf_hostid_from_hostnqn(hostnqn);
 	nvmf_check_hostid_and_hostnqn(hostid, hostnqn);
 	h = nvme_lookup_host(r, hostnqn, hostid);
 	if (!h) {


### PR DESCRIPTION
Currently one sees a connect error during a nvme discover/connect if the hostnqn file exists, but not the hostid file. Fix this by ensuring the hostid is taken from the corresponding hostnqn for such scenarios.