### PR TITLE
ocp: Switch OCP plugin to use semantic versioning

### DIFF
--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -11,9 +11,10 @@
 #if !defined(OCP_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define OCP_NVME
 
+#define OCP_PLUGIN_VERSION   "1.17.0"
 #include "cmd.h"
 
-PLUGIN(NAME("ocp", "OCP cloud SSD extensions", NVME_VERSION),
+PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),
 	COMMAND_LIST(
 		ENTRY("smart-add-log", "Retrieve extended SMART Information", smart_add_log)
 		ENTRY("latency-monitor-log", "Get Latency Monitor Log Page", ocp_latency_monitor_log)


### PR DESCRIPTION
Title - I probably should have done this a lot earlier.

I (sort of arbitrarily) chose 77f6c8fc3ad808422127c052cdbd40b62cb348d7 to be the starting point for version ```1.0.0```. From there, I worked forward in the history and more or less added 1 to the minor version for every command added to the OCP plugin. Happy to take suggestions if anyone has a better idea.
