### PR TITLE
Allow connect to use configured TLS keys

### DIFF
--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -26,7 +26,8 @@ SYNOPSIS
 			[--keep-alive-tmo=<#> | -k <#>]
 			[--reconnect-delay=<#> | -c <#>]
 			[--ctrl-loss-tmo=<#> | -l <#>] [--tos=<#> | -T <#>]
-			[--keyring=<#>] [--tls_key=<#>]
+			[--keyring=<keyring>] [--tls-key=<tls-key>]
+			[--tls-key-identity=<identity>]
 			[--duplicate-connect | -D] [--disable-sqflow ]
 			[--hdr-digest | -g] [--data-digest | -G] [--tls]
 			[--concat] [--dump-config | -O] [--application=<id>]
@@ -151,11 +152,22 @@ OPTIONS
 --tos=<#>::
 	Type of service for the connection (TCP)
 
---keyring=<#>::
-	Keyring for TLS key lookup.
+--keyring=<keyring>::
+	Keyring for TLS key lookup, either the key id or the keyring name.
 
---tls_key=<#>::
-	TLS key for the connection (TCP).
+--tls-key=<tls-key>::
+	TLS key for the connection (TCP), either the TLS key in
+	interchange format or the key id. It's strongly recommended not
+	to provide the TLS key via the comamnd line due to security
+	concerns. Instead in production situation, the key should be
+	loaded into the keystore with 'nvme tls --import' and only the
+	'--tls' options used. The kernel will select the matching key.
+
+--tls-key-identity=<identity>::
+	The identity used for the tls-key. If none is provided the
+	tls-key provided via the comamnd line is considered a
+	configuration key and a derive key will be loaded into the
+	keyring.
 
 -D::
 --duplicate-connect::

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 			[--identity=<id-vers> | -I <id-vers>]
 			[--secret=<secret> | -s <secret>]
 			[--insert | -i]
+			[--keyfile=<keyfile> | -f <keyfile>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
 
 DESCRIPTION
@@ -80,6 +81,11 @@ OPTIONS
 --insert::
 	Insert the resulting TLS key into the keyring without printing out
 	the key in PSK interchange format.
+
+-f <keyfile>
+--keyfile=<keyfile>
+	Append the resulting TLS key to keyfile. This command line option is
+	depending on --insert.
 
 -o <fmt>::
 --output-format=<fmt>::

--- a/fabrics.c
+++ b/fabrics.c
@@ -81,8 +81,10 @@ static const char *nvmf_reconnect_delay	= "reconnect timeout period in seconds";
 static const char *nvmf_ctrl_loss_tmo	= "controller loss timeout period in seconds";
 static const char *nvmf_fast_io_fail_tmo = "fast I/O fail timeout (default off)";
 static const char *nvmf_tos		= "type of service";
-static const char *nvmf_keyring		= "Keyring for TLS key lookup";
-static const char *nvmf_tls_key		= "TLS key to use";
+static const char *nvmf_keyring		= "Keyring for TLS key lookup (key id or keyring name)";
+static const char *nvmf_tls_key		= "TLS key to use (key id or key in interchange format)";
+static const char *nvmf_tls_key_legacy	= "TLS key to use (key id)";
+static const char *nvmf_tls_key_identity = "TLS key identity";
 static const char *nvmf_dup_connect	= "allow duplicate connections between same transport host and subsystem port";
 static const char *nvmf_disable_sqflow	= "disable controller sq flow control (default false)";
 static const char *nvmf_hdr_digest	= "enable transport protocol header digest (TCP transport)";
@@ -103,6 +105,9 @@ static const char *nvmf_context		= "execution context identification string";
 		OPT_STRING("hostnqn",         'q', "STR", &hostnqn,       nvmf_hostnqn),         \
 		OPT_STRING("hostid",          'I', "STR", &hostid,        nvmf_hostid),          \
 		OPT_STRING("dhchap-secret",   'S', "STR", &hostkey,       nvmf_hostkey),         \
+		OPT_STRING("keyring",          0,  "STR", &keyring,       nvmf_keyring),         \
+		OPT_STRING("tls-key",          0,  "STR", &tls_key,       nvmf_tls_key),         \
+		OPT_STRING("tls-key-identity", 0,  "STR", &tls_key_identity, nvmf_tls_key_identity), \
 		OPT_INT("nr-io-queues",       'i', &c.nr_io_queues,       nvmf_nr_io_queues),    \
 		OPT_INT("nr-write-queues",    'W', &c.nr_write_queues,    nvmf_nr_write_queues), \
 		OPT_INT("nr-poll-queues",     'P', &c.nr_poll_queues,     nvmf_nr_poll_queues),  \
@@ -112,8 +117,7 @@ static const char *nvmf_context		= "execution context identification string";
 		OPT_INT("ctrl-loss-tmo",      'l', &c.ctrl_loss_tmo,      nvmf_ctrl_loss_tmo),   \
 		OPT_INT("fast_io_fail_tmo",   'F', &c.fast_io_fail_tmo,   nvmf_fast_io_fail_tmo),\
 		OPT_INT("tos",                'T', &c.tos,                nvmf_tos),             \
-		OPT_INT("keyring",              0, &c.keyring,            nvmf_keyring),         \
-		OPT_INT("tls_key",              0, &c.tls_key,            nvmf_tls_key),         \
+		OPT_INT("tls_key",              0, &c.tls_key,            nvmf_tls_key_legacy),  \
 		OPT_FLAG("duplicate-connect", 'D', &c.duplicate_connect,  nvmf_dup_connect),     \
 		OPT_FLAG("disable-sqflow",      0, &c.disable_sqflow,     nvmf_disable_sqflow),  \
 		OPT_FLAG("hdr-digest",        'g', &c.hdr_digest,         nvmf_hdr_digest),      \
@@ -407,7 +411,8 @@ static int discover_from_conf_file(nvme_root_t r, nvme_host_t h,
 {
 	char *transport = NULL, *traddr = NULL, *trsvcid = NULL;
 	char *hostnqn = NULL, *hostid = NULL, *hostkey = NULL;
-	char *subsysnqn = NULL;
+	char *subsysnqn = NULL, *keyring = NULL, *tls_key = NULL;
+	char *tls_key_identity = NULL;
 	char *ptr, **argv, *p, line[4096];
 	int argc, ret = 0;
 	unsigned int verbose = 0;
@@ -681,6 +686,8 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	char *subsysnqn = NVME_DISC_SUBSYS_NAME;
 	char *hostnqn = NULL, *hostid = NULL, *hostkey = NULL;
 	char *transport = NULL, *traddr = NULL, *trsvcid = NULL;
+	char *keyring = NULL, *tls_key = NULL;
+	char *tls_key_identity = NULL;
 	char *config_file = PATH_NVMF_CONFIG;
 	_cleanup_free_ char *hnqn = NULL;
 	_cleanup_free_ char *hid = NULL;
@@ -935,12 +942,41 @@ static int nvme_connect_config(nvme_root_t r, const char *hostnqn, const char *h
 	return ret;
 }
 
+static void nvme_parse_tls_args(const char *keyring, const char *tls_key,
+				const char *tls_key_identity,
+				struct nvme_fabrics_config *cfg, nvme_ctrl_t c)
+{
+	if (keyring) {
+		char *endptr;
+		long id = strtol(keyring, &endptr, 0);
+
+		if (endptr != keyring)
+			cfg->keyring = id;
+		else
+			nvme_ctrl_set_keyring(c, keyring);
+	}
+
+	if (tls_key_identity)
+		nvme_ctrl_set_tls_key_identity(c, tls_key_identity);
+
+	if (tls_key) {
+		char *endptr;
+		long id = strtol(tls_key, &endptr, 0);
+
+		if (endptr != tls_key)
+			cfg->tls_key = id;
+		else
+			nvme_ctrl_set_tls_key(c, tls_key);
+	}
+}
+
 int nvmf_connect(const char *desc, int argc, char **argv)
 {
 	char *subsysnqn = NULL;
 	char *transport = NULL, *traddr = NULL;
 	char *trsvcid = NULL, *hostnqn = NULL, *hostid = NULL;
-	char *hostkey = NULL, *ctrlkey = NULL;
+	char *hostkey = NULL, *ctrlkey = NULL, *keyring = NULL;
+	char *tls_key = NULL, *tls_key_identity = NULL;
 	_cleanup_free_ char *hnqn = NULL;
 	_cleanup_free_ char *hid = NULL;
 	char *config_file = NULL;
@@ -953,7 +989,6 @@ int nvmf_connect(const char *desc, int argc, char **argv)
 	nvme_print_flags_t flags;
 	struct nvme_fabrics_config cfg = { 0 };
 	char *format = "normal";
-
 
 	NVMF_ARGS(opts, cfg,
 		  OPT_STRING("dhchap-ctrl-secret", 'C', "STR", &ctrlkey,      nvmf_ctrlkey),
@@ -1061,8 +1096,11 @@ do_connect:
 		errno = ENOMEM;
 		goto out_free;
 	}
+
 	if (ctrlkey)
 		nvme_ctrl_set_dhchap_key(c, ctrlkey);
+
+	nvme_parse_tls_args(keyring, tls_key, tls_key_identity, &cfg, c);
 
 	errno = 0;
 	ret = nvmf_add_ctrl(h, c, &cfg);
@@ -1286,6 +1324,7 @@ int nvmf_config(const char *desc, int argc, char **argv)
 	_cleanup_free_ char *hnqn = NULL;
 	_cleanup_free_ char *hid = NULL;
 	char *hostkey = NULL, *ctrlkey = NULL;
+	char *keyring = NULL, *tls_key = NULL, *tls_key_identity = NULL;
 	char *config_file = PATH_NVMF_CONFIG;
 	unsigned int verbose = 0;
 	_cleanup_nvme_root_ nvme_root_t r = NULL;
@@ -1375,9 +1414,11 @@ int nvmf_config(const char *desc, int argc, char **argv)
 				nvme_strerror(errno));
 			return -errno;
 		}
-		nvmf_update_config(c, &cfg);
 		if (ctrlkey)
 			nvme_ctrl_set_dhchap_key(c, ctrlkey);
+		nvme_parse_tls_args(keyring, tls_key, tls_key_identity, &cfg, c);
+
+		nvmf_update_config(c, &cfg);
 	}
 
 	if (update_config)

--- a/meson.build
+++ b/meson.build
@@ -252,6 +252,7 @@ endforeach
 udev_files = [
   '65-persistent-net-nbft.rules',
   '70-nvmf-autoconnect.rules',
+  '70-nvmf-keys.rules',
   '71-nvmf-netapp.rules',
 ]
 

--- a/nvme.c
+++ b/nvme.c
@@ -9181,7 +9181,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 	const char *secret =
 	    "Optional secret (in hexadecimal characters) to be used for the TLS key.";
 	const char *hmac = "HMAC function to use for the retained key (1 = SHA-256, 2 = SHA-384).";
-	const char *identity = "TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0";
+	const char *version = "TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0";
 	const char *hostnqn = "Host NQN for the retained key.";
 	const char *subsysnqn = "Subsystem NQN for the retained key.";
 	const char *keyring = "Keyring for the retained key.";
@@ -9202,7 +9202,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		char		*subsysnqn;
 		char		*secret;
 		unsigned char	hmac;
-		unsigned char	identity;
+		unsigned char	version;
 		bool		insert;
 	};
 
@@ -9213,7 +9213,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		.subsysnqn	= NULL,
 		.secret		= NULL,
 		.hmac		= 1,
-		.identity	= 0,
+		.version	= 0,
 		.insert		= false,
 	};
 
@@ -9224,7 +9224,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		  OPT_STR("subsysnqn",	'c', &cfg.subsysnqn,	subsysnqn),
 		  OPT_STR("secret",	's', &cfg.secret,	secret),
 		  OPT_BYTE("hmac",	'm', &cfg.hmac,		hmac),
-		  OPT_BYTE("identity",	'I', &cfg.identity,	identity),
+		  OPT_BYTE("identity",	'I', &cfg.version,	version),
 		  OPT_FLAG("insert",	'i', &cfg.insert,	insert));
 
 	err = parse_args(argc, argv, desc, opts);
@@ -9234,9 +9234,9 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		nvme_show_error("Invalid HMAC identifier %u", cfg.hmac);
 		return -EINVAL;
 	}
-	if (cfg.identity > 1) {
+	if (cfg.version > 1) {
 		nvme_show_error("Invalid TLS identity version %u",
-				cfg.identity);
+				cfg.version);
 		return -EINVAL;
 	}
 	if (cfg.insert) {
@@ -9288,7 +9288,7 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 	if (cfg.insert) {
 		tls_key = nvme_insert_tls_key_versioned(cfg.keyring,
 					cfg.keytype, cfg.hostnqn,
-					cfg.subsysnqn, cfg.identity,
+					cfg.subsysnqn, cfg.version,
 					cfg.hmac, raw_secret, key_len);
 		if (tls_key <= 0) {
 			nvme_show_error("Failed to insert key, error %d", errno);

--- a/nvme.c
+++ b/nvme.c
@@ -9201,8 +9201,8 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		char		*hostnqn;
 		char		*subsysnqn;
 		char		*secret;
-		unsigned int	hmac;
-		unsigned int	identity;
+		unsigned char	hmac;
+		unsigned char	identity;
 		bool		insert;
 	};
 
@@ -9223,8 +9223,8 @@ static int gen_tls_key(int argc, char **argv, struct command *command, struct pl
 		  OPT_STR("hostnqn",	'n', &cfg.hostnqn,	hostnqn),
 		  OPT_STR("subsysnqn",	'c', &cfg.subsysnqn,	subsysnqn),
 		  OPT_STR("secret",	's', &cfg.secret,	secret),
-		  OPT_UINT("hmac",	'm', &cfg.hmac,		hmac),
-		  OPT_UINT("identity",	'I', &cfg.identity,	identity),
+		  OPT_BYTE("hmac",	'm', &cfg.hmac,		hmac),
+		  OPT_BYTE("identity",	'I', &cfg.identity,	identity),
 		  OPT_FLAG("insert",	'i', &cfg.insert,	insert));
 
 	err = parse_args(argc, argv, desc, opts);
@@ -9322,7 +9322,7 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 		char		*hostnqn;
 		char		*subsysnqn;
 		char		*keydata;
-		unsigned int	identity;
+		unsigned char	identity;
 		bool		insert;
 	};
 
@@ -9342,7 +9342,7 @@ static int check_tls_key(int argc, char **argv, struct command *command, struct 
 		  OPT_STR("hostnqn",	'n', &cfg.hostnqn,	hostnqn),
 		  OPT_STR("subsysnqn",	'c', &cfg.subsysnqn,	subsysnqn),
 		  OPT_STR("keydata",	'd', &cfg.keydata,	keydata),
-		  OPT_UINT("identity",	'I', &cfg.identity,	identity),
+		  OPT_BYTE("identity",	'I', &cfg.identity,	identity),
 		  OPT_FLAG("insert",	'i', &cfg.insert,	insert));
 
 	err = parse_args(argc, argv, desc, opts);

--- a/nvme.c
+++ b/nvme.c
@@ -9411,11 +9411,18 @@ static void __scan_tls_key(long keyring_id, long key_id,
 	_cleanup_free_ const unsigned char *key_data = NULL;
 	_cleanup_free_ char *encoded_key = NULL;
 	int key_len;
+	int ver, hmac;
+	char type;
 
 	key_data = nvme_read_key(keyring_id, key_id, &key_len);
 	if (!key_data)
 		return;
-	encoded_key = nvme_export_tls_key(key_data, key_len);
+
+	if (sscanf(desc, "NVMe%01d%c%02d %*s", &ver, &type, &hmac) != 3)
+		return;
+
+	encoded_key = nvme_export_tls_key_versioned(ver, hmac,
+						    key_data, key_len);
 	if (!encoded_key)
 		return;
 	fprintf(fd, "%s %s\n", desc, encoded_key);

--- a/nvme.c
+++ b/nvme.c
@@ -9480,6 +9480,7 @@ static int tls_key(int argc, char **argv, struct command *command, struct plugin
 	const char *revoke = "Revoke key from the keyring.";
 
 	_cleanup_file_ FILE *fd = NULL;
+	mode_t old_umask = 0;
 	int cnt, err = 0;
 
 	struct config {
@@ -9519,6 +9520,8 @@ static int tls_key(int argc, char **argv, struct command *command, struct plugin
 			mode = "r";
 		else
 			mode = "w";
+
+		old_umask = umask(0);
 
 		fd = fopen(cfg.keyfile, mode);
 		if (!fd) {
@@ -9573,6 +9576,11 @@ static int tls_key(int argc, char **argv, struct command *command, struct plugin
 
 		if (argconfig_parse_seen(opts, "verbose"))
 			printf("revoking key\n");
+	}
+
+	if (old_umask != 0 && fd) {
+		umask(old_umask);
+		chmod(cfg.keyfile, 0600);
 	}
 
 	return err;

--- a/nvmf-autoconnect/udev-rules/70-nvmf-keys.rules.in
+++ b/nvmf-autoconnect/udev-rules/70-nvmf-keys.rules.in
@@ -1,0 +1,7 @@
+#
+# nvmf-keys.rules:
+#   Load pre-shared keys into the kernel keyring when
+#   the PSK keyring module gets loaded.
+#
+#
+ACTION=="add", SUBSYSTEM=="module", KERNEL=="nvme_tcp", TEST=="@SYSCONFDIR@/tls-keys", RUN+="@SBINDIR@/nvme tls --import --keyfile @SYSCONFDIR@/tls-keys"

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 5f0eb7fbd9a77f7dd6551be3ff98b19891ba4226
+revision = 6f13888ab994cd42e83818f018913d78a5a7000b
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Extend the ` --tls_key` and `--keyring` argument to accept also configured keys.

Depends on https://github.com/linux-nvme/libnvme/pull/894

