### PR TITLE
plugins/solidigm: Automatic retry smaller telemetry chunk size.

### DIFF
--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -13,7 +13,7 @@
 
 #include "cmd.h"
 
-#define SOLIDIGM_PLUGIN_VERSION "1.7"
+#define SOLIDIGM_PLUGIN_VERSION "1.8"
 
 PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_VERSION),
 	COMMAND_LIST(

--- a/plugins/solidigm/solidigm-util.c
+++ b/plugins/solidigm/solidigm-util.c
@@ -37,3 +37,19 @@ int sldgm_get_uuid_index(struct nvme_dev *dev, __u8 *index)
 
 	return sldgm_find_uuid_index(&uuid_list, index);
 }
+
+int sldgm_dynamic_telemetry(int dev_fd, bool create, bool ctrl, bool log_page, __u8 mtds,
+			    enum nvme_telemetry_da da, struct nvme_telemetry_log **log_buffer,
+			    size_t *log_buffer_size)
+{
+	int err;
+	size_t max_data_tx = (1 << mtds) * NVME_LOG_PAGE_PDU_SIZE;
+
+	do {
+		err = nvme_get_telemetry_log(dev_fd, create, ctrl, log_page, max_data_tx, da,
+					     log_buffer, log_buffer_size);
+		max_data_tx /= 2;
+		create = false;
+	} while (err == -EPERM && max_data_tx >= NVME_LOG_PAGE_PDU_SIZE);
+	return err;
+}

--- a/plugins/solidigm/solidigm-util.h
+++ b/plugins/solidigm/solidigm-util.h
@@ -7,7 +7,8 @@
 
 #include "nvme.h"
 
-#define DRIVER_MAX_TX_256K (256 * 1024)
-
 int sldgm_find_uuid_index(struct nvme_id_uuid_list *uuid_list, __u8 *index);
 int sldgm_get_uuid_index(struct nvme_dev *dev, __u8 *index);
+int sldgm_dynamic_telemetry(int dev_fd, bool create, bool ctrl, bool log_page, __u8 mtds,
+			    enum nvme_telemetry_da da, struct nvme_telemetry_log **log_buffer,
+			    size_t *log_buffer_size);


### PR DESCRIPTION
Retry to retrieve telemetry with smaller chunk size, because some systems are failing to retrieve telemetry in 256KB chunks.