### PR TITLE
build: add sdist build step back

### DIFF
--- a/.github/workflows/libnvme-release-python.yml
+++ b/.github/workflows/libnvme-release-python.yml
@@ -85,6 +85,10 @@ jobs:
           git add meson.build
           git commit -m "ci: set project version to ${DEV_VERSION}"
 
+      - name: Build sdist
+         run: |
+          pipx run build --sdist
+
       - name: Validate sdist
         run: |
           pipx run twine check dist/*.tar.gz


### PR DESCRIPTION
The last commit dropped the sdist build step. Add it back.