### PR TITLE
nvme: sanitize call to strerror()

### DIFF
--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -289,7 +289,7 @@ int nvme_scan_topology(struct nvme_global_ctx *ctx, nvme_scan_filter_t f, void *
 	ctrls.num = nvme_scan_ctrls(&ctrls.ents);
 	if (ctrls.num < 0) {
 		nvme_msg(ctx, LOG_DEBUG, "failed to scan ctrls: %s\n",
-			 strerror(ctrls.num));
+			 strerror(-ctrls.num));
 		return ctrls.num;
 	}
 
@@ -307,7 +307,7 @@ int nvme_scan_topology(struct nvme_global_ctx *ctx, nvme_scan_filter_t f, void *
 	subsys.num = nvme_scan_subsystems(&subsys.ents);
 	if (subsys.num < 0) {
 		nvme_msg(ctx, LOG_DEBUG, "failed to scan subsystems: %s\n",
-			 strerror(subsys.num));
+			 strerror(-subsys.num));
 		return subsys.num;
 	}
 
@@ -840,7 +840,7 @@ static int nvme_subsystem_scan_namespaces(struct nvme_global_ctx *ctx, nvme_subs
 	if (namespaces.num < 0) {
 		nvme_msg(ctx, LOG_DEBUG,
 			 "failed to scan namespaces for subsys %s: %s\n",
-			 s->subsysnqn, strerror(namespaces.num));
+			 s->subsysnqn, strerror(-namespaces.num));
 		return namespaces.num;
 	}
 
@@ -850,7 +850,7 @@ static int nvme_subsystem_scan_namespaces(struct nvme_global_ctx *ctx, nvme_subs
 		if (ret < 0)
 			nvme_msg(ctx, LOG_DEBUG,
 				 "failed to scan namespace %s: %s\n",
-				 namespaces.ents[i]->d_name, strerror(ret));
+				 namespaces.ents[i]->d_name, strerror(-ret));
 	}
 
 	return 0;

