### PR TITLE
plugins/ocp: Split ocp_get_uuid_index() into find and get functions.

### DIFF
--- a/plugins/ocp/ocp-utils.c
+++ b/plugins/ocp/ocp-utils.c
@@ -1,17 +1,30 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /*
- * Copyright (c) 2022 Solidigm.
+ * Copyright (c) 2022-2024 Solidigm.
  *
  * Author: leonardo.da.cunha@solidigm.com
  */
 
 #include <unistd.h>
+#include <errno.h>
 #include "ocp-utils.h"
-#include "nvme-print.h"
 
 const unsigned char ocp_uuid[NVME_UUID_LEN] = {
 	0xc1, 0x94, 0xd5, 0x5b, 0xe0, 0x94, 0x47, 0x94, 0xa2, 0x1d,
 	0x29, 0x99, 0x8f, 0x56, 0xbe, 0x6f };
+
+int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, int *index)
+{
+	int i = nvme_uuid_find(uuid_list, ocp_uuid);
+
+	*index = 0;
+	if (i > 0)
+		*index = i;
+	else
+		return -errno;
+
+	return 0;
+}
 
 int ocp_get_uuid_index(struct nvme_dev *dev, int *index)
 {
@@ -22,11 +35,5 @@ int ocp_get_uuid_index(struct nvme_dev *dev, int *index)
 	if (err)
 		return err;
 
-	for (int i = 0; i < NVME_ID_UUID_LIST_MAX; i++) {
-		if (memcmp(ocp_uuid, &uuid_list.entry[i].uuid, NVME_UUID_LEN) == 0) {
-			*index = i + 1;
-			break;
-		}
-	}
-	return err;
+	return ocp_find_uuid_index(&uuid_list, index);
 }

--- a/plugins/ocp/ocp-utils.h
+++ b/plugins/ocp/ocp-utils.h
@@ -1,18 +1,32 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 /*
- * Copyright (c) 2022 Solidigm.
+ * Copyright (c) 2022-2024 Solidigm.
  *
  * Author: leonardo.da.cunha@solidigm.com
  */
 
 #include "nvme.h"
 
+/*
+ * UUID assigned for OCP.
+ */
+extern const unsigned char ocp_uuid[NVME_UUID_LEN];
+
 /**
  * ocp_get_uuid_index() - Get OCP UUID index
  * @dev:	nvme device
  * @index:	integer pointer to here to save the index
- * @result:	The command completion result from CQE dword0
  *
- * Return: Zero if nvme device has UUID list log page, or result of get uuid list otherwise.
+ * Return: Zero if nvme device has UUID list log page, or positive result of get uuid list
+ *         or negative POSIX error code otherwise.
  */
 int ocp_get_uuid_index(struct nvme_dev *dev, int *index);
+
+/**
+ * ocp_find_uuid_index() - Find OCP UUID index in UUID list
+ * @uuid_list:	uuid_list retrieved from Identify UUID List (CNS 0x17)
+ * @index:	integer pointer to here to save the index
+ *
+ * Return: Zero if nvme device has UUID list log page, Negative POSIX error code otherwise.
+ */
+int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, int *index);


### PR DESCRIPTION
Enable reuse of OCP UUID discovery logic from other plugins. Enable single call to nvme_identify_uuid() when dealing with multiple UUIDs