### PR TITLE
nvme: Add fw-download warning message for FWUG alignment error

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4884,7 +4884,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 
 	struct config cfg = {
 		.fw         = "",
-		.xfer       = 4096,
+		.xfer       = 0,
 		.offset     = 0,
 		.progress   = false,
 		.ignore_ovr = false,

--- a/nvme.c
+++ b/nvme.c
@@ -4872,7 +4872,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	int err;
 	struct stat sb;
 	void *fw_buf;
-	struct nvme_id_ctrl ctrl;
+	struct nvme_id_ctrl ctrl = { 0 };
 
 	struct config {
 		char	*fw;
@@ -4932,6 +4932,10 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 			cfg.xfer = ctrl.fwug * 4096;
 	} else if (cfg.xfer % 4096)
 		cfg.xfer = 4096;
+
+	if (ctrl.fwug && ctrl.fwug != 0xff && fw_size % cfg.xfer)
+		nvme_show_error("WARNING: firmware file size %u not conform to FWUG alignment %lu",
+				fw_size, cfg.xfer);
 
 	fw_buf = nvme_alloc_huge(fw_size, &mh);
 	if (!fw_buf)


### PR DESCRIPTION
Check the firmware file size if not aligned with FWUG value.