### PR TITLE
nvme-print-stdout: change stdout_d() to not print all zeros

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4903,7 +4903,7 @@ static void stdout_lba_status_info(__u64 result)
 
 static bool line_equal(unsigned char *buf, int len, int width, int offset)
 {
-	if (!offset || len < offset + width)
+	if (!offset || len < offset + width || log_level >= LOG_DEBUG)
 		return false;
 
 	return !memcmp(buf + offset - width, buf + offset, width);


### PR DESCRIPTION
This is for the id-ns command empty vendor-specific fields.
  Note: This will change for other commands d() outputs.