### PR TITLE
nvme: use io passthru for write_uncor

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -7067,7 +7067,7 @@ static int write_uncor(int argc, char **argv, struct command *acmd, struct plugi
 
 	nvme_init_write_uncorrectable(&cmd, cfg.namespace_id, cfg.start_block,
 		cfg.block_count, cfg.dtype << 4, cfg.dspec);
-	err = nvme_submit_admin_passthru(hdl, &cmd, NULL);
+	err = nvme_submit_io_passthru(hdl, &cmd, NULL);
 	if (err < 0)
 		nvme_show_error("write uncorrectable: %s", nvme_strerror(err));
 	else if (err != 0)


### PR DESCRIPTION
The Write Uncorrectable command is part of the IO commands, thus use the nvme_submit_io_passthru interface instead of the admin one.

Fixes: 927398903d9c ("nvme: rework nvme_io command")
Fixes: https://github.com/nvme-experiments/nvme-cli/issues/96