### PR TITLE
nvme: use _cleanup_free_ type buffer for get-feature command

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4650,8 +4650,8 @@ static int get_feature_id_changed(struct nvme_dev *dev, struct feat_cfg cfg,
 	int err_def = 0;
 	__u32 result;
 	__u32 result_def;
-	void *buf = NULL;
-	void *buf_def = NULL;
+	_cleanup_free_ void *buf = NULL;
+	_cleanup_free_ void *buf_def = NULL;
 
 	if (changed)
 		cfg.sel = 0;
@@ -4669,9 +4669,6 @@ static int get_feature_id_changed(struct nvme_dev *dev, struct feat_cfg cfg,
 	if (err || !changed || err_def || result != result_def ||
 	    (buf && buf_def && !strcmp(buf, buf_def)))
 		get_feature_id_print(cfg, err, result, buf);
-
-	free(buf);
-	free(buf_def);
 
 	return err;
 }


### PR DESCRIPTION
Reduce the buffer free calls.