### PR TITLE
nvme-print-json: Bugfix status json key of sanitize-log

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -1365,7 +1365,7 @@ static void json_sanitize_log(struct nvme_sanitize_log_page *sanitize_log,
 	status_str = nvme_sstat_status_to_string(status);
 	sprintf(str, "(%d) %s", status & NVME_SANITIZE_SSTAT_STATUS_MASK,
 		status_str);
-	obj_add_str(sstat, status_str, str);
+	obj_add_str(sstat, "status", str);
 
 	obj_add_obj(dev, "sstat", sstat);
 	obj_add_uint(dev, "cdw10_info", le32_to_cpu(sanitize_log->scdw10));


### PR DESCRIPTION
There is a history of combining duplicated json keys before.
Fixes: 1d7c092f9dac ("nvme-print-json: Combine duplicated json key and val string variables")
Fixes: 59a0f125cb08 ("nvme-print-json: Delete static const char string global variables")
But there is a local variable with the same name, so the key and value are the same.
    
Reviewed-by: Sangkuk Lee <sangkuk0.lee@samsung.com>
Reported-by: Kiryong Kim <kiryong1.kim@samsung.com>
Signed-off-by: Minsik Jeon <hmi.jeon@samsung.com>
Co-authored-by: Steven Seungcheol Lee <sc108.lee@samsung.com>