### PR TITLE
ocp: combine to use GUID length definitions

### DIFF
--- a/plugins/ocp/ocp-fw-activation-history.c
+++ b/plugins/ocp/ocp-fw-activation-history.c
@@ -16,7 +16,7 @@
 #include "ocp-utils.h"
 #include "ocp-print.h"
 
-static const unsigned char ocp_fw_activation_history_guid[16] = {
+static const unsigned char ocp_fw_activation_history_guid[GUID_LEN] = {
 	0x6D, 0x79, 0x9a, 0x76,
 	0xb4, 0xda, 0xf6, 0xa3,
 	0xe2, 0x4d, 0xb2, 0x8a,

--- a/plugins/ocp/ocp-hardware-component-log.h
+++ b/plugins/ocp/ocp-hardware-component-log.h
@@ -4,13 +4,13 @@
  */
 #include "cmd.h"
 #include "common.h"
+#include "ocp-nvme.h"
 
 #ifndef OCP_HARDWARE_COMPONENT_LOG_H
 #define OCP_HARDWARE_COMPONENT_LOG_H
 
 #define LID_HWCOMP 0xc6
 #define HWCOMP_RSVD2_LEN 14
-#define GUID_LEN 16
 #define HWCOMP_SIZE_LEN 16
 #define HWCOMP_RSVD48_LEN 16
 

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -47,7 +47,7 @@
 #define C3_LATENCY_MON_OPCODE			0xC3
 #define NVME_FEAT_OCP_LATENCY_MONITOR		0xC5
 
-static __u8 lat_mon_guid[C3_GUID_LENGTH] = {
+static __u8 lat_mon_guid[GUID_LEN] = {
 	0x92, 0x7a, 0xc0, 0x8c,
 	0xd0, 0x84, 0x6c, 0x9c,
 	0x70, 0x43, 0xe6, 0xd4,
@@ -1587,7 +1587,7 @@ out:
 #define C5_UNSUPPORTED_REQS_LEN            4096
 #define C5_UNSUPPORTED_REQS_OPCODE         0xC5
 
-static __u8 unsupported_req_guid[C5_GUID_LENGTH] = {
+static __u8 unsupported_req_guid[GUID_LEN] = {
 	0x2F, 0x72, 0x9C, 0x0E,
 	0x99, 0x23, 0x2C, 0xBB,
 	0x63, 0x48, 0x32, 0xD0,
@@ -1695,7 +1695,7 @@ static int ocp_unsupported_requirements_log(int argc, char **argv, struct comman
 #define C1_ERROR_RECOVERY_LOG_BUF_LEN       0x200
 #define C1_ERROR_RECOVERY_OPCODE            0xC1
 
-static __u8 error_recovery_guid[C1_GUID_LENGTH] = {
+static __u8 error_recovery_guid[GUID_LEN] = {
 	0x44, 0xd9, 0x31, 0x21,
 	0xfe, 0x30, 0x34, 0xae,
 	0xab, 0x4d, 0xfd, 0x3d,
@@ -1798,7 +1798,7 @@ static int ocp_error_recovery_log(int argc, char **argv, struct command *cmd, st
 
 #define C4_DEV_CAP_REQ_LEN			0x1000
 #define C4_DEV_CAP_REQ_OPCODE		0xC4
-static __u8 dev_cap_req_guid[C4_GUID_LENGTH] = {
+static __u8 dev_cap_req_guid[GUID_LEN] = {
 	0x97, 0x42, 0x05, 0x0d,
 	0xd1, 0xe1, 0xc9, 0x98,
 	0x5d, 0x49, 0x58, 0x4b,
@@ -2523,7 +2523,7 @@ static int ocp_telemetry_str_log_format(int argc, char **argv, struct command *c
 #define C7_TCG_CONFIGURATION_LEN           512
 #define C7_TCG_CONFIGURATION_OPCODE        0xC7
 
-static __u8 tcg_configuration_guid[C7_GUID_LENGTH] = {
+static __u8 tcg_configuration_guid[GUID_LEN] = {
 	0x06, 0x40, 0x24, 0xBD,
 	0x7E, 0xE0, 0xE6, 0x83,
 	0xC0, 0x47, 0x54, 0xFA,

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -87,7 +87,7 @@ struct __packed ssd_latency_monitor_log {
 	__u8	log_page_guid[0x10];		/* 0x1F0 */
 };
 
-#define C3_GUID_LENGTH				16
+#define GUID_LEN 16
 
 #define C3_ACTIVE_BUCKET_TIMER_INCREMENT	5
 #define C3_ACTIVE_THRESHOLD_INCREMENT		5
@@ -98,7 +98,6 @@ struct __packed ssd_latency_monitor_log {
 #define WRITE		2
 #define TRIM		1
 
-#define C5_GUID_LENGTH                     16
 #define C5_NUM_UNSUPPORTED_REQ_ENTRIES     253
 
 /*
@@ -117,10 +116,9 @@ struct __packed unsupported_requirement_log {
 	__u8    unsupported_req_list[C5_NUM_UNSUPPORTED_REQ_ENTRIES][16];
 	__u8    rsvd2[14];
 	__le16  log_page_version;
-	__u8    log_page_guid[C5_GUID_LENGTH];
+	__u8    log_page_guid[GUID_LEN];
 };
 
-#define C1_GUID_LENGTH                      16
 #define C1_PREV_PANIC_IDS_LENGTH            4
 
 /**
@@ -160,10 +158,8 @@ struct __packed ocp_error_recovery_log_page {
 	__le64  prev_panic_id[C1_PREV_PANIC_IDS_LENGTH]; /* 32 bytes     - 0x20 - 0x3F */
 	__u8    reserved2[0x1ae];                        /* 430 bytes    - 0x40 - 0x1ED */
 	__le16  log_page_version;                        /* 2 bytes      - 0x1EE - 0x1EF */
-	__u8    log_page_guid[0x10];                     /* 16 bytes     - 0x1F0 - 0x1FF */
+	__u8    log_page_guid[GUID_LEN];                 /* 16 bytes     - 0x1F0 - 0x1FF */
 };
-
-#define C4_GUID_LENGTH				16
 
 /**
  * struct ocp_device_capabilities_log_page -	Device Capability Log page
@@ -193,10 +189,8 @@ struct __packed ocp_device_capabilities_log_page {
 	__u8    dssd_pwr_state_desc[128];
 	__u8    reserved[3934];
 	__le16  log_page_version;
-	__u8    log_page_guid[16];
+	__u8    log_page_guid[GUID_LEN];
 };
-
-#define C7_GUID_LENGTH                     16
 
 /*
  * struct tcg_configuration_log - TCG Configuration Log Page Structure
@@ -244,7 +238,7 @@ struct __packed tcg_configuration_log {
 	__u32   tcg_ec;
 	__u8    rsvd3[458];
 	__le16  log_page_version;
-	__u8    log_page_guid[C7_GUID_LENGTH];
+	__u8    log_page_guid[GUID_LEN];
 
 };
 #endif /* OCP_NVME_H */

--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -393,10 +393,10 @@ static void json_c3_log(struct nvme_dev *dev, struct ssd_latency_monitor_log *lo
 	json_object_add_value_uint(root, "Log Page Version",
 		le16_to_cpu(log_data->log_page_version));
 
-	char guid[(C3_GUID_LENGTH * 2) + 1];
+	char guid[(GUID_LEN * 2) + 1];
 	char *ptr = &guid[0];
 
-	for (i = C3_GUID_LENGTH - 1; i >= 0; i--)
+	for (i = GUID_LEN - 1; i >= 0; i--)
 		ptr += sprintf(ptr, "%02X", log_data->log_page_guid[i]);
 
 	json_object_add_value_string(root, "Log Page GUID", guid);
@@ -412,7 +412,7 @@ static void json_c5_log(struct nvme_dev *dev, struct unsupported_requirement_log
 	int j;
 	struct json_object *root;
 	char unsup_req_list_str[40];
-	char guid_buf[C5_GUID_LENGTH];
+	char guid_buf[GUID_LEN];
 	char *guid = guid_buf;
 
 	root = json_create_object();
@@ -430,8 +430,8 @@ static void json_c5_log(struct nvme_dev *dev, struct unsupported_requirement_log
 	json_object_add_value_int(root, "Log Page Version",
 				  le16_to_cpu(log_data->log_page_version));
 
-	memset((void *)guid, 0, C5_GUID_LENGTH);
-	for (j = C5_GUID_LENGTH - 1; j >= 0; j--)
+	memset((void *)guid, 0, GUID_LEN);
+	for (j = GUID_LEN - 1; j >= 0; j--)
 		guid += sprintf(guid, "%02x", log_data->log_page_guid[j]);
 	json_object_add_value_string(root, "Log page GUID", guid_buf);
 
@@ -526,7 +526,7 @@ static void json_c9_log(struct telemetry_str_log_format *log_data, __u8 *log_dat
 	struct json_object *root = json_create_object();
 	char res_arr[48];
 	char *res = res_arr;
-	char guid_buf[C9_GUID_LENGTH];
+	char guid_buf[GUID_LEN];
 	char *guid = guid_buf;
 	char fifo_arr[16];
 	char *fifo = fifo_arr;
@@ -557,8 +557,8 @@ static void json_c9_log(struct telemetry_str_log_format *log_data, __u8 *log_dat
 		res += sprintf(res, "%d", log_data->reserved1[j]);
 	json_object_add_value_string(root, "Reserved", res_arr);
 
-	memset((void *)guid, 0, C9_GUID_LENGTH);
-	for (j = C9_GUID_LENGTH - 1; j >= 0; j--)
+	memset((void *)guid, 0, GUID_LEN);
+	for (j = GUID_LEN - 1; j >= 0; j--)
 		guid += sprintf(guid, "%02x", log_data->log_page_guid[j]);
 	json_object_add_value_string(root, "Log page GUID", guid_buf);
 
@@ -768,7 +768,7 @@ static void json_c7_log(struct nvme_dev *dev, struct tcg_configuration_log *log_
 {
 	int j;
 	struct json_object *root;
-	char guid_buf[C7_GUID_LENGTH];
+	char guid_buf[GUID_LEN];
 	char *guid = guid_buf;
 	char res_arr[458];
 	char *res = res_arr;
@@ -820,8 +820,8 @@ static void json_c7_log(struct nvme_dev *dev, struct tcg_configuration_log *log_
 	json_object_add_value_int(root, "Log Page Version",
 				  le16_to_cpu(log_data->log_page_version));
 
-	memset((void *)guid, 0, C7_GUID_LENGTH);
-	for (j = C7_GUID_LENGTH - 1; j >= 0; j--)
+	memset((void *)guid, 0, GUID_LEN);
+	for (j = GUID_LEN - 1; j >= 0; j--)
 		guid += sprintf(guid, "%02x", log_data->log_page_guid[j]);
 	json_object_add_value_string(root, "Log page GUID", guid_buf);
 

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -256,10 +256,10 @@ static void stdout_c3_log(struct nvme_dev *dev, struct ssd_latency_monitor_log *
 	printf("  Log Page Version                   %d\n",
 	       le16_to_cpu(log_data->log_page_version));
 
-	char guid[(C3_GUID_LENGTH * 2) + 1];
+	char guid[(GUID_LEN * 2) + 1];
 	char *ptr = &guid[0];
 
-	for (i = C3_GUID_LENGTH - 1; i >= 0; i--)
+	for (i = GUID_LEN - 1; i >= 0; i--)
 		ptr += sprintf(ptr, "%02X", log_data->log_page_guid[i]);
 
 	printf("  Log Page GUID                      %s\n", guid);
@@ -344,7 +344,7 @@ static void stdout_c5_log(struct nvme_dev *dev, struct unsupported_requirement_l
 	printf("  Log Page Version			: 0x%x\n",
 	       le16_to_cpu(log_data->log_page_version));
 	printf("  Log page GUID				: 0x");
-	for (j = C5_GUID_LENGTH - 1; j >= 0; j--)
+	for (j = GUID_LEN - 1; j >= 0; j--)
 		printf("%02x", log_data->log_page_guid[j]);
 	printf("\n");
 }
@@ -381,7 +381,7 @@ static void stdout_c1_log(struct ocp_error_recovery_log_page *log_data)
 	printf("  Log Page Version                  : 0x%x\n",
 	       le16_to_cpu(log_data->log_page_version));
 	printf("  Log page GUID                     : 0x");
-	for (i = C1_GUID_LENGTH - 1; i >= 0; i--)
+	for (i = GUID_LEN - 1; i >= 0; i--)
 		printf("%02x", log_data->log_page_guid[i]);
 	printf("\n");
 }
@@ -414,7 +414,7 @@ static void stdout_c4_log(struct ocp_device_capabilities_log_page *log_data)
 	printf("  Log Page Version						: 0x%x\n",
 	       le16_to_cpu(log_data->log_page_version));
 	printf("  Log page GUID							: 0x");
-	for (i = C4_GUID_LENGTH - 1; i >= 0; i--)
+	for (i = GUID_LEN - 1; i >= 0; i--)
 		printf("%02x", log_data->log_page_guid[i]);
 	printf("\n");
 }
@@ -446,7 +446,7 @@ static void stdout_c9_log(struct telemetry_str_log_format *log_data, __u8 *log_d
 	printf("\n");
 
 	printf("  Log page GUID                                   : 0x");
-	for (j = C9_GUID_LENGTH - 1; j >= 0; j--)
+	for (j = GUID_LEN - 1; j >= 0; j--)
 		printf("%02x", log_data->log_page_guid[j]);
 	printf("\n");
 
@@ -685,7 +685,7 @@ static void stdout_c7_log(struct nvme_dev *dev, struct tcg_configuration_log *lo
 	printf("  Log Page Version                                       : 0x%x\n",
 	       le16_to_cpu(log_data->log_page_version));
 	printf("  Log page GUID                                          : 0x");
-	for (j = C7_GUID_LENGTH - 1; j >= 0; j--)
+	for (j = GUID_LEN - 1; j >= 0; j--)
 		printf("%02x", log_data->log_page_guid[j]);
 	printf("\n");
 }

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -18,9 +18,8 @@
 /* C0 SCAO Log Page */
 #define C0_SMART_CLOUD_ATTR_LEN			0x200
 #define C0_SMART_CLOUD_ATTR_OPCODE		0xC0
-#define C0_GUID_LENGTH				16
 
-static __u8 scao_guid[C0_GUID_LENGTH] = {
+static __u8 scao_guid[GUID_LEN] = {
 	0xC5, 0xAF, 0x10, 0x28,
 	0xEA, 0xBF, 0xF2, 0xA4,
 	0x9C, 0x4F, 0x6F, 0x7C,

--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -280,7 +280,7 @@ struct request_data ocp_header_in_da1[] = {
 	{ "Minor Version", 2 },
 	{ "Reserved1", 4 },
 	{ "Timestamp", 8 },
-	{ "Log page GUID", 16 },
+	{ "Log page GUID", GUID_LEN },
 	{ "Number Telemetry Profiles Supported", 1 },
 	{ "Telemetry Profile Selected", 1 },
 	{ "Reserved2", 6 },
@@ -419,7 +419,7 @@ struct request_data smart_extended[] = {
 	{ "Lowest Permitted Firmware Revision", 8 },
 	{ "Reserved4", 278 },
 	{ "Log Page Version", 2 },
-	{ "Log page GUID", 16 }
+	{ "Log page GUID", GUID_LEN }
 };
 
 #ifdef CONFIG_JSONC

--- a/plugins/ocp/ocp-telemetry-decode.h
+++ b/plugins/ocp/ocp-telemetry-decode.h
@@ -10,6 +10,7 @@
 #include "nvme-print.h"
 #include "util/utils.h"
 #include "common.h"
+#include "ocp-nvme.h"
 
 extern __u8 *ptelemetry_buffer;
 extern __u8 *pstring_buffer;
@@ -401,7 +402,7 @@ struct telemetry_data_area_1 {
 	__le16 minor_version;
 	__u8   reserved1[4];
 	__le64 timestamp;
-	__u8   log_page_guid[16];
+	__u8   log_page_guid[GUID_LEN];
 	__u8   no_of_tps_supp;
 	__u8   tps;
 	__u8   reserved2[6];
@@ -437,7 +438,6 @@ struct telemetry_data_area_1 {
 #define DEFAULT_OUTPUT_FORMAT_JSON "json"
 
 /* C9 Telemetry String Log Format Log Page */
-#define C9_GUID_LENGTH                           16
 #define C9_TELEMETRY_STRING_LOG_ENABLE_OPCODE    0xC9
 #define C9_TELEMETRY_STR_LOG_LEN                 432
 #define C9_TELEMETRY_STR_LOG_SIST_OFST           431
@@ -569,7 +569,7 @@ enum ocp_telemetry_debug_event_class_types {
 struct __packed telemetry_str_log_format {
 	__u8    log_page_version;
 	__u8    reserved1[15];
-	__u8    log_page_guid[C9_GUID_LENGTH];
+	__u8    log_page_guid[GUID_LEN];
 	__le64  sls;
 	__u8    reserved2[24];
 	__le64  sits;
@@ -781,7 +781,7 @@ struct __packed nvme_ocp_telemetry_smart_extended
 	__le64 lowest_permitted_firmware_revision;               // Bytes 215:208
 	__u8 reserved4[278];                                     // Bytes 493:216
 	__le16 log_page_version;                                 // Bytes 495:494
-	__u8 log_page_guid[16];                                  // Bytes 511:496
+	__u8 log_page_guid[GUID_LEN];                            // Bytes 511:496
 };
 
 struct __packed nvme_ocp_event_fifo_data
@@ -818,7 +818,7 @@ struct __packed nvme_ocp_header_in_da1
 	__le16 minor_version;                                                // Bytes 3:2
 	__le32 reserved1;                                                    // Bytes 7:4
 	__le64 time_stamp;                                                   // Bytes 15:8
-	__u8 log_page_guid[16];                                              // Bytes 31:16
+	__u8 log_page_guid[GUID_LEN];                                        // Bytes 31:16
 	__u8 num_telemetry_profiles_supported;                               // Byte 32
 	__u8 telemetry_profile_selected;                                     // Byte 33
 	__u8 reserved2[6];                                                   // Bytes 39:34
@@ -919,7 +919,7 @@ struct __packed nvme_ocp_telemetry_string_header
 {
 	__u8 version;                   //0:0
 	__u8 reserved1[15];             //15:1
-	__u8 guid[16];                  //32:16
+	__u8 guid[GUID_LEN];            //32:16
 	__le64 string_log_size;         //39:32
 	__u8 reserved2[24];             //63:40
 	__le64 sits;                    //71:64 Statistics Identifier String Table Start(SITS)


### PR DESCRIPTION
This reduces the duplicated GUID length 16 bytes definitions.