### PR TITLE
build: handle PyPi versioning scheme for library versioning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,9 @@ endif
 # version to be composed of 2 or 3 digits after stripping trailing identifiers
 # such as "-rc.*". If the project version is composed of only two digits, then
 # we append '.0' to it.
-ver_digits = meson.project_version().split('-')[0]
+ver = meson.project_version()
+ver_digits = ver.split('-')[0]
+ver_digits = ver_digits.split('.dev')[0]
 num_digits = ver_digits.split('.').length()
 if num_digits < 2 or num_digits > 3
     error('Invalid version: ', meson.project_version())


### PR DESCRIPTION
When building the test CI build for Python, the versioning scheme is switched to a PyPi scheme. That is X.Y.devN, where N is the git commit distance to the last tag.

The version string for the library needs to be of type X.Y.Z, thus the '.dev' part has to be splitted away.

Fixes: #3030 