### PR TITLE
plugins/ocp: Use structure for ocp smart log

### DIFF
--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -138,13 +138,12 @@ static void json_fw_activation_history(const struct fw_activation_history *fw_hi
 	printf("\n");
 }
 
-static void json_smart_extended_log_v1(void *data)
+static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
 {
 	struct json_object *root;
 	struct json_object *pmuw;
 	struct json_object *pmur;
 	uint16_t smart_log_ver = 0;
-	__u8 *log_data = data;
 	char guid[40];
 
 	root = json_create_object();
@@ -152,70 +151,71 @@ static void json_smart_extended_log_v1(void *data)
 	pmur = json_create_object();
 
 	json_object_add_value_uint64(pmuw, "hi",
-				     (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW + 8]));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_written[8]));
 	json_object_add_value_uint64(pmuw, "lo",
-				     (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW]));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_written));
 	json_object_add_value_object(root, "Physical media units written", pmuw);
 	json_object_add_value_uint64(pmur, "hi",
-				     (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR + 8]));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_read[8]));
 	json_object_add_value_uint64(pmur, "lo",
-				     (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR]));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_read));
 	json_object_add_value_object(root, "Physical media units read", pmur);
 	json_object_add_value_uint64(root, "Bad user nand blocks - Raw",
-				     int48_to_long(&log_data[SCAO_BUNBR]));
+		int48_to_long(log->bad_user_nand_blocks_raw));
 	json_object_add_value_uint(root, "Bad user nand blocks - Normalized",
-		(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BUNBN]));
+		le16_to_cpu(log->bad_user_nand_blocks_normalized));
 	json_object_add_value_uint64(root, "Bad system nand blocks - Raw",
-				     int48_to_long(&log_data[SCAO_BSNBR]));
+		int48_to_long(log->bad_system_nand_blocks_raw));
 	json_object_add_value_uint(root, "Bad system nand blocks - Normalized",
-		(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BSNBN]));
+		le16_to_cpu(log->bad_system_nand_blocks_normalized));
 	json_object_add_value_uint64(root, "XOR recovery count",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_XRC]));
+		le64_to_cpu(log->xor_recovery_count));
 	json_object_add_value_uint64(root, "Uncorrectable read error count",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UREC]));
+		le64_to_cpu(log->uncorrectable_read_err_count));
 	json_object_add_value_uint64(root, "Soft ecc error count",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SEEC]));
+		le64_to_cpu(log->soft_ecc_err_count));
 	json_object_add_value_uint(root, "End to end detected errors",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EEDC]));
+		le32_to_cpu(log->end_to_end_detected_err));
 	json_object_add_value_uint(root, "End to end corrected errors",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EECE]));
+		le32_to_cpu(log->end_to_end_corrected_err));
 	json_object_add_value_uint(root, "System data percent used",
-		(__u8)log_data[SCAO_SDPU]);
-	json_object_add_value_uint64(root, "Refresh counts", int56_to_long(&log_data[SCAO_RFSC]));
+		log->system_data_used_percent);
+	json_object_add_value_uint64(root, "Refresh counts",
+		int56_to_long(log->refresh_counts));
 	json_object_add_value_uint(root, "Max User data erase counts",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_MXUDEC]));
+		le32_to_cpu(log->user_data_erase_count_max));
 	json_object_add_value_uint(root, "Min User data erase counts",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_MNUDEC]));
+		le32_to_cpu(log->user_data_erase_count_min));
 	json_object_add_value_uint(root, "Number of Thermal throttling events",
-		(__u8)log_data[SCAO_NTTE]);
+		log->thermal_throttling_event_count);
 	json_object_add_value_uint(root, "Current throttling status",
-		(__u8)log_data[SCAO_CTS]);
+		log->thermal_throttling_current_status);
 	json_object_add_value_uint64(root, "PCIe correctable error count",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PCEC]));
+		le64_to_cpu(log->pcie_correctable_err_count));
 	json_object_add_value_uint(root, "Incomplete shutdowns",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_ICS]));
+		le32_to_cpu(log->incomplete_shoutdowns));
 	json_object_add_value_uint(root, "Percent free blocks",
-		(__u8)log_data[SCAO_PFB]);
+		log->percent_free_blocks);
 	json_object_add_value_uint(root, "Capacitor health",
-		(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_CPH]));
+		le16_to_cpu(log->capacitor_health));
 	json_object_add_value_uint64(root, "Unaligned I/O",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UIO]));
+		le64_to_cpu(log->unaligned_io));
 	json_object_add_value_uint64(root, "Security Version Number",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SVN]));
+		le64_to_cpu(log->security_version));
 	json_object_add_value_uint64(root, "NUSE - Namespace utilization",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_NUSE]));
+		le64_to_cpu(log->total_nuse));
 	json_object_add_value_uint128(root, "PLP start count",
-		le128_to_cpu(&log_data[SCAO_PSC]));
+		le128_to_cpu(log->plp_start_count));
 	json_object_add_value_uint128(root, "Endurance estimate",
-		le128_to_cpu(&log_data[SCAO_EEST]));
-	smart_log_ver = (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_LPV]);
+		le128_to_cpu(log->endurance_estimate));
+	smart_log_ver = le16_to_cpu(log->log_page_version);
 
 	json_object_add_value_uint(root, "Log page version", smart_log_ver);
 
 	memset((void *)guid, 0, 40);
 	sprintf((char *)guid, "0x%"PRIx64"%"PRIx64"",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_LPG + 8]),
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_LPG]));
+		le64_to_cpu(*(uint64_t *)&log->log_page_guid[8]),
+		le64_to_cpu(*(uint64_t *)&log->log_page_guid));
 	json_object_add_value_string(root, "Log page GUID", guid);
 
 	switch (smart_log_ver) {
@@ -224,38 +224,37 @@ static void json_smart_extended_log_v1(void *data)
 	default:
 	case 4:
 		json_object_add_value_uint(root, "NVMe Command Set Errata Version",
-					   (__u8)log_data[SCAO_NCSEV]);
+						log->nvme_cmdset_errata_version);
 		json_object_add_value_uint(root, "Lowest Permitted Firmware Revision",
-					   le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
+						le64_to_cpu(log->lowest_permitted_fw_rev));
 		fallthrough;
 	case 2 ... 3:
 		json_object_add_value_uint(root, "Errata Version Field",
-					   (__u8)log_data[SCAO_EVF]);
+						log->dssd_errata_version);
 		json_object_add_value_uint(root, "Point Version Field",
-					   le16_to_cpu(*(uint16_t *)&log_data[SCAO_PVF]));
+						le16_to_cpu(log->dssd_point_version));
 		json_object_add_value_uint(root, "Minor Version Field",
-					   le16_to_cpu(*(uint16_t *)&log_data[SCAO_MIVF]));
+						le16_to_cpu(log->dssd_minor_version));
 		json_object_add_value_uint(root, "Major Version Field",
-					   (__u8)log_data[SCAO_MAVF]);
+						log->dssd_major_version);
 		json_object_add_value_uint(root, "NVMe Base Errata Version",
-					   (__u8)log_data[SCAO_NBEV]);
+						log->nvme_base_errata_version);
 		json_object_add_value_uint(root, "PCIe Link Retraining Count",
-					   le64_to_cpu(*(uint64_t *)&log_data[SCAO_PLRC]));
+						le64_to_cpu(log->pcie_link_retaining_count));
 		json_object_add_value_uint(root, "Power State Change Count",
-					   le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
+						le64_to_cpu(log->power_state_change_count));
 	}
 	json_print_object(root, NULL);
 	printf("\n");
 	json_free_object(root);
 }
 
