### PR TITLE
nvme: add --compat flag for 'gen-tls-key' and 'check-tls-key'

### DIFF
--- a/Documentation/nvme-check-tls-key.txt
+++ b/Documentation/nvme-check-tls-key.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 			[--output-format=<fmt> | -o <fmt>]
 			[--identity=<id-vers> | -I <id-vers>]
 			[--insert | -i ]
+			[--compat | -C ]
 			[--keyfile=<keyfile> | -f <keyfile>]
 			[--verbose | -v]
 
@@ -61,6 +62,11 @@ OPTIONS
 -i:
 --insert:
 	Insert the derived 'retained' key in the keyring.
+
+-C:
+--compat:
+	Use the original algorithm when deriving TLS keys for
+	compatibility with older implentations.
 
 -f <keyfile>
 --keyfile=<keyfile>

--- a/Documentation/nvme-gen-tls-key.txt
+++ b/Documentation/nvme-gen-tls-key.txt
@@ -16,6 +16,7 @@ SYNOPSIS
 			[--identity=<id-vers> | -I <id-vers>]
 			[--secret=<secret> | -s <secret>]
 			[--insert | -i]
+			[--compat | -C]
 			[--keyfile=<keyfile> | -f <keyfile>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
 
@@ -27,7 +28,8 @@ The resulting key is either printed in the PSK interchange format
 'retained' key into the specified keyring if the '--insert' option
 is given.
 When the PSK should be inserted into the keyring a 'retained' key
-is derived from the secret key material. The resulting 'retained'
+is derived from the secret key material using the HKDF-Expand-Label
+algorithm from RFC 8446. The resulting 'retained'
 key is stored with the identity
 'NVMe0R0<hmac> <host NQN> <subsystem NQN>'
 (for identity version '0') or
@@ -81,6 +83,11 @@ OPTIONS
 --insert::
 	Insert the resulting TLS key into the keyring without printing out
 	the key in PSK interchange format.
+
+-C:
+--compat:
+	Use the original non-RFC 8446 compliant algorithm when
+	deriving TLS keys for compatibility with older implentations.
 
 -f <keyfile>
 --keyfile=<keyfile>

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/linux-nvme/libnvme.git
-revision = fde6b1f51646f7f0b4a12f61f08e2bb621f01903
+revision = c2a699342fb45cbac99a8f400695bd74f8782342
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
Add a '--compat' flag for 'gen-tls-key' and 'check-tls-key' to allow interoperability with older implementations.