### PR TITLE
plugins/micron: Added support for OCP telemetry (internal) log parsing. Datacenter NVMe SSD Specification v2.5r9 section 4.9

### DIFF
--- a/Documentation/cmd-plugins.txt
+++ b/Documentation/cmd-plugins.txt
@@ -46,6 +46,9 @@ linknvme:nvme-micron-smart-add-log[1]::
 linknvme:nvme-micron-temperature-stats[1]::
 	Retrieves temperature information of given micron device
 
+linknvme:nvme-micron-ocp-telemetry-log-parse[1]::
+	Parse OCP Telemetry DA1 and DA2 logs.
+
 linknvme:nvme-netapp-ontapdevices[1]::
 	Display information about ONTAP devices
 

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -80,6 +80,7 @@ adoc_sources = [
   'nvme-micron-selective-download',
   'nvme-micron-smart-add-log',
   'nvme-micron-temperature-stats',
+  'nvme-micron-ocp-telemetry-log-parse',
   'nvme-netapp-ontapdevices',
   'nvme-netapp-smdevices',
   'nvme-ns-descs',

--- a/Documentation/nvme-micron-ocp-telemetry-log-parse.txt
+++ b/Documentation/nvme-micron-ocp-telemetry-log-parse.txt
@@ -1,0 +1,88 @@
+nvme-micron-ocp-telemetry-log-parse
+===================================
+
+NAME
+----
+nvme-micron-ocp-telemetry-log-parse - Parses OCP Telemetry DA1 and DA2 logs.
+
+SYNOPSIS
+--------
+[verse]
+'nvme micron ocp-telemetry-log-parse' <device>
+			[--telemetry-log=<file> | -l <file>]
+			[--string-log=<file> | -s <file>]
+			[--output-file=<file> | -o <file>]
+			[--format=<fmt> | -f <fmt>]
+
+DESCRIPTION
+-----------
+For the given NVMe device, parses the telemetry log and string log
+(in binary format) and provides the parsed data in json and normal text formats.
+
+The <device> parameter is mandatory and may be either the NVMe
+character device (ex: /dev/nvme0), or a namespace block device (ex:
+/dev/nvme0n1).
+
+This will only work on Micron devices of model numbers 51Bx. Support for new
+devices may be added subsequently. Results for any other device are undefined.
+
+OPTIONS
+-------
+-l <file>::
+--telemetry-log=<file>::
+	This option will allow the users to specify input telemetry-log file name.
+
+-o <file>::
+--string-log=<file>::
+	This option will allow the users to specify input string-log file name.
+
+-o <file>::
+--output-file=<file>::
+	This option will allow the users to specify the output file name.
+
+-f <fmt>::
+--format=<fmt>::
+	Set the reporting format to 'normal', 'json'. Only one output format can be
+	used at a time.
+
+EXAMPLES
+--------
+* Parse nvme_host_telemetry_log.bin with nvmelog_ocp_c9.bin and output parsed
+json data into nvme_cli_telemetry_host.json
++
+------------
+# sudo ./nvme micron ocp-telemetry-log-parse --format=json
+ --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin"
+ --output-file=nvme_cli_telemetry_host.json /dev/nvme0
+------------
+
+* Parse nvme_host_telemetry_log.bin with nvmelog_ocp_c9.bin and output parsed
+text data into nvme_cli_telemetry_host_normal.txt
++
+------------
+# sudo ./nvme micron ocp-telemetry-log-parse --format=normal
+ --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin"
+ --output-file=nvme_cli_telemetry_host_normal.txt /dev/nvme0
+------------
+
+* Parse nvme_host_telemetry_log.bin with nvmelog_ocp_c9.bin and redirect parsed
+json data into nvme_cli_telemetry_host_console.json
++
+------------
+#  sudo ./nvme micron ocp-telemetry-log-parse --format=json
+ --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin"
+ > nvme_cli_telemetry_host_console.txt /dev/nvme0
+------------
+
+* Parse nvme_host_telemetry_log.bin with nvmelog_ocp_c9.bin and redirect parsed
+text data into nvme_cli_telemetry_host_console.json
++
+------------
+# sudo ./nvme micron ocp-telemetry-log-parse --format=normal
+ --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin"
+ > nvme_cli_telemetry_host_console.txt /dev/nvme0
+------------
+
+NVME
+----
+Part of the nvme-user suite

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -111,6 +111,7 @@ _nvme () {
 	'version:show the program version'
 	'ocp:OCP cloud SSD extensions'
 	'solidigm:Solidigm plug-in extensions'
+	'micron:Micron plug-in extensions'
 	'help:print brief descriptions of all nvme commands'
 	'json:dump output in json format'
 	)
@@ -515,6 +516,29 @@ _nvme () {
 				;;
 			esac
 			;;
+		(*)
+			_files
+			;;
+		esac
+			;;
+		(micron)
+			case ${words[2]} in
+			(ocp-telemetry-log-parse)
+				local _ocp-telemetry-log-parse
+				_ocp-telemetry-log-parse=(
+				/dev/nvme':supply a device to use (required)'
+				--output-file=':Output file name with path'
+				-o':alias for --output-file'
+				--telemetry-log=':Telemetry log binary'
+				-l':alias for --telemetry-log'
+				--string-log=':String log binary'
+				-s':alias for --string-log'
+				--format':Output format: normal|json'
+				-f':alias for --format'
+				)
+				_arguments '*:: :->subcmds'
+				_describe -t commands "nvme micron ocp-telemetry-log-parse" _ocp-telemetry-log-parse
+				;;
 		(*)
 			_files
 			;;
@@ -2525,6 +2549,34 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme solidigm options" _solidigm
+			;;
+		(micron)
+			local micron
+			_micron=(
+			select-download':Selective Firmware Download'
+			vs-temperature-stats':Retrieve Micron temperature statistics'
+			vs-pcie-stats':Retrieve Micron PCIe error stats'
+			clear-pcie-correctable-errors':Clear correctable PCIe errors'
+			vs-internal-log':Retrieve Micron logs'
+			vs-telemetry-controller-option':Enable/Disable controller telemetry log generation'
+			vs-nand-stats':Retrieve NAND Stats'
+			vs-smart-ext-log':Retrieve extended SMART logs'
+			vs-drive-info':Retrieve Drive information'
+			plugin-version':Display plugin version info'
+			cloud-SSD-plugin-version':Display plugin version info'
+			log-page-directory':Retrieve log page directory'
+			vs-fw-activate-history':Display FW activation history'
+			latency-tracking':Latency monitoring feature control'
+			latency-stats':Latency information for tracked commands'
+			latency-logs':Latency log details tracked by drive'
+			vs-smart-add-log':Retrieve extended SMART data'
+			clear-fw-activate-history':Clear FW activation history'
+			vs-smbus-option':Enable/Disable SMBUS on the drive'
+			ocp-telemetry-log-parse':Parse OCP Telemetry DA1 and DA2 logs'
+			help':Display this help'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme micron options" _micron
 			;;
 		(help)
 			local _h

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -884,6 +884,10 @@ plugin_micron_opts () {
 		"vs-smbus-option")
 		opts+=" --option= -o --value= -v --save= -s"
 			;;
+		"ocp-telemetry-log-parse")
+		opts+=" --format= -f --telemetry-log= -l --string-log= -s \
+			--output-file= -o"
+			;;
 		"help")
 		opts+=$NO_OPTS
 			;;
@@ -1524,7 +1528,7 @@ _nvme_subcmds () {
 			vs-drive-info plugin-version cloud-SSD-plugin-version \
 			log-page-directory vs-fw-activate-history \
 			vs-error-reason-identifier vs-smart-add-log \
-			clear-fw-activate-history vs-smbus-option"
+			clear-fw-activate-history vs-smbus-option ocp-telemetry-log-parse"
 		[seagate]="vs-temperature-stats vs-log-page-sup \
 			vs-smart-add-log vs-pcie-stats clear-pcie-correctable-errors \
 			get-host-tele get-ctrl-tele vs-internal-log \

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -11,6 +11,8 @@ if json_c_dep.found()
     'plugins/inspur/inspur-nvme.c',
     'plugins/intel/intel-nvme.c',
     'plugins/memblaze/memblaze-nvme.c',
+    'plugins/micron/micron-utils.c',
+    'plugins/micron/micron-ocp-telemetry.c',
     'plugins/micron/micron-nvme.c',
     'plugins/nbft/nbft-plugin.c',
     'plugins/netapp/netapp-nvme.c',

--- a/plugins/micron/micron-nvme.h
+++ b/plugins/micron/micron-nvme.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) Micron, Inc 2024.
+ *
+ * @file: micron-nvme.h
+ * @brief: This module contains all the constructs needed for micron nvme-cli plugin.
+ * @authors:Chaithanya Shoba <ashoba@micron.com>,
+ */
 #undef CMD_INC_FILE
 #define CMD_INC_FILE plugins/micron/micron-nvme
 
@@ -28,6 +35,8 @@ PLUGIN(NAME("micron", "Micron vendor specific extensions", NVME_VERSION),
 		ENTRY("vs-smart-add-log", "Retrieve extended SMART data", micron_ocp_smart_health_logs)
 		ENTRY("clear-fw-activate-history", "Clear FW activation history", micron_clr_fw_activation_history)
 		ENTRY("vs-smbus-option", "Enable/Disable SMBUS on the drive", micron_smbus_option)
+		ENTRY("ocp-telemetry-log-parse", "Parse OCP Telemetry DA1 and DA2 logs",
+			micron_ocp_telemetry_log_parse)
 	)
 );
 

