### PR TITLE
libnvme/ioctl: limit to use NVME_IOCTL_IO64_CMD only for block dev

### DIFF
--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -178,7 +178,7 @@ out:
 int nvme_submit_io_passthru(struct nvme_transport_handle *hdl,
 		struct nvme_passthru_cmd *cmd)
 {
-	if (hdl->ioctl64)
+	if (hdl->ioctl_io64)
 		return nvme_submit_passthru64(hdl, NVME_IOCTL_IO64_CMD, cmd);
 	return nvme_submit_passthru32(hdl, NVME_IOCTL_IO_CMD, cmd);
 }
@@ -188,7 +188,7 @@ int nvme_submit_admin_passthru(struct nvme_transport_handle *hdl,
 {
 	switch (hdl->type) {
 	case NVME_TRANSPORT_HANDLE_TYPE_DIRECT:
-		if (hdl->ioctl64)
+		if (hdl->ioctl_admin64)
 			return nvme_submit_passthru64(hdl,
 				NVME_IOCTL_ADMIN64_CMD, cmd);
 		if (cmd->opcode == nvme_admin_fabrics)

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -160,8 +160,12 @@ static int __nvme_transport_handle_open_direct(
 
 	if (hdl->ctx->ioctl_probing) {
 		ret = ioctl(hdl->fd, NVME_IOCTL_ADMIN64_CMD, &dummy);
-		if (ret > 0)
-			hdl->ioctl64 = true;
+		if (ret > 0) {
+			hdl->ioctl_admin64 = true;
+			ret = ioctl(hdl->fd, NVME_IOCTL_IO64_CMD, &dummy);
+			if (ret != -1 || errno != ENOTTY)
+				hdl->ioctl_io64 = true;
+		}
 	}
 
 	return 0;
@@ -211,7 +215,7 @@ int nvme_open(struct nvme_global_ctx *ctx, const char *name,
 		hdl->fd = 0xFD;
 
 		if (!strcmp(name, "NVME_TEST_FD64"))
-			hdl->ioctl64 = true;
+			hdl->ioctl_admin64 = true;
 
 		*hdlp = hdl;
 		return 0;

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -113,7 +113,8 @@ struct nvme_transport_handle {
 	/* direct */
 	int fd;
 	struct stat stat;
-	bool ioctl64;
+	bool ioctl_admin64;
+	bool ioctl_io64;
 
 	/* mi */
 	struct nvme_mi_ep *ep;


### PR DESCRIPTION
Since currently NVME_IOCTL_IO64_CMD not supported for the char dev. Currently the char dev nvmeX not able be used for the io-passthru command. Also previously NVME_IOCTL_IO_CMD used for the io-passthru command. Therefore for the char dev nvmeX use NVME_IOCTL_IO_CMD instead.