### PR TITLE
nvme: add fallback support for block vs char device to verify command

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -8539,6 +8539,10 @@ static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin
 	if (err)
 		return err;
 
+	err = open_fallback_chardev(ctx, cfg.nsid, &hdl);
+	if (err)
+		return err;
+
 	if (cfg.prinfo > 0xf)
 		return -EINVAL;
 


### PR DESCRIPTION
Also the verify commands depends operating on a block device. The kernel lacks the fallback support in the NVME_IOCTL_IO64_CMD to lookup the namespace.

Fixes: #https://github.com/linux-nvme/nvme-cli/issues/3002