### PR TITLE
nvme: Support show-regs for nvmeof

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -406,7 +406,18 @@ bool nvme_is_fabrics_reg(int offset)
 	case NVME_REG_CC:
 	case NVME_REG_CSTS:
 	case NVME_REG_NSSR:
-	case NVME_REG_CRTO:
+		return true;
+	default:
+		break;
+	}
+
+	return false;
+}
+
+bool nvme_is_fabrics_optional_reg(int offset)
+{
+	switch (offset) {
+	case NVME_REG_NSSR:
 		return true;
 	default:
 		break;

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -322,6 +322,7 @@ void nvme_show_error_status(int status, const char *msg, ...);
 void nvme_show_init(void);
 void nvme_show_finish(void);
 bool nvme_is_fabrics_reg(int offset);
+bool nvme_is_fabrics_optional_reg(int offset);
 bool nvme_registers_cmbloc_support(__u32 cmbsz);
 bool nvme_registers_pmrctl_ready(__u32 pmrctl);
 const char *nvme_degrees_string(long t);


### PR DESCRIPTION
Get properties only at offsets that support nvme fabric registers.
Since crto was not found in the nvmeof spec, it is removed.
Also, NSSR is only optional register. If the device is not supported by the optional register, the error is ignored.

Reviewed-by: Steven Seungcheol <sc108.lee@samsung.com>
Signed-off-by: Minsik Jeon <hmi.jeon@samsung.com>