### PR TITLE
build: use official download action

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -43,11 +43,10 @@ jobs:
     needs: build-appimage
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'linux-nvme/nvme-cli' }}
     steps:
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@v6
+      - uses: actions/download-artifact@v4
         with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: success
+          name: AppImage
+          path: AppImage
       - name: FTP Deployer
         uses: sand4rt/ftp-deployer@v1.8
         with:


### PR DESCRIPTION
There is no point in using 3rd party actions for downloading the artifacts. Let's use the official one.