### PR TITLE
udev: Add custom udev rules for HPE Alletra Storage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -267,6 +267,7 @@ udev_files = [
   '65-persistent-net-nbft.rules',
   '70-nvmf-autoconnect.rules',
   '70-nvmf-keys.rules',
+  '71-nvme-hpe.rules',
   '71-nvmf-netapp.rules',
   '71-nvmf-vastdata.rules',
 ]

--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -33,6 +33,7 @@ touch %{buildroot}@SYSCONFDIR@/nvme/hostid
 @UDEVRULESDIR@/65-persistent-net-nbft.rules
 @UDEVRULESDIR@/70-nvmf-autoconnect.rules
 @UDEVRULESDIR@/70-nvmf-keys.rules
+@UDEVRULESDIR@/71-nvmf-hpe.rules
 @UDEVRULESDIR@/71-nvmf-netapp.rules
 @UDEVRULESDIR@/71-nvmf-vastdata.rules
 @DRACUTRILESDIR@/70-nvmf-autoconnect.conf

--- a/nvmf-autoconnect/udev-rules/71-nvme-hpe.rules.in
+++ b/nvmf-autoconnect/udev-rules/71-nvme-hpe.rules.in
@@ -1,0 +1,5 @@
+# Set appropriate iopolicy for HPE Alletra Storage MP
+ACTION=="add", SUBSYSTEM=="nvme-subsystem", ATTR{subsystype}=="nvm", ATTR{model}=="HPE Alletra", ATTR{iopolicy}="round-robin"
+
+# Set ctrl_loss_tmo to -1 for HPE Alletra Storage MP NVMe/TCP
+ACTION!="remove", SUBSYSTEM=="nvme", KERNEL=="nvme*", ATTR{transport}=="tcp", ATTR{model}=="HPE Alletra", ATTR{ctrl_loss_tmo}="-1"


### PR DESCRIPTION
HPE Alletra Storage arrays support NVMe-oF block access.
1. The "round-robin" iopolicy is preferred for performance benefits.
2. Setting ctrl_loss_tmo to -1 for NVMe/TCP controllers enables indefinite reconnect attempts after a path loss, and disables purging of the path on the host.