### PR TITLE
plugin/ocp_get_feature_fid_c3h:Added the OCP Get Feature FID=C3h comm…

### DIFF
--- a/Documentation/nvme-ocp-get-clear-pcie-correctable-errors.txt
+++ b/Documentation/nvme-ocp-get-clear-pcie-correctable-errors.txt
@@ -1,0 +1,62 @@
+nvme-ocp-get-clear-pcie-correctable-errors(1)
+=========================================
+
+NAME
+----
+nvme-ocp-get-clear-pcie-correctable-errors - Define and print get-clear-pcie-correctable-errors value
+
+SYNOPSIS
+--------
+[verse]
+'nvme ocp get-clear-pcie-correctable-errors' <device> [--sel=<select> | -s <select>]
+			[--namespace-id <nsid> | -n <nsid>] [--no-uuid | -u]
+
+DESCRIPTION
+-----------
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0) or block device (ex: /dev/nvme0n1).
+
+This will only work on OCP compliant devices supporting this feature.
+Results for any other device are undefined.
+
+On success it returns 0, error code otherwise.
+
+OPTIONS
+-------
+-n <nsid>::
+--namespace-id=<nsid>::
+	NSID: Assign the different kind of nsid value(like
+	active, inactive and invalid nsids) and check
+	the get feature command response:
+
+-s <select>::
+--sel=<select>::
+	Select (SEL): This field specifies which value of the attributes
+	to return in the provided data:
++
+[]
+|==================
+|Select|Description
+|0|Current
+|1|Default
+|2|Saved
+|3|Supported capabilities
+|4-7|Reserved
+|==================
+
+-u::
+--no-uuid::
+	Do not try to automatically detect UUID index for this command (required
+	for old OCP 1.0 support)
+
+EXAMPLES
+--------
+* Has the program issue a get-clear-pcie-correctable-errors to retrieve the 0xC3 get features.
++
+------------
+# nvme ocp get-clear-pcie-correctable-errors /dev/nvme0
+------------
+
+NVME
+----
+Part of the nvme-user suite.

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -411,6 +411,20 @@ _nvme () {
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp get-latency-monitor options" _ocp_get_latency_monitor_feature
 				;;
+			(get-clear-pcie-correctable-errors)
+				local _get_clear_pcie_correctable_error_counters
+				_get_clear_pcie_correctable_error_counters=(
+				/dev/nvme':supply a device to use (required)'
+				--sel=':select from 0 - current, 1 - default, 2 - saved, 3 - supported'
+				-s':alias to --sel'
+				--namespace-id=':valid, invalid and inactive nsid'
+				-n':alias to --namespace-id'
+				--no-uuid':Skip UUID index search'
+				-u':alias for --no-uuid'
+				)
+				_arguments '*:: :->subcmds'
+				_describe -t commands "nvme ocp get-clear-pcie-correctable-errors options" _get_clear_pcie_correctable_error_counters
+				;;
 			(*)
 				_files
 				;;
@@ -2858,6 +2872,7 @@ _nvme () {
 			set-error-injection':set error injection'
 			hardware-component-log':retrieve hardware component log'
 			get-latency-monitor':Get Latency Monitor Feature'
+			get-clear-pcie-correctable-errors':retrieve clear pcie correctable errors'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme ocp options" _ocp

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1652,6 +1652,10 @@ plugin_ocp_opts () {
 		opts+=" --sel= -s \
 			--namespace-id= -n --no-uuid -u"
 			;;
+		"get-clear-pcie-correctable-errors")
+		opts+=" --sel= -s \
+			--namespace-id= -n --no-uuid -u"
+			;;
 		"help")
 		opts+=$NO_OPTS
 			;;
@@ -1733,7 +1737,8 @@ _nvme_subcmds () {
 			telemetry-string-log set-telemetry-profile \
 			set-dssd-async-event-config get-dssd-async-event-config \
 			get-error-injection set-error-injection \
-			hardware-component-log get-latency-monitor"
+			hardware-component-log get-latency-monitor \
+			get-clear-pcie-correctable-errors"
 		[mangoboost]="id-ctrl"
 	)
 

--- a/plugins/ocp/ocp-clear-features.c
+++ b/plugins/ocp/ocp-clear-features.c
@@ -75,6 +75,81 @@ close_dev:
 	return err;
 }
 
