### PR TITLE
Revert "build(deps): bump AppImageCrafters/build-appimage from 1.3 to 2"

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -21,7 +21,7 @@ jobs:
        run: |
          scripts/build.sh appimage
      - name: build AppImage
-       uses: AppImageCrafters/build-appimage@v2
+       uses: AppImageCrafters/build-appimage@v1.3
        with:
          recipe: .github/AppImageBuilder.yml
      - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This reverts commit 158eb8d82c497c104cf9c2d4665983084cc8ae0e.

This breaks the build with

'appimagecrafters/appimage-builder:0.8.2' should be either '[path]/Dockerfile' or 'docker://image[:tag]'.

v2 was released a couple of years ago, so I don't expect this gets fixed at all. Instead go back to last good version.