### PR TITLE
plugins/virtium: use time_t for time_stamp values

### DIFF
--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -32,14 +32,14 @@ static char vt_default_log_file_name[256];
 struct vtview_log_header {
 	char				path[256];
 	char				test_name[256];
-	long				time_stamp;
+	time_t				time_stamp;
 	struct nvme_id_ctrl		raw_ctrl;
 	struct nvme_firmware_slot	raw_fw;
 };
 
 struct vtview_smart_log_entry {
 	char			path[256];
-	long			time_stamp;
+	time_t			time_stamp;
 	struct nvme_id_ns	raw_ns;
 	struct nvme_id_ctrl	raw_ctrl;
 	struct nvme_smart_log	raw_smart;


### PR DESCRIPTION
On recent Ubuntu Oracular (24.10) builders, -Wincompatible-pointer-types will cause build errors (see [nvme-cli 2.9.1-1ubuntu1 build failure on armhf](https://launchpadlibrarian.net/740677619/buildlog_ubuntu-oracular-armhf.nvme-cli_2.9.1-1ubuntu1_BUILDING.txt.gz).

In the vtview_log structs, `time_t` should be used for any `time_stamp` values instead of `long.` This ensures correct builds on 32-bit architectures even with 64-bit `time_t` (e.g. armhf on Ubuntu).