### PR TITLE
build: automatically add a thank you note on PR merge

### DIFF
--- a/.github/workflows/thanks.yml
+++ b/.github/workflows/thanks.yml
@@ -1,0 +1,26 @@
+name: Comment on Merged PR
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  comment-on-merge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment on merged PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const comment = 'Thanks for your contribution!';
+
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: comment,
+            });


### PR DESCRIPTION
Be friendly and add a thank you note to all merged PRs. Currently, I type it always by hand.