### PR TITLE
ocp: Fixes for OCP 2.5 Telemetry DA1 FIFO Event Parsing

### DIFF
--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -11,7 +11,7 @@
 #if !defined(OCP_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define OCP_NVME
 
-#define OCP_PLUGIN_VERSION   "2.9.0"
+#define OCP_PLUGIN_VERSION   "2.9.1"
 #include "cmd.h"
 
 PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),

--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -64,6 +64,7 @@ void print_telemetry_fifo_event(__u8 class_type,
 	if (class_type) {
 		class_str = telemetry_event_class_to_string(class_type);
 		printf("Event Class : %s\n", class_str);
+		printf("  Size      : 0x%02x\n", size);
 	}
 
 	switch (class_type)	{
@@ -75,9 +76,8 @@ void print_telemetry_fifo_event(__u8 class_type,
 				(int)((le64_to_cpu(timestamp%3600)/60)),
 				(int)(le64_to_cpu(timestamp%60)));
 
-		printf("  Event ID  : 0x%02x %s\n", id, telemetry_ts_event_to_string(id));
+		printf("  Event ID  : 0x%04x %s\n", id, telemetry_ts_event_to_string(id));
 		printf("  Timestamp : %s\n", time_str);
-		printf("  Size      : %d\n", size);
 		if (size > 8) {
 			printf("  VU Data : 0x");
 			for (j = 8; j < size; j++)
@@ -87,7 +87,7 @@ void print_telemetry_fifo_event(__u8 class_type,
 		break;
 
 	case TELEMETRY_PCIE_CLASS:
-		printf("  Event ID : 0x%02x %s\n",
+		printf("  Event ID : 0x%04x %s\n",
 			id, telemetry_pcie_event_id_to_string(id));
 		printf("  State    : 0x%02x %s\n",
 			data[0], telemetry_pcie_state_data_to_string(data[0]));
@@ -95,7 +95,7 @@ void print_telemetry_fifo_event(__u8 class_type,
 			data[1], telemetry_pcie_speed_data_to_string(data[1]));
 		printf("  Width    : 0x%02x %s\n",
 			data[2], telemetry_pcie_width_data_to_string(data[2]));
-		if (size > 4) {
+		if (size > 8) {
 			printf("  VU Data : ");
 			for (j = 4; j < size; j++)
 				printf("%x", data[j]);
@@ -104,7 +104,7 @@ void print_telemetry_fifo_event(__u8 class_type,
 		break;
 
 	case TELEMETRY_NVME_CLASS:
-		printf("  Event ID          : 0x%02x %s\n",
+		printf("  Event ID          : 0x%04x %s\n",
 			id, telemetry_nvme_event_id_to_string(id));
 		if ((id == ADMIN_QUEUE_NONZERO_STATUS) ||
 			(id == IO_QUEUE_NONZERO_STATUS)) {
@@ -127,47 +127,49 @@ void print_telemetry_fifo_event(__u8 class_type,
 			printf("  CSTS Reg Data : 0x%08x\n",
 					le32_to_cpu(csts_reg_data));
 		}
+		/* jal Fixme - not correct for all cases
 		if (size > 8)
 			print_vu_event_data(size, (__u8 *)&data[8]);
+		*/
 		break;
 
 	case TELEMETRY_RESET_CLASS:
-		printf("  Event ID          : 0x%02x %s\n",
+		printf("  Event ID          : 0x%04x %s\n",
 			id, telemetry_reset_event_id_to_string(id));
 		if (size)
 			print_vu_event_data(size, data);
 		break;
 
 	case TELEMETRY_BOOT_SEQ_CLASS:
-		printf("  Event ID          : 0x%02x %s\n",
+		printf("  Event ID          : 0x%04x %s\n",
 			id, telemetry_boot_seq_event_id_to_string(id));
 		if (size)
 			print_vu_event_data(size, data);
 		break;
 
 	case TELEMETRY_FW_ASSERT_CLASS:
-		printf("  Event ID          : 0x%02x %s\n",
+		printf("  Event ID          : 0x%04x %s\n",
 			id, telemetry_fw_assert_event_id_to_string(id));
 		if (size)
 			print_vu_event_data(size, data);
 		break;
 
 	case TELEMETRY_TEMPERATURE_CLASS:
-		printf("  Event ID          : 0x%02x %s\n",
+		printf("  Event ID          : 0x%04x %s\n",
 			id, telemetry_temperature_event_id_to_string(id));
 		if (size)
 			print_vu_event_data(size, data);
 		break;
 
 	case TELEMETRY_MEDIA_DBG_CLASS:
-		printf("  Event ID          : 0x%02x %s\n",
+		printf("  Event ID          : 0x%04x %s\n",
 			id, telemetry_media_debug_event_id_to_string(id));
 		if (size)
 			print_vu_event_data(size, data);
 		break;
 
 	case TELEMETRY_MEDIA_WEAR_CLASS:
-		printf("  Event ID          : 0x%02x %s\n",
+		printf("  Event ID          : 0x%04x %s\n",
 			id, telemetry_media_debug_event_id_to_string(id));
 		__u32 host_tb_written = *(__u32 *)&data[0];
 		__u32 media_tb_written = *(__u32 *)&data[4];
@@ -642,43 +644,58 @@ void parse_time_stamp_event(struct nvme_ocp_telemetry_event_descriptor *pevent_d
 {
 	struct nvme_ocp_time_stamp_dbg_evt_class_format *ptime_stamp_event =
 		(struct nvme_ocp_time_stamp_dbg_evt_class_format *) pevent_specific_data;
-
-	int vu_event_id = (int)ptime_stamp_event->vu_event_identifier;
-
-	unsigned int data_size = ((pevent_descriptor->event_data_size * SIZE_OF_DWORD)-
-					sizeof(struct nvme_ocp_time_stamp_dbg_evt_class_format));
-
-	__u8 *pdata = (__u8 *)ptime_stamp_event +
-					sizeof(struct nvme_ocp_time_stamp_dbg_evt_class_format);
-
+	struct nvme_ocp_common_dbg_evt_class_vu_data *ptime_stamp_event_vu_data = NULL;
+	__le16 vu_event_id = 0;
+	__u8 *pdata = NULL;
 	char description_str[256] = "";
+	unsigned int vu_data_size = 0;
+	bool vu_data = false;
 
-	parse_ocp_telemetry_string_log(0, ptime_stamp_event->vu_event_identifier,
-				       pevent_descriptor->debug_event_class_type,
-				       VU_EVENT_STRING, description_str);
+	if ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) >
+		 sizeof(struct nvme_ocp_time_stamp_dbg_evt_class_format)) {
+		vu_data = true;
+		vu_data_size =
+			((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
+			 (sizeof(struct nvme_ocp_time_stamp_dbg_evt_class_format) + SIZE_OF_VU_EVENT_ID));
+
+		ptime_stamp_event_vu_data = (struct nvme_ocp_common_dbg_evt_class_vu_data *)
+			(ptime_stamp_event + sizeof(struct nvme_ocp_time_stamp_dbg_evt_class_format));
+		vu_event_id = ptime_stamp_event_vu_data->vu_event_identifier;
+		pdata = (__u8 *)&(ptime_stamp_event_vu_data->data);
+
+		parse_ocp_telemetry_string_log(0, vu_event_id,
+					       pevent_descriptor->debug_event_class_type,
+					       VU_EVENT_STRING, description_str);
+	}
 
 	if (pevent_fifos_object != NULL) {
 		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
 						ptime_stamp_event->time_stamp, DATA_SIZE_8);
-		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
-					   vu_event_id);
-		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
-					     description_str);
-		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
-						data_size);
+		if (vu_data) {
+			json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+						   vu_event_id);
+			json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+							 description_str);
+			json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+							vu_data_size);
+		}
 	} else {
 		if (fp) {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 					     ptime_stamp_event->time_stamp, DATA_SIZE_8, fp);
-			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		} else {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 				ptime_stamp_event->time_stamp, DATA_SIZE_8, fp);
-			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		}
 	}
 }
@@ -689,37 +706,57 @@ void parse_pcie_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descrip
 {
 	struct nvme_ocp_pcie_dbg_evt_class_format *ppcie_event =
 				(struct nvme_ocp_pcie_dbg_evt_class_format *) pevent_specific_data;
-	int vu_event_id = (int) ppcie_event->vu_event_identifier;
-	unsigned int data_size = ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
-					sizeof(struct nvme_ocp_pcie_dbg_evt_class_format));
-	__u8 *pdata = (__u8 *) ppcie_event + sizeof(struct nvme_ocp_pcie_dbg_evt_class_format);
+	struct nvme_ocp_common_dbg_evt_class_vu_data *ppcie_event_vu_data = NULL;
+	__le16 vu_event_id = 0;
+	__u8 *pdata = NULL;
 	char description_str[256] = "";
+	unsigned int vu_data_size = 0;
+	bool vu_data = false;
 
-	parse_ocp_telemetry_string_log(0, ppcie_event->vu_event_identifier,
-	       pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+	if ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) >
+		 sizeof(struct nvme_ocp_pcie_dbg_evt_class_format)) {
+		vu_data = true;
+		vu_data_size =
+			((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
+			 (sizeof(struct nvme_ocp_pcie_dbg_evt_class_format) + SIZE_OF_VU_EVENT_ID));
+
+		ppcie_event_vu_data = (struct nvme_ocp_common_dbg_evt_class_vu_data *)
+			(ppcie_event + sizeof(struct nvme_ocp_pcie_dbg_evt_class_format));
+		vu_event_id = ppcie_event_vu_data->vu_event_identifier;
+		pdata = (__u8 *)&(ppcie_event_vu_data->data);
+
+		parse_ocp_telemetry_string_log(0, vu_event_id,
+		       pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+	}
 
 	if (pevent_fifos_object != NULL) {
 		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
 						ppcie_event->pCIeDebugEventData, DATA_SIZE_4);
-		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
-					   vu_event_id);
-		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
-					     description_str);
-		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
-						data_size);
+		if (vu_data) {
+			json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+					vu_event_id);
+			json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+					description_str);
+			json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+					vu_data_size);
+		}
 	} else {
 		if (fp) {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 					     ppcie_event->pCIeDebugEventData, DATA_SIZE_4, fp);
-			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		} else {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 					     ppcie_event->pCIeDebugEventData, DATA_SIZE_4, fp);
-			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		}
 	}
 }
