### PR TITLE
nvme-cli: sanitize free() handling

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2287,8 +2287,7 @@ static void json_phy_rx_eom_log(struct nvme_phy_rx_eom_log *log, __u16 controlle
 	if (allocated_eyes) {
 		for (i = 0; i < log->nd; i++) {
 			/* Free any Printable Eye strings allocated */
-			if (allocated_eyes[i])
-				free(allocated_eyes[i]);
+			free(allocated_eyes[i]);
 		}
 	}
 

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -122,8 +122,7 @@ static void show_memblaze_smart_log_new(struct nvme_memblaze_smart_log *s, unsig
 	__u8 *raw = malloc(RAW_SIZE * sizeof(__u8));
 
 	if (!nm) {
-		if (raw)
-			free(raw);
+		free(raw);
 		return;
 	}
 	if (!raw) {
@@ -320,8 +319,7 @@ static void show_memblaze_smart_log_old(struct nvme_memblaze_smart_log *smart,
 		__u8 *raw = malloc(RAW_SIZE * sizeof(__u8));
 
 		if (!nm) {
-			if (raw)
-				free(raw);
+			free(raw);
 			return;
 		}
 		if (!raw) {

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -2345,8 +2345,7 @@ static int micron_telemetry_log(int fd, __u8 type, __u8 **data,
 		err = nvme_get_log_telemetry_host(fd, 0, bs, buffer);
 	if (err) {
 		fprintf(stderr, "Failed to get telemetry log header for 0x%X\n", type);
-		if (buffer)
-			free(buffer);
+		free(buffer);
 		return err;
 	}
 
@@ -2359,10 +2358,8 @@ static int micron_telemetry_log(int fd, __u8 type, __u8 **data,
 
 	if (!data_area[da]) {
 		fprintf(stderr, "Requested telemetry data for 0x%X is empty\n", type);
-		if (buffer) {
-			free(buffer);
-			buffer = NULL;
-		}
+		free(buffer);
+		buffer = NULL;
 		return -1;
 	}
 
@@ -2384,8 +2381,7 @@ static int micron_telemetry_log(int fd, __u8 type, __u8 **data,
 		*data = buffer;
 	} else {
 		fprintf(stderr, "Failed to get telemetry data for 0x%x\n", type);
-		if (buffer)
-			free(buffer);
+		free(buffer);
 	}
 
 	return err;
@@ -2410,10 +2406,8 @@ static int GetTelemetryData(int fd, const char *dir)
 			sprintf(msg, "telemetry log: 0x%X", tmap[i].log);
 			WriteData(buffer, logSize, dir, tmap[i].file, msg);
 		}
-		if (buffer) {
-			free(buffer);
-			buffer = NULL;
-		}
+		free(buffer);
+		buffer = NULL;
 		logSize = 0;
 	}
 	return err;
@@ -3733,14 +3727,11 @@ static int GetOcpEnhancedTelemetryLog(int fd, const char *dir, int nLogID)
 			}
 		}
 
-		if (pTelemetryBuffer != NULL) {
-			free(pTelemetryBuffer);
-			pTelemetryBuffer = NULL;
-		}
+		free(pTelemetryBuffer);
+		pTelemetryBuffer = NULL;
 	}
 	// free mem of header, all areas
-	if (pTelemetryDataHeader != NULL)
-		free(pTelemetryDataHeader);
+	free(pTelemetryDataHeader);
 
 	return err;
 }
@@ -4102,10 +4093,8 @@ static int micron_internal_logs(int argc, char **argv, struct command *cmd,
 			WriteData(dataBuffer, bSize, strCtrlDirName, aVendorLogs[i].strFileName, msg);
 		}
 
-		if (dataBuffer) {
-			free(dataBuffer);
-			dataBuffer = NULL;
-		}
+		free(dataBuffer);
+		dataBuffer = NULL;
 	}
 
 	err = ZipAndRemoveDir(strMainDirName, cfg.package);

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -246,8 +246,7 @@ static int get_additional_feature(int argc, char **argv, struct command *cmd, st
 	err = nvme_get_features(&args);
 	if (err > 0)
 		nvme_show_status(err);
-	if (buf)
-		free(buf);
+	free(buf);
 	return err;
 }
 
