### PR TITLE
nvme-print-json: display only verbose output

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -203,11 +203,6 @@ static void obj_print(struct json_object *o)
 		json_print(o);
 }
 
-static bool human(void)
-{
-	return json_print_ops.flags & VERBOSE;
-}
-
 static void json_id_iocs(struct nvme_id_iocs *iocs)
 {
 	struct json_object *r = json_create_object();
@@ -669,21 +664,17 @@ static void json_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 	nvme_uint128_t media_errors = le128_to_cpu(smart->media_errors);
 	nvme_uint128_t num_err_log_entries = le128_to_cpu(smart->num_err_log_entries);
 
-	if (human()) {
-		struct json_object *crt = json_create_object();
+	struct json_object *crt = json_create_object();
 
-		obj_add_int(crt, "value", smart->critical_warning);
-		obj_add_int(crt, "available_spare", smart->critical_warning & 1);
-		obj_add_int(crt, "temp_threshold", (smart->critical_warning & 2) >> 1);
-		obj_add_int(crt, "reliability_degraded", (smart->critical_warning & 4) >> 2);
-		obj_add_int(crt, "ro", (smart->critical_warning & 8) >> 3);
-		obj_add_int(crt, "vmbu_failed", (smart->critical_warning & 0x10) >> 4);
-		obj_add_int(crt, "pmr_ro", (smart->critical_warning & 0x20) >> 5);
+	obj_add_int(crt, "value", smart->critical_warning);
+	obj_add_int(crt, "available_spare", smart->critical_warning & 1);
+	obj_add_int(crt, "temp_threshold", (smart->critical_warning & 2) >> 1);
+	obj_add_int(crt, "reliability_degraded", (smart->critical_warning & 4) >> 2);
+	obj_add_int(crt, "ro", (smart->critical_warning & 8) >> 3);
+	obj_add_int(crt, "vmbu_failed", (smart->critical_warning & 0x10) >> 4);
+	obj_add_int(crt, "pmr_ro", (smart->critical_warning & 0x20) >> 5);
 
-		obj_add_obj(r, "critical_warning", crt);
-	} else {
-		obj_add_int(r, "critical_warning", smart->critical_warning);
-	}
+	obj_add_obj(r, "critical_warning", crt);
 
 	obj_add_int(r, "temperature", temperature);
 	obj_add_int(r, "avail_spare", smart->avail_spare);
@@ -1322,24 +1313,8 @@ static void json_single_property_human(int offset, uint64_t value64, struct json
 static void json_single_property(int offset, uint64_t value64)
 {
 	struct json_object *r = json_create_object();
-	char json_str[STR_LEN];
-	uint32_t value32 = (uint32_t)value64;
 
-	if (human()) {
-		json_single_property_human(offset, value64, r);
-	} else {
-		sprintf(json_str, "0x%02x", offset);
-		obj_add_str(r, "property", json_str);
-
-		obj_add_str(r, "name", nvme_register_to_string(offset));
-
-		if (nvme_is_64bit_reg(offset))
-			sprintf(json_str, "%"PRIx64"", value64);
-		else
-			sprintf(json_str, "%x", value32);
-
-		obj_add_str(r, "value", json_str);
-	}
+	json_single_property_human(offset, value64, r);
 
 	json_print(r);
 }
@@ -2491,12 +2466,10 @@ static void json_print_nvme_subsystem_list(nvme_root_t r, bool show_ana)
 			obj_add_str(subsystem_attrs, "Name", nvme_subsystem_get_name(s));
 			obj_add_str(subsystem_attrs, "NQN", nvme_subsystem_get_nqn(s));
 
-			if (json_print_ops.flags & VERBOSE) {
-				obj_add_str(subsystem_attrs, "IOPolicy",
-						nvme_subsystem_get_iopolicy(s));
-				obj_add_str(subsystem_attrs, "Type",
-						nvme_subsystem_get_type(s));
-			}
+			obj_add_str(subsystem_attrs, "IOPolicy",
+					nvme_subsystem_get_iopolicy(s));
+			obj_add_str(subsystem_attrs, "Type",
+					nvme_subsystem_get_type(s));
 
 			array_add_obj(subsystems, subsystem_attrs);
 			paths = json_create_array();
@@ -2517,120 +2490,84 @@ static void json_ctrl_registers_cap(void *bar, struct json_object *r)
 {
 	uint64_t cap = mmio_read64(bar + NVME_REG_CAP);
 
-	if (human())
-		json_registers_cap((struct nvme_bar_cap *)&cap, obj_create_array_obj(r, "cap"));
-	else
-		obj_add_uint64(r, "cap", cap);
+	json_registers_cap((struct nvme_bar_cap *)&cap, obj_create_array_obj(r, "cap"));
 }
 
 static void json_ctrl_registers_vs(void *bar, struct json_object *r)
 {
 	uint32_t vs = mmio_read32(bar + NVME_REG_VS);
 
-	if (human())
-		json_registers_version(vs, obj_create_array_obj(r, "vs"));
-	else
-		obj_add_int(r, "vs", vs);
+	json_registers_version(vs, obj_create_array_obj(r, "vs"));
 }
 
 static void json_ctrl_registers_intms(void *bar, struct json_object *r)
 {
 	uint32_t intms = mmio_read32(bar + NVME_REG_INTMS);
 
-	if (human())
-		json_registers_intms(intms, obj_create_array_obj(r, "intms"));
-	else
-		obj_add_int(r, "intms", intms);
+	json_registers_intms(intms, obj_create_array_obj(r, "intms"));
 }
 
 static void json_ctrl_registers_intmc(void *bar, struct json_object *r)
 {
 	uint32_t intmc = mmio_read32(bar + NVME_REG_INTMC);
 
-	if (human())
-		json_registers_intmc(intmc, obj_create_array_obj(r, "intmc"));
-	else
-		obj_add_int(r, "intmc", intmc);
+	json_registers_intmc(intmc, obj_create_array_obj(r, "intmc"));
 }
 
 static void json_ctrl_registers_cc(void *bar, struct json_object *r)
 {
 	uint32_t cc = mmio_read32(bar + NVME_REG_CC);
 
-	if (human())
-		json_registers_cc(cc, obj_create_array_obj(r, "cc"));
-	else
-		obj_add_int(r, "cc", cc);
+	json_registers_cc(cc, obj_create_array_obj(r, "cc"));
 }
 
 static void json_ctrl_registers_csts(void *bar, struct json_object *r)
 {
 	uint32_t csts = mmio_read32(bar + NVME_REG_CSTS);
 
-	if (human())
-		json_registers_csts(csts, obj_create_array_obj(r, "csts"));
-	else
-		obj_add_int(r, "csts", csts);
+	json_registers_csts(csts, obj_create_array_obj(r, "csts"));
 }
 
 static void json_ctrl_registers_nssr(void *bar, struct json_object *r)
 {
 	uint32_t nssr = mmio_read32(bar + NVME_REG_NSSR);
 
-	if (human())
-		json_registers_nssr(nssr, obj_create_array_obj(r, "nssr"));
-	else
-		obj_add_int(r, "nssr", nssr);
+	json_registers_nssr(nssr, obj_create_array_obj(r, "nssr"));
 }
 
 static void json_ctrl_registers_nssd(void *bar, struct json_object *r)
 {
 	uint32_t nssd = mmio_read32(bar + NVME_REG_NSSD);
 
-	if (human())
-		json_registers_nssd(nssd, obj_create_array_obj(r, "nssd"));
-	else
-		obj_add_int(r, "nssd", nssd);
+	json_registers_nssd(nssd, obj_create_array_obj(r, "nssd"));
 }
 
 static void json_ctrl_registers_crto(void *bar, struct json_object *r)
 {
 	uint32_t crto = mmio_read32(bar + NVME_REG_CRTO);
 
-	if (human())
-		json_registers_crto(crto, obj_create_array_obj(r, "crto"));
-	else
-		obj_add_int(r, "crto", crto);
+	json_registers_crto(crto, obj_create_array_obj(r, "crto"));
 }
 
 static void json_ctrl_registers_aqa(void *bar, struct json_object *r)
 {
 	uint32_t aqa = mmio_read32(bar + NVME_REG_AQA);
 
-	if (human())
-		json_registers_aqa(aqa, obj_create_array_obj(r, "aqa"));
-	else
-		obj_add_int(r, "aqa", aqa);
+	json_registers_aqa(aqa, obj_create_array_obj(r, "aqa"));
 }
 
 static void json_ctrl_registers_asq(void *bar, struct json_object *r)
 {
 	uint64_t asq = mmio_read64(bar + NVME_REG_ASQ);
 
-	if (human())
-		json_registers_asq(asq, obj_create_array_obj(r, "asq"));
-	else
-		obj_add_uint64(r, "asq", asq);
+	json_registers_asq(asq, obj_create_array_obj(r, "asq"));
 }
 
 static void json_ctrl_registers_acq(void *bar, struct json_object *r)
 {
 	uint64_t acq = mmio_read64(bar + NVME_REG_ACQ);
 
-	if (human())
-		json_registers_acq(acq, obj_create_array_obj(r, "acq"));
-	else
-		obj_add_uint64(r, "acq", acq);
+	json_registers_acq(acq, obj_create_array_obj(r, "acq"));
 }
 
 static void json_ctrl_registers_cmbloc(void *bar, struct json_object *r)
@@ -2639,113 +2576,79 @@ static void json_ctrl_registers_cmbloc(void *bar, struct json_object *r)
 	uint32_t cmbsz;
 	bool support;
 
-	if (human()) {
-		cmbsz = mmio_read32(bar + NVME_REG_CMBSZ);
-		support = nvme_registers_cmbloc_support(cmbsz);
-		json_registers_cmbloc(cmbloc, support, obj_create_array_obj(r, "cmbloc"));
-	} else {
-		obj_add_int(r, "cmbloc", cmbloc);
-	}
+	cmbsz = mmio_read32(bar + NVME_REG_CMBSZ);
+	support = nvme_registers_cmbloc_support(cmbsz);
+	json_registers_cmbloc(cmbloc, support, obj_create_array_obj(r, "cmbloc"));
 }
 
 static void json_ctrl_registers_cmbsz(void *bar, struct json_object *r)
 {
 	uint32_t cmbsz = mmio_read32(bar + NVME_REG_CMBSZ);
 
-	if (human())
-		json_registers_cmbsz(cmbsz, obj_create_array_obj(r, "cmbsz"));
-	else
-		obj_add_int(r, "cmbsz", cmbsz);
+	json_registers_cmbsz(cmbsz, obj_create_array_obj(r, "cmbsz"));
 }
 
 static void json_ctrl_registers_bpinfo(void *bar, struct json_object *r)
 {
 	uint32_t bpinfo = mmio_read32(bar + NVME_REG_BPINFO);
 
-	if (human())
-		json_registers_bpinfo(bpinfo, obj_create_array_obj(r, "bpinfo"));
-	else
-		obj_add_int(r, "bpinfo", bpinfo);
+	json_registers_bpinfo(bpinfo, obj_create_array_obj(r, "bpinfo"));
 }
 
 static void json_ctrl_registers_bprsel(void *bar, struct json_object *r)
 {
 	uint32_t bprsel = mmio_read32(bar + NVME_REG_BPRSEL);
 
-	if (human())
-		json_registers_bprsel(bprsel, obj_create_array_obj(r, "bprsel"));
-	else
-		obj_add_int(r, "bprsel", bprsel);
+	json_registers_bprsel(bprsel, obj_create_array_obj(r, "bprsel"));
 }
 
 static void json_ctrl_registers_bpmbl(void *bar, struct json_object *r)
 {
 	uint64_t bpmbl = mmio_read64(bar + NVME_REG_BPMBL);
 
-	if (human())
-		json_registers_bpmbl(bpmbl, obj_create_array_obj(r, "bpmbl"));
-	else
-		obj_add_uint64(r, "bpmbl", bpmbl);
+	json_registers_bpmbl(bpmbl, obj_create_array_obj(r, "bpmbl"));
 }
 
 static void json_ctrl_registers_cmbmsc(void *bar, struct json_object *r)
 {
 	uint64_t cmbmsc = mmio_read64(bar + NVME_REG_CMBMSC);
 
-	if (human())
-		json_registers_cmbmsc(cmbmsc, obj_create_array_obj(r, "cmbmsc"));
-	else
-		obj_add_uint64(r, "cmbmsc", cmbmsc);
+	json_registers_cmbmsc(cmbmsc, obj_create_array_obj(r, "cmbmsc"));
 }
 
 static void json_ctrl_registers_cmbsts(void *bar, struct json_object *r)
 {
 	uint32_t cmbsts = mmio_read32(bar + NVME_REG_CMBSTS);
 
-	if (human())
-		json_registers_cmbsts(cmbsts, obj_create_array_obj(r, "cmbsts"));
-	else
-		obj_add_int(r, "cmbsts", cmbsts);
+	json_registers_cmbsts(cmbsts, obj_create_array_obj(r, "cmbsts"));
 }
 
 static void json_ctrl_registers_cmbebs(void *bar, struct json_object *r)
 {
 	uint32_t cmbebs = mmio_read32(bar + NVME_REG_CMBEBS);
 
-	if (human())
-		json_registers_cmbebs(cmbebs, obj_create_array_obj(r, "cmbebs"));
-	else
-		obj_add_int(r, "cmbebs", cmbebs);
+	json_registers_cmbebs(cmbebs, obj_create_array_obj(r, "cmbebs"));
 }
 
 static void json_ctrl_registers_cmbswtp(void *bar, struct json_object *r)
 {
 	uint32_t cmbswtp = mmio_read32(bar + NVME_REG_CMBSWTP);
 
-	if (human())
-		json_registers_cmbswtp(cmbswtp, obj_create_array_obj(r, "cmbswtp"));
-	else
-		obj_add_int(r, "cmbswtp", cmbswtp);
+	json_registers_cmbswtp(cmbswtp, obj_create_array_obj(r, "cmbswtp"));
 }
 
 static void json_ctrl_registers_pmrcap(void *bar, struct json_object *r)
 {
 	uint32_t pmrcap = mmio_read32(bar + NVME_REG_PMRCAP);
 
-	if (human())
-		json_registers_pmrcap(pmrcap, obj_create_array_obj(r, "pmrcap"));
-	else
-		obj_add_int(r, "pmrcap", pmrcap);
+	json_registers_pmrcap(pmrcap, obj_create_array_obj(r, "pmrcap"));
 }
 
 static void json_ctrl_registers_pmrctl(void *bar, struct json_object *r)
 {
 	uint32_t pmrctl = mmio_read32(bar + NVME_REG_PMRCTL);
 
-	if (human())
-		json_registers_pmrctl(pmrctl, obj_create_array_obj(r, "pmrctl"));
-	else
-		obj_add_int(r, "pmrctl", pmrctl);
+	json_registers_pmrctl(pmrctl, obj_create_array_obj(r, "pmrctl"));
 }
 
 static void json_ctrl_registers_pmrsts(void *bar, struct json_object *r)
@@ -2754,53 +2657,37 @@ static void json_ctrl_registers_pmrsts(void *bar, struct json_object *r)
 	uint32_t pmrctl;
 	bool ready;
 
-	if (human()) {
-		pmrctl = mmio_read32(bar + NVME_REG_PMRCTL);
-		ready = nvme_registers_pmrctl_ready(pmrctl);
-		json_registers_pmrsts(pmrsts, ready, obj_create_array_obj(r, "pmrsts"));
-	} else {
-		obj_add_int(r, "pmrsts", pmrsts);
-	}
+	pmrctl = mmio_read32(bar + NVME_REG_PMRCTL);
+	ready = nvme_registers_pmrctl_ready(pmrctl);
+	json_registers_pmrsts(pmrsts, ready, obj_create_array_obj(r, "pmrsts"));
 }
 
 static void json_ctrl_registers_pmrebs(void *bar, struct json_object *r)
 {
 	uint32_t pmrebs = mmio_read32(bar + NVME_REG_PMREBS);
 
-	if (human())
-		json_registers_pmrebs(pmrebs, obj_create_array_obj(r, "pmrebs"));
-	else
-		obj_add_int(r, "pmrebs", pmrebs);
+	json_registers_pmrebs(pmrebs, obj_create_array_obj(r, "pmrebs"));
 }
 
 static void json_ctrl_registers_pmrswtp(void *bar, struct json_object *r)
 {
 	uint32_t pmrswtp = mmio_read32(bar + NVME_REG_PMRSWTP);
 
-	if (human())
-		json_registers_pmrswtp(pmrswtp, obj_create_array_obj(r, "pmrswtp"));
-	else
-		obj_add_int(r, "pmrswtp", pmrswtp);
+	json_registers_pmrswtp(pmrswtp, obj_create_array_obj(r, "pmrswtp"));
 }
 
 static void json_ctrl_registers_pmrmscl(void *bar, struct json_object *r)
 {
 	uint32_t pmrmscl = mmio_read32(bar + NVME_REG_PMRMSCL);
 
-	if (human())
-		json_registers_pmrmscl(pmrmscl, obj_create_array_obj(r, "pmrmscl"));
-	else
-		obj_add_uint(r, "pmrmscl", pmrmscl);
+	json_registers_pmrmscl(pmrmscl, obj_create_array_obj(r, "pmrmscl"));
 }
 
 static void json_ctrl_registers_pmrmscu(void *bar, struct json_object *r)
 {
 	uint32_t pmrmscu = mmio_read32(bar + NVME_REG_PMRMSCU);
 
-	if (human())
-		json_registers_pmrmscu(pmrmscu, obj_create_array_obj(r, "pmrmscu"));
-	else
-		obj_add_uint(r, "pmrmscu", pmrmscu);
+	json_registers_pmrmscu(pmrmscu, obj_create_array_obj(r, "pmrmscu"));
 }
 
 static void json_ctrl_registers(void *bar, bool fabrics)
