### PR TITLE
nvme: check-tls-key fails despite having hostnqn file

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -8715,14 +8715,14 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 	}
 
 	if (cfg.subsysnqn) {
-		if (cfg.insert && !cfg.hostnqn) {
+		if (!cfg.hostnqn) {
 			cfg.hostnqn = nvmf_hostnqn_from_file();
 			if (!cfg.hostnqn) {
 				nvme_show_error("Failed to read host NQN");
 				return -EINVAL;
 			}
 		}
-	} else if (cfg.insert || cfg.identity == 1) {
+	} else {
 		nvme_show_error("Need to specify a subsystem NQN");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Nvme check-tls-key requires both hostnqn and subsysnqn to be specified along with the keydata. Ideally, it should be able to fetch the hostnqn string from the hostnqn file if no hostnqn option is passed, irrespective of whether the insert option is specified or not. Also passing the subsysnqn option is required not just for identity v1, but for v0 as well, irrespective of the insert option. Fix accordingly.