### PR TITLE
ocp-nvme: fix the error display of Hardware Component Log

### DIFF
--- a/plugins/ocp/ocp-hardware-component-log.c
+++ b/plugins/ocp/ocp-hardware-component-log.c
@@ -193,8 +193,7 @@ static int get_hwcomp_log_data(struct nvme_dev *dev, struct hwcomp_log *log)
 	print_info_array("guid", log->guid, ARRAY_SIZE(log->guid));
 	print_info("size: %s\n", uint128_t_to_string(le128_to_cpu(log->size)));
 
-	args.len = uint128_t_to_double(le128_to_cpu(log->size)) * sizeof(__le32) -
-		offsetof(struct __packed hwcomp_log, desc);
+	args.len = uint128_t_to_double(le128_to_cpu(log->size)) * sizeof(__le32) - desc_offset;
 	log->desc = calloc(1, args.len);
 	if (!log->desc) {
 		fprintf(stderr, "error: ocp: calloc: %s\n", strerror(errno));

--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -73,7 +73,7 @@ static void json_hwcomp_log(struct hwcomp_log *log, __u32 id, bool list)
 	obj_add_byte_array(r, "Log page GUID", log->guid, ARRAY_SIZE(log->guid));
 	obj_add_nprix64(r, "Hardware Component Log Size", (unsigned long long)log_size);
 	obj_add_byte_array(r, "Reserved48", log->rsvd48, ARRAY_SIZE(log->rsvd48));
-	print_hwcomp_descs_json(log->desc, log_size, id, list,
+	print_hwcomp_descs_json(log->desc, log_size - offsetof(struct hwcomp_log, desc), id, list,
 				obj_create_array_obj(r, "Component Descriptions"));
 
 	json_print(r);

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -41,6 +41,7 @@ static void stdout_hwcomp_log(struct hwcomp_log *log, __u32 id, bool list)
 	printf("Hardware Component Log Size: 0x%"PRIx64"\n", (uint64_t)log_size);
 	print_array("Reserved48", log->rsvd48, ARRAY_SIZE(log->rsvd48));
 	printf("Component Descriptions\n");
+	log_size -= offsetof(struct hwcomp_log, desc);
 	while (log_size > 0) {
 		e.date_lot_size = le64_to_cpu(e.desc->date_lot_size) * sizeof(__le32);
 		e.date_lot_code = e.date_lot_size ? (__u8 *)e.desc + date_lot_code_offset : NULL;


### PR DESCRIPTION
The display of Hardware Component (Log Identifier C6h) failures to comply with protocol OCP2.5

Issue: https://github.com/linux-nvme/nvme-cli/issues/2566