### PR TITLE
build: commit CI-generated version so sdist gets correct metadata

### DIFF
--- a/.github/workflows/libnvme-release-python.yml
+++ b/.github/workflows/libnvme-release-python.yml
@@ -57,6 +57,11 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Configure git identity for CI
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Compute dev version from git
         id: version
         run: |
@@ -67,11 +72,18 @@ jobs:
           echo "dev_version=$VERSION" >> $GITHUB_OUTPUT
           echo "Computed dev version: $VERSION"
 
-      - name: Build sdist
+      - name: Patch project version in meson.build
         env:
-          MESONPY_PROJECT_VERSION: ${{ steps.version.outputs.dev_version }}
+          DEV_VERSION: ${{ steps.version.outputs.dev_version }}
         run: |
-          pipx run build --sdist
+          sed -i -e "/^project(/,/)/ s/^\(\s*\)version:\s*.*/\1version: '${DEV_VERSION}',/" meson.build
+
+      - name: Commit CI version bump
+        env:
+          DEV_VERSION: ${{ steps.version.outputs.dev_version }}
+        run: |
+          git add meson.build
+          git commit -m "ci: set project version to ${DEV_VERSION}"
 
       - name: Validate sdist
         run: |


### PR DESCRIPTION
The sdist must contain a unique, correctly set version string. Overriding the version via MESONPY_PROJECT_VERSION does not work when building from a Git checkout, and modifying meson.build alone is insufficient because uncommitted changes are not included in the source archive.

Create a temporary, local commit in CI so the generated tarball carries the correct version metadata.