### PR TITLE
documentation fix for format cmd

### DIFF
--- a/Documentation/nvme-format.txt
+++ b/Documentation/nvme-format.txt
@@ -93,9 +93,9 @@ cryptographically. This is accomplished by deleting the encryption key.
 --pil=<pil>::
 	Protection Information Location: If set to ‘1’ and protection
 	information is enabled, then protection information is transferred
-	as the first eight bytes of metadata. If cleared to ‘0’ and
+	as the first bytes of metadata. If cleared to ‘0’ and
 	protection information is enabled, then protection information
-	is transferred as the last eight bytes of metadata. Defaults to 0.
+	is transferred as the last bytes of metadata. Defaults to 0.
 
 -i <pi>::
 --pi=<pi>::

--- a/nvme.c
+++ b/nvme.c
@@ -6083,7 +6083,7 @@ static int format_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 		"Can also be used to change LBAF to change the namespaces reported physical block format.";
 	const char *lbaf = "LBA format to apply (required)";
 	const char *ses = "[0-2]: secure erase";
-	const char *pil = "[0-1]: protection info location last/first 8 bytes of metadata";
+	const char *pil = "[0-1]: protection info location last/first bytes of metadata";
 	const char *pi = "[0-3]: protection info off/Type 1/Type 2/Type 3";
 	const char *ms = "[0-1]: extended format off/on";
 	const char *reset = "Automatically reset the controller after successful format";


### PR DESCRIPTION
Protection Information is not only 8 bytes of the metadata, it can also be 16 bytes such as in 32b and 64b guard protection formats.
