### PR TITLE
Revert "nvme-print-json: remove obj_print helper"

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -179,6 +179,12 @@ static void json_print(struct json_object *r)
 	json_free_object(r);
 }
 
+static void obj_print(struct json_object *o)
+{
+	if (!json_r)
+		json_print(o);
+}
+
 static bool human(void)
 {
 	return json_print_ops.flags & VERBOSE;
@@ -759,7 +765,7 @@ static void json_select_result(enum nvme_features_id fid, __u32 result)
 	sprintf(json_str, "Feature: %#0*x: select", fid ? 4 : 2, fid);
 	obj_add_array(r, json_str, feature);
 
-	json_print(r);
+	obj_print(r);
 }
 
 static void json_self_test_log(struct nvme_self_test_log *self_test, __u8 dst_entries,
@@ -3433,7 +3439,7 @@ static void json_feature_show(enum nvme_features_id fid, int sel, unsigned int r
 	sprintf(json_str, "%#0*x", result ? 10 : 8, result);
 	obj_add_str(r, nvme_select_to_string(sel), json_str);
 
-	json_print(r);
+	obj_print(r);
 }
 
 static void json_feature_show_fields(enum nvme_features_id fid, unsigned int result,
@@ -3556,7 +3562,7 @@ static void json_feature_show_fields(enum nvme_features_id fid, unsigned int res
 		break;
 	}
 
-	json_print(r);
+	obj_print(r);
 }
 
 void json_id_ctrl_rpmbs(__le32 ctrl_rpmbs)
@@ -3610,7 +3616,7 @@ void json_d(unsigned char *buf, int len, int width, int group)
 	d_json(buf, len, width, group, data);
 	obj_add_array(r, json_str, data);
 
-	json_print(r);
+	obj_print(r);
 }
 
 static void json_nvme_list_ctrl(struct nvme_ctrl_list *ctrl_list)
@@ -4311,7 +4317,7 @@ static void json_output_status(int status)
 
 	if (status < 0) {
 		obj_add_str(r, "error", nvme_strerror(errno));
-		json_print(r);
+		obj_print(r);
 		return;
 	}
 
@@ -4332,7 +4338,7 @@ static void json_output_status(int status)
 		break;
 	}
 
-	json_print(r);
+	obj_print(r);
 }
 
 static void json_output_error_status(int status, const char *msg, va_list ap)
@@ -4353,7 +4359,7 @@ static void json_output_error_status(int status, const char *msg, va_list ap)
 
 	if (status < 0) {
 		obj_add_str(r, "error", nvme_strerror(errno));
-		json_print(r);
+		obj_print(r);
 		return;
 	}
 
@@ -4376,7 +4382,7 @@ static void json_output_error_status(int status, const char *msg, va_list ap)
 
 	obj_add_int(r, "value", val);
 
-	json_print(r);
+	obj_print(r);
 }
 
 static void json_output_message(bool error, const char *msg, va_list ap)
@@ -4391,7 +4397,7 @@ static void json_output_message(bool error, const char *msg, va_list ap)
 
 	free(value);
 
-	json_print(r);
+	obj_print(r);
 }
 
 static void json_output_perror(const char *msg)


### PR DESCRIPTION
This reverts commit b854cbda04a19b7dcfcbeb569146cf9ab79fd5f3.