### PR TITLE
Refactor and extend logging

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -45,6 +45,7 @@
 #include "nbft.h"
 #include "nvme-print.h"
 #include "fabrics.h"
+#include "util/logging.h"
 
 #define PATH_NVMF_DISC		SYSCONFDIR "/nvme/discovery.conf"
 #define PATH_NVMF_CONFIG	SYSCONFDIR "/nvme/config.json"

--- a/fabrics.c
+++ b/fabrics.c
@@ -716,7 +716,9 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	if (!strcmp(config_file, "none"))
 		config_file = NULL;
 
-	r = nvme_create_root(stderr, map_log_level(verbose, quiet));
+	log_level = map_log_level(verbose, quiet);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		fprintf(stderr, "Failed to create topology root: %s\n",
 			nvme_strerror(errno));
@@ -944,7 +946,9 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	if (!strcmp(config_file, "none"))
 		config_file = NULL;
 
-	r = nvme_create_root(stderr, map_log_level(verbose, quiet));
+	log_level = map_log_level(verbose, quiet);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		fprintf(stderr, "Failed to create topology root: %s\n",
 			nvme_strerror(errno));
@@ -1104,7 +1108,9 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 		return -EINVAL;
 	}
 
-	r = nvme_create_root(stderr, map_log_level(cfg.verbose, false));
+	log_level = map_log_level(cfg.verbose, false);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		fprintf(stderr, "Failed to create topology root: %s\n",
 			nvme_strerror(errno));
@@ -1172,7 +1178,9 @@ int nvmf_disconnect_all(const char *desc, int argc, char **argv)
 	if (ret)
 		return ret;
 
-	r = nvme_create_root(stderr, map_log_level(cfg.verbose, false));
+	log_level = map_log_level(cfg.verbose, false);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		fprintf(stderr, "Failed to create topology root: %s\n",
 			nvme_strerror(errno));
@@ -1240,7 +1248,9 @@ int nvmf_config(const char *desc, int argc, char **argv)
 	if (!strcmp(config_file, "none"))
 		config_file = NULL;
 
-	r = nvme_create_root(stderr, map_log_level(verbose, quiet));
+	log_level = map_log_level(verbose, quiet);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		fprintf(stderr, "Failed to create topology root: %s\n",
 			nvme_strerror(errno));
@@ -1392,7 +1402,9 @@ int nvmf_dim(const char *desc, int argc, char **argv)
 		return -EINVAL;
 	}
 
-	r = nvme_create_root(stderr, map_log_level(cfg.verbose, false));
+	log_level = map_log_level(cfg.verbose, false);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		fprintf(stderr, "Failed to create topology root: %s\n",
 			nvme_strerror(errno));

--- a/fabrics.c
+++ b/fabrics.c
@@ -38,10 +38,11 @@
 #include <sys/types.h>
 #include <linux/types.h>
 
+#include <libnvme.h>
+
 #include "common.h"
 #include "nvme.h"
 #include "nbft.h"
-#include "libnvme.h"
 #include "nvme-print.h"
 #include "fabrics.h"
 

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -428,9 +428,3 @@ int nvme_cli_security_receive(struct nvme_dev *dev,
 
 	return -ENODEV;
 }
-
-void nvme_cli_set_debug(struct nvme_dev *dev, bool set)
-{
-	if (dev->type == NVME_DEV_DIRECT)
-		nvme_set_debug(set);
-}

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -147,5 +147,4 @@ int nvme_cli_security_send(struct nvme_dev *dev,
 int nvme_cli_security_receive(struct nvme_dev *dev,
 			      struct nvme_security_receive_args* args);
 
-void nvme_cli_set_debug(struct nvme_dev *dev, bool set);
 #endif /* _NVME_WRAP_H */

--- a/nvme.c
+++ b/nvme.c
@@ -63,6 +63,7 @@
 #include "nvme-wrap.h"
 #include "util/argconfig.h"
 #include "util/suffix.h"
+#include "util/logging.h"
 #include "fabrics.h"
 #define CREATE_CMD
 #include "nvme-builtin.h"
@@ -195,36 +196,6 @@ const char *nvme_strerror(int errnum)
 	if (errnum >= ENVME_CONNECT_RESOLVE)
 		return nvme_errno_to_string(errnum);
 	return strerror(errnum);
-}
-
-int map_log_level(int verbose, bool quiet)
-{
-	int log_level;
-
-	/*
-	 * LOG_NOTICE is unused thus the user has to provide two 'v' for getting
-	 * any feedback at all. Thus skip this level
-	 */
-	verbose++;
-
-	switch (verbose) {
-	case 0:
-		log_level = LOG_WARNING;
-		break;
-	case 1:
-		log_level = LOG_NOTICE;
-		break;
-	case 2:
-		log_level = LOG_INFO;
-		break;
-	default:
-		log_level = LOG_DEBUG;
-		break;
-	}
-	if (quiet)
-		log_level = LOG_ERR;
-
-	return log_level;
 }
 
 static ssize_t getrandom_bytes(void *buf, size_t buflen)

