### PR TITLE
udev: Add custom udev rule for the Vast Data Block array

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -254,6 +254,7 @@ udev_files = [
   '70-nvmf-autoconnect.rules',
   '70-nvmf-keys.rules',
   '71-nvmf-netapp.rules',
+  '71-nvmf-vastdata.rules',
 ]
 
 foreach file : udev_files

--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -34,6 +34,7 @@ touch %{buildroot}@SYSCONFDIR@/nvme/hostid
 @UDEVRULESDIR@/70-nvmf-autoconnect.rules
 @UDEVRULESDIR@/70-nvmf-keys.rules
 @UDEVRULESDIR@/71-nvmf-netapp.rules
+@UDEVRULESDIR@/71-nvmf-vastdata.rules
 @DRACUTRILESDIR@/70-nvmf-autoconnect.conf
 @SYSTEMDDIR@/nvmf-connect@.service
 @SYSTEMDDIR@/nvmefc-boot-connections.service

--- a/nvmf-autoconnect/udev-rules/71-nvmf-vastdata.rules.in
+++ b/nvmf-autoconnect/udev-rules/71-nvmf-vastdata.rules.in
@@ -1,0 +1,5 @@
+# Enable round-robin for Vast Data Block Subsystem
+ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{subsystype}=="nvm", ATTR{model}=="VASTData", ATTR{iopolicy}="round-robin"
+
+# Set ctrl_loss_tmo to -1 for Vast Data Block Controller
+ACTION!="remove", SUBSYSTEM=="nvme", KERNEL=="nvme*", ATTR{model}=="VASTData", ATTR{ctrl_loss_tmo}="-1"


### PR DESCRIPTION
Vast Data array supports NVMe-oF block access, and it prefers the host to use round-robin path selection for performance benefits.

In addition, disable the ctrl_loss_tmo in case of prolonged maintenance operations.