### PR TITLE
PyPI: fix missing symbolic link libnvme.so.x ->  libnvme.so.X.Y.Z

### DIFF
--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -55,6 +55,25 @@ libnvme = library(
     install: true,
 )
 
+# Explicitly create the symlinks in the same directory. When building the
+# PyPI package (pipx run build --sdist), the symbolic link don't get installed
+# unless we explicitly set them as below.
+# 1st: libnvme.so.X -> libnvme.so.X.Y.Z
+major_version = libnvme_so_version.split('.')[0]
+install_symlink(
+    'libnvme.so.@0@'.format(major_version),
+    pointing_to: 'libnvme.so.@0@'.format(libnvme_so_version),
+    install_dir: get_option('libdir'),
+)
+
+# 2nd: libnvme.so -> libnvme.so.X
+major_version = libnvme_so_version.split('.')[0]
+install_symlink(
+    'libnvme.so',
+    pointing_to: 'libnvme.so.@0@'.format(major_version),
+    install_dir: get_option('libdir'),
+)
+
 pkg = import('pkgconfig')
 pkg.generate(libnvme,
     filebase: 'libnvme',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 [build-system]
 build-backend = 'mesonpy'
-requires = ['meson-python']
+requires = ['meson-python', 'meson', 'ninja', 'swig']
 
 [project]
 name = "libnvme"


### PR DESCRIPTION
When we "pip install" a PyPI package previously built with "pipx run build --sdist", there is a missing symbolic link in the directory where libnvme.so.X.Y.Z is installed.

For example, let's say we build libnvme.so.3.0.0. There needs to be a symbolic link installed along with the library as follows:

libnvme.so.3 -> libnvme.so.3.0.0