### PR TITLE
nvme-print: add new field added in TP4090

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -269,10 +269,11 @@ static void json_nvme_id_ns(struct nvme_id_ns *ns, unsigned int nsid,
 		obj_add_int(r, "nsattr", ns->nsattr);
 		obj_add_int(r, "nvmsetid", le16_to_cpu(ns->nvmsetid));
 
-		if (ns->nsfeat & 0x10) {
+		if (ns->nsfeat & 0x30) {
 			obj_add_int(r, "npwg", le16_to_cpu(ns->npwg));
 			obj_add_int(r, "npwa", le16_to_cpu(ns->npwa));
-			obj_add_int(r, "npdg", le16_to_cpu(ns->npdg));
+			if (ns->nsfeat & 0x10)
+				obj_add_int(r, "npdg", le16_to_cpu(ns->npdg));
 			obj_add_int(r, "npda", le16_to_cpu(ns->npda));
 			obj_add_int(r, "nows", le16_to_cpu(ns->nows));
 		}
@@ -3063,6 +3064,8 @@ static void json_nvme_nvm_id_ns(struct nvme_nvm_id_ns *nvm_ns,
 
 		array_add_obj(elbafs, elbaf);
 	}
+	if (ns->nsfeat & 0x20)
+		obj_add_int(r, "npdgl", le32_to_cpu(nvm_ns->npdgl));
 
 	json_print(r);
 }

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 926456937807434a716624cee4ee01e6add3b74d
+revision = fce9d7f977cf08e196ee7a3085a59393b46663f9
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
As per TP4090, a new field support is added as NPDGL (Namespace Preferred Deallocate Granularity Large) and so the bit-field of NSFEAT, OPTPERF get extended by 1 bit.


Reviewed-by: Steven Seungcheol Lee <sc108.lee@samsung.com>
Reviewed-by: Mohit Kapoor <mohit.kap@samsung.com>