### PR TITLE
OCP Telemetry Data Statistics Parsing Fix

### DIFF
--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -11,7 +11,7 @@
 #if !defined(OCP_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define OCP_NVME
 
-#define OCP_PLUGIN_VERSION   "2.11.0"
+#define OCP_PLUGIN_VERSION   "2.12.0"
 #include "cmd.h"
 
 PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),

--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -464,8 +464,11 @@ void json_add_formatted_u32_str(struct json_object *pobject, const char *msg, un
 void json_add_formatted_var_size_str(struct json_object *pobject, const char *msg, __u8 *pdata,
 	unsigned int data_size)
 {
-	char description_str[256] = "";
+	char *description_str = NULL;
 	char temp_buffer[3] = { 0 };
+
+	/* Allocate 2 chars for each value in the data + 2 bytes for the null terminator */
+	description_str = (char *) calloc(1, data_size*2 + 2);
 
 	for (size_t i = 0; i < data_size; ++i) {
 		sprintf(temp_buffer, "%02X", pdata[i]);
@@ -473,6 +476,7 @@ void json_add_formatted_var_size_str(struct json_object *pobject, const char *ms
 	}
 
 	json_object_add_value_string(pobject, msg, description_str);
+	free(description_str);
 }
 #endif /* CONFIG_JSONC */
 

--- a/util/utils.c
+++ b/util/utils.c
@@ -138,8 +138,11 @@ unsigned char *read_binary_file(char *data_dir_path, const char *bin_path,
 
 void print_formatted_var_size_str(const char *msg, const __u8 *pdata, size_t data_size, FILE *fp)
 {
-	char description_str[1024] = "";
+	char *description_str = NULL;
 	char temp_buffer[3] = { 0 };
+
+	/* Allocate 2 chars for each value in the data + 2 bytes for the null terminator */
+	description_str = (char *) calloc(1, data_size*2 + 2);
 
 	for (size_t i = 0; i < data_size; ++i) {
 		sprintf(temp_buffer, "%02X", pdata[i]);
@@ -150,6 +153,7 @@ void print_formatted_var_size_str(const char *msg, const __u8 *pdata, size_t dat
 		fp = stdout;
 
 	fprintf(fp, "%s: %s\n", msg, description_str);
+	free(description_str);
 }
 
 void process_field_size_16(int offset, char *sfield, __u8 *buf, char *datastr)


### PR DESCRIPTION
The function print_formatted_var_size_str (in util/utils.c) which is used to print the telemetry statistics additional data had a string array (used for printing out the data) with a hard coded length of 1024 chars.  The Stats data with 80 DW's of data would exceed the size of that array.  Therefore, the code was changed to allocate a buffer large enough to contain the full string data.  