-static void json_smart_extended_log_v2(void *data)
+static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
 {
 	struct json_object *root;
 	struct json_object *pmuw;
 	struct json_object *pmur;
 	uint16_t smart_log_ver = 0;
-	__u8 *log_data = data;
 	char guid[40];
 
 	root = json_create_object();
@@ -263,71 +262,71 @@ static void json_smart_extended_log_v2(void *data)
 	pmur = json_create_object();
 
 	json_object_add_value_uint64(pmuw, "hi",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW + 8] & 0xFFFFFFFFFFFFFFFF));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_written[8]));
 	json_object_add_value_uint64(pmuw, "lo",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW] & 0xFFFFFFFFFFFFFFFF));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_written));
 	json_object_add_value_object(root, "physical_media_units_written", pmuw);
 	json_object_add_value_uint64(pmur, "hi",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR + 8] & 0xFFFFFFFFFFFFFFFF));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_read[8]));
 	json_object_add_value_uint64(pmur, "lo",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR] & 0xFFFFFFFFFFFFFFFF));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_read));
 	json_object_add_value_object(root, "physical_media_units_read", pmur);
 	json_object_add_value_uint64(root, "bad_user_nand_blocks_raw",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_BUNBR] & 0x0000FFFFFFFFFFFF));
+		int48_to_long(log->bad_user_nand_blocks_raw));
 	json_object_add_value_uint(root, "bad_user_nand_blocks_normalized",
-		(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BUNBN]));
+		le16_to_cpu(log->bad_user_nand_blocks_normalized));
 	json_object_add_value_uint64(root, "bad_system_nand_blocks_raw",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_BSNBR] & 0x0000FFFFFFFFFFFF));
+		int48_to_long(log->bad_system_nand_blocks_raw));
 	json_object_add_value_uint(root, "bad_system_nand_blocks_normalized",
-		(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BSNBN]));
+		le16_to_cpu(log->bad_system_nand_blocks_normalized));
 	json_object_add_value_uint64(root, "xor_recovery_count",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_XRC]));
+		le64_to_cpu(log->xor_recovery_count));
 	json_object_add_value_uint64(root, "uncorrectable_read_errors",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UREC]));
+		le64_to_cpu(log->uncorrectable_read_err_count));
 	json_object_add_value_uint64(root, "soft_ecc_error_count",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SEEC]));
+		le64_to_cpu(log->soft_ecc_err_count));
 	json_object_add_value_uint(root, "end_to_end_detected_errors",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EEDC]));
+		le32_to_cpu(log->end_to_end_detected_err));
 	json_object_add_value_uint(root, "end_to_end_corrected_errors",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EECE]));
+		le32_to_cpu(log->end_to_end_corrected_err));
 	json_object_add_value_uint(root, "system_data_percent_used",
-		(__u8)log_data[SCAO_SDPU]);
+		log->system_data_used_percent);
 	json_object_add_value_uint64(root, "refresh_count",
-		(uint64_t)(le64_to_cpu(*(uint64_t *)&log_data[SCAO_RFSC]) & 0x00FFFFFFFFFFFFFF));
+		int56_to_long(log->refresh_counts));
 	json_object_add_value_uint(root, "max_user_data_erase_count",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_MXUDEC]));
+		le32_to_cpu(log->user_data_erase_count_max));
 	json_object_add_value_uint(root, "min_user_data_erase_count",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_MNUDEC]));
+		le32_to_cpu(log->user_data_erase_count_min));
 	json_object_add_value_uint(root, "thermal_throttling_events",
-		(__u8)log_data[SCAO_NTTE]);
+		log->thermal_throttling_event_count);
 	json_object_add_value_uint(root, "current_throttling_status",
-		(__u8)log_data[SCAO_CTS]);
+		log->thermal_throttling_current_status);
 	json_object_add_value_uint64(root, "pcie_correctable_errors",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PCEC]));
+		le64_to_cpu(log->pcie_correctable_err_count));
 	json_object_add_value_uint(root, "incomplete_shutdowns",
-		(uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_ICS]));
+		le32_to_cpu(log->incomplete_shoutdowns));
 	json_object_add_value_uint(root, "percent_free_blocks",
-		(__u8)log_data[SCAO_PFB]);
+		log->percent_free_blocks);
 	json_object_add_value_uint(root, "capacitor_health",
-		(uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_CPH]));
+		le16_to_cpu(log->capacitor_health));
 	json_object_add_value_uint64(root, "unaligned_io",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UIO]));
+		le64_to_cpu(log->unaligned_io));
 	json_object_add_value_uint64(root, "security_version_number",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SVN]));
+		le64_to_cpu(log->security_version));
 	json_object_add_value_uint64(root, "nuse_namespace_utilization",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_NUSE]));
+		le64_to_cpu(log->total_nuse));
 	json_object_add_value_uint128(root, "plp_start_count",
-		le128_to_cpu(&log_data[SCAO_PSC]));
+		le128_to_cpu(log->plp_start_count));
 	json_object_add_value_uint128(root, "endurance_estimate",
-		le128_to_cpu(&log_data[SCAO_EEST]));
-	smart_log_ver = (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_LPV]);
+		le128_to_cpu(log->endurance_estimate));
+	smart_log_ver = le16_to_cpu(log->log_page_version);
 
 	json_object_add_value_uint(root, "log_page_version", smart_log_ver);
 
 	memset((void *)guid, 0, 40);
 	sprintf((char *)guid, "0x%"PRIx64"%"PRIx64"",
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_LPG + 8]),
-		(uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_LPG]));
+		le64_to_cpu(*(uint64_t *)&log->log_page_guid[8]),
+		le64_to_cpu(*(uint64_t *)&log->log_page_guid));
 	json_object_add_value_string(root, "log_page_guid", guid);
 
 	switch (smart_log_ver) {
@@ -336,40 +335,40 @@ static void json_smart_extended_log_v2(void *data)
 	default:
 	case 4:
 		json_object_add_value_uint(root, "nvme_command_set_errata_version",
-					   (__u8)log_data[SCAO_NCSEV]);
+						log->nvme_cmdset_errata_version);
 		json_object_add_value_uint(root, "lowest_permitted_firmware_revision",
-					   le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
+						le64_to_cpu(log->lowest_permitted_fw_rev));
 		fallthrough;
 	case 2 ... 3:
 		json_object_add_value_uint(root, "errata_version_field",
-					   (__u8)log_data[SCAO_EVF]);
+						log->dssd_errata_version);
 		json_object_add_value_uint(root, "point_version_field",
-					   le16_to_cpu(*(uint16_t *)&log_data[SCAO_PVF]));
+						le16_to_cpu(log->dssd_point_version));
 		json_object_add_value_uint(root, "minor_version_field",
-					   le16_to_cpu(*(uint16_t *)&log_data[SCAO_MIVF]));
+						le16_to_cpu(log->dssd_minor_version));
 		json_object_add_value_uint(root, "major_version_field",
-					   (__u8)log_data[SCAO_MAVF]);
+						log->dssd_major_version);
 		json_object_add_value_uint(root, "nvme_base_errata_version",
-					   (__u8)log_data[SCAO_NBEV]);
+						log->nvme_base_errata_version);
 		json_object_add_value_uint(root, "pcie_link_retraining_count",
-					   le64_to_cpu(*(uint64_t *)&log_data[SCAO_PLRC]));
+						le64_to_cpu(log->pcie_link_retaining_count));
 		json_object_add_value_uint(root, "power_state_change_count",
-					   le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
+						le64_to_cpu(log->power_state_change_count));
 	}
 	json_print_object(root, NULL);
 	printf("\n");
 	json_free_object(root);
 }
 
