### PR TITLE
plugins/micron: Fix code scanning alert

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -226,7 +226,6 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 	int length = 0;
 	int nIndex = 0;
 	char *strTemp = NULL;
-	struct stat dirStat;
 	int j;
 	int k = 0;
 	int i = 0;
@@ -304,16 +303,15 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 	strMainDirName[nIndex] = '\0';
 
 	j = 1;
-	while (!stat(strMainDirName, &dirStat)) {
+	while (mkdir(strMainDirName, 0777) < 0) {
+		if (errno != EEXIST) {
+			err = -1;
+			goto exit_status;
+		}
 		strMainDirName[nIndex] = '\0';
 		sprintf(strAppend, "-%d", j);
 		strcat(strMainDirName, strAppend);
 		j++;
-	}
-
-	if (mkdir(strMainDirName, 0777) < 0) {
-		err = -1;
-		goto exit_status;
 	}
 
 	if (strOSDirName) {
@@ -331,7 +329,7 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 				rmdir(strOSDirName);
 			rmdir(strMainDirName);
 			err = -1;
-	}
+		}
 	}
 
 exit_status:


### PR DESCRIPTION
Fix the time-of-check time-of-use filesystem race condition.