### PR TITLE
nvme: do not output debug infos on info level

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -330,12 +330,12 @@ static int open_blkdev_direct(char *dev, int flags, __u32 nsid)
 
 	if (blkdev) {
 		fd = open(blkdev, flags);
-		print_info("blkdev: %s, fd: %d\n", blkdev, fd);
+		print_debug("blkdev: %s, fd: %d\n", blkdev, fd);
 	}
 
 	if (fd < 0) {
 		fd = open(dev, flags);
-		print_info("dev: %s, fd: %d\n", dev, fd);
+		print_debug("dev: %s, fd: %d\n", dev, fd);
 	}
 
 	return fd;

--- a/util/logging.h
+++ b/util/logging.h
@@ -5,10 +5,16 @@
 
 #include <stdbool.h>
 
-#define print_info(...) \
-	do { \
-		if (log_level >= LOG_INFO) \
-			printf(__VA_ARGS__); \
+#define print_info(...)				\
+	do {					\
+		if (log_level >= LOG_INFO)	\
+			printf(__VA_ARGS__);	\
+	} while (false)
+
+#define print_debug(...)			\
+	do {					\
+		if (log_level >= LOG_DEBUG)	\
+			printf(__VA_ARGS__);	\
 	} while (false)
 
 extern int log_level;


### PR DESCRIPTION
Do not clutter the info message level with debug information.