### PR TITLE
Add support for retrieving data area 4

### DIFF
--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -41,6 +41,11 @@ static int sndk_do_cap_telemetry_log(struct nvme_dev *dev, const char *file,
 	struct nvme_id_ctrl ctrl;
 	__u64 capabilities = 0;
 	nvme_root_t r;
+	bool host_behavior_changed = false;
+	struct nvme_feat_host_behavior prev = {0};
+	__u32 result;
+
+
 
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	err = nvme_identify_ctrl(dev_fd(dev), &ctrl);
@@ -60,6 +65,23 @@ static int sndk_do_cap_telemetry_log(struct nvme_dev *dev, const char *file,
 	if (type == SNDK_TELEMETRY_TYPE_HOST) {
 		host_gen = 1;
 		ctrl_init = 0;
+
+		if (data_area == 4) {
+			if (!(ctrl.lpa & 0x40)) {
+				fprintf(stderr, "Telemetry data area 4 not supported by device\n");
+				return -EINVAL;
+			}
+
+			int err = nvme_get_features_host_behavior(dev_fd(dev), 0, &prev, &result);
+
+			if (!err && !prev.etdas) {
+				struct nvme_feat_host_behavior da4_enable = prev;
+
+				da4_enable.etdas = 1;
+				nvme_set_features_host_behavior(dev_fd(dev), 0, &da4_enable);
+				host_behavior_changed = true;
+			}
+		}
 	} else if (type == SNDK_TELEMETRY_TYPE_CONTROLLER) {
 		if (capabilities & SNDK_DRIVE_CAP_INTERNAL_LOG) {
 			err = sndk_check_ctrl_telemetry_option_disabled(dev);
@@ -134,6 +156,9 @@ static int sndk_do_cap_telemetry_log(struct nvme_dev *dev, const char *file,
 		fprintf(stderr, "ERROR: %s: fsync: %s\n", __func__, strerror(errno));
 		err = -1;
 	}
+
+	if (host_behavior_changed)
+		nvme_set_features_host_behavior(dev_fd(dev), 0, &prev);
 
 	free(log);
 close_output:

--- a/plugins/sandisk/sandisk-nvme.h
+++ b/plugins/sandisk/sandisk-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(SANDISK_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define SANDISK_NVME
 
-#define SANDISK_PLUGIN_VERSION   "3.0.1"
+#define SANDISK_PLUGIN_VERSION   "3.0.2"
 #include "cmd.h"
 
 PLUGIN(NAME("sndk", "Sandisk vendor specific extensions", SANDISK_PLUGIN_VERSION),


### PR DESCRIPTION
 This change will check if data area 4 is supported and set the etdas bit in feature id 0x16 if supported.
