### PR TITLE
Fix build failure in generate-accessors with -Werror set.

### DIFF
--- a/libnvme/src/nvme/meson.build
+++ b/libnvme/src/nvme/meson.build
@@ -20,6 +20,7 @@ headers_to_scan = [
 generate_accessors = executable(
     'generate-accessors',
     'generate-accessors.c',
+    c_args: ['-D_GNU_SOURCE'],
     dependencies: [
         config_dep,
     ],


### PR DESCRIPTION
The generate-accessors native executable uses asprintf() which requires _GNU_SOURCE. While the main project defines this flag via add_project_arguments(), native executables don't inherit these settings and need it explicitly defined.

This fix adds -D_GNU_SOURCE to the c_args for the generate_accessors executable, resolving the implicit declaration warning that becomes a build error when -Werror is enabled.