### PR TITLE
nvme-print: check locale to use temperatures in degrees fahrenheit

### DIFF
--- a/Documentation/nvme-smart-log.txt
+++ b/Documentation/nvme-smart-log.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme smart-log' <device> [--namespace-id=<nsid> | -n <nsid>]
-			[--raw-binary | -b] [--fahrenheit | -f]
+			[--raw-binary | -b]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
 
 DESCRIPTION
@@ -37,10 +37,6 @@ OPTIONS
 -b::
 --raw-binary::
 	Print the raw SMART log buffer to stdout.
-
--f::
---fahrenheit::
-	Print the temperatures in degrees fahrenheit.
 
 -o <fmt>::
 --output-format=<fmt>::

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -998,8 +998,6 @@ _nvme () {
 			-b':alias to --raw-binary'
 			--verbose':show infos verbosely'
 			-v':alias to --verbose'
-			--fahrenheit'show temperatures in degrees fahrenheit'
-			-f':alias to --fahrenheit'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme smart-log options" _smartlog

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -149,7 +149,7 @@ nvme_list_opts () {
 			;;
 		"smart-log")
 		opts+=" --namespace-id= -n --raw-binary -b \
-			--output-format= -o --verbose -v --fahrenheit -f"
+			--output-format= -o --verbose -v"
 			;;
 		"ana-log")
 		opts+=" --output-format -o"

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -3297,7 +3297,7 @@ static void json_feature_show_fields_temp_thresh(struct json_object *r, unsigned
 	obj_add_uint(r, "Threshold Temperature Select (TMPSEL)", field);
 	obj_add_str(r, "TMPSEL description", nvme_feature_temp_sel_to_string(field));
 
-	sprintf(json_str, "%ld Celsius", kelvin_to_celsius(result & 0xffff));
+	sprintf(json_str, "%s", nvme_degrees_string(result & 0xffff));
 	obj_add_str(r, "Temperature Threshold (TMPTH)", json_str);
 
 	sprintf(json_str, "%u K", result & 0xffff);
@@ -3467,13 +3467,13 @@ static void json_feature_show_fields_hctm(struct json_object *r, unsigned int re
 	sprintf(json_str, "%u K", result >> 16);
 	obj_add_str(r, "Thermal Management Temperature 1 (TMT1)", json_str);
 
-	sprintf(json_str, "%ld Celsius", kelvin_to_celsius(result >> 16));
+	sprintf(json_str, "%s", nvme_degrees_string(result >> 16));
 	obj_add_str(r, "TMT1 celsius", json_str);
 
 	sprintf(json_str, "%u K", result & 0xffff);
 	obj_add_str(r, "Thermal Management Temperature 2", json_str);
 
-	sprintf(json_str, "%ld Celsius", kelvin_to_celsius(result & 0xffff));
+	sprintf(json_str, "%s", nvme_degrees_string(result & 0xffff));
 	obj_add_str(r, "TMT2 celsius", json_str);
 }
 

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3883,7 +3883,6 @@ static void stdout_smart_log(struct nvme_smart_log *smart, unsigned int nsid, co
 	__u16 temperature = smart->temperature[1] << 8 | smart->temperature[0];
 	int i;
 	bool human = stdout_print_ops.flags & VERBOSE;
-	bool fahrenheit = !!(stdout_print_ops.flags & FAHRENHEIT);
 
 	printf("Smart Log for NVME device:%s namespace-id:%x\n", devname, nsid);
 	printf("critical_warning			: %#x\n", smart->critical_warning);
@@ -3904,7 +3903,7 @@ static void stdout_smart_log(struct nvme_smart_log *smart, unsigned int nsid, co
 	}
 
 	printf("temperature				: %s (%u K)\n",
-	       nvme_degrees_string(temperature, fahrenheit), temperature);
+	       nvme_degrees_string(temperature), temperature);
 	printf("available_spare				: %u%%\n", smart->avail_spare);
 	printf("available_spare_threshold		: %u%%\n", smart->spare_thresh);
 	printf("percentage_used				: %u%%\n", smart->percent_used);
@@ -3941,7 +3940,7 @@ static void stdout_smart_log(struct nvme_smart_log *smart, unsigned int nsid, co
 		if (!temperature)
 			continue;
 		printf("Temperature Sensor %d			: %s (%u K)\n", i + 1,
-		       nvme_degrees_string(temperature, fahrenheit), temperature);
+		       nvme_degrees_string(temperature), temperature);
 	}
 
 	printf("Thermal Management T1 Trans Count	: %u\n",

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1968,15 +1968,15 @@ static void stdout_id_ctrl_apsta(__u8 apsta)
 
 static void stdout_id_ctrl_wctemp(__le16 wctemp)
 {
-	printf(" [15:0] : %ld °C (%u K)\tWarning Composite Temperature Threshold (WCTEMP)\n",
-	       kelvin_to_celsius(le16_to_cpu(wctemp)), le16_to_cpu(wctemp));
+	printf(" [15:0] : %s (%u K)\tWarning Composite Temperature Threshold (WCTEMP)\n",
+	       nvme_degrees_string(le16_to_cpu(wctemp)), le16_to_cpu(wctemp));
 	printf("\n");
 }
 
 static void stdout_id_ctrl_cctemp(__le16 cctemp)
 {
-	printf(" [15:0] : %ld °C (%u K)\tCritical Composite Temperature Threshold (CCTEMP)\n",
-	       kelvin_to_celsius(le16_to_cpu(cctemp)), le16_to_cpu(cctemp));
+	printf(" [15:0] : %s (%u K)\tCritical Composite Temperature Threshold (CCTEMP)\n",
+	       nvme_degrees_string(le16_to_cpu(cctemp)), le16_to_cpu(cctemp));
 	printf("\n");
 }
 
@@ -2025,15 +2025,15 @@ static void stdout_id_ctrl_hctma(__le16 ctrl_hctma)
 
 static void stdout_id_ctrl_mntmt(__le16 mntmt)
 {
-	printf(" [15:0] : %ld °C (%u K)\tMinimum Thermal Management Temperature (MNTMT)\n",
-	       kelvin_to_celsius(le16_to_cpu(mntmt)), le16_to_cpu(mntmt));
+	printf(" [15:0] : %s (%u K)\tMinimum Thermal Management Temperature (MNTMT)\n",
+	       nvme_degrees_string(le16_to_cpu(mntmt)), le16_to_cpu(mntmt));
 	printf("\n");
 }
 
 static void stdout_id_ctrl_mxtmt(__le16 mxtmt)
 {
-	printf(" [15:0] : %ld °C (%u K)\tMaximum Thermal Management Temperature (MXTMT)\n",
-	       kelvin_to_celsius(le16_to_cpu(mxtmt)), le16_to_cpu(mxtmt));
+	printf(" [15:0] : %s (%u K)\tMaximum Thermal Management Temperature (MXTMT)\n",
+	       nvme_degrees_string(le16_to_cpu(mxtmt)), le16_to_cpu(mxtmt));
 	printf("\n");
 }
 
@@ -4452,8 +4452,8 @@ static void stdout_feature_show_fields(enum nvme_features_id fid,
 		field = (result & 0x000f0000) >> 16;
 		printf("\tThreshold Temperature Select (TMPSEL): %u - %s\n",
 		       field, nvme_feature_temp_sel_to_string(field));
-		printf("\tTemperature Threshold         (TMPTH): %ld °C (%u K)\n",
-		       kelvin_to_celsius(result & 0x0000ffff), result & 0x0000ffff);
+		printf("\tTemperature Threshold         (TMPTH): %s (%u K)\n",
+		       nvme_degrees_string(result & 0x0000ffff), result & 0x0000ffff);
 		break;
 	case NVME_FEAT_FID_ERR_RECOVERY:
 		printf("\tDeallocated or Unwritten Logical Block Error Enable (DULBE): %s\n",
@@ -4518,10 +4518,10 @@ static void stdout_feature_show_fields(enum nvme_features_id fid,
 		printf("\tKeep Alive Timeout (KATO) in milliseconds: %u\n", result);
 		break;
 	case NVME_FEAT_FID_HCTM:
-		printf("\tThermal Management Temperature 1 (TMT1) : %u K (%ld °C)\n",
-		       result >> 16, kelvin_to_celsius(result >> 16));
-		printf("\tThermal Management Temperature 2 (TMT2) : %u K (%ld °C)\n",
-		       result & 0x0000ffff, kelvin_to_celsius(result & 0x0000ffff));
+		printf("\tThermal Management Temperature 1 (TMT1) : %u K (%s)\n",
+		       result >> 16, nvme_degrees_string(result >> 16));
+		printf("\tThermal Management Temperature 2 (TMT2) : %u K (%s)\n",
+		       result & 0x0000ffff, nvme_degrees_string(result & 0x0000ffff));
 		break;
 	case NVME_FEAT_FID_NOPSC:
 		printf("\tNon-Operational Power State Permissive Mode Enable (NOPPME): %s\n",

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -813,8 +813,10 @@ const char *nvme_degrees_string(long t)
 	if (fahrenheit)
 		val = kelvin_to_fahrenheit(t);
 
-	sprintf(str, "%ld °%s", val, fahrenheit ? "F" : "C");
-
+	if (nvme_is_output_format_json())
+		sprintf(str, "%ld %s", val, fahrenheit ? "Fahrenheit" : "Celsius");
+	else
+		sprintf(str, "%ld °%s", val, fahrenheit ? "F" : "C");
 
 	return str;
 }

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -322,5 +322,5 @@ void nvme_show_finish(void);
 bool nvme_is_fabrics_reg(int offset);
 bool nvme_registers_cmbloc_support(__u32 cmbsz);
 bool nvme_registers_pmrctl_ready(__u32 pmrctl);
-const char *nvme_degrees_string(long t, bool fahrenheit);
+const char *nvme_degrees_string(long t);
 #endif /* NVME_PRINT_H */

--- a/nvme.c
+++ b/nvme.c
@@ -216,7 +216,6 @@ static const char *doper = "directive operation";
 static const char *dry = "show command instead of sending";
 static const char *dspec_w_dtype = "directive specification associated with directive type";
 static const char *dtype = "directive type";
-static const char *fahrenheit = "show temperatures in degrees fahrenheit";
 static const char *force_unit_access = "force device to commit data before command completes";
 static const char *human_readable_directive = "show directive in readable format";
 static const char *human_readable_identify = "show identify in readable format";
@@ -550,7 +549,6 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 		__u32	namespace_id;
 		bool	raw_binary;
 		bool	human_readable;
-		bool	fahrenheit;
 	};
 
 	struct config cfg = {
@@ -562,8 +560,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	NVME_ARGS(opts,
 		  OPT_UINT("namespace-id",   'n', &cfg.namespace_id,   namespace),
 		  OPT_FLAG("raw-binary",     'b', &cfg.raw_binary,     raw_output),
-		  OPT_FLAG("human-readable", 'H', &cfg.human_readable, human_readable_info),
-		  OPT_FLAG("fahrenheit",     'f', &cfg.fahrenheit,     fahrenheit));
+		  OPT_FLAG("human-readable", 'H', &cfg.human_readable, human_readable_info));
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
@@ -580,9 +577,6 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 
 	if (cfg.human_readable)
 		flags |= VERBOSE;
-
-	if (cfg.fahrenheit)
-		flags |= FAHRENHEIT;
 
 	smart_log = nvme_alloc(sizeof(*smart_log));
 	if (!smart_log)

--- a/nvme.h
+++ b/nvme.h
@@ -38,7 +38,6 @@ enum nvme_print_flags {
 	JSON		= 1 << 1,	/* display in json format */
 	VS		= 1 << 2,	/* hex dump vendor specific data areas */
 	BINARY		= 1 << 3,	/* binary dump raw bytes */
-	FAHRENHEIT	= 1 << 4,	/* show temperatures in degrees fahrenheit */
 };
 
 typedef uint32_t nvme_print_flags_t;


### PR DESCRIPTION
Delete the fahrenheit option separately.