### PR TITLE
libnvme/json: check write return value for build warnings

### DIFF
--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -435,10 +435,9 @@ int json_update_config(struct nvme_global_ctx *ctx, int fd)
 	ret = json_object_to_fd(fd, json_root,
 				JSON_C_TO_STRING_PRETTY |
 				JSON_C_TO_STRING_NOSLASHESCAPE);
-	write(fd, "\n", 1);
-	if (ret < 0) {
+	if (ret < 0 || write(fd, "\n", 1) < 0) {
 		nvme_msg(ctx, LOG_ERR, "Failed to write JSON config file: %s\n",
-			 json_util_get_last_err());
+			 ret ? json_util_get_last_err() : strerror(errno));
 		ret = -EIO;
 	}
 	json_object_put(json_root);


### PR DESCRIPTION
Since the following build warnings output.

[61/232] Compiling C object libnvme/src/libnvme-test.so.p/nvme_json.c.o ../libnvme/src/nvme/json.c: In function ‘json_update_config’: ../libnvme/src/nvme/json.c:438:9: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  438 |         write(fd, "\n", 1);
      |         ^~~~~~~~~~~~~~~~~~
[62/232] Compiling C object libnvme/src/libnvme.so.3.0.0.p/nvme_json.c.o
../libnvme/src/nvme/json.c: In function ‘json_update_config’:
../libnvme/src/nvme/json.c:438:9: warning: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  438 |         write(fd, "\n", 1);
      |         ^~~~~~~~~~~~~~~~~~

Fixes: 74b30d2556c3 ("json: update nvme_dump_config to a file descriptor")