### PR TITLE
wdc:  Fixed check for supported log pages

### DIFF
--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.12.0"
+#define WDC_PLUGIN_VERSION   "2.13.0"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),

--- a/plugins/wdc/wdc-utils.c
+++ b/plugins/wdc/wdc-utils.c
@@ -29,6 +29,13 @@
 #include "nvme-print.h"
 #include "wdc-utils.h"
 
+/* UUID field with value of 0 indicates end of UUID List*/
+const uint8_t UUID_END[] = {
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
 int wdc_UtilsSnprintf(char *buffer, unsigned int sizeOfBuffer, const char *format, ...)
 {
 	int res = 0;
@@ -194,3 +201,40 @@ bool wdc_UuidEqual(struct nvme_id_uuid_list_entry *entry1, struct nvme_id_uuid_l
 {
 	return !memcmp(entry1->uuid, entry2->uuid, NVME_UUID_LEN);
 }
+
+bool wdc_FindUuidIndex(struct nvme_dev *dev,
+		struct nvme_id_uuid_list_entry *uuid_entry,
+		int *uuid_index)
+{
+	bool uuid_found = false;
+	int index = 0;
+	struct nvme_id_uuid_list uuid_list;
+
+	*uuid_index = 0;
+
+	memset(&uuid_list, 0, sizeof(struct nvme_id_uuid_list));
+	if (wdc_CheckUuidListSupport(dev, &uuid_list)) {
+		struct nvme_id_uuid_list_entry *uuid_list_entry_ptr =
+			(struct nvme_id_uuid_list_entry *)&uuid_list.entry[0];
+
+		while (index <= NVME_ID_UUID_LIST_MAX &&
+				!wdc_UuidEqual(uuid_list_entry_ptr,
+					(struct nvme_id_uuid_list_entry *)UUID_END)) {
+
+			if (wdc_UuidEqual(uuid_list_entry_ptr, uuid_entry)) {
+				uuid_found = true;
+				break;
+			}
+
+			index++;
+			uuid_list_entry_ptr =
+				(struct nvme_id_uuid_list_entry *)&uuid_list.entry[index];
+		}
+
+		if (uuid_found)
+			*uuid_index = index + 1;
+	}
+
+	return uuid_found;
+}
+

--- a/plugins/wdc/wdc-utils.h
+++ b/plugins/wdc/wdc-utils.h
@@ -77,5 +77,10 @@ int wdc_UtilsStrCompare(char *pcSrc, char *pcDst);
 int wdc_UtilsCreateDir(char *path);
 int wdc_WriteToFile(char *fileName, char *buffer, unsigned int bufferLen);
 void wdc_StrFormat(char *formatter, size_t fmt_sz, char *tofmt, size_t tofmtsz);
-bool wdc_CheckUuidListSupport(struct nvme_dev *dev, struct nvme_id_uuid_list *uuid_list);
-bool wdc_UuidEqual(struct nvme_id_uuid_list_entry *entry1, struct nvme_id_uuid_list_entry *entry2);
+bool wdc_CheckUuidListSupport(struct nvme_dev *dev,
+		struct nvme_id_uuid_list *uuid_list);
+bool wdc_UuidEqual(struct nvme_id_uuid_list_entry *entry1,
+		struct nvme_id_uuid_list_entry *entry2);
+bool wdc_FindUuidIndex(struct nvme_dev *dev,
+		struct nvme_id_uuid_list_entry *uuid_entry,
+		int *uuid_index);


### PR DESCRIPTION
Add checking of the supoorted log pages (log id 0) for currently supported log pages.  The previous code was only checking a vendor specific log page for this info. Also the uuid index value was added so the supported log pages can be checked for a specific uuid.