### PR TITLE
nvme-print-json: print CMBEBS and CMBSWTP in json format

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2812,8 +2812,6 @@ static void json_ctrl_registers(void *bar, bool fabrics)
 	json_ctrl_registers_cc(bar, r);
 	json_ctrl_registers_csts(bar, r);
 	json_ctrl_registers_nssr(bar, r);
-	json_ctrl_registers_nssd(bar, r);
-	json_ctrl_registers_crto(bar, r);
 	json_ctrl_registers_aqa(bar, r);
 	json_ctrl_registers_asq(bar, r);
 	json_ctrl_registers_acq(bar, r);
@@ -2826,6 +2824,8 @@ static void json_ctrl_registers(void *bar, bool fabrics)
 	json_ctrl_registers_cmbsts(bar, r);
 	json_ctrl_registers_cmbebs(bar, r);
 	json_ctrl_registers_cmbswtp(bar, r);
+	json_ctrl_registers_nssd(bar, r);
+	json_ctrl_registers_crto(bar, r);
 	json_ctrl_registers_pmrcap(bar, r);
 	json_ctrl_registers_pmrctl(bar, r);
 	json_ctrl_registers_pmrsts(bar, r);


### PR DESCRIPTION
1. Print the CMBEBS and CMBSWTP register in json format
2. Print the Controller Register values in order based on the offset.