### PR TITLE
Fixed OCP Latency Monitor stdout spacing in column header

### DIFF
--- a/plugins/ocp/ocp-print-stdout.c
+++ b/plugins/ocp/ocp-print-stdout.c
@@ -279,7 +279,7 @@ static void stdout_c3_log(struct nvme_dev *dev, struct ssd_latency_monitor_log *
 	printf("  Log Page GUID                      %s\n", guid);
 	printf("\n");
 
-	printf("%64s%92s%119s\n", "Read", "Write", "Deallocate/Trim");
+	printf("%64s     %27s     %27s\n", "Read", "Write", "Deallocate/Trim");
 	for (i = 0; i < C3_BUCKET_NUM; i++) {
 		printf("  Active Bucket Counter: Bucket %d    %27d     %27d     %27d\n",
 		       i,


### PR DESCRIPTION
Fixed OCP Latency Monitor stdout spacing in column header

version 2.11
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/c17ffe50-a65e-4360-8136-c371b9b21f1f" />

fix
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/cc878a81-d7f3-40b6-b772-eb3a3daa1434" />
