### PR TITLE
nvme: use argconfig_parse_seen to check the parameter

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -6415,7 +6415,8 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 		 * should use the buffer method if the value exceeds this
 		 * length.
 		 */
-		if (cfg.feature_id == NVME_FEAT_FID_TIMESTAMP && cfg.value) {
+		if (cfg.feature_id == NVME_FEAT_FID_TIMESTAMP &&
+		    argconfig_parse_seen(opts, "value")) {
 			memcpy(buf, &cfg.value, NVME_FEAT_TIMESTAMP_DATA_SIZE);
 		} else {
 			if (strlen(cfg.file))


### PR DESCRIPTION
The value of NVME_FEAT_FID_TIMESTAMP cannot be set to 0 through 'set-feature -f 0xe -v 0'
Using argconfig_parse_seen() can fix this issue