### PR TITLE
nvme-builtin: sort command list as alphabetical order

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -10911,14 +10911,14 @@ int main(int argc, char **argv)
 
 	nvme.extensions->parent = &nvme;
 	if (argc < 2) {
-		general_help(&builtin);
+		general_help(&builtin, NULL);
 		return 0;
 	}
 	setlocale(LC_ALL, "");
 
 	err = handle_plugin(argc - 1, &argv[1], nvme.extensions);
 	if (err == -ENOTTY)
-		general_help(&builtin);
+		general_help(&builtin, NULL);
 
 	return err ? 1 : 0;
 }

--- a/plugin.h
+++ b/plugin.h
@@ -31,7 +31,7 @@ struct command {
 	char *alias;
 };
 
-void general_help(struct plugin *plugin);
+void general_help(struct plugin *plugin, char *str);
 int handle_plugin(int argc, char **argv, struct plugin *plugin);
 
 #endif


### PR DESCRIPTION
This is to find easily the sub-commands name from the help list.