### PR TITLE
fabrics: fix fabrics_connect() error message

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -708,8 +708,8 @@ do_connect:
 
 	ret = nvmf_connect(ctx, fctx);
 	if (ret) {
-		fprintf(stderr, "failed to connected: %s\n",
-			nvme_strerror(ret));
+		fprintf(stderr, "failed to connect: %s\n",
+			nvme_strerror(-ret));
 		return ret;
 	}
 


### PR DESCRIPTION
Seeing below error message displayed during nvme connect error scenarios:

failed to connected: Unknown error -1013

Fix this by ensuring the appropriate ret value is passed to nvme_strerror(). And while at it, correct the message text grammar as well.