### PR TITLE
nvme: add get and set feature commands symbolic names

### DIFF
--- a/Documentation/nvme-get-feature.txt
+++ b/Documentation/nvme-get-feature.txt
@@ -44,6 +44,55 @@ OPTIONS
 --feature-id=<fid>::
 	The feature id to send with the command. Value provided should
 	be in hex.
++
+[]
+|=================
+|Value|Definition
+|0x01 \| 'arbitration'| Arbitration
+|0x02 \| 'power-mgmt'| Power Management
+|0x03 \| 'lba-range'| LBA Range Type
+|0x04 \| 'temp-thresh'| Temperature Threshold
+|0x05 \| 'err-recovery'| Error Recovery
+|0x06 \| 'volatile-wc'| Volatile Write Cache
+|0x07 \| 'num-queues'| Number of Queues
+|0x08 \| 'irq-coalesce'| Interrupt Coalescing
+|0x09 \| 'irq-config'| Interrupt Vector Configuration
+|0x0a \| 'write-atomic'| Write Atomicity Normal
+|0x0b \| 'async-event'| Asynchronous Event Configuration
+|0x0c \| 'auto-pst'| Autonomous Power State Transition
+|0x0d \| 'host-mem-buf'| Host Memory Buffer
+|0x0e \| 'timestamp'| Timestamp
+|0x0f \| 'kato'| Keep Alive Timer
+|0x10 \| 'hctm'| Host Controlled Thermal Management
+|0x11 \| 'nopsc'| Non-Operational Power State Config
+|0x12 \| 'rrl'| Read Recovery Level Config
+|0x13 \| 'plm-config'| Predictable Latency Mode Config
+|0x14 \| 'plm-window'| Predictable Latency Mode Window
+|0x15 \| 'lba-sts-interval'| LBA Status Information Report Interval
+|0x16 \| 'host-behavior'| Host Behavior Support
+|0x17 \| 'sanitize'| Sanitize Config
+|0x18 \| 'endurance-evt-cfg'| Endurance Group Event Configuration
+|0x19 \| 'iocs-profile'| I/O Command Set Profile
+|0x1a \| 'spinup-control'| Spinup Control
+|0x1b \| 'power-loss-signal'| Power Loss Signaling Config
+|0x1c \| 'perf-characteristics'|Performance Characteristics
+|0x1d \| 'fdp'| Flexible Data Placement
+|0x1e \| 'fdp-events'| FDP Events
+|0x1f \| 'ns-admin-label'| Namespace Admin Label
+|0x20 \| 'key-value'| Key Value Configuration
+|0x21 \| 'ctrl-data-queue'| Controller Data Queue
+|0x78 \| 'emb-mgmt-ctrl-addr'| Embedded Management Controller Address
+|0x79 \| 'host-mgmt-agent-addr'|Host Management Agent Address
+|0x7d \| 'enh-ctrl-metadata'| Enhanced Controller Metadata
+|0x7e \| 'ctrl-metadata'| Controller Metadata
+|0x7f \| 'ns-metadata'| Namespace Metadata
+|0x80 \| 'sw-progress'| Software Progress Marker
+|0x81 \| 'host-id'| Host Identifier
+|0x82 \| 'resv-mask'| Reservation Notification Mask
+|0x83 \| 'resv-persist'| Reservation Persistence
+|0x84 \| 'write-protect'| Namespace Write Protection Config
+|0x85 \| 'bp-write-protect'| Boot Partition Write Protection Config
+|=================
 
 -s <select>::
 --sel=<select>::

--- a/Documentation/nvme-set-feature.txt
+++ b/Documentation/nvme-set-feature.txt
@@ -39,6 +39,55 @@ OPTIONS
 --feature-id=<fid>::
 	The feature id to send with the command. Value provided should
 	be in hex.
