### PR TITLE
Allow service to also disconnect at shutdown

### DIFF
--- a/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
@@ -22,6 +22,8 @@ RemoveIPC=yes
 RestrictAddressFamilies=AF_INET AF_INET6
 Type=oneshot
 ExecStart=@SBINDIR@/nvme connect-all --context=autoconnect
+RemainAfterExit=true
+ExecStop=@SBINDIR@/nvme disconnect-all
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Added to keep service running in background, so that nvme can be disconnected at shutdown.

Currently, at least on Ubuntu, a variety of services hang due to the nvme device files being tied to active connections, which no longer work once the network has been brought down. This fixes that. Connections will be terminated before passing network-online.target.