### PR TITLE
ioctl: avoid segfault for list & list-subsys commands

### DIFF
--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -126,7 +126,7 @@ static int nvme_submit_passthru32(struct nvme_transport_handle *hdl,
 	int err = 0;
 
 	user_data = hdl->submit_entry(hdl, cmd);
-	if (hdl->ctx->dry_run)
+	if (hdl->ctx && hdl->ctx->dry_run)
 		goto out;
 
 	memcpy(&cmd32, cmd, offsetof(struct linux_passthru_cmd32, result));
@@ -156,7 +156,7 @@ static int nvme_submit_passthru64(struct nvme_transport_handle *hdl,
 	int err = 0;
 
 	user_data = hdl->submit_entry(hdl, cmd);
-	if (hdl->ctx->dry_run)
+	if (hdl->ctx && hdl->ctx->dry_run)
 		goto out;
 
 	do {


### PR DESCRIPTION
Below segfault seen in nvme_submit_passthru64() while running list and list-subsys commands:

scan controller nvme0
lookup subsystem /sys/class/nvme-subsystem/nvme-subsys0/nvme0 scan controller nvme0 path nvme0c0n1
failed to scan ctrl nvme0: Success
scan subsystem nvme-subsys0
scan subsystem nvme-subsys0 namespace nvme0n1
Segmentation fault (core dumped)

This is due to an invalid dereferencing of the nvme_transport_handle structure content at hdl->ctx->dry_run. Fix the same.