### PR TITLE
ocp: OCP 2.5 Telemetry DA 1 and 2 Parsing Updates

### DIFF
--- a/plugins/ocp/meson.build
+++ b/plugins/ocp/meson.build
@@ -4,5 +4,6 @@ sources += [
   'plugins/ocp/ocp-clear-features.c',
   'plugins/ocp/ocp-smart-extended-log.c',
   'plugins/ocp/ocp-fw-activation-history.c',
+  'plugins/ocp/ocp-telemetry-decode.c',
 ]
 

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -27,6 +27,7 @@
 #include "ocp-smart-extended-log.h"
 #include "ocp-clear-features.h"
 #include "ocp-fw-activation-history.h"
+#include "ocp-telemetry-decode.h"
 
 #define CREATE_CMD
 #include "ocp-nvme.h"
@@ -805,57 +806,6 @@ static int eol_plp_failure_mode(int argc, char **argv, struct command *cmd,
 ///////////////////////////////////////////////////////////////////////////////
 /// Telemetry Log
 
-#define TELEMETRY_HEADER_SIZE 512
-#define TELEMETRY_BYTE_PER_BLOCK 512
-#define TELEMETRY_TRANSFER_SIZE 1024
-#define FILE_NAME_SIZE 2048
-
-enum TELEMETRY_TYPE {
-	TELEMETRY_TYPE_NONE       = 0,
-	TELEMETRY_TYPE_HOST       = 7,
-	TELEMETRY_TYPE_CONTROLLER = 8,
-	TELEMETRY_TYPE_HOST_0     = 9,
-	TELEMETRY_TYPE_HOST_1     = 10,
-};
-
-struct telemetry_initiated_log {
-	__u8  LogIdentifier;
-	__u8  Reserved1[4];
-	__u8  IEEE[3];
-	__le16 DataArea1LastBlock;
-	__le16 DataArea2LastBlock;
-	__le16 DataArea3LastBlock;
-	__u8  Reserved2[368];
-	__u8  DataAvailable;
-	__u8  DataGenerationNumber;
-	__u8  ReasonIdentifier[128];
-};
-
-struct telemetry_data_area_1 {
-	__le16 major_version;
-	__le16 minor_version;
-	__u8  reserved1[4];
-	__le64	timestamp;
-	__u8    log_page_guid[16];
-	__u8    no_of_tps_supp;
-	__u8    tps;
-	__u8  reserved2[6];
-	__le16  sls;
-	__u8  reserved3[8];
-	__le16 fw_revision;
-	__u8  reserved4[32];
-	__le16  da1_stat_start;
-	__le16  da1_stat_size;
-	__le16  da2_stat_start;
-	__le16  da2_stat_size;
-	__u8  reserved5[32];
-	__u8    event_fifo_da[16];
-	__le64	event_fifo_start[16];
-	__le64	event_fifo_size[16];
-	__u8  reserved6[80];
-	__u8  smart_health_info[512];
-	__u8  smart_health_info_extended[512];
-};
 static void get_serial_number(struct nvme_id_ctrl *ctrl, char *sn)
 {
 	int i;
@@ -867,39 +817,20 @@ static void get_serial_number(struct nvme_id_ctrl *ctrl, char *sn)
 	}
 }
 