@@ -730,38 +767,57 @@ void parse_nvme_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descrip
 {
 	struct nvme_ocp_nvme_dbg_evt_class_format *pnvme_event =
 				(struct nvme_ocp_nvme_dbg_evt_class_format *) pevent_specific_data;
-	int vu_event_id = (int) pnvme_event->vu_event_identifier;
-	unsigned int data_size = ((pevent_descriptor->event_data_size *
-	SIZE_OF_DWORD) - sizeof(struct nvme_ocp_nvme_dbg_evt_class_format));
-	__u8 *pdata = (__u8 *) pnvme_event + sizeof(struct nvme_ocp_nvme_dbg_evt_class_format);
+	struct nvme_ocp_common_dbg_evt_class_vu_data *pnvme_event_vu_data = NULL;
+	__le16 vu_event_id = 0;
+	__u8 *pdata = NULL;
 	char description_str[256] = "";
+	unsigned int vu_data_size = 0;
+	bool vu_data = false;
 
-	parse_ocp_telemetry_string_log(0, pnvme_event->vu_event_identifier,
-				       pevent_descriptor->debug_event_class_type, VU_EVENT_STRING,
-				       description_str);
+	if ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) >
+		 sizeof(struct nvme_ocp_nvme_dbg_evt_class_format)) {
+		vu_data = true;
+		vu_data_size =
+			((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
+			 (sizeof(struct nvme_ocp_nvme_dbg_evt_class_format) + SIZE_OF_VU_EVENT_ID));
+		pnvme_event_vu_data = (struct nvme_ocp_common_dbg_evt_class_vu_data *)
+			(pnvme_event + sizeof(struct nvme_ocp_nvme_dbg_evt_class_format));
+
+		vu_event_id = pnvme_event_vu_data->vu_event_identifier;
+		pdata = (__u8 *)&(pnvme_event_vu_data->data);
+
+		parse_ocp_telemetry_string_log(0, vu_event_id,
+			pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+	}
 
 	if (pevent_fifos_object != NULL) {
 		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
-						pnvme_event->nvmeDebugEventData, DATA_SIZE_8);
-		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
-					   vu_event_id);
-		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
-					     description_str);
-		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
-						data_size);
+			pnvme_event->nvmeDebugEventData, DATA_SIZE_8);
+		if (vu_data) {
+			json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+						   vu_event_id);
+			json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+							 description_str);
+			json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+							vu_data_size);
+		}
 	} else {
 		if (fp) {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 					     pnvme_event->nvmeDebugEventData, DATA_SIZE_8, fp);
-			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		} else {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 					      pnvme_event->nvmeDebugEventData, DATA_SIZE_8, fp);
-			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		}
 	}
 }
