### PR TITLE
build: add install step to doc CI build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -123,6 +123,7 @@ config_meson_docs() {
         -Ddocs=all                              \
         -Ddocs-build=true                       \
         --force-fallback-for=libnvme            \
+        --prefix=/tmp/usr                       \
         -Dlibnvme:werror=false                  \
         "${BUILDDIR}"
 }
@@ -154,7 +155,12 @@ test_meson_coverage() {
 }
 
 install_meson_appimage() {
-    "${MESON}" install                             \
+    "${MESON}" install                          \
+        -C "${BUILDDIR}"
+}
+
+install_meson_docs() {
+    "${MESON}" install                          \
         -C "${BUILDDIR}"
 }
 


### PR DESCRIPTION
We had some fallouts which were happened at the install step when the documentation was build. Let's add this step, so we catch those errors in future.

Fixes: #2448 