### PR TITLE
Revert attach/detach command line interface changes

### DIFF
--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -16,7 +16,7 @@ jobs:
       #BDEV0 is an environment variable of the self-hosted runner instance
       #that contains a valid nvme ctrl name which is capable of the nvm
       #command set.
-      options: '--privileged -e BDEV0'
+      options: '--privileged -v "/dev":"/dev":z -e BDEV0'
     steps:
       - name: Output kernel version
         run: |

--- a/nvme.c
+++ b/nvme.c
@@ -7465,23 +7465,6 @@ static int copy_cmd(int argc, char **argv, struct command *cmd, struct plugin *p
 	return err;
 }
 
-static void io_cmd_show_error(struct nvme_dev *dev, int err, const char *cmd)
-{
-	if (err > 0) {
-		nvme_show_status(err);
-		return;
-	}
-
-	nvme_show_init();
-
-	nvme_show_error("%s: %s", cmd, nvme_strerror(errno));
-
-	if (is_chardev(dev))
-		nvme_show_result("char device provided but blkdev is needed, e.g. /dev/nvme0n1");
-
-	nvme_show_finish();
-}
-
 static int flush_cmd(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "Commit data and metadata associated with\n"
@@ -7517,8 +7500,10 @@ static int flush_cmd(int argc, char **argv, struct command *cmd, struct plugin *
 	}
 
 	err = nvme_flush(dev_fd(dev), cfg.namespace_id);
-	if (err)
-		io_cmd_show_error(dev, err, "flush");
+	if (err < 0)
+		nvme_show_error("flush: %s", nvme_strerror(errno));
+	else if (err != 0)
+		nvme_show_status(err);
 	else
 		printf("NVMe Flush: success\n");
 

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -429,16 +429,3 @@ bool argconfig_parse_seen(struct argconfig_commandline_options *s,
 
 	return false;
 }
-
-void *argconfig_get_value(struct argconfig_commandline_options *s, const char *option)
-{
-	for (; s && s->option; s++) {
-		if (!strcmp(s->option, option)) {
-			if (s->seen)
-				return s->default_value;
-			break;
-		}
-	}
-
-	return NULL;
-}

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -190,5 +190,4 @@ int argconfig_parse_comma_sep_array_u64(char *string, __u64 *val,
 void print_word_wrapped(const char *s, int indent, int start, FILE *stream);
 bool argconfig_parse_seen(struct argconfig_commandline_options *options,
 			  const char *option);
-void *argconfig_get_value(struct argconfig_commandline_options *s, const char *option);
 #endif


### PR DESCRIPTION
These changes broke the nightly CI runs. We were unable to figure out in time what it causes the fail, thus revert these changes.
 
Introduced here with #2665 to address #2662

Fixes: #2668
 