@@ -770,34 +826,37 @@ void parse_common_event(struct nvme_ocp_telemetry_event_descriptor *pevent_descr
 			    struct json_object *pevent_descriptor_obj, __u8 *pevent_specific_data,
 			    struct json_object *pevent_fifos_object, FILE *fp)
 {
-	struct nvme_ocp_common_dbg_evt_class_format *pcommon_debug_event =
-			(struct nvme_ocp_common_dbg_evt_class_format *) pevent_specific_data;
-	int vu_event_id = (int) pcommon_debug_event->vu_event_identifier;
-	unsigned int data_size = ((pevent_descriptor->event_data_size *
-	SIZE_OF_DWORD) - sizeof(struct nvme_ocp_common_dbg_evt_class_format));
-	__u8 *pdata = (__u8 *) pcommon_debug_event +
-					sizeof(struct nvme_ocp_common_dbg_evt_class_format);
-	char description_str[256] = "";
+	if (pevent_specific_data) {
+		struct nvme_ocp_common_dbg_evt_class_vu_data *pcommon_debug_event_vu_data =
+				(struct nvme_ocp_common_dbg_evt_class_vu_data *) pevent_specific_data;
 
-	parse_ocp_telemetry_string_log(0, pcommon_debug_event->vu_event_identifier,
-		pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+		__le16 vu_event_id = pcommon_debug_event_vu_data->vu_event_identifier;;
+		char description_str[256] = "";
+		__u8 *pdata = (__u8 *)&(pcommon_debug_event_vu_data->data);
 
-	if (pevent_fifos_object != NULL) {
-		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
-					   vu_event_id);
-		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
-					     description_str);
-		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
-						data_size);
-	} else {
-		if (fp) {
-			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+		unsigned int vu_data_size = ((pevent_descriptor->event_data_size *
+			SIZE_OF_DWORD) - SIZE_OF_VU_EVENT_ID);
+
+		parse_ocp_telemetry_string_log(0, vu_event_id,
+			   pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+
+		if (pevent_fifos_object != NULL) {
+			json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+						   vu_event_id);
+			json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+							 description_str);
+			json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+							vu_data_size);
 		} else {
-			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (fp) {
+				fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			} else {
+				printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		}
 	}
 }
