### PR TITLE
Use C99 types for uint32_t

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -34,6 +34,7 @@
 #include <inttypes.h>
 #include <locale.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -9075,8 +9076,8 @@ static int check_dhchap_key(int argc, char **argv, struct command *command, stru
 
 	unsigned char decoded_key[128];
 	unsigned int decoded_len;
-	u_int32_t crc = crc32(0L, NULL, 0);
-	u_int32_t key_crc;
+	uint32_t crc = crc32(0L, NULL, 0);
+	uint32_t key_crc;
 	int err = 0, hmac;
 	struct config {
 		char	*key;
@@ -9144,10 +9145,10 @@ static int check_dhchap_key(int argc, char **argv, struct command *command, stru
 		return -EINVAL;
 	}
 	crc = crc32(crc, decoded_key, decoded_len);
-	key_crc = ((u_int32_t)decoded_key[decoded_len]) |
-		   ((u_int32_t)decoded_key[decoded_len + 1] << 8) |
-		   ((u_int32_t)decoded_key[decoded_len + 2] << 16) |
-		   ((u_int32_t)decoded_key[decoded_len + 3] << 24);
+	key_crc = ((uint32_t)decoded_key[decoded_len]) |
+		   ((uint32_t)decoded_key[decoded_len + 1] << 8) |
+		   ((uint32_t)decoded_key[decoded_len + 2] << 16) |
+		   ((uint32_t)decoded_key[decoded_len + 3] << 24);
 	if (key_crc != crc) {
 		nvme_show_error("CRC mismatch (key %08x, crc %08x)", key_crc, crc);
 		return -EINVAL;

--- a/plugins/innogrit/typedef.h
+++ b/plugins/innogrit/typedef.h
@@ -53,14 +53,14 @@ struct vsc_smart_log {
 	unsigned int low_pwr_cnt;
 	unsigned int wa;
 	unsigned int ps3_entry_cnt;
-	u_char highest_temp[4];
+	unsigned char highest_temp[4];
 	unsigned int weight_ec;
 	unsigned int slc_cap_mb;
 	unsigned long long nand_page_write_cnt;
 	unsigned int program_error_cnt;
 	unsigned int erase_error_cnt;
-	u_char flash_type;
-	u_char reserved2[3];
+	unsigned char flash_type;
+	unsigned char reserved2[3];
 	unsigned int hs_crc_err_cnt;
 	unsigned int ddr_ecc_err_cnt;
 	unsigned int reserved3[44];

--- a/util/base64.c
+++ b/util/base64.c
@@ -20,6 +20,7 @@
  * MA  02110-1301, USA.
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -42,7 +43,7 @@ static const char base64_table[65] =
 int base64_encode(const unsigned char *src, int srclen, char *dst)
 {
 	int i, bits = 0;
-	u_int32_t ac = 0;
+	uint32_t ac = 0;
 	char *cp = dst;
 
 	for (i = 0; i < srclen; i++) {
@@ -77,7 +78,7 @@ int base64_encode(const unsigned char *src, int srclen, char *dst)
  */
 int base64_decode(const char *src, int srclen, unsigned char *dst)
 {
-	u_int32_t ac = 0;
+	uint32_t ac = 0;
 	int i, bits = 0;
 	unsigned char *bp = dst;
 


### PR DESCRIPTION
<stdint.h> provides `uint32_t`, while `u_int_32` is an unofficial/internal typedef that glibc happens to provide. This fixes the build on musl.

Bug: https://bugs.gentoo.org/931194