### PR TITLE
nvme: Use libnvme sysfs function to get NVMe controller directory

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5256,7 +5256,7 @@ static void *mmap_registers(struct nvme_dev *dev)
 	void *membase;
 	int fd;
 
-	sprintf(path, "/sys/class/nvme/%s/device/resource0", dev->name);
+	sprintf(path, "%s/%s/device/resource0", nvme_ctrl_sysfs_dir(), dev->name);
 	fd = open(path, O_RDONLY);
 	if (fd < 0) {
 		if (log_level >= LOG_DEBUG)

--- a/nvme.h
+++ b/nvme.h
@@ -45,8 +45,6 @@ enum nvme_cli_topo_ranking {
 	NVME_CLI_TOPO_CTRL,
 };
 
-#define SYS_NVME "/sys/class/nvme"
-
 enum nvme_dev_type {
 	NVME_DEV_DIRECT,
 	NVME_DEV_MI,


### PR DESCRIPTION
Also delete the SYS_NVME definition unused instead.