-static void json_smart_extended_log(void *data, unsigned int version)
+static void json_smart_extended_log(struct ocp_smart_extended_log *log, unsigned int version)
 {
 	switch (version) {
 	default:
 	case 1:
-		json_smart_extended_log_v1(data);
+		json_smart_extended_log_v1(log);
 		break;
 	case 2:
-		json_smart_extended_log_v2(data);
+		json_smart_extended_log_v2(log);
 	}
 }
 static void json_telemetry_log(struct ocp_telemetry_parse_options *options)

--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -144,6 +144,7 @@ static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
 	struct json_object *pmuw;
 	struct json_object *pmur;
 	uint16_t smart_log_ver = 0;
+	uint16_t dssd_version = 0;
 	char guid[40];
 
 	root = json_create_object();
@@ -231,10 +232,12 @@ static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
 	case 2 ... 3:
 		json_object_add_value_uint(root, "Errata Version Field",
 						log->dssd_errata_version);
+		memcpy(&dssd_version, log->dssd_point_version, sizeof(dssd_version));
 		json_object_add_value_uint(root, "Point Version Field",
-						le16_to_cpu(log->dssd_point_version));
+						le16_to_cpu(dssd_version));
+		memcpy(&dssd_version, log->dssd_minor_version, sizeof(dssd_version));
 		json_object_add_value_uint(root, "Minor Version Field",
-						le16_to_cpu(log->dssd_minor_version));
+						le16_to_cpu(dssd_version));
 		json_object_add_value_uint(root, "Major Version Field",
 						log->dssd_major_version);
 		json_object_add_value_uint(root, "NVMe Base Errata Version",
@@ -255,6 +258,7 @@ static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
 	struct json_object *pmuw;
 	struct json_object *pmur;
 	uint16_t smart_log_ver = 0;
+	uint16_t dssd_version = 0;
 	char guid[40];
 
 	root = json_create_object();
@@ -342,10 +346,12 @@ static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
 	case 2 ... 3:
 		json_object_add_value_uint(root, "errata_version_field",
 						log->dssd_errata_version);
+		memcpy(&dssd_version, log->dssd_point_version, sizeof(dssd_version));
 		json_object_add_value_uint(root, "point_version_field",
-						le16_to_cpu(log->dssd_point_version));
+						le16_to_cpu(dssd_version));
+		memcpy(&dssd_version, log->dssd_minor_version, sizeof(dssd_version));
 		json_object_add_value_uint(root, "minor_version_field",
-						le16_to_cpu(log->dssd_minor_version));
+						le16_to_cpu(dssd_version));
 		json_object_add_value_uint(root, "major_version_field",
 						log->dssd_major_version);
 		json_object_add_value_uint(root, "nvme_base_errata_version",

--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -145,7 +145,10 @@ static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
 	struct json_object *pmur;
 	uint16_t smart_log_ver = 0;
 	uint16_t dssd_version = 0;
+	int i = 0;
 	char guid[40];
+	char ascii_arr[65];
+	char *ascii = ascii_arr;
 
 	root = json_create_object();
 	pmuw = json_create_object();
@@ -228,6 +231,49 @@ static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
 						log->nvme_cmdset_errata_version);
 		json_object_add_value_uint(root, "Lowest Permitted Firmware Revision",
 						le64_to_cpu(log->lowest_permitted_fw_rev));
+		json_object_add_value_uint(root, "NVMe Over Pcie Errata Version",
+						log->nvme_over_pcie_errate_version);
+		json_object_add_value_uint(root, "NVMe Mi Errata Version",
+						log->nvme_mi_errata_version);
+		json_object_add_value_uint(root, "Total media dies",
+						le16_to_cpu(log->total_media_dies));
+		json_object_add_value_uint(root, "Total die failure tolerance",
+						le16_to_cpu(log->total_die_failure_tolerance));
+		json_object_add_value_uint(root, "Max temperature recorded",
+						le16_to_cpu(log->max_temperature_recorded));
+		json_object_add_value_uint64(root, "Nand avg erase count",
+						le64_to_cpu(log->nand_avg_erase_count));
+		json_object_add_value_uint(root, "Command timeouts",
+						le32_to_cpu(log->command_timeouts));
+		json_object_add_value_uint(root, "Sys area program fail count raw",
+						le32_to_cpu(log->sys_area_program_fail_count_raw));
+		json_object_add_value_uint(root, "Sys area program fail count noralized",
+						log->sys_area_program_fail_count_normalized);
+		json_object_add_value_uint(root, "Sys area uncorrectable read count raw",
+						le32_to_cpu(log->sys_area_uncorr_read_count_raw));
+		json_object_add_value_uint(root, "Sys area uncorrectable read count noralized",
+						log->sys_area_uncorr_read_count_normalized);
+		json_object_add_value_uint(root, "Sys area erase fail count raw",
+						le32_to_cpu(log->sys_area_erase_fail_count_raw));
+		json_object_add_value_uint(root, "Sys area erase fail count noralized",
+						log->sys_area_erase_fail_count_normalized);
+		json_object_add_value_uint(root, "Max peak power capability",
+						le16_to_cpu(log->max_peak_power_capability));
+		json_object_add_value_uint(root, "Current max avg power",
+						le16_to_cpu(log->current_max_avg_power));
+		json_object_add_value_uint64(root, "Lifetime power consumed",
+						int48_to_long(log->lifetime_power_consumed));
+		memset((void *)ascii, 0, 65);
+		for (i = 0; i < 8; i++)
+			ascii += sprintf(ascii, "%c", log->dssd_firmware_revision[i]);
+		json_object_add_value_string(root, "Dssd firmware revision", ascii_arr);
+		json_object_add_value_string(root, "Dssd firmware build UUID",
+						util_uuid_to_string(log->dssd_firmware_build_uuid));
+		ascii = ascii_arr;
+		memset((void *)ascii, 0, 65);
+		for (i = 0; i < 64; i++)
+			ascii += sprintf(ascii, "%c", log->dssd_firmware_build_label[i]);
+		json_object_add_value_string(root, "Dssd firmware build label", ascii_arr);
 		fallthrough;
 	case 2 ... 3:
 		json_object_add_value_uint(root, "Errata Version Field",
@@ -257,9 +303,12 @@ static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
 	struct json_object *root;
 	struct json_object *pmuw;
 	struct json_object *pmur;
+	int i = 0;
 	uint16_t smart_log_ver = 0;
 	uint16_t dssd_version = 0;
 	char guid[40];
+	char ascii_arr[65];
+	char *ascii = ascii_arr;
 
 	root = json_create_object();
 	pmuw = json_create_object();
@@ -342,6 +391,49 @@ static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
 						log->nvme_cmdset_errata_version);
 		json_object_add_value_uint(root, "lowest_permitted_firmware_revision",
 						le64_to_cpu(log->lowest_permitted_fw_rev));
