### PR TITLE
ocp: delete internal-log command telemetry type none value definition

### DIFF
--- a/Documentation/nvme-ocp-internal-log.txt
+++ b/Documentation/nvme-ocp-internal-log.txt
@@ -64,9 +64,10 @@ OPTIONS
 
 -t <type>::
 --telemetry-type=<type>::
-	If set to 1, controller shall capture the Telemetry Host-Initiated data
+	Set the telemetry type to 'host', 'host0', 'host1' or 'controller'.
+	If set to host1, controller shall capture the Telemetry Host-Initiated data
 	representing the internal state of the controller at the time the associated
-	Get Log Page command is processed. If cleared to 0, controller shall not
+	Get Log Page command is processed. If set to host0, controller shall not
 	update this data.
 
 EXAMPLES

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -181,7 +181,7 @@ _nvme () {
 				local _internal_log
 				_internal_log=(
 				/dev/nvme':supply a device to use (required)'
-				--telemetry-type=':Telemetry Type; host or controller generated'
+				--telemetry-type=':Telemetry Type; host, host0, host1 or controller generated'
 				-t':alias for --telemetry-type'
 				--data-area=':Telemetry Data Area; 1 or 2'
 				-a':alias for --data-area'

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1418,7 +1418,7 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	const char *output_format = "output format normal|json";
 	const char *data_area = "Telemetry Data Area; 1 or 2;\n"
 			"e.g. '-a 1 for Data Area 1.'\n'-a 2 for Data Areas 1 and 2.';\n";
-	const char *telemetry_type = "Telemetry Type; 'host' or 'controller'";
+	const char *telemetry_type = "Telemetry Type; 'host', 'host0', 'host1' or 'controller'";
 
 	struct nvme_dev *dev;
 	int err = 0;
@@ -1486,7 +1486,8 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 		else if (!strcmp(opt.telemetry_type, "controller"))
 			tele_type = TELEMETRY_TYPE_CONTROLLER;
 		else {
-			nvme_show_error("telemetry-type should be host or controller.\n");
+			nvme_show_error(
+			    "telemetry-type should be host, host0, host1 or controller.\n");
 			goto out;
 		}
 	} else {

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1537,60 +1537,6 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 				nvme_show_result("Status:(%x)\n", err);
 		}
 		break;
-	case TELEMETRY_TYPE_NONE:
-		printf("\n-------------------------------------------------------------\n");
-		/* Host 0 (lsp == 0) must be executed before Host 1 (lsp == 1). */
-		printf("\nExtracting Telemetry Host 0 Dump (Data Area 1)...\n");
-
-		err = get_telemetry_dump(dev, opt.output_file, sn,
-				TELEMETRY_TYPE_HOST_0, 1, true);
-		if (err)
-			fprintf(stderr, "NVMe Status: %s(%x)\n", nvme_status_to_string(err, false),
-				err);
-
-		printf("\n-------------------------------------------------------------\n");
-
-		printf("\nExtracting Telemetry Host 0 Dump (Data Area 3)...\n");
-
-		err = get_telemetry_dump(dev, opt.output_file, sn,
-				TELEMETRY_TYPE_HOST_0, 3, false);
-		if (err)
-			fprintf(stderr, "NVMe Status: %s(%x)\n", nvme_status_to_string(err, false),
-				err);
-
-		printf("\n-------------------------------------------------------------\n");
-
-		printf("\nExtracting Telemetry Host 1 Dump (Data Area 1)...\n");
-
-		err = get_telemetry_dump(dev, opt.output_file, sn,
-				TELEMETRY_TYPE_HOST_1, 1, true);
-		if (err)
-			fprintf(stderr, "NVMe Status: %s(%x)\n", nvme_status_to_string(err, false),
-				err);
-
-		printf("\n-------------------------------------------------------------\n");
-
-		printf("\nExtracting Telemetry Host 1 Dump (Data Area 3)...\n");
-
-		err = get_telemetry_dump(dev, opt.output_file, sn,
-				TELEMETRY_TYPE_HOST_1, 3, false);
-		if (err)
-			fprintf(stderr, "NVMe Status: %s(%x)\n", nvme_status_to_string(err, false),
-				err);
-
-		printf("\n-------------------------------------------------------------\n");
-
-		printf("\nExtracting Telemetry Controller Dump (Data Area 3)...\n");
-
-		if (is_support_telemetry_controller == true) {
-			err = get_telemetry_dump(dev, opt.output_file, sn,
-					TELEMETRY_TYPE_CONTROLLER, 3, true);
-			if (err)
-				fprintf(stderr, "NVMe Status: %s(%x)\n", nvme_status_to_string(err, false), err);
-		}
-
-		printf("\n-------------------------------------------------------------\n");
-		break;
 	case TELEMETRY_TYPE_HOST_0:
 	case TELEMETRY_TYPE_HOST_1:
 	default:

--- a/plugins/ocp/ocp-telemetry-decode.h
+++ b/plugins/ocp/ocp-telemetry-decode.h
@@ -353,7 +353,6 @@ static const char * const telemetry_media_wear_event_id_str[] = {
 #define FILE_NAME_SIZE 2048
 
 enum TELEMETRY_TYPE {
-	TELEMETRY_TYPE_NONE       = 0,
 	TELEMETRY_TYPE_HOST       = 7,
 	TELEMETRY_TYPE_CONTROLLER = 8,
 	TELEMETRY_TYPE_HOST_0     = 9,


### PR DESCRIPTION
Since the type none value never set by the command handling.