### PR TITLE
scaleflux: enable sfx-nvme.c build without json-c dependencies checking

### DIFF
--- a/plugins/dapustor/dapustor-nvme.c
+++ b/plugins/dapustor/dapustor-nvme.c
@@ -96,7 +96,6 @@ struct nvme_extended_additional_smart_log {
 	struct nvme_additional_smart_log_item	inflight_write_io_cmd;
 };
 
-#ifdef CONFIG_JSONC
 static void show_dapustor_add_smart_log_jsn(struct nvme_additional_smart_log *smart,
 					    struct json_object *dev_stats)
 {
@@ -349,9 +348,6 @@ static void show_dapustor_smart_log_jsn(struct nvme_additional_smart_log *smart,
 	json_print_object(root, NULL);
 	json_free_object(root);
 }
-#else /* CONFIG_JSONC */
-#define show_dapustor_smart_log_jsn(smart, ext_smart, nsid,  devname, has_ext)
-#endif /* CONFIG_JSONC */
 
 static void show_dapustor_add_smart_log(struct nvme_additional_smart_log *smart)
 {

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -74,7 +74,6 @@ struct nvme_vu_id_ctrl_field { /* CDR MR5 */
 	__u8			mic_fw[4];
 };
 
-#ifdef CONFIG_JSONC
 static void json_intel_id_ctrl(struct nvme_vu_id_ctrl_field *id,
 	char *health, char *bl, char *ww, char *mic_bl, char *mic_fw,
 	struct json_object *root)
@@ -90,9 +89,6 @@ static void json_intel_id_ctrl(struct nvme_vu_id_ctrl_field *id,
 	json_object_add_value_string(root, "mic_bl", mic_bl);
 	json_object_add_value_string(root, "mic_fw", mic_fw);
 }
-#else /* CONFIG_JSONC */
-#define json_intel_id_ctrl(id, health, bl, ww, mic_bl, mic_fw, root)
-#endif /* CONFIG_JSONC */
 
 static void intel_id_ctrl(__u8 *vs, struct json_object *root)
 {
@@ -138,7 +134,6 @@ static int id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *pl
 	return __id_ctrl(argc, argv, cmd, plugin, intel_id_ctrl);
 }
 
-#ifdef CONFIG_JSONC
 static void show_intel_smart_log_jsn(struct nvme_additional_smart_log *smart,
 		unsigned int nsid, const char *devname)
 {
@@ -261,9 +256,6 @@ static void show_intel_smart_log_jsn(struct nvme_additional_smart_log *smart,
 	json_print_object(root, NULL);
 	json_free_object(root);
 }
-#else /* CONFIG_JSONC */
-#define show_intel_smart_log_jsn(smart, nsid, devname)
-#endif /* CONFIG_JSONC */
 
 static char *id_to_key(__u8 id)
 {
@@ -693,7 +685,6 @@ static int lat_stats_log_scale(int i)
  *     "type" : "write" or "read",
  *     "values" : {
  */
-#ifdef CONFIG_JSONC
 static void lat_stats_make_json_root(
 	struct json_object *root, struct json_object *bucket_list,
 	int write)
@@ -825,7 +816,6 @@ static void json_lat_stats_4_0(struct intel_lat_stats *stats,
 	json_print_object(root, NULL);
 	json_free_object(root);
 }
-#endif /* CONFIG_JSONC */
 
 static void show_lat_stats_3_0(struct intel_lat_stats *stats)
 {
@@ -856,7 +846,6 @@ static void show_lat_stats_4_0(struct intel_lat_stats *stats)
 	}
 }
 
-#ifdef CONFIG_JSONC
 static void json_lat_stats_v1000_0(struct optane_lat_stats *stats, int write)
 {
 	int i;
@@ -905,7 +894,6 @@ static void json_lat_stats_v1000_0(struct optane_lat_stats *stats, int write)
 	json_free_object(root);
 
 }
-#endif /* CONFIG_JSONC */
 
 static void show_lat_stats_v1000_0(struct optane_lat_stats *stats, int write)
 {
@@ -939,7 +927,6 @@ static void show_lat_stats_v1000_0(struct optane_lat_stats *stats, int write)
 
 }
 
-#ifdef CONFIG_JSONC
 static void json_lat_stats(int write)
 {
 	switch (media_version[MEDIA_MAJOR_IDX]) {
@@ -980,9 +967,6 @@ static void json_lat_stats(int write)
 	}
 	printf("\n");
 }
-#else /* CONFIG_JSONC */
-#define json_lat_stats(write)
-#endif /* CONFIG_JSONC */
 
 static void print_dash_separator(int count)
 {

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/seagate/seagate-nvme.c',
     'plugins/solidigm/solidigm-nvme.c',
     'plugins/ssstc/ssstc-nvme.c',
     'plugins/wdc/wdc-nvme.c',
@@ -27,6 +26,7 @@ sources += [
   'plugins/netapp/netapp-nvme.c',
   'plugins/nvidia/nvidia-nvme.c',
   'plugins/scaleflux/sfx-nvme.c',
+  'plugins/seagate/seagate-nvme.c',
   'plugins/shannon/shannon-nvme.c',
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -3,7 +3,6 @@
 if json_c_dep.found()
   sources += [
     'plugins/solidigm/solidigm-nvme.c',
-    'plugins/ssstc/ssstc-nvme.c',
     'plugins/wdc/wdc-nvme.c',
     'plugins/wdc/wdc-utils.c',
   ]
@@ -28,6 +27,7 @@ sources += [
   'plugins/scaleflux/sfx-nvme.c',
   'plugins/seagate/seagate-nvme.c',
   'plugins/shannon/shannon-nvme.c',
+  'plugins/ssstc/ssstc-nvme.c',
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',
   'plugins/virtium/virtium-nvme.c',

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -3,8 +3,6 @@
 if json_c_dep.found()
   sources += [
     'plugins/solidigm/solidigm-nvme.c',
-    'plugins/wdc/wdc-nvme.c',
-    'plugins/wdc/wdc-utils.c',
   ]
   subdir('solidigm')
 endif
@@ -31,6 +29,8 @@ sources += [
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',
   'plugins/virtium/virtium-nvme.c',
+  'plugins/wdc/wdc-nvme.c',
+  'plugins/wdc/wdc-utils.c',
   'plugins/ymtc/ymtc-nvme.c',
   'plugins/zns/zns.c',
 ]

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -2,7 +2,6 @@
 
 if json_c_dep.found()
   sources += [
-    'plugins/scaleflux/sfx-nvme.c',
     'plugins/seagate/seagate-nvme.c',
     'plugins/solidigm/solidigm-nvme.c',
     'plugins/ssstc/ssstc-nvme.c',
@@ -27,6 +26,7 @@ sources += [
   'plugins/nbft/nbft-plugin.c',
   'plugins/netapp/netapp-nvme.c',
   'plugins/nvidia/nvidia-nvme.c',
+  'plugins/scaleflux/sfx-nvme.c',
   'plugins/shannon/shannon-nvme.c',
   'plugins/toshiba/toshiba-nvme.c',
   'plugins/transcend/transcend-nvme.c',

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -737,11 +737,10 @@ static int micron_temp_stats(int argc, char **argv, struct command *cmd,
 	struct format cfg = {
 		.fmt = "normal",
 	};
-#ifdef CONFIG_JSONC
+
 	bool is_json = false;
 	struct json_object *root;
 	struct json_object *logPages;
-#endif /* CONFIG_JSONC */
 	struct nvme_dev *dev;
 	nvme_print_flags_t flags;
 
@@ -762,10 +761,8 @@ static int micron_temp_stats(int argc, char **argv, struct command *cmd,
 		return err;
 	}
 
-#ifdef CONFIG_JSONC
-	if (!strcmp(cfg.fmt, "json"))
+	if (flags & JSON)
 		is_json = true;
-#endif /* CONFIG_JSONC */
 
 	err = nvme_get_log_smart(dev_fd(dev), 0xffffffff, false, &smart_log);
 	if (!err) {
@@ -775,7 +772,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *cmd,
 			tempSensors[i] = le16_to_cpu(smart_log.temp_sensor[i]);
 			tempSensors[i] = tempSensors[i] ? tempSensors[i] - 273 : 0;
 		}
-#ifdef CONFIG_JSONC
+
 		if (is_json) {
 			struct json_object *stats = json_create_object();
 			char tempstr[64] = { 0 };
@@ -798,14 +795,11 @@ static int micron_temp_stats(int argc, char **argv, struct command *cmd,
 			printf("\n");
 			json_free_object(root);
 		} else {
-#endif /* CONFIG_JSONC */
 			printf("Micron temperature information:\n");
 			printf("%-10s : %u C\n", "Current Composite Temperature", temperature);
 			for (i = 0; i < SensorCount && tempSensors[i]; i++)
 				printf("%-10s%d : %u C\n", "Temperature Sensor #", i + 1, tempSensors[i]);
-#ifdef CONFIG_JSONC
 		}
-#endif /* CONFIG_JSONC */
 	}
 	dev_close(dev);
 	return err;
@@ -827,9 +821,7 @@ static int micron_pcie_stats(int argc, char **argv,
 	struct nvme_passthru_cmd admin_cmd = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	char *res;
-#ifdef CONFIG_JSONC
 	bool is_json = true;
-#endif /* CONFIG_JSONC */
 	bool counters = false;
 	struct format {
 		char *fmt;
@@ -929,10 +921,8 @@ static int micron_pcie_stats(int argc, char **argv,
 		return err;
 	}
 
-#ifdef CONFIG_JSONC
-	if (!strcmp(cfg.fmt, "normal"))
+	if (flags & NORMAL)
 		is_json = false;
-#endif /* CONFIG_JSONC */
 
 	if (eModel == M5407) {
 		admin_cmd.opcode = 0xD6;
@@ -1013,7 +1003,6 @@ static int micron_pcie_stats(int argc, char **argv,
 	uncorrectable_errors = (__u32)strtol(uncorrectable, NULL, 16);
 
 print_stats:
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		struct json_object *root = json_create_object();
 		struct json_object *pcieErrors = json_create_array();
@@ -1036,9 +1025,6 @@ print_stats:
 		printf("\n");
 		json_free_object(root);
 	} else if (counters == true) {
-#else /* CONFIG_JSONC */
-	if (counters == true) {
-#endif /* CONFIG_JSONC */
 		__u8 *pcounter = (__u8 *)&pcie_error_counters;
 
 		for (i = 0; i < ARRAY_SIZE(pcie_correctable_errors); i++)
@@ -1354,14 +1340,11 @@ fb_log_page[] = {
 
 static void print_smart_cloud_health_log(__u8 *buf, bool is_json)
 {
-#ifdef CONFIG_JSONC
 	struct json_object *root;
 	struct json_object *logPages;
-#endif /* CONFIG_JSONC */
 	struct json_object *stats = NULL;
 	int field_count = ARRAY_SIZE(ocp_c0_log_page);
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		root = json_create_object();
 		stats = json_create_object();
@@ -1369,30 +1352,24 @@ static void print_smart_cloud_health_log(__u8 *buf, bool is_json)
 		json_object_add_value_array(root, "OCP SMART Cloud Health Log: 0xC0",
 					    logPages);
 	}
-#endif /* CONFIG_JSONC */
 
 	generic_structure_parser(buf, ocp_c0_log_page, field_count, stats, 0, NULL);
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		json_array_add_value_object(logPages, stats);
 		json_print_object(root, NULL);
 		printf("\n");
 		json_free_object(root);
 	}
-#endif /* CONFIG_JSONC */
 }
 
 static void print_nand_stats_fb(__u8 *buf, __u8 *buf2, __u8 nsze, bool is_json, __u8 spec)
 {
-#ifdef CONFIG_JSONC
 	struct json_object *root;
 	struct json_object *logPages;
-#endif /* CONFIG_JSONC */
 	struct json_object *stats = NULL;
 	int field_count = ARRAY_SIZE(fb_log_page);
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		root = json_create_object();
 		stats = json_create_object();
@@ -1400,7 +1377,6 @@ static void print_nand_stats_fb(__u8 *buf, __u8 *buf2, __u8 nsze, bool is_json, 
 		json_object_add_value_array(root, "Extended Smart Log Page : 0xFB",
 					    logPages);
 	}
-#endif /* CONFIG_JSONC */
 
 	generic_structure_parser(buf, fb_log_page, field_count, stats, spec, NULL);
 
@@ -1408,36 +1384,29 @@ static void print_nand_stats_fb(__u8 *buf, __u8 *buf2, __u8 nsze, bool is_json, 
 	if (buf2) {
 		init_d0_log_page(buf2, nsze);
 
-#ifdef CONFIG_JSONC
 		if (is_json) {
 			for (int i = 0; i < 7; i++)
 				json_object_add_value_string(stats,
 						 d0_log_page[i].field,
 						 d0_log_page[i].datastr);
 		} else {
-#endif /* CONFIG_JSONC */
 			for (int i = 0; i < 7; i++)
 				printf("%-40s : %s\n", d0_log_page[i].field, d0_log_page[i].datastr);
-#ifdef CONFIG_JSONC
 		}
-#endif /* CONFIG_JSONC */
 	}
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		json_array_add_value_object(logPages, stats);
 		json_print_object(root, NULL);
 		printf("\n");
 		json_free_object(root);
 	}
-#endif /* CONFIG_JSONC */
 }
 
 static void print_nand_stats_d0(__u8 *buf, __u8 oacs, bool is_json)
 {
 	init_d0_log_page(buf, oacs);
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		struct json_object *root = json_create_object();
 		struct json_object *stats = json_create_object();
@@ -1457,12 +1426,9 @@ static void print_nand_stats_d0(__u8 *buf, __u8 oacs, bool is_json)
 		printf("\n");
 		json_free_object(root);
 	} else {
-#endif /* CONFIG_JSONC */
 		for (int i = 0; i < 7; i++)
 			printf("%-40s : %s\n", d0_log_page[i].field, d0_log_page[i].datastr);
-#ifdef CONFIG_JSONC
 	}
-#endif /* CONFIG_JSONC */
 }
 
 static bool nsze_from_oacs; /* read nsze for now from idd[4059] */
@@ -1552,36 +1518,28 @@ out:
 
 static void print_ext_smart_logs_e1(__u8 *buf, bool is_json)
 {
-#ifdef CONFIG_JSONC
 	struct json_object *root;
 	struct json_object *logPages;
-#endif /* CONFIG_JSONC */
 	struct json_object *stats = NULL;
 	int field_count = ARRAY_SIZE(e1_log_page);
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		root = json_create_object();
 		stats = json_create_object();
 		logPages = json_create_array();
 		json_object_add_value_array(root, "SMART Extended Log:0xE1", logPages);
 	} else {
-#endif /* CONFIG_JSONC */
 		printf("SMART Extended Log:0xE1\n");
-#ifdef CONFIG_JSONC
 	}
-#endif /* CONFIG_JSONC */
 
 	generic_structure_parser(buf, e1_log_page, field_count, stats, 0, NULL);
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		json_array_add_value_object(logPages, stats);
 		json_print_object(root, NULL);
 		printf("\n");
 		json_free_object(root);
 	}
-#endif /* CONFIG_JSONC */
 }
 
 static int micron_smart_ext_log(int argc, char **argv,
@@ -2015,10 +1973,8 @@ static int micron_drive_info(int argc, char **argv, struct command *cmd,
 		unsigned char bs_ver_minor;
 	} dinfo = { 0 };
 	enum eDriveModel model = UNKNOWN_MODEL;
-#ifdef CONFIG_JSONC
 	bool is_json = false;
 	struct json_object *root, *driveInfo;
-#endif /* CONFIG_JSONC */
 	struct nvme_dev *dev;
 	struct format {
 		char *fmt;
@@ -2052,10 +2008,8 @@ static int micron_drive_info(int argc, char **argv, struct command *cmd,
 		return err;
 	}
 
-#ifdef CONFIG_JSONC
 	if (!strcmp(cfg.fmt, "json"))
 		is_json = true;
-#endif /* CONFIG_JSONC */
 
 	if (model == M5407) {
 		admin_cmd.opcode = 0xD4,
@@ -2080,7 +2034,6 @@ static int micron_drive_info(int argc, char **argv, struct command *cmd,
 		dinfo.ftl_unit_size = ctrl.vs[822];
 	}
 
-#ifdef CONFIG_JSONC
 	if (is_json) {
 		struct json_object *pinfo = json_create_object();
 		char tempstr[64] = { 0 };
@@ -2106,7 +2059,6 @@ static int micron_drive_info(int argc, char **argv, struct command *cmd,
 		printf("\n");
 		json_free_object(root);
 	} else {
-#endif /* CONFIG_JSONC */
 		printf("Drive Hardware Version: %u.%u\n",
 				dinfo.hw_ver_major, dinfo.hw_ver_minor);
 
@@ -2116,9 +2068,7 @@ static int micron_drive_info(int argc, char **argv, struct command *cmd,
 		if (dinfo.bs_ver_major || dinfo.bs_ver_minor)
 			printf("Boot  Spec.Version: %u.%u\n",
 			       dinfo.bs_ver_major, dinfo.bs_ver_minor);
-#ifdef CONFIG_JSONC
 	}
-#endif /* CONFIG_JSONC */
 
 	dev_close(dev);
 	return 0;

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -248,7 +248,6 @@ static void netapp_get_ontap_labels(char *vsname, char *nspath,
 	}
 }
 
-#ifdef CONFIG_JSONC
 static void netapp_smdevice_json(struct json_object *devices, char *devname,
 		char *arrayname, char *volname, int nsid, char *nguid,
 		char *ctrl, char *astate, char *version, unsigned long long lba,
@@ -294,7 +293,6 @@ static void netapp_ontapdevice_json(struct json_object *devices, char *devname,
 
 	json_array_add_value_object(devices, device_attrs);
 }
-#endif /* CONFIG_JSONC */
 
 static void netapp_smdevices_print_verbose(struct smdevice_info *devices,
 		int count, int format, const char *devname)
@@ -442,7 +440,6 @@ static void netapp_smdevices_print_regular(struct smdevice_info *devices,
 	}
 }
 
-#ifdef CONFIG_JSONC
 static void netapp_smdevices_print_json(struct smdevice_info *devices,
 		int count, const char *devname)
 {
@@ -511,9 +508,6 @@ out:
 	printf("\n");
 	json_free_object(root);
 }
-#else /* CONFIG_JSONC */
-#define netapp_smdevices_print_json(devices, count, devname)
-#endif /* CONFIG_JSONC */
 
 static void netapp_ontapdevices_print_verbose(struct ontapdevice_info *devices,
 		int count, int format, const char *devname)
@@ -629,7 +623,6 @@ static void netapp_ontapdevices_print_regular(struct ontapdevice_info *devices,
 	}
 }
 
-#ifdef CONFIG_JSONC
 static void netapp_ontapdevices_print_json(struct ontapdevice_info *devices,
 		int count, const char *devname)
 {
@@ -686,9 +679,6 @@ out:
 	printf("\n");
 	json_free_object(root);
 }
-#else /* CONFIG_JSONC */
-#define netapp_ontapdevices_print_json(devices, count, devname)
-#endif /* CONFIG_JSONC */
 
 static int nvme_get_ontap_c2_log(int fd, __u32 nsid, void *buf, __u32 buflen)
 {

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -101,6 +101,7 @@ int nvme_sfx_get_features(int fd, __u32 nsid, __u32 fid, __u32 *result)
 	return err;
 }
 
+#ifdef CONFIG_JSONC
 static void show_sfx_smart_log_jsn(struct nvme_additional_smart_log *smart,
 		unsigned int nsid, const char *devname)
 {
@@ -239,6 +240,9 @@ static void show_sfx_smart_log_jsn(struct nvme_additional_smart_log *smart,
 	printf("\n");
 	json_free_object(root);
 }
+#else /* CONFIG_JSONC */
+#define show_sfx_smart_log_jsn(smart, nsid, devname)
+#endif /* CONFIG_JSONC */
 
 static void show_sfx_smart_log(struct nvme_additional_smart_log *smart,
 		unsigned int nsid, const char *devname)
@@ -328,7 +332,9 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 	    "Get ScaleFlux vendor specific additional smart log (optionally, for the specified namespace), and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
+#ifdef CONFIG_JSONC
 	const char *json = "Dump output in json format";
+#endif /* CONFIG_JSONC */
 	struct nvme_dev *dev;
 	struct config {
 		__u32 namespace_id;
@@ -347,7 +353,6 @@ static int get_additional_smart_log(int argc, char **argv, struct command *cmd, 
 		OPT_FLAG_JSON("json",	 'j', &cfg.json,	 json),
 		OPT_END()
 	};
-
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -2049,19 +2049,26 @@ static int sfx_status(int argc, char **argv, struct command *cmd, struct plugin 
 		printf("%-35s%s\n",		"PCIe Link Status:",			link_string);
 		printf("%-35s%s\n",		"PCIe Device Status:",			pcie_status);
 		if (sfx_smart.friendly_changecap_support) {
-			printf("%-35s%llu GB\n", "Current Formatted Capacity:",	sfx_smart.cur_formatted_capability);
-			printf("%-35s%llu GB\n", "Max Formatted Capacity:",		sfx_smart.max_formatted_capability);
-			printf("%-35s%llu\n",	"Extendible Capacity LBA count:",	sfx_smart.extendible_cap_lbacount);
-		} else if (capacity_valid)
-			printf("%-35s%llu GB\n", "Formatted  Capacity:",	capacity);
-		printf("%-35s%llu GB\n",	"Provisioned Capacity:",	IDEMA_CAP2GB(sfx_smart.total_physical_capability));
+			printf("%-35s%"PRIu64" GB\n", "Current Formatted Capacity:",
+			       (uint64_t)sfx_smart.cur_formatted_capability);
+			printf("%-35s%"PRIu64" GB\n", "Max Formatted Capacity:",
+			       (uint64_t)sfx_smart.max_formatted_capability);
+			printf("%-35s%"PRIu64"\n", "Extendible Capacity LBA count:",
+			       (uint64_t)sfx_smart.extendible_cap_lbacount);
+		} else if (capacity_valid) {
+			printf("%-35s%"PRIu64" GB\n", "Formatted  Capacity:", (uint64_t)capacity);
+		}
+		printf("%-35s%"PRIu64" GB\n", "Provisioned Capacity:",
+		       (uint64_t)IDEMA_CAP2GB(sfx_smart.total_physical_capability));
 		printf("%-35s%u%%\n",	"Compression Ratio:",			sfx_smart.comp_ratio);
 		printf("%-35s%u%%\n",	"Physical Used Ratio:",			sfx_smart.physical_usage_ratio);
-		printf("%-35s%llu GB\n",	"Free Physical Space:",		IDEMA_CAP2GB(sfx_smart.free_physical_capability));
+		printf("%-35s%"PRIu64" GB\n", "Free Physical Space:",
+		       (uint64_t)IDEMA_CAP2GB(sfx_smart.free_physical_capability));
 		printf("%-35s%s\n",		"Firmware Verification:",					(sfx_smart.otp_rsa_en) ? "On":"Off");
 		printf("%-35s%s\n",		"IO Speed:",					io_speed);
 		printf("%-35s%s\n",		"NUMA Node:",					numa_node);
-		printf("%-35s%lluK\n",	"Indirection Unit:",			(4*sfx_freespace.map_unit));
+		printf("%-35s%"PRIu64"K\n", "Indirection Unit:",
+		       (uint64_t)(4*sfx_freespace.map_unit));
 		printf("%-35s%.2f\n",	"Lifetime WAF:",				write_amp);
 		printf("%-35s%s\n",		"Critical Warning(s):",			path);
 	}

--- a/plugins/ssstc/ssstc-nvme.c
+++ b/plugins/ssstc/ssstc-nvme.c
@@ -383,7 +383,9 @@ int ssstc_get_add_smart_log(int argc, char **argv, struct command *cmd, struct p
 		"(optionally, for the specified namespace), and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "Dump output in binary format";
+#ifdef CONFIG_JSONC
 	const char *json = "Dump output in json format";
+#endif /* CONFIG_JSONC */
 
 	struct nvme_additional_smart_log smart_log_add;
 	struct nvme_dev *dev;

--- a/util/json.h
+++ b/util/json.h
@@ -61,6 +61,7 @@ struct json_object;
 #define json_object_add_value_uint64(o, k, v) ((void)(v))
 #define json_object_add_value_uint128(o, k, v)
 #define json_object_add_value_double(o, k, v)
+#define json_object_add_value_float(o, k, v)
 #define json_object_add_value_array(o, k, v) ((void)(v))
 #define json_object_add_value_object(o, k, v) ((void)(v))
 #define json_array_add_value_object(o, k) ((void)(k))

--- a/util/json.h
+++ b/util/json.h
@@ -67,5 +67,6 @@ struct json_object;
 #define json_object_add_value_object(o, k, v) ((void)(v))
 #define json_array_add_value_object(o, k) ((void)(k))
 #define json_print_object(o, u) ((void)(o))
+#define json_object_array_add(o, k) ((void)(k))
 #endif /* CONFIG_JSONC */
 #endif /* __JSON__H */

--- a/util/json.h
+++ b/util/json.h
@@ -51,13 +51,16 @@ struct json_object *util_json_object_new_uint128(nvme_uint128_t val);
 struct json_object *util_json_object_new_uint128(nvme_uint128_t val);
 
 uint64_t util_json_object_get_uint64(struct json_object *obj);
-
-#else /* !CONFIG_JSONC */
-
+#else /* CONFIG_JSONC */
 struct json_object;
 
 #define json_object_add_value_string(o, k, v)
-
-#endif
-
-#endif
+#define json_create_object(o) NULL
+#define json_free_object(o) ((void)(o))
+#define json_object_add_value_uint(o, k, v)
+#define json_object_add_value_int(o, k, v)
+#define json_print_object(o, u)
+#define json_object_add_value_double(o, k, v)
+#define json_object_add_value_object(o, k, v) ((void)(v))
+#endif /* CONFIG_JSONC */
+#endif /* __JSON__H */

--- a/util/json.h
+++ b/util/json.h
@@ -56,11 +56,14 @@ struct json_object;
 
 #define json_object_add_value_string(o, k, v)
 #define json_create_object(o) NULL
+#define json_create_array(a) NULL
 #define json_free_object(o) ((void)(o))
 #define json_object_add_value_uint(o, k, v)
-#define json_object_add_value_int(o, k, v)
-#define json_print_object(o, u)
+#define json_object_add_value_int(o, k, v) ((void)(v))
 #define json_object_add_value_double(o, k, v)
+#define json_object_add_value_array(o, k, v) ((void)(v))
 #define json_object_add_value_object(o, k, v) ((void)(v))
+#define json_array_add_value_object(o, k) ((void)(k))
+#define json_print_object(o, u) ((void)(o))
 #endif /* CONFIG_JSONC */
 #endif /* __JSON__H */

--- a/util/json.h
+++ b/util/json.h
@@ -9,7 +9,6 @@
 /* Wrappers around json-c's API */
 
 #define json_create_object(o) json_object_new_object(o)
-#define json_create_array(a) json_object_new_array(a)
 #define json_free_object(o) json_object_put(o)
 #define json_free_array(a) json_object_put(a)
 #define json_object_add_value_uint(o, k, v) \
@@ -56,7 +55,6 @@ struct json_object;
 
 #define json_object_add_value_string(o, k, v)
 #define json_create_object(o) NULL
-#define json_create_array(a) NULL
 #define json_free_object(o) ((void)(o))
 #define json_object_add_value_uint(o, k, v) ((void)(v))
 #define json_object_add_value_int(o, k, v) ((void)(v))
@@ -67,6 +65,9 @@ struct json_object;
 #define json_object_add_value_object(o, k, v) ((void)(v))
 #define json_array_add_value_object(o, k) ((void)(k))
 #define json_print_object(o, u) ((void)(o))
+#define json_object_new_array(a) NULL
 #define json_object_array_add(o, k) ((void)(k))
 #endif /* CONFIG_JSONC */
+#define json_create_array(a) json_object_new_array(a)
+
 #endif /* __JSON__H */

--- a/util/json.h
+++ b/util/json.h
@@ -58,8 +58,10 @@ struct json_object;
 #define json_create_object(o) NULL
 #define json_create_array(a) NULL
 #define json_free_object(o) ((void)(o))
-#define json_object_add_value_uint(o, k, v)
+#define json_object_add_value_uint(o, k, v) ((void)(v))
 #define json_object_add_value_int(o, k, v) ((void)(v))
+#define json_object_add_value_uint64(o, k, v) ((void)(v))
+#define json_object_add_value_uint128(o, k, v)
 #define json_object_add_value_double(o, k, v)
 #define json_object_add_value_array(o, k, v) ((void)(v))
 #define json_object_add_value_object(o, k, v) ((void)(v))

--- a/util/json.h
+++ b/util/json.h
@@ -11,34 +11,32 @@
 #define json_create_object(o) json_object_new_object(o)
 #define json_free_object(o) json_object_put(o)
 #define json_free_array(a) json_object_put(a)
-#define json_object_add_value_uint(o, k, v) \
-	json_object_object_add(o, k, json_object_new_uint64(v))
-#define json_object_add_value_int(o, k, v) \
-	json_object_object_add(o, k, json_object_new_int(v))
+#define json_object_add_value_uint(o, k, v) json_object_object_add(o, k, json_object_new_uint64(v))
+#define json_object_add_value_int(o, k, v) json_object_object_add(o, k, json_object_new_int(v))
 #ifndef CONFIG_JSONC_14
 #define json_object_new_uint64(v) util_json_object_new_uint64(v)
 #define json_object_get_uint64(v) util_json_object_get_uint64(v)
-#endif
+#endif /* CONFIG_JSONC_14 */
 #define json_object_add_value_uint64(o, k, v) \
 	json_object_object_add(o, k, json_object_new_uint64(v))
 #define json_object_add_value_uint128(o, k, v) \
 	json_object_object_add(o, k, util_json_object_new_uint128(v))
 #define json_object_add_value_double(o, k, v) \
 	json_object_object_add(o, k, util_json_object_new_double(v))
-#define json_object_add_value_float(o, k, v) \
-	json_object_object_add(o, k, json_object_new_double(v))
-static inline int json_object_add_value_string(struct json_object *o, const char *k, const char *v) {
+#define json_object_add_value_float(o, k, v) json_object_object_add(o, k, json_object_new_double(v))
+
+static inline int json_object_add_value_string(struct json_object *o, const char *k, const char *v)
+{
 	return json_object_object_add(o, k, v ? json_object_new_string(v) : NULL);
 }
-#define json_object_add_value_array(o, k, v) \
-	json_object_object_add(o, k, v)
-#define json_object_add_value_object(o, k, v) \
-	json_object_object_add(o, k, v)
-#define json_array_add_value_object(o, k) \
-	json_object_array_add(o, k)
-static inline int json_array_add_value_string(struct json_object *o, const char *v) {
+
+#define json_array_add_value_object(o, k) json_object_array_add(o, k)
+
+static inline int json_array_add_value_string(struct json_object *o, const char *v)
+{
 	return json_object_array_add(o, v ? json_object_new_string(v) : NULL);
 }
+
 #define json_print_object(o, u)						\
 	printf("%s", json_object_to_json_string_ext(o,			\
 		JSON_C_TO_STRING_PRETTY |				\
@@ -62,13 +60,16 @@ struct json_object;
 #define json_object_add_value_uint128(o, k, v)
 #define json_object_add_value_double(o, k, v)
 #define json_object_add_value_float(o, k, v)
-#define json_object_add_value_array(o, k, v) ((void)(v))
-#define json_object_add_value_object(o, k, v) ((void)(v))
 #define json_array_add_value_object(o, k) ((void)(k))
 #define json_print_object(o, u) ((void)(o))
+#define json_object_object_add(o, k, v) ((void)(v))
+#define json_object_new_int(v)
 #define json_object_new_array(a) NULL
 #define json_object_array_add(o, k) ((void)(k))
 #endif /* CONFIG_JSONC */
+
 #define json_create_array(a) json_object_new_array(a)
+#define json_object_add_value_array(o, k, v) json_object_object_add(o, k, v)
+#define json_object_add_value_object(o, k, v) json_object_object_add(o, k, v)
 
 #endif /* __JSON__H */


### PR DESCRIPTION
Only build json print codes with CONFIG_JSONC build option instead.