### PR TITLE
ocp: Update completions for ocp internal-log and telemetry-string-log

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -194,16 +194,16 @@ _nvme () {
 				/dev/nvme':supply a device to use (required)'
 				--telemetry-type=':Telemetry Type; host, host0, host1 or controller generated'
 				-t':alias for --telemetry-type'
-				--data-area=':Telemetry Data Area; 1 or 2'
+				--data-area=':Telemetry Data Area; 1, 2, 3, or 4'
 				-a':alias for --data-area'
 				--output-file=':Output file name with path'
-				-o':alias for --output-file'
+				-f':alias for --output-file'
 				--telemetry-log=':Telemetry log binary'
 				-l':alias for --telemetry-log'
 				--string-log=':String log binary'
 				-s':alias for --string-log'
 				--output-format':Output format: normal|json'
-				-f':alias for --output-format'
+				-o':alias for --output-format'
 				)
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp internal-log options" _internal_log
@@ -296,8 +296,10 @@ _nvme () {
 				local _telemetry_string_log
 				_telemetry_string_log=(
 				/dev/nvme':supply a device to use (required)'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
 				--output-file=':Output file name with path'
-				-o':alias for --output-file'
+				-f':alias for --output-file'
 				)
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp telemetry-string-log options" _telemetry_string_log

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1598,7 +1598,7 @@ plugin_ocp_opts () {
 			;;
 		"internal-log")
 		opts+=" --telemetry-log= -l --string-log= -s \
-			--output-file= -o --output-format= -f \
+			--output-file= -f --output-format= -o \
 			--data-area= -a --telemetry-type= -t"
 			;;
 		"clear-fw-activate-history")
@@ -1623,7 +1623,7 @@ plugin_ocp_opts () {
 		opts+=" --sel= -S --all -a --no-uuid -n"
 			;;
 		"telemetry-string-log")
-		opts+=" --output-file= -o"
+		opts+=" --output-file= -f --output-format= -o"
 			;;
 		"set-telemetry-profile")
 		opts+=" --telemetry-profile-select= -t"


### PR DESCRIPTION
 Update the output-format and output-file parameters to match changes made with these commits: e8b8c7f and 60733d8.
