### PR TITLE
nvme-wrap: use rotational media information log libnvme-mi API

### DIFF
--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -440,8 +440,5 @@ int nvme_cli_get_log_mgmt_addr_list(struct nvme_dev *dev, __u32 len,
 int nvme_cli_get_log_rotational_media_info(struct nvme_dev *dev, __u16 endgid, __u32 len,
 					   struct nvme_rotational_media_info_log *info)
 {
-	if (dev->type == NVME_DEV_DIRECT)
-		return nvme_get_log_rotational_media_info(dev->direct.fd, endgid, len, info);
-
-	return -ENODEV;
+	return do_admin_op(get_log_rotational_media_info, dev, endgid, len, info);
 }

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = d8d954209535ca2097f2a2284d10214332fbdad9
+revision = 4907ecb838a201f03a3b174d01939cf3bacd6902
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Since the libnvme-mi missed to add but will be added then use it.