### PR TITLE
ocp: fix for power-state argument checking

### DIFF
--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -2143,7 +2143,7 @@ static int set_dssd_power_state_feature(int argc, char **argv, struct command *c
 	if (err)
 		return err;
 
-	if (argconfig_parse_seen(opts, "power state"))
+	if (argconfig_parse_seen(opts, "power-state"))
 		err = set_dssd_power_state(dev, nsid, fid, cfg.power_state,
 					       cfg.save,
 					       !argconfig_parse_seen(opts, "no-uuid"));


### PR DESCRIPTION
Noticed this as part of supporting set-telemetry-profile, it seems that the power-state option is not being detected properly. With this fix the function is able to enter set_dssd_power_state when given the option or its alias.