### PR TITLE
nvme: fix virtual_mgmt cntlid parsing order

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4358,7 +4358,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *acmd, struct plug
 	};
 
 	NVME_ARGS(opts,
-		  OPT_UINT("cntlid", 'c', &cfg.cntlid, cntlid),
+		  OPT_SHRT("cntlid", 'c', &cfg.cntlid, cntlid),
 		  OPT_BYTE("rt",     'r', &cfg.rt,     rt),
 		  OPT_BYTE("act",    'a', &cfg.act,    act),
 		  OPT_SHRT("nr",     'n', &cfg.nr,     nr));


### PR DESCRIPTION
`cntlid` is declared as u16 but parsed as u32, overwriting the rt and act field after it. Currently we can only specify cntlid before rt and act. We remove this restriction now.