### PR TITLE
fabrics: fix mem leak at nvmf_connect()

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3419,6 +3419,7 @@ int nvmf_connect(struct nvme_global_ctx *ctx, struct nvmf_context *fctx)
 	if (err) {
 		nvme_msg(ctx, LOG_ERR, "could not add new controller: %s\n",
 			nvme_strerror(-err));
+		nvme_free_ctrl(c);
 		return err;
 	}
 


### PR DESCRIPTION
Valgrind revealed a mem leak if nvme_add_ctrl() returns with an error in nvmf_connect():

==22187== 467 (344 direct, 123 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 6
==22187==    at 0x4848C31: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==22187==    by 0x4887F03: nvme_create_ctrl (tree.c:1454)
==22187==    by 0x487CCA2: nvmf_connect (fabrics.c:3396)
==22187==    by 0x40A584: fabrics_connect (fabrics.c:681)
==22187==    by 0x445E28: handle_plugin (plugin.c:190)
==22187==    by 0x407680: main (nvme.c:11085)

Fix the same.