@@ -808,39 +867,58 @@ void parse_media_wear_event(struct nvme_ocp_telemetry_event_descriptor *pevent_d
 {
 	struct nvme_ocp_media_wear_dbg_evt_class_format *pmedia_wear_event =
 			(struct nvme_ocp_media_wear_dbg_evt_class_format *) pevent_specific_data;
-	int vu_event_id = (int) pmedia_wear_event->vu_event_identifier;
-	unsigned int data_size = ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
-					sizeof(struct nvme_ocp_media_wear_dbg_evt_class_format));
-	__u8 *pdata = (__u8 *) pmedia_wear_event +
-					sizeof(struct nvme_ocp_media_wear_dbg_evt_class_format);
-	char description_str[256] = "";
+	struct nvme_ocp_common_dbg_evt_class_vu_data *pmedia_wear_event_vu_data = NULL;
 
-	parse_ocp_telemetry_string_log(0, pmedia_wear_event->vu_event_identifier,
-					pevent_descriptor->debug_event_class_type, VU_EVENT_STRING,
-					description_str);
+	__le16 vu_event_id = 0;
+	__u8 *pdata = NULL;
+	char description_str[256] = "";
+	unsigned int vu_data_size = 0;
+	bool vu_data = false;
+
+	if ((pevent_descriptor->event_data_size * SIZE_OF_DWORD) >
+		 sizeof(struct nvme_ocp_media_wear_dbg_evt_class_format)) {
+		vu_data = true;
+		vu_data_size =
+			((pevent_descriptor->event_data_size * SIZE_OF_DWORD) -
+			 (sizeof(struct nvme_ocp_media_wear_dbg_evt_class_format) + SIZE_OF_VU_EVENT_ID));
+
+		pmedia_wear_event_vu_data = (struct nvme_ocp_common_dbg_evt_class_vu_data *)
+			(pmedia_wear_event + sizeof(struct nvme_ocp_media_wear_dbg_evt_class_format));
+		vu_event_id = pmedia_wear_event_vu_data->vu_event_identifier;
+		pdata = (__u8 *)&(pmedia_wear_event_vu_data->data);
+
+		parse_ocp_telemetry_string_log(0, vu_event_id,
+		       pevent_descriptor->debug_event_class_type, VU_EVENT_STRING, description_str);
+	}
 
 	if (pevent_fifos_object != NULL) {
 		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_CLASS_SPECIFIC_DATA,
 						pmedia_wear_event->currentMediaWear, DATA_SIZE_12);
-		json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
-					   vu_event_id);
-		json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
-					     description_str);
-		json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
-						data_size);
+		if (vu_data) {
+			json_add_formatted_u32_str(pevent_descriptor_obj, STR_VU_EVENT_ID_STRING,
+					vu_event_id);
+			json_object_add_value_string(pevent_descriptor_obj, STR_VU_EVENT_STRING,
+					description_str);
+			json_add_formatted_var_size_str(pevent_descriptor_obj, STR_VU_DATA, pdata,
+					vu_data_size);
+		}
 	} else {
 		if (fp) {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 				      pmedia_wear_event->currentMediaWear, DATA_SIZE_12, fp);
-			fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				fprintf(fp, "%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				fprintf(fp, "%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		} else {
 			print_formatted_var_size_str(STR_CLASS_SPECIFIC_DATA,
 				     pmedia_wear_event->currentMediaWear, DATA_SIZE_12, NULL);
-			printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
-			printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
-			print_formatted_var_size_str(STR_VU_DATA, pdata, data_size, fp);
+			if (vu_data) {
+				printf("%s: 0x%x\n", STR_VU_EVENT_ID_STRING, vu_event_id);
+				printf("%s: %s\n", STR_VU_EVENT_STRING, description_str);
+				print_formatted_var_size_str(STR_VU_DATA, pdata, vu_data_size, fp);
+			}
 		}
 	}
 }
