### PR TITLE
nvme: change NVME_ARGS -v and -o options ordering to back

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -879,7 +879,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 	};
 
 	NVME_ARGS(opts,
-		  OPT_FILE("output-file",     'O', &cfg.file_name, fname),
+		  OPT_FILE("output-file",     'o', &cfg.file_name, fname),
 		  OPT_UINT("host-generate",   'g', &cfg.host_gen,  hgen),
 		  OPT_FLAG("controller-init", 'c', &cfg.ctrl_init, cgen),
 		  OPT_UINT("data-area",       'd', &cfg.data_area, dgen),
@@ -2291,7 +2291,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 		  OPT_BYTE("log-id",       'i', &cfg.log_id,       log_id),
 		  OPT_UINT("log-len",      'l', &cfg.log_len,      log_len),
 		  OPT_UINT("aen",          'a', &cfg.aen,          aen),
-		  OPT_SUFFIX("lpo",        'L', &cfg.lpo,          lpo),
+		  OPT_SUFFIX("lpo",        'o', &cfg.lpo,          lpo),
 		  OPT_BYTE("lsp",          's', &cfg.lsp,          lsp),
 		  OPT_SHRT("lsi",          'S', &cfg.lsi,          lsi),
 		  OPT_FLAG("rae",          'r', &cfg.rae,          rae),
@@ -3090,7 +3090,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 		  OPT_STR("ncap-si",       'C', &cfg.ncap_si,  ncap_si),
 		  OPT_FLAG("azr",          'z', &cfg.azr,      azr),
 		  OPT_UINT("rar",          'r', &cfg.rar,      rar),
-		  OPT_UINT("ror",          'O', &cfg.ror,      ror),
+		  OPT_UINT("ror",          'o', &cfg.ror,      ror),
 		  OPT_UINT("rnumzrwa",     'u', &cfg.rnumzrwa, rnumzrwa),
 		  OPT_LIST("phndls",       'p', &cfg.phndls,   phndls));
 
@@ -3401,7 +3401,7 @@ int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin,
 	};
 
 	NVME_ARGS(opts,
-		  OPT_FLAG("vendor-specific", 'V', &cfg.vendor_specific, vendor_specific),
+		  OPT_FLAG("vendor-specific", 'v', &cfg.vendor_specific, vendor_specific),
 		  OPT_FLAG("raw-binary",      'b', &cfg.raw_binary,      raw_identify),
 		  OPT_FLAG("human-readable",  'H', &cfg.human_readable,  human_readable_identify));
 
@@ -3724,7 +3724,7 @@ static int id_ns(int argc, char **argv, struct command *cmd, struct plugin *plug
 	NVME_ARGS(opts,
 		  OPT_UINT("namespace-id",    'n', &cfg.namespace_id,    namespace_id_desired),
 		  OPT_FLAG("force",             0, &cfg.force,           force),
-		  OPT_FLAG("vendor-specific", 'V', &cfg.vendor_specific, vendor_specific),
+		  OPT_FLAG("vendor-specific", 'v', &cfg.vendor_specific, vendor_specific),
 		  OPT_FLAG("raw-binary",      'b', &cfg.raw_binary,      raw_identify),
 		  OPT_FLAG("human-readable",  'H', &cfg.human_readable,  human_readable_identify));
 
@@ -4887,7 +4887,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	NVME_ARGS(opts,
 		  OPT_FILE("fw",         'f', &cfg.fw,         fw),
 		  OPT_UINT("xfer",       'x', &cfg.xfer,       xfer),
-		  OPT_UINT("offset",     'O', &cfg.offset,     offset),
+		  OPT_UINT("offset",     'o', &cfg.offset,     offset),
 		  OPT_FLAG("progress",   'p', &cfg.progress,   progress),
 		  OPT_FLAG("ignore-ovr", 'i', &cfg.ignore_ovr, ignore_ovr));
 
@@ -6028,7 +6028,7 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	NVME_ARGS(opts,
-		  OPT_UINT("offset",         'O', &cfg.offset,         offset),
+		  OPT_UINT("offset",         'o', &cfg.offset,         offset),
 		  OPT_FLAG("human-readable", 'H', &cfg.human_readable, human_readable));
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
@@ -6063,8 +6063,8 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	NVME_ARGS(opts,
-		  OPT_UINT("offset", 'O', &cfg.offset, offset),
-		  OPT_UINT("value",  'V', &cfg.value,  value));
+		  OPT_UINT("offset", 'o', &cfg.offset, offset),
+		  OPT_UINT("value",  'v', &cfg.value,  value));
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
@@ -6383,7 +6383,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	NVME_ARGS(opts,
 		  OPT_UINT("namespace-id", 'n', &cfg.namespace_id, namespace_desired),
 		  OPT_BYTE("feature-id",   'f', &cfg.feature_id,   feature_id),
-		  OPT_SUFFIX("value",      'V', &cfg.value,        value),
+		  OPT_SUFFIX("value",      'v', &cfg.value,        value),
 		  OPT_UINT("cdw12",        'c', &cfg.cdw12,        cdw12),
 		  OPT_BYTE("uuid-index",   'U', &cfg.uuid_index,   uuid_index_specify),
 		  OPT_UINT("data-len",     'l', &cfg.data_len,     buf_len),
@@ -7799,7 +7799,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		  OPT_BYTE("dir-type",          'T', &cfg.dtype,             dtype_for_write),
 		  OPT_SHRT("dir-spec",          'S', &cfg.dspec,             dspec),
 		  OPT_BYTE("dsm",               'D', &cfg.dsmgmt,            dsm),
-		  OPT_FLAG("show-command",      'V', &cfg.show,              show),
+		  OPT_FLAG("show-command",      'v', &cfg.show,              show),
 		  OPT_FLAG("dry-run",           'w', &cfg.dry_run,           dry),
 		  OPT_FLAG("latency",           't', &cfg.latency,           latency),
 		  OPT_FLAG("force",               0, &cfg.force,             force));
