### PR TITLE
Enable data area 4 internal-log ocp plugin command

### DIFF
--- a/Documentation/nvme-ocp-internal-log.txt
+++ b/Documentation/nvme-ocp-internal-log.txt
@@ -14,8 +14,8 @@ SYNOPSIS
 'nvme ocp internal-log' <device>
 			[--telemetry-log=<file> | -l <file>]
 			[--string-log=<file> | -s <file>]
-			[--output-file=<file> | -o <file>]
-			[--output-format=<fmt> | -f <fmt>]
+			[--output-file=<file> | -f <file>]
+			[--output-format=<fmt> | -o <fmt>]
 			[--data-area=<da> | -a <da>]
 			[--telemetry-type=<type> | -t <type>]
 
@@ -48,19 +48,20 @@ OPTIONS
 	is specified, a live retrieval of payload on <device> will be
 	performed.
 
--o <file>::
+-f <file>::
 --output-file=<file>::
-	Filepath name to where human-readable output data will be saved to.
+	Filepath name used as the prefix for the telemetry and string log bin files
+	along with the human-readable parsed output file.
 
--f <fmt>::
+-o <fmt>::
 --output-format=<fmt>::
 	Set the reporting format to 'normal', 'json'. Only one output format can be
 	used at a time, the default value is 'json'.
 
 -a <da>::
 --data-area=<da>::
-	Retrieves the specific data area requested. Valid inputs are 1,2. If this
-	option is not specified, the default value is 1.
+	Retrieves the specific data area requested. Valid inputs are 1, 2, 3, or 4.
+	If this option is not specified, the default value is 1.
 
 -t <type>::
 --telemetry-type=<type>::

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -11,7 +11,7 @@
 #if !defined(OCP_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define OCP_NVME
 
-#define OCP_PLUGIN_VERSION   "2.15.2"
+#define OCP_PLUGIN_VERSION   "2.15.3"
 #include "cmd.h"
 
 PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),

--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1522,9 +1522,11 @@ int parse_statistics(struct json_object *root, struct nvme_ocp_telemetry_offsets
 int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 {
 	int status = 0;
+	char file_path[PATH_MAX];
 
 	if (options->output_file != NULL) {
-		FILE *fp = fopen(options->output_file, "w");
+		sprintf(file_path, "%s.%s", options->output_file, "txt");
+		FILE *fp = fopen(file_path, "w");
 
 		if (fp) {
 			fprintf(fp, STR_LINE);
@@ -1639,7 +1641,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			fprintf(fp, STR_LINE);
 			fclose(fp);
 		} else {
-			nvme_show_error("Failed to open %s file.\n", options->output_file);
+			nvme_show_error("Failed to open %s file.\n", file_path);
 			return -1;
 		}
 	} else {
@@ -1753,6 +1755,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 int print_ocp_telemetry_json(struct ocp_telemetry_parse_options *options)
 {
 	int status = 0;
+	char file_path[PATH_MAX];
 
 	//create json objects
 	struct json_object *root, *pheader, *preason_identifier, *da1_header, *smart_obj,
@@ -1848,13 +1851,14 @@ int print_ocp_telemetry_json(struct ocp_telemetry_parse_options *options)
 
 	if (options->output_file != NULL) {
 		const char *json_string = json_object_to_json_string(root);
-		FILE *fp = fopen(options->output_file, "w");
+		sprintf(file_path, "%s.%s", options->output_file, "json");
+		FILE *fp = fopen(file_path, "w");
 
 		if (fp) {
 			fputs(json_string, fp);
 			fclose(fp);
 		} else {
-			nvme_show_error("Failed to open %s file.\n", options->output_file);
+			nvme_show_error("Failed to open %s file.\n", file_path);
 			return -1;
 		}
 	} else {

--- a/plugins/ocp/ocp-telemetry-decode.h
+++ b/plugins/ocp/ocp-telemetry-decode.h
@@ -604,7 +604,7 @@ struct telemetry_data_area_1 {
 #define DEFAULT_ASCII_STRING_SIZE     16
 #define SIZE_OF_VU_EVENT_ID           2
 
-#define DEFAULT_TELEMETRY_BIN "telemetry.bin"
+#define DEFAULT_TELEMETRY_LOG "telemetry-log"
 #define DEFAULT_STRING_BIN "string.bin"
 #define DEFAULT_OUTPUT_FORMAT_JSON "json"
 


### PR DESCRIPTION
The current ocp internal-log command will only retrieve up to data area 3.  This change will enable retrieving of all 4 telemetry log data areas.

It will also refactor the code used to save off the 2 files collected:  telemetry log and string log along with the 1 generated file:  the parsed da 1 and 2 data.

Swap -o and -f on output-format and output-file parameters.
