### PR TITLE
nvme: plot eye chart data and hex dumping VS eye data

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -776,9 +776,9 @@ static void stdout_eom_printable_eye(struct nvme_eom_lane_desc *lane)
 	char *eye = (char *)lane->eye_desc;
 	int i, j;
 
-	for (i = 0; i < lane->nrows; i++) {
-		for (j = 0; j < lane->ncols; j++)
-			printf("%c", eye[i * lane->ncols + j]);
+	for (i = 0; i < le16_to_cpu(lane->nrows); i++) {
+		for (j = 0; j < le16_to_cpu(lane->ncols); j++)
+			printf("%c", eye[i * le16_to_cpu(lane->ncols) + j]);
 		printf("\n");
 	}
 }
@@ -790,6 +790,13 @@ static void stdout_phy_rx_eom_descs(struct nvme_phy_rx_eom_log *log)
 
 	for (i = 0; i < log->nd; i++) {
 		struct nvme_eom_lane_desc *desc = p;
+		unsigned char *vsdata = NULL;
+		unsigned int vsdataoffset = 0;
+		uint16_t nrows, ncols, edlen;
+
+		nrows = le16_to_cpu(desc->nrows);
+		ncols = le16_to_cpu(desc->ncols);
+		edlen = le16_to_cpu(desc->edlen);
 
 		printf("Measurement Status: %s\n",
 			desc->mstatus ? "Successful" : "Not Successful");
@@ -799,14 +806,28 @@ static void stdout_phy_rx_eom_descs(struct nvme_phy_rx_eom_log *log)
 		printf("Bottom: %u\n", le16_to_cpu(desc->bottom));
 		printf("Left: %u\n", le16_to_cpu(desc->left));
 		printf("Right: %u\n", le16_to_cpu(desc->right));
-		printf("Number of Rows: %u\n", le16_to_cpu(desc->nrows));
-		printf("Number of Columns: %u\n", le16_to_cpu(desc->ncols));
-		printf("Eye Data Length: %u\n", le16_to_cpu(desc->edlen));
+		printf("Number of Rows: %u\n", nrows);
+		printf("Number of Columns: %u\n", ncols);
+		printf("Eye Data Length: %u\n", desc->edlen);
 
 		if (NVME_EOM_ODP_PEFP(log->odp))
 			stdout_eom_printable_eye(desc);
 
 		/* Eye Data field is vendor specific */
+		if (edlen == 0)
+			continue;
+
+		/* Hex dump Vendor Specific Eye Data */
+		vsdata = malloc(edlen);
+		if (!vsdata)
+			return;
+
+		vsdataoffset = (nrows * ncols) + sizeof(struct nvme_eom_lane_desc);
+		vsdata = (unsigned char *)((unsigned char *)desc + vsdataoffset);
+		printf("Eye Data:\n");
+		d(vsdata, edlen, 16, 1);
+		printf("\n");
+		free(vsdata);
 
 		p += log->dsize;
 	}

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -4,7 +4,9 @@
  *
  * @file: micron-nvme.c
  * @brief: This module contains all the constructs needed for micron nvme-cli plugin.
- * @authors:Chaithanya Shoba <ashoba@micron.com>,
+ * @authors:Hanumanthu H <hanumanthuh@micron.com>
+ *			Chaithanya Shoba <ashoba@micron.com>
+ *			Sivaprasad Gutha <sivaprasadg@micron.com>
  */
 
 #include <stdio.h>

--- a/plugins/micron/micron-nvme.h
+++ b/plugins/micron/micron-nvme.h
@@ -3,7 +3,9 @@
  *
  * @file: micron-nvme.h
  * @brief: This module contains all the constructs needed for micron nvme-cli plugin.
- * @authors:Chaithanya Shoba <ashoba@micron.com>,
+ * @authors:Hanumanthu H <hanumanthuh@micron.com>
+ *			Chaithanya Shoba <ashoba@micron.com>
+ *			Sivaprasad Gutha <sivaprasadg@micron.com>
  */
 
 #undef CMD_INC_FILE


### PR DESCRIPTION
-Fixed segmentation fault issue in JSON output format for VS Eye data
-Added support to hex dump VS Eye data in both normal and JSON formats
-This enables customers to decode the raw eye chart data if needed
-Ensured compatibility with existing d() and obj_d() hex dump utilities
-Addressed all the review comments that are given as part of pull request #2828