### PR TITLE
solidigm: Eliminate <linux/limits.h>

### DIFF
--- a/plugins/solidigm/solidigm-market-log.c
+++ b/plugins/solidigm/solidigm-market-log.c
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <inttypes.h>
-#include <linux/limits.h>
 
 #include "common.h"
 #include "nvme.h"


### PR DESCRIPTION
ARG_MAX is defined in <limits.h>, per POSIX, but it's defined to be a variable in glibc. Instead, get rid of it entirely by using asprintf to construct the commands. This prevents us from trying a partially constructed command that might do something unintentional. For solidigm-market-log.c, there's no constants needed from <linux/limits.h>. With this we can delete it both places. 
