### PR TITLE
wdc: Add support for clear-assert-dump to SNTMP drives

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1913,7 +1913,7 @@ static __u64 wdc_get_drive_capabilities(nvme_root_t r, struct nvme_dev *dev)
 				WDC_DRIVE_CAP_FW_ACTIVATE_HISTORY_C2 |
 				WDC_DRIVE_CAP_VU_FID_CLEAR_PCIE |
 				WDC_DRIVE_CAP_VU_FID_CLEAR_FW_ACT_HISTORY |
-				/* WDC_DRIVE_CAP_INFO |   Currently not supported by FW  */
+				WDC_DRIVE_CAP_CLEAR_ASSERT |
 				WDC_DRIVE_CAP_CLOUD_SSD_VERSION |
 				WDC_DRIVE_CAP_LOG_PAGE_DIR |
 				WDC_DRIVE_CAP_DRIVE_STATUS |

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.14.1"
+#define WDC_PLUGIN_VERSION   "2.14.2"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
Add support for the clear-assert-dump wdc plugin command to SNTMP drives