@@ -895,12 +973,18 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 			(struct nvme_ocp_telemetry_event_descriptor *)
 			(pfifo_start + offset_to_move);
 
+		/* check if at the end of the list */
+		if (pevent_descriptor->debug_event_class_type == RESERVED_CLASS_TYPE)
+			break;
+
 		if (pevent_descriptor != NULL && pevent_descriptor->event_data_size >= 0) {
 			//Data is present in the form of DWORDS, So multiplying with sizeof(DWORD)
 			unsigned int data_size = pevent_descriptor->event_data_size *
 							SIZE_OF_DWORD;
 
-			__u8 *pevent_specific_data = (__u8 *)pevent_descriptor + event_des_size;
+			__u8 *pevent_specific_data = NULL;
+			if (pevent_descriptor != NULL && pevent_descriptor->event_data_size > 0)
+				pevent_specific_data = (__u8 *)pevent_descriptor + event_des_size;
 
 			char description_str[256] = "";
 
@@ -936,12 +1020,12 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 						pevent_descriptor->event_data_size);
 				} else {
 					printf("%s: 0x%x\n", STR_DBG_EVENT_CLASS_TYPE,
-					       pevent_descriptor->debug_event_class_type);
+					   pevent_descriptor->debug_event_class_type);
 					printf("%s: 0x%x\n", STR_EVENT_IDENTIFIER,
-					       pevent_descriptor->event_id);
+					   pevent_descriptor->event_id);
 					printf("%s: %s\n", STR_EVENT_STRING, description_str);
 					printf("%s: 0x%x\n", STR_EVENT_DATA_SIZE,
-					       pevent_descriptor->event_data_size);
+					   pevent_descriptor->event_data_size);
 				}
 
 				if (pevent_descriptor->debug_event_class_type >= 0x80)
