### PR TITLE
libnvme: Add nvme_getifaddrs()

### DIFF
--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -13,6 +13,8 @@
 #include <poll.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <ifaddrs.h>
 
 #include <nvme/fabrics.h>
 #include <nvme/mi.h>
@@ -273,6 +275,7 @@ struct nvme_global_ctx {
 	bool create_only;
 	bool dry_run;
 	struct nvme_fabric_options *options;
+	struct ifaddrs *ifaddrs_cache; /* init with nvme_getifaddrs() */
 };
 
 struct nvmf_discovery_ctx {
@@ -551,5 +554,19 @@ static inline char *xstrdup(const char *s)
 		return NULL;
 	return strdup(s);
 }
+
+/**
+ * nvme_getifaddrs - Cached wrapper around getifaddrs()
+ * @ctx: pointer to the global context
+ *
+ * On the first call, this function invokes the POSIX getifaddrs()
+ * and caches the result in the global context. Subsequent calls
+ * return the cached data. The caller must NOT call freeifaddrs()
+ * on the returned data. The cache will be freed when the global
+ * context is freed.
+ *
+ * Return: Pointer to I/F data, NULL on error (with errno set).
+ */
+const struct ifaddrs *nvme_getifaddrs(struct nvme_global_ctx *ctx);
 
 #endif /* _LIBNVME_PRIVATE_H */

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -1167,3 +1167,15 @@ void *__nvme_realloc(void *p, size_t len)
 
 	return result;
 }
+
+const struct ifaddrs *nvme_getifaddrs(struct nvme_global_ctx *ctx)
+{
+	if (!ctx->ifaddrs_cache) {
+		struct ifaddrs *p;
+
+		if (!getifaddrs(&p))
+			ctx->ifaddrs_cache = p;
+	}
+
+	return ctx->ifaddrs_cache;
+}


### PR DESCRIPTION
The POSIX `getifaddrs()` API returns the list of network interfaces on the system, but invoking it can be costly. On large-scale systems with hundreds of NVMe-over-TCP connections, this API may be called hundreds of times, resulting in increased latency.

This patch introduces `nvme_getifaddrs()`, a wrapper around `getifaddrs()` that caches the results on the first invocation and reuses the cached data on subsequent calls.

Fixes: https://github.com/linux-nvme/libnvme/issues/1098