### PR TITLE
nvme: retry commands on EAGAIN and EINTR (v2)

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = 81bd404245823763121278fdd5f01c8177e81218
+revision = 9851832179b622019c90b5b1fa243ccbec2d7477
 
 [provide]
 libnvme = libnvme_dep

--- a/util/meson.build
+++ b/util/meson.build
@@ -6,6 +6,7 @@ sources += [
   'util/crc32.c',
   'util/logging.c',
   'util/mem.c',
+  'util/sighdl.c',
   'util/suffix.c',
   'util/types.c',
   'util/utils.c'

--- a/util/sighdl.c
+++ b/util/sighdl.c
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include <signal.h>
+#include <errno.h>
+
+#include "sighdl.h"
+
+bool nvme_sigint_received;
+
+static void nvme_sigint_handler(int signum)
+{
+	nvme_sigint_received = true;
+}
+
+int nvme_install_sigint_handler(void)
+{
+	struct sigaction act;
+
+	sigemptyset(&act.sa_mask);
+	act.sa_handler = nvme_sigint_handler;
+	act.sa_flags = 0;
+
+	nvme_sigint_received = false;
+	if (sigaction(SIGINT, &act, NULL) == -1)
+		return -errno;
+
+	return 0;
+}

--- a/util/sighdl.h
+++ b/util/sighdl.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef __NVME_SIGHDL
+#define __NVME_SIGHDL
+
+#include <stdbool.h>
+
+extern bool nvme_sigint_received;
+
+int nvme_install_sigint_handler(void);
+
+#endif // __NVME_SIGHDL


### PR DESCRIPTION
The kernel started to return EAGAIN and EINTR. It is quiet likely that this was possible before but it happened not so often. Thus for users of nvme-cli it is a behavior change.

The first attempt was to handle this in libnvme itself. But it turns out we can't just blindly retry. It is necessary to check if the user has pressed Ctrl-C to terminate the program. Adding a signal handler inside the library is a no go. Thus add the retry logic to nvme-cli itself.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/2760 https://github.com/linux-nvme/nvme-cli/issues/2781 https://github.com/linux-nvme/nvme-cli/pull/2775

depends on https://github.com/linux-nvme/libnvme/pull/1010