### PR TITLE
nvmf-autoconnect: fix string encoding

### DIFF
--- a/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
+++ b/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
@@ -15,18 +15,18 @@ ENV{NVME_HOST_IFACE}=="", ENV{NVME_HOST_IFACE}="none"
 ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_AEN}=="0x70f002", \
   ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
   ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", ENV{NVME_HOST_IFACE}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}\t--host-iface=$env{NVME_HOST_IFACE}.service"
+  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device\x3d$kernel\t--transport\x3d$env{NVME_TRTYPE}\t--traddr\x3d$env{NVME_TRADDR}\t--trsvcid\x3d$env{NVME_TRSVCID}\t--host-traddr\x3d$env{NVME_HOST_TRADDR}\t--host-iface\x3d$env{NVME_HOST_IFACE}.service"
 
 # nvme-fc transport generated events (old-style for compatibility)
 ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
   ENV{NVMEFC_HOST_TRADDR}=="*",  ENV{NVMEFC_TRADDR}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device=none\t--transport=fc\t--traddr=$env{NVMEFC_TRADDR}\t--trsvcid=none\t--host-traddr=$env{NVMEFC_HOST_TRADDR}.service"
+  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device\x3dnone\t--transport\x3dfc\t--traddr\x3d$env{NVMEFC_TRADDR}\t--trsvcid\x3dnone\t--host-traddr\x3d$env{NVMEFC_HOST_TRADDR}.service"
 
 # A discovery controller just (re)connected, re-read the discovery log change to
 # check if there were any changes since it was last connected.
 ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_EVENT}=="rediscover", ATTR{cntrltype}=="discovery", \
   ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
   ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", ENV{NVME_HOST_IFACE}=="*", \
-  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device=$kernel\t--transport=$env{NVME_TRTYPE}\t--traddr=$env{NVME_TRADDR}\t--trsvcid=$env{NVME_TRSVCID}\t--host-traddr=$env{NVME_HOST_TRADDR}\t--host-iface=$env{NVME_HOST_IFACE}.service"
+  RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device\x3d$kernel\t--transport\x3d$env{NVME_TRTYPE}\t--traddr\x3d$env{NVME_TRADDR}\t--trsvcid\x3d$env{NVME_TRSVCID}\t--host-traddr\x3d$env{NVME_HOST_TRADDR}\t--host-iface\x3d$env{NVME_HOST_IFACE}.service"
 
 LABEL="autoconnect_end"


### PR DESCRIPTION
systemd reports that the arguments are not correctly encoded. Replace the = char with \x3 encoding.