### PR TITLE
nvme: use proper mask to get correct lbafu value

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -6264,8 +6264,8 @@ static int format_cmd(int argc, char **argv, struct command *cmd, struct plugin 
 	struct nvme_format_nvm_args args = {
 		.args_size	= sizeof(args),
 		.nsid		= cfg.namespace_id,
-		.lbafu		= (cfg.lbaf & NVME_NS_FLBAS_HIGHER_MASK) >> 4,
-		.lbaf		= cfg.lbaf & NVME_NS_FLBAS_LOWER_MASK,
+		.lbafu		= (cfg.lbaf >> 4) & 0x3,
+		.lbaf		= cfg.lbaf & 0xf,
 		.mset		= cfg.ms,
 		.pi		= cfg.pi,
 		.pil		= cfg.pil,


### PR DESCRIPTION
The NVME_NS_FLBAS_HIGHER/LOWER_MASK is used to get the format index value from Formatted LBA Size (FLBAS) field of Identify Namespace Data Structure. But, We are not getting the proper lbafu value while using the same macro on user passed format index value. So, use the proper mask to get the correct lbafu value.