### PR TITLE
Use libnvme helper to retrieve hostnqn/hostid

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -690,7 +690,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	char *hnqn = NULL, *hid = NULL;
 	char *context = NULL;
 	nvme_print_flags_t flags;
-	nvme_root_t r;
+	_cleanup_nvme_root_ nvme_root_t r = NULL;
 	nvme_host_t h;
 	nvme_ctrl_t c = NULL;
 	unsigned int verbose = 0;
@@ -749,7 +749,6 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 		if (errno != ENOENT)
 			fprintf(stderr, "Failed to scan topology: %s\n",
 				nvme_strerror(errno));
-		nvme_free_tree(r);
 		return ret;
 	}
 
@@ -894,7 +893,6 @@ out_free:
 	free(hid);
 	if (dump_config)
 		nvme_dump_config(r);
-	nvme_free_tree(r);
 
 	return ret;
 }
@@ -909,7 +907,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	char *config_file = PATH_NVMF_CONFIG;
 	char *context = NULL;
 	unsigned int verbose = 0;
-	nvme_root_t r;
+	_cleanup_nvme_root_ nvme_root_t r = NULL;
 	nvme_host_t h;
 	nvme_ctrl_t c;
 	int ret;
@@ -979,7 +977,6 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 		if (errno != ENOENT)
 			fprintf(stderr, "Failed to scan topology: %s\n",
 				nvme_strerror(errno));
-		nvme_free_tree(r);
 		return ret;
 	}
 	nvme_read_config(r, config_file);
@@ -1046,7 +1043,6 @@ out_free:
 	free(hid);
 	if (dump_config)
 		nvme_dump_config(r);
-	nvme_free_tree(r);
 	return -errno;
 }
 

--- a/fabrics.c
+++ b/fabrics.c
@@ -365,11 +365,15 @@ static int __discover(nvme_ctrl_t c, struct nvme_fabrics_config *defcfg,
 					nvme_free_ctrl(child);
 				}
 			} else if (errno == ENVME_CONNECT_ALREADY && !quiet) {
-				char *traddr = log->entries[i].traddr;
+				const char *subnqn = log->entries[i].subnqn;
+				const char *trtype = nvmf_trtype_str(log->entries[i].trtype);
+				const char *traddr = log->entries[i].traddr;
+				const char *trsvcid = log->entries[i].trsvcid;
 
 				fprintf(stderr,
-					"traddr=%s is already connected\n",
-					traddr);
+					"already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s\n",
+					nvme_host_get_hostnqn(h), subnqn,
+					trtype, traddr, trsvcid);
 			}
 		}
 	}

--- a/fabrics.c
+++ b/fabrics.c
@@ -690,6 +690,12 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	}
 	if (context)
 		nvme_root_set_application(r, context);
+
+	if (!nvme_read_config(r, config_file))
+		json_config = true;
+	if (!nvme_read_volatile_config(r))
+		json_config = true;
+
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
@@ -698,11 +704,6 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 				nvme_strerror(errno));
 		return ret;
 	}
-
-	if (!nvme_read_config(r, config_file))
-		json_config = true;
-	if (!nvme_read_volatile_config(r))
-		json_config = true;
 
 	ret = nvme_host_get_ids(r, hostnqn, hostid, &hnqn, &hid);
 	if (ret < 0)
@@ -911,6 +912,10 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	}
 	if (context)
 		nvme_root_set_application(r, context);
+
+	nvme_read_config(r, config_file);
+	nvme_read_volatile_config(r);
+
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
@@ -919,8 +924,6 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 				nvme_strerror(errno));
 		return ret;
 	}
-	nvme_read_config(r, config_file);
-	nvme_read_volatile_config(r);
 
 	ret = nvme_host_get_ids(r, hostnqn, hostid, &hnqn, &hid);
 	if (ret < 0)
@@ -1206,6 +1209,9 @@ int nvmf_config(const char *desc, int argc, char **argv)
 			nvme_strerror(errno));
 		return -errno;
 	}
+
+	nvme_read_config(r, config_file);
+
 	if (scan_tree) {
 		nvme_root_skip_namespaces(r);
 		ret = nvme_scan_topology(r, NULL, NULL);
@@ -1217,7 +1223,6 @@ int nvmf_config(const char *desc, int argc, char **argv)
 			return ret;
 		}
 	}
-	nvme_read_config(r, config_file);
 
 	if (modify_config) {
 		nvme_host_t h;

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = fce9d7f977cf08e196ee7a3085a59393b46663f9
+revision = f39802f9e6a9bc90cd7d45fcb1a5195d1890e74d
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
There are several  places to lookup the default hostnqn/hostid. Add a helper which implements a canonical way to do this.

Fixes: #https://github.com/linux-nvme/nvme-cli/issues/1956
Depends: https://github.com/linux-nvme/libnvme/pull/857