### PR TITLE
Update passthru wrappers

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 86e6d82bc78ae612012f67038b111b293163692e
+revision = 2d2d76fa08bfd0a3f82cb9db051e53992b4bded2
 
 [provide]
 libnvme = libnvme_dep

--- a/util/logging.c
+++ b/util/logging.c
@@ -2,6 +2,7 @@
 
 #include <inttypes.h>
 
+#include <errno.h>
 #include <stdint.h>
 #include <sys/ioctl.h>
 #include <sys/syslog.h>
@@ -104,8 +105,14 @@ int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
 		nvme_show_latency(start, end);
 	}
 
-	if (err >= 0 && result)
-		*result = cmd->result;
+	if (err >= 0) {
+		if (result)
+			*result = cmd->result;
+		if (cmd->result) {
+			errno = EPROTO;
+			err = -1;
+		}
+	}
 
 	return err;
 }
@@ -131,8 +138,14 @@ int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
 		nvme_show_latency(start, end);
 	}
 
-	if (err >= 0 && result)
-		*result = cmd->result;
+	if (err >= 0) {
+		if (result)
+			*result = cmd->result;
+		if (cmd->result) {
+			errno = EPROTO;
+			err = -1;
+		}
+	}
 
 	return err;
 }


### PR DESCRIPTION
libnvme fixed the error handling for the passthru commands. nvme-cli needs the same changes.