### PR TITLE
nvme-print-json: Fix linux kernel check patch errors

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -33,7 +33,7 @@
 
 static const uint8_t zero_uuid[16] = { 0 };
 static struct print_ops json_print_ops;
-static struct json_object *json_r = NULL;
+static struct json_object *json_r;
 
 static void json_feature_show_fields(enum nvme_features_id fid, unsigned int result,
 				     unsigned char *buf);
@@ -132,6 +132,7 @@ static void obj_add_int_secs(struct json_object *o, const char *k, int v)
 static void obj_add_result(struct json_object *o, const char *v, ...)
 {
 	va_list ap;
+
 	va_start(ap, v);
 	char *value;
 
@@ -149,6 +150,7 @@ static void obj_add_result(struct json_object *o, const char *v, ...)
 static void obj_add_key(struct json_object *o, const char *k, const char *v, ...)
 {
 	va_list ap;
+
 	va_start(ap, v);
 	char *value;
 
@@ -317,7 +319,7 @@ static void json_nvme_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 	json_print(r);
 }
 
- void json_nvme_id_ctrl(struct nvme_id_ctrl *ctrl,
+void json_nvme_id_ctrl(struct nvme_id_ctrl *ctrl,
 			void (*vs)(__u8 *vs, struct json_object *r))
 {
 	struct json_object *r = json_create_object();
@@ -389,7 +391,7 @@ static void json_nvme_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 	obj_add_int(r, "hmmaxd", le16_to_cpu(ctrl->hmmaxd));
 	obj_add_int(r, "nsetidmax", le16_to_cpu(ctrl->nsetidmax));
 	obj_add_int(r, "endgidmax", le16_to_cpu(ctrl->endgidmax));
-	obj_add_int(r, "anatt",ctrl->anatt);
+	obj_add_int(r, "anatt", ctrl->anatt);
 	obj_add_int(r, "anacap", ctrl->anacap);
 	obj_add_uint(r, "anagrpmax", le32_to_cpu(ctrl->anagrpmax));
 	obj_add_uint(r, "nanagrpid", le32_to_cpu(ctrl->nanagrpid));
@@ -449,7 +451,7 @@ static void json_nvme_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 		array_add_obj(psds, psd);
 	}
 
-	if(vs)
+	if (vs)
 		vs(ctrl->vs, r);
 
 	json_print(r);
@@ -705,7 +707,7 @@ static void json_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 		if (temp == 0)
 			continue;
 
-		sprintf(key, "temperature_sensor_%d",c+1);
+		sprintf(key, "temperature_sensor_%d", c + 1);
 		obj_add_int(r, key, temp);
 	}
 
@@ -1171,7 +1173,7 @@ static void json_registers_cmbmsc(uint64_t cmbmsc, struct json_object *r)
 		     cmbmsc & 1 ? "Enabled" : "Not enabled");
 }
 
-static void json_registers_cmbsts(uint32_t cmbsts , struct json_object *r)
+static void json_registers_cmbsts(uint32_t cmbsts, struct json_object *r)
 {
 	obj_add_uint_x(r, "cmbsts", cmbsts);
 
@@ -1311,8 +1313,8 @@ static void json_single_property(int offset, uint64_t value64)
 	json_print(r);
 }
 
