### PR TITLE
nvme: check for valid output format

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -881,6 +881,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 	size_t total_size;
 	__u8 *data_ptr = NULL;
 	int data_written = 0, data_remaining = 0;
+	nvme_print_flags_t flags;
 
 	struct config {
 		char	*file_name;
@@ -910,6 +911,12 @@ static int get_telemetry_log(int argc, char **argv, struct command *cmd,
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (!cfg.file_name) {
 		nvme_show_error("Please provide an output file!");
@@ -2305,6 +2312,7 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	_cleanup_free_ unsigned char *log = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -2356,6 +2364,12 @@ static int get_log(int argc, char **argv, struct command *cmd, struct plugin *pl
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.aen) {
 		cfg.log_len = 4096;
@@ -2846,6 +2860,7 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -2863,6 +2878,12 @@ static int delete_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
@@ -2887,6 +2908,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err, num;
 	__u16 list[NVME_ID_CTRL_LIST_MAX];
+	nvme_print_flags_t flags;
 
 	const char *namespace_id = "namespace to attach";
 	const char *cont = "optional comma-sep controller id list";
@@ -2908,6 +2930,12 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (is_blkdev(dev)) {
 		nvme_show_error("%s: a block device opened (dev: %s, nsid: %d)", cmd->name,
@@ -3108,6 +3136,7 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	_cleanup_free_ struct nvme_id_ns_granularity_list *gr_list = NULL;
 	__u32 align_nsze = 1 << 20; /* Default 1 MiB */
 	__u32 align_ncap = align_nsze;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u64	nsze;
@@ -3179,6 +3208,12 @@ static int create_ns(int argc, char **argv, struct command *cmd, struct plugin *
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.flbas != 0xff && cfg.bs != 0x00) {
 		nvme_show_error(
@@ -4078,6 +4113,7 @@ static int id_iocs(int argc, char **argv, struct command *cmd, struct plugin *pl
 	_cleanup_free_ struct nvme_id_iocs *iocs = NULL;
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u16	cntid;
@@ -4093,6 +4129,12 @@ static int id_iocs(int argc, char **argv, struct command *cmd, struct plugin *pl
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	iocs = nvme_alloc(sizeof(*iocs));
 	if (!iocs)
@@ -4169,12 +4211,19 @@ static int get_ns_id(int argc, char **argv, struct command *cmd, struct plugin *
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	unsigned int nsid;
 	int err;
+	nvme_print_flags_t flags;
 
 	NVME_ARGS(opts);
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	err = nvme_get_nsid(dev_fd(dev), &nsid);
 	if (err < 0) {
@@ -4486,6 +4535,7 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -4507,6 +4557,12 @@ static int device_self_test(int argc, char **argv, struct command *cmd, struct p
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.stc == NVME_ST_CODE_RESERVED) {
 		_cleanup_free_ struct nvme_self_test_log *log = NULL;
@@ -4803,6 +4859,12 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 	if (err)
 		return err;
 
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
+
 	if (!argconfig_parse_seen(opts, "namespace-id")) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
 		if (err < 0) {
@@ -4957,6 +5019,7 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	struct stat sb;
 	void *fw_buf;
 	struct nvme_id_ctrl ctrl = { 0 };
+	nvme_print_flags_t flags;
 
 	struct config {
 		char	*fw;
@@ -4984,6 +5047,12 @@ static int fw_download(int argc, char **argv, struct command *cmd, struct plugin
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	fw_fd = open(cfg.fw, O_RDONLY);
 	cfg.offset <<= 2;
@@ -5114,6 +5183,7 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	__u32 result;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u8	slot;
@@ -5135,6 +5205,12 @@ static int fw_commit(int argc, char **argv, struct command *cmd, struct plugin *
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.slot > 7) {
 		nvme_show_error("invalid slot:%d", cfg.slot);
@@ -5249,12 +5325,19 @@ static int ns_rescan(int argc, char **argv, struct command *cmd, struct plugin *
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	NVME_ARGS(opts);
 
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	err = nvme_ns_rescan(dev_fd(dev));
 	if (err < 0)
@@ -5279,6 +5362,7 @@ static int sanitize_cmd(int argc, char **argv, struct command *cmd, struct plugi
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		bool	no_dealloc;
@@ -5321,6 +5405,12 @@ static int sanitize_cmd(int argc, char **argv, struct command *cmd, struct plugi
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	switch (cfg.sanact) {
 	case NVME_SANITIZE_SANACT_EXIT_FAILURE:
@@ -6131,6 +6221,12 @@ static int get_property(int argc, char **argv, struct command *cmd, struct plugi
 	if (err)
 		return err;
 
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
+
 	if (cfg.offset == -1) {
 		nvme_show_error("offset required param");
 		return -EINVAL;
@@ -6155,6 +6251,7 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct set_reg_config cfg = {
 		.offset	= -1,
@@ -6168,6 +6265,12 @@ static int set_property(int argc, char **argv, struct command *cmd, struct plugi
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.offset == -1) {
 		nvme_show_error("offset required param");
@@ -6457,6 +6560,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	_cleanup_fd_ int ffd = STDIN_FILENO;
 	int err;
 	__u32 result;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -6492,6 +6596,12 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (!argconfig_parse_seen(opts, "namespace-id")) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
@@ -6608,6 +6718,7 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	_cleanup_fd_ int sec_fd = -1;
 	unsigned int sec_size;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -6638,6 +6749,12 @@ static int sec_send(int argc, char **argv, struct command *cmd, struct plugin *p
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.tl == 0) {
 		nvme_show_error("--tl unspecified or zero");
@@ -7148,6 +7265,7 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	__u32 nlbs[256] = {0,};
 	__u64 slbas[256] = {0,};
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -7184,6 +7302,12 @@ static int dsm(int argc, char **argv, struct command *cmd, struct plugin *plugin
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	nc = argconfig_parse_comma_sep_array_u32(cfg.ctx_attrs, ctx_attrs, ARRAY_SIZE(ctx_attrs));
 	nb = argconfig_parse_comma_sep_array_u32(cfg.blocks, nlbs, ARRAY_SIZE(nlbs));
@@ -7491,6 +7615,7 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -7521,6 +7646,12 @@ static int resv_acquire(int argc, char **argv, struct command *cmd, struct plugi
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
@@ -7568,6 +7699,7 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -7597,6 +7729,12 @@ static int resv_register(int argc, char **argv, struct command *cmd, struct plug
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
@@ -7652,6 +7790,7 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -7679,6 +7818,12 @@ static int resv_release(int argc, char **argv, struct command *cmd, struct plugi
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
@@ -8345,6 +8490,7 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	_cleanup_free_ void *sec_buf = NULL;
 	int err;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u32	namespace_id;
@@ -8378,6 +8524,12 @@ static int sec_recv(int argc, char **argv, struct command *cmd, struct plugin *p
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.size) {
 		sec_buf = nvme_alloc(cfg.size);
@@ -8516,6 +8668,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
 	int err = -1;
 	__u32 result;
+	nvme_print_flags_t flags;
 
 	struct config {
 		__u8	operation;
@@ -8540,6 +8693,12 @@ static int capacity_mgmt(int argc, char **argv, struct command *cmd, struct plug
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.operation > 0xf) {
 		nvme_show_error("invalid operation field: %u", cfg.operation);
@@ -8848,6 +9007,7 @@ static int passthru(int argc, char **argv, bool admin,
 	__u32 result;
 	const char *cmd_name = NULL;
 	struct timeval start_time, end_time;
+	nvme_print_flags_t flags_t;
 
 	struct passthru_config cfg = {
 		.opcode		= 0,
@@ -8903,6 +9063,12 @@ static int passthru(int argc, char **argv, bool admin,
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	err = validate_output_format(nvme_cfg.output_format, &flags_t);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
 
 	if (cfg.opcode & 0x01) {
 		cfg.write = true;


### PR DESCRIPTION
Several commands such as nvme get-feature, get-property, id_iocs, etc. don't check for a valid output format unlike other nvme commands. Fix the same.