### PR TITLE
plugins/mangoboost: Add plugin to support MangoBoost

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -123,6 +123,7 @@ _nvme () {
 	'solidigm:Solidigm plug-in extensions'
 	'fdp:FDP plug-in extensions'
 	'micron:Micron plug-in extensions'
+	'mangoboost:MangoBoost plug-in extensions'
 	'dapustor:DapuStor plug-in extensions'
 	'help:print brief descriptions of all nvme commands'
 	'json:dump output in json format'
@@ -657,6 +658,30 @@ _nvme () {
 			(*)
 				_files
 				;;
+			esac
+			;;
+                (mangoboost)
+                        case ${words[2]} in
+                        (id-ctrl)
+                                local _id_ctrl
+                                _id_ctrl=(
+                                --verbose':Increase output verbosity'
+                                -v':alias for --verbose'
+                                --output-format':Output format: normal|json|binary'
+                                -o':alias for --output-format'
+                                --vendor-specific':dump binary vendor field'
+                                -V':alias for --vendor-specific'
+                                --raw-binary':show identify in binary format'
+                                -b':alias for --raw-binary'
+                                --human-readable':show identify in readable format'
+                                -H':alias for --human-readable'
+                                )
+                                _arguments '*:: :->subcmds'
+                                _describe -t commands "nvme mangoboost id-ctrl options" _id_ctrl
+                                ;;
+                        (*)
+                                _files
+                                ;;
 			esac
 			;;
 		(*)
@@ -2895,6 +2920,16 @@ _nvme () {
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme dapustor options" _dapustor
 			;;
+		(mangoboost)
+			local _mangoboost
+			_mangoboost=(
+			id-ctrl':Send NVMe Identify Controller'
+			version':Shows the program version'
+			help':Display this help'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme mangoboost options" _mangoboost
+			;;
 		(help)
 			local _h
 			_h=( id-ctrl id-ns list-ns id-iocs create-ns delete-ns attach-ns detach-ns
@@ -2913,7 +2948,7 @@ _nvme () {
 			subsystem-reset ns-rescan get-lba-status dsm discover connect-all connect
 			dim disconnect disconnect-all gen-hostnqn show-hostnqn tls-key dir-receive
 			dir-send virt-mgmt rpmb version ocp solidigm dapustor mgmt-addr-list-log
-			rotational-media-info-log changed-alloc-ns-list-log fdp
+			rotational-media-info-log changed-alloc-ns-list-log fdp mangoboost
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "help: infos on a specific nvme command, or provide no option to see a synopsis of all nvme commands" _h

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1531,6 +1531,38 @@ plugin_inspur_opts () {
 	return 0
 }
 
+plugin_mangoboost_opts () {
+	local opts=""
+	local compargs=""
+
+	local nonopt_args=0
+	for (( i=0; i < ${#words[@]}-1; i++ )); do
+		if [[ ${words[i]} != -* ]]; then
+			let nonopt_args+=1
+		fi
+	done
+
+	if [ $nonopt_args -eq 3 ]; then
+		opts="/dev/nvme* "
+	fi
+
+	opts+=" "
+
+	case "$1" in
+		"id-ctrl")
+		opts+=" --raw-binary -b --human-readable -H \
+			--vendor-specific -v --output-format= -o"
+			;;
+		"help")
+		opts+=$NO_OPTS
+			;;
+	esac
+
+	COMPREPLY+=( $( compgen $compargs -W "$opts" -- $cur ) )
+
+	return 0
+}
+
 plugin_ocp_opts () {
 	local opts=""
 	local compargs=""
@@ -1698,6 +1730,7 @@ _nvme_subcmds () {
 			set-dssd-async-event-config get-dssd-async-event-config \
 			get-error-injection set-error-injection \
 			hardware-component-log"
+		[mangoboost]="id-ctrl"
 	)
 
 	# Associative array mapping plugins to corresponding option completions
@@ -1723,6 +1756,7 @@ _nvme_subcmds () {
 		[ymtc]="plugin_ymtc_opts"
 		[inspur]="plugin_inspur_opts"
 		[ocp]="plugin_ocp_opts"
+		[mangoboost]="plugin_mangoboost_opts"
 	)
 
 	# Top level commands

--- a/plugins/mangoboost/mangoboost-nvme.c
+++ b/plugins/mangoboost/mangoboost-nvme.c
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2025 MangoBoost Inc.
+ *
+ * Author: Jonghyeon Kim <jonghyeon.kim@mangoboost.io>
+ */
+
+#include <fcntl.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <inttypes.h>
+
+#include "common.h"
+#include "nvme.h"
+#include "libnvme.h"
+#include "plugin.h"
+
+#define CREATE_CMD
+#include "mangoboost-nvme.h"
+
+struct nvme_vu_id_ctrl_field {
+	__u16		json_rpc_2_0_mjr;
+	__u16		json_rpc_2_0_mnr;
+	__u16		json_rpc_2_0_ter;
+	__u8		reserved0[1018];
+};
+
+static void json_mangoboost_id_ctrl(struct nvme_vu_id_ctrl_field *id,
+		char *json_rpc_2_0_ver, struct json_object *root)
+{
+	json_object_add_value_string(root, "json_rpc_2_0_ver",
+				     json_rpc_2_0_ver);
+}
+
+static void mangoboost_id_ctrl(__u8 *vs, struct json_object *root)
+{
+	struct nvme_vu_id_ctrl_field *id = (struct nvme_vu_id_ctrl_field *)vs;
+	char json_rpc_2_0_ver[16] = { 0 };
+
+	snprintf(json_rpc_2_0_ver, sizeof(json_rpc_2_0_ver), "0x%04x%04x%04x",
+		 le16_to_cpu(id->json_rpc_2_0_mjr),
+		 le16_to_cpu(id->json_rpc_2_0_mnr),
+		 le16_to_cpu(id->json_rpc_2_0_ter));
+
+	if (root) {
+		json_mangoboost_id_ctrl(id, json_rpc_2_0_ver, root);
+		return;
+	}
+
+	printf("json_rpc_2_0_ver : %s\n", json_rpc_2_0_ver);
+}
+
+static int id_ctrl(int argc, char **argv, struct command *cmd,
+		struct plugin *plugin)
+{
+	return __id_ctrl(argc, argv, cmd, plugin, mangoboost_id_ctrl);
+}

--- a/plugins/mangoboost/mangoboost-nvme.h
+++ b/plugins/mangoboost/mangoboost-nvme.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2025 MangoBoost Inc.
+ *
+ * Author: Jonghyeon Kim <jonghyeon.kim@mangoboost.io>
+ */
+
+#undef CMD_INC_FILE
+#define CMD_INC_FILE plugins/mangoboost/mangoboost-nvme
+
+#if !defined(MANGOBOOST_NVME) || defined(CMD_HEADER_MULTI_READ)
+#define MANGOBOOST_NVME
+
+#include "cmd.h"
+
+PLUGIN(NAME("mangoboost", "MangoBoost vendor specific extensions", NVME_VERSION),
+	COMMAND_LIST(
+		ENTRY("id-ctrl", "Send NVMe Identify Controller", id_ctrl)
+	)
+);
+
+#endif
+
+#include "define_cmd.h"

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -10,6 +10,7 @@ sources += [
   'plugins/innogrit/innogrit-nvme.c',
   'plugins/inspur/inspur-nvme.c',
   'plugins/intel/intel-nvme.c',
+  'plugins/mangoboost/mangoboost-nvme.c',
   'plugins/memblaze/memblaze-nvme.c',
   'plugins/micron/micron-nvme.c',
   'plugins/nbft/nbft-plugin.c',


### PR DESCRIPTION
Mango StorageBoost-NTI[1] is supported on MangoBoost-DPU(MB-DPU) and seamlessly integrates with existing systems. With this technology, we accelerate NVMe-oF by offloading full-stack of TCP to DPU hardware.

This patch adds initial vendor specific extension of MangoBoost, which is id-ctrl command of MangoBoost NVMe virtual device.

[1] https://www.mangoboost.io/products/hardware/mango-storageboost-tm-nti