### PR TITLE
pulgin/ocp:Added the OCP2.7 supported Get feature FID=CAh command api

### DIFF
--- a/Documentation/nvme-ocp-get-idle-wakeup-time.txt
+++ b/Documentation/nvme-ocp-get-idle-wakeup-time.txt
@@ -1,0 +1,59 @@
+nvme-ocp-get-idle-wakeup-time(1)
+=========================================
+
+NAME
+----
+nvme-ocp-get-idle-wakeup-time - Define and print idle-wakeup-time value
+
+SYNOPSIS
+--------
+[verse]
+'nvme ocp get-idle-wakeup-time' <device> [--sel=<select> | -s <select>] [--namespace-id=<nsid> | -n <namespace-id>]
+
+DESCRIPTION
+-----------
+Define get-idle-wakeup-time.
+No argument prints current mode.
+
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0) or block device (ex: /dev/nvme0n1).
+
+This will only work on OCP compliant devices supporting this feature.
+Results for any other device are undefined.
+
+On success it returns 0, error code otherwise.
+
+OPTIONS
+-------
+
+-s <select>::
+--sel=<select>::
+	Select (SEL): This field specifies which value of the attributes
+	to return in the provided data:
+
+-n <namespace-id>::
+--namespace-id=<namespace-id>::
+	namespace-id (namespace-id): This field specifies which value of the attributes
+	to return in the provided data:
++
+[]
+|==================
+|Select|Description
+|0|Current
+|1|Default
+|2|Saved
+|3|Supported capabilities
+|4-7|Reserved
+|==================
+
+EXAMPLES
+--------
+* Has the program issue a get-idle-wakeup-time to retrieve the 0xCA get features.
++
+------------
+# nvme ocp get-idle-wakeup-time /dev/nvme0
+------------
+
+NVME
+----
+Part of the nvme-user suite.

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -50,6 +50,8 @@ PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),
 		      ocp_get_telemetry_profile_feature)
 		ENTRY("persistent-event-log", "Retrieve Persistent Event Log with OCP events",
 		      ocp_get_persistent_event_log)
+		ENTRY("get-idle-wakeup-time", "Get Idle Wake Up Time Config",
+		      ocp_get_idle_wakeup_time_config_feature)
 	)
 );
 
@@ -281,6 +283,7 @@ enum ocp_dssd_feature_id {
 	OCP_FID_DSSDPS, /* DSSD Power State */
 	OCP_FID_TEL_CFG, /* Telemetry Profile */
 	OCP_FID_DAEC, /* DSSD Asynchronous Event Configuration */
+	OCP_FID_IWTC, /* Idle Wake Up Time Configuration */
 };
 
 /*


### PR DESCRIPTION
Implemented the OCP 2.7 spec supported Get Feature FID=CAh command api to fetch idle wake up time configuration

Reviewed-by: Karthik Balan <karthik.b82@samsung.com>
Reviewed-by: Arunpandian J <arun.j@samsung.com>