### PR TITLE
dapustor: enable dapustor-nvme.c build without json-c dependencies ch…

### DIFF
--- a/plugins/dapustor/dapustor-nvme.c
+++ b/plugins/dapustor/dapustor-nvme.c
@@ -96,6 +96,7 @@ struct nvme_extended_additional_smart_log {
 	struct nvme_additional_smart_log_item	inflight_write_io_cmd;
 };
 
+#ifdef CONFIG_JSONC
 static void show_dapustor_add_smart_log_jsn(struct nvme_additional_smart_log *smart,
 					    struct json_object *dev_stats)
 {
@@ -348,6 +349,9 @@ static void show_dapustor_smart_log_jsn(struct nvme_additional_smart_log *smart,
 	json_print_object(root, NULL);
 	json_free_object(root);
 }
+#else /* CONFIG_JSONC */
+#define show_dapustor_smart_log_jsn(smart, ext_smart, nsid,  devname, has_ext)
+#endif /* CONFIG_JSONC */
 
 static void show_dapustor_add_smart_log(struct nvme_additional_smart_log *smart)
 {
@@ -505,7 +509,9 @@ static int dapustor_additional_smart_log(int argc, char **argv, struct command *
 	const char *desc = "Get DapuStor vendor specific additional smart log, and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "Dump output in binary format";
+#ifdef CONFIG_JSONC
 	const char *json = "Dump output in json format";
+#endif /* CONFIG_JSONC */
 
 	struct nvme_additional_smart_log smart_log;
 	struct nvme_extended_additional_smart_log ext_smart_log;
@@ -526,7 +532,9 @@ static int dapustor_additional_smart_log(int argc, char **argv, struct command *
 	OPT_ARGS(opts) = {
 		OPT_UINT("namespace-id", 'n', &cfg.namespace_id, namespace),
 		OPT_FLAG("raw-binary",   'b', &cfg.raw_binary,   raw),
+#ifdef CONFIG_JSONC
 		OPT_FLAG("json",         'j', &cfg.json,         json),
+#endif /* CONFIG_JSONC */
 		OPT_END()
 	};
 

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/dapustor/dapustor-nvme.c',
     'plugins/dell/dell-nvme.c',
     'plugins/fdp/fdp.c',
     'plugins/huawei/huawei-nvme.c',
@@ -23,6 +22,7 @@ endif
 
 sources += [
   'plugins/amzn/amzn-nvme.c',
+  'plugins/dapustor/dapustor-nvme.c',
   'plugins/dera/dera-nvme.c',
   'plugins/innogrit/innogrit-nvme.c',
   'plugins/inspur/inspur-nvme.c',


### PR DESCRIPTION
…eckin

Only build json print codes with CONFIG_JSONC build option instead.