### PR TITLE
build: update python workflow

### DIFF
--- a/.github/workflows/libnvme-release-python.yml
+++ b/.github/workflows/libnvme-release-python.yml
@@ -67,9 +67,9 @@ jobs:
           echo "dev_version=$VERSION" >> $GITHUB_OUTPUT
           echo "Computed dev version: $VERSION"
 
-      - name: Patch version in meson.build
+      - name: Patch project version in meson.build
         run: |
-          sed -i -e "0,/[ \t]version: /s/\([ \t]version: \).*/\1\'${{ steps.version.outputs.dev_version }}\',/" meson.build
+          sed -i -e "/^project(/,/)/ s/^\(\s*\)version:\s*.*/\1version: '${{ steps.version.outputs.dev_version }}',/" meson.build
 
       - name: Build sdist
         run: |
@@ -93,7 +93,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    if: github.repository == 'linux-nvme/libnvme'
+    if: github.repository == 'linux-nvme/nvme-cli'
     steps:
       - uses: actions/download-artifact@v6
         with:
@@ -113,7 +113,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linux-nvme/libnvme'
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linux-nvme/nvme-cli'
     steps:
       - name: Check if it is a release tag
         id: check-tag


### PR DESCRIPTION
The libnvme code is now in the nvme-cli repo. Also we need to be more precis with the version string update for pypi with the new versioning scheme. Thus make the matching of the sed expression more explicit.

Fixes: #3030 