### PR TITLE
PyPI: add meson options to build without nvme executable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,10 @@ dependencies = []
 "Homepage" = "https://github.com/linux-nvme/nvme-cli"
 "Source" = "https://github.com/linux-nvme/nvme-cli"
 "Bug Tracker" = "https://github.com/linux-nvme/nvme-cli/issues"
+
+[tool.meson-python.args]
+setup = [
+    "-Dnvme=disabled",
+    "-Dlibnvme=enabled",
+    "-Dpython=enabled",
+]


### PR DESCRIPTION
Now that nvme-cli and libnvme live in the same GitHub repository, meson builds both by default. When building the PyPI package, however, we only want to build `libnvme` and the Python bindings, not the `nvme` executable.

@igaw - I think this will fix the PyPI issue. This adds "`-Dnvme=disabled -Dlibnvme=enabled -Dpython=enabled`" to the `meson setup` options. If there are other options you would like to set (maybe `--prefix`, `--sysconfdir`, `--buildtype`, etc.) please feel free to update accordingly.