### PR TITLE
nvme: extend help message when mmap regs fails

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5354,7 +5354,7 @@ static void *mmap_registers(struct nvme_dev *dev, bool writable)
 	sprintf(path, "/sys/class/nvme/%s/device/resource0", dev->name);
 	fd = open(path, writable ? O_RDWR : O_RDONLY);
 	if (fd < 0) {
-		if (log_level >= LOG_DEBUG)
+		if (log_level >= LOG_INFO)
 			nvme_show_error("%s did not find a pci resource, open failed %s",
 					dev->name, strerror(errno));
 		return NULL;
@@ -5362,9 +5362,12 @@ static void *mmap_registers(struct nvme_dev *dev, bool writable)
 
 	membase = mmap(NULL, getpagesize(), prot, MAP_SHARED, fd, 0);
 	if (membase == MAP_FAILED) {
-		if (log_level >= LOG_DEBUG) {
-			fprintf(stderr, "%s failed to map. ", dev->name);
-			fprintf(stderr, "Did your kernel enable CONFIG_IO_STRICT_DEVMEM?\n");
+		if (log_level >= LOG_INFO) {
+			fprintf(stderr, "Failed to map registers to userspace.\n\n"
+				"Did your kernel enable CONFIG_IO_STRICT_DEVMEM?\n"
+				"You can disable this feature with command line argument\n\n"
+				"\tio_memory=relaxed\n\n"
+				"Also ensure secure boot is disabled.\n\n");
 		}
 		membase = NULL;
 	}


### PR DESCRIPTION
Newer kernels enable the lockdown feature when secure boot is enabled. This feature also prevents the register mapping into userspace. Thus it is not enough to have CONFIG_IO_STRICT_DEVMEM disabled. Extend the message with the hint also to disable secure boot.

Fixes: #2420