-static int get_telemetry_header(struct nvme_dev *dev, __u32 ns, __u8 tele_type,
-				__u32 data_len, void *data, __u8 nLSP, __u8 nRAE)
-{
-	struct nvme_passthru_cmd cmd = {
-		.opcode = nvme_admin_get_log_page,
-		.nsid = ns,
-		.addr = (__u64)(uintptr_t) data,
-		.data_len = data_len,
-	};
-
-	__u32 numd = (data_len >> 2) - 1;
-	__u16 numdu = numd >> 16;
-	__u16 numdl = numd & 0xffff;
-
-	cmd.cdw10 = tele_type | (nLSP & 0x0F) << 8 | (nRAE & 0x01) << 15 | (numdl & 0xFFFF) << 16;
-	cmd.cdw11 = numdu;
-	cmd.cdw12 = 0;
-	cmd.cdw13 = 0;
-	cmd.cdw14 = 0;
-
-	return nvme_submit_admin_passthru(dev_fd(dev), &cmd, NULL);
-}
-
 static void print_telemetry_header(struct telemetry_initiated_log *logheader,
 		int tele_type)
 {
 	if (logheader) {
 		unsigned int i = 0, j = 0;
+		__u8 dataGenNum;
 
-		if (tele_type == TELEMETRY_TYPE_HOST)
+		if (tele_type == TELEMETRY_TYPE_HOST) {
 			printf("============ Telemetry Host Header ============\n");
-		else
+			dataGenNum = logheader->DataHostGenerationNumber;
+		} else {
 			printf("========= Telemetry Controller Header =========\n");
+			dataGenNum = logheader->DataCtlrGenerationNumber;
+		}
 
 		printf("Log Identifier         : 0x%02X\n", logheader->LogIdentifier);
 		printf("IEEE                   : 0x%02X%02X%02X\n",
@@ -910,8 +841,10 @@ static void print_telemetry_header(struct telemetry_initiated_log *logheader,
 			le16_to_cpu(logheader->DataArea2LastBlock));
 		printf("Data Area 3 Last Block : 0x%04X\n",
 			le16_to_cpu(logheader->DataArea3LastBlock));
-		printf("Data Available         : 0x%02X\n",	logheader->DataAvailable);
-		printf("Data Generation Number : 0x%02X\n",	logheader->DataGenerationNumber);
+		printf("Data Available         : 0x%02X\n",
+			logheader->CtlrDataAvailable);
+		printf("Data Generation Number : 0x%02X\n",
+			dataGenNum);
 		printf("Reason Identifier      :\n");
 
 		for (i = 0; i < 8; i++) {
@@ -922,6 +855,7 @@ static void print_telemetry_header(struct telemetry_initiated_log *logheader,
 		printf("===============================================\n\n");
 	}
 }
+
 static int get_telemetry_data(struct nvme_dev *dev, __u32 ns, __u8 tele_type,
 							  __u32 data_len, void *data, __u8 nLSP, __u8 nRAE,
 							  __u64 offset)
@@ -935,10 +869,13 @@ static int get_telemetry_data(struct nvme_dev *dev, __u32 ns, __u8 tele_type,
 	__u32 numd = (data_len >> 2) - 1;
 	__u16 numdu = numd >> 16;
 	__u16 numdl = numd & 0xffff;
-	cmd.cdw10 = tele_type | (nLSP & 0x0F) << 8 | (nRAE & 0x01) << 15 | (numdl & 0xFFFF) << 16;
+	cmd.cdw10 = tele_type |
+			(nLSP & 0x0F) << 8 |
+			(nRAE & 0x01) << 15 |
+			(numdl & 0xFFFF) << 16;
 	cmd.cdw11 = numdu;
-	cmd.cdw12 = offset;
-	cmd.cdw13 = 0;
+	cmd.cdw12 = (__u32)(0x00000000FFFFFFFF & offset);
+	cmd.cdw13 = (__u32)((0xFFFFFFFF00000000 & offset) >> 8);
 	cmd.cdw14 = 0;
 	return nvme_submit_admin_passthru(dev_fd(dev), &cmd, NULL);
 }
@@ -951,116 +888,111 @@ static void print_telemetry_data_area_1(struct telemetry_data_area_1 *da1,
 			printf("============ Telemetry Host Data area 1 ============\n");
 		else
 			printf("========= Telemetry Controller Data area 1 =========\n");
-		printf("Major Version         : 0x%x\n", le16_to_cpu(da1->major_version));
-		printf("Minor Version         : 0x%x\n", le16_to_cpu(da1->minor_version));
-		for (i = 0; i < 4; i++)
-			printf("reserved1         : 0x%x\n", da1->reserved1[i]);
+		printf("Major Version     : 0x%x\n", le16_to_cpu(da1->major_version));
+		printf("Minor Version     : 0x%x\n", le16_to_cpu(da1->minor_version));
 		printf("Timestamp         : %"PRIu64"\n", le64_to_cpu(da1->timestamp));
-		for (i = 15; i >= 0; i--)
-			printf("%x", da1->log_page_guid[i]);
-		printf("Number Telemetry Profiles Supported         : 0x%x\n", da1->no_of_tps_supp);
-		printf("Telemetry Profile Selected (TPS)         : 0x%x\n", da1->tps);
-		for (i = 0; i < 6; i++)
-			printf("reserved2         : 0x%x\n", da1->reserved2[i]);
-		printf("Telemetry String Log Size (SLS)         : 0x%x\n", le16_to_cpu(da1->sls));
+		printf("Log Page GUID     : 0x");
+		for (int j = 15; j >= 0; j--)
+			printf("%02x", da1->log_page_guid[j]);
+		printf("\n");
+		printf("Number Telemetry Profiles Supported   : 0x%x\n",
+				da1->no_of_tps_supp);
+		printf("Telemetry Profile Selected (TPS)      : 0x%x\n",
+				da1->tps);
+		printf("Telemetry String Log Size (SLS)       : 0x%lx\n",
+				le64_to_cpu(da1->sls));
+		printf("Firmware Revision                     : ");
 		for (i = 0; i < 8; i++)
-			printf("reserved3         : 0x%x\n", da1->reserved3[i]);
-		printf("Firmware Revision         : 0x%x\n", le16_to_cpu(da1->fw_revision));
-		for (i = 0; i < 32; i++)
-			printf("reserved4         : 0x%x\n", da1->reserved4[i]);
-		printf("Data Area 1 Statistic Start         : 0x%x\n", le16_to_cpu(da1->da1_stat_start));
-		printf("Data Area 1 Statistic Size         : 0x%x\n", le16_to_cpu(da1->da1_stat_size));
-		printf("Data Area 2 Statistic Start         : 0x%x\n", le16_to_cpu(da1->da2_stat_start));
-		printf("Data Area 2 Statistic Size         : 0x%x\n", le16_to_cpu(da1->da2_stat_size));
-		for (i = 0; i < 32; i++)
-			printf("reserved5         : 0x%x\n", da1->reserved5[i]);
+			printf("%c", (char)da1->fw_revision[i]);
+		printf("\n");
+		printf("Data Area 1 Statistic Start           : 0x%lx\n",
+				le64_to_cpu(da1->da1_stat_start));
+		printf("Data Area 1 Statistic Size            : 0x%lx\n",
+				le64_to_cpu(da1->da1_stat_size));
+		printf("Data Area 2 Statistic Start           : 0x%lx\n",
+				le64_to_cpu(da1->da2_stat_start));
+		printf("Data Area 2 Statistic Size            : 0x%lx\n",
+				le64_to_cpu(da1->da2_stat_size));
 		for (i = 0; i < 16; i++) {
-			printf("Event FIFO %d Data Area         : 0x%x\n", i, da1->event_fifo_da[i]);
-			printf("Event FIFO %d Start         : %"PRIu64"\n", i, le64_to_cpu(da1->event_fifo_start[i]));
-			printf("Event FIFO %d Size         : %"PRIu64"\n", i, le64_to_cpu(da1->event_fifo_size[i]));
+			printf("Event FIFO %d Data Area                : 0x%x\n",
+					i, da1->event_fifo_da[i]);
+			printf("Event FIFO %d Start                    : 0x%"PRIx64"\n",
+					i, le64_to_cpu(da1->event_fifos[i].start));
+			printf("Event FIFO %d Size                     : 0x%"PRIx64"\n",
+					i, le64_to_cpu(da1->event_fifos[i].size));
 		}
-		for (i = 0; i < 80; i++)
-			printf("reserved6         : 0x%x\n", da1->reserved6[i]);
-		for (i = 0; i < 512; i++){
-			printf("SMART / Health Information         : 0x%x\n", da1->smart_health_info[i]);
-			printf("SMART / Health Information Extended         : 0x%x\n", da1->smart_health_info_extended[i]);
-		}
-		printf("===============================================\n\n");
-	}
-}
-static void print_telemetry_da1_stat(__u8 *da1_stat, int tele_type, __u16 buf_size)
-{
-	if (da1_stat) {
-		unsigned int i = 0;
-		if (tele_type == TELEMETRY_TYPE_HOST)
-			printf("============ Telemetry Host Data area 1 Statistics ============\n");
-		else
-			printf("========= Telemetry Controller Data area 1 Statistics =========\n");
-		while((i + 8) < buf_size) {
-			printf("Statistics Identifier         : 0x%x\n", (da1_stat[i] | da1_stat[i+1] << 8));
-			printf("Statistics info         : 0x%x\n", da1_stat[i+2]);
-			printf("NS info         : 0x%x\n", da1_stat[i+3]);
-			printf("Statistic Data Size         : 0x%x\n", (da1_stat[i+4] | da1_stat[i+5] << 8));
-			printf("Reserved         : 0x%x\n", (da1_stat[i+6] | da1_stat[i+7] << 8));
-			i = 8 + ((da1_stat[i+4] | da1_stat[i+5] << 8) * 4);
-		}
-		printf("===============================================\n\n");
-	}
-}
-static void print_telemetry_da1_fifo(__u8 *da1_fifo, int tele_type, __u16 buf_size)
-{
-	if (da1_fifo) {
-		unsigned int i = 0;
-		if (tele_type == TELEMETRY_TYPE_HOST)
-			printf("============ Telemetry Host Data area 1 FIFO ============\n");
-		else
-			printf("========= Telemetry Controller Data area 1 FIFO =========\n");
-		while((i + 4) < buf_size) {
-			printf("Debug Event Class Type         : 0x%x\n", da1_fifo[i]);
-			printf("Event ID         : 0x%x\n", (da1_fifo[i+1] | da1_fifo[i+2] << 8));
-			printf("Event Data Size         : 0x%x\n", da1_fifo[3]);
-			i = 4 + ((da1_fifo[3]) * 4);
-		}
-		printf("===============================================\n\n");
-	}
-}
-static void print_telemetry_da2_stat(__u8 *da1_stat, int tele_type, __u16 buf_size)
-{
-	if (da1_stat) {
-		unsigned int i = 0;
-		if (tele_type == TELEMETRY_TYPE_HOST)
-			printf("============ Telemetry Host Data area 1 Statistics ============\n");
-		else
-			printf("========= Telemetry Controller Data area 1 Statistics =========\n");
-		while((i + 8) < buf_size) {
-			printf("Statistics Identifier         : 0x%x\n", (da1_stat[i] | da1_stat[i+1] << 8));
-			printf("Statistics info         : 0x%x\n", da1_stat[i+2]);
-			printf("NS info         : 0x%x\n", da1_stat[i+3]);
-			printf("Statistic Data Size         : 0x%x\n", (da1_stat[i+4] | da1_stat[i+5] << 8));
-			printf("Reserved         : 0x%x\n", (da1_stat[i+6] | da1_stat[i+7] << 8));
-			i = 8 + ((da1_stat[i+4] | da1_stat[i+5] << 8) * 4);
-		}
-		printf("===============================================\n\n");
-	}
-}
-static void print_telemetry_da2_fifo(__u8 *da1_fifo, int tele_type, __u16 buf_size)
-{
-	if (da1_fifo) {
-		unsigned int i = 0;
-		if (tele_type == TELEMETRY_TYPE_HOST)
-			printf("============ Telemetry Host Data area 1 Statistics ============\n");
-		else
-			printf("========= Telemetry Controller Data area 1 Statistics =========\n");
-		while((i + 4) < buf_size) {
-			printf("Debug Event Class Type         : 0x%x\n", da1_fifo[i]);
-			printf("Event ID         : 0x%x\n", (da1_fifo[i+1] | da1_fifo[i+2] << 8));
-			printf("Event Data Size         : 0x%x\n", da1_fifo[3]);
-			i = 4 + ((da1_fifo[3]) * 4);
-		}
-		printf("===============================================\n\n");
-	}
-}
+		printf("SMART / Health Information     :\n");
+		printf("0x");
+		for (i = 0; i < 512; i++)
+			printf("%02x", da1->smart_health_info[i]);
+		printf("\n");
 
+		printf("SMART / Health Information Extended     :\n");
+		printf("0x");
+		for (i = 0; i < 512; i++)
+			printf("%02x", da1->smart_health_info_extended[i]);
+		printf("\n");
+
+		printf("===============================================\n\n");
+	}
+}
+static void print_telemetry_da_stat(struct telemetry_stats_desc *da_stat,
+		int tele_type,
+		__u16 buf_size,
+		__u8 data_area)
+{
+	if (da_stat) {
+		unsigned int i = 0;
+		struct telemetry_stats_desc *next_da_stat = da_stat;
+
+		if (tele_type == TELEMETRY_TYPE_HOST)
+			printf("============ Telemetry Host Data Area %d Statistics ============\n",
+				data_area);
+		else
+			printf("========= Telemetry Controller Data Area %d Statistics =========\n",
+				data_area);
+		while((i + 8) < buf_size) {
+			print_stats_desc(next_da_stat);
+			i += 8 + ((next_da_stat->size) * 4);
+			next_da_stat = (struct telemetry_stats_desc *)((__u64)da_stat + i);
+
+			if ((next_da_stat->id == 0) && (next_da_stat->size == 0))
+				break;
+		}
+		printf("===============================================\n\n");
+	}
+}
+static void print_telemetry_da_fifo(struct telemetry_event_desc *da_fifo,
+		__le64 buf_size,
+		int tele_type,
+		int da,
+		int index)
+{
+	if (da_fifo) {
+		unsigned int i = 0;
+		struct telemetry_event_desc *next_da_fifo = da_fifo;
+
+		if (tele_type == TELEMETRY_TYPE_HOST)
+			printf("========= Telemetry Host Data area %d Event FIFO %d =========\n",
+				da, index);
+		else
+			printf("====== Telemetry Controller Data area %d Event FIFO %d ======\n",
+				da, index);
+
+
+		while((i + 4) < buf_size) {
+			/* Print Event Data */
+			print_telemetry_fifo_event(next_da_fifo->class, /* Event class type */
+				next_da_fifo->id,                           /* Event ID         */
+				next_da_fifo->size,                         /* Event data size  */
+				(__u8 *)&next_da_fifo->data);               /* Event data       */
+
+			i += (4 + (next_da_fifo->size * 4));
+			next_da_fifo = (struct telemetry_event_desc *)((__u64)da_fifo + i);
+		}
+		printf("===============================================\n\n");
+	}
+}
 static int extract_dump_get_log(struct nvme_dev *dev, char *featurename, char *filename, char *sn,
 				int dumpsize, int transfersize, __u32 nsid, __u8 log_id,
 				__u8 lsp, __u64 offset, bool rae)
