### PR TITLE
nvme: telemetry ctrl-init need to clear RAE

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -875,7 +875,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 		.host_gen	= 1,
 		.ctrl_init	= false,
 		.data_area	= 3,
-		.rae		= true,
+		.rae		= false,
 	};
 
 	NVME_ARGS(opts,


### PR DESCRIPTION
if rae default is true, it's always true
so it was not possible to issue with RAE=0

If the host is reading the Telemetry Controller-Initiated log page, then the host reads any portion of that log page with the Retain Asynchronous Event bit cleared to ‘0’ to indicate to the controller that the host has completed reading the Telemetry Controller-Initiated log page