--- a/nvme.c
+++ b/nvme.c
@@ -110,7 +110,7 @@ struct passthru_config {
 
 #define NVME_ARGS(n, ...)                                                         \
 	struct argconfig_commandline_options n[] = {                              \
-		OPT_FLAG("verbose",      'v', NULL,               verbose),       \
+		OPT_INCR("verbose",      'v', &verbose_level,     verbose),       \
 		OPT_FMT("output-format", 'o', &output_format_val, output_format), \
 		##__VA_ARGS__,                                                    \
 		OPT_END()                                                         \
@@ -188,6 +188,7 @@ static const char dash[51] = {[0 ... 49] = '=', '\0'};
 static const char space[51] = {[0 ... 49] = ' ', '\0'};
 
 static char *output_format_val = "normal";
+int verbose_level;
 
 static void *mmap_registers(nvme_root_t r, struct nvme_dev *dev);
 
@@ -3223,7 +3224,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	if (argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
-	log_level = map_log_level(!!(flags & VERBOSE), false);
+	log_level = map_log_level(verbose_level, false);
 
 	r = nvme_create_root(stderr, log_level);
 	if (!r) {
@@ -3282,7 +3283,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	if (argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
-	log_level = map_log_level(!!(flags & VERBOSE), false);
+	log_level = map_log_level(verbose_level, false);
 
 	r = nvme_create_root(stderr, log_level);
 	if (!r) {
@@ -8865,7 +8866,7 @@ static int show_topology_cmd(int argc, char **argv, struct command *command, str
 		return -EINVAL;
 	}
 
-	log_level = map_log_level(!!(flags & VERBOSE), false);
+	log_level = map_log_level(verbose_level, false);
 
 	r = nvme_create_root(stderr, log_level);
 	if (!r) {

--- a/nvme.c
+++ b/nvme.c
@@ -52,9 +52,10 @@
 	#include <sys/random.h>
 #endif
 
+#include <libnvme.h>
+
 #include "common.h"
 #include "nvme.h"
-#include "libnvme.h"
 #include "nvme-print.h"
 #include "plugin.h"
 #include "util/base64.h"

--- a/nvme.c
+++ b/nvme.c
@@ -3223,7 +3223,9 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	if (argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
-	r = nvme_create_root(stderr, map_log_level(!!(flags & VERBOSE), false));
+	log_level = map_log_level(!!(flags & VERBOSE), false);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		if (devname)
 			nvme_show_error("Failed to scan nvme subsystem for %s", devname);
@@ -3280,7 +3282,9 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	if (argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
-	r = nvme_create_root(stderr, map_log_level(!!(flags & VERBOSE), false));
+	log_level = map_log_level(!!(flags & VERBOSE), false);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		nvme_show_error("Failed to create topology root: %s", nvme_strerror(errno));
 		return -errno;
@@ -5272,7 +5276,7 @@ static void *mmap_registers(nvme_root_t r, struct nvme_dev *dev)
 
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
-		if (map_log_level(0, false) >= LOG_DEBUG)
+		if (log_level >= LOG_DEBUG)
 			nvme_show_error("%s did not find a pci resource, open failed %s",
 					dev->name, strerror(errno));
 		return NULL;
@@ -5280,7 +5284,7 @@ static void *mmap_registers(nvme_root_t r, struct nvme_dev *dev)
 
 	membase = mmap(NULL, getpagesize(), PROT_READ, MAP_SHARED, fd, 0);
 	if (membase == MAP_FAILED) {
-		if (map_log_level(0, false) >= LOG_DEBUG) {
+		if (log_level >= LOG_DEBUG) {
 			fprintf(stderr, "%s failed to map. ", dev->name);
 			fprintf(stderr, "Did your kernel enable CONFIG_IO_STRICT_DEVMEM?\n");
 		}
@@ -8861,7 +8865,9 @@ static int show_topology_cmd(int argc, char **argv, struct command *command, str
 		return -EINVAL;
 	}
 
-	r = nvme_create_root(stderr, map_log_level(!!(flags & VERBOSE), false));
+	log_level = map_log_level(!!(flags & VERBOSE), false);
+
+	r = nvme_create_root(stderr, log_level);
 	if (!r) {
 		nvme_show_error("Failed to create topology root: %s", nvme_strerror(errno));
 		return -errno;

--- a/nvme.c
+++ b/nvme.c
@@ -373,8 +373,8 @@ int parse_and_open(struct nvme_dev **dev, int argc, char **argv,
 	ret = get_dev(dev, argc, argv, O_RDONLY);
 	if (ret < 0)
 		argconfig_print_help(desc, opts);
-	else if (argconfig_parse_seen(opts, "verbose"))
-		nvme_cli_set_debug(*dev, true);
+	else
+		log_level = map_log_level(verbose_level, false);
 
 	return ret;
 }
@@ -3224,7 +3224,6 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	if (argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
-	log_level = map_log_level(verbose_level, false);
 
 	r = nvme_create_root(stderr, log_level);
 	if (!r) {
@@ -3282,8 +3281,6 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 
 	if (argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
-
-	log_level = map_log_level(verbose_level, false);
 
 	r = nvme_create_root(stderr, log_level);
 	if (!r) {
@@ -8865,8 +8862,6 @@ static int show_topology_cmd(int argc, char **argv, struct command *command, str
 		nvme_show_error("Invalid ranking argument: %s", cfg.ranking);
 		return -EINVAL;
 	}
-
-	log_level = map_log_level(verbose_level, false);
 
 	r = nvme_create_root(stderr, log_level);
 	if (!r) {

--- a/nvme.h
+++ b/nvme.h
@@ -113,8 +113,6 @@ bool nvme_is_output_format_json(void);
 int __id_ctrl(int argc, char **argv, struct command *cmd,
 	struct plugin *plugin, void (*vs)(uint8_t *vs, struct json_object *root));
 
-extern int current_index;
-
 const char *nvme_strerror(int errnum);
 
 unsigned long long elapsed_utime(struct timeval start_time,

--- a/nvme.h
+++ b/nvme.h
@@ -125,5 +125,4 @@ void d(unsigned char *buf, int len, int width, int group);
 void d_raw(unsigned char *buf, unsigned len);
 uint64_t int48_to_long(uint8_t *data);
 
-int map_log_level(int verbose, bool quiet);
 #endif /* _NVME_H */

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = dd22963a614533e630968f2b6557d7ed93e0973c
+revision = d706ff266b45d1c17522d3c54a026fdab13fe346
 
 [provide]
 libnvme = libnvme_dep

--- a/util/logging.c
+++ b/util/logging.c
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "logging.h"
+
+int map_log_level(int verbose, bool quiet)
+{
+	int log_level;
+
+	/*
+	 * LOG_NOTICE is unused thus the user has to provide two 'v' for getting
+	 * any feedback at all. Thus skip this level
+	 */
+	verbose++;
+
+	switch (verbose) {
+	case 0:
+		log_level = LOG_WARNING;
+		break;
+	case 1:
+		log_level = LOG_NOTICE;
+		break;
+	case 2:
+		log_level = LOG_INFO;
+		break;
+	default:
+		log_level = LOG_DEBUG;
+		break;
+	}
+	if (quiet)
+		log_level = LOG_ERR;
+
+	return log_level;
+}

--- a/util/logging.c
+++ b/util/logging.c
@@ -2,6 +2,8 @@
 
 #include "logging.h"
 
+int log_level;
+
 int map_log_level(int verbose, bool quiet)
 {
 	int log_level;

--- a/util/logging.c
+++ b/util/logging.c
@@ -1,5 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <inttypes.h>
+
+#include <stdint.h>
+#include <sys/ioctl.h>
+#include <sys/syslog.h>
+#include <sys/time.h>
+#include <linux/types.h>
+
+#include <libnvme.h>
+
 #include "logging.h"
 
 int log_level;
@@ -32,4 +42,93 @@ int map_log_level(int verbose, bool quiet)
 		log_level = LOG_ERR;
 
 	return log_level;
+}
+
+static void nvme_show_common(struct nvme_passthru_cmd *cmd)
+{
+	printf("opcode       : %02x\n", cmd->opcode);
+	printf("flags        : %02x\n", cmd->flags);
+	printf("rsvd1        : %04x\n", cmd->rsvd1);
+	printf("nsid         : %08x\n", cmd->nsid);
+	printf("cdw2         : %08x\n", cmd->cdw2);
+	printf("cdw3         : %08x\n", cmd->cdw3);
+	printf("data_len     : %08x\n", cmd->data_len);
+	printf("metadata_len : %08x\n", cmd->metadata_len);
+	printf("addr         : %"PRIx64"\n", (uint64_t)(uintptr_t)cmd->addr);
+	printf("metadata     : %"PRIx64"\n", (uint64_t)(uintptr_t)cmd->metadata);
+	printf("cdw10        : %08x\n", cmd->cdw10);
+	printf("cdw11        : %08x\n", cmd->cdw11);
+	printf("cdw12        : %08x\n", cmd->cdw12);
+	printf("cdw13        : %08x\n", cmd->cdw13);
+	printf("cdw14        : %08x\n", cmd->cdw14);
+	printf("cdw15        : %08x\n", cmd->cdw15);
+	printf("timeout_ms   : %08x\n", cmd->timeout_ms);
+}
+
+static void nvme_show_command(struct nvme_passthru_cmd *cmd, int err, struct timeval start,
+			      struct timeval end)
+{
+	nvme_show_common(cmd);
+	printf("result       : %08x\n", cmd->result);
+	printf("err          : %d\n", err);
+	printf("latency      : %lu us\n",
+	       (end.tv_sec - start.tv_sec) * 1000000 + (end.tv_usec - start.tv_usec));
+}
+
+static void nvme_show_command64(struct nvme_passthru_cmd64 *cmd, int err, struct timeval start,
+			      struct timeval end)
+{
+	nvme_show_common((struct nvme_passthru_cmd *)cmd);
+	printf("result       : %"PRIx64"\n", (uint64_t)(uintptr_t)cmd->result);
+	printf("err          : %d\n", err);
+	printf("latency      : %lu us\n",
+	       (end.tv_sec - start.tv_sec) * 1000000 + (end.tv_usec - start.tv_usec));
+}
+
+int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
+			 struct nvme_passthru_cmd *cmd, __u32 *result)
+{
+	struct timeval start;
+	struct timeval end;
+	int err;
+
+	if (log_level >= LOG_DEBUG)
+		gettimeofday(&start, NULL);
+
+	err = ioctl(fd, ioctl_cmd, cmd);
+
+	if (log_level >= LOG_DEBUG) {
+		gettimeofday(&end, NULL);
+		nvme_show_command(cmd, err, start, end);
+	}
+
+	if (err >= 0 && result)
+		*result = cmd->result;
+
+	return err;
+}
+
+int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
+			   struct nvme_passthru_cmd64 *cmd,
+			   __u64 *result)
+{
+	struct timeval start;
+	struct timeval end;
+	int err;
+
+	if (log_level >= LOG_DEBUG)
+		gettimeofday(&start, NULL);
+
+
+	err = ioctl(fd, ioctl_cmd, cmd);
+
+	if (log_level >= LOG_DEBUG) {
+		gettimeofday(&end, NULL);
+		nvme_show_command64(cmd, err, start, end);
+	}
+
+	if (err >= 0 && result)
+		*result = cmd->result;
+
+	return err;
 }

--- a/util/logging.h
+++ b/util/logging.h
@@ -5,6 +5,8 @@
 
 #include <stdbool.h>
 
+extern int log_level;
+
 int map_log_level(int verbose, bool quiet);
 
 #endif // DEBUG_H_

--- a/util/logging.h
+++ b/util/logging.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#ifndef DEBUG_H_
+#define DEBUG_H_
+
+#include <stdbool.h>
+
+int map_log_level(int verbose, bool quiet);
+
+#endif // DEBUG_H_

--- a/util/meson.build
+++ b/util/meson.build
@@ -4,6 +4,7 @@ sources += [
   'util/argconfig.c',
   'util/base64.c',
   'util/crc32.c',
+  'util/logging.c',
   'util/mem.c',
   'util/suffix.c',
   'util/types.c',


### PR DESCRIPTION
Introduce a global log level which then can be forwarded to libnvme. Also provide our own low level passthru commands so that we extend it with extensive logging outputs. While it also support the 64 bit version of it.