### PR TITLE
nvme-print-json: extern json object add functions

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -25,7 +25,6 @@
 #define obj_add_array json_object_add_value_array
 #define obj_add_int json_object_add_value_int
 #define obj_add_obj json_object_add_value_object
-#define obj_add_str json_object_add_value_string
 #define obj_add_uint json_object_add_value_uint
 #define obj_add_uint128 json_object_add_value_uint128
 #define obj_add_uint64 json_object_add_value_uint64
@@ -75,7 +74,7 @@ static void obj_add_uint_x(struct json_object *o, const char *k, __u32 v)
 	obj_add_str(o, k, str);
 }
 
-static void obj_add_uint_0x(struct json_object *o, const char *k, __u32 v)
+void obj_add_uint_0x(struct json_object *o, const char *k, __u32 v)
 {
 	char str[STR_LEN];
 
@@ -83,15 +82,15 @@ static void obj_add_uint_0x(struct json_object *o, const char *k, __u32 v)
 	obj_add_str(o, k, str);
 }
 
-static void obj_add_uint_0nx(struct json_object *o, const char *k, __u32 v, int width)
+void obj_add_uint_0nx(struct json_object *o, const char *k, __u32 v, int width)
 {
 	char str[STR_LEN];
 
-	sprintf(str, "0x%02x", v);
+	sprintf(str, "0x%0*x", width, v);
 	obj_add_str(o, k, str);
 }
 
-static void obj_add_uint_02x(struct json_object *o, const char *k, __u32 v)
+void obj_add_uint_02x(struct json_object *o, const char *k, __u32 v)
 {
 	obj_add_uint_0nx(o, k, v, 2);
 }
@@ -104,7 +103,7 @@ static void obj_add_uint_nx(struct json_object *o, const char *k, __u32 v)
 	obj_add_str(o, k, str);
 }
 
-static void obj_add_nprix64(struct json_object *o, const char *k, uint64_t v)
+void obj_add_nprix64(struct json_object *o, const char *k, uint64_t v)
 {
 	char str[STR_LEN];
 
@@ -166,7 +165,7 @@ static void obj_add_key(struct json_object *o, const char *k, const char *v, ...
 	va_end(ap);
 }
 
-static struct json_object *obj_create_array_obj(struct json_object *o, const char *k)
+struct json_object *obj_create_array_obj(struct json_object *o, const char *k)
 {
 	struct json_object *array = json_create_array();
 	struct json_object *obj = json_create_object();
@@ -191,7 +190,7 @@ static struct json_object *obj_create(const char *k)
 	return obj;
 }
 
-static void json_print(struct json_object *r)
+void json_print(struct json_object *r)
 {
 	json_print_object(r, NULL);
 	printf("\n");
@@ -4783,4 +4782,37 @@ struct print_ops *nvme_get_json_print_ops(nvme_print_flags_t flags)
 {
 	json_print_ops.flags = flags;
 	return &json_print_ops;
+}
+
+void obj_add_byte_array(struct json_object *o, const char *k, unsigned char *buf, int len)
+{
+	int i;
+
+	_cleanup_free_ char *value = NULL;
+
+	if (!buf || !len) {
+		obj_add_str(o, k, "No information provided");
+		return;
+	}
+
+	value = calloc(1, (len + 1) * 2 + 1);
+
+	if (!value) {
+		obj_add_str(o, k, "Could not allocate string");
+		return;
+	}
+
+	sprintf(value, "0x");
+	for (i = 1; i <= len; i++)
+		sprintf(&value[i * 2], "%02x", buf[len - i]);
+
+	obj_add_str(o, k, value);
+}
+
+void obj_add_0nprix64(struct json_object *o, const char *k, uint64_t v, int width)
+{
+	char str[STR_LEN];
+
+	sprintf(str, "0x%0*"PRIx64"", width, v);
+	obj_add_str(o, k, str);
 }

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -20,6 +20,8 @@ typedef struct nvme_effects_log_node {
 
 #define STR_LEN 100
 
+#define obj_add_str json_object_add_value_string
+
 void d(unsigned char *buf, int len, int width, int group);
 void d_raw(unsigned char *buf, unsigned len);
 
@@ -324,4 +326,12 @@ bool nvme_registers_cmbloc_support(__u32 cmbsz);
 bool nvme_registers_pmrctl_ready(__u32 pmrctl);
 const char *nvme_degrees_string(long t);
 void print_array(char *name, __u8 *data, int size);
+void obj_add_uint_02x(struct json_object *o, const char *k, __u32 v);
+void json_print(struct json_object *r);
+void obj_add_uint_0x(struct json_object *o, const char *k, __u32 v);
+void obj_add_byte_array(struct json_object *o, const char *k, unsigned char *buf, int len);
+void obj_add_nprix64(struct json_object *o, const char *k, uint64_t v);
+struct json_object *obj_create_array_obj(struct json_object *o, const char *k);
+void obj_add_uint_0nx(struct json_object *o, const char *k, __u32 v, int width);
+void obj_add_0nprix64(struct json_object *o, const char *k, uint64_t v, int width);
 #endif /* NVME_PRINT_H */


### PR DESCRIPTION
Some additinal functions introduced and fix obj_add_uint_0nx error.