### PR TITLE
nvme: retry commands on EAGAIN and EINTR

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -65,6 +65,7 @@
 #include "util/argconfig.h"
 #include "util/suffix.h"
 #include "util/logging.h"
+#include "util/sighdl.h"
 #include "fabrics.h"
 #define CREATE_CMD
 #include "nvme-builtin.h"
@@ -4437,21 +4438,16 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *cmd, struc
 	return err;
 }
 
-static void intr_self_test(int signum)
-{
-	printf("\nInterrupted device self-test operation by %s\n", strsignal(signum));
-
-	errno = EINTR;
-}
-
 static int sleep_self_test(unsigned int seconds)
 {
-	errno = 0;
+	nvme_sigint_received = false;
 
 	sleep(seconds);
 
-	if (errno)
-		return -errno;
+	if (nvme_sigint_received) {
+		printf("\nInterrupted device self-test operation by SIGINT\n");
+		return -SIGINT;
+	}
 
 	return 0;
 }
@@ -4463,8 +4459,6 @@ static int wait_self_test(struct nvme_dev *dev)
 	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
 	int err, i = 0, p = 0, cnt = 0;
 	int wthr;
-
-	signal(SIGINT, intr_self_test);
 
 	ctrl = nvme_alloc(sizeof(*ctrl));
 	if (!ctrl)
@@ -10928,6 +10922,10 @@ int main(int argc, char **argv)
 		return 0;
 	}
 	setlocale(LC_ALL, "");
+
+	err = nvme_install_sigint_handler();
+	if (err)
+		return err;
 
 	err = handle_plugin(argc - 1, &argv[1], nvme.extensions);
 	if (err == -ENOTTY)

--- a/util/meson.build
+++ b/util/meson.build
@@ -6,6 +6,7 @@ sources += [
   'util/crc32.c',
   'util/logging.c',
   'util/mem.c',
+  'util/sighdl.c',
   'util/suffix.c',
   'util/types.c',
   'util/utils.c'

--- a/util/sighdl.c
+++ b/util/sighdl.c
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <signal.h>
+#include <errno.h>
+
+#include "sighdl.h"
+
+bool nvme_sigint_received;
+
+static void nvme_sigint_handler(int signum)
+{
+	nvme_sigint_received = true;
+}
+
+int nvme_install_sigint_handler(void)
+{
+	struct sigaction act;
+
+	sigemptyset(&act.sa_mask);
+	act.sa_handler = nvme_sigint_handler;
+	act.sa_flags = 0;
+
+	nvme_sigint_received = false;
+	if (sigaction(SIGINT, &act, NULL) == -1)
+		return -errno;
+
+	return 0;
+}

--- a/util/sighdl.h
+++ b/util/sighdl.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef __NVME_SIGHDL
+#define __NVME_SIGHDL
+
+#include <stdbool.h>
+
+extern bool nvme_sigint_received;
+
+int nvme_install_sigint_handler(void);
+
+#endif // __NVME_SIGHDL


### PR DESCRIPTION
The kernel started to return EAGAIN and EINTR. It is quiet likely that this was possible before but it happened not so often. Thus for users of nvme-cli it is a behavior change.

The first attempt was to handle this in libnvme itself. But it turns out we can't just blindly retry. It is necessary to check if the user has pressed Ctrl-C to terminate the program. Adding a signal handler inside the library is a no go. Thus add the retry logic to nvme-cli itself.

Fixes: #2760 #2781 #2775