### PR TITLE
nvme-print: fix the result of I/O Command Set Profile feature

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5034,7 +5034,7 @@ static void stdout_feature_show_fields(enum nvme_features_id fid,
 		printf("\tEndurance Group Critical Warnings  : %u\n", NVME_FEAT_EG_EGCW(result));
 		break;
 	case NVME_FEAT_FID_IOCS_PROFILE:
-		printf("\tI/O Command Set Profile: %s\n", result & 0x1 ? "True" : "False");
+		printf("\tI/O Command Set Profile: %u\n", NVME_GET(result, FEAT_IOCSP_IOCSCI));
 		break;
 	case NVME_FEAT_FID_SPINUP_CONTROL:
 		printf("\tSpinup control feature Enabled: %s\n", (result & 1) ? "True" : "False");


### PR DESCRIPTION
The Get Features command submitted for I/O Command Set Profile feature will return the I/O Command Set Combination Index [08:00] in Dword0 of completion queue entry. So, fixed the mask of the result.