### PR TITLE
plugins/solidigm: Automatic enabling Data Area 4 when retrieving Tele…

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -336,16 +336,10 @@ _nvme () {
 			(vs-internal-log)
 				local _vs_internal_log
 				_vs_internal_log=(
-				--type':Log type: ALL,
-                        CONTROLLERINITTELEMETRY,
-                        HOSTINITTELEMETRY,
-                        HOSTINITTELEMETRYNOGEN, NLOG,
-                        ASSERT, EVENT. Defaults to ALL.'
+				--type':Log type: ALL, CIT, HIT, NLOG, ASSERT, EVENT. Defaults to ALL.'
 				-t':alias for --type'
-				--namespace-id':Namespace to get logs from.'
-				-n':alias for --namespace-id'
-				--dir-prefix':Output dir prefix; defaults to device serial number.'
-				-p':alias for --dir-prefix'
+				--dir-name':Output directory; defaults to current working directory.'
+				-d':alias for --dir-name'
 				--verbose':To print out verbose info.'
 				-v':alias for --verbose'
 				)

--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -13,7 +13,7 @@
 
 #include "cmd.h"
 
-#define SOLIDIGM_PLUGIN_VERSION "1.2"
+#define SOLIDIGM_PLUGIN_VERSION "1.3"
 
 PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_VERSION),
 	COMMAND_LIST(


### PR DESCRIPTION
…metry.

vs-internal-log, stopped extracting Host Initiated Telemetry previous snapshot, simplified the type name of Telemetry snapshots to CIT and HIT, removed command options for setting namespace, and file prefix, and added command option to set output folder.