+		json_object_add_value_uint(root, "nvme_over_pcie_errata_version",
+						log->nvme_over_pcie_errate_version);
+		json_object_add_value_uint(root, "nvme_mi_errata_version",
+						log->nvme_mi_errata_version);
+		json_object_add_value_uint(root, "total_media_dies",
+						le16_to_cpu(log->total_media_dies));
+		json_object_add_value_uint(root, "total_die_failure_tolerance",
+						le16_to_cpu(log->total_die_failure_tolerance));
+		json_object_add_value_uint(root, "max_temperature_recorded",
+						le16_to_cpu(log->max_temperature_recorded));
+		json_object_add_value_uint64(root, "nand_avg_erase_count",
+						le64_to_cpu(log->nand_avg_erase_count));
+		json_object_add_value_uint(root, "command_timeouts",
+						le32_to_cpu(log->command_timeouts));
+		json_object_add_value_uint(root, "sys_area_program_fail_count_raw",
+						le32_to_cpu(log->sys_area_program_fail_count_raw));
+		json_object_add_value_uint(root, "sys_area_program_fail_count_noralized",
+						log->sys_area_program_fail_count_normalized);
+		json_object_add_value_uint(root, "sys_area_uncorrectable_read_count_raw",
+						le32_to_cpu(log->sys_area_uncorr_read_count_raw));
+		json_object_add_value_uint(root, "sys_area_uncorrectable_read_count_noralized",
+						log->sys_area_uncorr_read_count_normalized);
+		json_object_add_value_uint(root, "sys_area_erase_fail_count_raw",
+						le32_to_cpu(log->sys_area_erase_fail_count_raw));
+		json_object_add_value_uint(root, "sys_area_erase_fail_count_noralized",
+						log->sys_area_erase_fail_count_normalized);
+		json_object_add_value_uint(root, "max_peak_power_capability",
+						le16_to_cpu(log->max_peak_power_capability));
+		json_object_add_value_uint(root, "current_max_avg_power",
+						le16_to_cpu(log->current_max_avg_power));
+		json_object_add_value_uint64(root, "lifetime_power_consumed",
+						int48_to_long(log->lifetime_power_consumed));
+		memset((void *)ascii, 0, 65);
+		for (i = 0; i < 8; i++)
+			ascii += sprintf(ascii, "%c", log->dssd_firmware_revision[i]);
+		json_object_add_value_string(root, "dssd_firmware_revision", ascii_arr);
+		json_object_add_value_string(root, "dssd_firmware_build_uuid",
+						util_uuid_to_string(log->dssd_firmware_build_uuid));
+		ascii = ascii_arr;
+		memset((void *)ascii, 0, 65);
+		for (i = 0; i < 64; i++)
+			ascii += sprintf(ascii, "%c", log->dssd_firmware_build_label[i]);
+		json_object_add_value_string(root, "dssd_firmware_build_label", ascii_arr);
 		fallthrough;
 	case 2 ... 3:
 		json_object_add_value_uint(root, "errata_version_field",

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -101,6 +101,7 @@ static void stdout_smart_extended_log(struct ocp_smart_extended_log *log, unsign
 {
 	uint16_t smart_log_ver = 0;
 	uint16_t dssd_version = 0;
+	int i = 0;
 
 	printf("SMART Cloud Attributes :-\n");
 
@@ -172,6 +173,50 @@ static void stdout_smart_extended_log(struct ocp_smart_extended_log *log, unsign
 			log->nvme_cmdset_errata_version);
 		printf("  Lowest Permitted Firmware Revision            %"PRIu64"\n",
 			le64_to_cpu(log->lowest_permitted_fw_rev));
+		printf("  NVMe Over Pcie Errata Version			%d\n",
+			log->nvme_over_pcie_errate_version);
+		printf("  NVMe Mi Errata Version			%d\n",
+			log->nvme_mi_errata_version);
+		printf("  Total media dies				%"PRIu16"\n",
+			le16_to_cpu(log->total_media_dies));
+		printf("  Total die failure tolerance			%"PRIu16"\n",
+			le16_to_cpu(log->total_die_failure_tolerance));
+		printf("  Media dies offline				%"PRIu16"\n",
+			le16_to_cpu(log->media_dies_offline));
+		printf("  Max temperature recorded			%d\n",
+			le16_to_cpu(log->max_temperature_recorded));
+		printf("  Nand avg erase count				%"PRIu64"\n",
+			le64_to_cpu(log->nand_avg_erase_count));
+		printf("  Command timeouts				%"PRIu32"\n",
+			le32_to_cpu(log->command_timeouts));
+		printf("  Sys area program fail count raw		%"PRIu32"\n",
+			le32_to_cpu(log->sys_area_program_fail_count_raw));
+		printf("  Sys area program fail count noralized		%d\n",
+			le32_to_cpu(log->sys_area_program_fail_count_normalized));
+		printf("  Sys area uncorrectable read count raw		%"PRIu32"\n",
+			le32_to_cpu(log->sys_area_uncorr_read_count_raw));
+		printf("  Sys area uncorrectable read count noralized	%d\n",
+			le32_to_cpu(log->sys_area_uncorr_read_count_normalized));
+		printf("  Sys area erase fail count raw			%"PRIu32"\n",
+			le32_to_cpu(log->sys_area_erase_fail_count_raw));
+		printf("  Sys area erase fail count noralized		%d\n",
+			le32_to_cpu(log->sys_area_erase_fail_count_normalized));
+		printf("  Max peak power capability			%"PRIu16"\n",
+			le16_to_cpu(log->max_peak_power_capability));
+		printf("  Current max avg power				%"PRIu16"\n",
+			le16_to_cpu(log->current_max_avg_power));
+		printf("  Lifetime power consumed			%"PRIu64"\n",
+			int48_to_long(log->lifetime_power_consumed));
+		printf("  Dssd firmware revision			");
+		for (i = 0; i < sizeof(log->dssd_firmware_revision); i++)
+			printf("%c", log->dssd_firmware_revision[i]);
+		printf("\n");
+		printf("  Dssd firmware build UUID			%s\n",
+			util_uuid_to_string(log->dssd_firmware_build_uuid));
+		printf("  Dssd firmware build label			");
+		for (i = 0; i < sizeof(log->dssd_firmware_build_label); i++)
+			printf("%c", log->dssd_firmware_build_label[i]);
+		printf("\n");
 		fallthrough;
 	case 2 ... 3:
 		printf("  Errata Version Field                          %d\n",

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -97,101 +97,96 @@ static void stdout_fw_activation_history(const struct fw_activation_history *fw_
 	printf("\n");
 }
 
-static void stdout_smart_extended_log(void *data, unsigned int version)
+static void stdout_smart_extended_log(struct ocp_smart_extended_log *log, unsigned int version)
 {
 	uint16_t smart_log_ver = 0;
-	__u8 *log_data = data;
 
 	printf("SMART Cloud Attributes :-\n");
 
 	printf("  Physical media units written -		%"PRIu64" %"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW + 8]),
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUW]));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_written[8]),
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_written));
 	printf("  Physical media units read    -		%"PRIu64" %"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR + 8]),
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PMUR]));
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_read[8]),
+		le64_to_cpu(*(uint64_t *)&log->physical_media_units_read));
 	printf("  Bad user nand blocks - Raw			%"PRIu64"\n",
-	       int48_to_long(&log_data[SCAO_BUNBR]));
+		int48_to_long(log->bad_user_nand_blocks_raw));
 	printf("  Bad user nand blocks - Normalized		%d\n",
-	       (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BUNBN]));
+		le16_to_cpu(log->bad_user_nand_blocks_normalized));
 	printf("  Bad system nand blocks - Raw			%"PRIu64"\n",
-	       int48_to_long(&log_data[SCAO_BSNBR]));
+		int48_to_long(log->bad_system_nand_blocks_raw));
 	printf("  Bad system nand blocks - Normalized		%d\n",
-	       (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_BSNBN]));
+		le16_to_cpu(log->bad_system_nand_blocks_normalized));
 	printf("  XOR recovery count				%"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_XRC]));
+		le64_to_cpu(log->xor_recovery_count));
 	printf("  Uncorrectable read error count		%"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UREC]));
+		le64_to_cpu(log->uncorrectable_read_err_count));
 	printf("  Soft ecc error count				%"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SEEC]));
