### PR TITLE
plugins/lm: Refine Sequence Indicator description and macro usage

### DIFF
--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -280,7 +280,7 @@ static int lm_migration_send(int argc, char **argv, struct command *command, str
 			    "  1h = Suspend";
 	const char *dudmq = "Delete user data migration queue (DUDMQ) as part of suspend operation "
 			     "(CDW11[31])";
-	const char *seqind = "Sequence Indicator (CDW11[17:16])\n"
+	const char *seqind = "Sequence Indicator (CDW10[17:16])\n"
 			     "  0h = Not first not last\n"
 			     "  1h = First in two or more\n"
 			     "  2h = Last in two or more\n"
@@ -394,7 +394,7 @@ static int lm_migration_send(int argc, char **argv, struct command *command, str
 		.args_size = sizeof(args),
 		.fd = dev_fd(dev),
 		.sel = cfg.sel,
-		.mos = NVME_SET(cfg.seqind, LM_MIGRATION_SEND_MOS),
+		.mos = NVME_SET(cfg.seqind, LM_SEQIND),
 		.cntlid = cfg.cntlid,
 		.csuuidi = cfg.csuuidi,
 		.uidx = cfg.uidx,

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 89ac31f536baf15c1834f877b4c1fb9aca1cf94f
+revision = 56ca8b4d3180c89f80ee5c0380046f124f39ece4
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Changed the command dword reference in the sequence indicator (seqind) help text from CDW11 to CDW10. This aligns with the spec.

In the spec, `mos` field is at bits 31:16 of CDW10, and `seqind` is at bits 01:00 of `mos`, which gives us the final location of `(CDW10[17:16])`.

![Screenshot 2025-04-09 at 07 55 02](https://github.com/user-attachments/assets/bb145920-1acf-41e0-9ff1-aa6abb079062)

![Screenshot 2025-04-08 at 20 32 07](https://github.com/user-attachments/assets/27cd06ac-010c-4ff2-ac1d-038dc3d844f9)

Also changed the macro used for setting the sequence indicator bits in the `mos` field from LM_MIGRATION_SEND_MOS to LM_SEQIND.