### PR TITLE
ocp: fix telemetry string log output file handling

### DIFF
--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -2502,10 +2502,7 @@ static int get_c9_log_page(struct nvme_dev *dev, char *format)
 		return ret;
 	}
 
-	if (fmt == BINARY)
-		ret = get_c9_log_page_data(dev, 0, 1);
-	else
-		ret = get_c9_log_page_data(dev, 0, 0);
+	ret = get_c9_log_page_data(dev, 0, 0);
 
 	if (!ret) {
 		ocp_c9_log(log_data, pC9_string_buffer, total_log_page_sz, fmt);


### PR DESCRIPTION
ocp: fix telemetry string log output file handling

Fixed the code to avoid binary file creation by tool for ocp

Signed-off-by: Karthik <karthik.b82@samsung.com>