### PR TITLE
Allow specifiying data areas 1-4 when generating telemetry logs

### DIFF
--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1465,8 +1465,8 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *cmd, struct 
 	if (!opt.data_area) {
 		nvme_show_result("Missing data-area. Using default data area 1.\n");
 		opt.data_area = DATA_AREA_1;//Default data area 1
-	} else if (opt.data_area != 1 && opt.data_area != 2) {
-		nvme_show_result("Invalid data-area specified. Please specify 1 or 2.\n");
+	} else if ((opt.data_area < DATA_AREA_1) || (opt.data_area > DATA_AREA_4)) {
+		nvme_show_result("Invalid data-area specified. Please specify 1-4.\n");
 		goto out;
 	}
 


### PR DESCRIPTION
Allow users to specify data areas 1-4 when generating telemetry logs. Previously, the command is rejected if it is not 1 or 2. When users specify data area N, data areas <= N now get parsed into the output.

Closes: https://github.com/linux-nvme/nvme-cli/issues/2754