### PR TITLE
nvme: make --opcode argument mandatory

### DIFF
--- a/Documentation/nvme-admin-passthru.txt
+++ b/Documentation/nvme-admin-passthru.txt
@@ -47,6 +47,7 @@ OPTIONS
 -O <opcode>::
 --opcode=<opcode>::
 	The NVMe opcode to send to the device in the command
+	Required argument as this param is mandatory.
 
 -f <flags>::
 --flags=<flags>::

--- a/Documentation/nvme-io-passthru.txt
+++ b/Documentation/nvme-io-passthru.txt
@@ -46,6 +46,7 @@ OPTIONS
 -O <opcode>::
 --opcode=<opcode>::
 	The NVMe opcode to send to the device in the command
+	Required argument as this param is mandatory.
 
 -f <flags>::
 --flags=<flags>::

--- a/Documentation/nvme-nvme-mi-recv.txt
+++ b/Documentation/nvme-nvme-mi-recv.txt
@@ -30,6 +30,7 @@ OPTIONS
 -O <opcode>::
 --opcode=<opcode>::
 	The NVMe-MI opcode to send to the device in the command
+	Required argument as this param is mandatory.
 
 -n <nsid>::
 --namespace-id=<nsid>::

--- a/Documentation/nvme-nvme-mi-send.txt
+++ b/Documentation/nvme-nvme-mi-send.txt
@@ -30,6 +30,7 @@ OPTIONS
 -O <opcode>::
 --opcode=<opcode>::
 	The NVMe-MI opcode to send to the device in the command
+	Required argument as this param is mandatory.
 
 -n <nsid>::
 --namespace-id=<nsid>::

--- a/nvme.c
+++ b/nvme.c
@@ -9123,6 +9123,11 @@ static int passthru(int argc, char **argv, bool admin,
 		return err;
 	}
 
+	if (!argconfig_parse_seen(opts, "opcode")) {
+		nvme_show_error("%s: opcode parameter required", cmd->name);
+		return -EINVAL;
+	}
+
 	if (cfg.opcode & 0x01) {
 		cfg.write = true;
 		flags = O_RDONLY;
@@ -10185,6 +10190,11 @@ static int nvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc)
 	err = parse_and_open(&dev, argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	if (!argconfig_parse_seen(opts, "opcode")) {
+		nvme_show_error("%s: opcode parameter required", *argv);
+		return -EINVAL;
+	}
 
 	if (admin_opcode == nvme_admin_nvme_mi_send) {
 		flags = O_RDONLY;


### PR DESCRIPTION
The shorthand -o change for --output from --opcode before. Then the default opcode value zero used incorrectly if the -o used.