### PR TITLE
tree: fix nvme_subsystem_scan_namespaces() return handling

### DIFF
--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -922,7 +922,7 @@ static int nvme_scan_subsystem(struct nvme_global_ctx *ctx, const char *name)
 				continue;
 			if (strcmp(_s->name, name))
 				continue;
-			if (!nvme_subsystem_scan_namespaces(ctx, _s))
+			if (nvme_subsystem_scan_namespaces(ctx, _s))
 				return -EINVAL;
 			s = _s;
 		}
@@ -941,7 +941,7 @@ static int nvme_scan_subsystem(struct nvme_global_ctx *ctx, const char *name)
 		s = nvme_alloc_subsystem(h, name, subsysnqn);
 		if (!s)
 			return -ENOMEM;
-		if (!nvme_subsystem_scan_namespaces(ctx, s))
+		if (nvme_subsystem_scan_namespaces(ctx, s))
 			return -EINVAL;
 	} else if (strcmp(s->subsysnqn, subsysnqn)) {
 		nvme_msg(ctx, LOG_DEBUG, "NQN mismatch for subsystem '%s'\n",


### PR DESCRIPTION
nvme list-subsys with the -vv option currently displays the following:

scan controller nvme0
lookup subsystem /sys/class/nvme-subsystem/nvme-subsys0/nvme0 scan controller nvme0 path nvme0c0n1
scan subsystem nvme-subsys0
scan subsystem nvme-subsys0 namespace nvme0n1
failed to scan subsystem nvme-subsys0: Invalid argument ...

The invalid argument seen above is due to the wrong return handling of nvme_subsystem_scan_namespaces() in nvme_scan_subsystem(). Fix the same.