-struct json_object* json_effects_log(enum nvme_csi csi,
-			     struct nvme_cmd_effects_log *effects_log)
+struct json_object *json_effects_log(enum nvme_csi csi,
+				     struct nvme_cmd_effects_log *effects_log)
 {
 	struct json_object *r = json_create_object();
 	struct json_object *acs = json_create_object();
@@ -1536,7 +1538,7 @@ static void json_pel_smart_health(void *pevent_log_info, __u32 offset,
 		temp = le16_to_cpu(smart_event->temp_sensor[c]);
 		if (!temp)
 			continue;
-		sprintf(key, "temperature_sensor_%d",c + 1);
+		sprintf(key, "temperature_sensor_%d", c + 1);
 		obj_add_int(valid_attrs, key, temp);
 	}
 
@@ -2338,6 +2340,7 @@ static void json_nvme_fdp_events(struct nvme_fdp_events_log *log)
 
 		if (event->type == NVME_FDP_EVENT_REALLOC) {
 			struct nvme_fdp_event_realloc *mr;
+
 			mr = (struct nvme_fdp_event_realloc *)&event->type_specific;
 
 			obj_add_uint(obj_event, "nlbam", le16_to_cpu(mr->nlbam));
@@ -3426,7 +3429,7 @@ static void json_timestamp(struct json_object *r, struct nvme_timestamp *ts)
 
 	obj_add_uint64(r, "timestamp", int48_to_long(ts->timestamp));
 
-	if(!strftime(buffer, sizeof(buffer), "%c %Z", tm))
+	if (!strftime(buffer, sizeof(buffer), "%c %Z", tm))
 		sprintf(buffer, "%s", "-");
 
 	obj_add_str(r, "timestamp string", buffer);
@@ -4082,7 +4085,7 @@ static void json_detail_list(nvme_root_t t)
 		if (hostid)
 			obj_add_str(hss, "HostID", hostid);
 
-		nvme_for_each_subsystem(h , s) {
+		nvme_for_each_subsystem(h, s) {
 			struct json_object *jss = json_create_object();
 			struct json_object *jctrls = json_create_array();
 			struct json_object *jnss = json_create_array();
@@ -4208,9 +4211,10 @@ static void json_simple_list(nvme_root_t t)
 			nvme_subsystem_for_each_ns(s, n)
 				array_add_obj(jdevices, json_list_item_obj(n));
 
-			nvme_subsystem_for_each_ctrl(s, c)
+			nvme_subsystem_for_each_ctrl(s, c) {
 				nvme_ctrl_for_each_ns(c, n)
-				array_add_obj(jdevices, json_list_item_obj(n));
+					array_add_obj(jdevices, json_list_item_obj(n));
+			}
 		}
 	}
 
@@ -4480,7 +4484,7 @@ static void json_discovery_log(struct nvmf_discovery_log *log, int numrec)
 		obj_add_str(entry, "trtype", nvmf_trtype_str(e->trtype));
 		obj_add_str(entry, "adrfam", nvmf_adrfam_str(e->adrfam));
 		obj_add_str(entry, "subtype", nvmf_subtype_str(e->subtype));
-		obj_add_str(entry,"treq", nvmf_treq_str(e->treq));
+		obj_add_str(entry, "treq", nvmf_treq_str(e->treq));
 		obj_add_uint(entry, "portid", le16_to_cpu(e->portid));
 		obj_add_str(entry, "trsvcid", e->trsvcid);
 		obj_add_str(entry, "subnqn", e->subnqn);
@@ -4694,7 +4698,7 @@ static struct print_ops json_print_ops = {
 	.sanitize_log_page		= json_sanitize_log,
 	.secondary_ctrl_list		= json_nvme_list_secondary_ctrl,
 	.select_result			= json_select_result,
-	.self_test_log 			= json_self_test_log,
+	.self_test_log			= json_self_test_log,
 	.single_property		= json_single_property,
 	.smart_log			= json_smart_log,
 	.supported_cap_config_list_log	= json_supported_cap_config_log,

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -1185,61 +1185,64 @@ static void json_registers_pmrcap(uint32_t pmrcap, struct json_object *r)
 	obj_add_uint_x(r, "pmrcap", pmrcap);
 
 	obj_add_str(r, "Controller Memory Space Supported (CMSS)",
-	       ((pmrcap & 0x01000000) >> 24) ? "Supported" : "Not supported");
-	obj_add_uint_x(r, "Persistent Memory Region Timeout (PMRTO)", (pmrcap & 0xff0000) >> 16);
+		    NVME_PMRCAP_CMSS(pmrcap) ? "Supported" : "Not supported");
+	obj_add_uint_x(r, "Persistent Memory Region Timeout (PMRTO)", NVME_PMRCAP_PMRTO(pmrcap));
 	obj_add_uint_x(r, "Persistent Memory Region Write Barrier Mechanisms (PMRWBM)",
-			(pmrcap & 0x3c00) >> 10);
+		       NVME_PMRCAP_PMRWBM(pmrcap));
 	obj_add_str(r, "Persistent Memory Region Time Units (PMRTU)",
-		     (pmrcap & 0x300) >> 8 ? "minutes" : "500 milliseconds");
-	obj_add_uint_x(r, "Base Indicator Register (BIR)", (pmrcap & 0xe0) >> 5);
-	obj_add_str(r, "Write Data Support (WDS)", pmrcap & 0x10 ? "Supported" : "Not supported");
-	obj_add_str(r, "Read Data Support (RDS)", pmrcap & 8 ? "Supported" : "Not supported");
+		    NVME_PMRCAP_PMRTU(pmrcap) ? "minutes" : "500 milliseconds");
+	obj_add_uint_x(r, "Base Indicator Register (BIR)", NVME_PMRCAP_BIR(pmrcap));
+	obj_add_str(r, "Write Data Support (WDS)",
+		    NVME_PMRCAP_WDS(pmrcap) ? "Supported" : "Not supported");
+	obj_add_str(r, "Read Data Support (RDS)",
+		    NVME_PMRCAP_RDS(pmrcap) ? "Supported" : "Not supported");
 }
 
 static void json_registers_pmrctl(uint32_t pmrctl, struct json_object *r)
 {
 	obj_add_uint_x(r, "pmrctl", pmrctl);
 
-	obj_add_str(r, "Enable (EN)", pmrctl & 1 ? "Ready" : "Disabled");
+	obj_add_str(r, "Enable (EN)", NVME_PMRCTL_EN(pmrctl) ? "Ready" : "Disabled");
 }
 
 static void json_registers_pmrsts(uint32_t pmrsts, bool ready, struct json_object *r)
 {
 	obj_add_uint_x(r, "pmrsts", pmrsts);
 
-	obj_add_uint_x(r, "Controller Base Address Invalid (CBAI)", (pmrsts & 0x1000) >> 12);
+	obj_add_uint_x(r, "Controller Base Address Invalid (CBAI)", NVME_PMRSTS_CBAI(pmrsts));
 	obj_add_str(r, "Health Status (HSTS)",
-		    nvme_register_pmr_hsts_to_string((pmrsts & 0xe00) >> 9));
+		    nvme_register_pmr_hsts_to_string(NVME_PMRSTS_HSTS(pmrsts)));
 	obj_add_str(r, "Not Ready (NRDY)",
-		    !(pmrsts & 0x100) && ready ? "Ready" : "Not ready");
-	obj_add_uint_x(r, "Error (ERR)", pmrsts & 0xff);
+		    !NVME_PMRSTS_NRDY(pmrsts) && ready ? "Ready" : "Not ready");
+	obj_add_uint_x(r, "Error (ERR)", NVME_PMRSTS_ERR(pmrsts));
 }
 
 static void json_registers_pmrebs(uint32_t pmrebs, struct json_object *r)
 {
 	obj_add_uint_x(r, "pmrebs", pmrebs);
 
-	obj_add_uint_x(r, "PMR Elasticity Buffer Size Base (PMRWBZ)", (pmrebs & 0xffffff00) >> 8);
-	obj_add_str(r, "Read Bypass Behavior", pmrebs & 0x10 ? "Shall" : "May");
+	obj_add_uint_x(r, "PMR Elasticity Buffer Size Base (PMRWBZ)", NVME_PMREBS_PMRWBZ(pmrebs));
+	obj_add_str(r, "Read Bypass Behavior", NVME_PMREBS_RBB(pmrebs) ? "Shall" : "May");
 	obj_add_str(r, "PMR Elasticity Buffer Size Units (PMRSZU)",
-		    nvme_register_unit_to_string(pmrebs & 0xf));
+		    nvme_register_unit_to_string(NVME_PMREBS_PMRSZU(pmrebs)));
 }
 
 static void json_registers_pmrswtp(uint32_t pmrswtp, struct json_object *r)
 {
 	obj_add_uint_x(r, "pmrswtp", pmrswtp);
 
-	obj_add_uint_x(r, "PMR Sustained Write Throughput (PMRSWTV)", (pmrswtp & 0xffffff00) >> 8);
+	obj_add_uint_x(r, "PMR Sustained Write Throughput (PMRSWTV)",
+		       NVME_PMRSWTP_PMRSWTV(pmrswtp));
 	obj_add_key(r, "PMR Sustained Write Throughput Units (PMRSWTU)", "%s/second",
-		    nvme_register_unit_to_string(pmrswtp & 0xf));
+		    nvme_register_unit_to_string(NVME_PMRSWTP_PMRSWTU(pmrswtp)));
 }
 
 static void json_registers_pmrmscl(uint32_t pmrmscl, struct json_object *r)
 {
 	obj_add_uint_nx(r, "pmrmscl", pmrmscl);
 
-	obj_add_uint_nx(r, "Controller Base Address (CBA)", (pmrmscl & 0xfffff000) >> 12);
-	obj_add_uint_nx(r, "Controller Memory Space Enable (CMSE)", (pmrmscl & 2) >> 1);
+	obj_add_uint_nx(r, "Controller Base Address (CBA)", (uint32_t)NVME_PMRMSC_CBA(pmrmscl));
+	obj_add_uint_nx(r, "Controller Memory Space Enable (CMSE)", NVME_PMRMSC_CMSE(pmrmscl));
 }
 
 static void json_registers_pmrmscu(uint32_t pmrmscu, struct json_object *r)

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -1868,7 +1868,7 @@ static void json_lba_status(struct nvme_lba_status *list,
 		sprintf(json_str, "LSD entry %d", idx);
 		obj_add_array(r, json_str, lsde);
 		e = &list->descs[idx];
-		sprintf(json_str, "0x%016"PRIu64"", le64_to_cpu(e->dslba));
+		sprintf(json_str, "0x%016"PRIx64"", le64_to_cpu(e->dslba));
 		obj_add_str(lsde, "DSLBA", json_str);
 		sprintf(json_str, "0x%08x", le32_to_cpu(e->nlb));
 		obj_add_str(lsde, "NLB", json_str);

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2193,7 +2193,7 @@ static void json_supported_cap_config_log(
 				array_add_obj(set_list, set);
 			}
 			chan_desc = (struct nvme_end_grp_chan_desc *)
-			    (cap_log->cap_config_desc[i].egcd[j].nvmsetid[0] * sizeof(__u16) * egsets);
+			    &cap_log->cap_config_desc[i].egcd[j].nvmsetid[egsets];
 			egchans = le16_to_cpu(chan_desc->egchans);
 			obj_add_uint(endurance, "egchans", le16_to_cpu(chan_desc->egchans));
 			chan_list = json_create_array();

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1379,7 +1379,7 @@ static void stdout_registers_pmrcap(__u32 pmrcap)
 	printf("\tPersistent Memory Region Timeout                   (PMRTO): %x\n",
 	       NVME_PMRCAP_PMRTO(pmrcap));
 	printf("\tPersistent Memory Region Write Barrier Mechanisms (PMRWBM): %x\n",
-	       NVME_PMRCAP_PMRWMB(pmrcap));
+	       NVME_PMRCAP_PMRWBM(pmrcap));
 	printf("\tPersistent Memory Region Time Units                (PMRTU): ");
 	printf("PMR time unit is %s\n", NVME_PMRCAP_PMRTU(pmrcap) ? "minutes" : "500 milliseconds");
 	printf("\tBase Indicator Register                              (BIR): %x\n",


### PR DESCRIPTION
Note: The long line string and strncpy() warnings are not fixed.