### PR TITLE
nvme-print: introduce nvme_show_cmd_err() helper function

### DIFF
--- a/nvme-print.c
+++ b/nvme-print.c
@@ -520,12 +520,34 @@ void nvme_show_status(int status)
 		ops->show_status(status);
 }
 
+static void nvme_show_cmd_err(const char *msg, bool admin,
+			      struct nvme_passthru_cmd *cmd, int err)
+{
+	if (!err)
+		return;
+	else if (err < 0)
+		nvme_show_error("%s: %s", msg, nvme_strerror(-err));
+	else if (cmd)
+		nvme_show_opcode_status(err, false, cmd->opcode);
+	else
+		nvme_show_status(err);
+}
+
 void nvme_show_err(const char *msg, int err)
 {
-	if (err < 0)
-		nvme_show_error("%s: %s", msg, nvme_strerror(-err));
-	else if (err > 0)
-		nvme_show_status(err);
+	nvme_show_cmd_err(msg, false, NULL, err);
+}
+
+void nvme_show_io_cmd_err(const char *msg, struct nvme_passthru_cmd *cmd,
+			  int err)
+{
+	nvme_show_cmd_err(msg, false, cmd, err);
+}
+
+void nvme_show_admin_cmd_err(const char *msg, struct nvme_passthru_cmd *cmd,
+			     int err)
+{
+	nvme_show_cmd_err(msg, true, cmd, err);
 }
 
 void nvme_show_opcode_status(int status, bool admin, __u8 opcode)

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -160,6 +160,10 @@ struct print_ops *nvme_get_binary_print_ops(nvme_print_flags_t flags);
 
 void nvme_show_status(int status);
 void nvme_show_err(const char *msg, int err);
+void nvme_show_io_cmd_err(const char *msg, struct nvme_passthru_cmd *cmd,
+			  int err);
+void nvme_show_admin_cmd_err(const char *msg, struct nvme_passthru_cmd *cmd,
+			     int err);
 void nvme_show_opcode_status(int status, bool admin, __u8 opcode);
 void nvme_show_lba_status_info(__u64 result);
 void nvme_show_relatives(struct nvme_global_ctx *ctx, const char *name, nvme_print_flags_t flags);

--- a/nvme.c
+++ b/nvme.c
@@ -5604,10 +5604,10 @@ static int sanitize_ns_cmd(int argc, char **argv, struct command *acmd,
 
 	nvme_init_sanitize_ns(&cmd, cfg.sanact, cfg.ause, cfg.emvs);
 	err = nvme_submit_admin_passthru(hdl, &cmd);
-	if (err < 0)
-		nvme_show_error("sanitize ns: %s", nvme_strerror(err));
-	else if (err > 0)
-		nvme_show_status(err);
+	if (err) {
+		nvme_show_admin_cmd_err("sanitize ns", &cmd, err);
+		return err;
+	}
 
 	return err;
 }


### PR DESCRIPTION
Add the cmd argument for nvme_show_err() to use nvme_show_opcode_status(). Do not change nvme_show_err() itself so add nvme_show_cmd_err() instead. Also add admin variable into the nvme_passthru_cmd structure.