### PR TITLE
nvme: Add support for dsm command latency option

### DIFF
--- a/Documentation/nvme-dsm.txt
+++ b/Documentation/nvme-dsm.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 			[--idw=<write> | -w <write>] [--idr=<read> | -r <read>]
 			[--cdw11=<cdw11> | -c <cdw11>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
+			[--latency | -l]
 
 DESCRIPTION
 -----------
@@ -82,6 +83,10 @@ OPTIONS
 -v::
 --verbose::
 	Increase the information detail in the output.
+
+-l::
+--latency::
+	Print out the latency the IOCTL took (in us).
 
 EXAMPLES
 --------

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -1654,6 +1654,8 @@ _nvme () {
 			-r':alias of --idr'
 			--cdw11=':value for command dword 11'
 			-c':alias for --cdw11'
+			--latency':latency statistics will be output following dsm'
+			-l':alias of --latency'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme dsm options" _dsm

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -291,7 +291,8 @@ nvme_list_opts () {
 			;;
 		"dsm")
 		opts+=" --namespace-id= -n --ctx-attrs= -a --blocks= -b\
-			--slbs= -s --ad -d --idw -w --idr -r --cdw11= -c"
+			--slbs= -s --ad -d --idw -w --idr -r --cdw11= -c\
+			--latency -l"
 			;;
 		"copy")
 		opts+=" --namespace-id= -n --sdlba= -d --blocks= -b --slbs= -s \


### PR DESCRIPTION
The purpose to add is for adding performance statistics. Currently the latency option is only added for passthru() and submit_io(). The verbose option also outputs the latency but other debuging info. So add for the dsm command also to output only the latency info.