### PR TITLE
fabrics: add additional error messages for --concat

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -742,6 +742,11 @@ static int build_options(nvme_host_t h, nvme_ctrl_t c, char **argstr)
 		return -ENVME_CONNECT_INVAL;
 	}
 
+	if (cfg->concat && ctrlkey) {
+		nvme_msg(h->ctx, LOG_ERR, "cannot specify [--dhchap-ctrl-secret | -C] with --concat\n");
+		return -ENVME_CONNECT_INVAL;
+	}
+
 	if (cfg->tls) {
 		ret = __nvme_import_keys_from_config(h, c, &keyring_id, &key_id);
 		if (ret)


### PR DESCRIPTION
Secure channel concat TLS has some specific prerequisites and conditions. So add appropriate error messages for each of these.