@@ -2942,20 +2829,14 @@ static void json_ctrl_register_human(int offset, uint64_t value, struct json_obj
 
 static void json_ctrl_register(int offset, uint64_t value)
 {
-	bool human = json_print_ops.flags & VERBOSE;
 	struct json_object *r;
 	char json_str[STR_LEN];
 
 	sprintf(json_str, "register: %#04x", offset);
 	r = obj_create(json_str);
 
-	if (human) {
-		obj_add_uint64(r, nvme_register_to_string(offset), value);
-		json_ctrl_register_human(offset, value, r);
-	} else {
-		obj_add_str(r, "name", nvme_register_symbol_to_string(offset));
-		obj_add_uint64(r, "value", value);
-	}
+	obj_add_uint64(r, nvme_register_to_string(offset), value);
+	json_ctrl_register_human(offset, value, r);
 }
 
 static void json_nvme_cmd_set_independent_id_ns(struct nvme_id_independent_id_ns *ns,
@@ -3072,14 +2953,12 @@ static void json_nvme_id_ctrl_nvm(struct nvme_id_ctrl_nvm *ctrl_nvm)
 	obj_add_uint64(r, "dmsl", le64_to_cpu(ctrl_nvm->dmsl));
 	obj_add_uint(r, "aocs", le16_to_cpu(ctrl_nvm->aocs));
 
-	if (json_print_ops.flags & VERBOSE) {
-		__u16 rsvd = (ctrl_nvm->aocs & 0xfffe) >> 1;
-		__u8 ralbas = ctrl_nvm->aocs & 0x1;
+	__u16 rsvd = (ctrl_nvm->aocs & 0xfffe) >> 1;
+	__u8 ralbas = ctrl_nvm->aocs & 0x1;
 
-		if (rsvd)
-			obj_add_uint(r, "[15:1]: Reserved", rsvd);
-		obj_add_uint(r, "[0:0]: Reporting Allocated LBA Supported", ralbas);
-	}
+	if (rsvd)
+		obj_add_uint(r, "[15:1]: Reserved", rsvd);
+	obj_add_uint(r, "[0:0]: Reporting Allocated LBA Supported", ralbas);
 
 	json_print(r);
 }
@@ -4271,33 +4150,6 @@ static struct json_object *json_list_item_obj(nvme_ns_t n)
 	return r;
 }
 
