### PR TITLE
nvme: add command line argument to disable retries

### DIFF
--- a/logging.c
+++ b/logging.c
@@ -120,8 +120,9 @@ int nvme_submit_passthru(int fd, unsigned long ioctl_cmd,
 	if (!nvme_cfg.dry_run) {
 retry:
 		err = ioctl(fd, ioctl_cmd, cmd);
-		if (err && (errno == EAGAIN ||
-			    (errno == EINTR && !nvme_sigint_received))) {
+		if ((err && (errno == EAGAIN ||
+			     (errno == EINTR && !nvme_sigint_received))) &&
+		    !nvme_cfg.no_retries) {
 			nvme_log_retry(errno);
 			goto retry;
 		}
@@ -153,8 +154,9 @@ int nvme_submit_passthru64(int fd, unsigned long ioctl_cmd,
 	if (!nvme_cfg.dry_run) {
 retry:
 		err = ioctl(fd, ioctl_cmd, cmd);
-		if (err && (errno == EAGAIN ||
-			    (errno == EINTR && !nvme_sigint_received))) {
+		if ((err && (errno == EAGAIN ||
+			     (errno == EINTR && !nvme_sigint_received))) &&
+		    !nvme_cfg.no_retries) {
 			nvme_log_retry(errno);
 			goto retry;
 		}

--- a/nvme.h
+++ b/nvme.h
@@ -79,6 +79,7 @@ struct nvme_config {
 	int verbose;
 	__u32 timeout;
 	bool dry_run;
+	bool no_retries;
 	unsigned int output_format_ver;
 };
 
@@ -93,6 +94,8 @@ struct nvme_config {
 		##__VA_ARGS__,                                                         \
 		OPT_UINT("timeout",      't', &nvme_cfg.timeout,       timeout),       \
 		OPT_FLAG("dry-run",        0, &nvme_cfg.dry_run,       dry_run),       \
+		OPT_FLAG("no-retries",     0, &nvme_cfg.no_retries,                    \
+			 "disable retry logic on errors\n"),                           \
 		OPT_UINT("output-format-version", 0, &nvme_cfg.output_format_ver,      \
 			 "output format version: 1|2"),                                \
 		OPT_END()                                                              \


### PR DESCRIPTION
Allow the user to disable the retry logic. There are use cases in testing where the simple retry logic should not be applied, e.g. sending out admin passthru commands while a reset is issued. The admin passthru commands should just fail in this case.

Fixes #2846