+		le64_to_cpu(log->soft_ecc_err_count));
 	printf("  End to end detected errors			%"PRIu32"\n",
-	       (uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EEDC]));
+		le32_to_cpu(log->end_to_end_detected_err));
 	printf("  End to end corrected errors			%"PRIu32"\n",
-	       (uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_EECE]));
+		le32_to_cpu(log->end_to_end_corrected_err));
 	printf("  System data percent used			%d\n",
-	       (__u8)log_data[SCAO_SDPU]);
+		log->system_data_used_percent);
 	printf("  Refresh counts				%"PRIu64"\n",
-	       int56_to_long(&log_data[SCAO_RFSC]));
+		int56_to_long(log->refresh_counts));
 	printf("  Max User data erase counts			%"PRIu32"\n",
-	       (uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_MXUDEC]));
+		le32_to_cpu(log->user_data_erase_count_max));
 	printf("  Min User data erase counts			%"PRIu32"\n",
-	       (uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_MNUDEC]));
+		le32_to_cpu(log->user_data_erase_count_min));
 	printf("  Number of Thermal throttling events		%d\n",
-	       (__u8)log_data[SCAO_NTTE]);
+		log->thermal_throttling_event_count);
 	printf("  Current throttling status			0x%x\n",
-	       (__u8)log_data[SCAO_CTS]);
+		log->thermal_throttling_current_status);
 	printf("  PCIe correctable error count			%"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PCEC]));
+		le64_to_cpu(log->pcie_correctable_err_count));
 	printf("  Incomplete shutdowns				%"PRIu32"\n",
-	       (uint32_t)le32_to_cpu(*(uint32_t *)&log_data[SCAO_ICS]));
+		le32_to_cpu(log->incomplete_shoutdowns));
 	printf("  Percent free blocks				%d\n",
-	       (__u8)log_data[SCAO_PFB]);
+		log->percent_free_blocks);
 	printf("  Capacitor health				%"PRIu16"\n",
-	       (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_CPH]));
-	printf("  NVMe base errata version			%c\n",
-	       (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_CPH]));
-	printf("  NVMe command set errata version		%c\n",
-	       (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_CPH]));
+		le16_to_cpu(log->capacitor_health));
 	printf("  Unaligned I/O					%"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_UIO]));
+		le64_to_cpu(log->unaligned_io));
 	printf("  Security Version Number			%"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_SVN]));
+		le64_to_cpu(log->security_version));
 	printf("  NUSE - Namespace utilization			%"PRIu64"\n",
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_NUSE]));
+		le64_to_cpu(log->total_nuse));
 	printf("  PLP start count				%s\n",
-	       uint128_t_to_string(le128_to_cpu(&log_data[SCAO_PSC])));
+		uint128_t_to_string(le128_to_cpu(log->plp_start_count)));
 	printf("  Endurance estimate				%s\n",
-	       uint128_t_to_string(le128_to_cpu(&log_data[SCAO_EEST])));
-	smart_log_ver = (uint16_t)le16_to_cpu(*(uint16_t *)&log_data[SCAO_LPV]);
+		uint128_t_to_string(le128_to_cpu(log->endurance_estimate)));
+	smart_log_ver = le16_to_cpu(log->log_page_version);
 	printf("  Log page version				%"PRIu16"\n", smart_log_ver);
 	printf("  Log page GUID					0x");
