### PR TITLE
tree: open transport handle for the ns init fallback

### DIFF
--- a/libnvme/src/nvme/tree.h
+++ b/libnvme/src/nvme/tree.h
@@ -1564,7 +1564,8 @@ char *nvme_get_path_attr(nvme_path_t p, const char *attr);
  *
  * Return: 0 on success or negative error code otherwise
  */
-int nvme_scan_namespace(const char *name, nvme_ns_t *ns);
+int nvme_scan_namespace(struct nvme_global_ctx *ctx, const char *name,
+		nvme_ns_t *ns);
 
 /**
  * nvme_host_get_hostsymname() - Get the host's symbolic name

--- a/plugins/sandisk/sandisk-utils.c
+++ b/plugins/sandisk/sandisk-utils.c
@@ -48,7 +48,7 @@ int sndk_get_pci_ids(struct nvme_global_ctx *ctx, struct nvme_transport_handle *
 			nvme_ctrl_get_sysfs_dir(c));
 		nvme_free_ctrl(c);
 	} else {
-		ret = nvme_scan_namespace(name, &n);
+		ret = nvme_scan_namespace(ctx, name, &n);
 		if (!ret) {
 			fprintf(stderr, "Unable to find %s\n", name);
 			return ret;

--- a/plugins/solidigm/solidigm-get-drive-info.c
+++ b/plugins/solidigm/solidigm-get-drive-info.c
@@ -48,7 +48,7 @@ int sldgm_get_drive_info(int argc, char **argv, struct command *acmd, struct plu
 	if (!err)
 		n = nvme_ctrl_first_ns(c);
 	else {
-		err = nvme_scan_namespace(nvme_transport_handle_get_name(hdl), &n);
+		err = nvme_scan_namespace(ctx, nvme_transport_handle_get_name(hdl), &n);
 		if (err) {
 			nvme_show_error("solidigm-vs-drive-info: drive missing namespace");
 			return err;

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1490,7 +1490,7 @@ static int wdc_get_pci_ids(struct nvme_global_ctx *ctx, struct nvme_transport_ha
 			nvme_ctrl_get_sysfs_dir(c));
 		nvme_free_ctrl(c);
 	} else {
-		ret = nvme_scan_namespace(name, &n);
+		ret = nvme_scan_namespace(ctx, name, &n);
 		if (ret) {
 			fprintf(stderr, "Unable to find %s\n", name);
 			return ret;


### PR DESCRIPTION
Older kernels do not expose the sysfs entries the library needs. In this in this case it falls back to use a command to fetch the missing data. Though, the transport handle is not available yet. Open an temporary one. No need to optimize this code path, it is only for older kernels.

Fixes: #3009 

TODO: The tree API needs to be extended with the `nvme_global_ctx` argument