--- a/plugins/micron/micron-ocp-telemetry.c
+++ b/plugins/micron/micron-ocp-telemetry.c
@@ -1,0 +1,1416 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) Micron, Inc 2024.
+ *
+ * @file: micron-ocp-telemetry.c
+ * @brief: This module contains all the constructs needed for parsing (or)
+ *  decoding ocp telemetry log files.
+ * @author: Chaithanya Shoba <ashoba@micron.com>
+ */
+
+#include "micron-ocp-telemetry.h"
+
+//global buffers
+static unsigned char *ptelemetry_buffer;
+static unsigned char *pstring_buffer;
+
+struct statistic_entry statistic_identifiers_map[] = {
+	{ 0x00, "Error, this entry does not exist." },
+	{ 0x01, "Outstanding Admin Commands" },
+	{ 0x02, "Host Write Bandwidth"},
+	{ 0x03, "GC Write Bandwidth"},
+	{ 0x04, "Active Namespaces"},
+	{ 0x05, "Internal Write Workload"},
+	{ 0x06, "Internal Read Workload"},
+	{ 0x07, "Internal Write Queue Depth"},
+	{ 0x08, "Internal Read Queue Depth"},
+	{ 0x09, "Pending Trim LBA Count"},
+	{ 0x0A, "Host Trim LBA Request Count"},
+	{ 0x0B, "Current NVMe Power State"},
+	{ 0x0C, "Current DSSD Power State"},
+	{ 0x0D, "Program Fail Count"},
+	{ 0x0E, "Erase Fail Count"},
+	{ 0x0F, "Read Disturb Writes"},
+	{ 0x10, "Retention Writes"},
+	{ 0x11, "Wear Leveling Writes"},
+	{ 0x12, "Read Recovery Writes"},
+	{ 0x13, "GC Writes"},
+	{ 0x14, "SRAM Correctable Count"},
+	{ 0x15, "DRAM Correctable Count"},
+	{ 0x16, "SRAM Uncorrectable Count"},
+	{ 0x17, "DRAM Uncorrectable Count"},
+	{ 0x18, "Data Integrity Error Count"},
+	{ 0x19, "Read Retry Error Count"},
+	{ 0x1A, "PERST Events Count"},
+	{ 0x1B, "Max Die Bad Block"},
+	{ 0x1C, "Max NAND Channel Bad Block"},
+	{ 0x1D, "Minimum NAND Channel Bad Block"}
+};
+
+struct micron_vs_logpage host_log_page_header[] = {
+	{ "LogIdentifier", 1 },
+	{ "Reserved1", 4 },
+	{ "IEEE OUI Identifier", 3 },
+	{ "Telemetry Host-Initiated Data Area 1 Last Block", 2 },
+	{ "Telemetry Host-Initiated Data Area 2 Last Block", 2 },
+	{ "Telemetry Host-Initiated Data Area 3 Last Block", 2 },
+	{ "Reserved2", 2 },
+	{ "Telemetry Host-Initiated Data Area 4 Last Block", 4 },
+	{ "Reserved3", 360 },
+	{ "Telemetry Host-Initiated Scope", 1 },
+	{ "Telemetry Host Initiated Generation Number", 1 },
+	{ "Telemetry Host-Initiated Data Available", 1 },
+	{ "Telemetry Controller-Initiated Data Generation Number", 1 }
+};
+
+struct micron_vs_logpage controller_log_page_header[] = {
+	{ "LogIdentifier", 1 },
+	{ "Reserved1", 4 },
+	{ "IEEE OUI Identifier", 3 },
+	{ "Telemetry Host-Initiated Data Area 1 Last Block", 2 },
+	{ "Telemetry Host-Initiated Data Area 2 Last Block", 2 },
+	{ "Telemetry Host-Initiated Data Area 3 Last Block", 2 },
+	{ "Reserved2", 2 },
+	{ "Telemetry Host-Initiated Data Area 4 Last Block", 4 },
+	{ "Reserved3", 361 },
+	{ "Telemetry Controller-Initiated Scope", 1 },
+	{ "Telemetry Controller-Initiated Data Available", 1 },
+	{ "Telemetry Controller-Initiated Data Generation Number", 1 }
+};
+
+struct micron_vs_logpage reason_identifier[] = {
+	{ "Error ID", 64 },
+	{ "File ID", 8 },
+	{ "Line Number", 2 },
+	{ "Valid Flags", 1 },
+	{ "Reserved", 21 },
+	{ "VU Reason Extension", 32 }
+};
+
+struct micron_vs_logpage ocp_header_in_da1[] = {
+	{ "Major Version", 2 },
+	{ "Minor Version", 2 },
+	{ "Reserved1", 4 },
+	{ "Timestamp", 8 },
+	{ "Log page GUID", 16 },
+	{ "Number Telemetry Profiles Supported", 1 },
+	{ "Telemetry Profile Selected", 1 },
+	{ "Reserved2", 6 },
+	{ "Telemetry String Log Size", 8 },
+	{ "Reserved3", 8 },
+	{ "Firmware Revision", 8 },
+	{ "Reserved4", 32 },
+	{ "Data Area 1 Statistic Start", 8 },
+	{ "Data Area 1 Statistic Size", 8 },
+	{ "Data Area 2 Statistic Start", 8 },
+	{ "Data Area 2 Statistic Size", 8 },
+	{ "Reserved5", 32 },
+	{ "Event FIFO 1 Data Area", 1 },
+	{ "Event FIFO 2 Data Area", 1 },
+	{ "Event FIFO 3 Data Area", 1 },
+	{ "Event FIFO 4 Data Area", 1 },
+	{ "Event FIFO 5 Data Area", 1 },
+	{ "Event FIFO 6 Data Area", 1 },
+	{ "Event FIFO 7 Data Area", 1 },
+	{ "Event FIFO 8 Data Area", 1 },
+	{ "Event FIFO 9 Data Area", 1 },
+	{ "Event FIFO 10 Data Area", 1 },
+	{ "Event FIFO 11 Data Area", 1 },
+	{ "Event FIFO 12 Data Area", 1 },
+	{ "Event FIFO 13 Data Area", 1 },
+	{ "Event FIFO 14 Data Area", 1 },
+	{ "Event FIFO 15 Data Area", 1 },
+	{ "Event FIFO 16 Data Area", 1 },
+	{ "Event FIFO 1 Start", 8 },
+	{ "Event FIFO 1 Size", 8 },
+	{ "Event FIFO 2 Start", 8 },
+	{ "Event FIFO 2 Size", 8 },
+	{ "Event FIFO 3 Start", 8 },
+	{ "Event FIFO 3 Size", 8 },
+	{ "Event FIFO 4 Start", 8 },
+	{ "Event FIFO 4 Size", 8 },
+	{ "Event FIFO 5 Start", 8 },
+	{ "Event FIFO 5 Size", 8 },
+	{ "Event FIFO 6 Start", 8 },
+	{ "Event FIFO 6 Size", 8 },
+	{ "Event FIFO 7 Start", 8 },
+	{ "Event FIFO 7 Size", 8 },
+	{ "Event FIFO 8 Start", 8 },
+	{ "Event FIFO 8 Size", 8 },
+	{ "Event FIFO 9 Start", 8 },
+	{ "Event FIFO 9 Size", 8 },
+	{ "Event FIFO 10 Start", 8 },
+	{ "Event FIFO 10 Size", 8 },
+	{ "Event FIFO 11 Start", 8 },
+	{ "Event FIFO 11 Size", 8 },
+	{ "Event FIFO 12 Start", 8 },
+	{ "Event FIFO 12 Size", 8 },
+	{ "Event FIFO 13 Start", 8 },
+	{ "Event FIFO 13 Size", 8 },
+	{ "Event FIFO 14 Start", 8 },
+	{ "Event FIFO 14 Size", 8 },
+	{ "Event FIFO 15 Start", 8 },
+	{ "Event FIFO 15 Size", 8 },
+	{ "Event FIFO 16 Start", 8 },
+	{ "Event FIFO 16 Size", 8 },
+	{ "Reserved6", 80 }
+};
+
+struct micron_vs_logpage smart[] = {
+	{ "Critical Warning", 1 },
+	{ "Composite Temperature", 2 },
+	{ "Available Spare", 1 },
+	{ "Available Spare Threshold", 1 },
+	{ "Percentage Used", 1 },
+	{ "Reserved1", 26 },
+	{ "Data Units Read", 16 },
+	{ "Data Units Written", 16 },
+	{ "Host Read Commands", 16 },
+	{ "Host Write Commands", 16 },
+	{ "Controller Busy Time", 16 },
+	{ "Power Cycles", 16 },
+	{ "Power On Hours", 16 },
+	{ "Unsafe Shutdowns", 16 },
+	{ "Media and Data Integrity Errors", 16 },
+	{ "Number of Error Information Log Entries", 16 },
+	{ "Warning Composite Temperature Time", 4 },
+	{ "Critical Composite Temperature Time", 4 },
+	{ "Temperature Sensor 1", 2 },
+	{ "Temperature Sensor 2", 2 },
+	{ "Temperature Sensor 3", 2 },
+	{ "Temperature Sensor 4", 2 },
+	{ "Temperature Sensor 5", 2 },
+	{ "Temperature Sensor 6", 2 },
+	{ "Temperature Sensor 7", 2 },
+	{ "Temperature Sensor 8", 2 },
+	{ "Thermal Management Temperature 1 Transition Count", 4 },
+	{ "Thermal Management Temperature 2 Transition Count", 4 },
+	{ "Total Time for Thermal Management Temperature 1", 4 },
+	{ "Total Time for Thermal Management Temperature 2", 4 },
+	{ "Reserved2", 280 }
+};
+
+struct micron_vs_logpage smart_extended[] = {
+	{ "Physical Media Units Written", 16 },
+	{ "Physical Media Units Read", 16 },
+	{ "Bad User NAND Blocks Raw Count", 6 },
+	{ "Bad User NAND Blocks Normalized Value", 2 },
+	{ "Bad System NAND Blocks Raw Count", 6 },
+	{ "Bad System NAND Blocks Normalized Value", 2 },
+	{ "XOR Recovery Count", 8 },
+	{ "Uncorrectable Read Error Count", 8 },
+	{ "Soft ECC Error Count", 8 },
+	{ "End to End Correction Counts Detected Errors", 4 },
+	{ "End to End Correction Counts Corrected Errors", 4 },
+	{ "System Data Percent Used", 1 },
+	{ "Refresh Counts", 7 },
+	{ "Maximum User Data Erase Count", 4 },
+	{ "Minimum User Data Erase Count", 4 },
+	{ "Number of thermal throttling events", 1 },
+	{ "Current Throttling Status", 1 },
+	{ "Errata Version Field", 1 },
+	{ "Point Version Field", 2 },
+	{ "Minor Version Field", 2 },
+	{ "Major Version Field", 1 },
+	{ "PCIe Correctable Error Count", 8 },
+	{ "Incomplete Shutdowns", 4 },
+	{ "Reserved1", 4 },
+	{ "Percent Free Blocks", 1 },
+	{ "Reserved2", 7 },
+	{ "Capacitor Health", 2 },
+	{ "NVMe Base Errata Version", 1 },
+	{ "NVMe Command Set Errata Version", 1 },
+	{ "Reserved3", 4 },
+	{ "Unaligned IO", 8 },
+	{ "Security Version Number", 8 },
+	{ "Total NUSE", 8 },
+	{ "PLP Start Count", 16 },
+	{ "Endurance Estimate", 16 },
+	{ "PCIe Link Retraining Count", 8 },
+	{ "Power State Change Count", 8 },
+	{ "Lowest Permitted Firmware Revision", 8 },
+	{ "Reserved4", 278 },
+	{ "Log Page Version", 2 },
+	{ "Log page GUID", 16 }
+};
+
+void json_add_formatted_u32_str(struct json_object *pobject, const char *msg, unsigned int pdata)
+{
+	char data_str[70] = { 0 };
+
+	sprintf(data_str, "0x%x", pdata);
+	json_object_add_value_string(pobject, msg, data_str);
+}
+
+void json_add_formatted_var_size_str(struct json_object *pobject, const char *msg, __u8 *pdata,
+	unsigned int data_size)
+{
+	char description_str[256] = "";
+	char temp_buffer[3] = { 0 };
+
+	for (size_t i = 0; i < data_size; ++i) {
+		sprintf(temp_buffer, "%02X", pdata[i]);
+		strcat(description_str, temp_buffer);
+	}
+
+	json_object_add_value_string(pobject, msg, description_str);
+}
+
+int get_telemetry_das_offset_and_size(
+	struct nvme_ocp_telemetry_common_header *ptelemetry_common_header,
+	struct nvme_ocp_telemetry_offsets *ptelemetry_das_offset)
+{
+	if (NULL == ptelemetry_common_header || NULL == ptelemetry_das_offset) {
+		nvme_show_error("Invalid input arguments.");
+		return -1;
+	}
+
+	if (ptelemetry_common_header->log_id == NVME_HOST_TELEMETRY_LOG)
+		ptelemetry_das_offset->header_size =
+		sizeof(struct nvme_ocp_telemetry_host_initiated_header);
+	else if (ptelemetry_common_header->log_id == NVME_CNTRL_TELEMETRY_LOG)
+		ptelemetry_das_offset->header_size =
+		sizeof(struct nvme_ocp_telemetry_controller_initiated_header);
+	else
+		return -1;
+
+	ptelemetry_das_offset->da1_start_offset = ptelemetry_das_offset->header_size;
+	ptelemetry_das_offset->da1_size = ptelemetry_common_header->da1_last_block *
+		OCP_TELEMETRY_DATA_BLOCK_SIZE;
+
+	ptelemetry_das_offset->da2_start_offset = ptelemetry_das_offset->da1_start_offset +
+		ptelemetry_das_offset->da1_size;
+	ptelemetry_das_offset->da2_size =
+		(ptelemetry_common_header->da2_last_block -
+		ptelemetry_common_header->da1_last_block) * OCP_TELEMETRY_DATA_BLOCK_SIZE;
+
+	ptelemetry_das_offset->da3_start_offset = ptelemetry_das_offset->da2_start_offset +
+		ptelemetry_das_offset->da2_size;
+	ptelemetry_das_offset->da3_size =
+		(ptelemetry_common_header->da3_last_block -
+		ptelemetry_common_header->da2_last_block) * OCP_TELEMETRY_DATA_BLOCK_SIZE;
+
+	ptelemetry_das_offset->da4_start_offset = ptelemetry_das_offset->da3_start_offset +
+		ptelemetry_das_offset->da3_size;
+	ptelemetry_das_offset->da4_size =
+		(ptelemetry_common_header->da4_last_block -
+		ptelemetry_common_header->da3_last_block) * OCP_TELEMETRY_DATA_BLOCK_SIZE;
+
+	return 0;
+}
+
+int get_static_id_ascii_string(int identifier, char *description)
+{
+	if (pstring_buffer == NULL)
+		return -1;
+
+	struct nvme_ocp_telemetry_string_header *pocp_ts_header =
+		(struct nvme_ocp_telemetry_string_header *)pstring_buffer;
+
+	//Calculating the sizes of the tables. Note: Data is present in the form of DWORDS,
+	//So multiplying with sizeof(DWORD)
+	unsigned long long sits_table_size = (pocp_ts_header->sitsz) * SIZE_OF_DWORD;
+
+	//Calculating number of entries present in all 3 tables
+	int sits_entries = (int)sits_table_size /
+		sizeof(struct nvme_ocp_statistics_identifier_string_table);
+
+	for (int sits_entry = 0; sits_entry < sits_entries; sits_entry++) {
+		struct nvme_ocp_statistics_identifier_string_table
+			*peach_statistic_entry =
+			(struct nvme_ocp_statistics_identifier_string_table *)
+			(pstring_buffer + (pocp_ts_header->sits * SIZE_OF_DWORD) +
+			(sits_entry *
+			sizeof(struct nvme_ocp_statistics_identifier_string_table)));
+
+		if (identifier == (int)peach_statistic_entry->vs_statistic_identifier) {
+			char *pdescription = (char *)(pstring_buffer +
+				(pocp_ts_header->ascts * SIZE_OF_DWORD) +
+				(peach_statistic_entry->ascii_id_offset *
+				SIZE_OF_DWORD));
+
+			memcpy(description, pdescription,
+			       peach_statistic_entry->ascii_id_length + 1);
+
+			// If ASCII string isn't found, see in our internal Map
+			// for 2.5 Spec defined strings (id < 0x1D).
+			if ((description == NULL) && (identifier < 0x1D))
+				memcpy(description,
+				       statistic_identifiers_map[identifier].description,
+				       peach_statistic_entry->ascii_id_length + 1);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+int get_event_id_ascii_string(int identifier, int debug_event_class, char *description)
+{
+	if (pstring_buffer == NULL)
+		return -1;
+
+	struct nvme_ocp_telemetry_string_header *pocp_ts_header =
+		(struct nvme_ocp_telemetry_string_header *)pstring_buffer;
+
+	//Calculating the sizes of the tables. Note: Data is present in the form of DWORDS,
+	//So multiplying with sizeof(DWORD)
+	unsigned long long ests_table_size = (pocp_ts_header->estsz) * SIZE_OF_DWORD;
+
+	//Calculating number of entries present in all 3 tables
+	int ests_entries = (int)ests_table_size / sizeof(struct nvme_ocp_event_string_table);
+
+	for (int ests_entry = 0; ests_entry < ests_entries; ests_entry++) {
+		struct nvme_ocp_event_string_table *peach_event_entry =
+			(struct nvme_ocp_event_string_table *)
+			(pstring_buffer + (pocp_ts_header->ests * SIZE_OF_DWORD) +
+			(ests_entry * sizeof(struct nvme_ocp_event_string_table)));
+
+		if (identifier == (int)peach_event_entry->event_identifier &&
+			debug_event_class == (int)peach_event_entry->debug_event_class) {
+			char *pdescription = (char *)(pstring_buffer +
+				(pocp_ts_header->ascts * SIZE_OF_DWORD) +
+				(peach_event_entry->ascii_id_offset * SIZE_OF_DWORD));
+
+			memcpy(description, pdescription,
+			       peach_event_entry->ascii_id_length + 1);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+int get_vu_event_id_ascii_string(int identifier, int debug_event_class, char *description)
+{
+	if (pstring_buffer == NULL)
+		return -1;
+
+	struct nvme_ocp_telemetry_string_header *pocp_ts_header =
+		(struct nvme_ocp_telemetry_string_header *)pstring_buffer;
+
+	//Calculating the sizes of the tables. Note: Data is present in the form of DWORDS,
+	//So multiplying with sizeof(DWORD)
+	unsigned long long vuests_table_size = (pocp_ts_header->vu_estsz) * SIZE_OF_DWORD;
+
+	//Calculating number of entries present in all 3 tables
+	int vu_ests_entries = (int)vuests_table_size /
+		sizeof(struct nvme_ocp_vu_event_string_table);
+
+	for (int vu_ests_entry = 0; vu_ests_entry < vu_ests_entries; vu_ests_entry++) {
+		struct nvme_ocp_vu_event_string_table *peach_vu_event_entry =
+			(struct nvme_ocp_vu_event_string_table *)
+			(pstring_buffer + (pocp_ts_header->vu_ests * SIZE_OF_DWORD) +
+			(vu_ests_entry * sizeof(struct nvme_ocp_vu_event_string_table)));
+
+		if (identifier == (int)peach_vu_event_entry->vu_event_identifier &&
+			debug_event_class ==
+				(int)peach_vu_event_entry->debug_event_class) {
+			char *pdescription = (char *)(pstring_buffer +
+				(pocp_ts_header->ascts * SIZE_OF_DWORD) +
+				(peach_vu_event_entry->ascii_id_offset * SIZE_OF_DWORD));
+
+			memcpy(description, pdescription,
+			       peach_vu_event_entry->ascii_id_length + 1);
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+int parse_ocp_telemetry_string_log(int event_fifo_num, int identifier, int debug_event_class,
+	enum ocp_telemetry_string_tables string_table, char *description)
+{
+	if (pstring_buffer == NULL)
+		return -1;
+
+	if (event_fifo_num != 0) {
+		struct nvme_ocp_telemetry_string_header *pocp_ts_header =
+			(struct nvme_ocp_telemetry_string_header *)pstring_buffer;
+
+		if (*pocp_ts_header->fifo_ascii_string[event_fifo_num-1] != '\0')
+			memcpy(description, pocp_ts_header->fifo_ascii_string[event_fifo_num-1],
+			       16);
+		else
+			description = "";
+
+		return 0;
+	}
+
+	if (string_table == STATISTICS_IDENTIFIER_STRING)
+		get_static_id_ascii_string(identifier, description);
+	else if (string_table == EVENT_STRING)
+		get_event_id_ascii_string(identifier, debug_event_class, description);
+	else if (string_table == VU_EVENT_STRING)
+		get_vu_event_id_ascii_string(identifier, debug_event_class, description);
+
+	return 0;
+}
+
+void parse_time_stamp_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp)
+{
+	struct nvme_ocp_time_stamp_dbg_evt_class_format *ptime_stamp_event =
+		(struct nvme_ocp_time_stamp_dbg_evt_class_format *) pevent_specific_data;
+
+	int vu_event_id = (int)ptime_stamp_event->vu_event_identifier;
+
+	unsigned int data_size = ((pevent_descriptor->event_data_size * SIZE_OF_DWORD)-
+					sizeof(struct nvme_ocp_time_stamp_dbg_evt_class_format));
+
+	__u8 *pdata = (__u8 *)ptime_stamp_event +
+					sizeof(struct nvme_ocp_time_stamp_dbg_evt_class_format);
+
+	char description_str[256] = "";
+
+	parse_ocp_telemetry_string_log(0, ptime_stamp_event->vu_event_identifier,
+				       pevent_descriptor->debug_event_class_type,
+				       VU_EVENT_STRING, description_str);
+
+	if (pevent_fifos_object != NULL) {
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
+						ptime_stamp_event->time_stamp, DATA_SIZE_8);
+		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+					   vu_event_id);
+		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+					     description_str);
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+						data_size);
+	} else {
+		if (fp) {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+					     ptime_stamp_event->time_stamp, DATA_SIZE_8, fp);
+			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		} else {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+				ptime_stamp_event->time_stamp, DATA_SIZE_8, fp);
+			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		}
+	}
+}
+
+void parse_pcie_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp)
+{
+	struct nvme_ocp_pcie_dbg_evt_class_format *ppcie_event =
+				(struct nvme_ocp_pcie_dbg_evt_class_format *) pevent_specific_data;
+	int vu_event_id = (int) ppcie_event->vu_event_identifier;
+	unsigned int data_size = ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
+					sizeof(struct nvme_ocp_pcie_dbg_evt_class_format));
+	__u8 *pdata = (__u8 *) ppcie_event + sizeof(struct nvme_ocp_pcie_dbg_evt_class_format);
+	char description_str[256] = "";
+
+	parse_ocp_telemetry_string_log(0, ppcie_event->vu_event_identifier,
+	       pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+
+	if (pevent_fifos_object != NULL) {
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
+						ppcie_event->pCIeDebugEventData, DATA_SIZE_4);
+		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+					   vu_event_id);
+		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+					     description_str);
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+						data_size);
+	} else {
+		if (fp) {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+					     ppcie_event->pCIeDebugEventData, DATA_SIZE_4, fp);
+			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		} else {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+					     ppcie_event->pCIeDebugEventData, DATA_SIZE_4, fp);
+			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		}
+	}
+}
+
+void parse_nvme_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp)
+{
+	struct nvme_ocp_nvme_dbg_evt_class_format *pnvme_event =
+				(struct nvme_ocp_nvme_dbg_evt_class_format *) pevent_specific_data;
+	int vu_event_id = (int) pnvme_event->vu_event_identifier;
+	unsigned int data_size = ((pevent_descriptor->event_data_size *
+	SIZE_OF_DWORD) - sizeof(struct nvme_ocp_nvme_dbg_evt_class_format));
+	__u8 *pdata = (__u8 *) pnvme_event + sizeof(struct nvme_ocp_nvme_dbg_evt_class_format);
+	char description_str[256] = "";
+
+	parse_ocp_telemetry_string_log(0, pnvme_event->vu_event_identifier,
+				       pevent_descriptor->debug_event_class_type, VU_EVENT_STRING,
+				       description_str);
+
+	if (pevent_fifos_object != NULL) {
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
+						pnvme_event->nvmeDebugEventData, DATA_SIZE_8);
+		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+					   vu_event_id);
+		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+					     description_str);
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+						data_size);
+	} else {
+		if (fp) {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+					     pnvme_event->nvmeDebugEventData, DATA_SIZE_8, fp);
+			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		} else {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+					      pnvme_event->nvmeDebugEventData, DATA_SIZE_8, fp);
+			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		}
+	}
+}
+
+void parse_common_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp)
+{
+	struct nvme_ocp_common_dbg_evt_class_format *pcommon_debug_event =
+			(struct nvme_ocp_common_dbg_evt_class_format *) pevent_specific_data;
+	int vu_event_id = (int) pcommon_debug_event->vu_event_identifier;
+	unsigned int data_size = ((pevent_descriptor->event_data_size *
+	SIZE_OF_DWORD) - sizeof(struct nvme_ocp_common_dbg_evt_class_format));
+	__u8 *pdata = (__u8 *) pcommon_debug_event +
+					sizeof(struct nvme_ocp_common_dbg_evt_class_format);
+	char description_str[256] = "";
+
+	parse_ocp_telemetry_string_log(0, pcommon_debug_event->vu_event_identifier,
+		pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+
+	if (pevent_fifos_object != NULL) {
+		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+					   vu_event_id);
+		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+					     description_str);
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+						data_size);
+	} else {
+		if (fp) {
+			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		} else {
+			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		}
+	}
+}
+
+void parse_media_wear_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp)
+{
+	struct nvme_ocp_media_wear_dbg_evt_class_format *pmedia_wear_event =
+			(struct nvme_ocp_media_wear_dbg_evt_class_format *) pevent_specific_data;
+	int vu_event_id = (int) pmedia_wear_event->vu_event_identifier;
+	unsigned int data_size = ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
+					sizeof(struct nvme_ocp_media_wear_dbg_evt_class_format));
+	__u8 *pdata = (__u8 *) pmedia_wear_event +
+					sizeof(struct nvme_ocp_media_wear_dbg_evt_class_format);
+	char description_str[256] = "";
+
+	parse_ocp_telemetry_string_log(0, pmedia_wear_event->vu_event_identifier,
+					pevent_descriptor->debug_event_class_type, VU_EVENT_STRING,
+					description_str);
+
+	if (pevent_fifos_object != NULL) {
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
+						pmedia_wear_event->currentMediaWear, DATA_SIZE_12);
+		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+					   vu_event_id);
+		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+					     description_str);
+		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+						data_size);
+	} else {
+		if (fp) {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+				      pmedia_wear_event->currentMediaWear, DATA_SIZE_12, fp);
+			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		} else {
+			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
+				     pmedia_wear_event->currentMediaWear, DATA_SIZE_12, NULL);
+			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		}
+	}
+}
+
+int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
+	struct json_object *pevent_fifos_object, unsigned char *pstring_buffer,
+	struct nvme_ocp_telemetry_offsets *poffsets, __u64 fifo_size, FILE *fp)
+{
+	if (NULL == pfifo_start || NULL == poffsets) {
+		nvme_show_error("Input buffer was NULL");
+		return -1;
+	}
+
+	int status = 0;
+	unsigned int event_fifo_number = fifo_num + 1;
+	char *description = (char *)malloc((40 + 1) * sizeof(char));
+
+	memset(description, 0, sizeof(40));
+
+	status =
+		parse_ocp_telemetry_string_log(event_fifo_number, 0, 0, EVENT_STRING, description);
+
+	if (status != 0) {
+		nvme_show_error("Failed to get C9 String. status: %d\n", status);
+		return -1;
+	}
+
+	char event_fifo_name[100] = {0};
+
+	snprintf(event_fifo_name, sizeof(event_fifo_name), "%s%d%s%s", "EVENT FIFO ",
+		 event_fifo_number, " - ", description);
+
+	struct json_object *pevent_fifo_array = NULL;
+
+	if (pevent_fifos_object != NULL)
+		pevent_fifo_array = json_create_array();
+	else {
+		char buffer[1024] = {0};
+
+		sprintf(buffer, "%s%s\n%s", STR_LINE, event_fifo_name, STR_LINE);
+		if (fp)
+			fprintf(fp, "%s", buffer);
+		else
+			printf("%s", buffer);
+	}
+
+	int offset_to_move = 0;
+	unsigned int event_des_size = sizeof(struct nvme_ocp_telemetry_event_descriptor);
+
+	while ((fifo_size > 0) && (offset_to_move < fifo_size)) {
+		struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor =
+			(struct nvme_ocp_telemetry_event_descriptor *)
+			(pfifo_start + offset_to_move);
+
+		if (pevent_descriptor != NULL && pevent_descriptor->event_data_size >= 0) {
+			//Data is present in the form of DWORDS, So multiplying with sizeof(DWORD)
+			unsigned int data_size = pevent_descriptor->event_data_size *
+							SIZE_OF_DWORD;
+
+			__u8 *pevent_specific_data = (__u8 *)pevent_descriptor + event_des_size;
+
+			char description_str[256] = "";
+
+			parse_ocp_telemetry_string_log(0, pevent_descriptor->event_id,
+				pevent_descriptor->debug_event_class_type, EVENT_STRING,
+				description_str);
+
+			struct json_object *pevent_descriptor_obj =
+				((pevent_fifos_object != NULL)?json_create_object():NULL);
+
+			if (pevent_descriptor_obj != NULL) {
+				json_add_formatted_u32_str(pevent_descriptor_obj,
+					STR_DBG_EVENT_CLASS_TYPE,
+					pevent_descriptor->debug_event_class_type);
+				json_add_formatted_u32_str(pevent_descriptor_obj,
+					STR_EVENT_IDENTIFIER, pevent_descriptor->event_id);
+				json_object_add_value_string(pevent_descriptor_obj,
+					STR_EVENT_STRING, description_str);
+				json_add_formatted_u32_str(pevent_descriptor_obj,
+					STR_EVENT_DATA_SIZE, pevent_descriptor->event_data_size);
+
+				if (pevent_descriptor->debug_event_class_type >= 0x80)
+					json_add_formatted_var_size_str(pevent_descriptor_obj,
+						STR_VU_DATA, pevent_specific_data, data_size);
+			} else {
+				if (fp) {
+					fprintf(fp, "%s: 0x%x\n", STR_DBG_EVENT_CLASS_TYPE,
+						pevent_descriptor->debug_event_class_type);
+					fprintf(fp, "%s: 0x%x\n", STR_EVENT_IDENTIFIER,
+						pevent_descriptor->event_id);
+					fprintf(fp, "%s: %s\n", STR_EVENT_STRING, description_str);
+					fprintf(fp, "%s: 0x%x\n", STR_EVENT_DATA_SIZE,
+						pevent_descriptor->event_data_size);
+				} else {
+					printf("%s: 0x%x\n", STR_DBG_EVENT_CLASS_TYPE,
+					       pevent_descriptor->debug_event_class_type);
+					printf("%s: 0x%x\n", STR_EVENT_IDENTIFIER,
+					       pevent_descriptor->event_id);
+					printf("%s: %s\n", STR_EVENT_STRING, description_str);
+					printf("%s: 0x%x\n", STR_EVENT_DATA_SIZE,
+					       pevent_descriptor->event_data_size);
+				}
+
+				if (pevent_descriptor->debug_event_class_type >= 0x80)
+					print_formatted_var_size_str(STR_VU_DATA,
+						pevent_specific_data, data_size, fp);
+			}
+
+			switch (pevent_descriptor->debug_event_class_type) {
+			case TIME_STAMP_CLASS_TYPE:
+				parse_time_stamp_event(pevent_descriptor, pevent_descriptor_obj,
+					       pevent_specific_data, pevent_fifos_object, fp);
+				break;
+			case PCIE_CLASS_TYPE:
+				parse_pcie_event(pevent_descriptor, pevent_descriptor_obj,
+					       pevent_specific_data, pevent_fifos_object, fp);
+				break;
+			case NVME_CLASS_TYPE:
+				parse_nvme_event(pevent_descriptor, pevent_descriptor_obj,
+					       pevent_specific_data, pevent_fifos_object, fp);
+				break;
+			case RESET_CLASS_TYPE:
+			case BOOT_SEQUENCE_CLASS_TYPE:
+			case FIRMWARE_ASSERT_CLASS_TYPE:
+			case TEMPERATURE_CLASS_TYPE:
+			case MEDIA_CLASS_TYPE:
+				parse_common_event(pevent_descriptor, pevent_descriptor_obj,
+					       pevent_specific_data, pevent_fifos_object, fp);
+				break;
+			case MEDIA_WEAR_CLASS_TYPE:
+				parse_media_wear_event(pevent_descriptor, pevent_descriptor_obj,
+					       pevent_specific_data, pevent_fifos_object, fp);
+				break;
+			case STATISTIC_SNAPSHOT_CLASS_TYPE: {
+				struct nvme_ocp_statistic_snapshot_evt_class_format
+				*pStaticSnapshotEvent =
+					(struct nvme_ocp_statistic_snapshot_evt_class_format *)
+					pevent_specific_data;
+				struct nvme_ocp_telemetry_statistic_descriptor *pstatistic_entry =
+					(struct nvme_ocp_telemetry_statistic_descriptor *)
+					(&pStaticSnapshotEvent->statisticDescriptorData);
+
+				parse_statistic(pstatistic_entry, pevent_descriptor_obj, fp);
+				break;
+			}
+			case RESERVED_CLASS_TYPE:
+			default:
+				break;
+		}
+
+		if (pevent_descriptor_obj != NULL && pevent_fifo_array != NULL)
+			json_array_add_value_object(pevent_fifo_array, pevent_descriptor_obj);
+		else {
+			if (fp)
+				fprintf(fp, STR_LINE2);
+			else
+				printf(STR_LINE2);
+		}
+	} else
+		break;
+
+	offset_to_move += (pevent_descriptor->event_data_size * SIZE_OF_DWORD + event_des_size);
+	}
+
+	if (pevent_fifos_object != NULL && pevent_fifo_array != NULL)
+		json_object_add_value_array(pevent_fifos_object, event_fifo_name,
+			pevent_fifo_array);
+
+	free(description);
+	return 0;
+}
+
+int parse_event_fifos(struct json_object *root, struct nvme_ocp_telemetry_offsets *poffsets,
+	FILE *fp)
+{
+	if (poffsets == NULL) {
+		nvme_show_error("Input buffer was NULL");
+		return -1;
+	}
+
+	struct json_object *pevent_fifos_object = NULL;
+
+	if (root != NULL)
+		pevent_fifos_object = json_create_object();
+
+	__u8 *pda1_header_offset = ptelemetry_buffer + poffsets->da1_start_offset;//512
+	__u8 *pda2_offset = ptelemetry_buffer + poffsets->da2_start_offset;
+	struct nvme_ocp_header_in_da1 *pda1_header = (struct nvme_ocp_header_in_da1 *)
+		pda1_header_offset;
+	struct nvme_ocp_event_fifo_data event_fifo[MAX_NUM_FIFOS];
+
+	for (int fifo_num = 0; fifo_num < MAX_NUM_FIFOS; fifo_num++) {
+		event_fifo[fifo_num].event_fifo_num = fifo_num;
+		event_fifo[fifo_num].event_fifo_da = pda1_header->event_fifo_da[fifo_num];
+		event_fifo[fifo_num].event_fifo_start =
+			pda1_header->fifo_offsets[fifo_num].event_fifo_start;
+		event_fifo[fifo_num].event_fifo_size =
+			pda1_header->fifo_offsets[fifo_num].event_fifo_size;
+	}
+
+	//Parse all the FIFOs DA wise
+	for (int fifo_no = 0; fifo_no < MAX_NUM_FIFOS; fifo_no++) {
+		if (event_fifo[fifo_no].event_fifo_da == poffsets->data_area) {
+			__u64 fifo_offset =
+				(event_fifo[fifo_no].event_fifo_start  * SIZE_OF_DWORD);
+			__u64 fifo_size =
+				(event_fifo[fifo_no].event_fifo_size  * SIZE_OF_DWORD);
+			__u8 *pfifo_start = NULL;
+
+			if (event_fifo[fifo_no].event_fifo_da == 1)
+				pfifo_start = pda1_header_offset + fifo_offset;
+			else if (event_fifo[fifo_no].event_fifo_da == 2)
+				pfifo_start = pda2_offset + fifo_offset;
+			else {
+				nvme_show_error("Unsupported Data Area:[%d]", poffsets->data_area);
+				return -1;
+			}
+
+			int status = parse_event_fifo(fifo_no, pfifo_start, pevent_fifos_object,
+						      pstring_buffer, poffsets, fifo_size, fp);
+
+			if (status != 0) {
+				nvme_show_error("Failed to parse Event FIFO. status:%d\n", status);
+				return -1;
+			}
+		}
+	}
+
+	if (pevent_fifos_object != NULL && root != NULL) {
+		const char *data_area = (poffsets->data_area == 1 ? STR_DA_1_EVENT_FIFO_INFO :
+					STR_DA_2_EVENT_FIFO_INFO);
+
+		json_object_add_value_array(root, data_area, pevent_fifos_object);
+	}
+
+	return 0;
+}
+
+int parse_statistic(struct nvme_ocp_telemetry_statistic_descriptor *pstatistic_entry,
+		    struct json_object *pstats_array, FILE *fp)
+{
+	if (pstatistic_entry == NULL) {
+		nvme_show_error("Input buffer was NULL");
+		return -1;
+	}
+
+	unsigned int data_size = pstatistic_entry->statistic_data_size * SIZE_OF_DWORD;
+	__u8 *pdata = (__u8 *)pstatistic_entry +
+		sizeof(struct nvme_ocp_telemetry_statistic_descriptor);
+	char description_str[256] = "";
+
+	parse_ocp_telemetry_string_log(0, pstatistic_entry->statistic_id, 0,
+		STATISTICS_IDENTIFIER_STRING, description_str);
+
+	if (pstats_array != NULL) {
+		struct json_object *pstatistics_object = json_create_object();
+
+		json_add_formatted_u32_str(pstatistics_object, STR_STATISTICS_IDENTIFIER,
+			pstatistic_entry->statistic_id);
+		json_object_add_value_string(pstatistics_object, STR_STATISTICS_IDENTIFIER_STR,
+			description_str);
+		json_add_formatted_u32_str(pstatistics_object,
+			STR_STATISTICS_INFO_BEHAVIOUR_TYPE,
+			pstatistic_entry->statistic_info_behaviour_type);
+		json_add_formatted_u32_str(pstatistics_object, STR_STATISTICS_INFO_RESERVED,
+			pstatistic_entry->statistic_info_reserved);
+		json_add_formatted_u32_str(pstatistics_object, STR_NAMESPACE_IDENTIFIER,
+			pstatistic_entry->ns_info_nsid);
+		json_add_formatted_u32_str(pstatistics_object, STR_NAMESPACE_INFO_VALID,
+			pstatistic_entry->ns_info_ns_info_valid);
+		json_add_formatted_u32_str(pstatistics_object, STR_STATISTICS_DATA_SIZE,
+			pstatistic_entry->statistic_data_size);
+		json_add_formatted_u32_str(pstatistics_object, STR_RESERVED,
+			pstatistic_entry->reserved);
+		json_add_formatted_var_size_str(pstatistics_object, STR_STATISTICS_SPECIFIC_DATA,
+			pdata, data_size);
+
+		if (pstatistics_object != NULL)
+			json_array_add_value_object(pstats_array, pstatistics_object);
+	} else {
+		if (fp) {
+			fprintf(fp, "%s: 0x%x\n", STR_STATISTICS_IDENTIFIER,
+				pstatistic_entry->statistic_id);
+			fprintf(fp, "%s: %s\n", STR_STATISTICS_IDENTIFIER_STR, description_str);
+			fprintf(fp, "%s: 0x%x\n", STR_STATISTICS_INFO_BEHAVIOUR_TYPE,
+				pstatistic_entry->statistic_info_behaviour_type);
+			fprintf(fp, "%s: 0x%x\n", STR_STATISTICS_INFO_RESERVED,
+				pstatistic_entry->statistic_info_reserved);
+			fprintf(fp, "%s: 0x%x\n", STR_NAMESPACE_IDENTIFIER,
+				pstatistic_entry->ns_info_nsid);
+			fprintf(fp, "%s: 0x%x\n", STR_NAMESPACE_INFO_VALID,
+				pstatistic_entry->ns_info_ns_info_valid);
+			fprintf(fp, "%s: 0x%x\n", STR_STATISTICS_DATA_SIZE,
+				pstatistic_entry->statistic_data_size);
+			fprintf(fp, "%s: 0x%x\n", STR_RESERVED, pstatistic_entry->reserved);
+			print_formatted_var_size_str(STR_STATISTICS_SPECIFIC_DATA, pdata,
+				data_size, fp);
+			fprintf(fp, STR_LINE2);
+		} else {
+			printf("%s: 0x%x\n", STR_STATISTICS_IDENTIFIER,
+			       pstatistic_entry->statistic_id);
+			printf("%s: %s\n", STR_STATISTICS_IDENTIFIER_STR, description_str);
+			printf("%s: 0x%x\n", STR_STATISTICS_INFO_BEHAVIOUR_TYPE,
+			       pstatistic_entry->statistic_info_behaviour_type);
+			printf("%s: 0x%x\n", STR_STATISTICS_INFO_RESERVED,
+			       pstatistic_entry->statistic_info_reserved);
+			printf("%s: 0x%x\n", STR_NAMESPACE_IDENTIFIER,
+			       pstatistic_entry->ns_info_nsid);
+			printf("%s: 0x%x\n", STR_NAMESPACE_INFO_VALID,
+			       pstatistic_entry->ns_info_ns_info_valid);
+			printf("%s: 0x%x\n", STR_STATISTICS_DATA_SIZE,
+			       pstatistic_entry->statistic_data_size);
+			printf("%s: 0x%x\n", STR_RESERVED, pstatistic_entry->reserved);
+			print_formatted_var_size_str(STR_STATISTICS_SPECIFIC_DATA, pdata,
+						data_size, fp);
+			printf(STR_LINE2);
+		}
+	}
+
+	return 0;
+}
+
+int parse_statistics(struct json_object *root, struct nvme_ocp_telemetry_offsets *poffsets,
+		     FILE *fp)
+{
+	if (poffsets == NULL) {
+		nvme_show_error("Input buffer was NULL");
+		return -1;
+	}
+
+	__u8 *pda1_ocp_header_offset = ptelemetry_buffer + poffsets->header_size;//512
+	__u32 statistics_size = 0;
+	__u32 stats_da_1_start_dw = 0, stats_da_1_size_dw = 0;
+	__u32 stats_da_2_start_dw = 0, stats_da_2_size_dw = 0;
+	__u8 *pstats_offset = NULL;
+
+	if (poffsets->data_area == 1) {
+		__u32 stats_da_1_start = *(__u32 *)(pda1_ocp_header_offset +
+			offsetof(struct nvme_ocp_header_in_da1, da1_statistic_start));
+		__u32 stats_da_1_size = *(__u32 *)(pda1_ocp_header_offset +
+			offsetof(struct nvme_ocp_header_in_da1, da1_statistic_size));
+
+		//Data is present in the form of DWORDS, So multiplying with sizeof(DWORD)
+		stats_da_1_start_dw = (stats_da_1_start * SIZE_OF_DWORD);
+		stats_da_1_size_dw = (stats_da_1_size * SIZE_OF_DWORD);
+
+		pstats_offset = pda1_ocp_header_offset + stats_da_1_start_dw;
+		statistics_size = stats_da_1_size_dw;
+	} else if (poffsets->data_area == 2) {
+		__u32 stats_da_2_start = *(__u32 *)(pda1_ocp_header_offset +
+			offsetof(struct nvme_ocp_header_in_da1, da2_statistic_start));
+		__u32 stats_da_2_size = *(__u32 *)(pda1_ocp_header_offset +
+			offsetof(struct nvme_ocp_header_in_da1, da2_statistic_size));
+
+		stats_da_2_start_dw = (stats_da_2_start * SIZE_OF_DWORD);
+		stats_da_2_size_dw = (stats_da_2_size * SIZE_OF_DWORD);
+
+		pstats_offset = pda1_ocp_header_offset + poffsets->da1_size + stats_da_2_start_dw;
+		statistics_size = stats_da_2_size_dw;
+	} else {
+		nvme_show_error("Unsupported Data Area:[%d]", poffsets->data_area);
+		return -1;
+	}
+
+	struct json_object *pstats_array = ((root != NULL) ? json_create_array() : NULL);
+
+	__u32 stat_des_size = sizeof(struct nvme_ocp_telemetry_statistic_descriptor);//8
+	__u32 offset_to_move = 0;
+
+	while (((statistics_size > 0) && (offset_to_move < statistics_size))) {
+		struct nvme_ocp_telemetry_statistic_descriptor *pstatistic_entry =
+			(struct nvme_ocp_telemetry_statistic_descriptor *)
+			(pstats_offset + offset_to_move);
+
+		parse_statistic(pstatistic_entry, pstats_array, fp);
+		offset_to_move += (pstatistic_entry->statistic_data_size * SIZE_OF_DWORD +
+			stat_des_size);
+	}
+
+	if (root != NULL && pstats_array != NULL) {
+		const char *pdata_area =
+			(poffsets->data_area == 1 ? STR_DA_1_STATS : STR_DA_2_STATS);
+
+		json_object_add_value_array(root, pdata_area, pstats_array);
+	}
+
+	return 0;
+}
+
+int print_ocp_telemetry_normal(char *output_file)
+{
+	int status = 0;
+
+	if (output_file != NULL) {
+		FILE *fp = fopen(output_file, "w");
+
+		if (fp) {
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_LOG_PAGE_HEADER);
+			fprintf(fp, STR_LINE);
+			print_micron_vs_logs(ptelemetry_buffer, host_log_page_header,
+				ARRAY_SIZE(host_log_page_header), NULL, 0, fp);
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_REASON_IDENTIFIER);
+			fprintf(fp, STR_LINE);
+			__u8 *preason_identifier_offset = ptelemetry_buffer +
+				offsetof(struct nvme_ocp_telemetry_host_initiated_header,
+				reason_id);
+
+			print_micron_vs_logs(preason_identifier_offset, reason_identifier,
+				ARRAY_SIZE(reason_identifier), NULL, 0, fp);
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_TELEMETRY_HOST_DATA_BLOCK_1);
+			fprintf(fp, STR_LINE);
+
+			//Set DA to 1 and get offsets
+			struct nvme_ocp_telemetry_offsets offsets = { 0 };
+
+			offsets.data_area = 1;
+
+			struct nvme_ocp_telemetry_common_header *ptelemetry_common_header =
+				(struct nvme_ocp_telemetry_common_header *) ptelemetry_buffer;
+
+			get_telemetry_das_offset_and_size(ptelemetry_common_header, &offsets);
+
+			__u8 *pda1_header_offset = ptelemetry_buffer +
+				offsets.da1_start_offset;//512
+
+			print_micron_vs_logs(pda1_header_offset, ocp_header_in_da1,
+				 ARRAY_SIZE(ocp_header_in_da1), NULL, 0, fp);
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_SMART_HEALTH_INFO);
+			fprintf(fp, STR_LINE);
+			__u8 *pda1_smart_offset = pda1_header_offset +
+				offsetof(struct nvme_ocp_header_in_da1, smart_health_info);
+			//512+512 =1024
+
+			print_micron_vs_logs(pda1_smart_offset, smart, ARRAY_SIZE(smart),
+				NULL, 0, fp);
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_SMART_HEALTH_INTO_EXTENDED);
+			fprintf(fp, STR_LINE);
+			__u8 *pda1_smart_ext_offset = pda1_header_offset +
+							offsetof(struct nvme_ocp_header_in_da1,
+								 smart_health_info_extended);
+
+			print_micron_vs_logs(pda1_smart_ext_offset, smart_extended,
+					     ARRAY_SIZE(smart_extended), NULL, 0, fp);
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_DA_1_STATS);
+			fprintf(fp, STR_LINE);
+
+			status = parse_statistics(NULL, &offsets, fp);
+			if (status != 0) {
+				nvme_show_error("status: %d\n", status);
+				return -1;
+			}
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_DA_1_EVENT_FIFO_INFO);
+			fprintf(fp, STR_LINE);
+			status = parse_event_fifos(NULL, &offsets, fp);
+			if (status != 0) {
+				nvme_show_error("status: %d\n", status);
+				return -1;
+			}
+
+			//Set the DA to 2
+			offsets.data_area = 2;
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_DA_2_STATS);
+			fprintf(fp, STR_LINE);
+			status = parse_statistics(NULL, &offsets, fp);
+
+			if (status != 0) {
+				nvme_show_error("status: %d\n", status);
+				return -1;
+			}
+
+			fprintf(fp, STR_LINE);
+			fprintf(fp, "%s\n", STR_DA_2_EVENT_FIFO_INFO);
+			fprintf(fp, STR_LINE);
+			status = parse_event_fifos(NULL, &offsets, fp);
+			if (status != 0) {
+				nvme_show_error("status: %d\n", status);
+				return -1;
+			}
+
+			fprintf(fp, STR_LINE);
+
+			fclose(fp);
+		} else {
+			nvme_show_error("Failed to open %s file.\n", output_file);
+			return -1;
+		}
+	} else {
+		printf(STR_LINE);
+		printf("%s\n", STR_LOG_PAGE_HEADER);
+		printf(STR_LINE);
+		print_micron_vs_logs(ptelemetry_buffer, host_log_page_header,
+				     ARRAY_SIZE(host_log_page_header), NULL, 0, NULL);
+
+		printf(STR_LINE);
+		printf("%s\n", STR_REASON_IDENTIFIER);
+		printf(STR_LINE);
+		__u8 *preason_identifier_offset = ptelemetry_buffer +
+			offsetof(struct nvme_ocp_telemetry_host_initiated_header, reason_id);
+		print_micron_vs_logs(preason_identifier_offset, reason_identifier,
+				     ARRAY_SIZE(reason_identifier), NULL, 0, NULL);
+
+		printf(STR_LINE);
+		printf("%s\n", STR_TELEMETRY_HOST_DATA_BLOCK_1);
+		printf(STR_LINE);
+
+		//Set DA to 1 and get offsets
+		struct nvme_ocp_telemetry_offsets offsets = { 0 };
+
+		offsets.data_area = 1;
+
+		struct nvme_ocp_telemetry_common_header *ptelemetry_common_header =
+			(struct nvme_ocp_telemetry_common_header *) ptelemetry_buffer;
+
+		get_telemetry_das_offset_and_size(ptelemetry_common_header, &offsets);
+
+		__u8 *pda1_header_offset = ptelemetry_buffer + offsets.da1_start_offset;//512
+
+		print_micron_vs_logs(pda1_header_offset, ocp_header_in_da1,
+				     ARRAY_SIZE(ocp_header_in_da1), NULL, 0, NULL);
+
+		printf(STR_LINE);
+		printf("%s\n", STR_SMART_HEALTH_INFO);
+		printf(STR_LINE);
+		__u8 *pda1_smart_offset = pda1_header_offset +
+			offsetof(struct nvme_ocp_header_in_da1, smart_health_info);
+
+		print_micron_vs_logs(pda1_smart_offset, smart, ARRAY_SIZE(smart), NULL, 0, NULL);
+
+		printf(STR_LINE);
+		printf("%s\n", STR_SMART_HEALTH_INTO_EXTENDED);
+		printf(STR_LINE);
+		__u8 *pda1_smart_ext_offset = pda1_header_offset +
+			offsetof(struct nvme_ocp_header_in_da1, smart_health_info_extended);
+
+		print_micron_vs_logs(pda1_smart_ext_offset, smart_extended,
+				     ARRAY_SIZE(smart_extended), NULL, 0, NULL);
+
+		printf(STR_LINE);
+		printf("%s\n", STR_DA_1_STATS);
+		printf(STR_LINE);
+		status = parse_statistics(NULL, &offsets, NULL);
+		if (status != 0) {
+			nvme_show_error("status: %d\n", status);
+			return -1;
+		}
+
+		printf(STR_LINE);
+		printf("%s\n", STR_DA_1_EVENT_FIFO_INFO);
+		printf(STR_LINE);
+		status = parse_event_fifos(NULL, &offsets, NULL);
+		if (status != 0) {
+			nvme_show_error("status: %d\n", status);
+			return -1;
+		}
+
+		//Set the DA to 2
+		offsets.data_area = 2;
+
+		printf(STR_LINE);
+		printf("%s\n", STR_DA_2_STATS);
+		printf(STR_LINE);
+		status = parse_statistics(NULL, &offsets, NULL);
+		if (status != 0) {
+			nvme_show_error("status: %d\n", status);
+			return -1;
+		}
+
+		printf(STR_LINE);
+		printf("%s\n", STR_DA_2_EVENT_FIFO_INFO);
+		printf(STR_LINE);
+		status = parse_event_fifos(NULL, &offsets, NULL);
+		if (status != 0) {
+			nvme_show_error("status: %d\n", status);
+			return -1;
+		}
+
+		printf(STR_LINE);
+	}
+
+	return status;
+}
+
+int print_ocp_telemetry_json(char *output_file)
+{
+	int status = 0;
+
+	//create json objects
+	struct json_object *root, *pheader, *preason_identifier, *da1_header, *smart_obj,
+	*ext_smart_obj;
+
+	root = json_create_object();
+
+	//Add data to root json object
+
+	//"Log Page Header"
+	pheader = json_create_object();
+
+	print_micron_vs_logs(ptelemetry_buffer, host_log_page_header,
+			     ARRAY_SIZE(host_log_page_header), pheader, 0, NULL);
+	json_object_add_value_object(root, STR_LOG_PAGE_HEADER, pheader);
+
+	//"Reason Identifier"
+	preason_identifier = json_create_object();
+
+	__u8 *preason_identifier_offset = ptelemetry_buffer +
+		offsetof(struct nvme_ocp_telemetry_host_initiated_header, reason_id);
+
+	print_micron_vs_logs(preason_identifier_offset, reason_identifier,
+			     ARRAY_SIZE(reason_identifier), preason_identifier, 0, NULL);
+	json_object_add_value_object(pheader, STR_REASON_IDENTIFIER, preason_identifier);
+
+	struct nvme_ocp_telemetry_offsets offsets = { 0 };
+
+	//Set DA to 1 and get offsets
+	offsets.data_area = 1;
+	struct nvme_ocp_telemetry_common_header *ptelemetry_common_header =
+		(struct nvme_ocp_telemetry_common_header *) ptelemetry_buffer;
+
+	get_telemetry_das_offset_and_size(ptelemetry_common_header, &offsets);
+
+	//"Telemetry Host-Initiated Data Block 1"
+	__u8 *pda1_header_offset = ptelemetry_buffer + offsets.da1_start_offset;//512
+
+	da1_header = json_create_object();
+
+	print_micron_vs_logs(pda1_header_offset, ocp_header_in_da1, ARRAY_SIZE(ocp_header_in_da1),
+			     da1_header, 0, NULL);
+	json_object_add_value_object(root, STR_TELEMETRY_HOST_DATA_BLOCK_1, da1_header);
+
+	//"SMART / Health Information Log(LID-02h)"
+	__u8 *pda1_smart_offset = pda1_header_offset + offsetof(struct nvme_ocp_header_in_da1,
+								smart_health_info);
+	smart_obj = json_create_object();
+
+	print_micron_vs_logs(pda1_smart_offset, smart, ARRAY_SIZE(smart), smart_obj, 0, NULL);
+	json_object_add_value_object(da1_header, STR_SMART_HEALTH_INFO, smart_obj);
+
+	//"SMART / Health Information Extended(LID-C0h)"
+	__u8 *pda1_smart_ext_offset = pda1_header_offset + offsetof(struct nvme_ocp_header_in_da1,
+								    smart_health_info_extended);
+	ext_smart_obj = json_create_object();
+
+	print_micron_vs_logs(pda1_smart_ext_offset, smart_extended, ARRAY_SIZE(smart_extended),
+			     ext_smart_obj, 0, NULL);
+	json_object_add_value_object(da1_header, STR_SMART_HEALTH_INTO_EXTENDED, ext_smart_obj);
+
+	//Data Area 1 Statistics
+	status = parse_statistics(root, &offsets, NULL);
+	if (status != 0) {
+		nvme_show_error("status: %d\n", status);
+		return -1;
+	}
+
+	//Data Area 1 Event FIFOs
+	status = parse_event_fifos(root, &offsets, NULL);
+	if (status != 0) {
+		nvme_show_error("status: %d\n", status, NULL);
+		return -1;
+	}
+
+	//Set the DA to 2
+	offsets.data_area = 2;
+
+	//Data Area 2 Statistics
+	status = parse_statistics(root, &offsets, NULL);
+	if (status != 0) {
+		nvme_show_error("status: %d\n", status);
+		return -1;
+	}
+
+	//Data Area 2 Event FIFOs
+	status = parse_event_fifos(root, &offsets, NULL);
+	if (status != 0) {
+		nvme_show_error("status: %d\n", status);
+		return -1;
+	}
+
+	if (output_file != NULL) {
+		const char *json_string = json_object_to_json_string(root);
+		FILE *fp = fopen(output_file, "w");
+
+		if (fp) {
+			fputs(json_string, fp);
+			fclose(fp);
+		} else {
+			nvme_show_error("Failed to open %s file.\n", output_file);
+			return -1;
+		}
+	} else {
+		//Print root json object
+		json_print_object(root, NULL);
+		nvme_show_result("\n");
+		json_free_object(root);
+	}
+
+	return status;
+}
+
+int parse_ocp_telemetry_log(struct ocp_telemetry_parse_options *options)
+{
+	int status = 0;
+	long telemetry_buffer_size = 0;
+	long string_buffer_size = 0;
+	enum nvme_print_flags fmt;
+	unsigned char log_id;
+
+	// Read the data from the telemetry binary file
+	ptelemetry_buffer =
+		read_binary_file(NULL, options->telemetry_log, &telemetry_buffer_size, 1);
+	if (ptelemetry_buffer == NULL) {
+		nvme_show_error("Failed to read telemetry bin file.\n");
+		return -1;
+	}
+
+	log_id = ptelemetry_buffer[0];
+	if ((log_id != NVME_HOST_TELEMETRY_LOG) && (log_id != NVME_CNTRL_TELEMETRY_LOG)) {
+		nvme_show_error("Invalid LogPageId [0x%02X]\n", log_id);
+		return -1;
+	}
+
+	// Read the data from the string binary file
+	pstring_buffer = read_binary_file(NULL, options->string_log, &string_buffer_size, 1);
+	if (pstring_buffer == NULL) {
+		nvme_show_error("Failed to read string log bin file.\n");
+		return -1;
+	}
+
+	status = validate_output_format(options->output_fmt, &fmt);
+	if (status < 0) {
+		nvme_show_error("Invalid output format\n");
+		return status;
+	}
+
+	switch (fmt) {
+	case NORMAL:
+		print_ocp_telemetry_normal(options->output_file);
+		break;
+	case JSON:
+		print_ocp_telemetry_json(options->output_file);
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}

--- a/plugins/micron/micron-ocp-telemetry.h
+++ b/plugins/micron/micron-ocp-telemetry.h
@@ -1,0 +1,609 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) Micron, Inc 2024.
+ *
+ * @file: micron-ocp-telemetry.h
+ * @brief: This module contains all the constructs needed for parsing
+ *         (or) decoding ocp telemetry log files.
+ * @author: Chaithanya Shoba <ashoba@micron.com>
+ */
+
+#include "nvme.h"
+#include "nvme-print.h"
+#include "micron-utils.h"
+#include "common.h"
+
+#define DATA_SIZE_12   12
+#define DATA_SIZE_8    8
+#define DATA_SIZE_4    4
+#define NVME_HOST_TELEMETRY_LOG       0x07
+#define NVME_CNTRL_TELEMETRY_LOG      0x08
+#define MAX_BUFFER_32_KB              0x8000
+#define OCP_TELEMETRY_DATA_BLOCK_SIZE 512
+#define SIZE_OF_DWORD                 4
+#define MAX_NUM_FIFOS                 16
+#define DA1_OFFSET                    512
+#define DEFAULT_ASCII_STRING_SIZE     16
+
+#define STR_LOG_PAGE_HEADER "Log Page Header"
+#define STR_REASON_IDENTIFIER "Reason Identifier"
+#define STR_TELEMETRY_HOST_DATA_BLOCK_1 "Telemetry Host-Initiated Data Block 1"
+#define STR_SMART_HEALTH_INFO "SMART / Health Information Log(LID-02h)"
+#define STR_SMART_HEALTH_INTO_EXTENDED "SMART / Health Information Extended(LID-C0h)"
+#define STR_DA_1_STATS "Data Area 1 Statistics"
+#define STR_DA_2_STATS "Data Area 2 Statistics"
+#define STR_DA_1_EVENT_FIFO_INFO "Data Area 1 Event FIFO info"
+#define STR_DA_2_EVENT_FIFO_INFO "Data Area 2 Event FIFO info"
+#define STR_STATISTICS_IDENTIFIER "Statistics Identifier"
+#define STR_STATISTICS_IDENTIFIER_STR "Statistic Identifier String"
+#define STR_STATISTICS_INFO_BEHAVIOUR_TYPE "Statistics Info Behavior Type"
+#define STR_STATISTICS_INFO_RESERVED "Statistics Info Reserved"
+#define STR_NAMESPACE_IDENTIFIER "Namespace Identifier"
+#define STR_NAMESPACE_INFO_VALID "Namespace Information Valid"
+#define STR_STATISTICS_DATA_SIZE "Statistic Data Size"
+#define STR_RESERVED "Reserved"
+#define STR_STATISTICS_SPECIFIC_DATA "Statistic Specific Data"
+#define STR_CLASS_SPECIFIC_DATA "Class Specific Data"
+#define STR_DBG_EVENT_CLASS_TYPE "Debug Event Class type"
+#define STR_EVENT_IDENTIFIER "Event Identifier"
+#define STR_EVENT_STRING "Event String"
+#define STR_EVENT_DATA_SIZE "Event Data Size"
+#define STR_VU_EVENT_STRING "VU Event String"
+#define STR_VU_EVENT_ID_STRING "VU Event Identifier"
+#define STR_VU_DATA "VU Data"
+#define STR_LINE "==============================================================================\n"
+#define STR_LINE2 "-----------------------------------------------------------------------------\n"
+
+struct __packed nvme_ocp_telemetry_reason_id
+{
+	__u8 error_id[64];                // Bytes 63:00
+	__u8 file_id[8];                  // Bytes 71:64
+	__le16 line_number;               // Bytes 73:72
+	__u8 valid_flags;                 // Bytes 74
+	__u8 reserved[21];                // Bytes 95:75
+	__u8 vu_reason_ext[32];           // Bytes 127:96
+};
+
+struct __packed nvme_ocp_telemetry_common_header
+{
+	__u8 log_id;                             // Byte 00
+	__le32 reserved1;                        // Bytes 04:01
+	__u8 ieee_oui_id[3];                     // Bytes 07:05
+	__le16 da1_last_block;                   // Bytes 09:08
+	__le16 da2_last_block;                   // Bytes 11:10
+	__le16 da3_last_block;                   // Bytes 13:12
+	__le16 reserved2;                        // Bytes 15:14
+	__le32 da4_last_block;                   // Bytes 19:16
+};
+
+struct __packed nvme_ocp_telemetry_host_initiated_header
+{
+	struct nvme_ocp_telemetry_common_header commonHeader;    // Bytes 19:00
+	__u8 reserved3[360];                                     // Bytes 379:20
+	__u8 host_initiated_scope;                               // Byte 380
+	__u8 host_initiated_gen_number;                          // Byte 381
+	__u8 host_initiated_data_available;                      // Byte 382
+	__u8 ctrl_initiated_gen_number;                          // Byte 383
+	struct nvme_ocp_telemetry_reason_id reason_id;           // Bytes 511:384
+};
+
+struct __packed nvme_ocp_telemetry_controller_initiated_header
+{
+	struct nvme_ocp_telemetry_common_header commonHeader;   // Bytes 19:00
+	__u8 reserved3[361];                                    // Bytes 380:20
+	__u8 ctrl_initiated_scope;                              // Byte 381
+	__u8 ctrl_initiated_data_available;                     // Byte 382
+	__u8 ctrl_initiated_gen_number;                         // Byte 383
+	struct nvme_ocp_telemetry_reason_id reason_id;          // Bytes 511:384
+};
+
+struct __packed nvme_ocp_telemetry_smart
+{
+	__u8 critical_warning;                                         // Byte 0
+	__le16 composite_temperature;                                  // Bytes 2:1
+	__u8 available_spare;                                          // Bytes 3
+	__u8 available_spare_threshold;                                // Bytes 4
+	__u8 percentage_used;                                          // Bytes 5
+	__u8 reserved1[26];                                            // Bytes 31:6
+	__u8 data_units_read[16];                                      // Bytes 47:32
+	__u8 data_units_written[16];                                   // Bytes 63:48
+	__u8 host_read_commands[16];                                   // Byte  79:64
+	__u8 host_write_commands[16];                                  // Bytes 95:80
+	__u8 controller_busy_time[16];                                 // Bytes 111:96
+	__u8 power_cycles[16];                                         // Bytes 127:112
+	__u8 power_on_hours[16];                                       // Bytes 143:128
+	__u8 unsafe_shutdowns[16];                                     // Bytes 159:144
+	__u8 media_and_data_integrity_errors[16];                      // Bytes 175:160
+	__u8 number_of_error_information_log_entries[16];              // Bytes 191:176
+	__le32 warning_composite_temperature_time;                     // Byte  195:192
+	__le32 critical_composite_temperature_time;                    // Bytes 199:196
+	__le16 temperature_sensor1;                                    // Bytes 201:200
+	__le16 temperature_sensor2;                                    // Byte  203:202
+	__le16 temperature_sensor3;                                    // Byte  205:204
+	__le16 temperature_sensor4;                                    // Bytes 207:206
+	__le16 temperature_sensor5;                                    // Bytes 209:208
+	__le16 temperature_sensor6;                                    // Bytes 211:210
+	__le16 temperature_sensor7;                                    // Bytes 213:212
+	__le16 temperature_sensor8;                                    // Bytes 215:214
+	__le32 thermal_management_temperature1_transition_count;       // Bytes 219:216
+	__le32 thermal_management_temperature2_transition_count;       // Bytes 223:220
+	__le32 total_time_for_thermal_management_temperature1;         // Bytes 227:224
+	__le32 total_time_for_thermal_management_temperature2;         // Bytes 231:228
+	__u8 reserved2[280];                                           // Bytes 511:232
+};
+
+struct __packed nvme_ocp_telemetry_smart_extended
+{
+	__u8 physical_media_units_written[16];                   // Bytes 15:0
+	__u8 physical_media_units_read[16];                      // Bytes 31:16
+	__u8 bad_user_nand_blocks_raw_count[6];                  // Bytes 37:32
+	__le16 bad_user_nand_blocks_normalized_value;            // Bytes 39:38
+	__u8 bad_system_nand_blocks_raw_count[6];                // Bytes 45:40
+	__le16 bad_system_nand_blocks_normalized_value;          // Bytes 47:46
+	__le64 xor_recovery_count;                               // Bytes 55:48
+	__le64 uncorrectable_read_error_count;                   // Bytes 63:56
+	__le64 soft_ecc_error_count;                             // Bytes 71:64
+	__le32 end_to_end_correction_counts_detected_errors;     // Bytes 75:72
+	__le32 end_to_end_correction_counts_corrected_errors;    // Bytes 79:76
+	__u8 system_data_percent_used;                           // Byte  80
+	__u8 refresh_counts[7];                                  // Bytes 87:81
+	__le32 max_user_data_erase_count;                        // Bytes 91:88
+	__le32 min_user_data_erase_count;                        // Bytes 95:92
+	__u8 num_thermal_throttling_events;                      // Bytes 96
+	__u8 current_throttling_status;                          // Bytes 97
+	__u8  errata_version_field;                              // Byte 98
+	__le16 point_version_field;                              // Byte 100:99
+	__le16 minor_version_field;                              // Byte 102:101
+	__u8  major_version_field;                               // Byte 103
+	__le64 pcie_correctable_error_count;                     // Bytes 111:104
+	__le32 incomplete_shutdowns;                             // Bytes 115:112
+	__le32 reserved1;                                        // Bytes 119:116
+	__u8 percent_free_blocks;                                // Byte  120
+	__u8 reserved2[7];                                       // Bytes 127:121
+	__le16 capacitor_health;                                 // Bytes 129:128
+	__u8 nvme_base_errata_version;                           // Byte  130
+	__u8 nvme_command_set_errata_version;                    // Byte  131
+	__le32 reserved3;                                        // Bytes 135:132
+	__le64 unaligned_io;                                     // Bytes 143:136
+	__le64 security_version_number;                          // Bytes 151:144
+	__le64 total_nuse;                                       // Bytes 159:152
+	__u8 plp_start_count[16];                                // Bytes 175:160
+	__u8 endurance_estimate[16];                             // Bytes 191:176
+	__le64 pcie_link_retraining_count;                       // Bytes 199:192
+	__le64 power_state_change_count;                         // Bytes 207:200
+	__le64 lowest_permitted_firmware_revision;               // Bytes 215:208
+	__u8 reserved4[278];                                     // Bytes 493:216
+	__le16 log_page_version;                                 // Bytes 495:494
+	__u8 log_page_guid[16];                                  // Bytes 511:496
+};
+
+struct __packed nvme_ocp_event_fifo_data
+{
+	__le32 event_fifo_num;
+	__u8 event_fifo_da;
+	__le64 event_fifo_start;
+	__le64 event_fifo_size;
+};
+
+struct __packed nvme_ocp_telemetry_offsets
+{
+	__le32 data_area;
+	__le32 header_size;
+	__le32 da1_start_offset;
+	__le32 da1_size;
+	__le32 da2_start_offset;
+	__le32 da2_size;
+	__le32 da3_start_offset;
+	__le32 da3_size;
+	__le32 da4_start_offset;
+	__le32 da4_size;
+};
+
+struct __packed nvme_ocp_event_fifo_offsets
+{
+	__le64 event_fifo_start;
+	__le64 event_fifo_size;
+};
+
+struct __packed nvme_ocp_header_in_da1
+{
+	__le16 major_version;                                                // Bytes 1:0
+	__le16 minor_version;                                                // Bytes 3:2
+	__le32 reserved1;                                                    // Bytes 7:4
+	__le64 time_stamp;                                                   // Bytes 15:8
+	__u8 log_page_guid[16];                                              // Bytes 31:16
+	__u8 num_telemetry_profiles_supported;                               // Byte 32
+	__u8 telemetry_profile_selected;                                     // Byte 33
+	__u8 reserved2[6];                                                   // Bytes 39:34
+	__le64 string_log_size;                                              // Bytes 47:40
+	__le64 reserved3;                                                    // Bytes 55:48
+	__le64 firmware_revision;                                            // Bytes 63:56
+	__u8 reserved4[32];                                                  // Bytes 95:64
+	__le64 da1_statistic_start;                                          // Bytes 103:96
+	__le64 da1_statistic_size;                                           // Bytes 111:104
+	__le64 da2_statistic_start;                                          // Bytes 119:112
+	__le64 da2_statistic_size;                                           // Bytes 127:120
+	__u8 reserved5[32];                                                  // Bytes 159:128
+	__u8 event_fifo_da[16];                                              // Bytes 175:160
+	struct nvme_ocp_event_fifo_offsets fifo_offsets[16];                 // Bytes 431:176
+	__u8 reserved6[80];                                                  // Bytes 511:432
+	struct nvme_ocp_telemetry_smart smart_health_info;                   // Bytes 1023:512
+	struct nvme_ocp_telemetry_smart_extended smart_health_info_extended; // Bytes 1535:1024
+};
+
+struct __packed nvme_ocp_telemetry_statistic_descriptor
+{
+	__le16 statistic_id;                    // Bytes 1:0
+	__u8 statistic_info_behaviour_type : 4; // Byte  2(3:0)
+	__u8 statistic_info_reserved : 4;       // Byte  2(7:4)
+	__u8 ns_info_nsid : 7;                  // Bytes 3(6:0)
+	__u8 ns_info_ns_info_valid : 1;         // Bytes 3(7)
+	__le16 statistic_data_size;             // Bytes 5:4
+	__le16 reserved;                        // Bytes 7:6
+};
+
+struct __packed nvme_ocp_telemetry_event_descriptor
+{
+	__u8 debug_event_class_type;    // Byte 0
+	__le16 event_id;                // Bytes 2:1
+	__u8 event_data_size;           // Byte 3
+};
+
+struct __packed nvme_ocp_time_stamp_dbg_evt_class_format
+{
+	__u8 time_stamp[DATA_SIZE_8];             // Bytes 11:4
+	__le16 vu_event_identifier;               // Bytes 13:12
+};
+
+struct __packed nvme_ocp_pcie_dbg_evt_class_format
+{
+	__u8 pCIeDebugEventData[DATA_SIZE_4];     // Bytes 7:4
+	__le16 vu_event_identifier;               // Bytes 9:8
+};
+
+struct __packed nvme_ocp_nvme_dbg_evt_class_format
+{
+	__u8 nvmeDebugEventData[DATA_SIZE_8];     // Bytes 11:4
+	__le16 vu_event_identifier;               // Bytes 13:12
+};
+
+struct __packed nvme_ocp_common_dbg_evt_class_format
+{
+	__le16 vu_event_identifier;    // Bytes 5:4
+};
+
+struct __packed nvme_ocp_media_wear_dbg_evt_class_format
+{
+	__u8 currentMediaWear[DATA_SIZE_12];         // Bytes 15:4
+	__le16 vu_event_identifier;                  // Bytes 17:16
+};
+
+struct __packed nvme_ocp_statistic_snapshot_evt_class_format
+{
+	struct nvme_ocp_telemetry_statistic_descriptor statisticDescriptorData; // Bytes 11:10
+};
+
+struct __packed nvme_ocp_statistics_identifier_string_table
+{
+	__le16 vs_statistic_identifier;     //1:0
+	__u8 reserved1;                     //2
+	__u8 ascii_id_length;               //3
+	__le64 ascii_id_offset;             //11:4
+	__le32 reserved2;                   //15:12
+};
+
+struct __packed nvme_ocp_event_string_table
+{
+	__u8 debug_event_class;         //0
+	__le16 event_identifier;        //2:1
+	__u8 ascii_id_length;           //3
+	__le64 ascii_id_offset;         //11:4
+	__le32 reserved;                //15:12
+};
+
+struct __packed nvme_ocp_vu_event_string_table
+{
+	__u8 debug_event_class;        //0
+	__le16 vu_event_identifier;    //2:1
+	__u8 ascii_id_length;          //3
+	__le64 ascii_id_offset;        //11:4
+	__le32 reserved;               //15:12
+};
+
+struct __packed nvme_ocp_telemetry_string_header
+{
+	__u8 version;                   //0:0
+	__u8 reserved1[15];             //15:1
+	__u8 guid[16];                  //32:16
+	__le64 string_log_size;         //39:32
+	__u8 reserved2[24];             //63:40
+	__le64 sits;                    //71:64 Statistics Identifier String Table Start(SITS)
+	__le64 sitsz;                   //79:72 Statistics Identifier String Table Size (SITSZ)
+	__le64 ests;                    //87:80 Event String Table Start(ESTS)
+	__le64 estsz;                   //95:88 Event String Table Size(ESTSZ)
+	__le64 vu_ests;                 //103:96 VU Event String Table Start
+	__le64 vu_estsz;                //111:104 VU Event String Table Size
+	__le64 ascts;                   //119:112 ASCII Table start
+	__le64 asctsz;                  //127:120 ASCII Table Size
+	__u8 fifo_ascii_string[16][16]; //383:128
+	__u8 reserved3[48];             //431:384
+};
+
+struct __packed statistic_entry {
+	int identifier;
+	char *description;
+};
+
+struct __packed ocp_telemetry_parse_options {
+	char *telemetry_log;
+	char *string_log;
+	char *output_file;
+	char *output_fmt;
+};
+
+/**
+ * enum ocp_telemetry_data_area - Telemetry Data Areas
+ * @DATA_AREA_1:	Data Area 1
+ * @DATA_AREA_2:	Data Area 2
+ * @DATA_AREA_3:	Data Area 3
+ * @DATA_AREA_4:	Data Area 4
+ */
+enum ocp_telemetry_data_area {
+	DATA_AREA_1 = 0x01,
+	DATA_AREA_2 = 0x02,
+	DATA_AREA_3 = 0x03,
+	DATA_AREA_4 = 0x04,
+};
+
+/**
+ * enum ocp_telemetry_string_tables - OCP telemetry string tables
+ * @STATISTICS_IDENTIFIER_STRING:	Statistic Identifier string
+ * @EVENT_STRING:	Event String
+ * @VU_EVENT_STRING:	VU Event String
+ */
+enum ocp_telemetry_string_tables {
+	STATISTICS_IDENTIFIER_STRING = 0,
+	EVENT_STRING,
+	VU_EVENT_STRING
+};
+
+/**
+ * enum ocp_telemetry_debug_event_class_types - OCP Debug Event Class types
+ * @RESERVED_CLASS_TYPE:	       Reserved class
+ * @TIME_STAMP_CLASS_TYPE:	       Time stamp class
+ * @PCIE_CLASS_TYPE:	           PCIe class
+ * @NVME_CLASS_TYPE:	           NVME class
+ * @RESET_CLASS_TYPE:	           Reset class
+ * @BOOT_SEQUENCE_CLASS_TYPE:	   Boot Sequence class
+ * @FIRMWARE_ASSERT_CLASS_TYPE:	   Firmware Assert class
+ * @TEMPERATURE_CLASS_TYPE:	       Temperature class
+ * @MEDIA_CLASS_TYPE:	           Media class
+ * @MEDIA_WEAR_CLASS_TYPE:	       Media wear class
+ * @STATISTIC_SNAPSHOT_CLASS_TYPE: Statistic snapshot class
+ * @RESERVED:	                   Reserved class
+ * @VENDOR_UNIQUE_CLASS_TYPE:	   Vendor Unique class
+ */
+enum ocp_telemetry_debug_event_class_types {
+	RESERVED_CLASS_TYPE = 0x00,
+	TIME_STAMP_CLASS_TYPE = 0x01,
+	PCIE_CLASS_TYPE = 0x02,
+	NVME_CLASS_TYPE = 0x03,
+	RESET_CLASS_TYPE = 0x04,
+	BOOT_SEQUENCE_CLASS_TYPE = 0x05,
+	FIRMWARE_ASSERT_CLASS_TYPE = 0x06,
+	TEMPERATURE_CLASS_TYPE = 0x07,
+	MEDIA_CLASS_TYPE = 0x08,
+	MEDIA_WEAR_CLASS_TYPE = 0x09,
+	STATISTIC_SNAPSHOT_CLASS_TYPE = 0x0A,
+	//RESERVED = 7Fh-0Bh,
+	//VENDOR_UNIQUE_CLASS_TYPE = FFh-80h,
+};
+
+/**
+ * @brief parse the ocp telemetry host or controller log binary file
+ *        into json or text
+ *
+ * @param options, input pointer for inputs like telemetry log bin file,
+ *        string log bin file and output file etc.
+ *
+ * @return 0 success
+ */
+int parse_ocp_telemetry_log(struct ocp_telemetry_parse_options *options);
+
+/**
+ * @brief parse the ocp telemetry string log binary file to json or text
+ *
+ * @param event_fifo_num, input event FIFO number
+ * @param debug_event_class, input debug event class id
+ * @param string_table, input string table
+ * @param description, input description string
+ *
+ * @return 0 success
+ */
+int parse_ocp_telemetry_string_log(int event_fifo_num, int identifier, int debug_event_class,
+	enum ocp_telemetry_string_tables string_table, char *description);
+
+/**
+ * @brief gets the telemetry datas areas, offsets and sizes information
+ *
+ * @param ptelemetry_common_header, input telemetry common header pointer
+ * @param ptelemetry_das_offset, input telemetry offsets pointer
+ *
+ * @return 0 success
+ */
+int get_telemetry_das_offset_and_size(
+	struct nvme_ocp_telemetry_common_header *ptelemetry_common_header,
+	struct nvme_ocp_telemetry_offsets *ptelemetry_das_offset);
+
+/**
+ * @brief parses statistics data to text or json formats
+ *
+ * @param root, input time json root object pointer
+ * @param ptelemetry_das_offset, input telemetry offsets pointer
+ * @param fp, input file pointer
+ *
+ * @return 0 success
+ */
+int parse_statistics(struct json_object *root, struct nvme_ocp_telemetry_offsets *pOffsets,
+	FILE *fp);
+
+/**
+ * @brief parses a single statistic data to text or json formats
+ *
+ * @param pstatistic_entry, statistic entry pointer
+ * @param pstats_array, stats array pointer
+ * @param fp, input file pointer
+ *
+ * @return 0 success
+ */
+int parse_statistic(struct nvme_ocp_telemetry_statistic_descriptor *pstatistic_entry,
+	struct json_object *pstats_array, FILE *fp);
+
+/**
+ * @brief parses event fifos data to text or json formats
+ *
+ * @param root, input time json root object pointer
+ * @param poffsets, input telemetry offsets pointer
+ * @param fp, input file pointer
+ *
+ * @return 0 success
+ */
+int parse_event_fifos(struct json_object *root, struct nvme_ocp_telemetry_offsets *poffsets,
+	FILE *fp);
+
+/**
+ * @brief parses a single event fifo data to text or json formats
+ *
+ * @param fifo_num, input event fifo number
+ * @param pfifo_start, event fifo start pointer
+ * @param pevent_fifos_object, event fifos json object pointer
+ * @param ptelemetry_das_offset, input telemetry offsets pointer
+ * @param fifo_size, input event fifo size
+ * @param fp, input file pointer
+ *
+ * @return 0 success
+ */
+int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
+	struct json_object *pevent_fifos_object, unsigned char *pstring_buffer,
+	struct nvme_ocp_telemetry_offsets *poffsets, __u64 fifo_size, FILE *fp);
+
+/**
+ * @brief parses event fifos data to text or json formats
+ *
+ * @return 0 success
+ */
+int print_ocp_telemetry_normal(char *output_file);
+
+/**
+ * @brief parses event fifos data to text or json formats
+ *
+ * @return 0 success
+ */
+int print_ocp_telemetry_json(char *output_file);
+
+/**
+ * @brief gets statistic id ascii string
+ *
+ * @param identifier, string id
+ * @param description, string description
+ *
+ * @return 0 success
+ */
+int get_static_id_ascii_string(int identifier, char *description);
+
+/**
+ * @brief gets event id ascii string
+ *
+ * @param identifier, string id
+ * @param debug_event_class, debug event class
+ * @param description, string description
+ *
+ * @return 0 success
+ */
+int get_event_id_ascii_string(int identifier, int debug_event_class, char *description);
+
+/**
+ * @brief gets vu event id ascii string
+ *
+ * @param identifier, string id
+ * @param debug_event_class, debug event class
+ * @param description, string description
+ *
+ * @return 0 success
+ */
+int get_vu_event_id_ascii_string(int identifier, int debug_event_class, char *description);
+
+/**
+ * @brief parses a time-stamp event fifo data to text or json formats
+ *
+ * @param pevent_descriptor, input event descriptor data
+ * @param pevent_descriptor_obj, event descriptor json object pointer
+ * @param pevent_specific_data, input event specific data
+ * @param pevent_fifos_object, event fifos json object pointer
+ * @param fp, input file pointer
+ *
+ * @return
+ */
+void parse_time_stamp_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp);
+
+/**
+ * @brief parses a pcie event fifo data to text or json formats
+ *
+ * @param pevent_descriptor, input event descriptor data
+ * @param pevent_descriptor_obj, event descriptor json object pointer
+ * @param pevent_specific_data, input event specific data
+ * @param pevent_fifos_object, event fifos json object pointer
+ * @param fp, input file pointer
+ *
+ * @return
+ */
+void parse_pcie_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp);
+
+/**
+ * @brief parses a nvme event fifo data to text or json formats
+ *
+ * @param pevent_descriptor, input event descriptor data
+ * @param pevent_descriptor_obj, event descriptor json object pointer
+ * @param pevent_specific_data, input event specific data
+ * @param pevent_fifos_object, event fifos json object pointer
+ * @param fp, input file pointer
+ *
+ * @return
+ */
+void parse_nvme_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp);
+
+/**
+ * @brief parses common event fifo data to text or json formats
+ *
+ * @param pevent_descriptor, input event descriptor data
+ * @param pevent_descriptor_obj, event descriptor json object pointer
+ * @param pevent_specific_data, input event specific data
+ * @param pevent_fifos_object, event fifos json object pointer
+ * @param fp, input file pointer
+ *
+ * @return
+ */
+void parse_common_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp);
+
+/**
+ * @brief parses a media-wear event fifo data to text or json formats
+ *
+ * @param pevent_descriptor, input event descriptor data
+ * @param pevent_descriptor_obj, event descriptor json object pointer
+ * @param pevent_specific_data, input event specific data
+ * @param pevent_fifos_object, event fifos json object pointer
+ * @param fp, input file pointer
+ *
+ * @return
+ */
+void parse_media_wear_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descriptor,
+			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
+			    struct json_object *pevent_fifos_object, FILE *fp);

