### PR TITLE
sndk: Add plugin command support for SN-861

### DIFF
--- a/plugins/sandisk/sandisk-nvme.h
+++ b/plugins/sandisk/sandisk-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(SANDISK_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define SANDISK_NVME
 
-#define SANDISK_PLUGIN_VERSION   "3.0.7"
+#define SANDISK_PLUGIN_VERSION   "3.0.8"
 #include "cmd.h"
 
 PLUGIN(NAME("sndk", "Sandisk vendor specific extensions", SANDISK_PLUGIN_VERSION),

--- a/plugins/sandisk/sandisk-utils.c
+++ b/plugins/sandisk/sandisk-utils.c
@@ -737,7 +737,6 @@ __u64 sndk_get_enc_drive_capabilities(nvme_root_t r,
 				(void *)&drive_form_factor))
 			fprintf(stderr, "ERROR: SNDK: Getting Form Factor Failed\n");
 
-
 		/* verify the 0xC3 log page is supported */
 		if (run_wdc_nvme_check_supported_log_page(r, dev,
 			SNDK_LATENCY_MON_LOG_ID, 0))
@@ -772,6 +771,11 @@ __u64 sndk_get_enc_drive_capabilities(nvme_root_t r,
 			capabilities |= (SNDK_DRIVE_CAP_FW_ACTIVATE_HISTORY_C2 |
 					SNDK_DRIVE_CAP_VU_FID_CLEAR_FW_ACT_HISTORY |
 					SNDK_DRIVE_CAP_VU_FID_CLEAR_PCIE);
+
+			/* verify the 0xC0 log page is supported */
+			if (run_wdc_nvme_check_supported_log_page(r, dev,
+				SNDK_LATENCY_MON_LOG_ID, 0))
+				capabilities |= SNDK_DRIVE_CAP_C0_LOG_PAGE;
 
 			if ((drive_form_factor == SNDK_C2_FORM_FACTOR_SFF_U2) ||
 				(drive_form_factor == SNDK_C2_FORM_FACTOR_EDSFF_E3S))


### PR DESCRIPTION
These commit will add support for the vs-smart-add-log sandisk plugin command to the SN-861 drive when in a nvme over fabric attached case.