### PR TITLE
list-ctrl: limit to JSON and normal output

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2629,7 +2629,7 @@ static int list_ctrl(int argc, char **argv, struct command *cmd, struct plugin *
 		return err;
 
 	err = validate_output_format(nvme_cfg.output_format, &flags);
-	if (err < 0) {
+	if (err < 0 || (flags != JSON && flags != NORMAL)) {
 		nvme_show_error("Invalid output format");
 		return err;
 	}


### PR DESCRIPTION
Binary format is not implemented for list-ctrl, so limit output to normal and json formats only.