### PR TITLE
case NVME_CSI_KV implemented

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3863,6 +3863,10 @@ static void stdout_effects_log_page(enum nvme_csi csi,
 		printf("NVM Command Set Log Page\n");
 		printf("%-.80s\n", dash);
 		break;
+	case NVME_CSI_KV:
+		printf("KV Command Set Log Page\n");
+		printf("%-.80s\n", dash);
+		break;
 	case NVME_CSI_ZNS:
 		printf("ZNS Command Set Log Page\n");
 		printf("%-.80s\n", dash);


### PR DESCRIPTION
Before this commit it used to print Unknown when executing ./nvme effects-log <device> --csi = 1. After this commit we are able to see as a tittle KV Command Set Log Page.