### PR TITLE
nvme-print: print new fields of nvme_id_independent_id_ns

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -3025,6 +3025,9 @@ static void json_nvme_cmd_set_independent_id_ns(struct nvme_id_independent_id_ns
 	obj_add_int(r, "nvmsetid", le16_to_cpu(ns->nvmsetid));
 	obj_add_int(r, "endgid", le16_to_cpu(ns->endgid));
 	obj_add_int(r, "nstat", ns->nstat);
+	obj_add_int(r, "kpios", ns->kpios);
+	obj_add_int(r, "maxkt", le16_to_cpu(ns->maxkt));
+	obj_add_int(r, "rgrpid", le32_to_cpu(ns->rgrpid));
 
 	json_print(r);
 }

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -2917,11 +2917,20 @@ static void stdout_cmd_set_independent_id_ns_nsfeat(__u8 nsfeat)
 
 static void stdout_cmd_set_independent_id_ns_nstat(__u8 nstat)
 {
-	__u8 rsvd1 = (nstat & 0xfe) >> 1;
+	__u8 rsvd3 = (nstat & 0xf8) >> 3;
+	__u8 ioi = (nstat & 0x6) >> 1;
 	__u8 nrdy = nstat & 0x1;
 
-	if (rsvd1)
-		printf("  [7:1] : %#x\tReserved\n", rsvd1);
+	static const char * const ioi_string[] = {
+		"I/O performance degradation is not reported",
+		"Reserved",
+		"I/O performance is not currently degraded",
+		"I/O performance is currently degraded"
+	};
+
+	if (rsvd3)
+		printf("  [7:3] : %#x\tReserved\n", rsvd3);
+	printf("  [2:1] : %#x\t%s\n", ioi, ioi_string[ioi]);
 	printf("  [0:0] : %#x\tName space is %sready\n",
 		nrdy, nrdy ? "" : "not ");
 	printf("\n");
@@ -2955,6 +2964,11 @@ static void stdout_cmd_set_independent_id_ns(struct nvme_id_independent_id_ns *n
 	printf("nstat   : %#x\n", ns->nstat);
 	if (human)
 		stdout_cmd_set_independent_id_ns_nstat(ns->nstat);
+	printf("kpios   : %#x\n", ns->kpios);
+	if (human)
+		stdout_id_ns_kpios(ns->kpios);
+	printf("maxkt   : %#x\n", le16_to_cpu(ns->maxkt));
+	printf("rgrpid  : %#x\n", le32_to_cpu(ns->rgrpid));
 }
 
 static void stdout_id_ns_descs(void *data, unsigned int nsid)

--- a/nvme.c
+++ b/nvme.c
@@ -3954,7 +3954,7 @@ static int cmd_set_independent_id_ns(int argc, char **argv, struct command *cmd,
 		flags |= VERBOSE;
 
 	if (!cfg.namespace_id) {
-		err = cfg.namespace_id = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
+		err = nvme_get_nsid(dev_fd(dev), &cfg.namespace_id);
 		if (err < 0) {
 			nvme_show_perror("get-namespace-id");
 			return err;


### PR DESCRIPTION
Print new fields of I/O Command Set Independent Identify Namespace Data Structure
based on NVM Express Base Specification 2.1.