### PR TITLE
build: replace the version patching with mesonpy approach

### DIFF
--- a/.github/workflows/libnvme-release-python.yml
+++ b/.github/workflows/libnvme-release-python.yml
@@ -67,13 +67,9 @@ jobs:
           echo "dev_version=$VERSION" >> $GITHUB_OUTPUT
           echo "Computed dev version: $VERSION"
 
-      - name: Patch project version in meson.build
-        env:
-          DEV_VERSION: ${{ steps.version.outputs.dev_version }}
-        run: |
-          sed -i -e "/^project(/,/)/ s/^\(\s*\)version:\s*.*/\1version: '${DEV_VERSION}',/" meson.build
-
       - name: Build sdist
+        env:
+          MESONPY_PROJECT_VERSION: ${{ steps.version.outputs.dev_version }}
         run: |
           pipx run build --sdist
 


### PR DESCRIPTION
Under PEP 517, when the backend detects a VCS checkout, build does roughly this:

 - Creates an isolated build environment
 - Exports the source tree using git archive
 - Builds the sdist from that exported tree

Thus the changes in meson.build are not picked up. Though the version can be overwritten via the MESONPY_PROJECT_VERSION environment variable.