### PR TITLE
nvme-print-stdout: add print_array function

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5319,3 +5319,16 @@ struct print_ops *nvme_get_stdout_print_ops(nvme_print_flags_t flags)
 	stdout_print_ops.flags = flags;
 	return &stdout_print_ops;
 }
+
+void print_array(char *name, __u8 *data, int size)
+{
+	int i;
+
+	if (!name || !data || !size)
+		return;
+
+	printf("%s: 0x", name);
+	for (i = 0; i < size; i++)
+		printf("%02X", data[size - i - 1]);
+	printf("\n");
+}

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -323,4 +323,5 @@ bool nvme_is_fabrics_reg(int offset);
 bool nvme_registers_cmbloc_support(__u32 cmbsz);
 bool nvme_registers_pmrctl_ready(__u32 pmrctl);
 const char *nvme_degrees_string(long t);
+void print_array(char *name, __u8 *data, int size);
 #endif /* NVME_PRINT_H */


### PR DESCRIPTION
To reduce the repeated print code for arrays.