### PR TITLE
Add workflow to run tests on real hardware

### DIFF
--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -1,0 +1,93 @@
+---
+name: run-nightly-tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 01 * * *'
+
+jobs:
+  nightly-tests:
+    runs-on: nvme-nvm
+    steps:
+      - name: Output kernel version
+        run: |
+          uname -a
+      - name: Clean up test device
+        run: |
+          #BDEV0 is an environment variable of the self-hosted runner instance
+          #that contains a valid nvme ctrl name which is capable of the nvm
+          #command set.
+          CONTROLLER=$(echo /dev/${BDEV0} | sed 's/n[0-9]*$//')
+          sudo nvme delete-ns $CONTROLLER -n 0xffffffff
+          sudo nvme format $CONTROLLER -n 0xffffffff -l 0 -f
+          SIZE=$(sudo nvme id-ctrl $CONTROLLER --output-format=json | jq -r '{tnvmcap} | .[]' | awk '{print $1/512}')
+          sudo nvme create-ns -s $SIZE -c $SIZE -f 0 -d 0 --csi=0 $CONTROLLER
+          sudo nvme attach-ns $CONTROLLER -n 1 -c 0
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+          meson gcc pkg-config git libjson-c-dev libssl-dev libkeyutils-dev \
+          libdbus-1-dev libpython3-dev pipx python3-dev swig xz-utils
+          pipx ensurepath
+          sudo PIPX_BIN_DIR=/usr/local/bin pipx install nose2
+          sudo PIPX_BIN_DIR=/usr/local/bin pipx install flake8
+          sudo PIPX_BIN_DIR=/usr/local/bin pipx install mypy
+          sudo PIPX_BIN_DIR=/usr/local/bin pipx install autopep8
+          sudo PIPX_BIN_DIR=/usr/local/bin pipx install isort
+      - name: Build and install nvme-cli
+        run: |
+          scripts/build.sh -b release -c gcc
+          sudo meson install -C .build-ci
+          sudo ldconfig /usr/local/lib64
+      - name: Overwrite test config
+        run: |
+          CONTROLLER=$(echo /dev/${BDEV0} | sed 's/n[0-9]*$//')
+          cat > tests/config.json << EOF
+          {
+            "controller" : "$CONTROLLER",
+            "ns1": "/dev/${BDEV0}",
+            "log_dir": "tests/nvmetests/"
+          }
+          EOF
+      - name: Run on device tests
+        run: |
+          sudo nose2 --verbose --start-dir tests \
+          nvme_attach_detach_ns_test \
+          nvme_compare_test \
+          nvme_copy_test \
+          nvme_create_max_ns_test \
+          nvme_ctrl_reset_test \
+          nvme_dsm_test \
+          nvme_error_log_test \
+          nvme_flush_test \
+          nvme_format_test \
+          nvme_fw_log_test \
+          nvme_get_features_test \
+          nvme_get_lba_status_test \
+          nvme_id_ctrl_test \
+          nvme_id_ns_test \
+          nvme_lba_status_log_test \
+          nvme_read_write_test \
+          nvme_smart_log_test \
+          nvme_verify_test \
+          nvme_writeuncor_test \
+          nvme_writezeros_test
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs files
+          path: |
+            ./tests/nvmetests/**/*.log
+      - name: Clean up test device
+        if: always()
+        run: |
+          CONTROLLER=$(echo /dev/${BDEV0} | sed 's/n[0-9]*$//')
+          sudo nvme delete-ns $CONTROLLER -n 0xffffffff
+          sudo nvme format $CONTROLLER -n 0xffffffff -l 0 -f
+          SIZE=$(sudo nvme id-ctrl $CONTROLLER --output-format=json | jq -r '{tnvmcap} | .[]' | awk '{print $1/512}')
+          sudo nvme create-ns -s $SIZE -c $SIZE -f 0 -d 0 --csi=0 $CONTROLLER
+          sudo nvme attach-ns $CONTROLLER -n 1 -c 0

--- a/tests/nvme_attach_detach_ns_test.py
+++ b/tests/nvme_attach_detach_ns_test.py
@@ -52,8 +52,10 @@ class TestNVMeAttachDetachNSCmd(TestNVMe):
         super().setUp()
         self.dps = 0
         self.flbas = 0
