### PR TITLE
build: delete docs=disabled muon build option

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -195,7 +195,6 @@ tools_build_muon() {
 
     CC="${CC}" ninja="${SAMU}" stage1/muon-bootstrap setup    \
         -Dprefix="${TOOLDIR}"                                 \
-        -Ddocs=disabled                                       \
         -Dsamurai=disabled                                    \
         "${TOOLDIR}/build-muon"
     "${SAMU}" -C "${TOOLDIR}/build-muon"


### PR DESCRIPTION
Since currently the error output by the muon build.
  error invalid option: 'docs=disabled'