++
+[]
+|=================
+|Value|Definition
+|0x01 \| 'arbitration'| Arbitration
+|0x02 \| 'power-mgmt'| Power Management
+|0x03 \| 'lba-range'| LBA Range Type
+|0x04 \| 'temp-thresh'| Temperature Threshold
+|0x05 \| 'err-recovery'| Error Recovery
+|0x06 \| 'volatile-wc'| Volatile Write Cache
+|0x07 \| 'num-queues'| Number of Queues
+|0x08 \| 'irq-coalesce'| Interrupt Coalescing
+|0x09 \| 'irq-config'| Interrupt Vector Configuration
+|0x0a \| 'write-atomic'| Write Atomicity Normal
+|0x0b \| 'async-event'| Asynchronous Event Configuration
+|0x0c \| 'auto-pst'| Autonomous Power State Transition
+|0x0d \| 'host-mem-buf'| Host Memory Buffer
+|0x0e \| 'timestamp'| Timestamp
+|0x0f \| 'kato'| Keep Alive Timer
+|0x10 \| 'hctm'| Host Controlled Thermal Management
+|0x11 \| 'nopsc'| Non-Operational Power State Config
+|0x12 \| 'rrl'| Read Recovery Level Config
+|0x13 \| 'plm-config'| Predictable Latency Mode Config
+|0x14 \| 'plm-window'| Predictable Latency Mode Window
+|0x15 \| 'lba-sts-interval'| LBA Status Information Report Interval
+|0x16 \| 'host-behavior'| Host Behavior Support
+|0x17 \| 'sanitize'| Sanitize Config
+|0x18 \| 'endurance-evt-cfg'| Endurance Group Event Configuration
+|0x19 \| 'iocs-profile'| I/O Command Set Profile
+|0x1a \| 'spinup-control'| Spinup Control
+|0x1b \| 'power-loss-signal'| Power Loss Signaling Config
+|0x1c \| 'perf-characteristics'|Performance Characteristics
+|0x1d \| 'fdp'| Flexible Data Placement
+|0x1e \| 'fdp-events'| FDP Events
+|0x1f \| 'ns-admin-label'| Namespace Admin Label
+|0x20 \| 'key-value'| Key Value Configuration
+|0x21 \| 'ctrl-data-queue'| Controller Data Queue
+|0x78 \| 'emb-mgmt-ctrl-addr'| Embedded Management Controller Address
+|0x79 \| 'host-mgmt-agent-addr'|Host Management Agent Address
+|0x7d \| 'enh-ctrl-metadata'| Enhanced Controller Metadata
+|0x7e \| 'ctrl-metadata'| Controller Metadata
+|0x7f \| 'ns-metadata'| Namespace Metadata
+|0x80 \| 'sw-progress'| Software Progress Marker
+|0x81 \| 'host-id'| Host Identifier
+|0x82 \| 'resv-mask'| Reservation Notification Mask
+|0x83 \| 'resv-persist'| Reservation Persistence
+|0x84 \| 'write-protect'| Namespace Write Protection Config
+|0x85 \| 'bp-write-protect'| Boot Partition Write Protection Config
+|=================
 
 -l <data-len>::
 --data-len=<data-len>::

