### PR TITLE
ocp: TCG Configuration Log field added ocp v2.6

### DIFF
--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -11,7 +11,7 @@
 #if !defined(OCP_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define OCP_NVME
 
-#define OCP_PLUGIN_VERSION   "2.9.2"
+#define OCP_PLUGIN_VERSION   "2.9.3"
 #include "cmd.h"
 
 PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),
@@ -196,7 +196,7 @@ struct __packed ocp_device_capabilities_log_page {
 /*
  * struct tcg_configuration_log - TCG Configuration Log Page Structure
  * @state:                            state
- * @rsvd1:                            Reserved1
+ * @rsvd1:                            Reserved
  * @locking_sp_act_count:             Locking SP Activation Count
  * @type_rev_count:                   Tper Revert Count
  * @locking_sp_rev_count:             Locking SP Revert Count.
@@ -208,13 +208,14 @@ struct __packed ocp_device_capabilities_log_page {
  * @no_of_write_lock_locking_obj:     Number of Write Locked Locking Objects
  * @no_of_read_unlock_locking_obj:    Number of Read Unlocked Locking Objects
  * @no_of_read_unlock_locking_obj:    Number of Write Unlocked Locking Objects
- * @rsvd2:                            Reserved2
+ * @rsvd15:                           Reserved
  * @sid_auth_try_count:               SID Authentication Try Count
  * @sid_auth_try_limit:               SID Authentication Try Limit
  * @pro_tcg_rc:                       Programmatic TCG Reset Count
  * @pro_rlc:                          Programmatic Reset Lock Count
  * @tcg_ec:                           TCG Error Count
- * @rsvd3:                            Reserved3
+ * @no_of_ns_prov_locking_obj_ext:    Number of Namespace Provisioned Locking Objects Extended
+ * @rsvd38:                           Reserved
  * @log_page_version:                 Log Page Version
  */
 struct __packed tcg_configuration_log {
@@ -231,13 +232,14 @@ struct __packed tcg_configuration_log {
 	__u8    no_of_write_lock_locking_obj;
 	__u8    no_of_read_unlock_locking_obj;
 	__u8    no_of_write_unlock_locking_obj;
-	__u8    rsvd2;
+	__u8    rsvd15;
 	__le32  sid_auth_try_count;
 	__le32  sid_auth_try_limit;
 	__le32  pro_tcg_rc;
 	__le32  pro_rlc;
 	__le32  tcg_ec;
-	__u8    rsvd3[458];
+	__le16  no_of_ns_prov_locking_obj_ext;
+	__u8    rsvd38[456];
 	__le16  log_page_version;
 	__u8    log_page_guid[GUID_LEN];
 

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -646,59 +646,67 @@ static void stdout_c9_log(struct telemetry_str_log_format *log_data, __u8 *log_d
 static void stdout_c7_log(struct nvme_dev *dev, struct tcg_configuration_log *log_data)
 {
 	int j;
+	__u16 log_page_version = le16_to_cpu(log_data->log_page_version);
 
 	printf("TCG Configuration C7 Log Page Data-\n");
 
-	printf("  State                                                  : 0x%x\n",
-	       log_data->state);
-	printf("  Reserved1                                              : 0x");
+	printf("  State                                                    : 0x%x\n",
+		log_data->state);
+	printf("  Reserved1                                              : ");
 	for (j = 0; j < 3; j++)
 		printf("%d", log_data->rsvd1[j]);
 	printf("\n");
-	printf("  Locking SP Activation Count                            : 0x%x\n",
+	printf("  Locking SP Activation Count                              : 0x%x\n",
 	       log_data->locking_sp_act_count);
-	printf("  Tper Revert Count                                      : 0x%x\n",
+	printf("  Tper Revert Count                                        : 0x%x\n",
 	       log_data->type_rev_count);
-	printf("  Locking SP Revert Count                                : 0x%x\n",
+	printf("  Locking SP Revert Count                                  : 0x%x\n",
 	       log_data->locking_sp_rev_count);
-	printf("  Number of Locking Objects                              : 0x%x\n",
+	printf("  Number of Locking Objects                                : 0x%x\n",
 	       log_data->no_of_locking_obj);
-	printf("  Number of Single User Mode Locking Objects             : 0x%x\n",
+	printf("  Number of Single User Mode Locking Objects               : 0x%x\n",
 	       log_data->no_of_single_um_locking_obj);
-	printf("  Number of Range Provisioned Locking Objects            : 0x%x\n",
+	printf("  Number of Range Provisioned Locking Objects              : 0x%x\n",
 	       log_data->no_of_range_prov_locking_obj);
-	printf("  Number of Namespace Provisioned Locking Objects        : 0x%x\n",
+	printf("  Number of Namespace Provisioned Locking Objects          : 0x%x\n",
 	       log_data->no_of_ns_prov_locking_obj);
-	printf("  Number of Read Locked Locking Objects                  : 0x%x\n",
+	printf("  Number of Read Locked Locking Objects                    : 0x%x\n",
 	       log_data->no_of_read_lock_locking_obj);
-	printf("  Number of Write Locked Locking Objects                 : 0x%x\n",
+	printf("  Number of Write Locked Locking Objects                   : 0x%x\n",
 	       log_data->no_of_write_lock_locking_obj);
-	printf("  Number of Read Unlocked Locking Objects                : 0x%x\n",
+	printf("  Number of Read Unlocked Locking Objects                  : 0x%x\n",
 	       log_data->no_of_read_unlock_locking_obj);
-	printf("  Number of Write Unlocked Locking Objects               : 0x%x\n",
+	printf("  Number of Write Unlocked Locking Objects                 : 0x%x\n",
 	       log_data->no_of_write_unlock_locking_obj);
-	printf("  Reserved2                                              : 0x%x\n",
-	       log_data->rsvd2);
-
-	printf("  SID Authentication Try Count                           : 0x%x\n",
+	printf("  Reserved2                                              : %x\n",
+		log_data->rsvd15);
+	printf("  SID Authentication Try Count                             : 0x%x\n",
 	       le32_to_cpu(log_data->sid_auth_try_count));
-	printf("  SID Authentication Try Limit                           : 0x%x\n",
+	printf("  SID Authentication Try Limit                             : 0x%x\n",
 	       le32_to_cpu(log_data->sid_auth_try_limit));
-	printf("  Programmatic TCG Reset Count                           : 0x%x\n",
+	printf("  Programmatic TCG Reset Count                             : 0x%x\n",
 	       le32_to_cpu(log_data->pro_tcg_rc));
-	printf("  Programmatic Reset Lock Count                          : 0x%x\n",
+	printf("  Programmatic Reset Lock Count                            : 0x%x\n",
 	       le32_to_cpu(log_data->pro_rlc));
-	printf("  TCG Error Count                                        : 0x%x\n",
+	printf("  TCG Error Count                                          : 0x%x\n",
 	       le32_to_cpu(log_data->tcg_ec));
 
-	printf("  Reserved3                                              : 0x");
-	for (j = 0; j < 458; j++)
-		printf("%d", log_data->rsvd3[j]);
+	if (log_page_version == 1) {
+		printf("  Reserved3                                                : %d%d",
+			*(__u8 *)&log_data->no_of_ns_prov_locking_obj_ext,
+			*((__u8 *)&log_data->no_of_ns_prov_locking_obj_ext + 1));
+	} else {
+		printf("  Number of Namespace Provisioned Locking Objects Extended : 0x%x\n",
+			le16_to_cpu(log_data->no_of_ns_prov_locking_obj_ext));
+		printf("  Reserved3                                                : ");
+	}
+	for (j = 0; j < 456; j++)
+		printf("%d", log_data->rsvd38[j]);
 	printf("\n");
 
-	printf("  Log Page Version                                       : 0x%x\n",
-	       le16_to_cpu(log_data->log_page_version));
-	printf("  Log page GUID                                          : 0x");
+	printf("  Log Page Version                                         : 0x%x\n",
+	       log_page_version);
+	printf("  Log page GUID                                            : 0x");
 	for (j = GUID_LEN - 1; j >= 0; j--)
 		printf("%02x", log_data->log_page_guid[j]);
 	printf("\n");


### PR DESCRIPTION
Add Number of Namespace Provisioned Locking Objects Extended(TCGL-23)
remove reserved area prints (Shall be cleared to zero)
reserved area field name modified by byte address