### PR TITLE
nvme: update parse_args() return value handling

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3320,7 +3320,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 	NVME_ARGS(opts);
 
 	err = parse_args(argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	devname = NULL;
@@ -3378,7 +3378,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	NVME_ARGS(opts);
 
 	err = parse_args(argc, argv, desc, opts);
-	if (err < 0)
+	if (err)
 		return err;
 
 	err = validate_output_format(nvme_cfg.output_format, &flags);


### PR DESCRIPTION
Treat non-zero return values from parse_args() as errors, and not just negative return values. Also makes this consistent with other functions in nvme.c where parse_args() is invoked.