### PR TITLE
plugins/ocp: Fixed the OCP Telemetry Internal Log (LID:7h, 8h) fix

### DIFF
--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1139,7 +1139,7 @@ static void print_telemetry_da2_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for ( __u32 j = 0; j < (sds * 4); j++)
+			for (__u32 j = 0; j < (sds * 4); j++)
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -922,8 +922,10 @@ static void print_telemetry_header(struct telemetry_initiated_log *logheader,
 		printf("===============================================\n\n");
 	}
 }
-static int get_telemetry_data(struct nvme_dev *dev, __u32 ns, __u8 tele_type,
-								__le64 data_len, void *data, __u8 nLSP,
+static int get_telemetry_data(struct nvme_dev *dev, __u32 ns,
+								__u8 tele_type,
+								__le64 data_len, void *data,
+								__u8 nLSP,
 								__u8 nRAE, __le64 offset)
 {
 	struct nvme_passthru_cmd cmd = {
@@ -936,7 +938,8 @@ static int get_telemetry_data(struct nvme_dev *dev, __u32 ns, __u8 tele_type,
 	__u16 numdu = numd >> 16;
 	__u16 numdl = numd & 0xffff;
 
-	cmd.cdw10 = tele_type | (nLSP & 0x0F) << 8 | (nRAE & 0x01) << 15 | (numdl & 0xFFFF) << 16;
+	cmd.cdw10 = tele_type | (nLSP & 0x0F) << 8 |
+				(nRAE & 0x01) << 15 | (numdl & 0xFFFF) << 16;
 	cmd.cdw11 = numdu;
 	cmd.cdw12 = offset;
 	cmd.cdw13 = 0;
@@ -1069,7 +1072,7 @@ static void print_telemetry_da1_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for(__u32 j = 0; j < (sds * 4); j++)
+			for(__u32 j = 0; j < ( sds * 4 ); j++)
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));
@@ -1100,7 +1103,7 @@ static void print_telemetry_da1_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for (__u16 j = 0; j < (eds * 4); j++)
+				for (__u16 j = 0; j < ( eds * 4 ); j++)
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);
@@ -1136,7 +1139,7 @@ static void print_telemetry_da2_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for(__u32 j = 0; j < (sds * 4); j++)
+			for(__u32 j = 0; j < ( sds * 4 ); j++)
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1072,7 +1072,7 @@ static void print_telemetry_da1_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for( __u32 j = 0; j < ( sds * 4 ); j++ )
+			for (__u32 j = 0; j < ( sds * 4 ); j++)
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));
@@ -1103,7 +1103,7 @@ static void print_telemetry_da1_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for ( __u16 j = 0; j < ( eds * 4 ); j++ )
+				for (__u16 j = 0; j < ( eds * 4 ); j++)
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);
@@ -1139,7 +1139,7 @@ static void print_telemetry_da2_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for( __u32 j = 0; j < ( sds * 4 ); j++ )
+			for ( __u32 j = 0; j < ( sds * 4 ); j++)
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));
@@ -1171,7 +1171,7 @@ static void print_telemetry_da2_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for ( __u16 j = 0; j < (eds * 4); j++ )
+				for (__u16 j = 0; j < ( eds * 4 ); j++)
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1072,7 +1072,7 @@ static void print_telemetry_da1_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for(__u32 j = 0; j < ( sds * 4 ); j++)
+			for( __u32 j = 0; j < ( sds * 4 ); j++ )
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));
@@ -1103,7 +1103,7 @@ static void print_telemetry_da1_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for (__u16 j = 0; j < ( eds * 4 ); j++)
+				for ( __u16 j = 0; j < ( eds * 4 ); j++ )
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);
@@ -1139,7 +1139,7 @@ static void print_telemetry_da2_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for(__u32 j = 0; j < ( sds * 4 ); j++)
+			for( __u32 j = 0; j < ( sds * 4 ); j++ )
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));
@@ -1171,7 +1171,7 @@ static void print_telemetry_da2_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for (__u16 j = 0; j < (eds * 4); j++)
+				for ( __u16 j = 0; j < (eds * 4); j++ )
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -923,8 +923,8 @@ static void print_telemetry_header(struct telemetry_initiated_log *logheader,
 	}
 }
 static int get_telemetry_data(struct nvme_dev *dev, __u32 ns, __u8 tele_type,
-							  __le64 data_len, void *data, __u8 nLSP, __u8 nRAE,
-							  __le64 offset)
+								__le64 data_len, void *data, __u8 nLSP,
+								__u8 nRAE, __le64 offset)
 {
 	struct nvme_passthru_cmd cmd = {
 		.opcode = nvme_admin_get_log_page,
@@ -943,7 +943,9 @@ static int get_telemetry_data(struct nvme_dev *dev, __u32 ns, __u8 tele_type,
 	cmd.cdw14 = 0;
 	return nvme_submit_admin_passthru(dev_fd(dev), &cmd, NULL);
 }
-static void print_telemetry_data_area_1(struct telemetry_data_area_1 *da1, int tele_type, __le64 *eve_fifo_ofs_sz)
+static void print_telemetry_data_area_1(struct telemetry_data_area_1 *da1,
+										int tele_type,
+										__le64 *eve_fifo_ofs_sz)
 {
 	if (da1) {
 		__u32 i = 0;
@@ -984,10 +986,14 @@ static void print_telemetry_data_area_1(struct telemetry_data_area_1 *da1, int t
 		for (i = 0; i < 32; i++)
 			printf("%x", da1->reserved4[i]);
 		printf("\n");
-		printf("Data Area 1 Statistic Start         : 0x%lx\n", le64_to_cpu(da1->da1_stat_start));
-		printf("Data Area 1 Statistic Size         : 0x%lx\n", le64_to_cpu(da1->da1_stat_size));
-		printf("Data Area 2 Statistic Start         : 0x%lx\n", le64_to_cpu(da1->da2_stat_start));
-		printf("Data Area 2 Statistic Size         : 0x%lx\n", le64_to_cpu(da1->da2_stat_size));
+		printf("Data Area 1 Statistic Start         : 0x%lx\n",
+								le64_to_cpu(da1->da1_stat_start));
+		printf("Data Area 1 Statistic Size         : 0x%lx\n",
+								le64_to_cpu(da1->da1_stat_size));
+		printf("Data Area 2 Statistic Start         : 0x%lx\n",
+								le64_to_cpu(da1->da2_stat_start));
+		printf("Data Area 2 Statistic Size         : 0x%lx\n",
+								le64_to_cpu(da1->da2_stat_size));
 		printf("reserved5         :0x");
 		for (i = 0; i < 32; i++)
 			printf("%x", da1->reserved5[i]);

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1072,7 +1072,7 @@ static void print_telemetry_da1_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for (__u32 j = 0; j < ( sds * 4 ); j++)
+			for (__u32 j = 0; j < (sds * 4); j++)
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));
@@ -1103,7 +1103,7 @@ static void print_telemetry_da1_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for (__u16 j = 0; j < ( eds * 4 ); j++)
+				for (__u16 j = 0; j < (eds * 4); j++)
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);
@@ -1139,7 +1139,7 @@ static void print_telemetry_da2_stat(__u8 *da1_stat, int tele_type, __u16 buf_si
 			i = i + 8;
 			memcpy(ssd_buff, &da1_stat[i], sds * 4);
 			printf("Statistic Specific Data         :0x");
-			for ( __u32 j = 0; j < ( sds * 4 ); j++)
+			for ( __u32 j = 0; j < (sds * 4); j++)
 				printf("%x", ssd_buff[j]);
 			printf("\n");
 			i = (i + (sds * 4));
@@ -1171,7 +1171,7 @@ static void print_telemetry_da2_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for (__u16 j = 0; j < ( eds * 4 ); j++)
+				for (__u16 j = 0; j < (eds * 4); j++)
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1100,7 +1100,7 @@ static void print_telemetry_da1_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for (__u16 j = 0; j < (eds << 2); j++)
+				for (__u16 j = 0; j < (eds * 4); j++)
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);
@@ -1168,7 +1168,7 @@ static void print_telemetry_da2_fifo(__u8 *da1_fifo, int tele_type, __le64 buf_s
 				memset(esd_buf, 0, eds << 2);
 				memcpy(esd_buf, &da1_fifo[i], eds << 2);
 				printf("Event Specific Data : 0x");
-				for (__u16 j = 0; j < (eds << 2); j++)
+				for (__u16 j = 0; j < (eds * 4); j++)
 					printf("%x", da1_fifo[j]);
 				printf("\n");
 				i = i + (eds << 2);


### PR DESCRIPTION
This PR will take care the below failures for "internal-log"

1. Handle the Offset and NUMD value calculation properly as NVMe spec.
2. Changed the Statistic Info and Event FIFO info printing logic
3. Resolved the segmentation fault issue in buffer accessing time.

Signed-off-by: Vigneshwaran Saravanan/Vigneshwaran Saravanan <s.vignesh@samsung.com>

Reviewed-by: Karthik Balan <karthik.b82@samsung.com>, 
Reviewed-by: Arunpandian J <arun.j@samsung.com>, 
Reviewed-by: Jayakanthan Rajender <jaya.ganthan@samsung.com>