--- a/plugins/micron/micron-utils.c
+++ b/plugins/micron/micron-utils.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) Micron, Inc 2024.
+ *
+ * @file: micron-utils.h
+ * @brief: This module contains all the utilities needed for micron nvme plugin
+ *         and other micron modules.
+ * @author: Chaithanya Shoba <ashoba@micron.com>
+ */
+
+#include "micron-utils.h"
+
+int hex_to_int(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	else if (c >= 'A' && c <= 'F')
+		return 10 + (c - 'A');
+	else if (c >= 'a' && c <= 'f')
+		return 10 + (c - 'a');
+	else
+		return -1; // Invalid character
+}
+
+char *hex_to_ascii(const char *hex)
+{
+	int hex_length = strlen(hex);
+
+	char *text = NULL;
+
+	if (hex_length > 0) {
+		int symbol_count;
+		int odd_hex_count = hex_length % 2 == 1;
+
+		if (odd_hex_count)
+			symbol_count = (hex_length / 2) + 1;
+		else
+			symbol_count = hex_length / 2;
+
+		text = (char *)malloc(symbol_count + 1); // Allocate memory for the result
+
+		int last_index = hex_length - 1;
+
+		for (int i = last_index; i >= 0; --i) {
+			if ((last_index - i) % 2 != 0) {
+				int dec = 16 * hex_to_int(hex[i]) + hex_to_int(hex[i + 1]);
+
+				if (odd_hex_count)
+					text[i / 2 + 1] = dec;
+				else
+					text[i / 2] = dec;
+			} else if (i == 0) {
+				int dec = hex_to_int(hex[0]);
+
+				text[0] = dec;
+			}
+		}
+
+		text[symbol_count] = '\0'; // Terminate the string
+	}
+
+	return text;
+}
+
+unsigned char *read_binary_file(char *data_dir_path, const char *bin_path,
+				long *buffer_size, int retry_count)
+{
+	char *file_path = NULL;
+	FILE *bin_file = NULL;
+	size_t n_data = 0;
+	unsigned char *buffer = NULL;
+
+	/* set path */
+	if (data_dir_path == NULL) {
+		file_path = (char *)bin_path;
+	} else {
+		/* +2 for the / and null terminator */
+		file_path = (char *) calloc(1, strlen(data_dir_path) + strlen(bin_path) + 2);
+		if (!file_path)
+			return NULL;
+
+		if (strlen(bin_path) != 0)
+			sprintf(file_path, "%s/%s", data_dir_path, bin_path);
+		else
+			sprintf(file_path, "%s", data_dir_path);
+	}
+
+	/* open file */
+	for (int i = 0; i < retry_count; i++) {
+		bin_file = fopen(file_path, "rb");
+		if (bin_file != NULL)
+			break;
+		sleep((unsigned int)(retry_count > 1));
+	}
+
+	if (!bin_file) {
+		nvme_show_error("\nFailed to open %s", file_path);
+		if (file_path != bin_path)
+			free(file_path);
+		return NULL;
+	}
+
+	/* get size */
+	fseek(bin_file, 0, SEEK_END);
+	*buffer_size = ftell(bin_file);
+	fseek(bin_file, 0, SEEK_SET);
+	if (*buffer_size <= 0) {
+		fclose(bin_file);
+		return NULL;
+	}
+
+	/* allocate buffer */
+	buffer = (unsigned char *)malloc(*buffer_size);
+	if (!buffer) {
+		nvme_show_result("\nFailed to allocate %ld bytes!", *buffer_size);
+		fclose(bin_file);
+		return NULL;
+	}
+	memset(buffer, 0, *buffer_size);
+
+	/* Read data */
+	n_data = fread(buffer, 1, *buffer_size, bin_file);
+
+	/* Close file */
+	fclose(bin_file);
+
+	/* Validate we read data */
+	if (n_data != (size_t)*buffer_size) {
+		nvme_show_result("\nFailed to read %ld bytes from %s", *buffer_size, file_path);
+		return NULL;
+	}
+
+	if (file_path != bin_path)
+		free(file_path);
+	return buffer;
+}
+
+void print_formatted_var_size_str(const char *msg, const __u8 *pdata, size_t data_size, FILE *fp)
+{
+	char description_str[256] = "";
+	char temp_buffer[3] = { 0 };
+
+	for (size_t i = 0; i < data_size; ++i) {
+		sprintf(temp_buffer, "%02X", pdata[i]);
+		strcat(description_str, temp_buffer);
+	}
+
+	if (fp)
+		fprintf(fp, "%s: %s\n", msg, description_str);
+	else
+		printf("%s: %s\n", msg, description_str);
+}
+
+void process_field_size_16(int offset, char *sfield, __u8 *buf, char *datastr)
+{
+	__u64 lval_lo, lval_hi;
+
+	if (strstr(sfield, "GUID")) {
+		sprintf(datastr, "0x%"PRIx64"%"PRIx64"",
+			le64_to_cpu(*(__u64 *)(&buf[offset + 8])),
+			le64_to_cpu(*(__u64 *)(&buf[offset])));
+	} else {
+		lval_lo = *((__u64 *)(&buf[offset]));
+		lval_hi = *((__u64 *)(&buf[offset + 8]));
+
+		if (lval_hi)
+			sprintf(datastr, "0x%"PRIx64"%016"PRIx64"",
+				le64_to_cpu(lval_hi), le64_to_cpu(lval_lo));
+		else
+			sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+	}
+}
+
+void process_field_size_8(int offset, char *sfield, __u8 *buf, char *datastr)
+{
+	__u64 lval_lo;
+
+	if (strstr(sfield, "Boot SSD Spec Version")) {
+		sprintf(datastr, "%x.%x.%x.%x",
+		le16_to_cpu(*((__u16 *)(&buf[300]))),
+		le16_to_cpu(*((__u16 *)(&buf[302]))),
+		le16_to_cpu(*((__u16 *)(&buf[304]))),
+		le16_to_cpu(*((__u16 *)(&buf[306]))));
+	} else if (strstr(sfield, "Firmware Revision")) {
+		char buffer[30] = {'\0'};
+
+		lval_lo = *((__u64 *)(&buf[offset]));
+
+		sprintf(buffer, "%lx", __builtin_bswap64(lval_lo));
+		sprintf(datastr, "%s", hex_to_ascii(buffer));
+	} else if (strstr(sfield, "Timestamp")) {
+		char ts_buf[128];
+
+		lval_lo = *((__u64 *)(&buf[offset]));
+
+		convert_ts(le64_to_cpu(lval_lo), ts_buf);
+		sprintf(datastr, "%s", ts_buf);
+	} else {
+		lval_lo = *((__u64 *)(&buf[offset]));
+
+		sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+	}
+}
+
+void process_field_size_7(int offset, char *sfield, __u8 *buf, char *datastr)
+{
+	__u8 lval[8] = { 0 };
+	__u64 lval_lo;
+
+	/* 7 bytes will be in little-endian format, with last byte as MSB */
+	memcpy(&lval[0], &buf[offset], 7);
+	memcpy((void *)&lval_lo, lval, 8);
+	sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+}
+
+void process_field_size_6(int offset, char *sfield, __u8 *buf, char *datastr)
+{
+	__u32 ival;
+	__u16 sval;
+	__u64 lval_lo;
+
+	if (strstr(sfield, "DSSD Spec Version")) {
+		sprintf(datastr, "%x.%x.%x.%x", buf[103],
+			le16_to_cpu(*((__u16 *)(&buf[101]))),
+			le16_to_cpu(*((__u16 *)(&buf[99]))), buf[98]);
+	} else {
+		ival = *((__u32 *)(&buf[offset]));
+		sval = *((__u16 *)(&buf[offset + 4]));
+		lval_lo = (((__u64)sval << 32) | ival);
+
+		sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+	}
+}
+
+void process_field_size_default(int offset, char *sfield, __u8 *buf, int size, char *datastr)
+{
+	__u8  cval;
+	char description_str[256] = "0x";
+	char temp_buffer[3] = { 0 };
+
+	for (unsigned char i = 0; i < (unsigned char)size; i++) {
+		cval = (buf[offset + i]);
+
+		sprintf(temp_buffer, "%02X", cval);
+		strcat(description_str, temp_buffer);
+	}
+	sprintf(datastr, "%s", description_str);
+}
+
+void print_micron_vs_logs(__u8 *buf, struct micron_vs_logpage *log_page, int field_count,
+	struct json_object *stats, __u8 spec, FILE *fp)
+{
+	int offset = 0;
+
+	for (int field = 0; field < field_count; field++) {
+		char datastr[1024] = { 0 };
+		char *sfield = log_page[field].field;
+		int size = !spec ? log_page[field].size : log_page[field].size2;
+
+		if (!size || sfield == NULL)
+			continue;
+
+		switch (size) {
+		case FIELD_SIZE_16:
+			process_field_size_16(offset, sfield, buf, datastr);
+			break;
+		case FIELD_SIZE_8:
+			process_field_size_8(offset, sfield, buf, datastr);
+			break;
+		case FIELD_SIZE_7:
+			process_field_size_7(offset, sfield, buf, datastr);
+			break;
+		case FIELD_SIZE_6:
+			process_field_size_6(offset, sfield, buf, datastr);
+			break;
+		case FIELD_SIZE_4:
+			sprintf(datastr, "0x%x", le32_to_cpu(*((__u32 *)(&buf[offset]))));
+			break;
+		case FIELD_SIZE_3:
+			sprintf(datastr, "0x%02X%02X%02X",
+				buf[offset + 0], buf[offset + 1], buf[offset + 2]);
+			break;
+		case FIELD_SIZE_2:
+			sprintf(datastr, "0x%04x", le16_to_cpu(*((__u16 *)(&buf[offset]))));
+			break;
+		case FIELD_SIZE_1:
+			sprintf(datastr, "0x%02x", buf[offset]);
+			break;
+		default:
+			process_field_size_default(offset, sfield, buf, size, datastr);
+			break;
+		}
+		offset += size;
+		/* do not print reserved values */
+		if (strstr(sfield, "Reserved"))
+			continue;
+		if (stats)
+			json_object_add_value_string(stats, sfield, datastr);
+		else if (fp)
+			fprintf(fp, "%-40s : %-4s\n", sfield, datastr);
+		else
+			printf("%-40s : %-4s\n", sfield, datastr);
+	}
+}

