### PR TITLE
build: make 'clean' target an alias for 'purge'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,12 @@ ${NAME}: ${BUILD-DIR}
 .PHONY: clean
 clean:
 ifneq ("$(wildcard ${BUILD-DIR})","")
-	meson compile --clean -C ${BUILD-DIR}
-endif
-
-.PHONY: purge
-purge:
-ifneq ("$(wildcard ${BUILD-DIR})","")
 	rm -rf ${BUILD-DIR}
 	meson subprojects purge --confirm
 endif
+
+.PHONY: purge
+purge: clean
 
 .PHONY: install
 install: ${NAME}

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-strict: ${NAME}
 
 .PHONY: rpm
 rpm:
-	meson ${BUILD-DIR} \
+	meson setup ${BUILD-DIR} \
 		-Dudevrulesdir=$(shell rpm --eval '%{_udevrulesdir}') \
 		-Dsystemddir=$(shell rpm --eval '%{_unitdir}') \
 		-Ddocs=man -Ddocs-build=true
@@ -63,8 +63,8 @@ rpm:
 
 .PHONY: debug
 debug:
-	meson ${BUILD-DIR} --buildtype=debug
-	ninja -C ${BUILD-DIR}
+	meson setup ${BUILD-DIR} --buildtype=debug
+	meson compile -C ${BUILD-DIR}
 
 .PHONY: static
 static:

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,12 @@ debug:
 
 .PHONY: static
 static:
-	meson ${BUILD-DIR} --buildtype=release \
-		--default-library=static -Dc_link_args="-static" \
+	meson setup ${BUILD-DIR} --buildtype=release \
 		--wrap-mode=forcefallback \
-		-Dlibnvme:tests=false -Dlibnvme:keyutils=disabled
-	ninja -C ${BUILD-DIR}
+		--default-library=static \
+		-Dc_link_args="-static" \
+		-Dlibnvme:keyutils=disabled \
+		-Dlibnvme:liburing=disabled \
+		-Dlibnvme:python=disabled \
+		-Dlibnvme:openssl=disabled
+	meson compile -C ${BUILD-DIR}


### PR DESCRIPTION
Autotools and many handwritten Makefiles only provide a 'clean' target, which typically removes everything. However, the 'clean' target here does not fully do this, leaving some artifacts behind after it is run. This leads to confusion when, after cleaning, the build step still doesn't reflect configuration changes such as newly installed libraries.

Therefore, update the 'clean' target to behave like the 'purge' step.