### PR TITLE
nbft: enable nbft-plugin.c build without json-c dependencies checking

### DIFF
--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/netapp/netapp-nvme.c',
     'plugins/nvidia/nvidia-nvme.c',
     'plugins/scaleflux/sfx-nvme.c',
     'plugins/seagate/seagate-nvme.c',
@@ -27,13 +26,14 @@ sources += [
   'plugins/memblaze/memblaze-nvme.c',
   'plugins/micron/micron-nvme.c',
   'plugins/nbft/nbft-plugin.c',
+  'plugins/netapp/netapp-nvme.c',
   'plugins/shannon/shannon-nvme.c',
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',
   'plugins/virtium/virtium-nvme.c',
   'plugins/ymtc/ymtc-nvme.c',
   'plugins/zns/zns.c',
-  ]
+]
 
 subdir('ocp')
 subdir('lm')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/nbft/nbft-plugin.c',
     'plugins/netapp/netapp-nvme.c',
     'plugins/nvidia/nvidia-nvme.c',
     'plugins/scaleflux/sfx-nvme.c',
@@ -27,6 +26,7 @@ sources += [
   'plugins/intel/intel-nvme.c',
   'plugins/memblaze/memblaze-nvme.c',
   'plugins/micron/micron-nvme.c',
+  'plugins/nbft/nbft-plugin.c',
   'plugins/shannon/shannon-nvme.c',
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/nvidia/nvidia-nvme.c',
     'plugins/scaleflux/sfx-nvme.c',
     'plugins/seagate/seagate-nvme.c',
     'plugins/solidigm/solidigm-nvme.c',
@@ -27,6 +26,7 @@ sources += [
   'plugins/micron/micron-nvme.c',
   'plugins/nbft/nbft-plugin.c',
   'plugins/netapp/netapp-nvme.c',
+  'plugins/nvidia/nvidia-nvme.c',
   'plugins/shannon/shannon-nvme.c',
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -47,6 +47,7 @@ static char *mac_addr_to_string(unsigned char mac_addr[6])
 	return mac_string;
 }
 
+#ifdef CONFIG_JSONC
 static json_object *hfi_to_json(struct nbft_info_hfi *hfi)
 {
 	struct json_object *hfi_json;
@@ -348,6 +349,9 @@ fail:
 	json_free_object(nbft_json_array);
 	return -ENOMEM;
 }
+#else /* CONFIG_JSONC */
+#define json_show_nbfts(nbft_list, show_subsys, show_hfi, show_discovery) -EINVAL
+#endif /* CONFIG_JSONC */
 
 static void print_nbft_hfi_info(struct nbft_info *nbft)
 {

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -248,6 +248,7 @@ static void netapp_get_ontap_labels(char *vsname, char *nspath,
 	}
 }
 
+#ifdef CONFIG_JSONC
 static void netapp_smdevice_json(struct json_object *devices, char *devname,
 		char *arrayname, char *volname, int nsid, char *nguid,
 		char *ctrl, char *astate, char *version, unsigned long long lba,
@@ -293,6 +294,7 @@ static void netapp_ontapdevice_json(struct json_object *devices, char *devname,
 
 	json_array_add_value_object(devices, device_attrs);
 }
+#endif /* CONFIG_JSONC */
 
 static void netapp_smdevices_print_verbose(struct smdevice_info *devices,
 		int count, int format, const char *devname)
@@ -440,6 +442,7 @@ static void netapp_smdevices_print_regular(struct smdevice_info *devices,
 	}
 }
 
+#ifdef CONFIG_JSONC
 static void netapp_smdevices_print_json(struct smdevice_info *devices,
 		int count, const char *devname)
 {
@@ -508,6 +511,9 @@ out:
 	printf("\n");
 	json_free_object(root);
 }
+#else /* CONFIG_JSONC */
+#define netapp_smdevices_print_json(devices, count, devname)
+#endif /* CONFIG_JSONC */
 
 static void netapp_ontapdevices_print_verbose(struct ontapdevice_info *devices,
 		int count, int format, const char *devname)
@@ -623,6 +629,7 @@ static void netapp_ontapdevices_print_regular(struct ontapdevice_info *devices,
 	}
 }
 
+#ifdef CONFIG_JSONC
 static void netapp_ontapdevices_print_json(struct ontapdevice_info *devices,
 		int count, const char *devname)
 {
@@ -679,6 +686,9 @@ out:
 	printf("\n");
 	json_free_object(root);
 }
+#else /* CONFIG_JSONC */
+#define netapp_ontapdevices_print_json(devices, count, devname)
+#endif /* CONFIG_JSONC */
 
 static int nvme_get_ontap_c2_log(int fd, __u32 nsid, void *buf, __u32 buflen)
 {
@@ -829,8 +839,10 @@ static int netapp_output_format(char *format)
 		return -EINVAL;
 	if (!strcmp(format, "normal"))
 		return NNORMAL;
+#ifdef CONFIG_JSONC
 	if (!strcmp(format, "json"))
 		return NJSON;
+#endif /* CONFIG_JSONC */
 	if (!strcmp(format, "column"))
 		return NCOLUMN;
 	return -EINVAL;


### PR DESCRIPTION
Only build json print codes with CONFIG_JSONC build option instead.