### PR TITLE
fabrics: fix concat during connect-all

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1193,8 +1193,12 @@ static int nvmf_connect_disc_entry(nvme_host_t h,
 		c->cfg.disable_sqflow = true;
 
 	if (e->trtype == NVMF_TRTYPE_TCP &&
-	    e->tsas.tcp.sectype != NVMF_TCP_SECTYPE_NONE)
-		c->cfg.tls = true;
+	    e->tsas.tcp.sectype != NVMF_TCP_SECTYPE_NONE) {
+		if (e->treq & NVMF_TREQ_REQUIRED)
+			c->cfg.tls = true;
+		else if (e->treq & NVMF_TREQ_NOT_REQUIRED)
+			c->cfg.concat = true;
+	}
 
 	ret = nvmf_add_ctrl(h, c, cfg);
 	if (!ret) {


### PR DESCRIPTION
During nvme connect-all, if a discovery log page record reports the sectype as anything other than NVMF_TCP_SECTYPE_NONE in nvmf_connect_disc_entry(), it then assumes that tls should be default set for the same. But this holds true only for configured PSK TLS connections alone and not generated PSK TLS (i.e. secure channel concat) connections since both concat and tls flags are meant to be mutually exclusive. Fix the same.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/3034