### PR TITLE
nvme-print: use Completion Condition enum

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -1853,13 +1853,20 @@ static void json_lba_status(struct nvme_lba_status *list,
 	obj_add_uint(r, "Completion Condition (CMPC)", list->cmpc);
 
 	switch (list->cmpc) {
-	case 1:
-		obj_add_str(r, "cmpc-definition",
-		    "Completed due to transferring the amount of data specified in the MNDW field");
+	case NVME_LBA_STATUS_CMPC_NO_CMPC:
+		obj_add_str(r, "cmpc-definition", "No indication of the completion condition");
 		break;
-	case 2:
+	case NVME_LBA_STATUS_CMPC_INCOMPLETE:
 		obj_add_str(r, "cmpc-definition",
-		    "Completed due to having performed the action specified in the Action Type field over the number of logical blocks specified in the Range Length field");
+			"Completed transferring the amount of data specified in the"\
+			"MNDW field. But, additional LBA Status Descriptor Entries are"\
+			"available to transfer or scan did not complete (if ATYPE = 10h)");
+		break;
+	case NVME_LBA_STATUS_CMPC_COMPLETE:
+		obj_add_str(r, "cmpc-definition",
+			"Completed the specified action over the number of LBAs specified"\
+			"in the Range Length field and transferred all available LBA Status"\
+			"Descriptor Entries");
 		break;
 	default:
 		break;

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4685,15 +4685,18 @@ static void stdout_lba_status(struct nvme_lba_status *list,
 	printf("Completion Condition(CMPC): %u\n", list->cmpc);
 
 	switch (list->cmpc) {
-	case 1:
-		printf("\tCompleted due to transferring the amount of data"\
-			" specified in the MNDW field\n");
+	case NVME_LBA_STATUS_CMPC_NO_CMPC:
+		printf("\tNo indication of the completion condition\n");
 		break;
-	case 2:
-		printf("\tCompleted due to having performed the action\n"\
-			"\tspecified in the Action Type field over the\n"\
-			"\tnumber of logical blocks specified in the\n"\
-			"\tRange Length field\n");
+	case NVME_LBA_STATUS_CMPC_INCOMPLETE:
+		printf("\tCompleted transferring the amount of data specified in the\n"\
+			"\tMNDW field. But, additional LBA Status Descriptor Entries are\n"\
+			"\tavailable to transfer or scan did not complete (if ATYPE = 10h)\n");
+		break;
+	case NVME_LBA_STATUS_CMPC_COMPLETE:
+		printf("\tCompleted the specified action over the number of LBAs specified\n"\
+			"\tin the Range Length field and transferred all available LBA Status\n"\
+			"\tDescriptor Entries\n");
 		break;
 	default:
 		break;

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 55e29b85c9b85e69aff7b43dbd509b7be21b93ea
+revision = df12de68816f341b36e24f46822c4f727ed3e636
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Use the Completion Condition enum for LBA Status Descriptor.
Also, modified the print statement of Completion Condition.