-        self.nsze = 0x1400000
-        self.ncap = 0x1400000
+        (ds, ms) = self.get_lba_format_size()
+        ncap = int(self.get_ncap() / (ds+ms))
+        self.nsze = ncap
+        self.ncap = ncap
         self.setup_log_dir(self.__class__.__name__)
         self.ctrl_id = self.get_ctrl_id()
         self.delete_all_ns()

--- a/tests/nvme_compare_test.py
+++ b/tests/nvme_compare_test.py
@@ -45,9 +45,20 @@ class TestNVMeCompareCmd(TestNVMeIO):
               - test_log_dir : directory for logs, temp files.
     """
 
+    def compare_cmd_supported(self):
+        """ Wrapper for extracting optional NVM 'compare' command support
+            - Args:
+                - None
+            - Returns:
+                - True if 'compare' is supported, otherwise False
+        """
+        return int(self.get_id_ctrl_field_value("oncs"), 16) & (1 << 0)
+
     def setUp(self):
         """ Pre Section for TestNVMeCompareCmd """
         super().setUp()
+        if not self.compare_cmd_supported():
+            self.skipTest("because: Optional NVM Command 'Compare' (NVMCMPS) not supported")
         self.data_size = 1024
         self.start_block = 1023
         self.setup_log_dir(self.__class__.__name__)

--- a/tests/nvme_copy_test.py
+++ b/tests/nvme_copy_test.py
@@ -36,6 +36,7 @@ class TestNVMeCopy(TestNVMe):
         super().setUp()
         print("\nSetting up test...")
         self.ocfs = self.get_ocfs()
+        self.host_behavior_data = None
         cross_namespace_copy = self.ocfs & 0xc
         if cross_namespace_copy:
             # get host behavior support data

--- a/tests/nvme_create_max_ns_test.py
+++ b/tests/nvme_create_max_ns_test.py
@@ -54,6 +54,10 @@ class TestNVMeCreateMaxNS(TestNVMe):
         self.flbas = 0
         self.nsze = int(self.get_ncap() /
                         self.get_format() / self.get_max_ns())
+        # Make sure that we have enough capacity for each ns.
+        # Creating a ns might allocate more bits (NVMCAP) than specified by
+        # nsze and ncap.
+        self.nsze = int(self.nsze / 2)
         self.ncap = self.nsze
         self.setup_log_dir(self.__class__.__name__)
         self.max_ns = self.get_max_ns()
@@ -75,11 +79,12 @@ class TestNVMeCreateMaxNS(TestNVMe):
                                                      self.flbas,
                                                      self.dps), 0)
         self.attach_ns(self.ctrl_id, self.default_nsid)
-        super.tearDown()
+        super().tearDown()
 
     def test_attach_detach_ns(self):
         """ Testcase main """
-        for nsid in range(1, self.max_ns):
+        print(f"##### Testing max_ns: {self.max_ns}")
+        for nsid in range(1, self.max_ns + 1):
             print("##### Creating " + str(nsid))
             err = self.create_and_validate_ns(nsid,
                                               self.nsze,
@@ -90,9 +95,9 @@ class TestNVMeCreateMaxNS(TestNVMe):
             print("##### Attaching " + str(nsid))
             self.assertEqual(self.attach_ns(self.ctrl_id, nsid), 0)
             print("##### Running IOs in " + str(nsid))
-            self.run_ns_io(nsid, 0)
+            self.run_ns_io(nsid, 9, 1)
 
-        for nsid in range(1, self.max_ns):
+        for nsid in range(1, self.max_ns + 1):
             print("##### Detaching " + str(nsid))
             self.assertEqual(self.detach_ns(self.ctrl_id, nsid), 0)
             print("#### Deleting " + str(nsid))

--- a/tests/nvme_ctrl_reset_test.py
+++ b/tests/nvme_ctrl_reset_test.py
@@ -46,3 +46,5 @@ class TestNVMeCtrlReset(TestNVMe):
     def test_ctrl_reset(self):
         """ Testcase main """
         self.assertEqual(self.ctrl_reset(), 0)
+        # Check if sqs and cqs are setup again and I/O operations are possible
+        self.run_ns_io(self.default_nsid, 0, 10)

--- a/tests/nvme_format_test.py
+++ b/tests/nvme_format_test.py
@@ -37,6 +37,7 @@ Namespace Format testcase :-
            - Delete Namespace.
 """
 
