### PR TITLE
build: separate builds of libnvme and nvme-cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
       - name: build
         run: |
           scripts/build.sh -m muon
+
   build-make-static:
     name: make static
     runs-on: ubuntu-latest
@@ -99,3 +100,14 @@ jobs:
       - name: build
         run: |
           make static
+
+  build-distro:
+    name: build libnvme and nvme-cli separately
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/igaw/linux-nvme/debian:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build
+        run: |
+          scripts/build.sh distro


### PR DESCRIPTION
Build and install libnvme separately from libnvme. This should catch any attempts to include private headers from the library.

Also this is what distro usually do, so we should test this as well.