### PR TITLE
nvme-print-stdout: Use NVME_PMRCAP register definition to print

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1395,12 +1395,13 @@ static void stdout_registers_pmrsts(__u32 pmrsts, __u32 pmrctl)
 
 static void stdout_registers_pmrebs(__u32 pmrebs)
 {
-	printf("\tPMR Elasticity Buffer Size Base  (PMRWBZ): %x\n", (pmrebs & 0xffffff00) >> 8);
-	printf("\tRead Bypass Behavior                     : memory reads not conflicting with memory writes "\
-	       "in the PMR Elasticity Buffer %s bypass those memory writes\n",
-	       (pmrebs & 0x00000010) ? "SHALL" : "MAY");
+	printf("\tPMR Elasticity Buffer Size Base  (PMRWBZ): %x\n", NVME_PMREBS_PMRWBZ(pmrebs));
+	printf("\tRead Bypass Behavior                     : ");
+	printf("memory reads not conflicting with memory writes ");
+	printf("in the PMR Elasticity Buffer %s bypass those memory writes\n",
+	       NVME_PMREBS_RBB(pmrebs) ? "SHALL" : "MAY");
 	printf("\tPMR Elasticity Buffer Size Units (PMRSZU): %s\n",
-		nvme_register_pmr_pmrszu_to_string(pmrebs & 0x0000000f));
+	       nvme_register_pmr_pmrszu_to_string(NVME_PMREBS_PMRSZU(pmrebs)));
 }
 
 static void stdout_registers_pmrswtp(__u32 pmrswtp)

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1378,8 +1378,7 @@ static void stdout_registers_pmrcap(__u32 pmrcap)
 
 static void stdout_registers_pmrctl(__u32 pmrctl)
 {
-	printf("\tEnable (EN): PMR is %s\n", (pmrctl & 0x00000001) ?
-		"READY" : "Disabled");
+	printf("\tEnable (EN): PMR is %s\n", NVME_PMRCTL_EN(pmrctl) ? "READY" : "Disabled");
 }
 
 static void stdout_registers_pmrsts(__u32 pmrsts, __u32 pmrctl)

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1415,9 +1415,8 @@ static void stdout_registers_pmrswtp(__u32 pmrswtp)
 static void stdout_registers_pmrmscl(uint32_t pmrmscl)
 {
 	printf("\tController Base Address         (CBA): %#x\n",
-		(pmrmscl & 0xfffff000) >> 12);
-	printf("\tController Memory Space Enable (CMSE): %#x\n\n",
-		(pmrmscl & 0x00000002) >> 1);
+	       (uint32_t)NVME_PMRMSC_CBA(pmrmscl));
+	printf("\tController Memory Space Enable (CMSE): %#x\n\n", NVME_PMRMSC_CMSE(pmrmscl));
 }
 
 static void stdout_registers_pmrmscu(uint32_t pmrmscu)

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1383,16 +1383,14 @@ static void stdout_registers_pmrctl(__u32 pmrctl)
 
 static void stdout_registers_pmrsts(__u32 pmrsts, __u32 pmrctl)
 {
-	printf("\tController Base Address Invalid (CBAI): %x\n",
-		(pmrsts & 0x00001000) >> 12);
+	printf("\tController Base Address Invalid (CBAI): %x\n", NVME_PMRSTS_CBAI(pmrsts));
 	printf("\tHealth Status                   (HSTS): %s\n",
-		nvme_register_pmr_hsts_to_string((pmrsts & 0x00000e00) >> 9));
-	printf("\tNot Ready                       (NRDY): "\
-		"The Persistent Memory Region is %s to process "\
-		"PCI Express memory read and write requests\n",
-			(pmrsts & 0x00000100) == 0 && (pmrctl & 0x00000001) ?
-				"READY" : "Not Ready");
-	printf("\tError                            (ERR): %x\n", (pmrsts & 0x000000ff));
+	       nvme_register_pmr_hsts_to_string(NVME_PMRSTS_HSTS(pmrsts)));
+	printf("\tNot Ready                       (NRDY): ");
+	printf("The Persistent Memory Region is %s to process ",
+	       !NVME_PMRSTS_NRDY(pmrsts) && NVME_PMRCTL_EN(pmrctl) ? "READY" : "Not Ready");
+	printf("PCI Express memory read and write requests\n");
+	printf("\tError                            (ERR): %x\n", NVME_PMRSTS_ERR(pmrsts));
 }
 
 static void stdout_registers_pmrebs(__u32 pmrebs)

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1359,21 +1359,21 @@ static void stdout_registers_cmbsts(__u32 cmbsts)
 
 static void stdout_registers_pmrcap(__u32 pmrcap)
 {
-	printf("\tController Memory Space Supported                   (CMSS): "\
-	       "Referencing PMR with host supplied addresses is %s\n",
-	       ((pmrcap & 0x01000000) >> 24) ? "Supported" : "Not Supported");
+	printf("\tController Memory Space Supported                   (CMSS): ");
+	printf("Referencing PMR with host supplied addresses is %sSupported\n",
+	       NVME_PMRCAP_CMSS(pmrcap) ? "" : "Not ");
 	printf("\tPersistent Memory Region Timeout                   (PMRTO): %x\n",
-		(pmrcap & 0x00ff0000) >> 16);
+	       NVME_PMRCAP_PMRTO(pmrcap));
 	printf("\tPersistent Memory Region Write Barrier Mechanisms (PMRWBM): %x\n",
-		(pmrcap & 0x00003c00) >> 10);
-	printf("\tPersistent Memory Region Time Units                (PMRTU): PMR time unit is %s\n",
-		(pmrcap & 0x00000300) >> 8 ? "minutes" : "500 milliseconds");
+	       NVME_PMRCAP_PMRWMB(pmrcap));
+	printf("\tPersistent Memory Region Time Units                (PMRTU): ");
+	printf("PMR time unit is %s\n", NVME_PMRCAP_PMRTU(pmrcap) ? "minutes" : "500 milliseconds");
 	printf("\tBase Indicator Register                              (BIR): %x\n",
-		(pmrcap & 0x000000e0) >> 5);
-	printf("\tWrite Data Support                                   (WDS): Write data to the PMR is %s\n",
-		(pmrcap & 0x00000010) ? "supported" : "not supported");
-	printf("\tRead Data Support                                    (RDS): Read data from the PMR is %s\n",
-		(pmrcap & 0x00000008) ? "supported" : "not supported");
+	       NVME_PMRCAP_BIR(pmrcap));
+	printf("\tWrite Data Support                                   (WDS): ");
+	printf("Write data to the PMR is %ssupported\n", NVME_PMRCAP_WDS(pmrcap) ? "" : "not ");
+	printf("\tRead Data Support                                    (RDS): ");
+	printf("Read data from the PMR is %ssupported\n", NVME_PMRCAP_RDS(pmrcap) ? "" : "not ");
 }
 
 static void stdout_registers_pmrctl(__u32 pmrctl)

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1407,9 +1407,9 @@ static void stdout_registers_pmrebs(__u32 pmrebs)
 static void stdout_registers_pmrswtp(__u32 pmrswtp)
 {
 	printf("\tPMR Sustained Write Throughput       (PMRSWTV): %x\n",
-		(pmrswtp & 0xffffff00) >> 8);
+	       NVME_PMRSWTP_PMRSWTV(pmrswtp));
 	printf("\tPMR Sustained Write Throughput Units (PMRSWTU): %s/second\n",
-		nvme_register_pmr_pmrszu_to_string(pmrswtp & 0x0000000f));
+	       nvme_register_pmr_pmrszu_to_string(NVME_PMRSWTP_PMRSWTU(pmrswtp)));
 }
 
 static void stdout_registers_pmrmscl(uint32_t pmrmscl)


### PR DESCRIPTION
Change it instead of hardcoded register mask and shift values.