### PR TITLE
fabrics: set persistent when connecting to a discovery controller

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1120,6 +1120,16 @@ do_connect:
 
 	nvme_parse_tls_args(keyring, tls_key, tls_key_identity, &cfg, c);
 
+	/*
+	 * We are connecting to a discovery controller, so let's treat
+	 * this as a persistent connection and specify a KATO.
+	 */
+	if (!strcmp(subsysnqn, NVME_DISC_SUBSYS_NAME)) {
+		persistent = true;
+
+		set_discovery_kato(&cfg);
+	}
+
 	ret = nvme_add_ctrl(h, c, &cfg);
 	if (ret) {
 		fprintf(stderr, "could not add new controller: %s\n",


### PR DESCRIPTION
Currently a user can use the `nvme discover` to connect to a discovery controller. This then allows the user to use a --persistent argument to maintain a persistent or not. This correctly sets a KATO and works as expected.

A user can also perform `nvme connect` to connect to a discovery controller. In this case a KATO is not specified to the kernel (KATO of 0) yet we are actually creating a persistent connection. This results in the nvme target constantly generating keep-alive timeouts as a Linux target sets a KATO of 120 seconds (as allowed by the spec) yet we have no keep-alive timer running for the persistent connection.

This patch checks if we are connecting to a discovery controller and if we are sets the persistent option to true. We know it's a persistent connection because we are using `nvme connect` so we want to stay connected.

This fixes an issue where performing a
`nvme connect -n nqn.2014-08.org.nvmexpress.discovery ... ` to a Linux NVMe target would result in constant keep-alive timeouts from the target.