### PR TITLE
wdc: Fix SN861 capabilities in NVME-OF cases

### DIFF
--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.14.5"
+#define WDC_PLUGIN_VERSION   "2.14.6"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
In NVMe over Fabric cases, the pci device id is not available to use for identifying a drive.  Therefore, other fields from the Wd  C2 log page are used instead.

Signed-off-by: jeff-lien-sndk <jeff.lien@sandisk.com>

Reviewed-by: brandon-paupore-sndk <brandon.paupore@sandisk.com>