### PR TITLE
nvme-print: update list-subsys output for iopolicy

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1143,8 +1143,6 @@ static void stdout_subsys_config(nvme_subsystem_t s)
 	       nvme_subsystem_get_nqn(s));
 	printf("%*s   hostnqn=%s\n", len, " ",
 	       nvme_host_get_hostnqn(nvme_subsystem_get_host(s)));
-	printf("%*s   iopolicy=%s\n", len, " ",
-		nvme_subsystem_get_iopolicy(s));
 
 	if (stdout_print_ops.flags & VERBOSE) {
 		printf("%*s   model=%s\n", len, " ",
@@ -1153,6 +1151,8 @@ static void stdout_subsys_config(nvme_subsystem_t s)
 			nvme_subsystem_get_serial(s));
 		printf("%*s   firmware=%s\n", len, " ",
 			nvme_subsystem_get_fw_rev(s));
+		printf("%*s   iopolicy=%s\n", len, " ",
+			nvme_subsystem_get_iopolicy(s));
 		printf("%*s   type=%s\n", len, " ",
 			nvme_subsystem_get_type(s));
 	}


### PR DESCRIPTION
Before commit d0b4c6cf0, the iopolicy was displayed only in the verbose regular/json outputs of the list-subsys commands, similar to what is currently seen for the show-topology verbose outputs. But now, iopolicy is seen in the list-subsys regular output itself conflicting with its corresponding json output. So to maintain consistency across the board, move the iopolicy to the verbose output itself for the list-subsys command.