### PR TITLE
fabrics: fix valgrind errors for connect-all using JSON config file

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2588,6 +2588,8 @@ int nvmf_discovery_config_file(struct nvme_global_ctx *ctx,
 		nvme_free_ctrl(c);
 	} while (!err);
 
+	fctx->parser_cleanup(fctx, fctx->user_data);
+
 	if (err != -EOF)
 		return err;
 


### PR DESCRIPTION
Valgrind revealed multiple errors during a nvme connect-all while using the JSON config file. Fix the same.