### PR TITLE
fdp: build plugin not depended on json without json

### DIFF
--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/fdp/fdp.c',
     'plugins/huawei/huawei-nvme.c',
     'plugins/intel/intel-nvme.c',
     'plugins/micron/micron-nvme.c',
@@ -24,6 +23,7 @@ sources += [
   'plugins/dapustor/dapustor-nvme.c',
   'plugins/dell/dell-nvme.c',
   'plugins/dera/dera-nvme.c',
+  'plugins/fdp/fdp.c',
   'plugins/innogrit/innogrit-nvme.c',
   'plugins/inspur/inspur-nvme.c',
   'plugins/memblaze/memblaze-nvme.c',


### PR DESCRIPTION
fdp plugin does not use json so no need to check the build dependency.