### PR TITLE
sighdl: include stddef header file

### DIFF
--- a/util/sighdl.c
+++ b/util/sighdl.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include <signal.h>
 #include <errno.h>
+#include <stddef.h>
 
 #include "sighdl.h"
 


### PR DESCRIPTION
The header file required for the muon build on CentOS.