--- a/plugins/micron/micron-utils.h
+++ b/plugins/micron/micron-utils.h
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) Micron, Inc 2024.
+ *
+ * @file: micron-utils.h
+ * @brief: This module contains all the utilities needed for micron nvme plugin
+ *         and other micron modules.
+ * @author: Chaithanya Shoba <ashoba@micron.com>
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <time.h>
+#include <string.h>
+#include <libgen.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include "common.h"
+#include "nvme.h"
+#include "libnvme.h"
+#include <limits.h>
+#include "linux/types.h"
+#include "nvme-print.h"
+#include "util/cleanup.h"
+
+/* OCP and Vendor specific log data format */
+struct __packed micron_vs_logpage {
+	char *field;
+	int  size; /* FB client spec version 1.0 sizes - M5410 models */
+	int  size2; /* FB client spec version 0.7 sizes - M5407 models */
+};
+
+enum field_size {
+	FIELD_SIZE_16 = 16,
+	FIELD_SIZE_8 = 8,
+	FIELD_SIZE_7 = 7,
+	FIELD_SIZE_6 = 6,
+	FIELD_SIZE_4 = 4,
+	FIELD_SIZE_3 = 3,
+	FIELD_SIZE_2 = 2,
+	FIELD_SIZE_1 = 1
+};
+
+/**
+ * @brief converts a single hexadecimal character to its integer value.
+ *
+ * @param hex_char, input hex char
+ * @param ts_buf, output time string
+ *
+ * @return integer value of hexadecimal
+ */
+int hex_to_int(char c);
+
+/**
+ * @brief convert time_t format time to a human readable string
+ *
+ * @param hex_string, input hex string pointer
+ * @param ascii_buffer, output ascii buffer pointer
+ *
+ * @return nothing
+ */
+char *hex_to_ascii(const char *hex);
+
+/**
+ * @brief convert time_t format time to a human readable string
+ *
+ * @param data_dir_path, input data directory path pointer
+ * @param bin_path, input binary file path pointer
+ * @param buffer_size, input buffer size pointer
+ * @param retry_count, input retry count
+ *
+ * @return pointer to binary data buffer
+ */
+unsigned char *read_binary_file(char *data_dir_path, const char *bin_path, long *buffer_size,
+				int retry_count);
+
+/**
+ * @brief prints Micron VS log pages
+ *
+ * @param buf, input raw log data
+ * @param log_page, input format of the data
+ * @param field_count, intput log field count
+ * @param stats, input json object to add fields
+ * @param spec, input ocp spec index
+ * @param fp, input file pointer
+ *
+ * @return 0 success
+ */
+void print_micron_vs_logs(__u8 *buf, struct micron_vs_logpage *log_page, int field_count,
+			  struct json_object *stats, __u8 spec, FILE *fp);
+
+/**
+ * @brief prints raw data to the buffer
+ *
+ * @param msg, intput buffer to write data
+ * @param pdata, input raw data
+ * @param data_size, input size of the data
+ * @param fp, input file pointer
+ *
+ * @return 0 success
+ */
+void print_formatted_var_size_str(const char *msg, const __u8 *pdata, size_t data_size, FILE *fp);
+
+/**
+ * @brief prints raw data to the buffer
+ *
+ * @param offset, intput offset of the param
+ * @param sfield, intput field
+ * @param buf, input raw data
+ * @param datastr, output data buffer
+ *
+ * @return 0 success
+ */
+void process_field_size_16(int offset, char *sfield, __u8 *buf, char *datastr);
+
+/**
+ * @brief prints raw data to the buffer
+ *
+ * @param offset, intput offset of the param
+ * @param sfield, intput field
+ * @param buf, input raw data
+ * @param datastr, output data buffer
+ *
+ * @return 0 success
+ */
+void process_field_size_8(int offset, char *sfield, __u8 *buf, char *datastr);
+
+/**
+ * @brief prints raw data to the buffer
+ *
+ * @param offset, intput offset of the param
+ * @param sfield, intput field
+ * @param buf, input raw data
+ * @param datastr, output data buffer
+ *
+ * @return 0 success
+ */
+void process_field_size_7(int offset, char *sfield, __u8 *buf, char *datastr);
+
+/**
+ * @brief prints raw data to the buffer
+ *
+ * @param offset, intput offset of the param
+ * @param sfield, intput field
+ * @param buf, input raw data
+ * @param datastr, output data buffer
+ *
+ * @return 0 success
+ */
+void process_field_size_6(int offset, char *sfield, __u8 *buf, char *datastr);
+
+/**
+ * @brief prints raw data to the buffer
+ *
+ * @param offset, intput offset of the param
+ * @param sfield, intput field
+ * @param buf, input raw data
+ * @param size, input data size
+ * @param datastr, output data buffer
+ *
+ * @return 0 success
+ */
+void process_field_size_default(int offset, char *sfield, __u8 *buf, int size, char *datastr);


