### PR TITLE
Add correct git version to AppImage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -17,6 +17,13 @@ jobs:
       image: ghcr.io/igaw/linux-nvme/debian:latest
     steps:
      - uses: actions/checkout@v4
+       with:
+         fetch-depth: 0
+     - name: fixup permissions
+       env:
+         GITHUB_WORKSPACE: ${{ github.workspace }}
+       run: |
+         git config --global --add safe.directory "${GITHUB_WORKSPACE}"
      - name: build
        run: |
          scripts/build.sh appimage

--- a/meson.build
+++ b/meson.build
@@ -352,7 +352,8 @@ if meson.version().version_compare('>=0.53.0')
     }
     summary(dep_dict, section: 'Dependencies')
     conf_dict = {
-        'pdc enabled':       get_option('pdc-enabled')
+        'git version':       conf.get('GIT_VERSION'),
+        'pdc enabled':       get_option('pdc-enabled'),
     }
     summary(conf_dict, section: 'Configuration')
 endif

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,6 +23,7 @@ usage() {
     echo "  appimage            build AppImage target"
     echo "  distro              build libnvme and nvme-cli separately"
     echo "  docs                build documentation"
+    echo "  static              build a static binary"
     echo ""
     echo "configs with muon:"
     echo "  [default]           minimal static build"
@@ -123,6 +124,16 @@ config_meson_docs() {
         -Ddocs-build=true                       \
         --force-fallback-for=libnvme            \
         -Dlibnvme:werror=false                  \
+        "${BUILDDIR}"
+}
+
+config_meson_static() {
+    CC="${CC}" "${MESON}" setup                 \
+        --buildtype=release                     \
+        --default-library=static                \
+        --wrap-mode=forcefallback               \
+        -Dc_link_args="-static"                 \
+        -Dlibnvme:keyutils=disabled             \
         "${BUILDDIR}"
 }
 


### PR DESCRIPTION
The github checkout action is trying to be smart and breaks `git describe` in the process. Checkout the complete history so that we can do a `git describe`. Maybe there is a better strategy to get an usable git version string into the build. But for the time being, let's do the simplest thing and clone the complete repo.

Fixes: #2410 