### PR TITLE
wdc: Fix for vs-smart-add-log wdc plugin command

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1907,14 +1907,13 @@ static __u64 wdc_get_drive_capabilities(nvme_root_t r, struct nvme_dev *dev)
 		case WDC_NVME_SNTMP_DEV_ID:
 			capabilities |= (WDC_DRIVE_CAP_C0_LOG_PAGE |
 				WDC_DRIVE_CAP_C3_LOG_PAGE |
-				WDC_DRIVE_CAP_CA_LOG_PAGE |
 				WDC_DRIVE_CAP_OCP_C4_LOG_PAGE |
 				WDC_DRIVE_CAP_OCP_C5_LOG_PAGE |
 				WDC_DRIVE_CAP_DUI |
 				WDC_DRIVE_CAP_FW_ACTIVATE_HISTORY_C2 |
 				WDC_DRIVE_CAP_VU_FID_CLEAR_PCIE |
 				WDC_DRIVE_CAP_VU_FID_CLEAR_FW_ACT_HISTORY |
-				WDC_DRIVE_CAP_INFO |
+				/* WDC_DRIVE_CAP_INFO |   Currently not supported by FW  */
 				WDC_DRIVE_CAP_CLOUD_SSD_VERSION |
 				WDC_DRIVE_CAP_LOG_PAGE_DIR |
 				WDC_DRIVE_CAP_DRIVE_STATUS |
@@ -7317,6 +7316,7 @@ static int wdc_get_c0_log_page(nvme_root_t r, struct nvme_dev *dev, char *format
 	case WDC_NVME_SN650_DEV_ID_4:
 	case WDC_NVME_SN655_DEV_ID:
 	case WDC_NVME_SN655_DEV_ID_1:
+	case WDC_NVME_SNTMP_DEV_ID:
 		if (uuid_index == 0) {
 			ret = nvme_get_print_ocp_cloud_smart_log(dev,
 					uuid_index,

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.13.0"
+#define WDC_PLUGIN_VERSION   "2.14.0"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
Support for the 0xC0 log page needs to be added for the SNTMP device.
Removed support for parsing the 0xCA log page for
the SNTMP device.
Update the wdc plugin version to 2.14.0
Remove vs-drive-info support for SNTMP