### PR TITLE
nvme: make get-feature JSON output print everything

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4678,7 +4678,7 @@ static void get_feature_id_print(struct feat_cfg cfg, int err, __u32 result,
 			nvme_feature_show(cfg.feature_id, cfg.sel, result);
 			if (NVME_CHECK(cfg.sel, GET_FEATURES_SEL, SUPPORTED))
 				nvme_show_select_result(cfg.feature_id, result);
-			else if (verbose)
+			else if (verbose || !strcmp(nvme_cfg.output_format, "json"))
 				nvme_feature_show_fields(cfg.feature_id, result, buf);
 			else if (buf)
 				d(buf, cfg.data_len, 16, 1);


### PR DESCRIPTION
The nvme JSON outputs now print everything verbose. But this was missed out for the get-feature command, so fix the same here.