@@ -950,59 +1034,59 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 			}
 
 			switch (pevent_descriptor->debug_event_class_type) {
-			case TIME_STAMP_CLASS_TYPE:
-				parse_time_stamp_event(pevent_descriptor, pevent_descriptor_obj,
-					       pevent_specific_data, pevent_fifos_object, fp);
-				break;
-			case PCIE_CLASS_TYPE:
-				parse_pcie_event(pevent_descriptor, pevent_descriptor_obj,
-					       pevent_specific_data, pevent_fifos_object, fp);
-				break;
-			case NVME_CLASS_TYPE:
-				parse_nvme_event(pevent_descriptor, pevent_descriptor_obj,
-					       pevent_specific_data, pevent_fifos_object, fp);
-				break;
-			case RESET_CLASS_TYPE:
-			case BOOT_SEQUENCE_CLASS_TYPE:
-			case FIRMWARE_ASSERT_CLASS_TYPE:
-			case TEMPERATURE_CLASS_TYPE:
-			case MEDIA_CLASS_TYPE:
-				parse_common_event(pevent_descriptor, pevent_descriptor_obj,
-					       pevent_specific_data, pevent_fifos_object, fp);
-				break;
-			case MEDIA_WEAR_CLASS_TYPE:
-				parse_media_wear_event(pevent_descriptor, pevent_descriptor_obj,
-					       pevent_specific_data, pevent_fifos_object, fp);
-				break;
-			case STATISTIC_SNAPSHOT_CLASS_TYPE: {
-				struct nvme_ocp_statistic_snapshot_evt_class_format
-				*pStaticSnapshotEvent =
-					(struct nvme_ocp_statistic_snapshot_evt_class_format *)
-					pevent_specific_data;
-				struct nvme_ocp_telemetry_statistic_descriptor *pstatistic_entry =
-					(struct nvme_ocp_telemetry_statistic_descriptor *)
-					(&pStaticSnapshotEvent->statisticDescriptorData);
+				case TIME_STAMP_CLASS_TYPE:
+					parse_time_stamp_event(pevent_descriptor, pevent_descriptor_obj,
+							   pevent_specific_data, pevent_fifos_object, fp);
+					break;
+				case PCIE_CLASS_TYPE:
+					parse_pcie_event(pevent_descriptor, pevent_descriptor_obj,
+							   pevent_specific_data, pevent_fifos_object, fp);
+					break;
+				case NVME_CLASS_TYPE:
+					parse_nvme_event(pevent_descriptor, pevent_descriptor_obj,
+							   pevent_specific_data, pevent_fifos_object, fp);
+					break;
+				case RESET_CLASS_TYPE:
+				case BOOT_SEQUENCE_CLASS_TYPE:
+				case FIRMWARE_ASSERT_CLASS_TYPE:
+				case TEMPERATURE_CLASS_TYPE:
+				case MEDIA_CLASS_TYPE:
+					parse_common_event(pevent_descriptor, pevent_descriptor_obj,
+							   pevent_specific_data, pevent_fifos_object, fp);
+					break;
+				case MEDIA_WEAR_CLASS_TYPE:
+					parse_media_wear_event(pevent_descriptor, pevent_descriptor_obj,
+							   pevent_specific_data, pevent_fifos_object, fp);
+					break;
+				case STATISTIC_SNAPSHOT_CLASS_TYPE: {
+					struct nvme_ocp_statistic_snapshot_evt_class_format
+					*pStaticSnapshotEvent =
+						(struct nvme_ocp_statistic_snapshot_evt_class_format *)
+						pevent_specific_data;
+					struct nvme_ocp_telemetry_statistic_descriptor *pstatistic_entry =
+						(struct nvme_ocp_telemetry_statistic_descriptor *)
+						(&pStaticSnapshotEvent->statisticDescriptorData);
 
-				parse_statistic(pstatistic_entry, pevent_descriptor_obj, fp);
-				break;
+					parse_statistic(pstatistic_entry, pevent_descriptor_obj, fp);
+					break;
+				}
+				case RESERVED_CLASS_TYPE:
+				default:
+					break;
 			}
-			case RESERVED_CLASS_TYPE:
-			default:
-				break;
-		}
 
