### PR TITLE
ocp-nvme: Add a different formatting for JSON output

### DIFF
--- a/Documentation/nvme-ocp-smart-add-log.txt
+++ b/Documentation/nvme-ocp-smart-add-log.txt
@@ -9,7 +9,7 @@ compliant device
 SYNOPSIS
 --------
 [verse]
-'nvme ocp smart-add-log' <device> [--output-format=<fmt> | -o <fmt>]
+'nvme ocp smart-add-log' <device> [--output-format=<fmt> | -o <fmt>] [--output-format-version=<version>]
 
 DESCRIPTION
 -----------
@@ -22,6 +22,10 @@ device (ex: /dev/nvme0) or block device (ex: /dev/nvme0n1).
 This will only work on OCP compliant devices supporting this feature.
 Results for any other device are undefined.
 
+EXPERIMENTAL. The --output-format-version can be set to 2 to generate field names
+for the outputs that are easier to process via scripts. Note this is
+experimental and the field names are subject to change.
+
 On success it returns 0, error code otherwise.
 
 OPTIONS
@@ -30,6 +34,10 @@ OPTIONS
 --output-format=<fmt>::
 	Set the reporting format to 'normal' or 'json'. Only one output format
 	can be used at a time. The default is normal.
+
+--output-format-version=<version>::
+	Set the field labels in the reporting format to either '1'
+	(the original) or '2'. The default is 1. Note this is experimental.
 
 EXAMPLES
 --------

--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -98,7 +98,7 @@ static void stdout_fw_activation_history(const struct fw_activation_history *fw_
 	printf("\n");
 }
 
-static void stdout_smart_extended_log(void *data)
+static void stdout_smart_extended_log(void *data, unsigned int version)
 {
 	uint16_t smart_log_ver = 0;
 	__u8 *log_data = data;

--- a/plugins/ocp/ocp-print.c
+++ b/plugins/ocp/ocp-print.c
@@ -36,9 +36,9 @@ void ocp_fw_act_history(const struct fw_activation_history *fw_history, nvme_pri
 	ocp_print(fw_act_history, flags, fw_history);
 }
 
-void ocp_smart_extended_log(void *data, nvme_print_flags_t flags)
+void ocp_smart_extended_log(void *data, unsigned int version, nvme_print_flags_t flags)
 {
-	ocp_print(smart_extended_log, flags, data);
+	ocp_print(smart_extended_log, flags, data, version);
 }
 
 void ocp_show_telemetry_log(struct ocp_telemetry_parse_options *options, nvme_print_flags_t flags)

--- a/plugins/ocp/ocp-print.h
+++ b/plugins/ocp/ocp-print.h
@@ -10,7 +10,7 @@
 struct ocp_print_ops {
 	void (*hwcomp_log)(struct hwcomp_log *log, __u32 id, bool list);
 	void (*fw_act_history)(const struct fw_activation_history *fw_history);
-	void (*smart_extended_log)(void *data);
+	void (*smart_extended_log)(void *data, unsigned int version);
 	void (*telemetry_log)(struct ocp_telemetry_parse_options *options);
 	void (*c3_log)(struct nvme_dev *dev, struct ssd_latency_monitor_log *log_data);
 	void (*c5_log)(struct nvme_dev *dev, struct unsupported_requirement_log *log_data);
@@ -36,7 +36,7 @@ static inline struct ocp_print_ops *ocp_get_json_print_ops(nvme_print_flags_t fl
 
 void ocp_show_hwcomp_log(struct hwcomp_log *log, __u32 id, bool list, nvme_print_flags_t flags);
 void ocp_fw_act_history(const struct fw_activation_history *fw_history, nvme_print_flags_t flags);
-void ocp_smart_extended_log(void *data, nvme_print_flags_t flags);
+void ocp_smart_extended_log(void *data, unsigned int version, nvme_print_flags_t flags);
 void ocp_show_telemetry_log(struct ocp_telemetry_parse_options *options, nvme_print_flags_t flags);
 void ocp_c3_log(struct nvme_dev *dev, struct ssd_latency_monitor_log *log_data,
 		nvme_print_flags_t flags);

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -27,7 +27,8 @@ static __u8 scao_guid[GUID_LEN] = {
 	0xC9, 0x14, 0xD5, 0xAF
 };
 
-static int get_c0_log_page(struct nvme_dev *dev, char *format)
+static int get_c0_log_page(struct nvme_dev *dev, char *format,
+			   unsigned int format_version)
 {
 	nvme_print_flags_t fmt;
 	__u8 *data;
@@ -86,7 +87,7 @@ static int get_c0_log_page(struct nvme_dev *dev, char *format)
 		}
 
 		/* print the data */
-		ocp_smart_extended_log(data, fmt);
+		ocp_smart_extended_log(data, format_version, fmt);
 	} else {
 		fprintf(stderr, "ERROR : OCP : Unable to read C0 data from buffer\n");
 	}
@@ -105,14 +106,17 @@ int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
 
 	struct config {
 		char *output_format;
+		unsigned int output_format_version;
 	};
 
 	struct config cfg = {
 		.output_format = "normal",
+		.output_format_version = 1,
 	};
 
 	OPT_ARGS(opts) = {
 		OPT_FMT("output-format", 'o', &cfg.output_format, "output Format: normal|json"),
+		OPT_UINT("output-format-version", 0, &cfg.output_format_version, "output Format version: 1|2"),
 		OPT_END()
 	};
 
@@ -120,7 +124,8 @@ int ocp_smart_add_log(int argc, char **argv, struct command *cmd,
 	if (ret)
 		return ret;
 
-	ret = get_c0_log_page(dev, cfg.output_format);
+	ret = get_c0_log_page(dev, cfg.output_format,
+			      cfg.output_format_version);
 	if (ret)
 		fprintf(stderr, "ERROR : OCP : Failure reading the C0 Log Page, ret = %d\n",
 			ret);


### PR DESCRIPTION
The current OCP JSON format for the SMART extended log page is not condusive to metric collection via tools like Prometheus. So we add a new output mode that uses all lower case and underscores (instead of spaces). This should help with metric collection. At the same time we clean up some of the field names. We add a new argument (--output-format-version) to allow us to select which output version we want. Documentation updated to reflect this change and mark this as experimental.

Fixes #2577.