### PR TITLE
fabrics: update printing an error for ENOENT too

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1106,6 +1106,14 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
+		/*
+		 * Do not report an error when the modules are not
+		 * loaded, this allows the user to unconditionally call
+		 * disconnect.
+		 */
+		if (errno == ENOENT)
+			return 0;
+
 		fprintf(stderr, "Failed to scan topology: %s\n",
 			nvme_strerror(errno));
 		return -errno;
@@ -1174,9 +1182,16 @@ int nvmf_disconnect_all(const char *desc, int argc, char **argv)
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		if (errno != ENOENT)
-			fprintf(stderr, "Failed to scan topology: %s\n",
-				nvme_strerror(errno));
+		/*
+		 * Do not report an error when the modules are not
+		 * loaded, this allows the user to unconditionally call
+		 * disconnect.
+		 */
+		if (errno == ENOENT)
+			return 0;
+
+		fprintf(stderr, "Failed to scan topology: %s\n",
+			nvme_strerror(errno));
 		return -errno;
 	}
 

--- a/fabrics.c
+++ b/fabrics.c
@@ -738,9 +738,8 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		if (errno != ENOENT)
-			fprintf(stderr, "Failed to scan topology: %s\n",
-				nvme_strerror(errno));
+		fprintf(stderr, "Failed to scan topology: %s\n",
+			nvme_strerror(errno));
 		return ret;
 	}
 
@@ -958,9 +957,8 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		if (errno != ENOENT)
-			fprintf(stderr, "Failed to scan topology: %s\n",
-				nvme_strerror(errno));
+		fprintf(stderr, "Failed to scan topology: %s\n",
+			nvme_strerror(errno));
 		return ret;
 	}
 
@@ -1107,9 +1105,8 @@ int nvmf_disconnect(const char *desc, int argc, char **argv)
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		if (errno != ENOENT)
-			fprintf(stderr, "Failed to scan topology: %s\n",
-				nvme_strerror(errno));
+		fprintf(stderr, "Failed to scan topology: %s\n",
+			nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
 	}
@@ -1255,9 +1252,8 @@ int nvmf_config(const char *desc, int argc, char **argv)
 		nvme_root_skip_namespaces(r);
 		ret = nvme_scan_topology(r, NULL, NULL);
 		if (ret < 0) {
-			if (errno != ENOENT)
-				fprintf(stderr, "Failed to scan topology: %s\n",
-					nvme_strerror(errno));
+			fprintf(stderr, "Failed to scan topology: %s\n",
+				nvme_strerror(errno));
 			nvme_free_tree(r);
 			return ret;
 		}
@@ -1409,9 +1405,8 @@ int nvmf_dim(const char *desc, int argc, char **argv)
 	nvme_root_skip_namespaces(r);
 	ret = nvme_scan_topology(r, NULL, NULL);
 	if (ret < 0) {
-		if (errno != ENOENT)
-			fprintf(stderr, "Failed to scan topology: %s\n",
-				nvme_strerror(errno));
+		fprintf(stderr, "Failed to scan topology: %s\n",
+			nvme_strerror(errno));
 		nvme_free_tree(r);
 		return ret;
 	}

--- a/nvme.c
+++ b/nvme.c
@@ -3331,8 +3331,7 @@ static int list_subsys(int argc, char **argv, struct command *cmd,
 
 	err = nvme_scan_topology(r, filter, (void *)devname);
 	if (err) {
-		if (errno != ENOENT)
-			nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
+		nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
 		return -errno;
 	}
 
@@ -3370,8 +3369,7 @@ static int list(int argc, char **argv, struct command *cmd, struct plugin *plugi
 	}
 	err = nvme_scan_topology(r, NULL, NULL);
 	if (err < 0) {
-		if (errno != ENOENT)
-			nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
+		nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
 		return err;
 	}
 
@@ -9588,8 +9586,7 @@ static int show_topology_cmd(int argc, char **argv, struct command *command, str
 
 	err = nvme_scan_topology(r, NULL, NULL);
 	if (err < 0) {
-		if (errno != ENOENT)
-			nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
+		nvme_show_error("Failed to scan topology: %s", nvme_strerror(errno));
 		nvme_free_tree(r);
 		return err;
 	}


### PR DESCRIPTION
Many nvme commands such as discover, connect, connect-all, etc. simply return to the prompt without printing any useful error message when the respective nvme driver modules are not loaded in the kernel. This is because nothing gets printed when nvme_scan_topology() returns an ENOENT due to missing nvme system files stemming from not loading the appropriate nvme modules. Fix the same.