### PR TITLE
build: update libnvme wrap

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 7dfae44795b74478b0b67746ad3c0d43aa71d985
+revision = 770f7bb1a11fd46abebe76e4f8ee18c26b9579b2
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Get PIF enum and the new field added in TP4141a.
* db3ff1a - types: add enum for Protection Information Format.
* 770f7bb - types: add new filed added in TP4141a .

