### PR TITLE
ocp: Fix core dump during telemetry log decode

### DIFF
--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -11,7 +11,7 @@
 #if !defined(OCP_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define OCP_NVME
 
-#define OCP_PLUGIN_VERSION   "2.16.0"
+#define OCP_PLUGIN_VERSION   "3.0.0"
 #include "cmd.h"
 
 PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),

--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1225,6 +1225,9 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 				(le16_to_cpu((unsigned int)pStaticSnapshotEvent->stat_data_size) *
 					SIZE_OF_DWORD);
 
+			struct json_object *pstats_array =
+				((pevent_fifos_object != NULL) ? json_create_array() : NULL);
+
 			if (pStaticSnapshotEvent != NULL &&
 				pStaticSnapshotEvent->stat_data_size > 0) {
 				__u8 *pstatistic_entry =
@@ -1234,7 +1237,7 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 				parse_statistic(
 					(struct nvme_ocp_telemetry_statistic_descriptor *)
 						pstatistic_entry,
-					pevent_descriptor_obj,
+					pstats_array,
 					fp);
 			}
 		} else {


### PR DESCRIPTION
When decoding ocp 2.5 telemetry log with json output the internal-log ocp plugin command was hitting an issue that caused a core dump.  This commit will resolve that error.

Here's the actual error that this PR resolves:
nvme ocp internal-log /dev/nvme0n1 -f fifo_da_1-2_cctemp-telemetry.bin -s fifo_da_1-2_cctemp-string.bin --output-format json -t host -d 2

Missing telemetry-log. Fetching from drive...

telemetry.bin generated. Proceeding with next steps.

Extracting Telemetry Host Dump (Data Area 2)...
nvme: ./json_object.c:1490: json_object_array_add: Assertion `json_object_get_type(jso) == json_type_array' failed.
Aborted (core dumped)