### PR TITLE
nvme-print-stdout: Add helper function to print PIF in string form

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3056,6 +3056,20 @@ static void stdout_nvm_id_ns_pic(__u8 pic)
 	printf("\n");
 }
 
+static char *pif_to_string(__u8 pif)
+{
+	switch (pif) {
+	case NVME_NVM_PIF_16B_GUARD:
+		return "16b Guard";
+	case NVME_NVM_PIF_32B_GUARD:
+		return "32b Guard";
+	case NVME_NVM_PIF_64B_GUARD:
+		return "64b Guard";
+	default:
+		return "Reserved";
+	}
+}
+
 static void stdout_nvm_id_ns(struct nvme_nvm_id_ns *nvm_ns, unsigned int nsid,
 			     struct nvme_id_ns *ns, unsigned int lba_index,
 			     bool cap_only)
@@ -3086,10 +3100,7 @@ static void stdout_nvm_id_ns(struct nvme_nvm_id_ns *nvm_ns, unsigned int nsid,
 		if (verbose)
 			printf("Extended LBA Format %2d : Protection Information Format: "
 				"%s(%d) - Storage Tag Size (MSB): %-2d %s\n",
-				i, pif == 3 ? "Reserved" :
-					pif == 2 ? "64b Guard" :
-					pif == 1 ? "32b Guard" : "16b Guard",
-					pif, sts, i == lbaf ? in_use : "");
+				i, pif_to_string(pif), pif, sts, i == lbaf ? in_use : "");
 		else
 			printf("elbaf %2d : pif:%d sts:%-2d %s\n", i,
 				pif, sts, i == lbaf ? in_use : "");

--- a/nvme.c
+++ b/nvme.c
@@ -6830,15 +6830,15 @@ static int invalid_tags(__u64 storage_tag, __u64 ref_tag, __u8 sts, __u8 pif)
 	}
 
 	switch (pif) {
-	case 0:
+	case NVME_NVM_PIF_16B_GUARD:
 		if (ref_tag >= (1LL << (32 - sts)))
 			result = 1;
 		break;
-	case 1:
+	case NVME_NVM_PIF_32B_GUARD:
 		if (sts > 16 && ref_tag >= (1LL << (80 - sts)))
 			result = 1;
 		break;
-	case 2:
+	case NVME_NVM_PIF_64B_GUARD:
 		if (sts > 0 && ref_tag >= (1LL << (48 - sts)))
 			result = 1;
 		break;


### PR DESCRIPTION
Use PIF enum and add a helper function to print the Protection Information Format(PIF) in string form.