### PR TITLE
NBFT parser SSNS flags

### DIFF
--- a/nbft.c
+++ b/nbft.c
@@ -163,6 +163,17 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 				ret = nvmf_add_ctrl(h, c, cfg);
 
 				/*
+				 * In case this SSNS was marked as 'unavailable' and
+				 * the connection attempt failed again, ignore it.
+				 */
+				if (ret == -1 && (*ss)->unavailable) {
+					if (verbose >= 1)
+						fprintf(stderr,
+							"subsystem reported as unavailable, skipping\n");
+					continue;
+				}
+
+				/*
 				 * With TCP/DHCP, it can happen that the OS
 				 * obtains a different local IP address than the
 				 * firmware had. Retry without host_traddr.

--- a/nbft.c
+++ b/nbft.c
@@ -80,7 +80,7 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 		       char *hostnqn_sys, char *hostid_sys,
 		       const char *desc, bool connect,
 		       const struct nvme_fabrics_config *cfg, char *nbft_path,
-		       enum nvme_print_flags flags, bool verbose)
+		       enum nvme_print_flags flags, unsigned int verbose)
 {
 	char *hostnqn = NULL, *hostid = NULL, *host_traddr = NULL;
 	nvme_host_t h;

--- a/nbft.c
+++ b/nbft.c
@@ -188,7 +188,8 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 				if (ret == -1 && (*ss)->unavailable) {
 					if (verbose >= 1)
 						fprintf(stderr,
-							"subsystem reported as unavailable, skipping\n");
+							"SSNS %d reported as unavailable, skipping\n",
+							(*ss)->index);
 					continue;
 				}
 
@@ -218,12 +219,14 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 					ret = nvmf_add_ctrl(h, c, cfg);
 					if (ret == 0 && verbose >= 1)
 						fprintf(stderr,
-							"connect with host_traddr=\"%s\" failed, success after omitting host_traddr\n",
+							"SSNS %d: connect with host_traddr=\"%s\" failed, success after omitting host_traddr\n",
+							(*ss)->index,
 							host_traddr);
 				}
 
 				if (ret)
-					fprintf(stderr, "no controller found\n");
+					fprintf(stderr, "SSNS %d: no controller found\n",
+						(*ss)->index);
 				else {
 					if (flags == NORMAL)
 						print_connect_msg(c);

--- a/nbft.h
+++ b/nbft.h
@@ -16,4 +16,4 @@ extern int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg
 			      char *hostnqn_sys, char *hostid_sys,
 			      const char *desc, bool connect,
 			      const struct nvme_fabrics_config *cfg, char *nbft_path,
-			      enum nvme_print_flags flags, bool verbose);
+			      enum nvme_print_flags flags, unsigned int verbose);

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -168,7 +168,11 @@ static json_object *ssns_to_json(struct nbft_info_subsystem_ns *ss)
 	    || json_object_add_value_int(ss_json, "pdu_header_digest_required",
 					 ss->pdu_header_digest_required)
 	    || json_object_add_value_int(ss_json, "data_digest_required",
-					 ss->data_digest_required))
+					 ss->data_digest_required)
+	    || json_object_add_value_int(ss_json, "discovered",
+					 ss->discovered)
+	    || json_object_add_value_int(ss_json, "unavailable",
+					 ss->unavailable))
 		goto fail;
 
 	return ss_json;


### PR DESCRIPTION
This adds support for the newly introduced `unavailable` SSNS flag. Certain firmware (UEFI) implementations may include SSNS records in the ACPI NBFT table that failed to connect and optionally provide a detailed reason (TP-8029, not subject to this pull request).

In userspace I thought it might be beneficial to do another connection attempt, with expectation of failure. Such failure should not be reported nor should fail the whole connection process (`nvme connect-all --nbft`). Failure messages would still be reported in verbose mode.

As currently designed, three connection attempts are made: the pre-OS/UEFI phase, dracut and another try via the `nvmf-connect-nbft.service` systemd unit. Between these attempts networking may change, new routes added, tunnels established, etc.

Needs https://github.com/linux-nvme/libnvme/pull/781 and ~~https://github.com/linux-nvme/libnvme/pull/782~~