### PR TITLE
docs: Fix URLs referencing deprecated libnvme repo

### DIFF
--- a/Documentation/nvme-config.txt
+++ b/Documentation/nvme-config.txt
@@ -36,7 +36,7 @@ DESCRIPTION
 Read in the NVMe over Fabrics configuration from the specified JSON
 configuration file and allow to update or modify the contents.
 The JSON configuration file format is documented in
-https://github.com/linux-nvme/libnvme/blob/master/doc/config-schema.json
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/doc/config-schema.json
 
 OPTIONS
 -------
@@ -201,7 +201,7 @@ SEE ALSO
 --------
 nvme-discover(1)
 nvme-connect(1)
-https://github.com/linux-nvme/libnvme/blob/master/doc/config-schema.json
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/doc/config-schema.json
 
 AUTHORS
 -------

--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -127,7 +127,7 @@ OPTIONS
 	default @SYSCONFDIR@/nvme/config.json file or 'none' to not read in
 	an existing configuration file. The JSON configuration file
 	format is documented in
-	https://github.com/linux-nvme/libnvme/blob/master/doc/config-schema.json
+	https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/doc/config-schema.json
 
 -k <#>::
 --keep-alive-tmo=<#>::

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -102,7 +102,7 @@ OPTIONS
 	default @SYSCONFDIR@/nvme/config.json file or 'none' to not read in
 	an existing configuration file. The JSON configuration file
 	format is documented in
-	https://github.com/linux-nvme/libnvme/blob/master/doc/config-schema.json
+	https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/doc/config-schema.json
 
 -S <secret>::
 --dhchap-secret=<secret>::

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -146,7 +146,7 @@ OPTIONS
 	default @SYSCONFDIR@/nvme/config.json file or 'none' to not read in
 	an existing configuration file. The JSON configuration file
 	format is documented in
-	https://github.com/linux-nvme/libnvme/blob/master/doc/config-schema.json
+	https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/doc/config-schema.json
 
 -k <#>::
 --keep-alive-tmo=<#>::

--- a/libnvme/README.md
+++ b/libnvme/README.md
@@ -1,11 +1,9 @@
 # libnvme
 
-![MesonBuild](https://github.com/linux-nvme/libnvme/actions/workflows/build.yml/badge.svg)
-![PyBuild](https://github.com/linux-nvme/libnvme/actions/workflows/release-python.yml/badge.svg)
+![PyBuild](https://github.com/linux-nvme/nvme-cli/actions/workflows/release-python.yml/badge.svg)
 [![PyPI](https://img.shields.io/pypi/v/libnvme)](https://pypi.org/project/libnvme/)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/libnvme)](https://pypi.org/project/libnvme/)
-![GitHub](https://img.shields.io/github/license/linux-nvme/libnvme)
-[![codecov](https://codecov.io/gh/linux-nvme/libnvme/branch/master/graph/badge.svg)](https://codecov.io/gh/linux-nvme/libnvme)
+[![codecov](https://codecov.io/gh/linux-nvme/nvme-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/linux-nvme/nvme-cli)
 [![Read the Docs](https://img.shields.io/readthedocs/libnvme)](https://libnvme.readthedocs.io/en/latest/)
 
 This is the libnvme development C library. libnvme provides type

--- a/libnvme/doc/config-schema.json
+++ b/libnvme/doc/config-schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/linux-nvme/libnvme/doc/config-schema.json",
+    "$id": "https://github.com/linux-nvme/nvme-cli/libnvme/doc/config-schema.json",
     "title": "config.json",
     "description": "libnvme JSON configuration",
     "type": "object",

--- a/libnvme/doc/config-schema.json.in
+++ b/libnvme/doc/config-schema.json.in
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/linux-nvme/libnvme/doc/config-schema.json",
+    "$id": "https://github.com/linux-nvme/nvme-cli/libnvme/doc/config-schema.json",
     "title": "config.json",
     "description": "libnvme JSON configuration",
     "type": "object",


### PR DESCRIPTION
Change:
   `https://github.com/linux-nvme/libnvme/...`

To:
   `https://github.com/linux-nvme/nvme-cli/...`
