### PR TITLE
test/mi: avoid compile warning in test_admin_invalid_formats()

### DIFF
--- a/libnvme/test/mi.c
+++ b/libnvme/test/mi.c
@@ -602,7 +602,7 @@ static void test_admin_invalid_formats(nvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_rejected_command_cb, NULL);
 
 	hdl = nvme_mi_init_transport_handle(ep, 1);
-	assert(link);
+	assert(hdl);
 
 	/* unaligned req size */
 	len = 0;


### PR DESCRIPTION
Below compile warning seen in test_admin_invalid_formats():

INFO: autodetecting backend as ninja
INFO: calculating backend command to run: i
/usr/bin/ninja -C /usr/src/packages/BUILD/dec9/nvme-cli/build ninja: Entering directory `/usr/src/packages/BUILD/dec9/nvme-cli/build' [118/225] Compiling C object subprojects/libnvme/test/test-mi.p/mi.c.o In file included from ../subprojects/libnvme/ccan/ccan/list/list.h:6:0,
                 from ../subprojects/libnvme/src/nvme/private.h:12,
                 from ../subprojects/libnvme/test/mi.c:18:
../subprojects/libnvme/test/mi.c: In function ‘test_admin_invalid_formats’: ../subprojects/libnvme/test/mi.c:605:9: warning:
the address of ‘link’ will always evaluate as ‘true’ [-Waddress]
  assert(link);

Fix the same.