### PR TITLE
nvme: enforce ns granularity on ns create

### DIFF
--- a/Documentation/nvme-create-ns.txt
+++ b/Documentation/nvme-create-ns.txt
@@ -99,14 +99,16 @@ OPTIONS
 -S::
 --nsze-si::
 	The namespace size (NSZE) in standard SI units (aligned on 1Mib boundaries,
-	unless the controller recommends a smaller value).
+	unless the controller recommends a different value, see namespace
+	granularity).
 	The value SI suffixed is divided by the namespace LBA size to set as NSZE.
 	If the value not suffixed it is set as same with the nsze option.
 
 -C::
 --ncap-si::
 	The namespace capacity (NCAP) in standard SI units (aligned on 1Mib boundaries,
-	unless the controller recommends a smaller value).
+	unless the controller recommends a different value, see namespace
+	granularity).
 	The value SI suffixed is divided by the namespace LBA size to set as NCAP.
 	If the value not suffixed it is set as same with the ncap option.
 


### PR DESCRIPTION
When the device supports the namespace granularity feature, update the alignment requirements accordingly. Because this is likely to change the capacity of the namespace also issue a info what is going to happen.

Fixes: #2721 