### PR TITLE
nvme-print: Use 'unsigned int' instead of 'unsigned'

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -515,7 +515,7 @@ void nvme_show_cmd_set_independent_id_ns(
 	nvme_print(id_independent_id_ns, flags, ns, nsid);
 }
 
-void nvme_show_id_ns_descs(void *data, unsigned nsid, enum nvme_print_flags flags)
+void nvme_show_id_ns_descs(void *data, unsigned int nsid, enum nvme_print_flags flags)
 {
 	nvme_print(id_ns_descs, flags, data, nsid);
 }

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -212,7 +212,7 @@ void nvme_show_supported_cap_config_log(struct nvme_supported_cap_config_list_lo
 void nvme_show_ctrl_registers(void *bar, bool fabrics, enum nvme_print_flags flags);
 void nvme_show_ctrl_register(void *bar, bool fabrics, int offset, enum nvme_print_flags flags);
 void nvme_show_single_property(int offset, uint64_t prop, enum nvme_print_flags flags);
-void nvme_show_id_ns_descs(void *data, unsigned nsid, enum nvme_print_flags flags);
+void nvme_show_id_ns_descs(void *data, unsigned int nsid, enum nvme_print_flags flags);
 void nvme_show_lba_status(struct nvme_lba_status *list, unsigned long len,
 	enum nvme_print_flags flags);
 void nvme_show_list_items(nvme_root_t t, enum nvme_print_flags flags);


### PR DESCRIPTION
Fix for the checkpatch review error below.
  Error: WARNING: Prefer 'unsigned int' to bare use of 'unsigned'