--- a/nvme.c
+++ b/nvme.c
@@ -265,6 +265,54 @@ struct nvme_config nvme_cfg = {
 
 static void *mmap_registers(struct nvme_dev *dev, bool writable);
 
+static OPT_VALS(feature_name) = {
+	VAL_BYTE("arbitration", NVME_FEAT_FID_ARBITRATION),
+	VAL_BYTE("power-mgmt", NVME_FEAT_FID_POWER_MGMT),
+	VAL_BYTE("lba-range", NVME_FEAT_FID_LBA_RANGE),
+	VAL_BYTE("temp-thresh", NVME_FEAT_FID_TEMP_THRESH),
+	VAL_BYTE("err-recovery", NVME_FEAT_FID_ERR_RECOVERY),
+	VAL_BYTE("volatile-wc", NVME_FEAT_FID_VOLATILE_WC),
+	VAL_BYTE("num-queues", NVME_FEAT_FID_NUM_QUEUES),
+	VAL_BYTE("irq-coalesce", NVME_FEAT_FID_IRQ_COALESCE),
+	VAL_BYTE("irq-config", NVME_FEAT_FID_IRQ_CONFIG),
+	VAL_BYTE("write-atomic", NVME_FEAT_FID_WRITE_ATOMIC),
+	VAL_BYTE("async-event", NVME_FEAT_FID_ASYNC_EVENT),
+	VAL_BYTE("auto-pst", NVME_FEAT_FID_AUTO_PST),
+	VAL_BYTE("host-mem-buf", NVME_FEAT_FID_HOST_MEM_BUF),
+	VAL_BYTE("timestamp", NVME_FEAT_FID_TIMESTAMP),
+	VAL_BYTE("kato", NVME_FEAT_FID_KATO),
+	VAL_BYTE("hctm", NVME_FEAT_FID_HCTM),
+	VAL_BYTE("nopsc", NVME_FEAT_FID_NOPSC),
+	VAL_BYTE("rrl", NVME_FEAT_FID_RRL),
+	VAL_BYTE("plm-config", NVME_FEAT_FID_PLM_CONFIG),
+	VAL_BYTE("plm-window", NVME_FEAT_FID_PLM_WINDOW),
+	VAL_BYTE("lba-sts-interval", NVME_FEAT_FID_LBA_STS_INTERVAL),
+	VAL_BYTE("host-behavior", NVME_FEAT_FID_HOST_BEHAVIOR),
+	VAL_BYTE("sanitize", NVME_FEAT_FID_SANITIZE),
+	VAL_BYTE("endurance-evt-cfg", NVME_FEAT_FID_ENDURANCE_EVT_CFG),
+	VAL_BYTE("iocs-profile", NVME_FEAT_FID_IOCS_PROFILE),
+	VAL_BYTE("spinup-control", NVME_FEAT_FID_SPINUP_CONTROL),
+	VAL_BYTE("power-loss-signal", NVME_FEAT_FID_POWER_LOSS_SIGNAL),
+	VAL_BYTE("perf-characteristics", NVME_FEAT_FID_PERF_CHARACTERISTICS),
+	VAL_BYTE("fdp", NVME_FEAT_FID_FDP),
+	VAL_BYTE("fdp-events", NVME_FEAT_FID_FDP_EVENTS),
+	VAL_BYTE("ns-admin-label", NVME_FEAT_FID_NS_ADMIN_LABEL),
+	VAL_BYTE("key-value", NVME_FEAT_FID_KEY_VALUE),
+	VAL_BYTE("ctrl-data-queue", NVME_FEAT_FID_CTRL_DATA_QUEUE),
+	VAL_BYTE("emb-mgmt-ctrl-addr", NVME_FEAT_FID_EMB_MGMT_CTRL_ADDR),
+	VAL_BYTE("host-mgmt-agent-addr", NVME_FEAT_FID_HOST_MGMT_AGENT_ADDR),
+	VAL_BYTE("enh-ctrl-metadata", NVME_FEAT_FID_ENH_CTRL_METADATA),
+	VAL_BYTE("ctrl-metadata", NVME_FEAT_FID_CTRL_METADATA),
+	VAL_BYTE("ns-metadata", NVME_FEAT_FID_NS_METADATA),
+	VAL_BYTE("sw-progress", NVME_FEAT_FID_SW_PROGRESS),
+	VAL_BYTE("host-id", NVME_FEAT_FID_HOST_ID),
+	VAL_BYTE("resv-mask", NVME_FEAT_FID_RESV_MASK),
+	VAL_BYTE("resv-persist", NVME_FEAT_FID_RESV_PERSIST),
+	VAL_BYTE("write-protect", NVME_FEAT_FID_WRITE_PROTECT),
+	VAL_BYTE("bp-write-protect", NVME_FEAT_FID_BP_WRITE_PROTECT),
+	VAL_END()
+};
+
 const char *nvme_strerror(int errnum)
 {
 	if (errnum >= ENVME_CONNECT_RESOLVE)
@@ -4874,7 +4922,7 @@ static int get_feature(int argc, char **argv, struct command *cmd,
 	};
 
 	NVME_ARGS(opts,
-		  OPT_BYTE("feature-id",     'f', &cfg.feature_id,     feature_id),
+		  OPT_BYTE("feature-id",     'f', &cfg.feature_id,     feature_id, feature_name),
 		  OPT_UINT("namespace-id",   'n', &cfg.namespace_id,   namespace_id_desired),
 		  OPT_BYTE("sel",            's', &cfg.sel,            sel),
 		  OPT_UINT("data-len",       'l', &cfg.data_len,       buf_len),
@@ -6658,7 +6706,7 @@ static int set_feature(int argc, char **argv, struct command *cmd, struct plugin
 
 	NVME_ARGS(opts,
 		  OPT_UINT("namespace-id", 'n', &cfg.namespace_id, namespace_desired),
-		  OPT_BYTE("feature-id",   'f', &cfg.feature_id,   feature_id),
+		  OPT_BYTE("feature-id",   'f', &cfg.feature_id,   feature_id, feature_name),
 		  OPT_SUFFIX("value",      'V', &cfg.value,        value),
 		  OPT_UINT("cdw12",        'c', &cfg.cdw12,        cdw12),
 		  OPT_BYTE("uuid-index",   'U', &cfg.uuid_index,   uuid_index_specify),


### PR DESCRIPTION
The feature-id parameter can be set the symbolic names also.