### PR TITLE
nvme-print-json: append array object in json_support_log

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -3836,7 +3836,7 @@ static void json_support_log(struct nvme_supported_log_pages *support_log,
 		}
 	}
 
-	obj_add_obj(r, "supported_logs", valid);
+	obj_add_array(r, "supported_logs", valid);
 
 	json_print(r);
 }


### PR DESCRIPTION
The valid object is of type array not obj, thus use obj_add_array to add it to the root.

Fixes: #2213 