### PR TITLE
doc: correct id-ns vendor-specific short option

### DIFF
--- a/Documentation/nvme-id-ns.txt
+++ b/Documentation/nvme-id-ns.txt
@@ -8,7 +8,7 @@ nvme-id-ns - Send NVMe Identify Namespace, return result and structure
 SYNOPSIS
 --------
 [verse]
-'nvme id-ns' <device> [--vendor-specific | -v] [--raw-binary | -b]
+'nvme id-ns' <device> [--vendor-specific | -V] [--raw-binary | -b]
 			[--namespace-id=<nsid> | -n <nsid>] [--force]
 			[--human-readable | -H]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]


### PR DESCRIPTION
Fix to describe the short option `-v` as `-V`.