### PR TITLE
plugin/ocp_get_feature_fid_c8h:Added the OCP Get Feature FID=C8h comm…

### DIFF
--- a/Documentation/nvme-ocp-get-telemetry-profile.txt
+++ b/Documentation/nvme-ocp-get-telemetry-profile.txt
@@ -1,0 +1,62 @@
+nvme-ocp-get-telemetry-profile(1)
+=========================================
+
+NAME
+----
+nvme-ocp-get-telemetry-profile - Define and print get-telemetry-profile value
+
+SYNOPSIS
+--------
+[verse]
+'nvme ocp get-telemetry-profile' <device> [--sel=<select> | -s <select>]
+			[--namespace-id <nsid> | -n <nsid>] [--no-uuid | -u]
+
+DESCRIPTION
+-----------
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0) or block device (ex: /dev/nvme0n1).
+
+This will only work on OCP compliant devices supporting this feature.
+Results for any other device are undefined.
+
+On success it returns 0, error code otherwise.
+
+OPTIONS
+-------
+-n <nsid>::
+--namespace-id=<nsid>::
+	NSID: Assign the different kind of nsid value(like
+	active, inactive and invalid nsids) and check
+	the get feature command response:
+
+-s <select>::
+--sel=<select>::
+	Select (SEL): This field specifies which value of the attributes
+	to return in the provided data:
++
+[]
+|==================
+|Select|Description
+|0|Current
+|1|Default
+|2|Saved
+|3|Supported capabilities
+|4-7|Reserved
+|==================
+
+-u::
+--no-uuid::
+	Do not try to automatically detect UUID index for this command (required
+	for old OCP 1.0 support)
+
+EXAMPLES
+--------
+* Has the program issue a get-telemetry-profile to retrieve the 0xC8 get features.
++
+------------
+# nvme ocp get-telemetry-profile /dev/nvme0
+------------
+
+NVME
+----
+Part of the nvme-user suite.

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -425,6 +425,20 @@ _nvme () {
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp get-clear-pcie-correctable-errors options" _get_clear_pcie_correctable_error_counters
 				;;
+			(get-telemetry-profile)
+				local _ocp_get_telemetry_profile_feature
+				_ocp_get_telemetry_profile_feature=(
+				/dev/nvme':supply a device to use (required)'
+				--sel=':select from 0 - current, 1 - default, 2 - saved, 3 - supported'
+				-s':alias to --sel'
+				--namespace-id=':valid, invalid and inactive nsid'
+				-n':alias to --namespace-id'
+				--no-uuid':Skip UUID index search'
+				-u':alias for --no-uuid'
+				)
+				_arguments '*:: :->subcmds'
+				_describe -t commands "nvme ocp get-telemetry-profile options" _ocp_get_telemetry_profile_feature
+				;;
 			(*)
 				_files
 				;;
@@ -2873,6 +2887,7 @@ _nvme () {
 			hardware-component-log':retrieve hardware component log'
 			get-latency-monitor':Get Latency Monitor Feature'
 			get-clear-pcie-correctable-errors':retrieve clear pcie correctable errors'
+			get-telemetry-profile':retrieve Get Telemetry Profile Feature'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme ocp options" _ocp

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1656,6 +1656,10 @@ plugin_ocp_opts () {
 		opts+=" --sel= -s \
 			--namespace-id= -n --no-uuid -u"
 			;;
+		"get-telemetry-profile")
+		opts+=" --sel= -s \
+			--namespace-id= -n --no-uuid -u"
+			;;
 		"help")
 		opts+=$NO_OPTS
 			;;
@@ -1738,7 +1742,7 @@ _nvme_subcmds () {
 			set-dssd-async-event-config get-dssd-async-event-config \
 			get-error-injection set-error-injection \
 			hardware-component-log get-latency-monitor \
-			get-clear-pcie-correctable-errors"
+			get-clear-pcie-correctable-errors get-telemetry-profile"
 		[mangoboost]="id-ctrl"
 	)
 

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -46,6 +46,8 @@ PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),
 		      ocp_get_latency_monitor_feature)
 		ENTRY("get-clear-pcie-correctable-errors", "Clear PCIe correctable error counters",
 		      get_clear_pcie_correctable_error_counters)
+		ENTRY("get-telemetry-profile", "Get Telemetry Profile Feature",
+		      ocp_get_telemetry_profile_feature)
 	)
 );
 


### PR DESCRIPTION
…and api

Enabled Get Feature command (FID=C8h) api with sel, namespace-id, no-uuid command line arguments. namespace-id added to the test the command with active, inactive and invalid nsid values.

Reviewed-by: Karthik Balan <karthik.b82@samsung.com>
Reviewed-by: Arunpandian J <arun.j@samsung.com>