### PR TITLE
wdc: Fix uuid-index setting for WD 0xC2 log page

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1576,6 +1576,14 @@ static bool wdc_is_sn650_e1l(__u32 device_id)
 		return false;
 }
 
+static bool wdc_is_sn655(__u32 device_id)
+{
+	if (device_id == WDC_NVME_SN655_DEV_ID)
+		return true;
+	else
+		return false;
+}
+
 static bool wdc_is_zn350(__u32 device_id)
 {
 	return (device_id == WDC_NVME_ZN350_DEV_ID ||
@@ -2682,7 +2690,8 @@ static bool get_dev_mgment_data(nvme_root_t r, struct nvme_dev *dev,
 	memset(&uuid_list, 0, sizeof(struct nvme_id_uuid_list));
 	if (wdc_CheckUuidListSupport(dev, &uuid_list)) {
 		uuid_index = nvme_uuid_find(&uuid_list, WDC_UUID);
-		if (uuid_index < 0 && wdc_is_sn640_3(device_id))
+		if (uuid_index < 0 &&
+			(wdc_is_sn640_3(device_id) || wdc_is_sn655(device_id)))
 			uuid_index = nvme_uuid_find(&uuid_list, WDC_UUID_SN640_3);
 
 		if (uuid_index > 0)
@@ -2734,10 +2743,12 @@ static bool get_dev_mgment_cbs_data(nvme_root_t r, struct nvme_dev *dev,
 	memset(&uuid_list, 0, sizeof(struct nvme_id_uuid_list));
 	if (wdc_CheckUuidListSupport(dev, &uuid_list)) {
 		uuid_index = nvme_uuid_find(&uuid_list, WDC_UUID);
-		if (uuid_index < 0 && wdc_is_sn640_3(device_id))
+		if (uuid_index < 0 &&
+			(wdc_is_sn640_3(device_id) || wdc_is_sn655(device_id))) {
 			uuid_index = nvme_uuid_find(&uuid_list, WDC_UUID_SN640_3);
+		}
 
-		if (uuid_index < 0)
+		if (uuid_index > 0)
 			found = get_dev_mgmt_log_page_lid_data(dev, cbs_data, lid,
 							       log_id, uuid_index);
 

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.14.2"
+#define WDC_PLUGIN_VERSION   "2.14.3"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
Determine the current uuid-index value used for the WDC 0xC2 log page.
Update wdc plugin version to 2.14.3