### PR TITLE
nvme: do not issue warning when nvme_core module is not loaded

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -728,8 +728,9 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 		nvme_root_set_application(r, context);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
-			 nvme_strerror(errno));
+		if (errno != ENOENT)
+			fprintf(stderr, "Failed to scan topology: %s\n",
+				nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
 	}
@@ -958,8 +959,9 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 		nvme_root_set_application(r, context);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
-			 nvme_strerror(errno));
+		if (errno != ENOENT)
+			fprintf(stderr, "Failed to scan topology: %s\n",
+				nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
 	}
@@ -1118,8 +1120,9 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
-			 nvme_strerror(errno));
+		if (errno != ENOENT)
+			fprintf(stderr, "Failed to scan topology: %s\n",
+				nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
 	}
@@ -1188,8 +1191,9 @@ int nvmf_disconnect_all(const char *desc, int argc, char **argv)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
-			 nvme_strerror(errno));
+		if (errno != ENOENT)
+			fprintf(stderr, "Failed to scan topology: %s\n",
+				nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
 	}
@@ -1259,8 +1263,9 @@ int nvmf_config(const char *desc, int argc, char **argv)
 	if (scan_tree) {
 		ret = nvme_scan_topology(r, NULL, NULL);
 		if (ret < 0) {
-			fprintf(stderr, "Failed to scan topology: %s\n",
-				nvme_strerror(errno));
+			if (errno != ENOENT)
+				fprintf(stderr, "Failed to scan topology: %s\n",
+					nvme_strerror(errno));
 			nvme_free_tree(r);
 			return ret;
 		}
@@ -1412,8 +1417,9 @@ int nvmf_dim(const char *desc, int argc, char **argv)
 	}
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
-			 nvme_strerror(errno));
+		if (errno != ENOENT)
+			fprintf(stderr, "Failed to scan topology: %s\n",
+				nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
 	}

--- a/nvme.c
+++ b/nvme.c
@@ -3248,7 +3248,8 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 
 	err = nvme_scan_topology(r, filter, (void *)devname);
 	if (err) {
-		nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
+		if (errno != ENOENT)
+			nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
 		goto ret;
 	}
 
@@ -3289,7 +3290,8 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	}
 	err = nvme_scan_topology(r, NULL, NULL);
 	if (err < 0) {
-		nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
+		if (errno != ENOENT)
+			nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
 		nvme_free_tree(r);
 		return err;
 	}
@@ -8871,7 +8873,8 @@ static int show_topology_cmd(int argc, char **argv, struct command *command, str
 
 	err = nvme_scan_topology(r, NULL, NULL);
 	if (err < 0) {
-		nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
+		if (errno != ENOENT)
+			nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
 		nvme_free_tree(r);
 		return err;
 	}


### PR DESCRIPTION
nvme 1.x did not issue an warning when the nvme_core module was not loaded. Make 2.x behave in the same way.

Fixes: #2241