### PR TITLE
wdc: On FreeBSD, get the timezone the same as with real glibc

### DIFF
--- a/plugins/wdc/wdc-utils.c
+++ b/plugins/wdc/wdc-utils.c
@@ -81,7 +81,7 @@ int wdc_UtilsGetTime(PUtilsTimeInfo timeInfo)
 	timeInfo->second		=  currTimeInfo.tm_sec;
 	timeInfo->msecs			=  0;
 	timeInfo->isDST			=  currTimeInfo.tm_isdst;
-#if defined(__GLIBC__) && !defined(__UCLIBC__) && !defined(__MUSL__)
+#if (defined(__GLIBC__) && !defined(__UCLIBC__) && !defined(__MUSL__)) || defined(__FreeBSD__)
 	timeInfo->zone			= -currTimeInfo.tm_gmtoff / 60;
 #else
 	timeInfo->zone			= -1 * (timezone / SECONDS_IN_MIN);


### PR DESCRIPTION
FreeBSD 15 and newer finally has the timezone variable (prior it that was a compat function leftover from 4BSD). Older versions are still supported. Both have tm_gmoff, which I've always preferred for better portability.

I also considered dropping the defined(glibc), but wasn't sure how many other targets there are these days and thought this would be better. I really didn't want any FreeBSD ifdefs, but I don't know how to avoid this.
