### PR TITLE
doc: show where self-test results can be found

### DIFF
--- a/Documentation/nvme-device-self-test.txt
+++ b/Documentation/nvme-device-self-test.txt
@@ -22,6 +22,8 @@ device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
 
 On success, the corresponding test is initiated.
 
+The results of this test can be queried via 'nvme self-test-log <device>'.
+
 OPTIONS
 -------
 -n <NUM>::


### PR DESCRIPTION
As a first-time user I was wondering on where to find the `device-self-test` results.

I think adding this information to the `device-self-test` documentation would be quite useful.