### PR TITLE
plugins/sandisk: update calling arguments

### DIFF
--- a/plugins/sandisk/sandisk-utils.c
+++ b/plugins/sandisk/sandisk-utils.c
@@ -754,7 +754,7 @@ __u64 sndk_get_enc_drive_capabilities(struct nvme_global_ctx *ctx,
 					SNDK_DRIVE_CAP_VU_FID_CLEAR_PCIE);
 
 			/* verify the 0xC0 log page is supported */
-			if (run_wdc_nvme_check_supported_log_page(r, dev,
+			if (run_wdc_nvme_check_supported_log_page(ctx, hdl,
 				SNDK_LATENCY_MON_LOG_ID, 0))
 				capabilities |= SNDK_DRIVE_CAP_C0_LOG_PAGE;
 


### PR DESCRIPTION
The last commit was build against the old head which didn't have the new API. Update the run_wdc_nvme_check_supported_log_page call.

Fixes: 1d82b3dfd27a ("sndk: Add plugin command support for SN-861")