### PR TITLE
plugins/solidigm: Added Workload Tracker Triggers and Wall Time

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -376,6 +376,15 @@ _nvme () {
 				)
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp hardware-component-log options" _hardware_component_log
+			(set-telemetry-profile)
+				local _ocp_set_telemetry_profile_feature
+				_ocp_set_telemetry_profile_feature=(
+				/dev/nvme':supply a device to use (required)'
+				--telemetry-profile-select=':Telemetry Profile Select'
+				-t':alias for --telemetry-profile-select'
+				)
+				_arguments '*:: :->subcmds'
+				_describe -t commands "nvme ocp set-telemetry-profile options" _ocp_set_telemetry_profile_feature
 				;;
 			(*)
 				_files
@@ -552,15 +561,36 @@ _nvme () {
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme solidigm vs-drive-info" _vs_drive_info
 				;;
-			(set-telemetry-profile)
-				local _ocp_set_telemetry_profile_feature
-				_ocp_set_telemetry_profile_feature=(
-				/dev/nvme':supply a device to use (required)'
-				--telemetry-profile-select=':Telemetry Profile Select'
-				-t':alias for --telemetry-profile-select'
+			(workload-tracker)
+				local _workload_tracker
+				_workload_tracker=(
+				--enable':Enable Workload Tracker'
+				-e':alias for --enable'
+				--disable':Disable Workload Tracker'
+				-d':alias for --disable'
+				--sample-time=':Sample time in seconds'
+				-s':alias for --sample-time'
+				--type=':Workload Tracker type'
+				-t':alias for --type'
+				--run-time=':Run time in seconds'
+				-r':alias for --run-time'
+				--flush-freq=':Flush frequency in seconds'
+				-f':alias for --flush-freq'
+				--wall-clock':Use wall clock time'
+				-w':alias for --wall-clock'
+				--trigger-field=':Trigger field'
+				-T':alias for --trigger-field'
+				--trigger-threshold=':Trigger threshold'
+				-V':alias for --trigger-threshold'
+				--trigger-on-delta':Trigger on delta'
+				-D':alias for --trigger-on-delta'
+				--trigger-on-latency':Trigger on latency'
+				-L':alias for --trigger-on-latency'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
 				)
 				_arguments '*:: :->subcmds'
-				_describe -t commands "nvme ocp set-telemetry-profile options" _ocp_set_telemetry_profile_feature
+				_describe -t commands "nvme solidigm workload-tracker options" _workload_tracker
 				;;
 			(*)
 				_files
@@ -2623,6 +2653,7 @@ _nvme () {
 			log-page-directory':Retrieve log page directory'
 			temp-stats':Retrieve Temperature Statistics log'
 			vs-drive-info':Retrieve drive information'
+			workload-tracker':Enable/Disable and configure Workload Tracker'
 			cloud-SSDplugin-version':Prints plug-in OCP version'
 			version':Shows the program version'
 			help':Display this help'

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1181,6 +1181,13 @@ plugin_solidigm_opts () {
 		"temp-stats")
 		opts+=" --raw-binary -b"
 			;;
+		"workload-tracker")
+		opts+=" --enable -e --disable -d --sample-time= -s \
+		--type= -t --run-time= -r --flush-freq= -f \
+		--wall-clock -w --trigger-field= -T \
+		--trigger-threshold= -V --trigger-on-delta -D \
+		--trigger-on-latency -L --verbose -v"
+			;;
 		"version")
 		opts+=$NO_OPTS
 			;;
@@ -1588,7 +1595,7 @@ _nvme_subcmds () {
 			clear-pcie-correctable-errors parse-telemetry-log \
 			clear-fw-activate-history vs-fw-activate-history log-page-directory \
 			vs-drive-info cloud-SSDplugin-version market-log \
-			smart-log-add temp-stats version help"
+			smart-log-add temp-stats workload-tracker version help"
 		[transcend]="healthvalue badblock"
 		[dapustor]="smart-log-add"
 		[zns]="id-ctrl id-ns zone-mgmt-recv \

--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -13,7 +13,7 @@
 
 #include "cmd.h"
 
-#define SOLIDIGM_PLUGIN_VERSION "1.6"
+#define SOLIDIGM_PLUGIN_VERSION "1.7"
 
 PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_VERSION),
 	COMMAND_LIST(


### PR DESCRIPTION
Added Trigger configurations, Stopped converting timestamps to millisec, added optional property to display wall clock column. Fixed zsh misplaced auto-complete of ocp set-telemetry-profile.