### PR TITLE
ocp-nvme: set UUID index for eol-plp-failure-mode command to get

### DIFF
--- a/Documentation/nvme-ocp-eol-plp-failure-mode.txt
+++ b/Documentation/nvme-ocp-eol-plp-failure-mode.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 [verse]
 'nvme ocp eol-plp-failure-mode' <device> [--mode=<mode> | -m <mode>]
 			[--no-uuid | -n] [--save | -s]
-			[--sel=<select> | -s <select>]
+			[--sel=<select> | -S <select>]
 
 DESCRIPTION
 -----------

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -766,7 +766,7 @@ static int eol_plp_failure_mode(int argc, char **argv, struct command *cmd,
 			   "No argument prints current mode.";
 	const char *mode = "[0-3]: default/rom/wtm/normal";
 	const char *save = "Specifies that the controller shall save the attribute";
-	const char *sel = "[0-3,8]: current/default/saved/supported/changed";
+	const char *sel = "[0-3]: current/default/saved/supported";
 	const __u32 nsid = 0;
 	const __u8 fid = 0xc2;
 	struct nvme_dev *dev;


### PR DESCRIPTION
The value required from OCP version 2.0 for get feature command also.