### PR TITLE
wdc: Add Support for SN5100S

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -141,6 +141,10 @@
 #define WDC_NVME_SN810_DEV_ID				0x5011
 #define WDC_NVME_SN820CL_DEV_ID				0x5037
 
+#define WDC_NVME_SN5100S_DEV_ID_1			0x5061
+#define WDC_NVME_SN5100S_DEV_ID_2			0x5062
+#define WDC_NVME_SN5100S_DEV_ID_3			0x5063
+
 #define WDC_DRIVE_CAP_CAP_DIAG				0x0000000000000001
 #define WDC_DRIVE_CAP_INTERNAL_LOG			0x0000000000000002
 #define WDC_DRIVE_CAP_C1_LOG_PAGE			0x0000000000000004
@@ -1976,6 +1980,12 @@ static __u64 wdc_get_drive_capabilities(nvme_root_t r, struct nvme_dev *dev)
 		case WDC_NVME_SN7100_DEV_ID_3:
 			fallthrough;
 		case WDC_NVME_SN8000S_DEV_ID:
+			fallthrough;
+		case WDC_NVME_SN5100S_DEV_ID_1:
+			fallthrough;
+		case WDC_NVME_SN5100S_DEV_ID_2:
+			fallthrough;
+		case WDC_NVME_SN5100S_DEV_ID_3:
 			fallthrough;
 		case WDC_NVME_SN740_DEV_ID:
 		case WDC_NVME_SN740_DEV_ID_1:

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.11.0"
+#define WDC_PLUGIN_VERSION   "2.11.1"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
This commit will add support for the SN51000S drive which includes the following pci device ids:
0x5061, 0x5062, 0x5063.