### PR TITLE
nvme-print-stdout: Use NVME_GET for FID supported and effects FSP

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -602,7 +602,7 @@ static void stdout_fid_support_effects_log_human(__u32 fid_support)
 	printf("  CCC%s", (fid_support & NVME_FID_SUPPORTED_EFFECTS_CCC) ? set : clr);
 	printf("  USS%s", (fid_support & NVME_FID_SUPPORTED_EFFECTS_UUID_SEL) ? set : clr);
 
-	fsp = (fid_support >> NVME_FID_SUPPORTED_EFFECTS_SCOPE_SHIFT) & NVME_FID_SUPPORTED_EFFECTS_SCOPE_MASK;
+	fsp = NVME_GET(fid_support, FID_SUPPORTED_EFFECTS_SCOPE);
 
 	printf("  NAMESPACE SCOPE%s", (fsp & NVME_FID_SUPPORTED_EFFECTS_SCOPE_NS) ? set : clr);
 	printf("  CONTROLLER SCOPE%s", (fsp & NVME_FID_SUPPORTED_EFFECTS_SCOPE_CTRL) ? set : clr);

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -645,7 +645,7 @@ static void stdout_mi_cmd_support_effects_log_human(__u32 mi_cmd_support)
 	printf("  NIC%s", (mi_cmd_support & NVME_MI_CMD_SUPPORTED_EFFECTS_NIC) ? set : clr);
 	printf("  CCC%s", (mi_cmd_support & NVME_MI_CMD_SUPPORTED_EFFECTS_CCC) ? set : clr);
 
-	csp = (mi_cmd_support >> NVME_MI_CMD_SUPPORTED_EFFECTS_SCOPE_SHIFT) & NVME_MI_CMD_SUPPORTED_EFFECTS_SCOPE_MASK;
+	csp = NVME_GET(mi_cmd_support, MI_CMD_SUPPORTED_EFFECTS_SCOPE);
 
 	printf("  NAMESPACE SCOPE%s", (csp & NVME_MI_CMD_SUPPORTED_EFFECTS_SCOPE_NS) ? set : clr);
 	printf("  CONTROLLER SCOPE%s", (csp & NVME_MI_CMD_SUPPORTED_EFFECTS_SCOPE_CTRL) ? set : clr);


### PR DESCRIPTION
Use it with NVME_FID_SUPPORTED_EFFECTS register definitions existed.