### PR TITLE
nvme-print-stdout: Use persistent event log RCI definitions

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -224,14 +224,11 @@ static void stdout_persistent_event_log_rci(__le32 pel_header_rci)
 	__u8 rcpit = NVME_PEL_RCI_RCPIT(rci);
 	__u16 rcpid = NVME_PEL_RCI_RCPID(rci);
 
-	if(rsvd19)
+	if (rsvd19)
 		printf("  [31:19] : %#x\tReserved\n", rsvd19);
-	printf("\tReporting Context Exists (RCE): %s(%u)\n",
-		rce ? "true" : "false", rce);
+	printf("\tReporting Context Exists (RCE): %s(%u)\n", rce ? "true" : "false", rce);
 	printf("\tReporting Context Port Identifier Type (RCPIT): %u(%s)\n", rcpit,
-		(rcpit == 0x00) ? "Does not already exist" :
-		(rcpit == 0x01) ? "NVM subsystem port" :
-		(rcpit == 0x02) ? "NVMe-MI port" : "Reserved");
+	       nvme_pel_rci_rcpit_to_string(rcpit));
 	printf("\tReporting Context Port Identifier (RCPID): %#x\n\n", rcpid);
 }
 

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -219,10 +219,10 @@ static void stdout_predictable_latency_event_agg_log(
 static void stdout_persistent_event_log_rci(__le32 pel_header_rci)
 {
 	__u32 rci = le32_to_cpu(pel_header_rci);
-	__u32 rsvd19 = (rci & 0xfff80000) >> 19;
-	__u8 rce = (rci & 0x40000) >> 18;
-	__u8 rcpit = (rci & 0x30000) >> 16;
-	__u16 rcpid = rci & 0xffff;
+	__u32 rsvd19 = NVME_PEL_RCI_RSVD(rci);
+	__u8 rce = NVME_PEL_RCI_RCE(rci);
+	__u8 rcpit = NVME_PEL_RCI_RCPIT(rci);
+	__u16 rcpid = NVME_PEL_RCI_RCPID(rci);
 
 	if(rsvd19)
 		printf("  [31:19] : %#x\tReserved\n", rsvd19);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -890,64 +890,63 @@ void nvme_show_lba_status_info(__u32 result)
 	nvme_print(lba_status_info, NORMAL, result);
 }
 
-const char *nvme_host_metadata_type_to_string(enum nvme_features_id fid,
-					      __u8 type)
+const char *nvme_host_metadata_type_to_string(enum nvme_features_id fid, __u8 type)
 {
-       switch (fid) {
-       case NVME_FEAT_FID_ENH_CTRL_METADATA:
-       case NVME_FEAT_FID_CTRL_METADATA:
-	       switch (type) {
-	       case NVME_CTRL_METADATA_OS_CTRL_NAME:
-		       return "Operating System Controller Name";
-	       case NVME_CTRL_METADATA_OS_DRIVER_NAME:
-		       return "Operating System Driver Name";
-	       case NVME_CTRL_METADATA_OS_DRIVER_VER:
-		       return "Operating System Driver Version";
-	       case NVME_CTRL_METADATA_PRE_BOOT_CTRL_NAME:
-		       return "Pre-boot Controller Name";
-	       case NVME_CTRL_METADATA_PRE_BOOT_DRIVER_NAME:
-		       return "Pre-boot Driver Name";
-	       case NVME_CTRL_METADATA_PRE_BOOT_DRIVER_VER:
-		       return "Pre-boot Driver Version";
-	       case NVME_CTRL_METADATA_SYS_PROC_MODEL:
-		       return "System Processor Model";
-	       case NVME_CTRL_METADATA_CHIPSET_DRV_NAME:
-		       return "Chipset Driver Name";
-	       case NVME_CTRL_METADATA_CHIPSET_DRV_VERSION:
-		       return "Chipset Driver Version";
-	       case NVME_CTRL_METADATA_OS_NAME_AND_BUILD:
-		       return "Operating System Name and Build";
-	       case NVME_CTRL_METADATA_SYS_PROD_NAME:
-		       return "System Product Name";
-	       case NVME_CTRL_METADATA_FIRMWARE_VERSION:
-		       return "Firmware Version";
-	       case NVME_CTRL_METADATA_OS_DRIVER_FILENAME:
-		       return "Operating System Driver Filename";
-	       case NVME_CTRL_METADATA_DISPLAY_DRV_NAME:
-		       return "Display Driver Name";
-	       case NVME_CTRL_METADATA_DISPLAY_DRV_VERSION:
-		       return "Display Driver Version";
-	       case NVME_CTRL_METADATA_HOST_DET_FAIL_REC:
-		       return "Host-Determined Failure Record";
-	       default:
-		       return "Unknown Controller Type";
-	       }
-       case NVME_FEAT_FID_NS_METADATA:
-	       switch (type) {
-	       case NVME_NS_METADATA_OS_NS_NAME:
-		       return "Operating System Namespace Name";
-	       case NVME_NS_METADATA_PRE_BOOT_NS_NAME:
-		       return "Pre-boot Namespace Name";
-	       case NVME_NS_METADATA_OS_NS_QUAL_1:
-		       return "Operating System Namespace Name Qualifier 1";
-	       case NVME_NS_METADATA_OS_NS_QUAL_2:
-		       return "Operating System Namespace Name Qualifier 2";
-	       default:
-		       return "Unknown Namespace Type";
-	       }
-       default:
-	       return "Unknown Feature";
-       }
+	switch (fid) {
+	case NVME_FEAT_FID_ENH_CTRL_METADATA:
+	case NVME_FEAT_FID_CTRL_METADATA:
+		switch (type) {
+		case NVME_CTRL_METADATA_OS_CTRL_NAME:
+			return "Operating System Controller Name";
+		case NVME_CTRL_METADATA_OS_DRIVER_NAME:
+			return "Operating System Driver Name";
+		case NVME_CTRL_METADATA_OS_DRIVER_VER:
+			return "Operating System Driver Version";
+		case NVME_CTRL_METADATA_PRE_BOOT_CTRL_NAME:
+			return "Pre-boot Controller Name";
+		case NVME_CTRL_METADATA_PRE_BOOT_DRIVER_NAME:
+			return "Pre-boot Driver Name";
+		case NVME_CTRL_METADATA_PRE_BOOT_DRIVER_VER:
+			return "Pre-boot Driver Version";
+		case NVME_CTRL_METADATA_SYS_PROC_MODEL:
+			return "System Processor Model";
+		case NVME_CTRL_METADATA_CHIPSET_DRV_NAME:
+			return "Chipset Driver Name";
+		case NVME_CTRL_METADATA_CHIPSET_DRV_VERSION:
+			return "Chipset Driver Version";
+		case NVME_CTRL_METADATA_OS_NAME_AND_BUILD:
+			return "Operating System Name and Build";
+		case NVME_CTRL_METADATA_SYS_PROD_NAME:
+			return "System Product Name";
+		case NVME_CTRL_METADATA_FIRMWARE_VERSION:
+			return "Firmware Version";
+		case NVME_CTRL_METADATA_OS_DRIVER_FILENAME:
+			return "Operating System Driver Filename";
+		case NVME_CTRL_METADATA_DISPLAY_DRV_NAME:
+			return "Display Driver Name";
+		case NVME_CTRL_METADATA_DISPLAY_DRV_VERSION:
+			return "Display Driver Version";
+		case NVME_CTRL_METADATA_HOST_DET_FAIL_REC:
+			return "Host-Determined Failure Record";
+		default:
+			return "Unknown Controller Type";
+		}
+	case NVME_FEAT_FID_NS_METADATA:
+		switch (type) {
+		case NVME_NS_METADATA_OS_NS_NAME:
+			return "Operating System Namespace Name";
+		case NVME_NS_METADATA_PRE_BOOT_NS_NAME:
+			return "Pre-boot Namespace Name";
+		case NVME_NS_METADATA_OS_NS_QUAL_1:
+			return "Operating System Namespace Name Qualifier 1";
+		case NVME_NS_METADATA_OS_NS_QUAL_2:
+			return "Operating System Namespace Name Qualifier 2";
+		default:
+			return "Unknown Namespace Type";
+		}
+	default:
+		return "Unknown Feature";
+	}
 }
 
 const char *nvme_pel_rci_rcpit_to_string(enum nvme_pel_rci_rcpit rcpit)

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -950,6 +950,21 @@ const char *nvme_host_metadata_type_to_string(enum nvme_features_id fid,
        }
 }
 
