### PR TITLE
micron: enable micron-nvme.c build without json-c dependencies checking

### DIFF
--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/micron/micron-nvme.c',
     'plugins/nbft/nbft-plugin.c',
     'plugins/netapp/netapp-nvme.c',
     'plugins/nvidia/nvidia-nvme.c',
@@ -27,6 +26,7 @@ sources += [
   'plugins/inspur/inspur-nvme.c',
   'plugins/intel/intel-nvme.c',
   'plugins/memblaze/memblaze-nvme.c',
+  'plugins/micron/micron-nvme.c',
   'plugins/shannon/shannon-nvme.c',
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',


### PR DESCRIPTION
Only build json print codes with CONFIG_JSONC build option instead.