### PR TITLE
nbft: Report proper error codes from discover_from_nbft()

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -681,6 +681,7 @@ static int nvme_read_config_checked(nvme_root_t r, const char *filename)
 	return 0;
 }
 
+/* returns negative errno values */
 int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 {
 	char *subsysnqn = NVME_DISC_SUBSYS_NAME;
@@ -757,7 +758,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 	if (ret < 0) {
 		fprintf(stderr, "Failed to scan topology: %s\n",
 			nvme_strerror(errno));
-		return ret;
+		return -errno;
 	}
 
 	ret = nvme_host_get_ids(r, hostnqn, hostid, &hnqn, &hid);
@@ -766,7 +767,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 
 	h = nvme_lookup_host(r, hnqn, hid);
 	if (!h) {
-		ret = ENOMEM;
+		ret = -ENOMEM;
 		goto out_free;
 	}
 
@@ -781,10 +782,9 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 
 	if (!device && !transport && !traddr) {
 		if (!nonbft)
-			discover_from_nbft(r, hostnqn, hostid,
-					   hnqn, hid, desc, connect,
-					   &cfg, nbft_path, flags, verbose);
-
+			ret = discover_from_nbft(r, hostnqn, hostid,
+						  hnqn, hid, desc, connect,
+						  &cfg, nbft_path, flags, verbose);
 		if (nbft)
 			goto out_free;
 
@@ -876,7 +876,7 @@ int nvmf_discover(const char *desc, int argc, char **argv, bool connect)
 				fprintf(stderr,
 					"failed to add controller, error %s\n",
 					nvme_strerror(errno));
-			ret = errno;
+			ret = -errno;
 			goto out_free;
 		}
 	}


### PR DESCRIPTION
In case of a connection failure of any SSNS records that are not marked as 'unavailable', report proper error code so that nvme-cli callers may retry the operation.

The semantics of most functions is to return 0 zero for success and negative errno numbers in case of an error.