### PR TITLE
Makefile: Add new targets and update meson command syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ NAME          := nvme
 .DEFAULT_GOAL := ${NAME}
 BUILD-DIR     := .build
 
+.PHONY: update-subprojects
+update-subprojects:
+	meson subprojects update
+
 ${BUILD-DIR}:
 	meson setup $@
 	@echo "Configuration located in: $@"
@@ -28,19 +32,29 @@ endif
 purge:
 ifneq ("$(wildcard ${BUILD-DIR})","")
 	rm -rf ${BUILD-DIR}
+	meson subprojects purge --confirm
 endif
 
-.PHONY: install dist
-install dist: ${BUILD-DIR}
-	cd ${BUILD-DIR} && meson $@
+.PHONY: install
+install: ${NAME}
+	meson install -C ${BUILD-DIR} --skip-subprojects
 
 .PHONY: uninstall
 uninstall:
 	cd ${BUILD-DIR} && meson --internal uninstall
 
+.PHONY: dist
+dist: ${NAME}
+	meson dist -C ${BUILD-DIR} --formats gztar
+
 .PHONY: test
-test: ${BUILD-DIR}
-	ninja -C ${BUILD-DIR} $@
+test: ${NAME}
+	meson test -C ${BUILD-DIR}
+
+# Test strictly nvme-cli (do not run tests on all the subprojects)
+.PHONY: test-strict
+test-strict: ${NAME}
+	meson test -C ${BUILD-DIR} --suite nvme-cli
 
 .PHONY: rpm
 rpm:

--- a/subprojects/openssl.wrap
+++ b/subprojects/openssl.wrap
@@ -1,0 +1,2 @@
+[wrap-redirect]
+filename = libnvme/subprojects/openssl.wrap


### PR DESCRIPTION
Although this is a project based on the meson build system, a Makefile is provided for repetitive commands such as building or testing. 

 This pull request simply updates the meson syntax for some of the existing targets and provides a few additional targets as follows:

- For the "install" target, use "--skip-subprojects" so that only nvme-cli (and not the subprojects) get installed.
- For the "purge" target, add "meson subprojects purge".
- Added "update-subprojects" target
- Added "test-strict" target. This is to limit testing to nvme-cli and not all the subprojects.