-	printf("%"PRIx64"%"PRIx64"\n", (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_LPG + 8]),
-	       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_LPG]));
+	printf("%"PRIx64"%"PRIx64"\n", le64_to_cpu(*(uint64_t *)&log->log_page_guid[8]),
+		le64_to_cpu(*(uint64_t *)&log->log_page_guid));
 	switch (smart_log_ver) {
 	case 0 ... 1:
 		break;
 	default:
 	case 4:
 		printf("  NVMe Command Set Errata Version               %d\n",
-		       (__u8)log_data[SCAO_NCSEV]);
+			log->nvme_cmdset_errata_version);
 		printf("  Lowest Permitted Firmware Revision            %"PRIu64"\n",
-		       le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
+			le64_to_cpu(log->lowest_permitted_fw_rev));
 		fallthrough;
 	case 2 ... 3:
 		printf("  Errata Version Field                          %d\n",
-		       (__u8)log_data[SCAO_EVF]);
+			log->dssd_errata_version);
 		printf("  Point Version Field                           %"PRIu16"\n",
-		       le16_to_cpu(*(uint16_t *)&log_data[SCAO_PVF]));
+			le16_to_cpu(log->dssd_point_version));
 		printf("  Minor Version Field                           %"PRIu16"\n",
-		       le16_to_cpu(*(uint16_t *)&log_data[SCAO_MIVF]));
+			le16_to_cpu(log->dssd_minor_version));
 		printf("  Major Version Field                           %d\n",
-		       (__u8)log_data[SCAO_MAVF]);
+			log->dssd_major_version);
 		printf("  NVMe Base Errata Version                      %d\n",
-		       (__u8)log_data[SCAO_NBEV]);
+			log->nvme_base_errata_version);
 		printf("  PCIe Link Retraining Count                    %"PRIu64"\n",
-		       (uint64_t)le64_to_cpu(*(uint64_t *)&log_data[SCAO_PLRC]));
+			le64_to_cpu(log->pcie_link_retaining_count));
 		printf("  Power State Change Count                      %"PRIu64"\n",
-		       le64_to_cpu(*(uint64_t *)&log_data[SCAO_PSCC]));
+			le64_to_cpu(log->power_state_change_count));
 	}
 	printf("\n");
 }

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -100,6 +100,7 @@ static void stdout_fw_activation_history(const struct fw_activation_history *fw_
 static void stdout_smart_extended_log(struct ocp_smart_extended_log *log, unsigned int version)
 {
 	uint16_t smart_log_ver = 0;
+	uint16_t dssd_version = 0;
 
 	printf("SMART Cloud Attributes :-\n");
 
@@ -175,10 +176,12 @@ static void stdout_smart_extended_log(struct ocp_smart_extended_log *log, unsign
 	case 2 ... 3:
 		printf("  Errata Version Field                          %d\n",
 			log->dssd_errata_version);
+		memcpy(&dssd_version, log->dssd_point_version, sizeof(dssd_version));
 		printf("  Point Version Field                           %"PRIu16"\n",
-			le16_to_cpu(log->dssd_point_version));
+			le16_to_cpu(dssd_version));
+		memcpy(&dssd_version, log->dssd_minor_version, sizeof(dssd_version));
 		printf("  Minor Version Field                           %"PRIu16"\n",
-			le16_to_cpu(log->dssd_minor_version));
+			le16_to_cpu(dssd_version));
 		printf("  Major Version Field                           %d\n",
 			log->dssd_major_version);
 		printf("  NVMe Base Errata Version                      %d\n",

--- a/plugins/ocp/ocp-print.c
+++ b/plugins/ocp/ocp-print.c
@@ -36,9 +36,10 @@ void ocp_fw_act_history(const struct fw_activation_history *fw_history, nvme_pri
 	ocp_print(fw_act_history, flags, fw_history);
 }
 
-void ocp_smart_extended_log(void *data, unsigned int version, nvme_print_flags_t flags)
+void ocp_smart_extended_log(struct ocp_smart_extended_log *log, unsigned int version,
+		nvme_print_flags_t flags)
 {
-	ocp_print(smart_extended_log, flags, data, version);
+	ocp_print(smart_extended_log, flags, log, version);
 }
 
 void ocp_show_telemetry_log(struct ocp_telemetry_parse_options *options, nvme_print_flags_t flags)

--- a/plugins/ocp/ocp-print.h
+++ b/plugins/ocp/ocp-print.h
@@ -37,7 +37,8 @@ static inline struct ocp_print_ops *ocp_get_json_print_ops(nvme_print_flags_t fl
 
 void ocp_show_hwcomp_log(struct hwcomp_log *log, __u32 id, bool list, nvme_print_flags_t flags);
 void ocp_fw_act_history(const struct fw_activation_history *fw_history, nvme_print_flags_t flags);
-void ocp_smart_extended_log(void *data, unsigned int version, nvme_print_flags_t flags);
+void ocp_smart_extended_log(struct ocp_smart_extended_log *log, unsigned int version,
+		nvme_print_flags_t flags);
 void ocp_show_telemetry_log(struct ocp_telemetry_parse_options *options, nvme_print_flags_t flags);
 void ocp_c3_log(struct nvme_dev *dev, struct ssd_latency_monitor_log *log_data,
 		nvme_print_flags_t flags);

--- a/plugins/ocp/ocp-print.h
+++ b/plugins/ocp/ocp-print.h
@@ -4,13 +4,14 @@
 
 #include "ocp-hardware-component-log.h"
 #include "ocp-fw-activation-history.h"
+#include "ocp-smart-extended-log.h"
 #include "ocp-telemetry-decode.h"
 #include "ocp-nvme.h"
 
 struct ocp_print_ops {
 	void (*hwcomp_log)(struct hwcomp_log *log, __u32 id, bool list);
 	void (*fw_act_history)(const struct fw_activation_history *fw_history);
-	void (*smart_extended_log)(void *data, unsigned int version);
+	void (*smart_extended_log)(struct ocp_smart_extended_log *log, unsigned int version);
 	void (*telemetry_log)(struct ocp_telemetry_parse_options *options);
 	void (*c3_log)(struct nvme_dev *dev, struct ssd_latency_monitor_log *log_data);
 	void (*c5_log)(struct nvme_dev *dev, struct unsupported_requirement_log *log_data);

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -31,7 +31,7 @@ static int get_c0_log_page(struct nvme_dev *dev, char *format,
 			   unsigned int format_version)
 {
 	nvme_print_flags_t fmt;
-	__u8 *data;
+	struct ocp_smart_extended_log *data;
 	int i;
 	int ret;
 	int fd = dev_fd(dev);
@@ -68,7 +68,7 @@ static int get_c0_log_page(struct nvme_dev *dev, char *format,
 		/* check log page guid */
 		/* Verify GUID matches */
 		for (i = 0; i < 16; i++) {
-			if (scao_guid[i] != data[SCAO_LPG + i])	{
+			if (scao_guid[i] != data->log_page_guid[i]) {
 				int j;
 
 				fprintf(stderr, "ERROR : OCP : Unknown GUID in C0 Log Page data\n");
@@ -78,7 +78,7 @@ static int get_c0_log_page(struct nvme_dev *dev, char *format,
 
 				fprintf(stderr, "\nERROR : OCP : Actual GUID:    0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", data[SCAO_LPG + j]);
+					fprintf(stderr, "%x", data->log_page_guid[j]);
 				fprintf(stderr, "\n");
 
 				ret = -1;

--- a/plugins/ocp/ocp-smart-extended-log.h
+++ b/plugins/ocp/ocp-smart-extended-log.h
@@ -16,47 +16,72 @@ struct command;
 struct plugin;
 
 /**
- * struct ocp_smart_extended_log -	SMART / Health Information Extended
- * @physical_media_units_written:	Physical Media Units Written
- * @physical_media_units_read:		Physical Media Units Read
- * @bad_user_nand_blocks_raw:		Bad User NAND Blocks raw
- * @bad_user_nand_blocks_normalized:	Bad User NAND Blocks normalized
- * @bad_system_nand_blocks_raw:		Bad System NAND Blocks raw
- * @bad_system_nand_blocks_normalized:	Bad System NAND Blocks normalized
- * @xor_recovery_count:			XOR Recovery Count
- * @uncorrectable_read_err_count:	Uncorrectable Read Error Count
- * @soft_ecc_err_count:			Soft ECC Error Count
- * @end_to_end_detected_err:		End to End detected errors
- * @end_to_end_corrected_err:		End to End corrected errors
- * @system_data_used_percent:		System data percent used
- * @refresh_counts:			Refresh Counts
- * @user_data_erase_count_max:		Max User data erase counts
- * @user_data_erase_count_min:		Min User data erase counts
- * @thermal_throttling_event_count:	Number of Thermal throttling events
- * @dssd_errata_version:		DSSD Errata Version
- * @dssd_point_version:			DSSD Point Version
- * @dssd_minor_version:			DSSD Minor Version
- * @dssd_major_version:			DSSD Major Version
- * @pcie_correctable_err_count:		PCIe Correctable Error Count
- * @incomplete_shoutdowns:		Incomplete Shutdowns
- * @rsvd116:				Reserved
- * @percent_free_blocks:		Percent free blocks
- * @rsvd121:				Reserved
- * @capacitor_health:			Capacitor health
- * @nvme_base_errata_version:		NVM Express Base Errata Version
- * @nvme_cmdset_errata_version:		NVMe Command Set Errata Version
- * @rsvd132:				Reserved
- * @unaligned_io:			Unaligned I/O
- * @security_version:			Security Version Number
- * @total_nuse:				Total NUSE - Namespace utilization
- * @plp_start_count:			PLP start count
- * @endurance_estimate:			Endurance Estimate
- * @pcie_link_retaining_count:		PCIe Link Retraining Count
- * @power_state_change_count:		Power State Change Count
- * @lowest_permitted_fw_rev:		Lowest Permitted Firmware Revision -------------
- * @rsvd216:				Reserved
- * @log_page_version:			Log page version
- * @log_page_guid:			Log page GUID
+ * struct ocp_smart_extended_log -		SMART / Health Information Extended
+ * @physical_media_units_written:		Physical Media Units Written
+ * @physical_media_units_read:			Physical Media Units Read
+ * @bad_user_nand_blocks_raw:			Bad User NAND Blocks raw
+ * @bad_user_nand_blocks_normalized:		Bad User NAND Blocks normalized
+ * @bad_system_nand_blocks_raw:			Bad System NAND Blocks raw
+ * @bad_system_nand_blocks_normalized:		Bad System NAND Blocks normalized
+ * @xor_recovery_count:				XOR Recovery Count
+ * @uncorrectable_read_err_count:		Uncorrectable Read Error Count
+ * @soft_ecc_err_count:				Soft ECC Error Count
+ * @end_to_end_detected_err:			End to End detected errors
+ * @end_to_end_corrected_err:			End to End corrected errors
+ * @system_data_used_percent:			System data percent used
+ * @refresh_counts:				Refresh Counts
+ * @user_data_erase_count_max:			Max User data erase counts
+ * @user_data_erase_count_min:			Min User data erase counts
+ * @thermal_throttling_event_count:		Number of Thermal throttling events
+ * @dssd_errata_version:			DSSD Errata Version
+ * @dssd_point_version:				DSSD Point Version
+ * @dssd_minor_version:				DSSD Minor Version
+ * @dssd_major_version:				DSSD Major Version
+ * @pcie_correctable_err_count:			PCIe Correctable Error Count
+ * @incomplete_shoutdowns:			Incomplete Shutdowns
+ * @rsvd116:					Reserved
+ * @percent_free_blocks:			Percent free blocks
+ * @rsvd121:					Reserved
+ * @capacitor_health:				Capacitor health
+ * @nvme_base_errata_version:			NVM Express Base Errata Version
+ * @nvme_cmdset_errata_version:			NVMe Command Set Errata Version
+ * @rsvd132:					Reserved
+ * @nvme_over_pcie_errate_version:		NVMe Over Pcie Errata Version
+ * @nvme_mi_errata_version:			NVMe MI Errata Version
+ * @unaligned_io:				Unaligned I/O
+ * @security_version:				Security Version Number
+ * @total_nuse:					Total NUSE - Namespace utilization
+ * @plp_start_count:				PLP start count
+ * @endurance_estimate:				Endurance Estimate
+ * @pcie_link_retaining_count:			PCIe Link Retraining Count
+ * @power_state_change_count:			Power State Change Count
+ * @lowest_permitted_fw_rev:			Lowest Permitted Firmware Revision -------------
+ * @rsvd216:					Reserved
+ * @total_media_dies:				Total media dies
+ * @total_die_failure_tolerance:		Total die failure tolerance
+ * @media_dies_offline:				Media dies offline
+ * @max_temperature_recorded:			Max temperature recorded
+ * @rsvd223:					Reserved
+ * @nand_avg_erase_count:			Nand avg erase count
+ * @command_timeouts:				Command timeouts
+ * @sys_area_program_fail_count_raw:		Sys area program fail count raw
+ * @sys_area_program_fail_count_normalized:	Sys area program fail count noralized
+ * @revd241:					Reserved
+ * @sys_area_uncorr_read_count_raw:		Sys area uncorrectable read count raw
+ * @sys_area_uncorr_read_count_normalized:	Sys area uncorrectable read count noralized
+ * @revd249:					Reserved
+ * @sys_area_erase_fail_count_raw:		Sys area erase fail count raw
+ * @sys_area_erase_fail_count_normalized:	Sys area erase fail count noralized
+ * @revd257:					Reserved
+ * @max_peak_power_capability:			Max peak power capability
+ * @current_max_avg_power:			Current max avg power
+ * @lifetime_power_consumed:			Lifetime power consumed
+ * @dssd_firmware_revision:			Dssd firmware revision
+ * @dssd_firmware_build_uuid:			Dssd firmware build UUID
+ * @dssd_firmware_build_label:			Dssd firmware build label
+ * @revd358:					Reserved
+ * @log_page_version:				Log page version
+ * @log_page_guid:				Log page GUID
  */
 struct ocp_smart_extended_log {
 	__u8   physical_media_units_written[16];	/* [15:0] */
@@ -88,7 +113,9 @@ struct ocp_smart_extended_log {
 	__le16 capacitor_health;			/* [129:128] */
 	__u8   nvme_base_errata_version;		/* [130] */
 	__u8   nvme_cmdset_errata_version;		/* [131] */
-	__u8   rsvd132[4];				/* [135:132] */
+	__u8   nvme_over_pcie_errate_version;		/* [132] */
+	__u8   nvme_mi_errata_version;			/* [133] */
+	__u8   rsvd134[2];				/* [135:134] */
 	__le64 unaligned_io;				/* [143:136] */
 	__le64 security_version;			/* [151:144] */
 	__le64 total_nuse;				/* [159:152] */
@@ -97,9 +124,31 @@ struct ocp_smart_extended_log {
 	__le64 pcie_link_retaining_count;		/* [199:192] */
 	__le64 power_state_change_count;		/* [207:200] */
 	__le64 lowest_permitted_fw_rev;			/* [215:208] */
-	__u8   rsvd216[278];				/* [493:216] */
-	__le16  log_page_version;			/* [495:494] */
-	__u8    log_page_guid[16];			/* [511:496] */
+	__le16 total_media_dies;			/* [217:216] */
+	__le16 total_die_failure_tolerance;		/* [219:218] */
+	__le16 media_dies_offline;			/* [221:220] */
+	__u8   max_temperature_recorded;		/* [222] */
+	__u8   rsvd223;					/* [223] */
+	__le64 nand_avg_erase_count;			/* [231:224] */
+	__le32 command_timeouts;			/* [235:232] */
+	__le32 sys_area_program_fail_count_raw;		/* [239:236] */
+	__u8   sys_area_program_fail_count_normalized;	/* [240] */
+	__u8   rsvd241[3];				/* [243:241] */
+	__le32 sys_area_uncorr_read_count_raw;		/* [247:244] */
+	__u8   sys_area_uncorr_read_count_normalized;	/* [248] */
+	__u8   rsvd249[3];				/* [251:249] */
+	__le32 sys_area_erase_fail_count_raw;		/* [255:252] */
+	__u8   sys_area_erase_fail_count_normalized;	/* [256] */
+	__u8   rsvd257[3];				/* [259:257] */
+	__le16 max_peak_power_capability;		/* [261:260] */
+	__le16 current_max_avg_power;			/* [263:262] */
+	__u8   lifetime_power_consumed[6];		/* [269:264] */
+	__u8   dssd_firmware_revision[8];		/* [277:270] */
+	__u8   dssd_firmware_build_uuid[16];		/* [293:278] */
+	__u8   dssd_firmware_build_label[64];		/* [375:294] */
+	__u8   rsvd358[136];				/* [493:358] */
+	__le16 log_page_version;			/* [495:494] */
+	__u8   log_page_guid[16];			/* [511:496] */
 };
 
 int ocp_smart_add_log(int argc, char **argv, struct command *cmd,

--- a/plugins/ocp/ocp-smart-extended-log.h
+++ b/plugins/ocp/ocp-smart-extended-log.h
@@ -58,7 +58,7 @@ struct plugin;
  * @log_page_version:			Log page version
  * @log_page_guid:			Log page GUID
  */
-struct __packed ocp_smart_extended_log {
+struct ocp_smart_extended_log {
 	__u8   physical_media_units_written[16];	/* [15:0] */
 	__u8   physical_media_units_read[16];		/* [31:16] */
 	__u8   bad_user_nand_blocks_raw[6];		/* [37:32] */
@@ -77,8 +77,8 @@ struct __packed ocp_smart_extended_log {
 	__u8   thermal_throttling_event_count;		/* [96] */
 	__u8   thermal_throttling_current_status;	/* [97] */
 	__u8   dssd_errata_version;			/* [98] */
-	__le16 dssd_point_version;			/* [100:99] */
-	__le16 dssd_minor_version;			/* [102:101] */
+	__u8   dssd_point_version[2];			/* [100:99] */
+	__u8   dssd_minor_version[2];			/* [102:101] */
 	__u8   dssd_major_version;			/* [103] */
 	__le64 pcie_correctable_err_count;		/* [111:104] */
 	__le32 incomplete_shoutdowns;			/* [115:112] */

--- a/plugins/ocp/ocp-smart-extended-log.h
+++ b/plugins/ocp/ocp-smart-extended-log.h
@@ -6,50 +6,100 @@
  *          Venkat Ramesh <venkatraghavan@fb.com>
  */
 
+#include "common.h"
+#include "linux/types.h"
+
 #ifndef OCP_SMART_EXTENDED_LOG_H
 #define OCP_SMART_EXTENDED_LOG_H
 
 struct command;
 struct plugin;
 
-enum {
-	SCAO_PMUW	= 0,	/* Physical media units written */
-	SCAO_PMUR	= 16,	/* Physical media units read */
-	SCAO_BUNBR	= 32,	/* Bad user nand blocks raw */
-	SCAO_BUNBN	= 38,	/* Bad user nand blocks normalized */
-	SCAO_BSNBR	= 40,	/* Bad system nand blocks raw */
-	SCAO_BSNBN	= 46,	/* Bad system nand blocks normalized */
-	SCAO_XRC	= 48,	/* XOR recovery count */
-	SCAO_UREC	= 56,	/* Uncorrectable read error count */
-	SCAO_SEEC	= 64,	/* Soft ecc error count */
-	SCAO_EEDC	= 72,	/* End to end detected errors */
-	SCAO_EECE	= 76,	/* End to end corrected errors */
-	SCAO_SDPU	= 80,	/* System data percent used */
-	SCAO_RFSC	= 81,	/* Refresh counts */
-	SCAO_MXUDEC	= 88,	/* Max User data erase counts */
-	SCAO_MNUDEC	= 92,	/* Min User data erase counts */
-	SCAO_NTTE	= 96,	/* Number of Thermal throttling events */
-	SCAO_CTS	= 97,	/* Current throttling status */
-	SCAO_EVF	= 98,	/* Errata Version Field */
-	SCAO_PVF	= 99,	/* Point Version Field */
-	SCAO_MIVF	= 101,	/* Minor Version Field */
-	SCAO_MAVF	= 103,	/* Major Version Field */
-	SCAO_PCEC	= 104,	/* PCIe correctable error count */
-	SCAO_ICS	= 112,	/* Incomplete shutdowns */
-	SCAO_PFB	= 120,	/* Percent free blocks */
-	SCAO_CPH	= 128,	/* Capacitor health */
-	SCAO_NBEV	= 130,  /* NVMe Base Errata Version */
-	SCAO_NCSEV	= 131,  /* NVMe Command Set Errata Version */
-	SCAO_UIO	= 136,	/* Unaligned I/O */
-	SCAO_SVN	= 144,	/* Security Version Number */
-	SCAO_NUSE	= 152,	/* NUSE - Namespace utilization */
-	SCAO_PSC	= 160,	/* PLP start count */
-	SCAO_EEST	= 176,	/* Endurance estimate */
-	SCAO_PLRC	= 192,	/* PCIe Link Retraining Count */
-	SCAO_PSCC	= 200,	/* Power State Change Count */
-	SCAO_LPFR	= 208,	/* Lowest Permitted Firmware Revision */
-	SCAO_LPV	= 494,	/* Log page version */
-	SCAO_LPG	= 496,	/* Log page GUID */
+/**
+ * struct ocp_smart_extended_log -	SMART / Health Information Extended
+ * @physical_media_units_written:	Physical Media Units Written
+ * @physical_media_units_read:		Physical Media Units Read
+ * @bad_user_nand_blocks_raw:		Bad User NAND Blocks raw
+ * @bad_user_nand_blocks_normalized:	Bad User NAND Blocks normalized
+ * @bad_system_nand_blocks_raw:		Bad System NAND Blocks raw
+ * @bad_system_nand_blocks_normalized:	Bad System NAND Blocks normalized
+ * @xor_recovery_count:			XOR Recovery Count
+ * @uncorrectable_read_err_count:	Uncorrectable Read Error Count
+ * @soft_ecc_err_count:			Soft ECC Error Count
+ * @end_to_end_detected_err:		End to End detected errors
+ * @end_to_end_corrected_err:		End to End corrected errors
+ * @system_data_used_percent:		System data percent used
+ * @refresh_counts:			Refresh Counts
+ * @user_data_erase_count_max:		Max User data erase counts
+ * @user_data_erase_count_min:		Min User data erase counts
+ * @thermal_throttling_event_count:	Number of Thermal throttling events
+ * @dssd_errata_version:		DSSD Errata Version
+ * @dssd_point_version:			DSSD Point Version
+ * @dssd_minor_version:			DSSD Minor Version
+ * @dssd_major_version:			DSSD Major Version
+ * @pcie_correctable_err_count:		PCIe Correctable Error Count
+ * @incomplete_shoutdowns:		Incomplete Shutdowns
+ * @rsvd116:				Reserved
+ * @percent_free_blocks:		Percent free blocks
+ * @rsvd121:				Reserved
+ * @capacitor_health:			Capacitor health
+ * @nvme_base_errata_version:		NVM Express Base Errata Version
+ * @nvme_cmdset_errata_version:		NVMe Command Set Errata Version
+ * @rsvd132:				Reserved
+ * @unaligned_io:			Unaligned I/O
+ * @security_version:			Security Version Number
+ * @total_nuse:				Total NUSE - Namespace utilization
+ * @plp_start_count:			PLP start count
+ * @endurance_estimate:			Endurance Estimate
+ * @pcie_link_retaining_count:		PCIe Link Retraining Count
+ * @power_state_change_count:		Power State Change Count
+ * @lowest_permitted_fw_rev:		Lowest Permitted Firmware Revision -------------
+ * @rsvd216:				Reserved
+ * @log_page_version:			Log page version
+ * @log_page_guid:			Log page GUID
+ */
+struct __packed ocp_smart_extended_log {
+	__u8   physical_media_units_written[16];	/* [15:0] */
+	__u8   physical_media_units_read[16];		/* [31:16] */
+	__u8   bad_user_nand_blocks_raw[6];		/* [37:32] */
+	__le16 bad_user_nand_blocks_normalized;		/* [39:38] */
+	__u8   bad_system_nand_blocks_raw[6];		/* [45:40] */
+	__le16 bad_system_nand_blocks_normalized;	/* [47:46] */
+	__le64 xor_recovery_count;			/* [55:48] */
+	__le64 uncorrectable_read_err_count;		/* [63:56] */
+	__le64 soft_ecc_err_count;			/* [71:64] */
+	__le32 end_to_end_detected_err;			/* [75:72] */
+	__le32 end_to_end_corrected_err;		/* [79:76] */
+	__u8   system_data_used_percent;		/* [80] */
+	__u8   refresh_counts[7];			/* [87:81] */
+	__le32 user_data_erase_count_max;		/* [91:88] */
+	__le32 user_data_erase_count_min;		/* [95:92] */
+	__u8   thermal_throttling_event_count;		/* [96] */
+	__u8   thermal_throttling_current_status;	/* [97] */
+	__u8   dssd_errata_version;			/* [98] */
+	__le16 dssd_point_version;			/* [100:99] */
+	__le16 dssd_minor_version;			/* [102:101] */
+	__u8   dssd_major_version;			/* [103] */
+	__le64 pcie_correctable_err_count;		/* [111:104] */
+	__le32 incomplete_shoutdowns;			/* [115:112] */
+	__u8   rsvd116[4];				/* [119:116] */
+	__u8   percent_free_blocks;			/* [120] */
+	__u8   rsvd121[7];				/* [127:121] */
+	__le16 capacitor_health;			/* [129:128] */
+	__u8   nvme_base_errata_version;		/* [130] */
+	__u8   nvme_cmdset_errata_version;		/* [131] */
+	__u8   rsvd132[4];				/* [135:132] */
+	__le64 unaligned_io;				/* [143:136] */
+	__le64 security_version;			/* [151:144] */
+	__le64 total_nuse;				/* [159:152] */
+	__u8   plp_start_count[16];			/* [175:160] */
+	__u8   endurance_estimate[16];			/* [191:176] */
+	__le64 pcie_link_retaining_count;		/* [199:192] */
+	__le64 power_state_change_count;		/* [207:200] */
+	__le64 lowest_permitted_fw_rev;			/* [215:208] */
+	__u8   rsvd216[278];				/* [493:216] */
+	__le16  log_page_version;			/* [495:494] */
+	__u8    log_page_guid[16];			/* [511:496] */
 };
 
 int ocp_smart_add_log(int argc, char **argv, struct command *cmd,


### PR DESCRIPTION
printed log tested (same), except below
Remove wrong duplicated prints from stdout
  NVMe base errata version
  NVMe command set errata version