### PR TITLE
nvme: fix security buffer allocation size

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -8226,7 +8226,7 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 		return err;
 
 	if (cfg.size) {
-		sec_buf = nvme_alloc(sizeof(*sec_buf));
+		sec_buf = nvme_alloc(cfg.size);
 		if (!sec_buf)
 			return -ENOMEM;
 	}


### PR DESCRIPTION
`sizeof(*sec_buf)` should return 1, which would mean `sec_buf` is not properly allocated to receive data from the target device. This fixes that.