### PR TITLE
wdc: Plugin fixes and updates

### DIFF
--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.3.5"
+#define WDC_PLUGIN_VERSION   "2.3.6"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),

--- a/plugins/wdc/wdc-utils.c
+++ b/plugins/wdc/wdc-utils.c
@@ -192,15 +192,5 @@ bool wdc_CheckUuidListSupport(struct nvme_dev *dev, struct nvme_id_uuid_list *uu
 
 bool wdc_UuidEqual(struct nvme_id_uuid_list_entry *entry1, struct nvme_id_uuid_list_entry *entry2)
 {
-	int i;
-
-	for (i = 0; i < 16; i++) {
-		if (entry1->uuid[i] != entry2->uuid[i])
-			break;
-	}
-
-	if (i == 16)
-		return true;
-	else
-		return false;
+	return !memcmp(entry1, entry2, NVME_UUID_LEN);
 }


### PR DESCRIPTION
Fix a potential buffer overrun error when
retrieving the VU internal debug data log.

Fix vs-smart-add-log for SN-861 drives

Simplify the wdc_UuidEqual function