### PR TITLE
nvme: avoid segfault in check-tls-key due to null subsysnqn/hostnqn

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -8727,14 +8727,14 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 	}
 
 	if (cfg.subsysnqn) {
-		if (cfg.insert && !cfg.hostnqn) {
+		if (!cfg.hostnqn) {
 			cfg.hostnqn = nvmf_hostnqn_from_file();
 			if (!cfg.hostnqn) {
 				nvme_show_error("Failed to read host NQN");
 				return -EINVAL;
 			}
 		}
-	} else if (cfg.insert || cfg.identity == 1) {
+	} else {
 		nvme_show_error("Need to specify a subsystem NQN");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Running nvme check-tls-key hits a segfault as seen below:

nvme check-tls-key
-d NVMeTLSkey-1:01:bB7soUnpHfxVg53sCY21KY3nLbqLit2RcIO8Rbdf3mKhcKaM: Segmentation fault (core dumped)

This is because the strlen check on subsysnqn & hostnqn crashes in libnvme's nvme_identity_len() at src/nvme/linux.c due to them being null. Both subsysnqn and hostnqn are mandatory for generating a PSK identity or inserting the retained key, which is what this command attempts to do. So to avoid this segfault, ensure both the subsysnqn and hostnqn are properly updated in check_tls_key() of nvme-cli's nvme.c before proceeding ahead.