### PR TITLE
doc: Fix short option name for cfg-file

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -18,7 +18,7 @@ SYNOPSIS
 			[--hostid=<hostid> | -I <hostid>]
 			[--raw=<filename> | -r <filename>]
 			[--device=<device> | -d <device>]
-			[--cfg-file=<cfg> | -C <cfg>]
+			[--config=<filename> | -J <cfg>]
 			[--keep-alive-tmo=<sec> | -k <sec>]
 			[--reconnect-delay=<#> | -c <#>]
 			[--ctrl-loss-tmo=<#>	 | -l <#>]
@@ -121,8 +121,8 @@ OPTIONS
 	command "connect-all" or "discover". <device> follows the format
 	nvme*, eg. nvme0, nvme1.
 
--C <cfg>::
---config-file=<cfg>::
+-J <filename>::
+--config=<filename>::
 	Use the specified JSON configuration file instead of the
 	default @SYSCONFDIR@/nvme/config.json file or 'none' to not read in
 	an existing configuration file. The JSON configuration file

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 			[--host-iface=<iface> | -f <iface>]
 			[--hostnqn=<hostnqn> | -q <hostnqn>]
 			[--hostid=<hostid> | -I <hostid>]
-			[--config-file=<cfg> | -J <cfg>]
+			[--config=<filename> | -J <filename>]
 			[--dhchap-secret=<secret> | -S <secret>]
 			[--dhchap-ctrl-secret=<secret> | -C <secret>]
 			[--nr-io-queues=<#> | -i <#>]
@@ -95,8 +95,8 @@ OPTIONS
 	UUID(Universally Unique Identifier) to be discovered which should be
 	formatted.
 
--J <cfg>::
---config-file=<cfg>::
+-J <filename>::
+--config=<filename>::
 	Use the specified JSON configuration file instead of the
 	default @SYSCONFDIR@/nvme/config.json file or 'none' to not read in
 	an existing configuration file. The JSON configuration file

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -18,7 +18,7 @@ SYNOPSIS
 			[--hostid=<hostid> | -I <hostid>]
 			[--raw=<filename> | -r <filename>]
 			[--device=<device> | -d <device>]
-			[--cfg-file=<cfg> | -C <cfg>]
+			[--config=<filename> | -J <filename>]
 			[--keep-alive-tmo=<sec> | -k <sec>]
 			[--reconnect-delay=<#> | -c <#>]
 			[--ctrl-loss-tmo=<#> | -l <#>]
@@ -140,8 +140,8 @@ OPTIONS
 	command "connect-all" or "discover". <device> follows the format
 	nvme*, eg. nvme0, nvme1.
 
--C <cfg>::
---config-file=<cfg>::
+-J <filename>::
+--config=<filename>::
 	Use the specified JSON configuration file instead of the
 	default @SYSCONFDIR@/nvme/config.json file or 'none' to not read in
 	an existing configuration file. The JSON configuration file


### PR DESCRIPTION
It was renamed to "-J" but some docs were left out.