### PR TITLE
wdc: Update and refactor the C0h log page parsing

### DIFF
--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.8.1"
+#define WDC_PLUGIN_VERSION   "2.9.0"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
Add OCP 2.5 fields
Create common functions to get and parse the
different variations of the C0 log page.