### PR TITLE
plugin: cleanup vs-internal-log documentation

### DIFF
--- a/Documentation/nvme-sndk-vs-internal-log.txt
+++ b/Documentation/nvme-sndk-vs-internal-log.txt
@@ -39,31 +39,37 @@ OPTIONS
 
 -d <DATA AREA>::
 --data-area=<DATA AREA>::
-	DUI data area to retrieve. The DUI data areas from 1 to <DATA AREA> will
-	be retrieved. This parameter is currently only supported on the SN340,
-	SN640, SN730, and SN840 devices.
+	Data area to retrieve. For capture with a --type value that includes
+	telemetry (CONTROLLER or HOST), this specifies the NVMe telemetry data
+	area to capture, containing data from areas 1 to <DATA AREA>. For
+	capture without such a --type value, this specifies the amount of
+	vendor defined debug data to capture, and this is only supported on the
+	SN340, SN350, SN530, SN570, SN730, SN740, SN840, SN850X, SN5000,
+	SN5100S, SN7000S, SN7100, and SN7150 devices.
 
 -f <FILE SIZE>::
 --file-size=<FILE SIZE>::
-	Specifies the desired size of the data file starting at the passed in
-	offset. This allows the user to retrieve the data in several smaller
-	files of the passed in size. This parameter is currently only supported
-	on the SN340 device.
+	Deprecated. Specifies the desired size of the data file starting at the
+	passed in offset. This allows the user to retrieve the data in several
+	smaller files of the passed in size. This parameter is only supported on
+	the devices mentioned in the documentation of the --data-area parameter,
+	and only for capture with --type=NONE or --type not specified.
 
 -e <OFFSET>::
 --offset=<OFFSET>::
-	Specifies the data offset at which to start retrieving the data. This
-	parameter is used in combination with the file size parameter to
-	retrieve the data in several smaller files. This parameter is currently
-	only supported on the SN340 device.
+	Deprecated. Specifies the data offset at which to start retrieving the
+	data. This parameter is used in combination with the file size parameter
+	to retrieve the data in several smaller files. This parameter is only
+	supported on the devices mentioned in the documentation of the
+	--data-area parameter, and only for capture with --type=NONE or --type
+	not specified.
 
 -t <TYPE>::
 --type=<TYPE>::
 	Specifies the telemetry type - NONE, HOST, or CONTROLLER. This parameter
-	is used to get either the host generated or controller initiated
-	telemetry log page. If not specified or none is specified, the command
-	will return the default E6 log data. This parameter is currently only
-	supported on the SN640 and SN840 devices.
+	is used to get either the host-initiated or controller-initiated
+	telemetry log page. If not specified or if <TYPE> is NONE, the command
+	will return vendor defined debug data.
 
 -v <VERBOSE>::
 --verbose=<VERBOSE>::

--- a/Documentation/nvme-wdc-vs-internal-log.txt
+++ b/Documentation/nvme-wdc-vs-internal-log.txt
@@ -31,39 +31,45 @@ OPTIONS
 -o <FILE>::
 --output-file=<FILE>::
 	Output file; defaults to device serial number followed by
-	"_internal_fw_log_<date>_<time>.bin" suffix
+	"_internal_fw_log_<date>_<time>.bin" suffix.
 
 -s <SIZE>::
 --transfer-size=<SIZE>::
-	Transfer size; defaults to 0x10000 (65536 decimal) bytes
+	Transfer size; defaults to 0x10000 (65536 decimal) bytes.
 
 -d <DATA AREA>::
 --data-area=<DATA AREA>::
-	DUI data area to retrieve. The DUI data areas from 1 to <DATA AREA> will
-	be retrieved. This parameter is currently only supported on the SN340,
-	SN640, SN730, and SN840 devices.
+	Data area to retrieve. For capture with a --type value that includes
+	telemetry (CONTROLLER or HOST), this specifies the NVMe telemetry data
+	area to capture, containing data from areas 1 to <DATA AREA>. For
+	capture without such a --type value, this specifies the amount of
+	vendor defined debug data to capture, and this is only supported on the
+	SN340, SN350, SN530, SN570, SN730, SN740, SN840, SN850X, SN5000,
+	SN5100S, SN7000S, SN7100, and SN7150 devices.
 
 -f <FILE SIZE>::
 --file-size=<FILE SIZE>::
 	Specifies the desired size of the data file starting at the passed in
 	offset. This allows the user to retrieve the data in several smaller
