### PR TITLE
plugins/lm: Pass numd option to nvme_lm_migration_recv

### DIFF
--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -521,6 +521,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *command, str
 		.csuuidi = cfg.csuuidi,
 		.offset = cfg.offset,
 		.cntlid = cfg.cntlid,
+		.numd = cfg.numd,
 		.data = data,
 		.result = &result,
 	};


### PR DESCRIPTION
Forward the user-provided 'numd' value from the command-line options to the underlying nvme_lm_migration_recv library function call.

The `lm_migration_recv` function parsed the `--numd` option but failed to pass the value (`cfg.numd`) when calling the library function `nvme_lm_migration_recv`.

The library function `nvme_lm_migration_recv` requires this value to set command parameters (CDW15) and calculate the expected data transfer length. [libnvme/src/nvme/ioctl.c at master · linux-nvme/libnvme](https://github.com/linux-nvme/libnvme/blob/master/src/nvme/ioctl.c#L2406)