### PR TITLE
nvme_cli/tests: nose2 --verbose --start-dir tests nvme_compare_test" command failed 

### DIFF
--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -358,7 +358,7 @@ class TestNVMe(unittest.TestCase):
         """
         create_ns_cmd = f"{self.nvme_bin} create-ns {self.ctrl} " + \
             f"--nsze={str(nsze)} --ncap={str(ncap)} --flbas={str(flbas)} " + \
-            f"--dps={str(dps)} --verbose --output-format=json"
+            f"--dps={str(dps)}"
         return subprocess.Popen(create_ns_cmd, shell=True,
                                 stdout=subprocess.PIPE, encoding='utf-8')
 
@@ -376,8 +376,8 @@ class TestNVMe(unittest.TestCase):
         proc = self.create_ns(nsze, ncap, flbas, dps)
         err = proc.wait()
         if err == 0:
-            json_output = json.loads(proc.stdout.read())
-            self.assertEqual(int(json_output['nsid']), nsid,
+            output = proc.stdout.read()
+            self.assertEqual(int(output.strip().split(':')[-1]), nsid,
                              "ERROR : create namespace failed")
             id_ns_cmd = f"{self.nvme_bin} id-ns {self.ctrl} " + \
                 f"--namespace-id={str(nsid)}"


### PR DESCRIPTION
Test team tried to run the following command and got the error:

nose2 --verbose --start-dir tests nvme_compare_test

test_write_zeros (nvme_writezeros_test.TestNVMeWriteZeros)
Testcae main ...
Using nvme binary 'nvme'
ERROR



======================================================================
ERROR: test_write_zeros (nvme_writezeros_test.TestNVMeWriteZeros)
Testcae main
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nvme-cli/tests/nvme_writezeros_test.py", line 52, in setUp
    super().setUp()
  File "/home/nvme-cli/tests/nvme_test_io.py", line 44, in setUp
    super().setUp()
  File "/home/nvme-cli/tests/nvme_test.py", line 80, in setUp
    self.create_and_attach_default_ns()
  File "/home/nvme-cli/tests/nvme_test.py", line 109, in create_and_attach_default_ns
    err = self.create_and_validate_ns(self.default_nsid,
  File "/home/nvme-cli/tests/nvme_test.py", line 379, in create_and_validate_ns
    json_output = json.loads(proc.stdout.read())
  File "/usr/lib64/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

----------------------------------------------------------------------
Ran 1 test in 0.961s

FAILED (errors=1)


When creating a namespace for the first time, output is text: create-ns: Success, created nsid:1
nvme create-ns /dev/nvme4 --nsze=390703446 --ncap=390703446 --flbas=0 --dps=0 --output-format=json
create-ns: Success, created nsid:1


When creating a namespace for the second time, output is in json format.
nvme create-ns /dev/nvme4 --nsze=390703446 --ncap=390703446 --flbas=0 --dps=0 --output-format=json
{
"status: 8469":[
{
"error":"Namespace Insufficient Capacity: Creating the namespace requires more free space than is currently available",
"type":"nvme"
}
]
}

We hits the ERROR when trying to call " json.loads(proc.stdout.read())." to read text.
So the patch fix the issue: use proc.stdout.read() instead of json.loads(proc.stdout.read()).

Signed-off-by: Wen Xiong<wenxiong@linux.ibm.com>