+const char *nvme_pel_rci_rcpit_to_string(enum nvme_pel_rci_rcpit rcpit)
+{
+	switch (rcpit) {
+	case NVME_PEL_RCI_RCPIT_NOT_EXIST:
+		return "Does not already exist";
+	case NVME_PEL_RCI_RCPIT_EST_PORT:
+		return "NVM subsystem port";
+	case NVME_PEL_RCI_RCPIT_EST_ME:
+		return "NVMe-MI port";
+	default:
+		break;
+	}
+	return "Reserved";
+}
+
 void nvme_feature_show(enum nvme_features_id fid, int sel, unsigned int result)
 {
 	nvme_print(show_feature, NORMAL, fid, sel, result);

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -302,6 +302,7 @@ const char *nvme_zone_state_to_string(__u8 state);
 const char *nvme_zone_type_to_string(__u8 cond);
 const char *nvme_plm_window_to_string(__u32 plm);
 const char *nvme_ns_wp_cfg_to_string(enum nvme_ns_write_protect_cfg state);
+const char *nvme_pel_rci_rcpit_to_string(enum nvme_pel_rci_rcpit rcpit);
 
 void nvme_dev_full_path(nvme_ns_t n, char *path, size_t len);
 void nvme_generic_full_path(nvme_ns_t n, char *path, size_t len);

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = bff7dda7e2a0f883d0b89e23fed725c916de3e61
+revision = dd22963a614533e630968f2b6557d7ed93e0973c
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Change the hardcoded the register bit shift to use the definitions.