### PR TITLE
fabrics: interpret return code from nvme_create_ctrl correctly

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1041,7 +1041,7 @@ int nvmf_connect_disc_entry(nvme_host_t h,
 
 	ret = nvme_create_ctrl(h->ctx, e->subnqn, transport, traddr,
 			       cfg->host_traddr, cfg->host_iface, trsvcid, &c);
-	if (!ret) {
+	if (ret) {
 		nvme_msg(h->ctx, LOG_DEBUG, "skipping discovery entry, "
 			 "failed to allocate %s controller with traddr %s\n",
 			 transport, traddr);


### PR DESCRIPTION
When changing how the return code handling is done, nvmf_connect_disc_entry was not correctly updated. When all is good there is no error code return.

Fixes: f4c6eee2939d ("rrc: return error codes directly")
Fixes: #https://github.com/linux-nvme/nvme-cli/issues/2969