### PR TITLE
nvme: update messages for few misc functions

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -5125,7 +5125,8 @@ static int subsystem_reset(int argc, char **argv, struct command *cmd, struct pl
 			nvme_show_error("Subsystem-reset: NVM Subsystem Reset not supported.");
 		else
 			nvme_show_error("Subsystem-reset: %s", nvme_strerror(errno));
-	}
+	} else if (argconfig_parse_seen(opts, "verbose"))
+		printf("resetting subsystem through %s\n", dev->name);
 
 	return err;
 }
@@ -5146,6 +5147,8 @@ static int reset(int argc, char **argv, struct command *cmd, struct plugin *plug
 	err = nvme_ctrl_reset(dev_fd(dev));
 	if (err < 0)
 		nvme_show_error("Reset: %s", nvme_strerror(errno));
+	else if (argconfig_parse_seen(opts, "verbose"))
+		printf("resetting controller %s\n", dev->name);
 
 	return err;
 }
@@ -5166,6 +5169,8 @@ static int ns_rescan(int argc, char **argv, struct command *cmd, struct plugin *
 	err = nvme_ns_rescan(dev_fd(dev));
 	if (err < 0)
 		nvme_show_error("Namespace Rescan: %s\n", nvme_strerror(errno));
+	else if (argconfig_parse_seen(opts, "verbose"))
+		printf("rescanning namespaces through %s\n", dev->name);
 
 	return err;
 }


### PR DESCRIPTION
Print a helpful success message (under verbose option) for few functions like subsystem_reset(), reset() and ns_rescan().