@@ -8405,7 +8405,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 	};
 
 	NVME_ARGS(opts,
-		  OPT_BYTE("operation",   'O', &cfg.operation,    operation),
+		  OPT_BYTE("operation",   'o', &cfg.operation,    operation),
 		  OPT_SHRT("element-id",  'i', &cfg.element_id,   element_id),
 		  OPT_UINT("cap-lower",   'l', &cfg.dw11,         cap_lower),
 		  OPT_UINT("cap-upper",   'u', &cfg.dw12,         cap_upper));
@@ -8612,7 +8612,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *cmd, struct plugi
 	};
 
 	NVME_ARGS(opts,
-		  OPT_BYTE("ofi",	'O', &cfg.ofi,      ofi_desc),
+		  OPT_BYTE("ofi",	'o', &cfg.ofi,      ofi_desc),
 		  OPT_BYTE("ifc",	'f', &cfg.ifc,      ifc_desc),
 		  OPT_BYTE("prhbt",	'p', &cfg.prhbt,    prhbt_desc),
 		  OPT_BYTE("scp",	's', &cfg.scp,      scp_desc),
@@ -8749,7 +8749,7 @@ static int passthru(int argc, char **argv, bool admin,
 	};
 
 	NVME_ARGS(opts,
-		  OPT_BYTE("opcode",       'O', &cfg.opcode,       opcode),
+		  OPT_BYTE("opcode",       'o', &cfg.opcode,       opcode),
 		  OPT_BYTE("flags",        'f', &cfg.flags,        cflags),
 		  OPT_BYTE("prefill",      'p', &cfg.prefill,      prefill),
 		  OPT_SHRT("rsvd",         'R', &cfg.rsvd,         rsvd),
@@ -9828,7 +9828,7 @@ static int nvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc)
 	};
 
 	NVME_ARGS(opts,
-		  OPT_BYTE("opcode", 'O', &cfg.opcode, opcode),
+		  OPT_BYTE("opcode", 'o', &cfg.opcode, opcode),
 		  OPT_UINT("namespace-id", 'n', &cfg.namespace_id, namespace_desired),
 		  OPT_UINT("data-len", 'l', &cfg.data_len, data_len),
 		  OPT_UINT("nmimt", 'm', &cfg.nmimt, nmimt),

--- a/nvme.h
+++ b/nvme.h
@@ -79,18 +79,21 @@ struct nvme_config {
 	__u32 timeout;
 };
 
+#define NVME_OPT(n, ...) \
+	struct argconfig_commandline_options n[] = { \
+		__VA_ARGS__, \
+		OPT_END()\
+	}
+
 /*
  * the ordering of the arguments matters, as the argument parser uses the first match, thus any
- * command which defines -t shorthand will match first.
+ * command which defines -v, -o and -t shorthand will match first.
  */
-#define NVME_ARGS(n, ...)                                                              \
-	struct argconfig_commandline_options n[] = {                                   \
-		OPT_INCR("verbose",      'v', &nvme_cfg.verbose,       verbose),       \
-		OPT_FMT("output-format", 'o', &nvme_cfg.output_format, output_format), \
-		##__VA_ARGS__,                                                         \
-		OPT_UINT("timeout",      't', &nvme_cfg.timeout,       timeout),       \
-		OPT_END()                                                              \
-	}
+#define NVME_ARGS(n, ...) \
+	NVME_OPT(n, ##__VA_ARGS__, \
+		 OPT_INCR("verbose",      'v', &nvme_cfg.verbose,       verbose), \
+		 OPT_FMT("output-format", 'o', &nvme_cfg.output_format, output_format), \
+		 OPT_UINT("timeout",      't', &nvme_cfg.timeout,       timeout))
 
 static inline int __dev_fd(struct nvme_dev *dev, const char *func, int line)
 {


### PR DESCRIPTION
This reverts the short options -o and -v changes as before. Before the short option -o used for admin-passthru command opcode option. But currently changed the short option -o for output-format option.

Fixes: 0ded9387b ("nvme: Change short option -o and -v duplicated to upper case")