### PR TITLE
plugins: update default telemetry retrieval DA

### DIFF
--- a/plugins/sandisk/sandisk-nvme.h
+++ b/plugins/sandisk/sandisk-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(SANDISK_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define SANDISK_NVME
 
-#define SANDISK_PLUGIN_VERSION   "3.0.8"
+#define SANDISK_PLUGIN_VERSION   "3.1.0"
 #include "cmd.h"
 
 PLUGIN(NAME("sndk", "Sandisk vendor specific extensions", SANDISK_PLUGIN_VERSION),

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.14.7"
+#define WDC_PLUGIN_VERSION   "2.15.0"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
Instead of retrieving just Data Area 3, check for DA4 support and use that if available by default. This should ensure the default case captures as much telemetry data as possible, while still allowing explicit capture of a smaller data area.


Reviewed-by: Jeffrey Lien <jeff.lien@sandisk.com>