-	files of the passed in size. This parameter is currently only supported
-	on the SN340 device.
+	files of the passed in size. This parameter is only supported on the
+	devices mentioned in the documentation of the --data-area parameter,
+	and only for capture with --type=NONE or --type not specified.
 
 -e <OFFSET>::
 --offset=<OFFSET>::
 	Specifies the data offset at which to start retrieving the data. This
 	parameter is used in combination with the file size parameter to
-	retrieve the data in several smaller files. This parameter is currently
-	only supported on the SN340 device.
+	retrieve the data in several smaller files. This parameter is only
+	supported on the devices mentioned in the documentation of the
+	--data-area parameter, and only for capture with --type=NONE or --type
+	not specified.
 
 -t <TYPE>::
 --type=<TYPE>::
 	Specifies the telemetry type - NONE, HOST, or CONTROLLER. This parameter
-	is used to get either the host generated or controller initiated
-	telemetry log page. If not specified or none is specified, the command
-	will return the default E6 log data. This parameter is currently only
-	supported on the SN640 and SN840 devices.
+	is used to get either the host-initiated or controller-initiated
+	telemetry log page. If not specified or if <TYPE> is NONE, the command
+	will return vendor defined debug data.
 
 -v <VERBOSE>::
 --verbose=<VERBOSE>::

--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -310,12 +310,16 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 	const char *file = "Output file pathname.";
 	const char *size = "Data retrieval transfer size.";
 	const char *data_area =
-		"Data area to retrieve up to. Currently only supported on the SN340, SN640, SN730, and SN840 devices.";
-	const char *file_size = "Output file size. Currently only supported on the SN340 device.";
+		"Data area to retrieve up to. Supported for telemetry, see man page for other use cases.";
+	const char *file_size =
+		"Output file size. Deprecated, see man page for supported devices.";
 	const char *offset =
-		"Output file data offset. Currently only supported on the SN340 device.";
+		"Output file data offset. Deprecated, see man page for supported devices.";
 	const char *type =
-		"Telemetry type - NONE, HOST, or CONTROLLER Currently only supported on the SN530, SN640, SN730, SN740, SN810, SN840 and ZN350 devices.";
+		"Telemetry type - NONE, HOST, or CONTROLLER:\n" \
+		"  NONE - Default, capture without using NVMe telemetry.\n" \
+		"  HOST - Host-initiated telemetry.\n" \
+		"  CONTROLLER - Controller-initiated telemetry.";
 	const char *verbose = "Display more debug messages.";
 	char f[PATH_MAX] = {0};
 	char fileSuffix[PATH_MAX] = {0};

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -4296,12 +4296,16 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 	const char *file = "Output file pathname.";
 	const char *size = "Data retrieval transfer size.";
 	const char *data_area =
-		"Data area to retrieve up to. Currently only supported on the SN340, SN640, SN730, and SN840 devices.";
-	const char *file_size = "Output file size. Currently only supported on the SN340 device.";
+		"Data area to retrieve up to. Supported for telemetry, see man page for other use cases.";
+	const char *file_size =
+		"Output file size. See man page for supported devices.";
 	const char *offset =
-		"Output file data offset. Currently only supported on the SN340 device.";
+		"Output file data offset. See man page for supported devices.";
 	const char *type =
-		"Telemetry type - NONE, HOST, or CONTROLLER Currently only supported on the SN530, SN640, SN730, SN740, SN810, SN840 and ZN350 devices.";
+		"Telemetry type - NONE, HOST, or CONTROLLER:\n" \
+		"  NONE - Default, capture without using NVMe telemetry.\n" \
+		"  HOST - Host-initiated telemetry.\n" \
+		"  CONTROLLER - Controller-initiated telemetry.";
 	const char *verbose = "Display more debug messages.";
 	char f[PATH_MAX] = {0};
 	char fb[PATH_MAX/2] = {0};


### PR DESCRIPTION
Some of these statements are out of date and missing important clarifying information. This attempts to clear that up and point out some parameters that are now deprecated.

Reviewed-by: Jeffrey Lien <jeff.lien@sandisk.com>