### PR TITLE
sndk: Use libnvme functions to set/clear etdas bit

### DIFF
--- a/plugins/sandisk/sandisk-nvme.h
+++ b/plugins/sandisk/sandisk-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(SANDISK_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define SANDISK_NVME
 
-#define SANDISK_PLUGIN_VERSION   "3.0.3"
+#define SANDISK_PLUGIN_VERSION   "3.0.4"
 #include "cmd.h"
 
 PLUGIN(NAME("sndk", "Sandisk vendor specific extensions", SANDISK_PLUGIN_VERSION),


### PR DESCRIPTION
To get telemetry log da4, the code needs to set the etdas bit.  The bit will be restored after the log has been retrieved.

Signed-off-by: jeff-lien-sndk <jeff.lien@sandisk.com>

Reviewed-by: brandon-paupore-sndk <brandon.paupore@sandisk.com>