### PR TITLE
nvme: add EMVS support to sanitize command

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 8194960d93c9e4343d2cba456e7d1822b2e60563
+revision = 5f0eb7fbd9a77f7dd6551be3ff98b19891ba4226
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Add Enter Media Verification State (EMVS) support to sanitize command.
TP4152 - Post-Sanitize Media Verification 2024.04.01 Ratified.