### PR TITLE
sed: only re-read partition table after unlock.

### DIFF
--- a/plugins/sed/sedopal_cmd.c
+++ b/plugins/sed/sedopal_cmd.c
@@ -235,8 +235,21 @@ int sedopal_cmd_lock(int fd)
  */
 int sedopal_cmd_unlock(int fd)
 {
+	int rc;
 
-	return sedopal_lock_unlock(fd, OPAL_RW);
+	rc = sedopal_lock_unlock(fd, OPAL_RW);
+
+	/*
+	 * If the unlock was successful, force a re-read of the
+	 * partition table. Return rc of unlock operation.
+	 */
+	if (rc == 0) {
+		if (ioctl(fd, BLKRRPART, 0) != 0)
+			fprintf(stderr,
+				"Warning: failed re-reading partition\n");
+	}
+
+	return rc;
 }
 
 /*
@@ -259,18 +272,6 @@ int sedopal_lock_unlock(int fd, int lock_state)
 	if (rc != 0)
 		fprintf(stderr,
 			"Error: failed locking or unlocking - %d\n", rc);
-
-	/*
-	 * If the unlock was successful, force a re-read of the
-	 * partition table.
-	 */
-	if (rc == 0) {
-		rc = ioctl(fd, BLKRRPART, 0);
-		if (rc != 0)
-			fprintf(stderr,
-				"Error: failed re-reading partition\n");
-	}
-
 	return rc;
 }
 


### PR DESCRIPTION
The partition table was being re-read after both lock and unlock operations. The re-read would fail with an error message after a lock since the partiton was no longer readable.