### PR TITLE
nvme: fix verbose logging for certain commands

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -578,7 +578,7 @@ static int get_smart_log(int argc, char **argv, struct command *cmd, struct plug
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	if (cfg.fahrenheit)
@@ -1091,7 +1091,7 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	list_head_init(&log_pages);
@@ -2432,7 +2432,7 @@ static int sanitize_log(int argc, char **argv, struct command *command, struct p
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	sanitize_log = nvme_alloc(sizeof(*sanitize_log));
@@ -2481,7 +2481,7 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *cm
 		return err;
 	}
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	fid_support_log = nvme_alloc(sizeof(*fid_support_log));
@@ -2530,7 +2530,7 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 		return err;
 	}
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	mi_cmd_support_log = nvme_alloc(sizeof(*mi_cmd_support_log));
@@ -3455,7 +3455,7 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	if (cfg.vendor_specific)
 		flags |= VS;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	ctrl = nvme_alloc(sizeof(*ctrl));
@@ -3775,7 +3775,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 	if (cfg.vendor_specific)
 		flags |= VS;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	if (!cfg.namespace_id) {
@@ -3847,7 +3847,7 @@ static int cmd_set_independent_id_ns(int argc, char **argv, struct command *cmd,
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	if (!cfg.namespace_id) {
@@ -4001,7 +4001,7 @@ static int id_uuid(int argc, char **argv, struct command *cmd, struct plugin *pl
 	if (cfg.raw_binary)
 		flags = BINARY;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	uuid_list = nvme_alloc(sizeof(*uuid_list));
@@ -4241,7 +4241,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *cmd, struct 
 		return err;
 	}
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	caps = nvme_alloc(sizeof(*caps));
@@ -5440,7 +5440,7 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 		return err;
 	}
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	bar = mmap_registers(dev, false);
@@ -5716,7 +5716,7 @@ static int get_register(int argc, char **argv, struct command *cmd, struct plugi
 		return err;
 	}
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 
 	bar = mmap_registers(dev, false);
@@ -8509,7 +8509,7 @@ static int dir_receive(int argc, char **argv, struct command *cmd, struct plugin
 	if (err)
 		return err;
 
-	if (cfg.human_readable)
+	if (cfg.human_readable || argconfig_parse_seen(opts, "verbose"))
 		flags |= VERBOSE;
 	if (cfg.raw_binary)
 		flags = BINARY;

--- a/util/logging.c
+++ b/util/logging.c
@@ -92,15 +92,14 @@ int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
 	struct timeval end;
 	int err;
 
-	if (log_level >= LOG_INFO)
+	if (log_level >= LOG_DEBUG)
 		gettimeofday(&start, NULL);
 
 	err = ioctl(fd, ioctl_cmd, cmd);
 
-	if (log_level >= LOG_INFO) {
+	if (log_level >= LOG_DEBUG) {
 		gettimeofday(&end, NULL);
-		if (log_level >= LOG_DEBUG)
-			nvme_show_command(cmd, err);
+		nvme_show_command(cmd, err);
 		nvme_show_latency(start, end);
 	}
 
@@ -118,16 +117,15 @@ int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
 	struct timeval end;
 	int err;
 
-	if (log_level >= LOG_INFO)
+	if (log_level >= LOG_DEBUG)
 		gettimeofday(&start, NULL);
 
 
 	err = ioctl(fd, ioctl_cmd, cmd);
 
-	if (log_level >= LOG_INFO) {
+	if (log_level >= LOG_DEBUG) {
 		gettimeofday(&end, NULL);
-		if (log_level >= LOG_DEBUG)
-			nvme_show_command64(cmd, err);
+		nvme_show_command64(cmd, err);
 		nvme_show_latency(start, end);
 	}
 


### PR DESCRIPTION
Verbose logging for certain nvme commands like id-ctrl, id-ns, smart-log, sanitize-log, etc. does not print anything additional or verbose compared to the regular output. These commands already implement a human-readable option which works fine, but it is the verbose option that is broken. So fix the verbose option here to ensure it is on par with the human-readable option. Later if required, we can eliminate any one of these options for these commands to avoid redundancy.