-		if (pevent_descriptor_obj != NULL && pevent_fifo_array != NULL)
-			json_array_add_value_object(pevent_fifo_array, pevent_descriptor_obj);
-		else {
-			if (fp)
-				fprintf(fp, STR_LINE2);
-			else
-				printf(STR_LINE2);
-		}
-	} else
-		break;
+			if (pevent_descriptor_obj != NULL && pevent_fifo_array != NULL)
+				json_array_add_value_object(pevent_fifo_array, pevent_descriptor_obj);
+			else {
+				if (fp)
+					fprintf(fp, STR_LINE2);
+				else
+					printf(STR_LINE2);
+			}
+		} else
+			break;
 
-	offset_to_move += (pevent_descriptor->event_data_size * SIZE_OF_DWORD + event_des_size);
+		offset_to_move += (pevent_descriptor->event_data_size * SIZE_OF_DWORD + event_des_size);
 	}
 
 	if (pevent_fifos_object != NULL && pevent_fifo_array != NULL)
@@ -1241,9 +1325,14 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			fprintf(fp, STR_LINE);
 			fprintf(fp, "%s\n", STR_LOG_PAGE_HEADER);
 			fprintf(fp, STR_LINE);
-			if (!strcmp(options->telemetry_type, "host"))
-				generic_structure_parser(ptelemetry_buffer, host_log_page_header,
-					ARRAY_SIZE(host_log_page_header), NULL, 0, fp);
+			if (!strcmp(options->telemetry_type, "host")) {
+				if ((ptelemetry_buffer == NULL) ||
+					(ARRAY_SIZE(host_log_page_header) == 0))
+					printf("skip generic_structure_parser\n");
+				else
+					generic_structure_parser(ptelemetry_buffer, host_log_page_header,
+							ARRAY_SIZE(host_log_page_header), NULL, 0, fp);
+			}
 			else if (!strcmp(options->telemetry_type, "controller"))
 				generic_structure_parser(ptelemetry_buffer,
 					controller_log_page_header,
@@ -1350,9 +1439,15 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 		printf(STR_LINE);
 		printf("%s\n", STR_LOG_PAGE_HEADER);
 		printf(STR_LINE);
-		if (!strcmp(options->telemetry_type, "host"))
-			generic_structure_parser(ptelemetry_buffer, host_log_page_header,
-					     ARRAY_SIZE(host_log_page_header), NULL, 0, NULL);
+		if (!strcmp(options->telemetry_type, "host")) {
+			if ((ptelemetry_buffer == NULL) ||
+				(ARRAY_SIZE(host_log_page_header) == 0))
+				printf("skip generic_structure_parser\n");
+			else {
+				generic_structure_parser(ptelemetry_buffer, host_log_page_header,
+					ARRAY_SIZE(host_log_page_header), NULL, 0, NULL);
+			}
+		}
 		else if (!strcmp(options->telemetry_type, "controller"))
 			generic_structure_parser(ptelemetry_buffer, controller_log_page_header,
 				     ARRAY_SIZE(controller_log_page_header), NULL, 0, NULL);
@@ -1363,7 +1458,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 		__u8 *preason_identifier_offset = ptelemetry_buffer +
 			offsetof(struct nvme_ocp_telemetry_host_initiated_header, reason_id);
 		generic_structure_parser(preason_identifier_offset, reason_identifier,
-				     ARRAY_SIZE(reason_identifier), NULL, 0, NULL);
+			ARRAY_SIZE(reason_identifier), NULL, 0, NULL);
 
 		printf(STR_LINE);
 		printf("%s\n", STR_TELEMETRY_HOST_DATA_BLOCK_1);