@@ -367,8 +366,7 @@ static int set_additional_feature(int argc, char **argv, struct command *cmd, st
 		nvme_show_status(err);
 
 free:
-	if (buf)
-		free(buf);
+	free(buf);
 	return err;
 }
 

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -118,8 +118,7 @@ static int nvme_get_sct_status(int fd, __u32 device_mask)
 		}
 	}
 end:
-	if (data)
-		free(data);
+	free(data);
 	return err;
 }
 
@@ -321,8 +320,7 @@ static int nvme_get_internal_log(int fd, const char *const filename, bool curren
 end:
 	if (o_fd >= 0)
 		close(o_fd);
-	if (page_data)
-		free(page_data);
+	free(page_data);
 	return err;
 }
 
@@ -416,8 +414,7 @@ static int nvme_get_vendor_log(struct nvme_dev *dev, __u32 namespace_id,
 			d(log, log_len, 16, 1);
 	}
 end:
-	if (log)
-		free(log);
+	free(log);
 	return err;
 }
 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -7301,8 +7301,7 @@ static int wdc_get_c0_log_page(nvme_root_t r, struct nvme_dev *dev, char *format
 			ret = -1;
 		}
 
-		if (data)
-			free(data);
+		free(data);
 		break;
 	default:
 		fprintf(stderr, "ERROR: WDC: Unknown device id - 0x%x\n", device_id);
@@ -8590,8 +8589,7 @@ static int wdc_vs_cloud_log(int argc, char **argv, struct command *command,
 		ret = -1;
 	}
 
-	if (data)
-		free(data);
+	free(data);
 
 out:
 	nvme_free_tree(r);
@@ -8674,8 +8672,7 @@ static int wdc_vs_hw_rev_log(int argc, char **argv, struct command *command,
 	}
 
 free_buf:
-	if (data)
-		free(data);
+	free(data);
 
 out:
 	nvme_free_tree(r);
@@ -8758,8 +8755,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *command,
 		phys_media_units_written_tlc = int128_to_double(ext_smart_log_ptr->ext_smart_pmuwt);
 		phys_media_units_written_slc = int128_to_double(ext_smart_log_ptr->ext_smart_pmuws);
 
-		if (data)
-			free(data);
+		free(data);
 	} else {
 		fprintf(stderr, "ERROR: WDC %s: get smart cloud log failure\n", __func__);
 		ret = -1;
@@ -9896,8 +9892,7 @@ static int wdc_fetch_log_directory(struct nvme_dev *dev, struct WDC_DE_VU_LOG_DI
 	directory->numOfValidLogEntries = entryId;
 
 end:
-	if (fileDirectory)
-		free(fileDirectory);
+	free(fileDirectory);
 	return ret;
 }
 
@@ -10043,8 +10038,7 @@ static int wdc_de_get_dump_trace(struct nvme_dev *dev, const char *filePath, __u
 			ret);
 	}
 
-	if (readBuffer)
-		free(readBuffer);
+	free(readBuffer);
 
 	return ret;
 }
@@ -11533,8 +11527,7 @@ static int wdc_do_vs_nand_stats_sn810_2(struct nvme_dev *dev, char *format)
 	}
 
 out:
-	if (data)
-		free(data);
+	free(data);
 	return ret;
 }
 
@@ -12313,8 +12306,7 @@ static int wdc_cloud_boot_SSD_version(int argc, char **argv, struct command *com
 			ret = -1;
 		}
 
-		if (data)
-			free(data);
+		free(data);
 	} else {
 		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
 	}

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -32,8 +32,7 @@ static int show_ymtc_smart_log(struct nvme_dev *dev, __u32 nsid,
 	u8 *raw = malloc(RAW_SIZE * sizeof(u8));
 
 	if (!nm) {
-		if (raw)
-			free(raw);
+		free(raw);
 		return -1;
 	}
 	if (!raw) {


### PR DESCRIPTION
As per the POSIX manual, free() is NULL-safe i.e. we could call it without first checking whether the respective pointer is non-NULL. So apply that here.

Suggested-by: Martin Belanger <martin.belanger@dell.com>