+import math
 import subprocess
 import time
 
@@ -63,10 +64,14 @@ class TestNVMeFormatCmd(TestNVMe):
     def setUp(self):
         """ Pre Section for TestNVMeFormatCmd """
         super().setUp()
-        self.dps = 0                 # ns data protection settings
-        self.flbas = 0               # ns formattes logical block settings
-        self.nsze = 0x1400000        # ns size
-        self.ncap = 0x1400000        # ns capacity
+        self.dps = 0
+        self.flbas = 0
+        # Assuming run_ns_io with 4KiB * 10 writes.
+        # Calculating minimum required ncap for this workload
+        (ds, _) = self.get_lba_format_size()
+        ncap = int(math.ceil((4096*10)/ds))
+        self.ncap = ncap
+        self.nsze = ncap
         self.ctrl_id = self.get_ctrl_id()
         self.lba_format_list = []
         self.ms_list = []

--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -94,6 +94,8 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
         else:
             get_feat_cmd = "nvme get-feature " + self.ctrl + \
                            " --feature-id=" + str(feature_id) + " -H"
+            if str(feature_id) == "0x05":
+                get_feat_cmd += f" --namespace-id={self.default_nsid}"
             proc = subprocess.Popen(get_feat_cmd,
                                     shell=True,
                                     stdout=subprocess.PIPE,

--- a/tests/nvme_get_lba_status_test.py
+++ b/tests/nvme_get_lba_status_test.py
@@ -26,11 +26,12 @@ class TestNVMeGetLbaStatusCmd(TestNVMe):
     def setUp(self):
         """ Pre Section for TestNVMeGetLbaStatusCmd. """
         super().setUp()
+        if not self.get_lba_status_supported():
+            self.skipTest("because: Optional Admin Command 'Get LBA Status' (OACS->GLSS) not supported")
         self.start_lba = 0
         self.block_count = 0
-        self.namespace = 1
         self.max_dw = 1
-        self.action = 11
+        self.action = 0x11
         self.range_len = 1
         self.setup_log_dir(self.__class__.__name__)
 
@@ -51,7 +52,7 @@ class TestNVMeGetLbaStatusCmd(TestNVMe):
         """
         err = 0
         get_lba_status_cmd = "nvme get-lba-status " + self.ctrl + \
-                             " --namespace-id=" + str(self.namespace) + \
+                             " --namespace-id=" + str(self.ns1) + \
                              " --start-lba=" + str(self.start_lba) + \
                              " --max-dw=" + str(self.max_dw) + \
                              " --action=" + str(self.action) + \

--- a/tests/nvme_lba_status_log_test.py
+++ b/tests/nvme_lba_status_log_test.py
@@ -26,6 +26,8 @@ class TestNVMeLbaStatLogCmd(TestNVMe):
     def setUp(self):
         """ Pre Section for TestNVMeLbaStatLogCmd. """
         super().setUp()
+        if not self.get_lba_status_supported():
+            self.skipTest("because: Optional Admin Command 'Get LBA Status' (OACS->GLSS) not supported")
         self.setup_log_dir(self.__class__.__name__)
 
     def tearDown(self):

--- a/tests/nvme_smart_log_test.py
+++ b/tests/nvme_smart_log_test.py
@@ -85,5 +85,5 @@ class TestNVMeSmartLogCmd(TestNVMe):
         """ Testcase main """
         self.assertEqual(self.get_smart_log_ctrl(), 0)
         smlp = self.supp_check_id_ctrl("lpa")
-        if smlp & 0x1 == True:
+        if smlp & 0x1:
             self.assertEqual(self.get_smart_log_all_ns(), 0)

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -439,7 +439,7 @@ class TestNVMe(unittest.TestCase):
             - Returns:
                 - 0 on success, error code on failure.
         """
-        pattern = re.compile("^ Entry\[[ ]*[0-9]+\]")
+        pattern = re.compile(r"^ Entry\[[ ]*[0-9]+\]")
         error_log_cmd = "nvme error-log " + self.ctrl
         proc = subprocess.Popen(error_log_cmd,
                                 shell=True,

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -466,7 +466,7 @@ class TestNVMe(unittest.TestCase):
         if not vendor:
             id_ctrl_cmd = "nvme id-ctrl " + self.ctrl
         else:
-            id_ctrl_cmd = "nvme id-ctrl -v " + self.ctrl
+            id_ctrl_cmd = "nvme id-ctrl --vendor-specific " + self.ctrl
         print(id_ctrl_cmd)
         proc = subprocess.Popen(id_ctrl_cmd,
                                 shell=True,

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -70,6 +70,30 @@ class TestNVMe(unittest.TestCase):
         """ Post Section for TestNVMe. """
         if self.clear_log_dir is True:
             shutil.rmtree(self.log_dir, ignore_errors=True)
+        self.create_and_attach_default_ns()
+
+    def create_and_attach_default_ns(self):
+        """ Creates a default namespace with the full capacity of the ctrls NVM
+            - Args:
+                - None
+            - Returns:
+                - None
+        """
+        self.dps = 0
+        self.flbas = 0
+        (ds, ms) = self.get_lba_format_size()
+        ncap = int(self.get_ncap() / (ds+ms))
+        self.nsze = ncap
+        self.ncap = ncap
+        self.ctrl_id = self.get_ctrl_id()
+        self.delete_all_ns()
+        err = self.create_and_validate_ns(self.default_nsid,
+                                          self.nsze,
+                                          self.ncap,
+                                          self.flbas,
+                                          self.dps)
+        self.assertEqual(err, 0)
+        self.assertEqual(self.attach_ns(self.ctrl_id, self.default_nsid), 0)
 
     def validate_pci_device(self):
         """ Validate underlying device belongs to pci subsystem.

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -435,25 +435,8 @@ class TestNVMe(unittest.TestCase):
                                 encoding='utf-8')
         err = proc.wait()
         self.assertEqual(err, 0, "ERROR : nvme smart log failed")
-
-        for line in proc.stdout:
-            if "data_units_read" in line:
-                data_units_read = \
-                    line.replace(",", "", 1)
-            if "data_units_written" in line:
-                data_units_written = \
-                    line.replace(",", "", 1)
-            if "host_read_commands" in line:
-                host_read_commands = \
-                    line.replace(",", "", 1)
-            if "host_write_commands" in line:
-                host_write_commands = \
-                    line.replace(",", "", 1)
-
-        print("data_units_read " + data_units_read)
-        print("data_units_written " + data_units_written)
-        print("host_read_commands " + host_read_commands)
-        print("host_write_commands " + host_write_commands)
+        smart_log_output = proc.communicate()[0]
+        print(f"{smart_log_output}")
         return err
 
     def get_id_ctrl(self, vendor=False):

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -208,6 +208,15 @@ class TestNVMe(unittest.TestCase):
         print(max_ns)
         return int(max_ns)
 
+    def get_lba_status_supported(self):
+        """ Check if 'Get LBA Status' command is supported by the device
+            - Args:
+                - None
+            - Returns:
+                - True if 'Get LBA Status' command is supported, otherwise False
+        """
+        return int(self.get_id_ctrl_field_value("oacs"), 16) & (1 << 9)
+
     def get_lba_format_size(self):
         """ Wrapper for extracting lba format size of the given flbas
             - Args:

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -500,7 +500,7 @@ class TestNVMe(unittest.TestCase):
 
         return 0 if err_log_entry_count == entry_count else 1
 
-    def run_ns_io(self, nsid, lbads):
+    def run_ns_io(self, nsid, lbads, count=10):
         """ Wrapper to run ios on namespace under test.
             - Args:
                 - lbads : LBA Data size supported in power of 2 format.
@@ -510,14 +510,14 @@ class TestNVMe(unittest.TestCase):
         block_size = mmap.PAGESIZE if int(lbads) < 9 else 2 ** int(lbads)
         ns_path = self.ctrl + "n" + str(nsid)
         io_cmd = "dd if=" + ns_path + " of=/dev/null" + " bs=" + \
-                 str(block_size) + " count=10 > /dev/null 2>&1"
+                 str(block_size) + " count=" + str(count) + " > /dev/null 2>&1"
         print(io_cmd)
         run_io = subprocess.Popen(io_cmd, shell=True, stdout=subprocess.PIPE,
                                   encoding='utf-8')
         run_io_result = run_io.communicate()[1]
         self.assertEqual(run_io_result, None)
         io_cmd = "dd if=/dev/zero of=" + ns_path + " bs=" + \
-                 str(block_size) + " count=10 > /dev/null 2>&1"
+                 str(block_size) + " count=" + str(count) + " > /dev/null 2>&1"
         print(io_cmd)
         run_io = subprocess.Popen(io_cmd, shell=True, stdout=subprocess.PIPE,
                                   encoding='utf-8')


### PR DESCRIPTION
This PR introduces a GitHub workflow that runs all test cases under the
`tests` directory on real hardware.
 
In preparation, the existing test cases are fixed, such that the new
`run-tests` workflow completes successfully (see actions on my fork's master
branch).
 
The infrastructure that provides the self-hosted GitHub runner with real nvme
devices attached to it are provided by Western Digital Corporation.
On a high-level overview, this infrastructure contains multiple storage nodes
that form a Kubernetes cluster. Within this Kubernetes cluster, KubeVirt
virtual machines can be spawned on demand with different hardware
configurations. Those VMs are owned by different users. One user group that
is separated in its own namespace is self-hosted GitHub runners.
 
The overall goal of this infrastructure is to provide device access to open
source projects for testing purposes. The first two pioneering candidates to
make use of this service are nvme-cli and ZenFS (see https://github.com/westerndigitalcorporation/zenfs/pull/294).
 
The new self-hosted GitHub runner IaC is to be open-sourced.
 
If people want to see other nvme devices for testing in GitHub workflows, we
are happy to discuss details on how to move forward with integrating new
test devices.
 
**Initial requirements for this self-hosted runner**:
- Share NVMe devices (both NVM and ZNS command sets. Western Digital
  Ultrastar® SN640 and Western Digital Ultrastar® ZN540 are provided)
- Update the VM kernel nightly with Linus' master branch (through cron job)
- Security:
  - Running in a dedicated KubeVirt VM, one per repository.
  - Restricted cluster network access: KubeVirt masquerade interface that only opens
    necessary ports.
  - Privileged code execution within the VM ('gh-runner' user). The VM will be reset
    after each workflow run.
  - Running in the gh-runner namespace with NetworkPolicies where
    ssh is just allowed from local IPs, https is just allowed to and from
    external addresses (no access to internal cluster services), access to VM
    image repository access just from local IPs.
  - /etc/hosts.allow and /etc/hosts.deny rules for the gh-runner instances that
    only allow sshd access from cluster local IPs into the VM.
 
 
**IMPORTANT: Configuration required by the GitHub repo that uses the self-hosted runner**:
- A single self-hosted runner instance (Kubevirt VM) is only allowed to serve
  one repository
- Optionally: Prevent a group of people from allowing actions:
Repo -> Settings -> Actions -> General -> Actions permissions
- Prevent PR's from executing code on the self-hosted runner before getting approved:
Repo -> Settings -> Actions -> General -> 'Require approval for all outside
collaborators' -> Save
- Restrict write access to the repository with the GITHUB_TOKEN:
Repo -> Settings -> Actions -> General -> 'Read repository content and packages
permissions' -> Save
- Preventing GitHub Actions from creating or approving pull requests through the
  GITHUB_TOKEN:
Repo -> Settings -> Actions -> General -> DISABLE 'Allow GitHub Actions to
create and approve pull requests' -> Save
- In reviews watch out for code injection and secret leaks within workflows
  (https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
 
 
In a GitHub workflow that uses a container on the self-hosted instance, the
block device has to be passed into the container:
```
...
    container:
      image: ghcr.io/igaw/linux-nvme/debian.python:latest
      options: '--device=/dev/nvme0n1:/dev/nvme0n1'
...
``` 

Before this PR gets merged we should make sure that the self-hosted runner is
added to the repository, which requires a token exchange on a side channel. :)

