### PR TITLE
nvme-print: fix error information log page endianness error

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -474,8 +474,8 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries,
 		obj_add_uint64(error, "error_count", le64_to_cpu(err_log[i].error_count));
 		obj_add_int(error, "sqid", le16_to_cpu(err_log[i].sqid));
 		obj_add_int(error, "cmdid", le16_to_cpu(err_log[i].cmdid));
-		obj_add_int(error, "status_field", le16_to_cpu(err_log[i].status_field >> 0x1));
-		obj_add_int(error, "phase_tag", le16_to_cpu(err_log[i].status_field & 0x1));
+		obj_add_int(error, "status_field", le16_to_cpu(err_log[i].status_field) >> 0x1);
+		obj_add_int(error, "phase_tag", le16_to_cpu(err_log[i].status_field) & 0x1);
 		obj_add_int(error, "parm_error_location",
 			    le16_to_cpu(err_log[i].parm_error_location));
 		obj_add_uint64(error, "lba", le64_to_cpu(err_log[i].lba));

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -3664,8 +3664,7 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 		printf("cmdid		: %#x\n", err_log[i].cmdid);
 		printf("status_field	: %#x (%s)\n", status,
 			nvme_status_to_string(status, false));
-		printf("phase_tag	: %#x\n",
-			le16_to_cpu(err_log[i].status_field & 0x1));
+		printf("phase_tag	: %#x\n", le16_to_cpu(err_log[i].status_field) & 0x1);
 		printf("parm_err_loc	: %#x\n",
 			err_log[i].parm_error_location);
 		printf("lba		: %#"PRIx64"\n",


### PR DESCRIPTION
Convert the status and phase tag fields to native byte order at first.