### PR TITLE
nvme: add dry-run NVME_ARGS default option

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -19,7 +19,7 @@
 #define nvme_print(name, flags, ...)				\
 	do {							\
 		struct print_ops *ops = nvme_print_ops(flags);	\
-		if (ops && ops->name)				\
+		if (ops && ops->name && !nvme_cfg.dry_run)	\
 			ops->name(__VA_ARGS__);			\
 	} while (false)
 

--- a/nvme.c
+++ b/nvme.c
@@ -102,7 +102,6 @@ struct passthru_config {
 	char	*metadata;
 	bool	raw_binary;
 	bool	show_command;
-	bool	dry_run;
 	bool	read;
 	bool	write;
 	__u8	prefill;
@@ -192,6 +191,7 @@ const char *output_format = "Output format: normal|binary";
 #endif /* CONFIG_JSONC */
 const char *timeout = "timeout value, in milliseconds";
 const char *verbose = "Increase output verbosity";
+const char *dry_run = "show command instead of sending";
 
 static const char *app_tag = "app tag for end-to-end PI";
 static const char *app_tag_mask = "app tag mask for end-to-end PI";
@@ -201,7 +201,6 @@ static const char *csi = "command set identifier";
 static const char *buf_len = "buffer len (if) data is sent or received";
 static const char *domainid = "Domain Identifier";
 static const char *doper = "directive operation";
-static const char *dry = "show command instead of sending";
 static const char *dspec_w_dtype = "directive specification associated with directive type";
 static const char *dtype = "directive type";
 static const char *endgid = "Endurance Group Identifier (ENDGID)";
@@ -444,6 +443,8 @@ static int parse_args(int argc, char *argv[], const char *desc,
 
 	log_level = map_log_level(nvme_cfg.verbose, false);
 	nvme_init_default_logging(stderr, log_level, false, false);
+
+	set_dry_run(nvme_cfg.dry_run);
 
 	return 0;
 }
@@ -8075,7 +8076,6 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		__u16	dspec;
 		__u8	dsmgmt;
 		bool	show;
-		bool	dry_run;
 		bool	latency;
 		bool	force;
 	};
@@ -8100,7 +8100,6 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		.dspec			= 0,
 		.dsmgmt			= 0,
 		.show			= false,
-		.dry_run		= false,
 		.latency		= false,
 		.force			= false,
 	};
@@ -8125,7 +8124,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		  OPT_SHRT("dir-spec",          'S', &cfg.dspec,             dspec),
 		  OPT_BYTE("dsm",               'D', &cfg.dsmgmt,            dsm),
 		  OPT_FLAG("show-command",      'V', &cfg.show,              show),
-		  OPT_FLAG("dry-run",           'w', &cfg.dry_run,           dry),
+		  OPT_FLAG("dry-run",           'w', &nvme_cfg.dry_run,      dry_run),
 		  OPT_FLAG("latency",           't', &cfg.latency,           latency),
 		  OPT_FLAG("force",               0, &cfg.force,             force));
 
@@ -8301,7 +8300,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		}
 	}
 
