### PR TITLE
nvme-print: Add Sanitize Media Verification Event in PEL log

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -518,6 +518,9 @@ static void stdout_persistent_event_log(void *pevent_log_info,
 			printf("Over Temperature: %u\n", thermal_exc_event->over_temp);
 			printf("Threshold: %u\n", thermal_exc_event->threshold);
 			break;
+		case NVME_PEL_SANITIZE_MEDIA_VERIF_EVENT:
+			printf("Sanitize Media Verification Event\n");
+			break;
 		default:
 			printf("Reserved Event\n\n");
 			break;

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -179,6 +179,8 @@ static const char *pel_event_to_string(int type)
 		return "Set Telemetry CRT Event";
 	case NVME_PEL_THERMAL_EXCURSION_EVENT:
 		return "Thermal Excursion Event";
+	case NVME_PEL_SANITIZE_MEDIA_VERIF_EVENT:
+		return "Sanitize Media Verification Event";
 	case NVME_PEL_VENDOR_SPECIFIC_EVENT:
 		return "Vendor Specific Event";
 	case NVME_PEL_TCG_DEFINED_EVENT:


### PR DESCRIPTION
Add Sanitize Media Verification Event in Persistent Event Log.
TP4152 - Post-Sanitize Media Verification 2024.04.01 Ratified.