### PR TITLE
ocp-telemetry-decode: fix ascii string lookup

### DIFF
--- a/plugins/ocp/ocp-telemetry-decode.h
+++ b/plugins/ocp/ocp-telemetry-decode.h
@@ -1174,7 +1174,7 @@ int print_ocp_telemetry_json(struct ocp_telemetry_parse_options *options);
  *
  * @return 0 success
  */
-int get_static_id_ascii_string(int identifier, char *description);
+int get_statistic_id_ascii_string(int identifier, char *description);
 
 /**
  * @brief gets event id ascii string


### PR DESCRIPTION
Lookup ascii string in VU Event Identifier String Table for vendor unique event classes. Fix not looking up spec-defined statistic id name. Fix typo ('static' => 'statistic').

