### PR TITLE
Use ANA log page fixes from libnvme

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -256,11 +256,11 @@ int nvme_cli_get_log_predictable_lat_event(struct nvme_dev *dev, bool rae,
 			   len, log);
 }
 
-int nvme_cli_get_log_ana(struct nvme_dev *dev,
-			 enum nvme_log_ana_lsp lsp, bool rae,
-			 __u64 offset, __u32 len, void *log)
+int nvme_cli_get_ana_log_atomic(struct nvme_dev *dev, bool rgo, bool rae,
+				unsigned int retries,
+				struct nvme_ana_log *log, __u32 *len)
 {
-	return do_admin_op(get_log_ana, dev, lsp, rae, offset, len, log);
+	return do_admin_op(get_ana_log_atomic, dev, rgo, rae, retries, log, len);
 }
 
 int nvme_cli_get_log_lba_status(struct nvme_dev *dev, bool rae,

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -88,9 +88,9 @@ int nvme_cli_get_log_predictable_lat_nvmset(struct nvme_dev *dev,
 					    struct nvme_nvmset_predictable_lat_log *log);
 int nvme_cli_get_log_predictable_lat_event(struct nvme_dev *dev, bool rae,
 					   __u32 offset, __u32 len, void *log);
-int nvme_cli_get_log_ana(struct nvme_dev *dev,
-			 enum nvme_log_ana_lsp lsp, bool rae,
-			 __u64 offset, __u32 len, void *log);
+int nvme_cli_get_ana_log_atomic(struct nvme_dev *dev, bool rgo, bool rae,
+				unsigned int retries,
+				struct nvme_ana_log *log, __u32 *len);
 int nvme_cli_get_log_lba_status(struct nvme_dev *dev, bool rae,
 				__u64 offset, __u32 len, void *log);
 int nvme_cli_get_log_endurance_grp_evt(struct nvme_dev *dev, bool rae,

--- a/nvme.c
+++ b/nvme.c
@@ -630,11 +630,7 @@ static int get_ana_log(int argc, char **argv, struct command *cmd,
 		return err;
 	}
 
-	ana_log_len = sizeof(struct nvme_ana_log) +
-		le32_to_cpu(ctrl->nanagrpid) * sizeof(struct nvme_ana_group_desc);
-	if (!(ctrl->anacap & (1 << 6)))
-		ana_log_len += le32_to_cpu(ctrl->mnan) * sizeof(__le32);
-
+	ana_log_len = nvme_get_ana_log_len_from_id_ctrl(ctrl, cfg.groups);
 	ana_log = nvme_alloc(ana_log_len);
 	if (!ana_log)
 		return -ENOMEM;

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 770f7bb1a11fd46abebe76e4f8ee18c26b9579b2
+revision = 40f4f703829b51dfeb4206eb500e73b7d2dae27d
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Depends on linux-nvme/libnvme/pull/848

---

`nvme ana-log` only includes space for MNAN namespace IDs
in the allocated ANA log page buffer if bit 6 of ANACAP
in the Identify Controller structure isn't set.

But the specification says:
Bit 6 if set to '1', then the ANAGRPID field in the Identify Namespace
data structure (refer to the NVM Command Set Specification)
does not change while the namespace is attached to any controller

There is no suggestion that NSIDs won't be returned in the ANA log page.

However, we can exclude space for NSIDs from the allocated buffer
if the Get Log Page command is going to be sent with the RGO bit set,
i.e. the `--groups` argument is passed.

Therefore, use the `libnvme` helper `nvme_get_ana_log_len_from_id_ctrl()`
to calculate the maximum ANA log page length.
It ignores ANACAP and takes the RGO setting into account.

---

`nvme ana-log` currently uses `libnvme`'s `nvme{,_mi_admin}_get_log_ana()`
function to fetch the ANA log page.
As described in the commit adding `nvme_get_ana_log_atomic()` to `libnvme`,
this has the potential to overread the ANA log page
and may result in a torn result if the log page changes concurrently.
Use `nvme{,_mi_admin}_get_ana_log_atomic()` to only fetch up to the end
of the ANA log page and protect against concurrent log page changes.