### PR TITLE
ocp: support OCP 2.5 Set Telemetry Profile feature

### DIFF
--- a/Documentation/nvme-ocp-set-telemetry-profile.txt
+++ b/Documentation/nvme-ocp-set-telemetry-profile.txt
@@ -1,0 +1,43 @@
+nvme-ocp-set-telemetry-profile(1)
+=================================
+
+NAME
+----
+nvme-ocp-set-telemetry-profile - Set Telemetry Profile
+
+SYNOPSIS
+--------
+[verse]
+'nvme ocp set-telemetry-profile' <device>
+			[--telemetry-profile-select=<tps> | -t <tps>]
+
+DESCRIPTION
+-----------
+For the NVMe device given, sets the OCP Set Telemetry Profile Feature
+
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0) or block device (ex: /dev/nvme0n1).
+
+This will only work on OCP compliant devices supporting this feature.
+Results for any other device are undefined.
+
+On success it returns 0, error code otherwise.
+
+OPTIONS
+-------
+-t <tps>::
+--tps=<tps>::
+	Telemetry Profile Select. The device shall collect debug data per the
+	specified profile number.
+
+EXAMPLES
+--------
+* Has the program issue a set-telemetry-profile command to use profile five.
++
+------------
+# nvme ocp set-telemetry-profile /dev/nvme0 -t 5
+------------
+
+NVME
+----
+Part of the nvme-user suite.

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -263,6 +263,16 @@ _nvme () {
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp internal-log options" _internal_log
 				;;
+			(set-telemetry-profile)
+				local _ocp_set_telemetry_profile_feature
+				_ocp_set_telemetry_profile_feature=(
+				/dev/nvme':supply a device to use (required)'
+				--telemetry-profile-select=':Telemetry Profile Select'
+				-t':alias for --telemetry-profile-select'
+				)
+				_arguments '*:: :->subcmds'
+				_describe -t commands "nvme ocp set-telemetry-profile options" _ocp_set_telemetry_profile_feature
+				;;
 			(*)
 				_files
 				;;
@@ -2073,6 +2083,7 @@ _nvme () {
 			device-capability-log':Get Device capability log'
 			set-dssd-power-state-feature':Set DSSD Power State'
 			telemetry-string-log':Retrieve Telemetry string Log Page'
+			set-telemetry-profile':Set Telemetry Profile'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme ocp options" _ocp

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1361,6 +1361,9 @@ plugin_ocp_opts () {
 		"telemetry-string-log")
 		opts+=" --output-file= -o"
 			;;
+		"set-telemetry-profile")
+		opts+=" --telemetry-profile-select= -t"
+			;;
 		"help")
 		opts+=$NO_OPTS
 			;;
@@ -1430,7 +1433,8 @@ _nvme_subcmds () {
 			clear-fw-activate-history eol-plp-failure-mode \
 			clear-pcie-correctable-error-counters \
 			vs-fw-activate-history device-capability-log \
-			set-dssd-power-state-feature telemetry-string-log"
+			set-dssd-power-state-feature telemetry-string-log \
+			set-telemetry-profile"
 	)
 
 	# Associative array mapping plugins to corresponding option completions

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -30,6 +30,7 @@ PLUGIN(NAME("ocp", "OCP cloud SSD extensions", NVME_VERSION),
 		ENTRY("set-plp-health-check-interval", "Set PLP Health Check Interval", set_plp_health_check_interval)
 		ENTRY("get-plp-health-check-interval", "Get PLP Health Check Interval", get_plp_health_check_interval)
 		ENTRY("telemetry-string-log", "Retrieve Telemetry string Log Page", ocp_telemetry_str_log_format)
+		ENTRY("set-telemetry-profile", "Set Telemetry Profile Feature", ocp_set_telemetry_profile_feature)
 	)
 );
 


### PR DESCRIPTION
Adds a new OCP plugin function to set the device telemetry profile, configuring what debug data shall be collected by the device.