### PR TITLE
plugins/ocp: Adjusted variable type size carrying UUID index to 8 bit.

### DIFF
--- a/plugins/ocp/ocp-clear-features.c
+++ b/plugins/ocp/ocp-clear-features.c
@@ -18,7 +18,7 @@ static int ocp_clear_feature(int argc, char **argv, const char *desc, const __u8
 	__u32 result = 0;
 	__u32 clear = 1 << 31;
 	struct nvme_dev *dev;
-	int uuid_index = 0;
+	__u8 uuid_index = 0;
 	bool uuid = true;
 	int err;
 

--- a/plugins/ocp/ocp-fw-activation-history.c
+++ b/plugins/ocp/ocp-fw-activation-history.c
@@ -162,7 +162,7 @@ int ocp_fw_activation_history_log(int argc, char **argv, struct command *cmd,
 	if (err)
 		return err;
 
-	int uuid_index = 0;
+	__u8 uuid_index = 0;
 
 	/*
 	 * Best effort attempt at uuid. Otherwise, assume no index (i.e. 0)

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -705,7 +705,7 @@ static int eol_plp_failure_mode_set(struct nvme_dev *dev, const __u32 nsid,
 {
 	__u32 result;
 	int err;
-	int uuid_index = 0;
+	__u8 uuid_index = 0;
 
 	if (uuid) {
 		/* OCP 2.0 requires UUID index support */
@@ -2066,7 +2066,7 @@ static int ocp_set_telemetry_profile(struct nvme_dev *dev, __u8 tps)
 {
 	__u32 result;
 	int err;
-	int uuid_index = 0;
+	__u8 uuid_index = 0;
 
 	/* OCP 2.0 requires UUID index support */
 	err = ocp_get_uuid_index(dev, &uuid_index);
@@ -2152,7 +2152,7 @@ static int set_dssd_power_state(struct nvme_dev *dev, const __u32 nsid,
 {
 	__u32 result;
 	int err;
-	int uuid_index = 0;
+	__u8 uuid_index = 0;
 
 	if (uuid) {
 		/* OCP 2.0 requires UUID index support */
@@ -2255,7 +2255,7 @@ static int set_plp_health_check_interval(int argc, char **argv, struct command *
 	struct nvme_dev *dev;
 	int err;
 	__u32 result;
-	int uuid_index = 0;
+	__u8 uuid_index = 0;
 
 	struct config {
 		__le16 plp_health_interval;
@@ -2395,7 +2395,7 @@ static int set_dssd_async_event_config(int argc, char **argv, struct command *cm
 	struct nvme_dev *dev;
 	int err;
 	__u32 result;
-	int uuid_index = 0;
+	__u8 uuid_index = 0;
 
 	struct config {
 		bool epn;

--- a/plugins/ocp/ocp-utils.c
+++ b/plugins/ocp/ocp-utils.c
@@ -13,7 +13,7 @@ const unsigned char ocp_uuid[NVME_UUID_LEN] = {
 	0xc1, 0x94, 0xd5, 0x5b, 0xe0, 0x94, 0x47, 0x94, 0xa2, 0x1d,
 	0x29, 0x99, 0x8f, 0x56, 0xbe, 0x6f };
 
-int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, int *index)
+int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, __u8 *index)
 {
 	int i = nvme_uuid_find(uuid_list, ocp_uuid);
 
@@ -26,7 +26,7 @@ int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, int *index)
 	return 0;
 }
 
-int ocp_get_uuid_index(struct nvme_dev *dev, int *index)
+int ocp_get_uuid_index(struct nvme_dev *dev, __u8 *index)
 {
 	struct nvme_id_uuid_list uuid_list;
 	int err = nvme_identify_uuid(dev_fd(dev), &uuid_list);

--- a/plugins/ocp/ocp-utils.h
+++ b/plugins/ocp/ocp-utils.h
@@ -17,10 +17,10 @@ extern const unsigned char ocp_uuid[NVME_UUID_LEN];
  * @dev:	nvme device
  * @index:	integer pointer to here to save the index
  *
- * Return: Zero if nvme device has UUID list log page, or positive result of get uuid list
+ * Return: Zero if nvme device has UUID list identify page, or positive result of get uuid list
  *         or negative POSIX error code otherwise.
  */
-int ocp_get_uuid_index(struct nvme_dev *dev, int *index);
+int ocp_get_uuid_index(struct nvme_dev *dev, __u8 *index);
 
 /**
  * ocp_find_uuid_index() - Find OCP UUID index in UUID list
@@ -29,4 +29,4 @@ int ocp_get_uuid_index(struct nvme_dev *dev, int *index);
  *
  * Return: Zero if nvme device has UUID list log page, Negative POSIX error code otherwise.
  */
-int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, int *index);
+int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, __u8 *index);

--- a/plugins/solidigm/solidigm-util.c
+++ b/plugins/solidigm/solidigm-util.c
@@ -10,7 +10,7 @@
 
 __u8 solidigm_get_vu_uuid_index(struct nvme_dev *dev)
 {
-	int ocp_uuid_index = 0;
+	__u8 ocp_uuid_index = 0;
 
 	if (ocp_get_uuid_index(dev, &ocp_uuid_index) == 0)
 		if (ocp_uuid_index == 2)


### PR DESCRIPTION
Changed uuidx type to __u8 in the related function calls, because that's the type that will feed struct nvme_get_log_args.