### PR TITLE
nvme-print: use LC_MEASUREMENT to check fahrenheit temperature

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -789,8 +789,8 @@ static bool is_temperature_fahrenheit(void)
 	const char *locale, *underscore;
 	char country[3] = { 0 };
 
-	setlocale(LC_ALL, "");
-	locale = setlocale(LC_ALL, NULL);
+	setlocale(LC_MEASUREMENT, "");
+	locale = setlocale(LC_MEASUREMENT, NULL);
 
 	if (!locale || strlen(locale) < 2)
 		return false;


### PR DESCRIPTION
Previously used LC_ALL so not checked correctly if LC_MEASUREMENT set.