### PR TITLE
nvme: output copy command success message for json format

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -7601,7 +7601,7 @@ static int copy_cmd(int argc, char **argv, struct command *cmd, struct plugin *p
 	else if (err != 0)
 		nvme_show_status(err);
 	else
-		printf("NVMe Copy: success\n");
+		nvme_show_key_value("NVMe Copy", "success");
 
 	return err;
 }


### PR DESCRIPTION
Use nvme_show_key_value() to output the message as json format.