### PR TITLE
dell: build plugin not depended on json without json

### DIFF
--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/dell/dell-nvme.c',
     'plugins/fdp/fdp.c',
     'plugins/huawei/huawei-nvme.c',
     'plugins/intel/intel-nvme.c',
@@ -23,6 +22,7 @@ endif
 sources += [
   'plugins/amzn/amzn-nvme.c',
   'plugins/dapustor/dapustor-nvme.c',
+  'plugins/dell/dell-nvme.c',
   'plugins/dera/dera-nvme.c',
   'plugins/innogrit/innogrit-nvme.c',
   'plugins/inspur/inspur-nvme.c',


### PR DESCRIPTION
dell plugin does not use json so no need to check the build dependency.