### PR TITLE
logging: suppress logging except during normal output

### DIFF
--- a/logging.c
+++ b/logging.c
@@ -27,6 +27,12 @@ struct submit_data {
 int log_level;
 static struct submit_data sb;
 
+bool is_printable_at_level(int level)
+{
+	return ((log_level >= level) &&
+		(strcmp(nvme_cfg.output_format, "normal") == 0));
+}
+
 int map_log_level(int verbose, bool quiet)
 {
 	int log_level;

--- a/logging.h
+++ b/logging.h
@@ -5,16 +5,16 @@
 
 #include <stdbool.h>
 
-#define print_info(...)				\
-	do {					\
-		if (log_level >= LOG_INFO)	\
-			printf(__VA_ARGS__);	\
+#define print_info(...)					\
+	do {						\
+		if (is_printable_at_level(LOG_INFO))	\
+			printf(__VA_ARGS__);		\
 	} while (false)
 
-#define print_debug(...)			\
-	do {					\
-		if (log_level >= LOG_DEBUG)	\
-			printf(__VA_ARGS__);	\
+#define print_debug(...)				\
+	do {						\
+		if (is_printable_at_level(LOG_DEBUG))	\
+			printf(__VA_ARGS__);		\
 	} while (false)
 
 extern int log_level;
@@ -29,6 +29,7 @@ void nvme_submit_exit(struct nvme_transport_handle *hdl,
 bool nvme_decide_retry(struct nvme_transport_handle *hdl,
 		struct nvme_passthru_cmd *cmd, int err);
 
+bool is_printable_at_level(int level);
 int map_log_level(int verbose, bool quiet);
 
 #endif // DEBUG_H_


### PR DESCRIPTION
Suppress the logging macros `print_info` and `print_debug` except during "normal" output. This ensures that "json" and "binary" output formats do not include unnecessary warnings.

This was originally causing issue with create-ns command printing warnings about namespace granularity alignment when using JSON option. See issue #2993.