@@ -1146,10 +1078,12 @@ static int get_telemetry_dump(struct nvme_dev *dev, char *filename, char *sn,
 			      enum TELEMETRY_TYPE tele_type, int data_area, bool header_print)
 {
 	__u32 err = 0, nsid = 0;
-	__u8 lsp = 0, rae = 0;
+	__le64 da1_sz = 512, m_512_sz = 0, da1_off = 0, m_512_off = 0, diff = 0,
+		temp_sz = 0, temp_ofst = 0;
+	__u8 lsp = 0, rae = 0, flag = 0;
+	__u8 data[TELEMETRY_HEADER_SIZE] = { 0 };
 	unsigned int i = 0;
-	char data[TELEMETRY_TRANSFER_SIZE] = { 0 };
-	char data1[1536] = { 0 };
+	char data1[TELEMETRY_DATA_SIZE] = { 0 };
 	char *featurename = 0;
 	struct telemetry_initiated_log *logheader = (struct telemetry_initiated_log *)data;
 	struct telemetry_data_area_1 *da1 = (struct telemetry_data_area_1 *)data1;
@@ -1172,50 +1106,244 @@ static int get_telemetry_dump(struct nvme_dev *dev, char *filename, char *sn,
 		rae = 1;
 	}
 
-	err = get_telemetry_header(dev, nsid, tele_type, TELEMETRY_HEADER_SIZE,
-				(void *)data, lsp, rae);
-	if (err)
+	/* Get the telemetry header */
+	err = get_telemetry_data(dev, nsid, tele_type, TELEMETRY_HEADER_SIZE,
+				(void *)data, lsp, rae, 0);
+	if (err) {
+		printf("get_telemetry_header failed, err: %d.\n", err);
 		return err;
+	}
 
 	if (header_print)
 		print_telemetry_header(logheader, tele_type);
-	err = get_telemetry_data(dev, nsid, tele_type, 1536,
+
+	/* Get the telemetry data */
+	err = get_telemetry_data(dev, nsid, tele_type, TELEMETRY_DATA_SIZE,
 				(void *)data1, lsp, rae, 512);
-	if (err)
+	if (err) {
+		printf("get_telemetry_data failed for type: 0x%x, err: %d.\n", tele_type, err);
 		return err;
+	}
+
 	print_telemetry_data_area_1(da1, tele_type);
-	char *da1_stat = calloc((da1->da1_stat_size * 4), sizeof(char));
-	err = get_telemetry_data(dev, nsid, tele_type, (da1->da1_stat_size) * 4,
-				(void *)da1_stat, lsp, rae, (da1->da1_stat_start) * 4);
-	if (err)
-		return err;
-	print_telemetry_da1_stat((void *)da1_stat, tele_type, (da1->da1_stat_size) * 4);
-	for (i = 0; i < 17 ; i++){
-		if (da1->event_fifo_da[i] == 1){
-			char *da1_fifo = calloc((da1->event_fifo_size[i]) * 4, sizeof(char));
-			err = get_telemetry_data(dev, nsid, tele_type, (da1->event_fifo_size[i]) * 4,
-				(void *)da1_stat, lsp, rae, (da1->event_fifo_start[i]) * 4);
-			if (err)
+
+	/* Print the Data Area 1 Stats */
+	if (da1->da1_stat_size != 0) {
+		diff = 0;
+		da1_sz = (da1->da1_stat_size) * 4;
+		m_512_sz = (da1->da1_stat_size) * 4;
+		da1_off = (da1->da1_stat_start) * 4;
+		m_512_off = (da1->da1_stat_start) * 4;
+		temp_sz = (da1->da1_stat_size) * 4;
+		temp_ofst = (da1->da1_stat_start) * 4;
+		flag = 0;
+
+		if ((da1_off % 512) > 0) {
+			m_512_off = (__le64) ((da1_off / 512));
+			da1_off = m_512_off * 512;
+			diff = temp_ofst - da1_off;
+			flag = 1;
+		}
+
+		if (da1_sz < 512)
+			da1_sz = 512;
+		else if ((da1_sz % 512) > 0) {
+			if (flag == 0) {
+				m_512_sz = (__le64) ((da1_sz / 512) + 1);
+				da1_sz = m_512_sz * 512;
+			} else {
+				if (diff < 512)
+					diff = 1;
+				else
+					diff = (diff / 512) * 512;
+
+				m_512_sz = (__le64) ((da1_sz / 512) + 1 + diff + 1);
+				da1_sz = m_512_sz * 512;
+			}
+		}
+
+		char *da1_stat = calloc(da1_sz, sizeof(char));
+
+		err = get_telemetry_data(dev, nsid, tele_type, da1_sz,
+				(void *)da1_stat, lsp, rae, da1_off);
+		if (err) {
+			printf("get_telemetry_data da1 stats failed, err: %d.\n", err);
+			return err;
+		}
+
+		print_telemetry_da_stat((void *)(da1_stat + (temp_ofst - da1_off)),
+				tele_type, (da1->da1_stat_size) * 4, 1);
+	}
+
+	/* Print the Data Area 1 Event FIFO's */
+	for (i = 0; i < 16 ; i++) {
+		if ((da1->event_fifo_da[i] == 1) && (da1->event_fifos[i].size != 0)) {
+			diff = 0;
+			da1_sz = da1->event_fifos[i].size * 4;
+			m_512_sz = da1->event_fifos[i].size * 4;
+			da1_off = da1->event_fifos[i].start * 4;
+			m_512_off = da1->event_fifos[i].start * 4;
+			temp_sz = da1->event_fifos[i].size * 4;
+			temp_ofst = da1->event_fifos[i].start * 4;
+			flag = 0;
+
+			if ((da1_off % 512) > 0) {
+				m_512_off = (__le64) ((da1_off / 512));
+				da1_off = m_512_off * 512;
+				diff = temp_ofst - da1_off;
+				flag = 1;
+			}
+
+			if (da1_sz < 512)
+				da1_sz = 512;
+			else if ((da1_sz % 512) > 0) {
+				if (flag == 0) {
+					m_512_sz = (__le64) ((da1_sz / 512) + 1);
+					da1_sz = m_512_sz * 512;
+				} else {
+					if (diff < 512)
+						diff = 1;
+					else
+						diff = (diff / 512) * 512;
+
+					m_512_sz = (__le64) ((da1_sz / 512) + 1 + diff + 1);
+					da1_sz = m_512_sz * 512;
+				}
+			}
+
+			char *da1_fifo = calloc(da1_sz, sizeof(char));
+
+			err = get_telemetry_data(dev, nsid, tele_type,
+					(da1->event_fifos[i].size) * 4,
+					(void *)da1_fifo, lsp, rae, da1_off);
+			if (err) {
+				printf("get_telemetry_data da1 event fifos failed, err: %d.\n",
+					err);
 				return err;
-			print_telemetry_da1_fifo((void *)da1_fifo, tele_type, (da1->event_fifo_size[i]) * 4);
+			}
+			print_telemetry_da_fifo((void *)(da1_fifo + (temp_ofst - da1_off)),
+					temp_sz,
+					tele_type,
+					da1->event_fifo_da[i],
+					i);
 		}
 	}
-	char *da2_stat = calloc((da1->da2_stat_size * 4), sizeof(char));
-	err = get_telemetry_data(dev, nsid, tele_type, (da1->da2_stat_size) * 4,
-				(void *)da2_stat, lsp, rae, (da1->da2_stat_start) * 4);
-	if (err)
-		return err;
-	print_telemetry_da2_stat((void *)da2_stat, tele_type, (da1->da2_stat_size) * 4);
-	for (i = 0; i < 17 ; i++){
-		if (da1->event_fifo_da[i] == 2){
-			char *da1_fifo = calloc((da1->event_fifo_size[i]) * 4, sizeof(char));
-			err = get_telemetry_data(dev, nsid, tele_type, (da1->event_fifo_size[i]) * 4,
-				(void *)da1_stat, lsp, rae, (da1->event_fifo_start[i]) * 4);
-			if (err)
+
+	/* Print the Data Area 2 Stats */
+	if (da1->da2_stat_size != 0) {
+		da1_off = (da1->da2_stat_start) * 4;
+		temp_ofst = (da1->da2_stat_start) * 4;
+		da1_sz = (da1->da2_stat_size) * 4;
+		diff = 0;
+		flag = 0;
+
+		if (da1->da2_stat_start == 0) {
+			da1_off = 512 + (logheader->DataArea1LastBlock * 512);
+			temp_ofst = 512 + (le16_to_cpu(logheader->DataArea1LastBlock) * 512);
+			if ((da1_off % 512) == 0) {
+				m_512_off = (__le64) (((da1_off) / 512));
+				da1_off = m_512_off * 512;
+				diff = temp_ofst - da1_off;
+				flag = 1;
+			}
+		} else {
+
+			if (((da1_off * 4) % 512) > 0) {
+				m_512_off = (__le64) ((((da1->da2_stat_start) * 4) / 512));
+				da1_off = m_512_off * 512;
+				diff = ((da1->da2_stat_start) * 4) - da1_off;
+				flag = 1;
+			}
+		}
+
+		if (da1_sz < 512)
+			da1_sz = 512;
+		else if ((da1_sz % 512) > 0) {
+			if (flag == 0) {
+				m_512_sz = (__le64) ((da1->da2_stat_size / 512) + 1);
+				da1_sz = m_512_sz * 512;
+			} else {
+				if (diff < 512)
+					diff = 1;
+				else
+					diff = (diff / 512) * 512;
+				m_512_sz = (__le64) ((da1->da2_stat_size / 512) + 1 + diff + 1);
+				da1_sz = m_512_sz * 512;
+			}
+		}
+
+		char *da2_stat = calloc(da1_sz, sizeof(char));
+
+		err = get_telemetry_data(dev, nsid, tele_type, da1_sz,
+				(void *)da2_stat, lsp, rae, da1_off);
+		if (err) {
+			printf("get_telemetry_data da2 stats failed, err: %d.\n", err);
+			return err;
+		}
+
+		print_telemetry_da_stat((void *)(da2_stat + (temp_ofst - da1_off)),
+			tele_type,
+			(da1->da2_stat_size) * 4,
+			2);
+	}
+
+	/* Print the Data Area 2 Event FIFO's */
+	for (i = 0; i < 16 ; i++) {
+		if ((da1->event_fifo_da[i] == 2) && (da1->event_fifos[i].size != 0)) {
+			diff = 0;
+			da1_sz = da1->event_fifos[i].size * 4;
+			m_512_sz = da1->event_fifos[i].size * 4;
+			da1_off = da1->event_fifos[i].start * 4;
+			m_512_off = da1->event_fifos[i].start * 4;
+			temp_sz = da1->event_fifos[i].size * 4;
+			temp_ofst = da1->event_fifos[i].start * 4;
+			flag = 0;
+
+			if ((da1_off % 512) > 0) {
+				m_512_off = (__le64) ((da1_off / 512));
+				da1_off = m_512_off * 512;
+				diff = temp_ofst - da1_off;
+				flag = 1;
+			}
+
+			if (da1_sz < 512)
+				da1_sz = 512;
+			else if ((da1_sz % 512) > 0) {
+				if (flag == 0) {
+					m_512_sz = (__le64) ((da1_sz / 512) + 1);
+					da1_sz = m_512_sz * 512;
+				}
+
+				else {
+					if (diff < 512)
+						diff = 1;
+					else
+						diff = (diff / 512) * 512;
+
+					m_512_sz = (__le64) ((da1_sz / 512) + 1 + diff + 1);
+					da1_sz = m_512_sz * 512;
+				}
+			}
+
+			char *da1_fifo = calloc(da1_sz, sizeof(char));
+
+			err = get_telemetry_data(dev, nsid, tele_type,
+					(da1->event_fifos[i].size) * 4,
+					(void *)da1_fifo, lsp, rae, da1_off);
+			if (err) {
+				printf("get_telemetry_data da2 event fifos failed, err: %d.\n",
+					err);
 				return err;
-			print_telemetry_da2_fifo((void *)da1_fifo, tele_type, (da1->event_fifo_size[i]) * 4);
+			}
+			print_telemetry_da_fifo((void *)(da1_fifo + (temp_ofst - da1_off)),
+					temp_sz,
+					tele_type,
+					da1->event_fifo_da[i],
+					i);
 		}
 	}
+
+	printf("------------------------------FIFO End---------------------------\n");
 
 	switch (data_area) {
 	case 1:
@@ -1406,8 +1534,9 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *cmd,
 
 	printf("telemetry-log done.\n");
 
-return err;
+	return err;
 }
+
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -1584,7 +1713,6 @@ out:
 	free(data);
 	return ret;
 }
-
 
 static int ocp_unsupported_requirements_log(int argc, char **argv, struct command *cmd,
 					    struct plugin *plugin)

--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright (c) 2024 Western Digital Corporation or its affiliates.
+ *
+ * Authors: Jeff Lien <jeff.lien@wdc.com>,
+ */
+
+#include "common.h"
+#include "nvme.h"
+#include "libnvme.h"
+#include "plugin.h"
+#include "linux/types.h"
+#include "util/types.h"
+#include "nvme-print.h"
+
+#include "ocp-telemetry-decode.h"
+
+
+void print_vu_event_data(__u32 size, __u8 *data)
+{
+	int j;
+	__u16 vu_event_id = *(__u16 *)data;
+
+	printf("  VU Event ID   : 0x%02x\n", le16_to_cpu(vu_event_id));
+	printf("  VU Data       : 0x");
+	for (j = 2; j < size; j++)
+		printf("%x", data[j]);
+	printf("\n\n");
+}
+
+void print_stats_desc(struct telemetry_stats_desc *stat_desc)
+{
+	int j;
+	/* Get the statistics Identifier string name and data size  */
+	__u16 stat_id = stat_desc->id;
+	__u32 stat_data_sz = ((stat_desc->size) * 4);
+
+	printf("Statistics Identifier         : 0x%x, %s\n",
+			stat_id, telemetry_stat_id_to_string(stat_id));
+	printf("Statistics info               : 0x%x\n", stat_desc->info);
+	printf("NS info                       : 0x%x\n", stat_desc->ns_info);
+	printf("Statistic Data Size           : 0x%x\n", le16_to_cpu(stat_data_sz));
+
+	if (stat_data_sz > 0) {
+		printf("%s  : 0x",
+				telemetry_stat_id_to_string(stat_id));
+		for (j = 0; j < stat_data_sz; j++)
+			printf("%02x", stat_desc->data[j]);
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void print_telemetry_fifo_event(__u8 class_type,
+		__u16 id, __u8 size_dw, __u8 *data)
+{
+	int j;
+	const char *class_str = NULL;
+	__u32 size = size_dw * 4;
+	char time_str[40];
+	uint64_t timestamp = 0;
+	memset((void *)time_str, '\0', 40);
+
+	if (class_type) {
+		class_str = telemetry_event_class_to_string(class_type);
+		printf("Event Class : %s\n", class_str);
+	}
+
+	switch (class_type)	{
+	case TELEMETRY_TIMESTAMP_CLASS:
+		timestamp = (0x0000FFFFFFFFFFFF & le64_to_cpu(*(uint64_t *)data));
+
+		memset((void *)time_str, 0, 9);
+		sprintf((char *)time_str, "%04d:%02d:%02d", (int)(le64_to_cpu(timestamp)/3600),
+				(int)((le64_to_cpu(timestamp%3600)/60)),
+				(int)(le64_to_cpu(timestamp%60)));
+
+		printf("  Event ID  : 0x%02x %s\n", id, telemetry_ts_event_to_string(id));
+		printf("  Timestamp : %s\n", time_str);
+		printf("  Size      : %d\n", size);
+		if (size > 8) {
+			printf("  VU Data : 0x");
+			for (j = 8; j < size; j++)
+				printf("%02x", data[j]);
+			printf("\n\n");
+		}
+		break;
+
+	case TELEMETRY_PCIE_CLASS:
+		printf("  Event ID : 0x%02x %s\n",
+			id, telemetry_pcie_event_id_to_string(id));
+		printf("  State    : 0x%02x %s\n",
+			data[0], telemetry_pcie_state_data_to_string(data[0]));
+		printf("  Speed    : 0x%02x %s\n",
+			data[1], telemetry_pcie_speed_data_to_string(data[1]));
+		printf("  Width    : 0x%02x %s\n",
+			data[2], telemetry_pcie_width_data_to_string(data[2]));
+		if (size > 4) {
+			printf("  VU Data : ");
+			for (j = 4; j < size; j++)
+				printf("%x", data[j]);
+			printf("\n\n");
+		}
+		break;
+
+	case TELEMETRY_NVME_CLASS:
+		printf("  Event ID          : 0x%02x %s\n",
+			id, telemetry_nvme_event_id_to_string(id));
+		if ((id == ADMIN_QUEUE_NONZERO_STATUS) ||
+			(id == IO_QUEUE_NONZERO_STATUS)) {
+			printf("  Cmd Op Code   : 0x%02x\n", data[0]);
+			__u16 status = *(__u16 *)&data[1];
+			__u16 cmd_id = *(__u16 *)&data[3];
+			__u16 sq_id = *(__u16 *)&data[5];
+
+			printf("  Status Code   : 0x%04x\n", le16_to_cpu(status));
+			printf("  Cmd ID        : 0x%04x\n", le16_to_cpu(cmd_id));
+			printf("  SQ ID         : 0x%04x\n", le16_to_cpu(sq_id));
+		} else if (id == CC_REGISTER_CHANGED) {
+			__u32 cc_reg_data = *(__u32 *)data;
+
+			printf("  CC Reg Data   : 0x%08x\n",
+					le32_to_cpu(cc_reg_data));
+		} else if (id == CSTS_REGISTER_CHANGED) {
+			__u32 csts_reg_data = *(__u32 *)data;
+
+			printf("  CSTS Reg Data : 0x%08x\n",
+					le32_to_cpu(csts_reg_data));
+		}
+		if (size > 8)
+			print_vu_event_data(size, (__u8 *)&data[8]);
+		break;
+
+	case TELEMETRY_RESET_CLASS:
+		printf("  Event ID          : 0x%02x %s\n",
+			id, telemetry_reset_event_id_to_string(id));
+		if (size)
+			print_vu_event_data(size, data);
+		break;
+
+	case TELEMETRY_BOOT_SEQ_CLASS:
+		printf("  Event ID          : 0x%02x %s\n",
+			id, telemetry_boot_seq_event_id_to_string(id));
+		if (size)
+			print_vu_event_data(size, data);
+		break;
+
+	case TELEMETRY_FW_ASSERT_CLASS:
+		printf("  Event ID          : 0x%02x %s\n",
+			id, telemetry_fw_assert_event_id_to_string(id));
+		if (size)
+			print_vu_event_data(size, data);
+		break;
+
+	case TELEMETRY_TEMPERATURE_CLASS:
+		printf("  Event ID          : 0x%02x %s\n",
+			id, telemetry_temperature_event_id_to_string(id));
+		if (size)
+			print_vu_event_data(size, data);
+		break;
+
+	case TELEMETRY_MEDIA_DBG_CLASS:
+		printf("  Event ID          : 0x%02x %s\n",
+			id, telemetry_media_debug_event_id_to_string(id));
+		if (size)
+			print_vu_event_data(size, data);
+		break;
+
+	case TELEMETRY_MEDIA_WEAR_CLASS:
+		printf("  Event ID          : 0x%02x %s\n",
+			id, telemetry_media_debug_event_id_to_string(id));
+		__u32 host_tb_written = *(__u32 *)&data[0];
+		__u32 media_tb_written = *(__u32 *)&data[4];
+		__u32 media_tb_erased = *(__u32 *)&data[8];
+
+		printf("  Host TB Written   : 0x%04x\n",
+			le16_to_cpu(host_tb_written));
+		printf("  Media TB Written  : 0x%04x\n",
+			le16_to_cpu(media_tb_written));
+		printf("  Media TB Erased   : 0x%04x\n",
+			le16_to_cpu(media_tb_erased));
+
+		if (size > 12)
+			print_vu_event_data(size, (__u8 *)&data[12]);
+		break;
+
+	case TELEMETRY_STAT_SNAPSHOT_CLASS:
+		printf("  Statistic ID      : 0x%02x %s\n",
+			id, telemetry_stat_id_to_string(id));
+		print_stats_desc((struct telemetry_stats_desc *)data);
+		break;
+
+	default:
+		/*
+		 * printf("Unknown Event Class Type\n");
+		 * printf("Data : 0x");
+		 * for (j = 0; j < size; j++)
+		 *   printf("%x", data[j]);
+		 * printf("\n\n");
+		 */
+		break;
+	}
+}

--- a/plugins/ocp/ocp-telemetry-decode.h
+++ b/plugins/ocp/ocp-telemetry-decode.h
@@ -1,0 +1,493 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* Copyright (c) 2024 Western Digital Corporation or its affiliates.
+ *
+ * Authors: Jeff Lien <jeff.lien@wdc.com>,
+ */
+
+/*****************************************************************************
+ * Telemetry Statistics ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_STATISTIC_ID {
+	TELEMETRY_STAT_ID_OAC		= 0x1,  /* Outstanding Admin Commands */
+	TELEMETRY_STAT_ID_HWB		= 0x2,  /* Host Write Bandwidth       */
+	TELEMETRY_STAT_ID_GCWB		= 0x3,  /* Garbage Collection Write Bandwidth */
+	TELEMETRY_STAT_ID_AN		= 0x4,  /* Active Namespaces  */
+	TELEMETRY_STAT_ID_IWW		= 0x5,  /* Internal Write Workload  */
+	TELEMETRY_STAT_ID_IRW		= 0x6,  /* Internal Read Workload  */
+	TELEMETRY_STAT_ID_IWQD		= 0x7,  /* Internal Write Queue Depth  */
+	TELEMETRY_STAT_ID_IRQD		= 0x8,  /* Internal Read Queue Depth  */
+	TELEMETRY_STAT_ID_PTC		= 0x9,  /* Pending Trim LBA Count  */
+	TELEMETRY_STAT_ID_HTRC		= 0xA,  /* Host Trim LBA Request Count  */
+	TELEMETRY_STAT_ID_CNPS		= 0xB,  /* Current NVMe Power State  */
+	TELEMETRY_STAT_ID_CDPS		= 0xC,  /* Current DSSD Power State  */
+	TELEMETRY_STAT_ID_PFC		= 0xD,  /* Program Fail Count  */
+	TELEMETRY_STAT_ID_EFC		= 0xE,  /* Erase Fail Count  */
+	TELEMETRY_STAT_ID_RDW		= 0xF,  /* Read Disturb Write  */
+	TELEMETRY_STAT_ID_RW		= 0x10, /* Retention Writes  */
+	TELEMETRY_STAT_ID_WLW		= 0x11, /* Wear Leveling Writes  */
+	TELEMETRY_STAT_ID_RRW		= 0x12, /* Read Recovery Writes  */
+	TELEMETRY_STAT_ID_GCW		= 0x13, /* Garbage Collection Writes  */
+	TELEMETRY_STAT_ID_SCC		= 0x14, /* SRAM Correctable Count  */
+	TELEMETRY_STAT_ID_DCC		= 0x15, /* DRAM Uncorrectable Count  */
+	TELEMETRY_STAT_ID_SUC		= 0x16, /* SRAM Correctable Count  */
+	TELEMETRY_STAT_ID_DUC		= 0x17, /* DRAM Uncorrectable Count  */
+	TELEMETRY_STAT_ID_DIEC		= 0x18, /* Data Integrity Error Count  */
+	TELEMETRY_STAT_ID_RREC		= 0x19, /* Read Retry Error Count  */
+	TELEMETRY_STAT_ID_PEC		= 0x1A, /* PERST Events Count  */
+	TELEMETRY_STAT_ID_MAXDBB	= 0x1B, /* Max Die Bad Block  */
+	TELEMETRY_STAT_ID_MAXCBB	= 0x1C, /* Max NAND Channel Bad Block  */
+	TELEMETRY_STAT_ID_MINCBB	= 0x1D, /* Min NAND Channel Bad Block  */
+};
+
+static const char * const telemetry_stat_id_str[] = {
+	[TELEMETRY_STAT_ID_OAC]		= "Outstanding Admin Commands",
+	[TELEMETRY_STAT_ID_HWB]		= "Host Write Bandwidth",
+	[TELEMETRY_STAT_ID_GCWB]	= "Garbage Collection Write Bandwidth",
+	[TELEMETRY_STAT_ID_AN]		= "Active Namespaces",
+	[TELEMETRY_STAT_ID_IWW]		= "Internal Write Workload",
+	[TELEMETRY_STAT_ID_IRW]		= "Internal Read Workload",
+	[TELEMETRY_STAT_ID_IWQD]	= "Internal Write Queue Depth",
+	[TELEMETRY_STAT_ID_IRQD]	= "Internal Read Queue Depth",
+	[TELEMETRY_STAT_ID_PTC]		= "Pending Trim LBA Count",
+	[TELEMETRY_STAT_ID_HTRC]	= "Host Trim LBA Request Count",
+	[TELEMETRY_STAT_ID_CNPS]	= "Current NVMe Power State",
+	[TELEMETRY_STAT_ID_CDPS]	= "Current DSSD Power State",
+	[TELEMETRY_STAT_ID_PFC]		= "Program Fail Count",
+	[TELEMETRY_STAT_ID_EFC]		= "Erase Fail Count",
+	[TELEMETRY_STAT_ID_RDW]		= "Read Disturb Write",
+	[TELEMETRY_STAT_ID_RW]		= "Retention Writes",
+	[TELEMETRY_STAT_ID_WLW]		= "Wear Leveling Writes",
+	[TELEMETRY_STAT_ID_RRW]		= "Read Recovery Writes",
+	[TELEMETRY_STAT_ID_GCW]		= "Garbage Collection Writes",
+	[TELEMETRY_STAT_ID_SCC]		= "SRAM Correctable Count",
+	[TELEMETRY_STAT_ID_DCC]		= "DRAM Correctable Count",
+	[TELEMETRY_STAT_ID_SUC]		= "SRAM Uncorrectable Count",
+	[TELEMETRY_STAT_ID_DUC]		= "DRAM Uncorrectable Count",
+	[TELEMETRY_STAT_ID_DIEC]	= "Data Integrity Error Count",
+	[TELEMETRY_STAT_ID_RREC]	= "Read Retry Error Count",
+	[TELEMETRY_STAT_ID_PEC]		= "PERST Events Count",
+	[TELEMETRY_STAT_ID_MAXDBB]	= "Max Die Bad Block",
+	[TELEMETRY_STAT_ID_MAXCBB]	= "Max NAND Channel Bad Block",
+	[TELEMETRY_STAT_ID_MINCBB]	= "Min NAND Channel Bad Block",
+};
+
+/*****************************************************************************
+ * Telemetry FIFO Event Class ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_EVENT_CLASS_TYPE {
+	TELEMETRY_TIMESTAMP_CLASS      = 0x1,
+	TELEMETRY_PCIE_CLASS           = 0x2,
+	TELEMETRY_NVME_CLASS           = 0x3,
+	TELEMETRY_RESET_CLASS          = 0x4,
+	TELEMETRY_BOOT_SEQ_CLASS       = 0x5,
+	TELEMETRY_FW_ASSERT_CLASS      = 0x6,
+	TELEMETRY_TEMPERATURE_CLASS    = 0x7,
+	TELEMETRY_MEDIA_DBG_CLASS      = 0x8,
+	TELEMETRY_MEDIA_WEAR_CLASS     = 0x9,
+	TELEMETRY_STAT_SNAPSHOT_CLASS  = 0xA,
+};
+
+static const char * const telemetry_event_class_str[] = {
+	[TELEMETRY_TIMESTAMP_CLASS]		= "Timestamp Class",
+	[TELEMETRY_PCIE_CLASS]			= "PCIe Class",
+	[TELEMETRY_NVME_CLASS]			= "NVMe Class",
+	[TELEMETRY_RESET_CLASS]			= "Reset Class",
+	[TELEMETRY_BOOT_SEQ_CLASS]		= "Boot Sequence Class",
+	[TELEMETRY_FW_ASSERT_CLASS]		= "FW Assert Class",
+	[TELEMETRY_TEMPERATURE_CLASS]	= "Temperature Class",
+	[TELEMETRY_MEDIA_DBG_CLASS]		= "Media Debug Class",
+	[TELEMETRY_MEDIA_WEAR_CLASS]	= "Media Wear Class",
+	[TELEMETRY_STAT_SNAPSHOT_CLASS]	= "Statistic Snapshot Class",
+};
+
+/*****************************************************************************
+ * Telemetry Timestamp Class (01h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_TIMESTAMP_EVENT_ID {
+	TIMESTAMP_HOST_CMD_ISSUED      = 0x0000,
+	TIMESTAMP_SNAPSHOT             = 0x0001,
+	TIMESTAMP_POWER_ON_HOURS       = 0x0002,
+};
+
+static const char * const telemetry_timestamp_event_id_str[] = {
+	[TIMESTAMP_HOST_CMD_ISSUED]		= "Timestamp Host Cmd Issued",
+	[TIMESTAMP_SNAPSHOT]			= "Timestamp Snapshot",
+	[TIMESTAMP_POWER_ON_HOURS]		= "Timestamp Power on Hours",
+};
+
+/*****************************************************************************
+ * Telemetry PCIE Class (02h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_PCIE_EVENT_ID {
+	PCIE_LINK_UP                   = 0x0000,
+	PCIE_LINK_DOWN                 = 0x0001,
+	PCIE_ERROR_DETECTED            = 0x0002,
+	PCIE_PERST_ASSERTED            = 0x0003,
+	PCIE_PERST_DEASSERTED          = 0x0004,
+	PCIE_REFCLK_STABLE             = 0x0005,
+	PCIE_VMAIN_STABLE              = 0x0006,
+	PCIE_LINK_NEGOTIATED           = 0x0007,
+};
+
+static const char * const telemetry_pcie_event_id_str[] = {
+	[PCIE_LINK_UP]				= "PCIe Link Up",
+	[PCIE_LINK_DOWN]			= "PCIe Link Down",
+	[PCIE_ERROR_DETECTED]		= "PCIe Error Detected",
+	[PCIE_PERST_ASSERTED]		= "PCIe PERST Asserted",
+	[PCIE_PERST_DEASSERTED]		= "PCIe PERST Deasserted",
+	[PCIE_REFCLK_STABLE]		= "PCIe Refclk Stable",
+	[PCIE_VMAIN_STABLE]			= "PCIe Vmain Stable",
+	[PCIE_LINK_NEGOTIATED]		= "PCIe Link Negotiated",
+};
+
+enum TELEMETRY_PCIE_STATE_DATA {
+	PCIE_STATE_UNCHANGED           = 0x00,
+	PCIE_SPEED_CHANGED             = 0x01,
+	PCIE_WIDTH_CHANGED             = 0x02,
+};
+
+static const char * const telemetry_pcie_state_data_str[] = {
+	[PCIE_STATE_UNCHANGED]	= "PCIe State Unchained",
+	[PCIE_SPEED_CHANGED]	= "PCIe Speed Changed",
+	[PCIE_WIDTH_CHANGED]	= "PCIe Width Changed",
+};
+
+enum TELEMETRY_PCIE_SPEED_DATA {
+	PCIE_LINK_GEN1			= 0x01,
+	PCIE_LINK_GEN2			= 0x02,
+	PCIE_LINK_GEN3			= 0x03,
+	PCIE_LINK_GEN4			= 0x04,
+	PCIE_LINK_GEN5			= 0x05,
+	PCIE_LINK_GEN6			= 0x06,
+	PCIE_LINK_GEN7			= 0x07,
+};
+
+static const char * const telemetry_pcie_speed_data_str[] = {
+	[PCIE_LINK_GEN1]		= "PCIe Link Speed Gen1",
+	[PCIE_LINK_GEN2]		= "PCIe Link Speed Gen2",
+	[PCIE_LINK_GEN3]		= "PCIe Link Speed Gen3",
+	[PCIE_LINK_GEN4]		= "PCIe Link Speed Gen4",
+	[PCIE_LINK_GEN5]		= "PCIe Link Speed Gen5",
+	[PCIE_LINK_GEN6]		= "PCIe Link Speed Gen6",
+	[PCIE_LINK_GEN7]		= "PCIe Link Speed Gen7",
+};
+
+enum TELEMETRY_PCIE_WIDTH_DATA {
+	PCIE_LINK_X1			= 0x01,
+	PCIE_LINK_X2			= 0x02,
+	PCIE_LINK_X4			= 0x03,
+	PCIE_LINK_X8			= 0x04,
+	PCIE_LINK_X16			= 0x05,
+};
+
+static const char * const telemetry_pcie_width_data_str[] = {
+	[PCIE_LINK_X1]			= "PCIe Link Width x1",
+	[PCIE_LINK_X2]			= "PCIe Link Width x2",
+	[PCIE_LINK_X4]			= "PCIe Link Width x4",
+	[PCIE_LINK_X8]			= "PCIe Link Width x8",
+	[PCIE_LINK_X16]			= "PCIe Link Width x16",
+};
+
+/*****************************************************************************
+ * Telemetry NVMe Class (03h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_NVME_EVENT_ID {
+	CC_EN_0_TO_1					= 0x0000,
+	CC_EN_1_TO_0					= 0x0001,
+	CSTS_RDY_0_TO_1					= 0x0002,
+	CSTS_RDY_1_TO_0					= 0x0003,
+	NVME_EVENT_ID_RESERVED			= 0x0004,
+	CREATE_IO_QUEUE_PROCESSED		= 0x0005,
+	ADMIN_QUEUE_CMD_PROCESSED		= 0x0006,
+	ADMIN_QUEUE_NONZERO_STATUS		= 0x0007,
+	IO_QUEUE_NONZERO_STATUS			= 0x0008,
+	CSTS_CFS_0_TO_1					= 0x0009,
+	ADMIN_QUEUE_BASE_WRITTEN		= 0x000A,
+	CC_REGISTER_CHANGED				= 0x000B,
+	CSTS_REGISTER_CHANGED			= 0x000C,
+	DELETE_IO_QUEUE_PROCESSED		= 0x000D,
+};
+
+static const char * const telemetry_nvme_event_id_str[] = {
+	[CC_EN_0_TO_1]					= "CC.EN Transitions from 0 to 1",
+	[CC_EN_1_TO_0]					= "CC.EN Transitions from 1 to 0",
+	[CSTS_RDY_0_TO_1]				= "CSTS.RDY Transitions from 0 to 1",
+	[CSTS_RDY_1_TO_0]				= "CSTS.RDY Transitions from 1 to 0",
+	[NVME_EVENT_ID_RESERVED]		= "Reserved NVMe Event ID",
+	[CREATE_IO_QUEUE_PROCESSED]		= "Create IO SQ or CQ Command Processed",
+	[ADMIN_QUEUE_CMD_PROCESSED]		= "Other Admin Queue Command Processed",
+	[ADMIN_QUEUE_NONZERO_STATUS]	= "Admin Command Returned Non-zero Status",
+	[IO_QUEUE_NONZERO_STATUS]		= "IO Command Returned Non-zero Status",
+	[CSTS_CFS_0_TO_1]				= "CSTS.CFS Transitions from 0 to 1",
+	[ADMIN_QUEUE_BASE_WRITTEN]		= "Admin SQ or CQ Base Address Written",
+	[CC_REGISTER_CHANGED]			= "CC Register Changed",
+	[CSTS_REGISTER_CHANGED]			= "CTS Register Changed",
+	[DELETE_IO_QUEUE_PROCESSED]		= "Delete IO SQ or CQ Command Processed",
+};
+
+/*****************************************************************************
+ * Telemetry Reset Class (04h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_RESET_EVENT_ID {
+	PCIE_CONVENTIONAL_HOT_RESET		= 0x0000,
+	MAIN_POWER_CYCLE				= 0x0001,
+	PERST							= 0x0002,
+	PCIE_FUNCTION_LEVEL_RESET		= 0x0003,
+	NVME_SUBSYSTEM_RESET			= 0x0004,
+};
+
+static const char * const telemetry_reset_event_id_str[] = {
+	[PCIE_CONVENTIONAL_HOT_RESET]	= "PCIE Conventional Hot Reset",
+	[MAIN_POWER_CYCLE]				= "Main Power_Cycle",
+	[PERST]							= "PERST",
+	[PCIE_FUNCTION_LEVEL_RESET]		= "PCIE Function Level Reset",
+	[NVME_SUBSYSTEM_RESET]			= "NVMe Subsytem Reset",
+};
+
+/*****************************************************************************
+ * Telemetry Boot Sequence Class (05h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_BOOT_SEQ_EVENT_ID {
+	MAIN_FW_BOOT_COMPLETE			= 0x0000,
+	FTL_LOAD_FROM_NVM_COMPLETE		= 0x0001,
+	FTL_REBUILD_STARTED				= 0x0002,
+	FTL_REBUILD_COMPLETE			= 0x0003,
+};
+
+static const char * const telemetry_boot_seq_event_id_str[] = {
+	[MAIN_FW_BOOT_COMPLETE]			= "Main Firmware Boot Complete",
+	[FTL_LOAD_FROM_NVM_COMPLETE]	= "FTL Load from NVM Complete",
+	[FTL_REBUILD_STARTED]			= "FTL Rebuild Started",
+	[FTL_REBUILD_COMPLETE]			= "FTL Rebuild Complete",
+};
+
+/*****************************************************************************
+ * Telemetry Firmware Assert Class (06h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_FW_ASSERT_EVENT_ID {
+	ASSERT_NVME_CODE				= 0x0000,
+	ASSERT_MEDIA_CODE				= 0x0001,
+	ASSERT_SECURITY_CODE			= 0x0002,
+	ASSERT_BACKGROUND_CODE			= 0x0003,
+	FTL_REBUILD_FAILED				= 0x0004,
+	FTL_DATA_MISMATCH				= 0x0005,
+	ASSERT_OTHER_CODE				= 0x0006,
+};
+
+static const char * const telemetry_fw_assert_event_id_str[] = {
+	[ASSERT_NVME_CODE]				= "Assert in NVMe Processing Code",
+	[ASSERT_MEDIA_CODE]				= "Assert in Media Code",
+	[ASSERT_SECURITY_CODE]			= "Assert in Security Code",
+	[ASSERT_BACKGROUND_CODE]		= "Assert in Background Services Code",
+	[FTL_REBUILD_FAILED]			= "FTL Rebuild Failed",
+	[FTL_DATA_MISMATCH]				= "FTL Data Mismatch",
+	[ASSERT_OTHER_CODE]				= "FTL Other Code",
+};
+
+/*****************************************************************************
+ * Telemetry Temperature Class (07h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_TEMPERATURE_EVENT_ID {
+	COMPOSITE_TEMP_DECREASE			= 0x0000,
+	COMPOSITE_TEMP_INCREASE_WCTEMP	= 0x0001,
+	COMPOSITE_TEMP_INCREASE_CCTEMP	= 0x0002,
+};
+
+static const char * const telemetry_temperature_event_id_str[] = {
+	[COMPOSITE_TEMP_DECREASE]			= "Composite Temp Decreases to (WCTEMP-2)",
+	[COMPOSITE_TEMP_INCREASE_WCTEMP]	= "Composite Temp Increases to WCTEMP",
+	[COMPOSITE_TEMP_INCREASE_CCTEMP]	= "Composite Temp Increases to CCTEMP",
+};
+
+/*****************************************************************************
+ * Telemetry Media Debug Class (08h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_MEDIA_DEBUG_EVENT_ID {
+	XOR_RECOVERY_INVOKED			= 0x0000,
+	UNCORRECTABLE_MEDIA_ERROR		= 0x0001,
+	BAD_BLOCK_PROGRAM_ERROR			= 0x0002,
+	BAD_BLOCK_ERASE_ERROR			= 0x0003,
+	BAD_BLOCK_READ_ERROR			= 0x0004,
+	PLANE_FAILURE_EVENT				= 0x0005,
+};
+
+static const char * const telemetry_media_debug_event_id_str[] = {
+	[XOR_RECOVERY_INVOKED]			= "XOR Recovery Invoked",
+	[UNCORRECTABLE_MEDIA_ERROR]		= "Uncorrectable Media Error",
+	[BAD_BLOCK_PROGRAM_ERROR]		= "Block Marked Bad Due to Program Error",
+	[BAD_BLOCK_ERASE_ERROR]			= "Block Marked Bad Due to Erase Error",
+	[BAD_BLOCK_READ_ERROR]			= "Block Marked Bad Due to Read Error",
+	[PLANE_FAILURE_EVENT]			= "Plane Failure Event",
+};
+
+/*****************************************************************************
+ * Telemetry Media Wear Class (09h) Event ID's and Strings
+ *****************************************************************************/
+enum TELEMETRY_MEDIA_WEAR_EVENT_ID {
+	MEDIA_WEAR						= 0x0000,
+};
+
+static const char * const telemetry_media_wear_event_id_str[] = {
+	[MEDIA_WEAR]					= "Media Wear",
+};
+
+
+/*****************************************************************************
+ * Telemetry Data Structures
+ *****************************************************************************/
+#define TELEMETRY_HEADER_SIZE 512
+#define TELEMETRY_DATA_SIZE 1536
+#define TELEMETRY_BYTE_PER_BLOCK 512
+#define TELEMETRY_TRANSFER_SIZE 1024
+#define FILE_NAME_SIZE 2048
+
+enum TELEMETRY_TYPE {
+	TELEMETRY_TYPE_NONE       = 0,
+	TELEMETRY_TYPE_HOST       = 7,
+	TELEMETRY_TYPE_CONTROLLER = 8,
+	TELEMETRY_TYPE_HOST_0     = 9,
+	TELEMETRY_TYPE_HOST_1     = 10,
+};
+
+struct telemetry_initiated_log {
+	__u8  LogIdentifier;
+	__u8  Reserved1[4];
+	__u8  IEEE[3];
+	__le16 DataArea1LastBlock;
+	__le16 DataArea2LastBlock;
+	__le16 DataArea3LastBlock;
+	__u8  Reserved2[2];
+	__le32 DataArea4LastBlock;
+	__u8  Reserved3[361];
+	__u8  DataHostGenerationNumber;
+	__u8  CtlrDataAvailable;
+	__u8  DataCtlrGenerationNumber;
+	__u8  ReasonIdentifier[128];
+};
+
+struct telemetry_stats_desc {
+	__le16 id;
+	__u8 info;
+	__u8 ns_info;
+	__le16 size;
+	__le16 rsvd1;
+	__u8 data[];
+};
+
+struct telemetry_event_desc {
+	__u8 class;
+	__le16 id;
+	__u8 size;
+	__u8 data[];
+};
+
+struct event_fifo {
+	__le64	start;
+	__le64	size;
+};
+
+struct telemetry_data_area_1 {
+	__le16 major_version;
+	__le16 minor_version;
+	__u8   reserved1[4];
+	__le64 timestamp;
+	__u8   log_page_guid[16];
+	__u8   no_of_tps_supp;
+	__u8   tps;
+	__u8   reserved2[6];
+	__le64 sls;
+	__u8   reserved3[8];
+	__u8   fw_revision[8];
+	__u8   reserved4[32];
+	__le64 da1_stat_start;
+	__le64 da1_stat_size;
+	__le64 da2_stat_start;
+	__le64 da2_stat_size;
+	__u8   reserved5[32];
+	__u8   event_fifo_da[16];
+	struct event_fifo event_fifos[16];
+	__u8   reserved6[80];
+	__u8   smart_health_info[512];
+	__u8   smart_health_info_extended[512];
+};
+
+
+/************************************************************
+ * Telemetry Parsing Function Prototypes
+ ************************************************************/
+void print_vu_event_data(__u32 size, __u8 *data);
+void print_stats_desc(struct telemetry_stats_desc *stat_desc);
+void print_telemetry_fifo_event(__u8 class_type,
+		__u16 id, __u8 size, __u8 *data);
+
+
+/************************************************************
+ * Telemetry ID to String Conversion Functions
+ ************************************************************/
+static inline const char *arg_str(const char * const *strings,
+		size_t array_size, size_t idx)
+{
+	if (idx < array_size && strings[idx])
+		return strings[idx];
+	return "unrecognized";
+}
+
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#define ARGSTR(s, i) arg_str(s, ARRAY_SIZE(s), i)
+
+static inline const char *telemetry_stat_id_to_string(int stat_id)
+{
+	return ARGSTR(telemetry_stat_id_str, stat_id);
+}
+static inline const char *telemetry_event_class_to_string(int class)
+{
+	return ARGSTR(telemetry_event_class_str, class);
+}
+static inline const char *telemetry_ts_event_to_string(int event_id)
+{
+	return ARGSTR(telemetry_timestamp_event_id_str, event_id);
+}
+static inline const char *telemetry_pcie_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_pcie_event_id_str, event_id);
+}
+static inline const char *telemetry_pcie_state_data_to_string(int pcie_state)
+{
+	return ARGSTR(telemetry_pcie_state_data_str, pcie_state);
+}
+static inline const char *telemetry_pcie_speed_data_to_string(int pcie_speed)
+{
+	return ARGSTR(telemetry_pcie_speed_data_str, pcie_speed);
+}
+static inline const char *telemetry_pcie_width_data_to_string(int pcie_width)
+{
+	return ARGSTR(telemetry_pcie_width_data_str, pcie_width);
+}
+static inline const char *telemetry_nvme_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_nvme_event_id_str, event_id);
+}
+static inline const char *telemetry_reset_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_reset_event_id_str, event_id);
+}
+static inline const char *telemetry_boot_seq_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_boot_seq_event_id_str, event_id);
+}
+static inline const char *telemetry_fw_assert_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_fw_assert_event_id_str, event_id);
+}
+static inline const char *telemetry_temperature_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_temperature_event_id_str, event_id);
+}
+static inline const char *telemetry_media_debug_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_media_debug_event_id_str, event_id);
+}
+static inline const char *telemetry_media_wear_event_id_to_string(int event_id)
+{
+	return ARGSTR(telemetry_media_wear_event_id_str, event_id);
+}


### PR DESCRIPTION
This commit will provide the first phase of changes needed for parsing of OCP 2.5 Telemetry Log Pages 7h and 8h, Data Areas 1 and 2.  It will decode the predefined classes for Data Area 1 and 2 Statistics, and Event FIFO's.