### PR TITLE
nvme-print-stdout: fix format index in stdout_nvm_id_ns

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3061,8 +3061,11 @@ static void stdout_nvm_id_ns(struct nvme_nvm_id_ns *nvm_ns, unsigned int nsid,
 {
 	int i, verbose = stdout_print_ops.flags & VERBOSE;
 	__u32 elbaf;
+	__u8 lbaf;
 	int pif, sts;
 	char *in_use = "(in use)";
+
+	nvme_id_ns_flbas_to_lbaf_inuse(ns->flbas, &lbaf);
 
 	if (!cap_only) {
 		printf("NVMe NVM Identify Namespace %d:\n", nsid);
@@ -3085,10 +3088,10 @@ static void stdout_nvm_id_ns(struct nvme_nvm_id_ns *nvm_ns, unsigned int nsid,
 				i, pif == 3 ? "Reserved" :
 					pif == 2 ? "64b Guard" :
 					pif == 1 ? "32b Guard" : "16b Guard",
-					pif, sts, i == (ns->flbas & 0xf) ? in_use : "");
+					pif, sts, i == lbaf ? in_use : "");
 		else
 			printf("elbaf %2d : pif:%d sts:%-2d %s\n", i,
-				pif, sts, i == (ns->flbas & 0xf) ? in_use : "");
+				pif, sts, i == lbaf ? in_use : "");
 	}
 }
 


### PR DESCRIPTION
This fix for nvme spec 2.0 where FLBAS bits 6:5 indicates the most significant 2 bits of the Format Index
that was used to format the namespace. So, use nvme_id_ns_flbas_to_lbaf_inuse function to get the proper
format index of the namespace.