### PR TITLE
nvme: Enable retrieving telemetry log data area 4

### DIFF
--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = a6497f6e8cb3bc3607e4a772b648a7887b0ab875
+revision = fde6b1f51646f7f0b4a12f61f08e2bb621f01903
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
When retrieving telemetry log data area 4, the etdas bit in the host behavior changed feature must be set. This commit will change the code to use new functions added to libnvme to set and clear that bit before and after retrieving data area 4.