### PR TITLE
nvme: add dry-run NVME_ARGS default option

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -19,7 +19,7 @@
 #define nvme_print(name, flags, ...)				\
 	do {							\
 		struct print_ops *ops = nvme_print_ops(flags);	\
-		if (ops && ops->name)				\
+		if (ops && ops->name && !nvme_cfg.dry_run)	\
 			ops->name(__VA_ARGS__);			\
 	} while (false)
 

--- a/nvme.h
+++ b/nvme.h
@@ -78,6 +78,7 @@ struct nvme_config {
 	char *output_format;
 	int verbose;
 	__u32 timeout;
+	bool dry_run;
 };
 
 /*
@@ -90,6 +91,7 @@ struct nvme_config {
 		OPT_FMT("output-format", 'o', &nvme_cfg.output_format, output_format), \
 		##__VA_ARGS__,                                                         \
 		OPT_UINT("timeout",      't', &nvme_cfg.timeout,       timeout),       \
+		OPT_FLAG("dry-run",        0, &nvme_cfg.dry_run,       dry_run),       \
 		OPT_END()                                                              \
 	}
 
@@ -131,6 +133,7 @@ static inline DEFINE_CLEANUP_FUNC(
 extern const char *output_format;
 extern const char *timeout;
 extern const char *verbose;
+extern const char *dry_run;
 extern struct nvme_config nvme_cfg;
 
 int validate_output_format(const char *format, nvme_print_flags_t *flags);

--- a/util/logging.h
+++ b/util/logging.h
@@ -20,5 +20,6 @@
 extern int log_level;
 
 int map_log_level(int verbose, bool quiet);
+void set_dry_run(bool enable);
 
 #endif // DEBUG_H_

--- a/util/logging.h
+++ b/util/logging.h
@@ -21,5 +21,5 @@ extern int log_level;
 
 int map_log_level(int verbose, bool quiet);
 void set_dry_run(bool enable);
-
+int nvme_submit_io(struct nvme_io_args *args, __u8 opcode, bool show, bool latency);
 #endif // DEBUG_H_


### PR DESCRIPTION
The option is to show command instead of sending.