--- a/nvme.c
+++ b/nvme.c
@@ -1711,7 +1711,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 
 	err = nvme_identify_ctrl(hdl, ctrl);
 	if (err < 0) {
-		nvme_show_error("identify controller: %s", nvme_strerror(err));
+		nvme_show_error("identify controller: %s", nvme_strerror(-err));
 		return err;
 	} else if (err) {
 		nvme_show_error("could not identify controller");
@@ -2907,7 +2907,7 @@ static bool is_ns_mgmt_support(struct nvme_transport_handle *hdl)
 static void ns_mgmt_show_status(struct nvme_transport_handle *hdl, int err, char *cmd, __u32 nsid)
 {
 	if (err < 0) {
-		nvme_show_error("%s: %s", cmd, nvme_strerror(err));
+		nvme_show_error("%s: %s", cmd, nvme_strerror(-err));
 		return;
 	}
 
@@ -2965,7 +2965,7 @@ static int delete_ns(int argc, char **argv, struct command *acmd, struct plugin 
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -3536,7 +3536,7 @@ static int list(int argc, char **argv, struct command *acmd, struct plugin *plug
 	}
 	err = nvme_scan_topology(ctx, NULL, NULL);
 	if (err < 0) {
-		nvme_show_error("Failed to scan topology: %s", nvme_strerror(err));
+		nvme_show_error("Failed to scan topology: %s", nvme_strerror(-err));
 		return err;
 	}
 
@@ -3851,7 +3851,7 @@ static int ns_descs(int argc, char **argv, struct command *acmd, struct plugin *
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -3932,7 +3932,7 @@ static int id_ns(int argc, char **argv, struct command *acmd, struct plugin *plu
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -4314,7 +4314,7 @@ static int get_ns_id(int argc, char **argv, struct command *acmd, struct plugin 
 
 	err = nvme_get_nsid(hdl, &nsid);
 	if (err < 0) {
-		nvme_show_error("get namespace ID: %s", nvme_strerror(err));
+		nvme_show_error("get namespace ID: %s", nvme_strerror(-err));
 		return -errno;
 	}
 
@@ -4940,7 +4940,7 @@ static int get_feature(int argc, char **argv, struct command *acmd,
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
 			if (errno != ENOTTY) {
-				nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+				nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 				return err;
 			}
 			cfg.namespace_id = NVME_NSID_ALL;
@@ -5354,7 +5354,7 @@ static int subsystem_reset(int argc, char **argv, struct command *acmd, struct p
 		if (errno == ENOTTY)
 			nvme_show_error("Subsystem-reset: NVM Subsystem Reset not supported.");
 		else
-			nvme_show_error("Subsystem-reset: %s", nvme_strerror(err));
+			nvme_show_error("Subsystem-reset: %s", nvme_strerror(-err));
 	} else if (argconfig_parse_seen(opts, "verbose"))
 		printf("resetting subsystem through %s\n", nvme_transport_handle_get_name(hdl));
 
@@ -5377,7 +5377,7 @@ static int reset(int argc, char **argv, struct command *acmd, struct plugin *plu
 
 	err = nvme_ctrl_reset(hdl);
 	if (err < 0)
-		nvme_show_error("Reset: %s", nvme_strerror(err));
+		nvme_show_error("Reset: %s", nvme_strerror(-err));
 	else if (argconfig_parse_seen(opts, "verbose"))
 		printf("resetting controller %s\n", nvme_transport_handle_get_name(hdl));
 
@@ -5407,7 +5407,7 @@ static int ns_rescan(int argc, char **argv, struct command *acmd, struct plugin 
 
 	err = nvme_ns_rescan(hdl);
 	if (err < 0)
-		nvme_show_error("Namespace Rescan: %s\n", nvme_strerror(err));
+		nvme_show_error("Namespace Rescan: %s\n", nvme_strerror(-err));
 	else if (argconfig_parse_seen(opts, "verbose"))
 		printf("rescanning namespaces through %s\n", nvme_transport_handle_get_name(hdl));
 
@@ -6572,7 +6572,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 	} else if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return -errno;
 		}
 	}
@@ -6780,7 +6780,7 @@ static int set_feature(int argc, char **argv, struct command *acmd, struct plugi
 		err = nvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
 			if (errno != ENOTTY) {
-				nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+				nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 				return -errno;
 			}
 			cfg.nsid = NVME_NSID_ALL;
@@ -7142,7 +7142,7 @@ static int write_uncor(int argc, char **argv, struct command *acmd, struct plugi
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -7415,7 +7415,7 @@ static int write_zeroes(int argc, char **argv,
 	if (!cfg.nsid) {
 		err = nvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -7535,7 +7535,7 @@ static int dsm(int argc, char **argv, struct command *acmd, struct plugin *plugi
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -7735,7 +7735,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 	if (!cfg.nsid) {
 		err = nvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -7815,7 +7815,7 @@ static int flush_cmd(int argc, char **argv, struct command *acmd, struct plugin 
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -7887,7 +7887,7 @@ static int resv_acquire(int argc, char **argv, struct command *acmd, struct plug
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -7963,7 +7963,7 @@ static int resv_register(int argc, char **argv, struct command *acmd, struct plu
 	if (!cfg.namespace_id) {
 		err = nvme_get_nsid(hdl, &cfg.namespace_id);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -8046,7 +8046,7 @@ static int resv_release(int argc, char **argv, struct command *acmd, struct plug
 	if (!cfg.nsid) {
 		err = nvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -8121,7 +8121,7 @@ static int resv_report(int argc, char **argv, struct command *acmd, struct plugi
 	if (!cfg.nsid) {
 		err = nvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -8308,7 +8308,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	if (!cfg.nsid) {
 		err = nvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -8605,7 +8605,7 @@ static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin
 	if (!cfg.nsid) {
 		err = nvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
-			nvme_show_error("get-namespace-id: %s", nvme_strerror(err));
+			nvme_show_error("get-namespace-id: %s", nvme_strerror(-err));
 			return err;
 		}
 	}
@@ -10126,7 +10126,7 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 		err = nvme_scan_tls_keys(ctx, cfg.keyring, __scan_tls_key, fd);
 		if (err < 0) {
 			nvme_show_error("Export of TLS keys failed with '%s'",
-				nvme_strerror(err));
+				nvme_strerror(-err));
 			return err;
 		}
 
@@ -10233,7 +10233,7 @@ static int show_topology_cmd(int argc, char **argv, struct command *acmd, struct
 
 	err = nvme_scan_topology(ctx, filter, (void *)devname);
 	if (err < 0) {
-		nvme_show_error("Failed to scan topology: %s", nvme_strerror(err));
+		nvme_show_error("Failed to scan topology: %s", nvme_strerror(-err));
 		return err;
 	}
 


### PR DESCRIPTION
Avoid passing a negative int to strerror() for cleaner handling.