### PR TITLE
fabrics: add additional debug messages for --tls and --concat

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1209,10 +1209,15 @@ static int nvmf_connect_disc_entry(nvme_host_t h,
 
 	if (e->trtype == NVMF_TRTYPE_TCP &&
 	    e->tsas.tcp.sectype != NVMF_TCP_SECTYPE_NONE) {
-		if (e->treq & NVMF_TREQ_REQUIRED)
+		if (e->treq & NVMF_TREQ_REQUIRED) {
+			nvme_msg(h->ctx, LOG_DEBUG, "setting --tls due to treq %s and sectype %s\n",
+					nvmf_treq_str(e->treq), nvmf_sectype_str(e->tsas.tcp.sectype));
 			c->cfg.tls = true;
-		else if (e->treq & NVMF_TREQ_NOT_REQUIRED)
+		} else if (e->treq & NVMF_TREQ_NOT_REQUIRED) {
+			nvme_msg(h->ctx, LOG_DEBUG, "setting --concat due to treq %s and sectype %s\n",
+					nvmf_treq_str(e->treq), nvmf_sectype_str(e->tsas.tcp.sectype));
 			c->cfg.concat = true;
+		}
 	}
 
 	ret = nvmf_add_ctrl(h, c, cfg);


### PR DESCRIPTION
Add additional debug messages when --tls and --concat is set respectively based on the treq and sectype fields for a given record in the discovery log page data during a nvme connect-all. This makes it easier to debug, otherwise can be quite confusing to the end user.