### PR TITLE
meson buildtarget + some warning fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     version: '2.8',
     default_options: [
       'c_std=gnu99',
-      'buildtype=debug',
+      'buildtype=debugoptimized',
       'prefix=/usr/local',
       'warning_level=1',
       'sysconfdir=etc',

--- a/nbft.c
+++ b/nbft.c
@@ -87,7 +87,7 @@ int discover_from_nbft(nvme_root_t r, char *hostnqn_arg, char *hostid_arg,
 	nvme_ctrl_t c;
 	int ret, i;
 	struct list_head nbft_list;
-	struct nbft_file_entry *entry;
+	struct nbft_file_entry *entry = NULL;
 	struct nbft_info_subsystem_ns **ss;
 	struct nbft_info_hfi *hfi;
 

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -1335,7 +1335,7 @@ struct json_object* json_effects_log(enum nvme_csi csi,
 static void json_effects_log_list(struct list_head *list)
 {
 	struct json_object *r = json_create_array();
-	nvme_effects_log_node_t *node;
+	nvme_effects_log_node_t *node = NULL;
 
 	list_for_each(list, node, node) {
 		struct json_object *json_page =

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3791,7 +3791,7 @@ static void stdout_effects_log_page(enum nvme_csi csi,
 
 static void stdout_effects_log_pages(struct list_head *list)
 {
-	nvme_effects_log_node_t *node;
+	nvme_effects_log_node_t *node = NULL;
 
 	list_for_each(list, node, node) {
 		stdout_effects_log_page(node->csi, &node->effects);

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -319,7 +319,7 @@ static int json_show_nbfts(struct list_head *nbft_list, bool show_subsys,
 			   bool show_hfi, bool show_discovery)
 {
 	struct json_object *nbft_json_array, *nbft_json;
-	struct nbft_file_entry *entry;
+	struct nbft_file_entry *entry = NULL;
 
 	nbft_json_array = json_create_array();
 	if (!nbft_json_array)
@@ -510,7 +510,7 @@ static void normal_show_nbfts(struct list_head *nbft_list, bool show_subsys,
 			      bool show_hfi, bool show_discovery)
 {
 	bool not_first = false;
-	struct nbft_file_entry *entry;
+	struct nbft_file_entry *entry = NULL;
 
 	list_for_each(nbft_list, entry, node) {
 		if (not_first)

--- a/plugins/sed/sedopal_cmd.c
+++ b/plugins/sed/sedopal_cmd.c
@@ -456,7 +456,7 @@ int sedopal_cmd_discover(int fd)
 	struct level_0_discovery_features *feat;
 	struct level_0_discovery_features *feat_end;
 	uint16_t code;
-	uint8_t locking_flags;
+	uint8_t locking_flags = 0;
 	char buf[4096];
 
 	discover.data = (__u64)buf;


### PR DESCRIPTION
The meson 'debug' buildtype defaults to '-O0 -g' which misses some important compiler warnings (as of gcc-13). While there's     no universal solution, the 'debugoptimized' buildtype supplies '-O2 -g' that appears to be a reasonable compromise for having    important compiler warnings by default.
    
Either way, the specified warning_level=1 always supplies '-Wall' that is unfortunately not enough with '-O0'.
