### PR TITLE
sed: add '--read-only' to 'sed initialize'

### DIFF
--- a/plugins/sed/sed.c
+++ b/plugins/sed/sed.c
@@ -23,6 +23,12 @@ OPT_ARGS(no_opts) = {
 	OPT_END()
 };
 
+OPT_ARGS(init_opts) = {
+	OPT_FLAG("read-only", 'r', &sedopal_lock_ro,
+		 "Set locking range to read-only"),
+	OPT_END()
+};
+
 OPT_ARGS(key_opts) = {
 	OPT_FLAG("ask-key", 'k', &sedopal_ask_key,
 			"prompt for SED authentication key"),
@@ -84,7 +90,7 @@ static int sed_opal_initialize(int argc, char **argv, struct command *cmd,
 	const char *desc = "Initialize a SED device for locking";
 	struct nvme_dev *dev;
 
-	err = sed_opal_open_device(&dev, argc, argv, desc, no_opts);
+	err = sed_opal_open_device(&dev, argc, argv, desc, init_opts);
 	if (err)
 		return err;
 

--- a/plugins/sed/sedopal_cmd.c
+++ b/plugins/sed/sedopal_cmd.c
@@ -35,6 +35,11 @@ bool sedopal_destructive_revert;
 bool sedopal_psid_revert;
 
 /*
+ * Lock read-only
+ */
+bool sedopal_lock_ro;
+
+/*
  * Map method status codes to error text
  */
 static const char * const sedopal_errors[] = {
@@ -206,7 +211,8 @@ int sedopal_cmd_initialize(int fd)
 	lr_setup.range_start = 0;
 	lr_setup.range_length = 0;
 	lr_setup.RLE = true;
-	lr_setup.WLE = true;
+	if (!sedopal_lock_ro)
+		lr_setup.WLE = true;
 
 	lr_setup.session.opal_key = key;
 	lr_setup.session.sum = 0;

--- a/plugins/sed/sedopal_cmd.h
+++ b/plugins/sed/sedopal_cmd.h
@@ -17,6 +17,7 @@ extern bool sedopal_ask_key;
 extern bool sedopal_ask_new_key;
 extern bool sedopal_destructive_revert;
 extern bool sedopal_psid_revert;
+extern bool sedopal_lock_ro;
 
 /*
  * Sub-commands supported by the sedopal command


### PR DESCRIPTION
By default 'sed initialize' will set the entire disk to read/write locked, ie no access is possible. That is all fine if the BIOS supports TCG Opal, as then the BIOS can unlock the drive before access. But for BIOS _not_ supporting TCG Opal this results in an inaccessible drive, and requires the user to use a different drive to boot and unlock the SED device.
This patch adds a flag '--read-only' to 'nvme sed initlialize' such that the 'read-lock enable' flag is not set for the locking range, and the device continues to be readable by the BIOS for booting.