### PR TITLE
udev: don't spread variables through all nodes

### DIFF
--- a/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
+++ b/nvmf-autoconnect/udev-rules/70-nvmf-autoconnect.rules.in
@@ -7,24 +7,24 @@
 ACTION!="change", GOTO="autoconnect_end"
 
 # For backwards compatibility. Make sure HOST_IFACE is not an empty string.
-ENV{NVME_HOST_IFACE}=="", ENV{NVME_HOST_IFACE}="none"
+SUBSYSTEM=="nvme", ENV{NVME_HOST_IFACE}=="", ENV{NVME_HOST_IFACE}="none"
 
 # Events from persistent discovery controllers or nvme-fc transport events
 # NVME_AEN:
 #   type 0x2 (NOTICE) info 0xf0 (DISCOVERY_LOG_CHANGE) log-page-id 0x70 (DISCOVERY_LOG_PAGE)
-ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_AEN}=="0x70f002", \
+SUBSYSTEM=="nvme", ENV{NVME_AEN}=="0x70f002", \
   ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
   ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", ENV{NVME_HOST_IFACE}=="*", \
   RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device\x3d$kernel\t--transport\x3d$env{NVME_TRTYPE}\t--traddr\x3d$env{NVME_TRADDR}\t--trsvcid\x3d$env{NVME_TRSVCID}\t--host-traddr\x3d$env{NVME_HOST_TRADDR}\t--host-iface\x3d$env{NVME_HOST_IFACE}.service"
 
 # nvme-fc transport generated events (old-style for compatibility)
-ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
+SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
   ENV{NVMEFC_HOST_TRADDR}=="*",  ENV{NVMEFC_TRADDR}=="*", \
   RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device\x3dnone\t--transport\x3dfc\t--traddr\x3d$env{NVMEFC_TRADDR}\t--trsvcid\x3dnone\t--host-traddr\x3d$env{NVMEFC_HOST_TRADDR}.service"
 
 # A discovery controller just (re)connected, re-read the discovery log change to
 # check if there were any changes since it was last connected.
-ACTION=="change", SUBSYSTEM=="nvme", ENV{NVME_EVENT}=="rediscover", ATTR{cntrltype}=="discovery", \
+SUBSYSTEM=="nvme", ENV{NVME_EVENT}=="rediscover", ATTR{cntrltype}=="discovery", \
   ENV{NVME_TRTYPE}=="*", ENV{NVME_TRADDR}=="*", \
   ENV{NVME_TRSVCID}=="*", ENV{NVME_HOST_TRADDR}=="*", ENV{NVME_HOST_IFACE}=="*", \
   RUN+="@SYSTEMCTL@ --no-block restart nvmf-connect@--device\x3d$kernel\t--transport\x3d$env{NVME_TRTYPE}\t--traddr\x3d$env{NVME_TRADDR}\t--trsvcid\x3d$env{NVME_TRSVCID}\t--host-traddr\x3d$env{NVME_HOST_TRADDR}\t--host-iface\x3d$env{NVME_HOST_IFACE}.service"


### PR DESCRIPTION
This has been discussed here https://github.com/systemd/systemd/issues/40670

NVME_HOST_IFACE=none is being set to every existing node device but this
shouldn't be done, we don't want this in /dev/peanutbutter.

Set it only for nvme subsystem devices.

While at it remove all the action change conditions that are always true
given the if it's any other kind of action a goto end in the beginning.