### PR TITLE
CI: allow manual workflow dispatches to run

### DIFF
--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   nightly-tests:
-    if: github.repository == 'linux-nvme/nvme-cli'
+    if: ${{ github.event_name == 'workflow_dispatch' || github.repository == 'linux-nvme/nvme-cli' }}
     runs-on: arc-vm-nvme-cli
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Allow running the nightly tests on manual workflow dispatches regardless of the repository. This allows us to start the job on forks that have the correct runner scale set deployed.

We want to do testing on https://github.com/nvme-experiments/nvme-cli after rebasing on this change.