### PR TITLE
nvme-print: use NVME_GET in sanitize log

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -1375,19 +1375,16 @@ static void json_sanitize_log(struct nvme_sanitize_log_page *sanitize_log,
 	struct json_object *r = json_create_object();
 	struct json_object *dev = json_create_object();
 	struct json_object *sstat = json_create_object();
+	__u16 status = le16_to_cpu(sanitize_log->sstat);
 	const char *status_str;
 	char str[128];
-	__u16 status = le16_to_cpu(sanitize_log->sstat);
 
 	obj_add_int(dev, "sprog", le16_to_cpu(sanitize_log->sprog));
-	obj_add_int(sstat, "global_erased", (status & NVME_SANITIZE_SSTAT_GLOBAL_DATA_ERASED) >> 8);
-	obj_add_int(sstat, "no_cmplted_passes",
-		    (status >> NVME_SANITIZE_SSTAT_COMPLETED_PASSES_SHIFT) &
-		    NVME_SANITIZE_SSTAT_COMPLETED_PASSES_MASK);
+	obj_add_int(sstat, "global_erased", NVME_GET(status, SANITIZE_SSTAT_GLOBAL_DATA_ERASED));
+	obj_add_int(sstat, "no_cmplted_passes", NVME_GET(status, SANITIZE_SSTAT_COMPLETED_PASSES));
 
 	status_str = nvme_sstat_status_to_string(status);
-	sprintf(str, "(%d) %s", status & NVME_SANITIZE_SSTAT_STATUS_MASK,
-		status_str);
+	sprintf(str, "(%d) %s", NVME_GET(status, SANITIZE_SSTAT_STATUS), status_str);
 	obj_add_str(sstat, "status", str);
 
 	obj_add_obj(dev, "sstat", sstat);

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4187,23 +4187,21 @@ static void stdout_sanitize_log_sprog(__u32 sprog)
 static void stdout_sanitize_log_sstat(__u16 status)
 {
 	const char *str = nvme_sstat_status_to_string(status);
+	__u16 gde;
 
-	printf("\t[2:0]\t%s\n", str);
-	str = "Number of completed passes if most recent operation was overwrite";
-	printf("\t[7:3]\t%s:\t%u\n", str,
-		(status >> NVME_SANITIZE_SSTAT_COMPLETED_PASSES_SHIFT) &
-			NVME_SANITIZE_SSTAT_COMPLETED_PASSES_MASK);
+	printf("  [2:0] : Sanitize Operation Status  : %#x\t%s\n",
+		NVME_GET(status, SANITIZE_SSTAT_STATUS), str);
+	printf("  [7:3] : Overwrite Passes Completed : %u\n",
+		NVME_GET(status, SANITIZE_SSTAT_COMPLETED_PASSES));
 
-	printf("\t  [8]\t");
-	if (status & NVME_SANITIZE_SSTAT_GLOBAL_DATA_ERASED)
-		str = "Global Data Erased set: no NS LB in the NVM subsystem "\
-			"has been written to and no PMR in the NVM subsystem "\
-			"has been enabled";
+	gde = NVME_GET(status, SANITIZE_SSTAT_GLOBAL_DATA_ERASED);
+	if (gde)
+		str = "No user data has been written in the NVM subsystem and"\
+		       " no PMR has been enabled in the NVM subsystem";
 	else
-		str = "Global Data Erased cleared: a NS LB in the NVM "\
-			"subsystem has been written to or a PMR in the NVM "\
-			"subsystem has been enabled";
-	printf("%s\n", str);
+		str = "User data has been written in the NVM subsystem or"\
+		       " PMR has been enabled in the NVM subsystem";
+	printf("  [8:8] : Global Data Erased         : %#x\t%s\n", gde, str);
 }
 
 static void stdout_estimate_sanitize_time(const char *text, uint32_t value)


### PR DESCRIPTION
Used NVME_GET macro in sanitize log. Also, updated the print statement as per NVM Express Base Specification Revision 2.1.