### PR TITLE
wdc: Add support for the get-drive-status command to SN861

### DIFF
--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.7.0"
+#define WDC_PLUGIN_VERSION   "2.8.0"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),

--- a/plugins/wdc/wdc-utils.c
+++ b/plugins/wdc/wdc-utils.c
@@ -192,5 +192,5 @@ bool wdc_CheckUuidListSupport(struct nvme_dev *dev, struct nvme_id_uuid_list *uu
 
 bool wdc_UuidEqual(struct nvme_id_uuid_list_entry *entry1, struct nvme_id_uuid_list_entry *entry2)
 {
-	return !memcmp(entry1, entry2, NVME_UUID_LEN);
+	return !memcmp(entry1->uuid, entry2->uuid, NVME_UUID_LEN);
 }


### PR DESCRIPTION
This change will use UUID lists to access the WD C2 log page and retrieve the correct info needed to display the drive status.