### PR TITLE
Add Windows support to meson build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ tests/*.pyc
 
 # Ignore PyPI build artifacts
 dist/
+
+.vscode/

--- a/libnvme/examples/meson.build
+++ b/libnvme/examples/meson.build
@@ -5,6 +5,10 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
+
+# Skip examples on Windows for now.
+if host_system != 'windows'
+
 executable(
     'telemetry-listen',
     ['telemetry-listen.c'],
@@ -90,3 +94,5 @@ if libdbus_dep.found()
         ],
     )
 endif
+
+endif # host_system != 'windows'

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -5,22 +5,27 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-sources = [
-    'nvme/accessors.c',
-    'nvme/base64.c',
-    'nvme/cmds.c',
-    'nvme/crc32.c',
-    'nvme/filters.c',
-    'nvme/ioctl.c',
-    'nvme/lib.c',
-    'nvme/linux.c',
-    'nvme/log.c',
-    'nvme/mi-mctp.c',
-    'nvme/mi.c',
-    'nvme/sysfs.c',
-    'nvme/tree.c',
-    'nvme/util.c',
-]
+sources = []
+if host_system == 'windows'
+    sources += []
+else
+    sources += [
+        'nvme/accessors.c',
+        'nvme/base64.c',
+        'nvme/cmds.c',
+        'nvme/crc32.c',
+        'nvme/filters.c',
+        'nvme/ioctl.c',
+        'nvme/lib.c',
+        'nvme/linux.c',
+        'nvme/log.c',
+        'nvme/mi-mctp.c',
+        'nvme/mi.c',
+        'nvme/sysfs.c',
+        'nvme/tree.c',
+        'nvme/util.c',
+    ]
+endif
 headers = [
     'nvme/accessors.h',
     'nvme/cmds.h',
@@ -50,10 +55,12 @@ if liburing_dep.found()
     sources += 'nvme/uring.c'
 endif
 
-if json_c_dep.found()
-    sources += 'nvme/json.c'
-else
-    sources += 'nvme/no-json.c'
+if host_system != 'windows'
+    if json_c_dep.found()
+        sources += 'nvme/json.c'
+    else
+        sources += 'nvme/no-json.c'
+    endif
 endif
 
 deps = [
@@ -61,10 +68,18 @@ deps = [
     ccan_dep,
     json_c_dep,
     keyutils_dep,
-    libdbus_dep,
-    liburing_dep,
     openssl_dep,
 ]
+if host_system == 'windows'
+    deps += [
+        kernel32_dep
+    ]
+else
+    deps += [
+        libdbus_dep,
+        liburing_dep,
+    ]
+endif
 
 nvme_ld = meson.current_source_dir() / 'libnvme.ld'
 nvmf_ld = meson.current_source_dir() / 'libnvmf.ld'

--- a/libnvme/test/meson.build
+++ b/libnvme/test/meson.build
@@ -21,6 +21,10 @@ endif
 # define as meson unit-tests, and therefore get run as part of the 'test'
 # target. However, they're available for developer use, when hardware is
 # available.
+
+# Skip tests on Windows for now.
+if host_system != 'windows'
+
 main = executable(
     'main-test',
     ['test.c'],
@@ -221,3 +225,5 @@ foreach hdr : [
     )
     test('libnvme - header/' + hdr, exe)
 endforeach
+
+endif # host_system != 'windows'

--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,6 @@ project(
     default_options: [
         'c_std=gnu99',
         'buildtype=debugoptimized',
-        'prefix=/usr/local',
         'warning_level=1',
         'sysconfdir=etc',
         'wrap_mode=nofallback',
@@ -34,6 +33,7 @@ fs = import('fs')
 
 cc = meson.get_compiler('c')
 cxx_available = add_languages('cpp', required: false, native: false)
+host_system = host_machine.system()
 
 ################################################################################
 # Determine which features we need to build: The nvme executable, the libnvme
@@ -51,7 +51,7 @@ cxx_available = add_languages('cpp', required: false, native: false)
 # dependencies are present. Also, -Dpython=enabled forces -Dlibnvme=enabled.
 want_nvme = get_option('nvme').disabled() == false
 want_libnvme = get_option('libnvme').disabled() == false
-want_fabrics = get_option('fabrics').disabled() == false
+want_fabrics = get_option('fabrics').disabled() == false and host_system != 'windows'
 want_docs = get_option('docs')
 want_docs_build = get_option('docs-build')
 
@@ -131,8 +131,12 @@ conf.set('RUNDIR', '"@0@"'.format(rundir))
 
 conf.set('CONFIG_FABRICS', want_fabrics, description: 'Is fabrics enabled')
 
+if host_system == 'windows'
+    kernel32_dep = cc.find_library('kernel32', required: true)
+endif
+
 # Check for libjson-c availability
-if get_option('json-c').disabled()
+if host_system == 'windows' or get_option('json-c').disabled()
     json_c_dep = dependency('', required: false)
 else
     json_c_dep = dependency(
@@ -365,7 +369,7 @@ conf.set10(
 
 is_static = get_option('default_library') == 'static'
 have_netdb = false
-if not is_static
+if not is_static and host_system != 'windows'
     have_netdb = cc.links(
         '''#include <sys/types.h>
         #include <sys/socket.h>
@@ -471,18 +475,26 @@ if want_nvme
     subdir('plugins')   # declares: plugin_sources
     subdir('util')      # declares: util_sources
 
-    sources = [
-        'libnvme-wrap.c',
-        'logging.c',
-        'nvme-cmds.c',
-        'nvme-models.c',
-        'nvme-print-binary.c',
-        'nvme-print-stdout.c',
-        'nvme-print.c',
-        'nvme-rpmb.c',
-        'nvme.c',
-        'plugin.c',
-    ]
+    sources = []
+    if host_system == 'windows'
+        sources += [
+            'nvme-dummy.c', # Dummy source file for Windows port bring up.
+        ]
+    else
+        sources += [
+            'libnvme-wrap.c',
+            'logging.c',
+            'nvme-cmds.c',
+            'nvme-models.c',
+            'nvme-print-binary.c',
+            'nvme-print-stdout.c',
+            'nvme-print.c',
+            'nvme-rpmb.c',
+            'nvme.c',
+            'plugin.c',
+        ]
+    endif
+
     if want_fabrics
         sources += 'fabrics.c'
     endif
@@ -495,16 +507,27 @@ if want_nvme
     sources += plugin_sources
     sources += util_sources
 
+    link_args_list = []
+    link_deps = [
+        config_dep,
+        ccan_dep,
+        libnvme_dep,
+        json_c_dep,
+    ]
+
+    if host_system == 'windows'
+        link_deps += [
+            kernel32_dep,
+        ]
+    else
+        link_args_list = ['-ldl']
+    endif
+
     executable(
         'nvme',
         sources,
-        dependencies: [
-            config_dep,
-            ccan_dep,
-            libnvme_dep,
-            json_c_dep,
-        ],
-        link_args: '-ldl',
+        dependencies: link_deps,
+        link_args: link_args_list,
         install: true,
         install_dir: sbindir,
     )
@@ -632,6 +655,11 @@ dep_dict = {
     'python3':          py3_dep.found(),
     'liburing':         liburing_dep.found(),
 }
+if host_system == 'windows'
+    dep_dict += {
+        'kernel32':     kernel32_dep.found(),
+    }
+endif
 summary(dep_dict, section: 'Dependencies', bool_yn: true)
 
 wanted_dict = {
@@ -648,4 +676,3 @@ conf_dict = {
     'pdc enabled':      get_option('pdc-enabled'),
 }
 summary(conf_dict, section: 'Configuration', bool_yn: true)
-

--- a/nvme-dummy.c
+++ b/nvme-dummy.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+	printf("This is a dummy executable for windows port bring up.\n");
+	return 0;
+}

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,34 +1,37 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Define all available plugins and their source files
-all_plugins = {
-  'amzn': ['plugins/amzn/amzn-nvme.c'],
-  'dapustor': ['plugins/dapustor/dapustor-nvme.c'],
-  'dell': ['plugins/dell/dell-nvme.c'],
-  'dera': ['plugins/dera/dera-nvme.c'],
-  'fdp': ['plugins/fdp/fdp.c'],
-  'huawei': ['plugins/huawei/huawei-nvme.c'],
-  'ibm': ['plugins/ibm/ibm-nvme.c'],
-  'innogrit': ['plugins/innogrit/innogrit-nvme.c'],
-  'inspur': ['plugins/inspur/inspur-nvme.c'],
-  'intel': ['plugins/intel/intel-nvme.c'],
-  'mangoboost': ['plugins/mangoboost/mangoboost-nvme.c'],
-  'memblaze': ['plugins/memblaze/memblaze-nvme.c'],
-  'micron': ['plugins/micron/micron-nvme.c'],
-  'netapp': ['plugins/netapp/netapp-nvme.c'],
-  'nvidia': ['plugins/nvidia/nvidia-nvme.c'],
-  'sandisk': ['plugins/sandisk/sandisk-nvme.c', 'plugins/sandisk/sandisk-utils.c'],
-  'scaleflux': ['plugins/scaleflux/sfx-nvme.c'],
-  'seagate': ['plugins/seagate/seagate-nvme.c'],
-  'shannon': ['plugins/shannon/shannon-nvme.c'],
-  'ssstc': ['plugins/ssstc/ssstc-nvme.c'],
-  'toshiba': ['plugins/toshiba/toshiba-nvme.c'],
-  'transcend': ['plugins/transcend/transcend-nvme.c'],
-  'virtium': ['plugins/virtium/virtium-nvme.c'],
-  'wdc': ['plugins/wdc/wdc-nvme.c', 'plugins/wdc/wdc-utils.c'],
-  'ymtc': ['plugins/ymtc/ymtc-nvme.c'],
-  'zns': ['plugins/zns/zns.c'],
-}
+all_plugins = {}
+if host_system != 'windows'
+  all_plugins += {
+    'amzn': ['plugins/amzn/amzn-nvme.c'],
+    'dapustor': ['plugins/dapustor/dapustor-nvme.c'],
+    'dell': ['plugins/dell/dell-nvme.c'],
+    'dera': ['plugins/dera/dera-nvme.c'],
+    'fdp': ['plugins/fdp/fdp.c'],
+    'huawei': ['plugins/huawei/huawei-nvme.c'],
+    'ibm': ['plugins/ibm/ibm-nvme.c'],
+    'innogrit': ['plugins/innogrit/innogrit-nvme.c'],
+    'inspur': ['plugins/inspur/inspur-nvme.c'],
+    'intel': ['plugins/intel/intel-nvme.c'],
+    'mangoboost': ['plugins/mangoboost/mangoboost-nvme.c'],
+    'memblaze': ['plugins/memblaze/memblaze-nvme.c'],
+    'micron': ['plugins/micron/micron-nvme.c'],
+    'netapp': ['plugins/netapp/netapp-nvme.c'],
+    'nvidia': ['plugins/nvidia/nvidia-nvme.c'],
+    'sandisk': ['plugins/sandisk/sandisk-nvme.c', 'plugins/sandisk/sandisk-utils.c'],
+    'scaleflux': ['plugins/scaleflux/sfx-nvme.c'],
+    'seagate': ['plugins/seagate/seagate-nvme.c'],
+    'shannon': ['plugins/shannon/shannon-nvme.c'],
+    'ssstc': ['plugins/ssstc/ssstc-nvme.c'],
+    'toshiba': ['plugins/toshiba/toshiba-nvme.c'],
+    'transcend': ['plugins/transcend/transcend-nvme.c'],
+    'virtium': ['plugins/virtium/virtium-nvme.c'],
+    'wdc': ['plugins/wdc/wdc-nvme.c', 'plugins/wdc/wdc-utils.c'],
+    'ymtc': ['plugins/ymtc/ymtc-nvme.c'],
+    'zns': ['plugins/zns/zns.c'],
+  }
+endif
 
 # Get the list of plugins to build
 selected_plugins = get_option('plugins')
@@ -46,22 +49,24 @@ if want_fabrics and 'nbft' in selected_plugins
     plugin_sources += ['plugins/nbft/nbft-plugin.c']
 endif
 
-if 'feat' in selected_plugins
-  subdir('feat')
-endif
+if host_system != 'windows'
+  if 'feat' in selected_plugins
+    subdir('feat')
+  endif
 
-if 'lm' in selected_plugins
-  subdir('lm')
-endif
+  if 'lm' in selected_plugins
+    subdir('lm')
+  endif
 
-if 'ocp' in selected_plugins
-  subdir('ocp')
-endif
+  if 'ocp' in selected_plugins
+    subdir('ocp')
+  endif
 
-if 'sed' in selected_plugins and conf.get('HAVE_SED_OPAL') != 0
-  subdir('sed')
-endif
+  if 'sed' in selected_plugins and conf.get('HAVE_SED_OPAL') != 0
+    subdir('sed')
+  endif
 
-if 'solidigm' in selected_plugins and json_c_dep.found()
-  subdir('solidigm')
+  if 'solidigm' in selected_plugins and json_c_dep.found()
+    subdir('solidigm')
+  endif
 endif

--- a/unit/meson.build
+++ b/unit/meson.build
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+# Skip on Windows for now.
+if host_system != 'windows'
+
 test_uint128 = executable(
     'test-uint128',
     ['test-uint128.c', '../util/types.c', '../util/suffix.c'],
@@ -59,3 +62,5 @@ test_argconfig_parse = executable(
 )
 
 test('nvme-cli - argconfig_parse', test_argconfig_parse)
+
+endif # host_system != 'windows'

--- a/util/meson.build
+++ b/util/meson.build
@@ -1,19 +1,25 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-util_sources = [
-    'util/argconfig.c',
-    'util/base64.c',
-    'util/crc32.c',
-    'util/mem.c',
-    'util/sighdl.c',
-    'util/suffix.c',
-    'util/types.c',
-    'util/utils.c',
-    'util/table.c'
-]
+util_sources = []
 
-if json_c_dep.found()
+if host_system == 'windows'
+    util_sources += []
+else
     util_sources += [
-        'util/json.c',
+        'util/argconfig.c',
+        'util/base64.c',
+        'util/crc32.c',
+        'util/mem.c',
+        'util/sighdl.c',
+        'util/suffix.c',
+        'util/types.c',
+        'util/utils.c',
+        'util/table.c'
     ]
+
+    if json_c_dep.found()
+        util_sources += [
+            'util/json.c',
+        ]
+    endif
 endif


### PR DESCRIPTION
feature: add windows support to meson build system

This is the first step in adding Windows build support to this project. The idea is to restructure the meson.build files to support windows without touching any of the code.

Signed-off-by: Brandon Capener <bcapener@micron.com>