### PR TITLE
util: remove unnecessary NULL check in cleanup_nvme_root()

### DIFF
--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -38,8 +38,7 @@ static inline void cleanup_fd(int *fd)
 
 static inline void cleanup_nvme_root(nvme_root_t *r)
 {
-	if (r)
-		nvme_free_tree(*r);
+	nvme_free_tree(*r);
 }
 #define _cleanup_nvme_root_ __cleanup__(cleanup_nvme_root)
 


### PR DESCRIPTION
`cleanup_nvme_root()` is checking whether the passed pointer is non-NULL, but since the pointer is to a local variable, this will always be true. Therefore, remove the check and always call `nvme_free_tree()`.