### PR TITLE
build: use proper shell variable expansion

### DIFF
--- a/.github/workflows/libnvme-release-python.yml
+++ b/.github/workflows/libnvme-release-python.yml
@@ -68,8 +68,10 @@ jobs:
           echo "Computed dev version: $VERSION"
 
       - name: Patch project version in meson.build
+        env:
+          DEV_VERSION: ${{ steps.version.outputs.dev_version }}
         run: |
-          sed -i -e "/^project(/,/)/ s/^\(\s*\)version:\s*.*/\1version: '${{ steps.version.outputs.dev_version }}',/" meson.build
+          sed -i -e "/^project(/,/)/ s/^\(\s*\)version:\s*.*/\1version: '${DEV_VERSION}',/" meson.build
 
       - name: Build sdist
         run: |


### PR DESCRIPTION
${{ steps.version.outputs.dev_version }} does not get expanded inside a shell script.

GitHub Actions expressions are resolved before the step runs, but only in YAML fields, not inside the runtime shell unless you pass them in explicitly.