### PR TITLE
docs: Fix read-the-docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,8 +16,8 @@ build:
     post_install:
       - pip3 install lxml
     pre_build:
-      - meson setup .build -Ddocs=rst -Ddocs-build=true || cat .build/meson-logs/meson-log.txt
+      - meson setup .build -Ddocs=rst -Ddocs-build=true -Dnvme=disabled -Dlibnvme=disabled -Dpython=disabled || cat .build/meson-logs/meson-log.txt
       - meson compile -C .build
 
 sphinx:
-  configuration: .build/doc/conf.py
+  configuration: .build/libnvme/doc/conf.py

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -265,13 +265,11 @@ adoc_includes = [
     'cmds-main.txt',
 ]
 
-want_docs = get_option('docs')
-want_docs_build = get_option('docs-build')
 if want_docs != 'false'
     mandir = join_paths(get_option('mandir'), 'man1')
     htmldir = join_paths(get_option('htmldir'), 'nvme')
 
-    asciidoctor = find_program('asciidoc', required: get_option('docs-build'))
+    asciidoctor = find_program('asciidoc', required: want_docs_build)
     if want_docs_build and asciidoctor.found()
         # Build documentation before installing
         foreach file : adoc_includes

--- a/libnvme/README.md
+++ b/libnvme/README.md
@@ -1,6 +1,6 @@
 # libnvme
 
-![PyBuild](https://github.com/linux-nvme/nvme-cli/actions/workflows/release-python.yml/badge.svg)
+![PyBuild](https://github.com/linux-nvme/nvme-cli/actions/workflows/libnvme-release-python.yml/badge.svg)
 [![PyPI](https://img.shields.io/pypi/v/libnvme)](https://pypi.org/project/libnvme/)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/libnvme)](https://pypi.org/project/libnvme/)
 [![codecov](https://codecov.io/gh/linux-nvme/nvme-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/linux-nvme/nvme-cli)

--- a/libnvme/doc/meson.build
+++ b/libnvme/doc/meson.build
@@ -49,8 +49,6 @@ subdir('rst')
 
 top_source_dir = meson.current_source_dir() + '/../'
 
-want_docs = get_option('docs')
-want_docs_build = get_option('docs-build')
 kernel_doc = find_program(top_source_dir + 'scripts/kernel-doc')
 kernel_doc_check = find_program(top_source_dir +'scripts/kernel-doc-check')
 

--- a/libnvme/doc/rst/meson.build
+++ b/libnvme/doc/rst/meson.build
@@ -1,17 +1,14 @@
-top_source_dir = meson.current_source_dir() + '/../../'
-
-want_docs = get_option('docs')
-
 if want_docs != 'false'
-    want_docs_build = get_option('docs-build')
-    rstdir = get_option('rstdir')
     if want_docs_build
-        kernel_doc = find_program(top_source_dir + 'scripts/kernel-doc')
-
-        rst_conf = configuration_data()
-        rst_conf.set('SYSCONFDIR', sysconfdir)
-
         if want_docs == 'all' or want_docs == 'rst' or want_docs == 'html'
+            top_source_dir = meson.current_source_dir() + '/../../'
+            kernel_doc = find_program(top_source_dir + 'scripts/kernel-doc')
+            rst_conf = configuration_data(
+                {
+                    'SYSCONFDIR' : sysconfdir,
+                }
+            )
+            rstdir = get_option('rstdir')
             foreach apif : api_files
                 afile = files(top_source_dir + 'src/nvme/' + apif)
                 subst = configure_file(

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -38,7 +38,6 @@ if want_libnvme
     if get_option('examples')
         subdir('examples')
     endif
-    subdir('doc')
 else
     # Fallback to using a pre-installed libnvme (if available)
     if std_prefix
@@ -60,3 +59,4 @@ else
     endif
 endif
 
+subdir('doc')

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,8 @@ cxx_available = add_languages('cpp', required: false, native: false)
 # dependencies are present. Also, -Dpython=enabled forces -Dlibnvme=enabled.
 want_nvme = get_option('nvme').disabled() == false
 want_libnvme = get_option('libnvme').disabled() == false
+want_docs = get_option('docs')
+want_docs_build = get_option('docs-build')
 
 feature_python = get_option('python')
 if feature_python.disabled()
@@ -561,9 +563,9 @@ if want_nvme
     if get_option('nvme-tests')
         subdir('tests')
     endif
-
-    subdir('Documentation')
 endif
+
+subdir('Documentation')
 
 
 ################################################################################
@@ -606,6 +608,7 @@ wanted_dict = {
     'nvme':             want_nvme,
     'libnvme':          want_libnvme,
     'python bindings ': want_python,
+    'build docs':       want_docs_build,
 }
 summary(wanted_dict, section: 'Features to build', bool_yn: true)
 


### PR DESCRIPTION
Allow Read-the-Docs web site to be able to build the docs.

@igaw - I made a change to the `meson.build` files to allow building the documentation without building anything else. This will allow the Read-the-Docs website to only build the documentation w/o anything else.

Note that the Read-the-Docs `libnvme` project (https://app.readthedocs.org/projects/libnvme/) needs to be updated to point to `linux-nvme/nvme-cli` instead of `linux-nvme/libnvme`.