### PR TITLE
sed_opal: Only build when we really have sed_opal headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -160,7 +160,7 @@ conf.set10(
         name: 'linux/sed-opal.h'
 
     ),
-    description: 'Is linux/sed-opa.h include-able?'
+    description: 'Is linux/sed-opal.h include-able?'
 )
 conf.set10(
     'HAVE_KEY_TYPE',

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -30,7 +30,7 @@ if json_c_dep.found()
   ]
   subdir('solidigm')
   subdir('ocp')
-  if conf.has('HAVE_SED_OPAL')
+  if conf.get('HAVE_SED_OPAL') != 0
     subdir('sed')
   endif
 endif


### PR DESCRIPTION
There's already code to not build the sed opal plugin when the necessary headers aren't present. However, it doesn't work, since HAVE_SED_OPAL is always defined to be either 0 or 1, so the meson has() return true, even when the value is 0, causing the sed-opal plugin to build, even when the header files it needs are missing.

Note: This came up in the context of my updating the FreeBSD port to the latest. Meson makes it a lot easier than before to do a minimal change port, but this is one of the few actual bugs that I found and so should change upstream. This issue is independent of my port, even though it came up in that context.

Also updated to add a second commit that fixes a spelling error in meson.build while I'm in the neighborhood.