### PR TITLE
Implement support for secure concatenation

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -27,7 +27,7 @@ SYNOPSIS
 			[--nr-poll-queues=<#> | -P <#>]
 			[--queue-size=<#> | -Q <#>] [--keyring=<#>]
 			[--tls_key=<#>] [--hdr-digest | -g] [--data-digest | -G]
-			[--persistent | -p] [--tls] [--quiet | -S]
+			[--persistent | -p] [--tls] [--concat] [--quiet | -S]
 			[--dump-config | -O] [--nbft] [--no-nbft]
 			[--nbft-path=<STR>] [--context=<STR>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
@@ -185,6 +185,9 @@ OPTIONS
 
 --tls::
 	Enable TLS encryption (TCP).
+
+--concat::
+	Enable secure concatenation (TCP).
 
 -S::
 --quiet::

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -29,7 +29,7 @@ SYNOPSIS
 			[--keyring=<#>] [--tls_key=<#>]
 			[--duplicate-connect | -D] [--disable-sqflow | -d]
 			[--hdr-digest | -g] [--data-digest | -G] [--tls]
-			[--dump-config | -O] [--application=<id>]
+			[--concat] [--dump-config | -O] [--application=<id>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
 
 DESCRIPTION
@@ -175,6 +175,9 @@ OPTIONS
 
 --tls::
 	Enable TLS encryption (TCP).
+
+--concat::
+	Enable secure concatenation (TCP).
 
 -O::
 --dump-config::

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -27,7 +27,7 @@ SYNOPSIS
 			[--nr-poll-queues=<#> | -P <#>]
 			[--queue-size=<#> | -Q <#>] [--keyring=<#>]
 			[--tls_key=<#>] [--hdr-digest | -g] [--data-digest | -G]
-			[--persistent | -p] [--quiet | -S] [--tls]
+			[--persistent | -p] [--quiet | -S] [--tls] [--concat]
 			[--dump-config | -O] [--output-format=<fmt> | -o <fmt>]
 			[--force] [--nbft] [--no-nbft] [--nbft-path=<STR>]
 			[--context=<STR>]
@@ -205,6 +205,9 @@ OPTIONS
 
 --tls::
 	Enable TLS encryption (TCP).
+
+--concat::
+	Enable secure concatenation (TCP).
 
 -S::
 --quiet::

--- a/fabrics.c
+++ b/fabrics.c
@@ -84,6 +84,7 @@ static const char *nvmf_disable_sqflow	= "disable controller sq flow control (de
 static const char *nvmf_hdr_digest	= "enable transport protocol header digest (TCP transport)";
 static const char *nvmf_data_digest	= "enable transport protocol data digest (TCP transport)";
 static const char *nvmf_tls		= "enable TLS";
+static const char *nvmf_concat		= "enable secure concatenation";
 static const char *nvmf_config_file	= "Use specified JSON configuration file or 'none' to disable";
 static const char *nvmf_context		= "execution context identification string";
 
@@ -113,6 +114,7 @@ static const char *nvmf_context		= "execution context identification string";
 		OPT_FLAG("hdr-digest",        'g', &c.hdr_digest,         nvmf_hdr_digest),      \
 		OPT_FLAG("data-digest",       'G', &c.data_digest,        nvmf_data_digest),     \
 		OPT_FLAG("tls",                 0, &c.tls,                nvmf_tls),             \
+		OPT_FLAG("concat",              0, &c.concat,             nvmf_concat),          \
 		__VA_ARGS__,                                                                     \
 		OPT_END()                                                                        \
 	}

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = f38b1d72e5077c827a3fdf8989dcc2dae70701d1
+revision = b5122474cc0f545e7a8868f9c0177a41428acb2b
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Add support for option '--concat' to enable secure concatenation after DH-HMAC-CHAP.

Signed-off-by: Hannes Reinecke <hare@suse.de>