### PR TITLE
nvme-print: sanitize error-log output

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3662,7 +3662,7 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 			le64_to_cpu(err_log[i].error_count));
 		printf("sqid		: %d\n", err_log[i].sqid);
 		printf("cmdid		: %#x\n", err_log[i].cmdid);
-		printf("status_field	: %#x(%s)\n", status,
+		printf("status_field	: %#x (%s)\n", status,
 			nvme_status_to_string(status, false));
 		printf("phase_tag	: %#x\n",
 			le16_to_cpu(err_log[i].status_field & 0x1));
@@ -3672,7 +3672,7 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 			le64_to_cpu(err_log[i].lba));
 		printf("nsid		: %#x\n", err_log[i].nsid);
 		printf("vs		: %d\n", err_log[i].vs);
-		printf("trtype		: %s\n",
+		printf("trtype		: %#x (%s)\n", err_log[i].trtype,
 			nvme_trtype_to_string(err_log[i].trtype));
 		printf("csi		: %d\n", err_log[i].csi);
 		printf("opcode		: %#x\n", err_log[i].opcode);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -678,11 +678,11 @@ const char *nvme_trtype_to_string(__u8 trtype)
 {
 	switch (trtype) {
 	case 0: return "The transport type is not indicated or the error "\
-		"is not transport related.";
-	case 1: return "RDMA Transport error.";
-	case 2: return "Fibre Channel Transport error.";
-	case 3: return "TCP Transport error.";
-	case 254: return "Intra-host Transport error.";
+		"is not transport related";
+	case 1: return "RDMA Transport error";
+	case 2: return "Fibre Channel Transport error";
+	case 3: return "TCP Transport error";
+	case 254: return "Intra-host Transport error";
 	default: return "Reserved";
 	};
 }


### PR DESCRIPTION
Minor textual and formatting changes to the error-log output.