### PR TITLE
Implement persistent keys

### DIFF
--- a/Documentation/nvme-tls-key.txt
+++ b/Documentation/nvme-tls-key.txt
@@ -1,0 +1,69 @@
+nvme-tls-key(1)
+======================
+
+NAME
+----
+nvme-tls-key - Manage NVMe TLS PSKs
+
+SYNOPSIS
+--------
+[verse]
+'nvme tls-key' [--keyring=<name> | -k <name>]
+			[--keytype=<type> | -t <type>]
+			[--keyfile=<file> | -f <file>]
+			[--import | -i] [--export | -e]
+			[--verbose | -v]
+
+DESCRIPTION
+-----------
+Import or export NVMe TLS pre-shared keys (PSKs) from the
+system keystore. When the '--export' option is given, all
+NVMe TLS PSKs are exported in the form
+
+<descriptions> <psk>
+
+where '<description>' is the key description from the
+exported key and '<psk>' is the key data in PSK interchange
+format 'NVMeTLSkey-1:01:<base64 encoded data>:'.
+Each key is exported in a single line.
+When the '--import' option is given key data is read in the
+same format and imported into the kernel keystore.
+
+OPTIONS
+-------
+-k <name>::
+--keyring=<name>::
+	Name of the keyring into which the 'retained' TLS key should be
+	stored. Default is '.nvme'.
+
+-t <type>::
+--keytype=<type>::
+	Type of the key for resulting TLS key.
+	Default is 'psk'.
+
+-k <file>::
+--keyfile=<file>::
+	File to read the keys from or write the keys to instead of
+	stdin / stdout.
+
+-i::
+--import::
+	Read the key data from the file specified by '--keyfile'
+	or stdin if not present.
+
+-e::
+--export::
+	Write the key data to the file specified by '--keyfile'
+	or stdou if not present.
+
+-v::
+--verbose::
+	Increase the information detail in the output.
+
+EXAMPLES
+--------
+No Examples
+
+NVME
+----
+Part of the nvme-user suite

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -101,6 +101,7 @@ COMMAND_LIST(
 	ENTRY("check-dhchap-key", "Validate NVMeoF DH-HMAC-CHAP host key", check_dhchap_key)
 	ENTRY("gen-tls-key", "Generate NVMeoF TLS PSK", gen_tls_key)
 	ENTRY("check-tls-key", "Validate NVMeoF TLS PSK", check_tls_key)
+	ENTRY("tls-key", "Manipulate NVMeoF TLS PSK", tls_key)
 	ENTRY("dir-receive", "Submit a Directive Receive command, return results", dir_receive)
 	ENTRY("dir-send", "Submit a Directive Send command, return results", dir_send)
 	ENTRY("virt-mgmt", "Manage Flexible Resources between Primary and Secondary Controller", virtual_mgmt)

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 93f83b9bc029f5830d51964b4c5346d2bc87ca2e
+revision = 4afd05fc959655714a9ff1b340a5dfe0c38df595
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Add a new utility 'tls-key' to import or export keys to or from the kernel keystore.