### PR TITLE
skip namespace scan for fabric commads

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -747,6 +747,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	}
 	if (context)
 		nvme_root_set_application(r, context);
+	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		if (errno != ENOENT)
@@ -976,6 +977,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	}
 	if (context)
 		nvme_root_set_application(r, context);
+	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		if (errno != ENOENT)
@@ -1136,6 +1138,7 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
+	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		if (errno != ENOENT)
@@ -1207,6 +1210,7 @@ int nvmf_disconnect_all(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
+	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		if (errno != ENOENT)
@@ -1279,6 +1283,7 @@ int nvmf_config(const char *desc, int argc, char **argv)
 		return -errno;
 	}
 	if (scan_tree) {
+		nvme_root_skip_namespaces(r);
 		ret = nvme_scan_topology(r, NULL, NULL);
 		if (ret < 0) {
 			if (errno != ENOENT)
@@ -1433,6 +1438,7 @@ int nvmf_dim(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
+	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
 		if (errno != ENOENT)


### PR DESCRIPTION
The fabric commands don't depend on the namespace information. Since we are hitting scalling issues with large number of namespaces, skip the scan for those.

Fixes: #2231 