### PR TITLE
plugins/ocp: Add --all-ns option to command set-error-injection.

### DIFF
--- a/Documentation/nvme-ocp-set-error-injection.txt
+++ b/Documentation/nvme-ocp-set-error-injection.txt
@@ -10,9 +10,8 @@ SYNOPSIS
 [verse]
 'nvme ocp set-error-injection' <device> [--data=<file> | -d <file>]
 			[--number=<num> | -n <num>] [--no-uuid | -N]
-			[--type=<type> | -t <type>] [--nrtdp=<num> | -r <num>]
-			[--verbose | -v] [--output-format=<fmt> | -o <fmt>]
-			[--timeout=<timeout>]
+			[--all-ns | -a] [--type=<type> | -t <type>]
+			[--nrtdp=<num> | -r <num>] [--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -40,22 +39,17 @@ OPTIONS
 	Do not try to automatically detect UUID index for this command (required
 	for old OCP 1.0 support)
 
+-a::
+--all-ns::
+	Apply to all namespaces
+
 -t <type>::
 --type=<type>::
-	Error injection type
+	Error injection type (1-22: see NOTES section for valid types)
 
 -r <num>::
 --nrtdp=<num>::
 	Number of reads to trigger device panic
-
--v::
---verbose::
-	Increase the information detail in the output.
-
--o <fmt>::
---output-format=<fmt>::
-	Set the reporting format to 'normal', 'json' or 'binary'. Only one
-	output format can be used at a time.
 
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
@@ -73,6 +67,38 @@ EXAMPLES
 ------------
 # nvme ocp set-error-injection /dev/nvme0 -t 2 -r 5
 ------------
+
+* Has the program issue a set-error-injection for all namespaces with type 1.
++
+------------
+# nvme ocp set-error-injection /dev/nvme0 -a -t 1
+------------
+
+NOTES
+-----
+Valid error injection types:
+1 - CPU/controller hang
+2 - NAND hang
+3 - PLP defect
+4 - Logical firmware error
+5 - DRAM corruption critical path
+6 - DRAM corruption non-critical path
+7 - NAND corruption
+8 - SRAM corruption
+9 - HW malfunction
+10 - No more NAND spares available
+11 - Incomplete shutdown
+12 - Metadata corruption
+13 - Critical garbage collection
+14 - Latency spike
+15 - I/O command failure
+16 - I/O command timeout
+17 - Admin command failure
+18 - Admin command timeout
+19 - Thermal throttle engaged
+20 - Thermal throttle disengaged
+21 - Critical temperature event
+22 - Die offline
 
 NVME
 ----


### PR DESCRIPTION
Different spec versions ask for different valid nsid values.