### PR TITLE
ioctl: use dummy passthru command

### DIFF
--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -76,6 +76,7 @@ void nvme_transport_handle_set_decide_retry(struct nvme_transport_handle *hdl,
 
 static int __nvme_transport_handle_open_direct(struct nvme_transport_handle *hdl, const char *devname)
 {
+	struct nvme_passthru_cmd dummy = { 0 };
 	_cleanup_free_ char *path = NULL;
 	char *name = basename(devname);
 	int ret, id, ns;
@@ -107,8 +108,8 @@ static int __nvme_transport_handle_open_direct(struct nvme_transport_handle *hdl
 		return -EINVAL;
 	}
 
-	ret = ioctl(hdl->fd, NVME_IOCTL_ADMIN64_CMD, NULL);
-	if (ret == -1 && errno != ENOTTY)
+	ret = ioctl(hdl->fd, NVME_IOCTL_ADMIN64_CMD, &dummy);
+	if (ret > 0)
 		hdl->ioctl64 = true;
 
 	return 0;


### PR DESCRIPTION
The ioctl probing is triggering a valgrind report. Let's pass in a empty command which will return a status code (0x4101) if the ioctl is supported.

==143223== Syscall param ioctl(generic) points to unaddressable byte(s)
==143223==    at 0x49BE36D: ioctl (ioctl.c:36)
==143223==    by 0x48644AB: __nvme_transport_handle_open_direct (linux.c:110)
==143223==    by 0x48646C1: nvme_open (linux.c:169)
==143223==    by 0x40DDBD: get_transport_handle (nvme.c:366)
==143223==    by 0x40DF00: parse_and_open (nvme.c:404)
==143223==    by 0x42F4BC: submit_io (nvme.c:8237)
==143223==    by 0x430268: read_cmd (nvme.c:8470)
==143223==    by 0x45CDD6: handle_plugin (plugin.c:190)
==143223==    by 0x43ACF2: main (nvme.c:11032)