@@ -1382,7 +1477,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 		__u8 *pda1_header_offset = ptelemetry_buffer + offsets.da1_start_offset;//512
 
 		generic_structure_parser(pda1_header_offset, ocp_header_in_da1,
-				     ARRAY_SIZE(ocp_header_in_da1), NULL, 0, NULL);
+			ARRAY_SIZE(ocp_header_in_da1), NULL, 0, NULL);
 
 		printf(STR_LINE);
 		printf("%s\n", STR_SMART_HEALTH_INFO);
@@ -1391,7 +1486,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			offsetof(struct nvme_ocp_header_in_da1, smart_health_info);
 
 		generic_structure_parser(pda1_smart_offset, smart, ARRAY_SIZE(smart), NULL, 0,
-					 NULL);
+			NULL);
 
 		printf(STR_LINE);
 		printf("%s\n", STR_SMART_HEALTH_INTO_EXTENDED);
@@ -1400,7 +1495,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			offsetof(struct nvme_ocp_header_in_da1, smart_health_info_extended);
 
 		generic_structure_parser(pda1_smart_ext_offset, smart_extended,
-				     ARRAY_SIZE(smart_extended), NULL, 0, NULL);
+			ARRAY_SIZE(smart_extended), NULL, 0, NULL);
 
 		printf(STR_LINE);
 		printf("%s\n", STR_DA_1_STATS);

--- a/plugins/ocp/ocp-telemetry-decode.h
+++ b/plugins/ocp/ocp-telemetry-decode.h
@@ -382,7 +382,7 @@ struct telemetry_stats_desc {
 	__u8 data[];
 };
 
-struct telemetry_event_desc {
+struct __packed telemetry_event_desc {
 	__u8 class;
 	__le16 id;
 	__u8 size;
@@ -428,6 +428,7 @@ struct telemetry_data_area_1 {
 #define MAX_NUM_FIFOS                 16
 #define DA1_OFFSET                    512
 #define DEFAULT_ASCII_STRING_SIZE     16
+#define SIZE_OF_VU_EVENT_ID           2
 
 #define DEFAULT_TELEMETRY_BIN "telemetry.bin"
 #define DEFAULT_STRING_BIN "string.bin"
@@ -856,30 +857,28 @@ struct __packed nvme_ocp_telemetry_event_descriptor
 struct __packed nvme_ocp_time_stamp_dbg_evt_class_format
 {
 	__u8 time_stamp[DATA_SIZE_8];             // Bytes 11:4
-	__le16 vu_event_identifier;               // Bytes 13:12
 };
 
 struct __packed nvme_ocp_pcie_dbg_evt_class_format
 {
 	__u8 pCIeDebugEventData[DATA_SIZE_4];     // Bytes 7:4
-	__le16 vu_event_identifier;               // Bytes 9:8
 };
 
 struct __packed nvme_ocp_nvme_dbg_evt_class_format
 {
 	__u8 nvmeDebugEventData[DATA_SIZE_8];     // Bytes 11:4
-	__le16 vu_event_identifier;               // Bytes 13:12
-};
-
-struct __packed nvme_ocp_common_dbg_evt_class_format
-{
-	__le16 vu_event_identifier;    // Bytes 5:4
 };
 
 struct __packed nvme_ocp_media_wear_dbg_evt_class_format
 {
 	__u8 currentMediaWear[DATA_SIZE_12];         // Bytes 15:4
-	__le16 vu_event_identifier;                  // Bytes 17:16
+
+};
+
+struct __packed nvme_ocp_common_dbg_evt_class_vu_data
+{
+	__le16 vu_event_identifier;         // Bytes 5:4
+	__u8 data[];                        // Bytes N:6
 };
 
 struct __packed nvme_ocp_statistic_snapshot_evt_class_format


### PR DESCRIPTION
This commit fixes several issues related to parsing the Telemetry DA 1 and 2 Event FIFO's.

Fixes parsing of VU Event Data.
    Added checking for VU data.
    Removed the vu_event_identifier field from the debug
    event class structs since it's not guaranteed to be there.
    Added nvme_ocp_common_dbg_evt_class_vu_data to be used
    to access the VU data.

    Added checking for NULL pointers

    Added a check for the end of the Event FIFO entries that will
    break from the while loop when detected.