### PR TITLE
nvme: fix segfault at nvme_match_devname()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -3458,8 +3458,10 @@ parse_lba:
 
 static bool nvme_match_devname(char *devname, nvme_ns_t ns)
 {
+	nvme_ctrl_t c = nvme_ns_get_ctrl(ns);
+
 	if (!strcmp(devname, nvme_ns_get_name(ns)) ||
-	    !strcmp(devname, nvme_ctrl_get_name(nvme_ns_get_ctrl(ns))) ||
+	    (c && !strcmp(devname, nvme_ctrl_get_name(c))) ||
 	    !strcmp(devname, nvme_ns_get_generic_name(ns)))
 		return true;
 


### PR DESCRIPTION
Passing the character device as an argument to nvme list-subsys can result in a segfault at nvme_match_devname() as seen in the below gdb stack trace:

(gdb) where
nvme_ctrl_get_name (c=0x0) at ../libnvme/src/nvme/tree.c:1085 0x000000000040e800 in nvme_match_devname (devname=0xf910df0 "0\342\220\017", ns=0x7ffd1ed57703) at ../nvme.c:3462 0x000000000040e853 in nvme_match_device_filter (s=0x0, c=0xf90dbe0, ns=0x0, f_args=0x30) at ../nvme.c:3471 (gdb)

This is because nvme_ns_get_ctrl() can return a NULL for multipathed ns devices. Fix the same.

Fixes: 51bc794fa863 ("nvme: allow char dev filter for show-topology and list-subsys commands")