### PR TITLE
Mark pointers in 32bit MMIO as volatile

### DIFF
--- a/common.h
+++ b/common.h
@@ -19,7 +19,7 @@
 
 static inline uint32_t mmio_read32(void *addr)
 {
-	leint32_t *p = addr;
+	const volatile leint32_t *p = addr;
 
 	return le32_to_cpu(*p);
 }
@@ -38,7 +38,7 @@ static inline uint64_t mmio_read64(void *addr)
 
 static inline void mmio_write32(void *addr, uint32_t value)
 {
-	leint32_t *p = addr;
+	volatile leint32_t *p = addr;
 
 	*p = cpu_to_le32(value);
 }


### PR DESCRIPTION
We observed a situation where the compiler combined the reads of two distinct calls to mmio_read32 into a single ldp instruction on ARM. This caused crashes on VMs where KVM could not support that instruction for MMIO. Recent refactors to stdout_ctrl_registers fixed the instance of the crash that we observed but we should fix the mmio helpers to prevent future occurences.