### PR TITLE
logging: retry ioctl on EINTR return value

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,6 +183,20 @@ else
   conf.set('fallthrough', 'do {} while (0) /* fallthrough */')
 endif
 
+if cc.has_function('TEMP_FAILURE_RETRY', prefix : '#include <errno.h>')
+  conf.set('TFR', 'TEMP_FAILURE_RETRY')
+else
+  conf.set('TFR(exp)', '''					\
+({								\
+	long int __result = 0; 					\
+	do {							\
+		__result = (long int)(exp);			\
+	} while ((__result == -1) && (errno == EINTR));		\
+	__result;						\
+})
+''')
+endif
+
 configure_file(
     output: 'config.h',
     configuration: conf

--- a/util/logging.c
+++ b/util/logging.c
@@ -7,6 +7,7 @@
 #include <sys/syslog.h>
 #include <sys/time.h>
 #include <linux/types.h>
+#include <errno.h>
 
 #include <libnvme.h>
 
@@ -96,7 +97,7 @@ int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
 	if (log_level >= LOG_DEBUG)
 		gettimeofday(&start, NULL);
 
-	err = ioctl(fd, ioctl_cmd, cmd);
+	err = TFR(ioctl(fd, ioctl_cmd, cmd));
 
 	if (log_level >= LOG_DEBUG) {
 		gettimeofday(&end, NULL);
@@ -122,7 +123,7 @@ int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
 		gettimeofday(&start, NULL);
 
 
-	err = ioctl(fd, ioctl_cmd, cmd);
+	err = TFR(ioctl(fd, ioctl_cmd, cmd));
 
 	if (log_level >= LOG_DEBUG) {
 		gettimeofday(&end, NULL);


### PR DESCRIPTION
Recent changes in the nvme-tcp transport started to return EINTR due to a signal while reading from a socket. The transport could retry the operation but so far this hasn't been implemented. Thus we retry in userpace the connect call when EINTR is returned.

Fixes: #https://github.com/linux-nvme/nvme-cli/issues/2760