### PR TITLE
nvme-print: add fallback for non-standard locale category

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -797,6 +797,10 @@ static bool is_fahrenheit_country(const char *country)
 	return false;
 }
 
+#ifndef LC_MEASUREMENT
+#define LC_MEASUREMENT LC_ALL
+#endif
+
 static bool is_temperature_fahrenheit(void)
 {
 	const char *locale, *underscore;


### PR DESCRIPTION
LC_MEASUREMENT is a GNU (libc) extension - fall back to LC_ALL if it's not defined.

Fixes build with musl libc