### PR TITLE
fabrics: do not leak nvme_ctrl_t object on connect

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -899,7 +899,7 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	unsigned int verbose = 0;
 	_cleanup_nvme_root_ nvme_root_t r = NULL;
 	nvme_host_t h;
-	nvme_ctrl_t c;
+	_cleanup_nvme_ctrl_ nvme_ctrl_t c = NULL;
 	int ret;
 	nvme_print_flags_t flags;
 	struct nvme_fabrics_config cfg = { 0 };

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -42,6 +42,9 @@ static inline void cleanup_nvme_root(nvme_root_t *r)
 }
 #define _cleanup_nvme_root_ __cleanup__(cleanup_nvme_root)
 
+static inline DEFINE_CLEANUP_FUNC(cleanup_nvme_ctrl, nvme_ctrl_t, nvme_free_ctrl)
+#define _cleanup_nvme_ctrl_ __cleanup__(cleanup_nvme_ctrl)
+
 static inline void free_uri(struct nvme_fabrics_uri **uri)
 {
 	if (*uri)


### PR DESCRIPTION
valgrinds reports that the nvme_ctrl_t is leaked in the connect command. Let's introduced a new cleanup helper for this.