### PR TITLE
nvme-print: print more details in ns-descs verbose output

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -2714,7 +2714,7 @@ static void stdout_cmd_set_independent_id_ns(struct nvme_id_independent_id_ns *n
 static void stdout_id_ns_descs(void *data, unsigned int nsid)
 {
 	int pos, len = 0;
-	int i;
+	int i, verbose = stdout_print_ops.flags & VERBOSE;
 	__u8 uuid[NVME_UUID_LEN];
 	char uuid_str[NVME_UUID_LEN_STRING];
 	__u8 eui64[8];
@@ -2727,6 +2727,12 @@ static void stdout_id_ns_descs(void *data, unsigned int nsid)
 
 		if (cur->nidl == 0)
 			break;
+
+		if (verbose) {
+			printf("loc     : %d\n", pos);
+			printf("nidt    : %d\n", (int)cur->nidt);
+			printf("nidl    : %d\n", (int)cur->nidl);
+		}
 
 		switch (cur->nidt) {
 		case NVME_NIDT_EUI64:

--- a/nvme.c
+++ b/nvme.c
@@ -3615,6 +3615,9 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 	if (cfg.raw_binary)
 		flags = BINARY;
 
+	if (argconfig_parse_seen(opts, "verbose"))
+		flags |= VERBOSE;
+
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
 		if (err < 0) {


### PR DESCRIPTION
Print more details such as loc, nidt & nidl (similar to the corresponding json output) in the ns-descs verbose output.