### PR TITLE
ns_descs: prevent buffer overrun and memory corruption

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3700,7 +3700,7 @@ static int ns_descs(int argc, char **argv, struct command *cmd, struct plugin *p
 		}
 	}
 
-	nsdescs = nvme_alloc(sizeof(*nsdescs));
+	nsdescs = nvme_alloc(NVME_IDENTIFY_DATA_SIZE);
 	if (!nsdescs)
 		return -ENOMEM;
 


### PR DESCRIPTION
nsdescs should point to an allocated memory of size NVME_IDENTIFY_DATA_SIZE bytes, not "sizeof(*void)" bytes.