### PR TITLE
PyPI: Only use major version for libnvme.so

### DIFF
--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -55,25 +55,6 @@ libnvme = library(
     install: true,
 )
 
-# Explicitly create the symlinks in the same directory. When building the
-# PyPI package (pipx run build --sdist), the symbolic link don't get installed
-# unless we explicitly set them as below.
-# 1st: libnvme.so.X -> libnvme.so.X.Y.Z
-major_version = libnvme_so_version.split('.')[0]
-install_symlink(
-    'libnvme.so.@0@'.format(major_version),
-    pointing_to: 'libnvme.so.@0@'.format(libnvme_so_version),
-    install_dir: get_option('libdir'),
-)
-
-# 2nd: libnvme.so -> libnvme.so.X
-major_version = libnvme_so_version.split('.')[0]
-install_symlink(
-    'libnvme.so',
-    pointing_to: 'libnvme.so.@0@'.format(major_version),
-    install_dir: get_option('libdir'),
-)
-
 pkg = import('pkgconfig')
 pkg.generate(libnvme,
     filebase: 'libnvme',

--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,12 @@ else
     libnvme_so_version = ver_digits + '.0'
 endif
 
+# For PyPI builds, use only the major version (e.g., '3' instead of '3.0.0').
+# This avoids the need for symbolic links which pip/wheel doesn't preserve.
+if get_option('pypi')
+    libnvme_so_version = libnvme_so_version.split('.')[0]
+endif
+
 ################################################################################
 prefixdir      = get_option('prefix')
 datadir        = join_paths(prefixdir, get_option('datadir'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -130,3 +130,9 @@ option(
   value: 'disabled',
   description : 'liburing support'
 )
+option(
+  'pypi',
+  type : 'boolean',
+  value : false,
+  description : 'building for PyPI (use short soversion, e.g. libnvme.so.3)'
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ setup = [
     "-Dnvme=disabled",
     "-Dlibnvme=enabled",
     "-Dpython=enabled",
+    "-Dpypi=true",
     "-Dtests=false",
     "-Dnvme-tests=false",
     "-Dexamples=false",


### PR DESCRIPTION
When building a pip (PyPI) package, do not set the libnvme.so version to major.minor.patch (e.g. libnvme.so.3.0.0), but instead just set it to the major (e.g. libnvme.so.3). pip/wheel do not care about the full versioning, and since symbolic links cannot be installed via pip (i.e. libnvme.so.3 -> libnvme.so.3.0.0), it's better to just skip the major.minor.patch versioning for PyPI.

To support this we're introducing a new config flag "pypi" to let meson know we're building for pip/PyPI.

@igaw - After doing more testing I found that the previous fix to set the symbolic links did not work. This PR reverts the  previous change and provides a simpler fix more in line with PyPI packages. 