### PR TITLE
fabrics: do no try do disconnect invalid ctrl

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2253,7 +2253,7 @@ static int _nvmf_discovery(struct nvme_global_ctx *ctx,
 			if (discover)
 				_nvmf_discovery(ctx, fctx, true, child);
 
-			if (disconnect) {
+			if (child && disconnect) {
 				nvme_disconnect_ctrl(child);
 				nvme_free_ctrl(child);
 			}


### PR DESCRIPTION
The ctrl object (child) can be NULL when either discovery is false or _nvmf_discovery fails. Thus only disconnect when it is a valid pointer.

Fixes: #3104 