### PR TITLE
nvme: sanitize effects-log verbose output

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5354,6 +5354,10 @@ static void *mmap_registers(struct nvme_dev *dev, bool writable)
 		prot |= PROT_WRITE;
 
 	sprintf(path, "/sys/class/nvme/%s/device/resource0", dev->name);
+
+	if (access(path, F_OK))
+		return NULL;
+
 	fd = open(path, writable ? O_RDWR : O_RDONLY);
 	if (fd < 0) {
 		if (log_level >= LOG_INFO)


### PR DESCRIPTION
The effects-log verbose output prints an annoying error message if the respective pci sysfs resource is unavailable:

nvme effects-log /dev/nvme0n1 -v
nvme0n1 did not find a pci resource, open failed No such file or directory NVM Command Set Log Page
...

Avoid printing this error if this pci sysfs resource does not exist.