### PR TITLE
ioctl: fix dms command

### DIFF
--- a/libnvme/src/nvme/ioctl.h
+++ b/libnvme/src/nvme/ioctl.h
@@ -4393,9 +4393,9 @@ static inline int nvme_flush(struct nvme_transport_handle *hdl, __u32 nsid)
  * @cmd:	Passthru command to use
  * @nsid:	Namespace identifier
  * @nr:		Number of block ranges in the data set management attributes
- * @idr:	DSM Deallocate attribute
- * @idw:	DSM Integral Dataset for Read attribute
- * @ad:		DSM Integral Dataset for Read attribute
+ * @idr:	DSM Integral Dataset for Read attribute
+ * @idw:	DSM Integral Dataset for Write attribute
+ * @ad:		DSM Deallocate attribute
  * @data:	User space destination address to transfer the data
  * @len:	Length of provided user buffer to hold the log data in bytes
  */
@@ -4410,7 +4410,7 @@ nvme_init_dsm(struct nvme_passthru_cmd *cmd,
 	cmd->nsid	= nsid;
 	cmd->data_len	= len;
 	cmd->addr	= (__u64)(uintptr_t)data;
-	cmd->cdw10 = NVME_FIELD_ENCODE(nr,
+	cmd->cdw10 = NVME_FIELD_ENCODE(nr - 1,
 			NVME_DSM_CDW10_NR_SHIFT,
 			NVME_DSM_CDW10_NR_MASK);
 	cmd->cdw11 = NVME_FIELD_ENCODE(idr,

--- a/libnvme/test/ioctl/misc.c
+++ b/libnvme/test/ioctl/misc.c
@@ -989,7 +989,7 @@ static void test_dsm(void)
 
 	arbitrary(dsm, dsm_size);
 	set_mock_io_cmds(&mock_io_cmd, 1);
-	nvme_init_dsm(&cmd, TEST_NSID, nr_ranges - 1, 0, 0, 1, dsm, dsm_size);
+	nvme_init_dsm(&cmd, TEST_NSID, nr_ranges, 0, 0, 1, dsm, dsm_size);
 	err = nvme_submit_io_passthru(test_hdl, &cmd, &result);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);


### PR DESCRIPTION
The DSM ranges data struct needs to be initialized. The rework dropped this part. Also the number of ranges for CDW10 is a 0's value (sic).

Fixes: 6c991dce76d4 ("src: rework nvme_dsm command")
Fixes: #https://github.com/nvme-experiments/nvme-cli/issues/97