-	if (cfg.show || cfg.dry_run) {
+	if (cfg.show || nvme_cfg.dry_run) {
 		printf("opcode       : %02x\n", opcode);
 		printf("nsid         : %02x\n", cfg.namespace_id);
 		printf("flags        : %02x\n", 0);
@@ -8319,7 +8318,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		printf("pif             : %02x\n", pif);
 		printf("sts             : %02x\n", sts);
 	}
-	if (cfg.dry_run)
+	if (nvme_cfg.dry_run)
 		return 0;
 
 	struct nvme_io_args args = {
@@ -9084,7 +9083,6 @@ static int passthru(int argc, char **argv, bool admin,
 		.metadata	= "",
 		.raw_binary	= false,
 		.show_command	= false,
-		.dry_run	= false,
 		.read		= false,
 		.write		= false,
 		.latency	= false,
@@ -9110,7 +9108,7 @@ static int passthru(int argc, char **argv, bool admin,
 		  OPT_FILE("metadata",     'M', &cfg.metadata,     metadata),
 		  OPT_FLAG("raw-binary",   'b', &cfg.raw_binary,   raw_dump),
 		  OPT_FLAG("show-command", 's', &cfg.show_command, show),
-		  OPT_FLAG("dry-run",      'd', &cfg.dry_run,      dry),
+		  OPT_FLAG("dry-run",      'd', &nvme_cfg.dry_run, dry_run),
 		  OPT_FLAG("read",         'r', &cfg.read,         re),
 		  OPT_FLAG("write",        'w', &cfg.write,        wr),
 		  OPT_FLAG("latency",      'T', &cfg.latency,      latency));
@@ -9187,7 +9185,7 @@ static int passthru(int argc, char **argv, bool admin,
 		}
 	}
 
-	if (cfg.show_command || cfg.dry_run) {
+	if (cfg.show_command || nvme_cfg.dry_run) {
 		printf("opcode       : %02x\n", cfg.opcode);
 		printf("flags        : %02x\n", cfg.flags);
 		printf("rsvd1        : %04x\n", cfg.rsvd);
@@ -9206,7 +9204,7 @@ static int passthru(int argc, char **argv, bool admin,
 		printf("cdw15        : %08x\n", cfg.cdw15);
 		printf("timeout_ms   : %08x\n", nvme_cfg.timeout);
 	}
-	if (cfg.dry_run)
+	if (nvme_cfg.dry_run)
 		return 0;
 
 	gettimeofday(&start_time, NULL);

--- a/nvme.h
+++ b/nvme.h
@@ -78,6 +78,7 @@ struct nvme_config {
 	char *output_format;
 	int verbose;
 	__u32 timeout;
+	bool dry_run;
 };
 
 /*
@@ -90,6 +91,7 @@ struct nvme_config {
 		OPT_FMT("output-format", 'o', &nvme_cfg.output_format, output_format), \
 		##__VA_ARGS__,                                                         \
 		OPT_UINT("timeout",      't', &nvme_cfg.timeout,       timeout),       \
+		OPT_FLAG("dry-run",        0, &nvme_cfg.dry_run,       dry_run),       \
 		OPT_END()                                                              \
 	}
 
@@ -131,6 +133,7 @@ static inline DEFINE_CLEANUP_FUNC(
 extern const char *output_format;
 extern const char *timeout;
 extern const char *verbose;
+extern const char *dry_run;
 extern struct nvme_config nvme_cfg;
 
 int validate_output_format(const char *format, nvme_print_flags_t *flags);

--- a/util/logging.c
+++ b/util/logging.c
@@ -13,6 +13,7 @@
 #include "logging.h"
 
 int log_level;
+static bool dry_run;
 
 int map_log_level(int verbose, bool quiet)
 {
@@ -42,6 +43,11 @@ int map_log_level(int verbose, bool quiet)
 		log_level = LOG_ERR;
 
 	return log_level;
+}
+
+void set_dry_run(bool enable)
+{
+	dry_run = enable;
 }
 
 static void nvme_show_common(struct nvme_passthru_cmd *cmd)
@@ -91,12 +97,13 @@ int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
 {
 	struct timeval start;
 	struct timeval end;
-	int err;
+	int err = 0;
 
 	if (log_level >= LOG_DEBUG)
 		gettimeofday(&start, NULL);
 
-	err = ioctl(fd, ioctl_cmd, cmd);
+	if (!dry_run)
+		err = ioctl(fd, ioctl_cmd, cmd);
 
 	if (log_level >= LOG_DEBUG) {
 		gettimeofday(&end, NULL);
@@ -116,13 +123,13 @@ int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
 {
 	struct timeval start;
 	struct timeval end;
-	int err;
+	int err = 0;
 
 	if (log_level >= LOG_DEBUG)
 		gettimeofday(&start, NULL);
 
-
-	err = ioctl(fd, ioctl_cmd, cmd);
+	if (!dry_run)
+		err = ioctl(fd, ioctl_cmd, cmd);
 
 	if (log_level >= LOG_DEBUG) {
 		gettimeofday(&end, NULL);

--- a/util/logging.h
+++ b/util/logging.h
@@ -20,5 +20,6 @@
 extern int log_level;
 
 int map_log_level(int verbose, bool quiet);
+void set_dry_run(bool enable);
 
 #endif // DEBUG_H_


### PR DESCRIPTION
The option is to show command instead of sending.

@ikegami-t 