### PR TITLE
wdc: invalid customer ID fix

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1784,10 +1784,11 @@ static __u64 wdc_get_drive_capabilities(nvme_root_t r, struct nvme_dev *dev)
 				capabilities |= WDC_DRIVE_CAP_D0_LOG_PAGE;
 
 			cust_id = wdc_get_fw_cust_id(r, dev);
-			if (cust_id == WDC_INVALID_CUSTOMER_ID) {
-				fprintf(stderr, "%s: ERROR: WDC: invalid customer id\n", __func__);
-				return -1;
-			}
+			/* Can still determine some capabilities in this case, but log an error */
+			if (cust_id == WDC_INVALID_CUSTOMER_ID)
+				fprintf(stderr,
+					"%s: ERROR: WDC: invalid customer ID; device ID = %x\n",
+					__func__, read_device_id);
 
 			if ((cust_id == WDC_CUSTOMER_ID_0x1004) || (cust_id == WDC_CUSTOMER_ID_0x1008) ||
 					(cust_id == WDC_CUSTOMER_ID_0x1005) || (cust_id == WDC_CUSTOMER_ID_0x1304))
@@ -1866,10 +1867,11 @@ static __u64 wdc_get_drive_capabilities(nvme_root_t r, struct nvme_dev *dev)
 					 WDC_DRIVE_CAP_REASON_ID | WDC_DRIVE_CAP_LOG_PAGE_DIR);
 
 			cust_id = wdc_get_fw_cust_id(r, dev);
-			if (cust_id == WDC_INVALID_CUSTOMER_ID) {
-				fprintf(stderr, "%s: ERROR: WDC: invalid customer id\n", __func__);
-				return -1;
-			}
+			/* Can still determine some capabilities in this case, but log an error */
+			if (cust_id == WDC_INVALID_CUSTOMER_ID)
+				fprintf(stderr,
+					"%s: ERROR: WDC: invalid customer ID; device ID = %x\n",
+					__func__, read_device_id);
 
 			if ((cust_id == WDC_CUSTOMER_ID_0x1004) ||
 			    (cust_id == WDC_CUSTOMER_ID_0x1008) ||

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.14.2"
+#define WDC_PLUGIN_VERSION   "2.14.3"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
The return value of this function represents what commands are supported by the target, so returning a -1 here incorrectly enables all capability checks. Instead, this updates the behavior to just log the error and continue to report the actual device capabilities.

Reviewed-by: Jeffrey Lien <jeff.lien@sandisk.com>