### PR TITLE
build: Add token for coverage test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,4 +19,5 @@ jobs:
           scripts/build.sh coverage
       - uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
The code coverage action is silently failing partly because the required Codecov token is missing.
Reading the token from the GitHub secrets.

The missing gpg package must be fixed in
https://github.com/linux-nvme/ci-containers.

Furthermore, fail the coverage workflow if the codecov-action errors out.


Please add the `CODECOV_TOKEN` to the GitHub secrets :)
