### PR TITLE
sed: Confirm entered password before initialization.

### DIFF
--- a/plugins/sed/sedopal_cmd.c
+++ b/plugins/sed/sedopal_cmd.c
@@ -171,6 +171,7 @@ int sedopal_cmd_initialize(int fd)
 	struct opal_user_lr_setup lr_setup = {};
 
 	sedopal_ask_key = true;
+	sedopal_ask_new_key = true;
 	rc = sedopal_set_key(&key);
 	if (rc != 0)
 		return rc;


### PR DESCRIPTION
Ask for password twice in case there is a typo in entering it.