### PR TITLE
nvme: remove double free in persistent-event-log

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1475,8 +1475,8 @@ static int get_persistent_event_log(int argc, char **argv,
 		"processing this persistent log page command.";
 	const char *log_len = "number of bytes to retrieve";
 
-	_cleanup_free_ struct nvme_persistent_event_log *pevent_collected = NULL;
 	_cleanup_free_ struct nvme_persistent_event_log *pevent = NULL;
+	struct nvme_persistent_event_log *pevent_collected = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	enum nvme_print_flags flags;


### PR DESCRIPTION
The pevent_collected structure uses the buffer address which is allocated using nvme_alloc_huge(). So, pevent_collected and mh.p has same address. Hence, removing _cleanup_free_ from pevent_collected to prevent double free.