### PR DESCRIPTION
**Description:**

- Added support for OCP telemetry (internal) log parsing as per OCP 2.5 specification - [Datacenter NVMe SSD Specification v2.5r9.pdf](https://github.com/user-attachments/files/16051920/Datacenter.NVMe.SSD.Specification.v2.5r9.pdf) section 4.9.

- The CLI command will take the input binary files (telemetry/internal logs LOG ID 0x07 or 0x08) and string log (0xC9) as inputs and provides a parsed JSON or text file as attached below:


**CLI Examples:**
$ sudo ./nvme micron ocp-telemetry-log-parse --format=normal --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin" --output-file="nvme_cli_telemetry_host_normal.txt" /dev/nvme0

$ sudo ./nvme micron ocp-telemetry-log-parse --format=json --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin" --output-file="nvme_cli_telemetry_host_normal.json" /dev/nvme0

$ sudo ./nvme micron ocp-telemetry-log-parse --format=normal --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin" > nvme_cli_telemetry_host_console.txt /dev/nvme0

$ sudo ./nvme micron ocp-telemetry-log-parse --format=json --string-log="nvmelog_ocp_c9.bin" --telemetry-log="nvme_host_telemetry_log.bin" > nvme_cli_telemetry_host_console.json /dev/nvme0

**Output Files:**
[nvme_cli_telemetry_host_console.json](https://github.com/linux-nvme/nvme-cli/files/15432245/nvme_cli_telemetry_host_console.json)
[nvme_cli_telemetry_host_console.txt](https://github.com/linux-nvme/nvme-cli/files/15432246/nvme_cli_telemetry_host_console.txt)
[nvme_cli_telemetry_host_normal.json](https://github.com/linux-nvme/nvme-cli/files/15432250/nvme_cli_telemetry_host_normal.json)
[nvme_cli_telemetry_host_normal.txt](https://github.com/linux-nvme/nvme-cli/files/15432251/nvme_cli_telemetry_host_normal.txt)

