### PR TITLE
nvme: Fix get-feature on big-endian systems

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -72,9 +72,9 @@
 #include "malloc.h"
 
 struct feat_cfg {
-	enum nvme_features_id feature_id;
+	__u8 feature_id;   /* enum nvme_features_id */
+	__u8 sel;          /* enum nvme_get_features_sel */
 	__u32 namespace_id;
-	enum nvme_get_features_sel sel;
 	__u32 cdw11;
 	__u32 cdw12;
 	__u8 uuid_index;


### PR DESCRIPTION
The `parse_and_open()` function uses `OPT_BYTE` to parse the feature_id and sel options. This means it writes a single byte to the memory locations for `feature_id` and `sel` in the `feat_cfg` struct.

However, these fields were declared as `enum`, which typically has the size of an `int`. On big-endian architectures, writing a single byte to the address of an `int` modifies the most significant byte, resulting in an incorrect value being read. This caused the `get-feature` command to fail. The command only worked on little-endian systems.

Fix the issue by changing the type for `feature_id` and `sel` to `__u8`. This ensures the fields are treated as single bytes, guaranteeing correct behavior on all architectures.