### PR TITLE
Revert "logging: fix error handling for ioctl passthru wrappers"

### DIFF
--- a/util/logging.c
+++ b/util/logging.c
@@ -2,7 +2,6 @@
 
 #include <inttypes.h>
 
-#include <errno.h>
 #include <stdint.h>
 #include <sys/ioctl.h>
 #include <sys/syslog.h>
@@ -105,14 +104,8 @@ int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
 		nvme_show_latency(start, end);
 	}
 
-	if (err >= 0) {
-		if (result)
-			*result = cmd->result;
-		if (cmd->result) {
-			errno = EPROTO;
-			err = -1;
-		}
-	}
+	if (err >= 0 && result)
+		*result = cmd->result;
 
 	return err;
 }
@@ -138,14 +131,8 @@ int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
 		nvme_show_latency(start, end);
 	}
 
-	if (err >= 0) {
-		if (result)
-			*result = cmd->result;
-		if (cmd->result) {
-			errno = EPROTO;
-			err = -1;
-		}
-	}
+	if (err >= 0 && result)
+		*result = cmd->result;
 
 	return err;
 }


### PR DESCRIPTION
This reverts commit a2b1aecb9075c7a8f9bad627fc45171bb533c8bd.

The result field is undefined for many commands and thus can have random values. Thus we can't blindly evaluate these for all commands.