### PR TITLE
nvme: allow mmap_registers from block device

### DIFF
--- a/Documentation/nvme-get-reg.txt
+++ b/Documentation/nvme-get-reg.txt
@@ -22,6 +22,9 @@ DESCRIPTION
 -----------
 Read and show the defined NVMe controller register.
 
+The <device> parameter is mandatory and must be the nvme admin character
+device (ex: /dev/nvme0).
+
 OPTIONS
 -------
 -O <offset>::

--- a/Documentation/nvme-set-reg.txt
+++ b/Documentation/nvme-set-reg.txt
@@ -22,6 +22,9 @@ DESCRIPTION
 -----------
 Writes and shows the defined NVMe controller register.
 
+The <device> parameter is mandatory and must be the nvme admin character
+device (ex: /dev/nvme0).
+
 OPTIONS
 -------
 -O <offset>::

--- a/nvme.c
+++ b/nvme.c
@@ -1113,7 +1113,10 @@ static int get_effects_log(int argc, char **argv, struct command *cmd, struct pl
 
 	if (cfg.csi < 0) {
 		__u64 cap;
-
+		if (is_blkdev(dev)) {
+			nvme_show_error("Block device isn't allowed without csi");
+			return -EINVAL;
+		}
 		bar = mmap_registers(dev, false);
 
 		if (bar) {
@@ -5611,6 +5614,11 @@ static int show_registers(int argc, char **argv, struct command *cmd, struct plu
 	if (err)
 		return err;
 
+	if (is_blkdev(dev)) {
+		nvme_show_error("Only character device is allowed");
+		return -EINVAL;
+	}
+
 	err = validate_output_format(nvme_cfg.output_format, &flags);
 	if (err < 0) {
 		nvme_show_error("Invalid output format");
@@ -5886,6 +5894,11 @@ static int get_register(int argc, char **argv, struct command *cmd, struct plugi
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	if (is_blkdev(dev)) {
+		nvme_show_error("Only character device is allowed");
+		return -EINVAL;
+	}
 
 	err = validate_output_format(nvme_cfg.output_format, &flags);
 	if (err < 0) {
@@ -6190,6 +6203,11 @@ static int set_register(int argc, char **argv, struct command *cmd, struct plugi
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	if (is_blkdev(dev)) {
+		nvme_show_error("Only character device is allowed");
+		return -EINVAL;
+	}
 
 	bar = mmap_registers(dev, true);
 


### PR DESCRIPTION
Below commands that use mmap_registers failed since a31081a3fa14 (v2.9)
nvme show-regs /dev/nvme0n1
nvme effects-log /dev/nvme0n1