### PR TITLE
nvme: add support for abort command

### DIFF
--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -124,6 +124,7 @@ COMMAND_LIST(
 	ENTRY("io-mgmt-send", "I/O Management Send", io_mgmt_send)
 	ENTRY("nvme-mi-recv", "Submit a NVMe-MI Receive command, return results", nmi_recv)
 	ENTRY("nvme-mi-send", "Submit a NVMe-MI Send command, return results", nmi_send)
+	ENTRY("abort", "Submit an Abort command ", abort_cmd)
 );
 
 #endif

--- a/nvme-wrap.c
+++ b/nvme-wrap.c
@@ -487,3 +487,8 @@ int nvme_cli_get_log_pull_model_ddc_req(struct nvme_dev *dev, bool rae, __u32 le
 {
 	return do_admin_op(get_log_pull_model_ddc_req, dev, rae, len, log);
 }
+
+int nvme_cli_abort(struct nvme_dev *dev, struct nvme_abort_args *args)
+{
+	return do_admin_args_op(abort, dev, args);
+}

--- a/nvme-wrap.h
+++ b/nvme-wrap.h
@@ -171,4 +171,6 @@ int nvme_cli_get_log_ave_discovery(struct nvme_dev *dev, bool rae, __u32 len,
 
 int nvme_cli_get_log_pull_model_ddc_req(struct nvme_dev *dev, bool rae, __u32 len,
 					struct nvme_pull_model_ddc_req_log *log);
+
+int nvme_cli_abort(struct nvme_dev *dev, struct nvme_abort_args *args);
 #endif /* _NVME_WRAP_H */

--- a/nvme.c
+++ b/nvme.c
@@ -2866,7 +2866,7 @@ static void ns_mgmt_show_status(struct nvme_dev *dev, int err, char *cmd, __u32 
 	} else {
 		nvme_show_status(err);
 		if (!is_ns_mgmt_support(dev))
-			nvme_show_result("NS management and attachment not supported");
+			nvme_show_error("NS management and attachment not supported");
 	}
 
 	nvme_show_finish();


### PR DESCRIPTION
The abort command can be submitted by the admin-passthru command. But better to support by the nvme abort command directly then add.