### PR TITLE
nvme-print: fix Arbitration Mechanism Supported

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1139,7 +1139,7 @@ static void stdout_registers_cap(struct nvme_bar_cap *cap)
 	printf("\tDoorbell Stride                   (DSTRD): %u bytes\n", 1 << (2 + cap->dstrd));
 	printf("\tTimeout                              (TO): %u ms\n", cap->to * 500);
 	printf("\tArbitration Mechanism Supported     (AMS): Weighted Round Robin with Urgent Priority Class is %s\n",
-	       cap->ams & 0x02 ? "Supported" : "Not supported");
+	       cap->ams & 0x01 ? "Supported" : "Not supported");
 	printf("\tContiguous Queues Required          (CQR): %s\n", cap->cqr ? "Yes" : "No");
 	printf("\tMaximum Queue Entries Supported    (MQES): %u\n\n", cap->mqes + 1);
 }


### PR DESCRIPTION
Fix the error of the `Arbitration Mechanism Supported`
in the Controller Capabilities field of Controller Properties.

Refer to Section 3.1.4.1 of [NVM Express® Base Specification](https://nvmexpress.org/wp-content/uploads/NVM-Express-Base-Specification-Revision-2.1-2024.08.05-Ratified.pdf), WRRUPC is indicated by bit 0 of AMS
