### PR TITLE
wdc:  Fix timestamp displayed by vs-firmware-activate-history command

### DIFF
--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.8.0"
+#define WDC_PLUGIN_VERSION   "2.8.1"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
The actual timestamp value is in bytes 0:5 of the 8 byte field. The code was using all 8 bytes so a change was made to mask off the top 2 bytes.  The timestamp calculations were also simplified to be more maintainable.