-static void json_simple_list(nvme_root_t t)
-{
-	struct json_object *r = json_create_object();
-	struct json_object *jdevices = json_create_array();
-
-	nvme_host_t h;
-	nvme_subsystem_t s;
-	nvme_ctrl_t c;
-	nvme_ns_t n;
-
-	nvme_for_each_host(t, h) {
-		nvme_for_each_subsystem(h, s) {
-			nvme_subsystem_for_each_ns(s, n)
-				array_add_obj(jdevices, json_list_item_obj(n));
-
-			nvme_subsystem_for_each_ctrl(s, c) {
-				nvme_ctrl_for_each_ns(c, n)
-					array_add_obj(jdevices, json_list_item_obj(n));
-			}
-		}
-	}
-
-	obj_add_array(r, "Devices", jdevices);
-
-	json_print(r);
-}
-
 static void json_list_item(nvme_ns_t n)
 {
 	struct json_object *r = json_list_item_obj(n);
@@ -4307,10 +4159,7 @@ static void json_list_item(nvme_ns_t n)
 
 static void json_print_list_items(nvme_root_t t)
 {
-	if (json_print_ops.flags & VERBOSE)
-		json_detail_list(t);
-	else
-		json_simple_list(t);
+	json_detail_list(t);
 }
 
 static unsigned int json_subsystem_topology_multipath(nvme_subsystem_t s,
@@ -4404,12 +4253,10 @@ static void json_simple_topology(nvme_root_t r)
 			obj_add_str(subsystem_attrs, "Name", nvme_subsystem_get_name(s));
 			obj_add_str(subsystem_attrs, "NQN", nvme_subsystem_get_nqn(s));
 
-			if (json_print_ops.flags & VERBOSE) {
-				obj_add_str(subsystem_attrs, "IOPolicy",
-						nvme_subsystem_get_iopolicy(s));
-				obj_add_str(subsystem_attrs, "Type",
-						nvme_subsystem_get_type(s));
-			}
+			obj_add_str(subsystem_attrs, "IOPolicy",
+					nvme_subsystem_get_iopolicy(s));
+			obj_add_str(subsystem_attrs, "Type",
+					nvme_subsystem_get_type(s));
 
 			array_add_obj(subsystems, subsystem_attrs);
 			namespaces = json_create_array();
@@ -4524,7 +4371,6 @@ static void json_directive_show(__u8 type, __u8 oper, __u16 spec, __u32 nsid, __
 				void *buf, __u32 len)
 {
 	struct json_object *r = json_create_object();
-	struct json_object *data;
 	char json_str[STR_LEN];
 
 	sprintf(json_str, "%#x", type);
@@ -4538,13 +4384,7 @@ static void json_directive_show(__u8 type, __u8 oper, __u16 spec, __u32 nsid, __
 	sprintf(json_str, "%#x", result);
 	obj_add_result(r, json_str);
 
-	if (json_print_ops.flags & VERBOSE) {
-		json_directive_show_fields(type, oper, result, buf, r);
-	} else if (buf) {
-		data = json_create_array();
-		d_json((unsigned char *)buf, len, 16, 1, data);
-		obj_add_array(r, "data", data);
-	}
+	json_directive_show_fields(type, oper, result, buf, r);
 
 	json_print(r);
 }


### PR DESCRIPTION
Having separate regular & verbose outputs makes more sense for the stdout outputs, and not necessarily for the JSON outputs. So let's make things simpler by having the JSON output everything, and nothing short.

Suggested-by: Daniel Wagner <dwagner@suse.de>