### PR TITLE
fabrics: fix mem leak in nvmf_check_hostid_and_hostnqn()

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -643,7 +643,8 @@ char *nvmf_hostid_from_hostnqn(const char *hostnqn)
 
 void nvmf_check_hostid_and_hostnqn(const char *hostid, const char *hostnqn, unsigned int verbose)
 {
-	char *hostid_from_file, *hostid_from_hostnqn;
+	_cleanup_free_ char *hostid_from_file = NULL;
+	_cleanup_free_ char *hostid_from_hostnqn = NULL;
 
 	if (!hostid)
 		return;
@@ -653,7 +654,6 @@ void nvmf_check_hostid_and_hostnqn(const char *hostid, const char *hostnqn, unsi
 		if (verbose)
 			fprintf(stderr,
 				"warning: use generated hostid instead of hostid file\n");
-		free(hostid_from_file);
 	}
 
 	if (!hostnqn)
@@ -664,7 +664,6 @@ void nvmf_check_hostid_and_hostnqn(const char *hostid, const char *hostnqn, unsi
 		if (verbose)
 			fprintf(stderr,
 				"warning: use hostid which does not match uuid in hostnqn\n");
-		free(hostid_from_hostnqn);
 	}
 }
 


### PR DESCRIPTION
Valgrind revealed a mem leak in nvmf_check_hostid_and_hostnqn() during nvme discover & connect. Leak traced to both hostid pointers not getting freed for cases where the hostid value matches the strings from both these respective hostid pointers. Fix the same.