### PR TITLE
nvme: change attach-ns to error out if wrong device given

### DIFF
--- a/Documentation/nvme-attach-ns.txt
+++ b/Documentation/nvme-attach-ns.txt
@@ -18,11 +18,14 @@ For the NVMe device given, sends the nvme namespace attach command for
 the provided namespace identifier, attaching to the provided list of
 controller identifiers.
 
+The <device> parameter is mandatory NVMe character device (ex: /dev/nvme0) but
+not a namespace block device (ex: /dev/nvme0n1).
+
 OPTIONS
 -------
 -n <nsid>::
 --namespace-id=<nsid>::
-	The namespace identifier to attach.
+	The namespace identifier to attach but not attached already.
 
 -c <ctrl-list,>::
 -controllers=<ctrl-list,>::

--- a/nvme.c
+++ b/nvme.c
@@ -2928,6 +2928,12 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	if (err)
 		return err;
 
+	if (is_blkdev(dev)) {
+		nvme_show_error("%s: a block device opened (dev: %s, nsid: %d)", cmd->name,
+				dev->name, cfg.namespace_id);
+		return -EINVAL;
+	}
+
 	if (!cfg.namespace_id) {
 		nvme_show_error("%s: namespace-id parameter required", cmd->name);
 		return -EINVAL;


### PR DESCRIPTION
Also updating the documentation.