### PR TITLE
build: Update meson commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,18 @@ NAME          := nvme
 BUILD-DIR     := .build
 
 ${BUILD-DIR}:
-	meson $@
+	meson setup $@
 	@echo "Configuration located in: $@"
 	@echo "-------------------------------------------------------"
 
 .PHONY: ${NAME}
 ${NAME}: ${BUILD-DIR}
-	ninja -C ${BUILD-DIR}
+	meson compile -C ${BUILD-DIR}
 
 .PHONY: clean
 clean:
 ifneq ("$(wildcard ${BUILD-DIR})","")
-	ninja -C ${BUILD-DIR} -t $@
+	meson compile --clean -C ${BUILD-DIR}
 endif
 
 .PHONY: purge


### PR DESCRIPTION
The `Makefile` is mainly used as a tool for people not familiar with `meson`. However, the `Makefile` is a good way to see how to invoke `meson` properly. This patch contains a few small fixes to match the preferred way of invoking `meson`.