### PR TITLE
nvme: extend error message for ns scan failures

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5098,7 +5098,7 @@ static int ns_rescan(int argc, char **argv, struct command *cmd, struct plugin *
 
 	err = nvme_ns_rescan(dev_fd(dev));
 	if (err < 0)
-		nvme_show_error("Namespace Rescan");
+		nvme_show_error("Namespace Rescan: %s\n", nvme_strerror(errno));
 
 	return err;
 }


### PR DESCRIPTION
When the scan operation fails, let's also report the error code in order to help understand why the operation failed.