### PR TITLE
libnvme: Rename NVME_LOG_*_DISCOVER to NVME_LOG_*_DISCOVERY

### DIFF
--- a/libnvme/examples/discover-loop.py
+++ b/libnvme/examples/discover-loop.py
@@ -31,11 +31,11 @@ def discover(host, ctrl, iteration):
 
     slp = ctrl.supported_log_pages()
     try:
-        dlp_supp_opts = slp[nvme.NVME_LOG_LID_DISCOVER] >> 16
+        dlp_supp_opts = slp[nvme.NVME_LOG_LID_DISCOVERY] >> 16
     except (TypeError, IndexError):
         dlp_supp_opts = 0
 
-    print(f"LID {nvme.NVME_LOG_LID_DISCOVER}h (Discovery), supports: {disc_supp_str(dlp_supp_opts)}")
+    print(f"LID {nvme.NVME_LOG_LID_DISCOVERY}h (Discovery), supports: {disc_supp_str(dlp_supp_opts)}")
 
     try:
         lsp = nvme.NVMF_LOG_DISC_LSP_PLEO if dlp_supp_opts & nvme.NVMF_LOG_DISC_LID_PLEOS else 0

--- a/libnvme/libnvme/README.md
+++ b/libnvme/libnvme/README.md
@@ -42,11 +42,11 @@ except Exception as e:
 supported_log_pages = ctrl.supported_log_pages()
 try:
     # Get the supported options for the Get Discovery Log Page command
-    dlp_supp_opts = supported_log_pages[nvme.NVME_LOG_LID_DISCOVER] >> 16
+    dlp_supp_opts = supported_log_pages[nvme.NVME_LOG_LID_DISCOVERY] >> 16
 except (TypeError, IndexError):
     dlp_supp_opts = 0
 
-print(f"LID {nvme.NVME_LOG_LID_DISCOVER:02x}h (Discovery), supports: {disc_supp_str(dlp_supp_opts)}")
+print(f"LID {nvme.NVME_LOG_LID_DISCOVERY:02x}h (Discovery), supports: {disc_supp_str(dlp_supp_opts)}")
 try:
     lsp = nvme.NVMF_LOG_DISC_LSP_PLEO if dlp_supp_opts & nvme.NVMF_LOG_DISC_LID_PLEOS else 0
     log_pages = ctrl.discover(lsp=lsp)

--- a/libnvme/src/nvme/ioctl.h
+++ b/libnvme/src/nvme/ioctl.h
@@ -6606,7 +6606,7 @@ nvme_get_log_discovery(struct nvme_transport_handle *hdl,
  * Submits the Get Log Page command specifically for the Host Discovery Log.
  * The @allhoste parameter is placed in the Log Specific Parameter (LSP) field.
  *
- * It automatically sets the Log Identifier (LID) to NVME_LOG_LID_HOST_DISCOVER.
+ * It automatically sets the Log Identifier (LID) to NVME_LOG_LID_HOST_DISCOVERY.
  *
  * Return: 0 on success, the NVMe command status on error, or a negative
  * errno otherwise.


### PR DESCRIPTION
The following 2 enums were renamed, but there were a few instances remaining to be renamed. Those were found in one comment and python example code (so nothing critical).

NVME_LOG_LID_DISCOVER      -> NVME_LOG_LID_DISCOVERY
NVME_LOG_LID_HOST_DISCOVER -> NVME_LOG_LID_HOST_DISCOVERY