+int get_ocp_error_counters(int argc, char **argv, struct command *cmd,
+			   struct plugin *plugin)
+{
+	const char *desc = "Define Issue Get Feature cmd (FID: 0xC3) Clear PCIe Corr Err Counters";
+	const char *sel = "[0-3]: current/default/saved/supported/";
+	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
+	const char *no_uuid = "Do not try to automatically detect UUID index";
+
+	_cleanup_nvme_dev_ struct nvme_dev *dev = NULL;
+
+	__u32 result;
+	int err;
+	bool uuid;
+	__u8 uuid_index = 0;
+
+	struct config {
+		__u8 sel;
+		__u32 nsid;
+	};
+
+	struct config cfg = {
+		.sel = 0,
+		.nsid = 0,
+	};
+
+	OPT_ARGS(opts) = {
+		OPT_BYTE("sel", 's', &cfg.sel, sel),
+		OPT_UINT("namespace-id", 'n', &cfg.nsid, nsid),
+		OPT_FLAG("no-uuid", 'u', NULL, no_uuid),
+		OPT_END()
+	};
+
+	err = parse_and_open(&dev, argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	uuid = !argconfig_parse_seen(opts, "no-uuid");
+
+	if (uuid) {
+		/* OCP 2.0 requires UUID index support */
+		err = ocp_get_uuid_index(dev, &uuid_index);
+		if (err || !uuid_index) {
+			nvme_show_error("ERROR: No OCP UUID index found");
+			return err;
+		}
+	}
+
+	struct nvme_get_features_args args = {
+		.args_size  = sizeof(args),
+		.fd         = dev_fd(dev),
+		.fid        = OCP_FID_CPCIE,
+		.nsid       = cfg.nsid,
+		.sel        = cfg.sel,
+		.cdw11      = 0,
+		.uuidx      = uuid_index,
+		.data_len   = 0,
+		.data       = NULL,
+		.timeout    = NVME_DEFAULT_IOCTL_TIMEOUT,
+		.result     = &result,
+	};
+
+	err = nvme_get_features(&args);
+	if (!err) {
+		printf("get-feature:0xC3 %s value: %#08x\n",
+		nvme_select_to_string(cfg.sel), result);
+
+		if (cfg.sel == NVME_GET_FEATURES_SEL_SUPPORTED)
+			nvme_show_select_result(0xC3, result);
+	} else {
+		nvme_show_error("Could not get feature: 0xC3");
+	}
+
+	return err;
+}
+
 int ocp_clear_fw_update_history(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	const char *desc = "OCP Clear Firmware Update History";

--- a/plugins/ocp/ocp-clear-features.h
+++ b/plugins/ocp/ocp-clear-features.h
@@ -10,3 +10,6 @@ int ocp_clear_fw_update_history(int argc, char **argv, struct command *cmd, stru
 
 int ocp_clear_pcie_correctable_errors(int argc, char **argv, struct command *cmd,
 					     struct plugin *plugin);
+
+int get_ocp_error_counters(int argc, char **argv, struct command *cmd,
+			    struct plugin *plugin);

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -2686,6 +2686,12 @@ static int clear_pcie_correctable_error_counters(int argc, char **argv, struct c
 	return ocp_clear_pcie_correctable_errors(argc, argv, cmd, plugin);
 }
 
+static int get_clear_pcie_correctable_error_counters(int argc, char **argv, struct command *cmd,
+						      struct plugin *plugin)
+{
+	return get_ocp_error_counters(argc, argv, cmd, plugin);
+}
+
 static int fw_activation_history_log(int argc, char **argv, struct command *cmd,
 				     struct plugin *plugin)
 {

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -44,6 +44,8 @@ PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),
 		ENTRY("hardware-component-log", "retrieve hardware component log", hwcomp_log)
 		ENTRY("get-latency-monitor", "Get Latency Monitor Feature",
 		      ocp_get_latency_monitor_feature)
+		ENTRY("get-clear-pcie-correctable-errors", "Clear PCIe correctable error counters",
+		      get_clear_pcie_correctable_error_counters)
 	)
 );
 


### PR DESCRIPTION
…and api

Enabled Get Feature command (FID=C3h) api with sel, namespace-id, no-uuid command line arguments. namespace-id added to the test the command with active, inactive and invalid nsid values.

Reviewed-by: Karthik Balan <karthik.b82@samsung.com>
Reviewed-by: Arunpandian J <arun.j@samsung.com>