### PR TITLE
ocp: fix firmware activation history entry endian

### DIFF
--- a/plugins/ocp/ocp-fw-activation-history.h
+++ b/plugins/ocp/ocp-fw-activation-history.h
@@ -16,27 +16,27 @@ struct plugin;
 struct __packed fw_activation_history_entry {
 	__u8 ver_num;
 	__u8 entry_length;
-	__u16 reserved1;
-	__u16 activation_count;
-	__u64 timestamp;
-	__u64 reserved2;
-	__u64 power_cycle_count;
+	__le16 reserved1;
+	__le16 activation_count;
+	__le64 timestamp;
+	__le64 reserved2;
+	__le64 power_cycle_count;
 	char previous_fw[8];
 	char new_fw[8];
 	__u8 slot_number;
 	__u8 commit_action;
-	__u16 result;
+	__le16 result;
 	__u8 reserved3[14];
 };
 
 struct __packed fw_activation_history {
 	__u8 log_id;
 	__u8 reserved1[3];
-	__u32 valid_entries;
+	__le32 valid_entries;
 	struct fw_activation_history_entry entries[20];
 	__u8 reserved2[2790];
-	__u16 log_page_version;
-	__u64 log_page_guid[2];
+	__le16 log_page_version;
+	__le64 log_page_guid[2];
 };
 
 int ocp_fw_activation_history_log(int argc, char **argv, struct command *cmd,

--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -88,7 +88,7 @@ static void json_fw_activation_history(const struct fw_activation_history *fw_hi
 
 	struct json_object *entries = json_create_array();
 
-	for (int index = 0; index < fw_history->valid_entries; index++) {
+	for (int index = 0; index < le32_to_cpu(fw_history->valid_entries); index++) {
 		const struct fw_activation_history_entry *entry = &fw_history->entries[index];
 		struct json_object *entry_obj = json_create_object();
 

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -64,10 +64,10 @@ static void stdout_fw_activation_history(const struct fw_activation_history *fw_
 
 	printf("  entries:\n");
 
-	for (int index = 0; index < fw_history->valid_entries; index++) {
+	for (int index = 0; index < le32_to_cpu(fw_history->valid_entries); index++) {
 		const struct fw_activation_history_entry *entry = &fw_history->entries[index];
 
-		printf("    entry[%d]:\n", le32_to_cpu(index));
+		printf("    entry[%d]:\n", index);
 		printf("      %-22s%d\n", "version number:", entry->ver_num);
 		printf("      %-22s%d\n", "entry length:", entry->entry_length);
 		printf("      %-22s%d\n", "activation count:",


### PR DESCRIPTION
Fix the entry data fields to little endian format. Basically print functions convert the fields data to cpu format. But still some errors then fixed the print functions also.