### PR TITLE
nvme: fix uninitialized value in error-log

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -1168,7 +1168,7 @@ static int get_error_log(int argc, char **argv, struct command *cmd, struct plug
 
 	_cleanup_free_ struct nvme_error_log_page *err_log = NULL;
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
-	struct nvme_id_ctrl ctrl;
+	struct nvme_id_ctrl ctrl = { 0 };
 	nvme_print_flags_t flags;
 	int err = -1;
 


### PR DESCRIPTION
Valgrind complained about an "uninitialized value created by a stack allocation" error while running the error-log command. Fix the same.