### PR TITLE
plugins/dapustor: dapustor smart-log-add update

### DIFF
--- a/Documentation/cmd-plugins.txt
+++ b/Documentation/cmd-plugins.txt
@@ -204,3 +204,6 @@ linknvme:nvme-zns-zrwa-flush-zone[1]::
 
 linknvme:nvme-inspur-nvme-vendor-log[1]::
 	NVMe Inspur Device Vendor log page request
+
+linknvme:nvme-dapustor-smart-log-add[1]::
+	NVMe DapuStor Additional SMART log page

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -14,6 +14,7 @@ adoc_sources = [
   'nvme-connect-all',
   'nvme-copy',
   'nvme-create-ns',
+  'nvme-dapustor-smart-log-add',
   'nvme-delete-ns',
   'nvme-dera-stat',
   'nvme-detach-ns',

--- a/Documentation/nvme-dapustor-smart-log-add.txt
+++ b/Documentation/nvme-dapustor-smart-log-add.txt
@@ -1,0 +1,65 @@
+nvme-dapustor-smart-log-add(1)
+==============================
+
+NAME
+----
+nvme-dapustor-smart-log-add - Send NVMe DapuStor Additional SMART log page request,
+returns result and log
+
+SYNOPSIS
+--------
+[verse]
+'nvme dapustor smart-log-add' <device> [--namespace-id=<nsid> | -n <nsid>]
+			[--raw-binary | -b] [--json | -j]
+
+DESCRIPTION
+-----------
+Retrieves the NVMe DapuStor Additional SMART log page from the device and
+provides the returned structure.
+
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
+
+On success, the returned smart log structure may be returned in one of
+several ways depending on the option flags; the structure may parsed by
+the program and printed in a readable format or the raw buffer may be
+printed to stdout for another program to parse.
+
+OPTIONS
+-------
+-n <nsid>::
+--namespace-id=<nsid>::
+	Retrieve the Additional SMART log for the given nsid. This is
+	optional and its success may depend on the device's capabilities
+	to provide this log on a per-namespace basis (see the NVMe
+	Identify Controller for this capability). The default nsid to
+	use is 0xffffffff for the device global SMART log.
+
+-b::
+--raw-binary::
+	Print the raw DapuStor Additional SMART log buffer to stdout.
+
+-j::
+--json::
+	Dump output in json format.
+
+EXAMPLES
+--------
+* Print the DapuStor Additional SMART log page in a human readable format:
++
+------------
+# nvme dapustor smart-log-add /dev/nvme0
+------------
++
+
+* Print the raw DapuStor Additional SMART log to a file:
++
+------------
+# nvme dapustor smart-log-add /dev/nvme0 --raw-binary > smart_log.raw
+------------
++
+It is probably a bad idea to not redirect stdout when using this mode.
+
+NVME
+----
+Part of the nvme-user suite

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1228,6 +1228,38 @@ plugin_transcend_opts () {
 	return 0
 }
 
+plugin_dapustor_opts () {
+	local opts=""
+	local compargs=""
+
+	local nonopt_args=0
+	for (( i=0; i < ${#words[@]}-1; i++ )); do
+		if [[ ${words[i]} != -* ]]; then
+			let nonopt_args+=1
+		fi
+	done
+
+	if [ $nonopt_args -eq 3 ]; then
+		opts="/dev/nvme* "
+	fi
+
+	opts+=" "
+
+	case "$1" in
+		"smart-log-add")
+		opts+=" --namespace-id= -n --raw-binary -b \
+			--json -j"
+			;;
+		"help")
+		opts+=$NO_OPTS
+			;;
+	esac
+
+	COMPREPLY+=( $( compgen $compargs -W "$opts" -- $cur ) )
+
+	return 0
+}
+
 plugin_zns_opts () {
 	local opts=""
 	local compargs=""
@@ -1554,6 +1586,7 @@ _nvme_subcmds () {
 			vs-drive-info cloud-SSDplugin-version market-log \
 			smart-log-add temp-stats version help"
 		[transcend]="healthvalue badblock"
+		[dapustor]="smart-log-add"
 		[zns]="id-ctrl id-ns zone-mgmt-recv \
 			zone-mgmt-send report-zones close-zone \
 			finish-zone open-zone reset-zone offline-zone \
@@ -1588,6 +1621,7 @@ _nvme_subcmds () {
 		[sfx]="plugin_sfx_opts"
 		[solidigm]="plugin_solidigm_opts"
 		[transcend]="plugin_transcend_opts"
+		[dapustor]="plugin_dapustor_opts"
 		[zns]="plugin_zns_opts"
 		[nvidia]="plugin_nvidia_opts"
 		[ymtc]="plugin_ymtc_opts"


### PR DESCRIPTION
Extended Additional SMART log is optional.
If the collection fails, the command dose not stop.

Add the manual of dapustor plugin.
*.1 and *.html can be generated automatically,
so I only added the nvme-dapustor-smart-log-add.txt file.

Update tab completion.