### PR TITLE
nvme: remove -t as alias for --timeout

### DIFF
--- a/Documentation/nvme-admin-passthru.txt
+++ b/Documentation/nvme-admin-passthru.txt
@@ -19,7 +19,7 @@ SYNOPSIS
 			[--metadata-len=<len> | -m <len>]
 			[--input-file=<file> | -i <file>]
 			[--read | -r] [--write | -w]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 			[--show-command | -s]
 			[--dry-run | -d]
 			[--raw-binary | -b]
@@ -124,7 +124,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-ave-discovery-log.txt
+++ b/Documentation/nvme-ave-discovery-log.txt
@@ -34,7 +34,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-capacity-mgmt.txt
+++ b/Documentation/nvme-capacity-mgmt.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 			[--cap-lower=<cap-lower> | -l <cap-lower>]
 			[--cap-upper=<cap-upper> | -u <cap-upper>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -56,7 +56,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-changed-alloc-ns-list-log.txt
+++ b/Documentation/nvme-changed-alloc-ns-list-log.txt
@@ -41,7 +41,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-copy.txt
+++ b/Documentation/nvme-copy.txt
@@ -27,7 +27,7 @@ SYNOPSIS
 			[--dir-spec=<spec> | -S <spec>]
 			[--format=<entry-format> | -F <entry-format>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -123,7 +123,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-create-ns.txt
+++ b/Documentation/nvme-create-ns.txt
@@ -20,7 +20,7 @@ SYNOPSIS
 			[--lbstm=<lbstm> | -l <lbstm>]
 			[--nphndls=<nphndls> | -n <nphndls>]
 			[--block-size=<block-size> | -b <block-size>]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 			[--nsze-si=<nsze-si> | -S <nsze-si>]
 			[--ncap-si=<ncap-si> | -C <ncap-si>]
 			[--azr | -z]
@@ -148,7 +148,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value 120,000. In milliseconds.
 

--- a/Documentation/nvme-delete-ns.txt
+++ b/Documentation/nvme-delete-ns.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 [verse]
 'nvme delete-ns' <device> [--namespace-id=<nsid> | -n <nsid>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -36,7 +36,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value 120,000. In milliseconds.
 

--- a/Documentation/nvme-device-self-test.txt
+++ b/Documentation/nvme-device-self-test.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 'nvme device-self-test' <device> [--namespace-id=<NUM> | -n <NUM>]
 			[--self-test-code=<NUM> | -s <NUM>] [--wait | -w]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -55,7 +55,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-dir-receive.txt
+++ b/Documentation/nvme-dir-receive.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 			[--req-resource=<nsr> | -r <nsr>]
 			[--human-readable | -H] [--raw-binary | -b]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -91,7 +91,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-dir-send.txt
+++ b/Documentation/nvme-dir-send.txt
@@ -17,7 +17,7 @@ SYNOPSIS
 			[--target-dir=<tdir> | -T <tdir>]
 			[--human-readable | -H] [--raw-binary | -b]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -95,7 +95,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-dispersed-ns-participating-nss-log.txt
+++ b/Documentation/nvme-dispersed-ns-participating-nss-log.txt
@@ -38,7 +38,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-dsm.txt
+++ b/Documentation/nvme-dsm.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 			[--idw=<write> | -w <write>] [--idr=<read> | -r <read>]
 			[--cdw11=<cdw11> | -c <cdw11>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -84,7 +84,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-effects-log.txt
+++ b/Documentation/nvme-effects-log.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 [verse]
 'nvme effects-log' <device> [--human-readable | -H] [--raw-binary | -b]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -46,7 +46,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-format.txt
+++ b/Documentation/nvme-format.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 			[--ses=<ses> | -s <ses>] [--pil=<pil> | -p <pil>]
 			[--pi=<pi> | -i <pi>] [--ms=<ms> | -m <ms>]
 			[--reset | -r] [--force]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
 
 DESCRIPTION
@@ -129,7 +129,6 @@ cryptographically. This is accomplished by deleting the encryption key.
 --force::
 	Just send the command immediately without warning of the implications.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value 600,000. In milliseconds.
 

--- a/Documentation/nvme-fw-commit.txt
+++ b/Documentation/nvme-fw-commit.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 			[--action=<action> | -a <action>]
 			[--bpid=<boot-partid> | -b <boot-partid>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -88,7 +88,6 @@ the BPID field as active and update BPINFO.ABPID.
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-fw-download.txt
+++ b/Documentation/nvme-fw-download.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 			[--xfer=<transfer-size> | -x <transfer-size>]
 			[--offset=<offset> | -O <offset>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -80,7 +80,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-get-feature.txt
+++ b/Documentation/nvme-get-feature.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 			[--raw-binary | -b] [--cdw11=<cdw11> | -c <cdw11>]
 			[--human-readable | -H] [--changed | -C]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -146,7 +146,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-get-lba-status.txt
+++ b/Documentation/nvme-get-lba-status.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 			[--max-dw=<max-dw> | -m <max-dw>]
 			[--action=<action-type> | -a <action-type>]
 			[--range-len=<range-len> | -l <range-len>]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
 
 DESCRIPTION
@@ -53,7 +53,6 @@ OPTIONS
 --range-len=<range-len>::
 	Range Length(RL) specifies the length of the range of contiguous LBAs beginning at SLBA
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-get-property.txt
+++ b/Documentation/nvme-get-property.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 'nvme get-property' <device> [--offset=<offset> | -O <offset>]
 			[--human-readable | -H]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -37,7 +37,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-get-reg.txt
+++ b/Documentation/nvme-get-reg.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 			[--bprsel] [--bpmbl] [--cmbmsc] [--nssd] [--pmrctl]
 			[--pmrmscl] [--pmrmscu]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -128,7 +128,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-host-discovery-log.txt
+++ b/Documentation/nvme-host-discovery-log.txt
@@ -40,7 +40,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-io-mgmt-recv.txt
+++ b/Documentation/nvme-io-mgmt-recv.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 			[--data=<FILE> | -d <FILE>]
 			[--data-len=<NUM> | -l <NUM>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -59,7 +59,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-io-mgmt-send.txt
+++ b/Documentation/nvme-io-mgmt-send.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 			[--data=<FILE> | -d <FILE>]
 			[--data-len=<NUM> | -l <NUM>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -58,7 +58,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-io-passthru.txt
+++ b/Documentation/nvme-io-passthru.txt
@@ -20,7 +20,7 @@ SYNOPSIS
 			[--read | -r] [--write | -w]
 			[--input-file=<file> | -i <file>]
 			[--metadata=<file> | -M <file>]
-			[--timeout=<timeout> | -t <timeout>] [--show-command | -s]
+			[--timeout=<timeout>] [--show-command | -s]
 			[--dry-run | -d] [--raw-binary | -b]
 			[--prefill=<prefill> | -p <prefill>]
 			[--latency | -T]
@@ -131,7 +131,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-list-ns.txt
+++ b/Documentation/nvme-list-ns.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 			[--csi=<command_set_identifier> | -y <command_set_identifier>]
 			[--all | -a]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -52,7 +52,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-lockdown.txt
+++ b/Documentation/nvme-lockdown.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 			[--scp=<scp> | -s <scp>]
 			[--uuid=<UUID_Index> | -U <UUID_Index>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -57,7 +57,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-mgmt-addr-list-log.txt
+++ b/Documentation/nvme-mgmt-addr-list-log.txt
@@ -30,7 +30,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-ocp-hardware-component-log.txt
+++ b/Documentation/nvme-ocp-hardware-component-log.txt
@@ -62,7 +62,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-pull-model-ddr-req-log.txt
+++ b/Documentation/nvme-pull-model-ddr-req-log.txt
@@ -34,7 +34,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-reachability-associations-log.txt
+++ b/Documentation/nvme-reachability-associations-log.txt
@@ -39,7 +39,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-reachability-groups-log.txt
+++ b/Documentation/nvme-reachability-groups-log.txt
@@ -39,7 +39,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-resv-register.txt
+++ b/Documentation/nvme-resv-register.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 			[--rrega=<rrega> | -r <rrega>]
 			[--cptpl=<cptpl> | -p <cptpl>] [--iekey | -i]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -94,7 +94,6 @@ Indicator option, defaults to '0'.
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-resv-report.txt
+++ b/Documentation/nvme-resv-report.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 			[--numd=<num-dwords> | -d <num-dwords>] [--eds | -e]
 			[--raw-binary | -b]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -57,7 +57,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-rotational-media-info-log.txt
+++ b/Documentation/nvme-rotational-media-info-log.txt
@@ -35,7 +35,6 @@ OPTIONS
 	Set the reporting format to 'normal', 'json' or 'binary'. Only one
 	output format can be used at a time.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-set-feature.txt
+++ b/Documentation/nvme-set-feature.txt
@@ -15,7 +15,7 @@ SYNOPSIS
 			[--data=<data-file> | -d <data-file>] [--save | -s]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
 			[--cdw12=<cdw12> | -c <cdw12>]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -128,7 +128,6 @@ OPTIONS
 --cdw12=<cdw12>::
 	The value for command dword 12, if applicable.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-set-property.txt
+++ b/Documentation/nvme-set-property.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 'nvme set-property' <device> [--offset=<offset> | -O <offset>]
 			[--value=<val> | -V <val>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -37,7 +37,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-set-reg.txt
+++ b/Documentation/nvme-set-reg.txt
@@ -16,7 +16,7 @@ SYNOPSIS
 			[--bpmbl=<val>] [--cmbmsc=<val>] [--nssd=<val>]
 			[--pmrctl=<val>] [--pmrmscl=<val>] [--pmrmscu=<val>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -93,7 +93,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-show-regs.txt
+++ b/Documentation/nvme-show-regs.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 [verse]
 'nvme show-regs' <device> [--human-readable | -H]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -42,7 +42,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-verify.txt
+++ b/Documentation/nvme-verify.txt
@@ -19,7 +19,7 @@ SYNOPSIS
 			[--storage-tag<storage-tag> | -S <storage-tag>]
 			[--storage-tag-check | -C]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -93,7 +93,6 @@ metadata is passes.
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-virt-mgmt.txt
+++ b/Documentation/nvme-virt-mgmt.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 			[--rt=<rt> | -r <rt>] [--act=<act> | -a <act>]
 			[--nr=<nr> | -n <nr>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -58,7 +58,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-write-uncor.txt
+++ b/Documentation/nvme-write-uncor.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 			[--dir-type=<dtype> | -T <dtype>]
 			[--dir-spec=<dspec> | -S <dspec>]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -52,7 +52,6 @@ OPTIONS
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-write-zeroes.txt
+++ b/Documentation/nvme-write-zeroes.txt
@@ -21,7 +21,7 @@ SYNOPSIS
 			[--dir-type=<dtype> | -T <dtype>]
 			[--dir-spec=<dspec> | -D <dspec>] [--namespace-zeroes | -Z]
 			[--output-format=<fmt> | -o <fmt>] [--verbose | -v]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -110,7 +110,6 @@ metadata is passes.
 --verbose::
 	Increase the information detail in the output.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-close-zone.txt
+++ b/Documentation/nvme-zns-close-zone.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 'nvme zns close-zone' <device> [--namespace-id=<NUM> | -n <NUM>]
 						[--start-lba=<LBA> | -s <LBA>]
 						[--select-all | -a]
-						[--timeout=<timeout> | -t <timeout>]
+						[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -37,7 +37,6 @@ OPTIONS
 --select-all::
 	Select all zones for this action
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-finish-zone.txt
+++ b/Documentation/nvme-zns-finish-zone.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 'nvme zns finish-zone' <device> [--namespace-id=<NUM> | -n <NUM>]
 						[--start-lba=<LBA> | -s <LBA>]
 						[--select-all | -a]
-						[--timeout=<timeout> | -t <timeout>]
+						[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -38,7 +38,6 @@ OPTIONS
 --select-all::
 	Select all zones for this action.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-offline-zone.txt
+++ b/Documentation/nvme-zns-offline-zone.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 'nvme zns offline-zone' <device> [--namespace-id=<NUM> | -n <NUM>]
 						[--start-lba=<LBA> | -s <LBA>]
 						[--select-all | -a]
-						[--timeout=<timeout> | -t <timeout>]
+						[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -37,7 +37,6 @@ OPTIONS
 --select-all::
 	Select all zones for this action
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-open-zone.txt
+++ b/Documentation/nvme-zns-open-zone.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 [verse]
 'nvme zns open-zone' <device> [--namespace-id=<NUM> | -n <NUM>]
 			[--start-lba=<LBA> | -s <LBA>] [--zrwaa | -r]
-			[--select-all | -a] [--timeout=<timeout> | -t <timeout>]
+			[--select-all | -a] [--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -40,7 +40,6 @@ OPTIONS
 --select-all::
 	Select all zones for this action
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-reset-zone.txt
+++ b/Documentation/nvme-zns-reset-zone.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 'nvme zns reset-zone' <device> [--namespace-id=<NUM> | -n <NUM>]
 			[--start-lba=<LBA> | -s <LBA>]
 			[--select-all | -a]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -38,7 +38,6 @@ OPTIONS
 --select-all::
 	Select all zones for this action
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-set-zone-desc.txt
+++ b/Documentation/nvme-zns-set-zone-desc.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 			[--start-lba=<IONUM>, -s <IONUM>]
 			[--zrwaa | -r]
 			[--data=<FILE>, -d <FILE>]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -41,7 +41,6 @@ OPTIONS
 --data=<FILE>::
 	Optional file for data (default stdin)
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-zone-mgmt-send.txt
+++ b/Documentation/nvme-zns-zone-mgmt-send.txt
@@ -13,7 +13,7 @@ SYNOPSIS
 			[--select-all, -a] [--zsa=<NUM>, -z <NUM>]
 			[--data-len=<IONUM>, -l <IONUM>]
 			[--data=<FILE>, -d <FILE>]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -58,7 +58,6 @@ OPTIONS
 --data=<FILE>::
 	Optional file for data (default stdin)
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/Documentation/nvme-zns-zrwa-flush-zone.txt
+++ b/Documentation/nvme-zns-zrwa-flush-zone.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 [verse]
 'nvme zns zrwa-flush-zone' <device> [--namespace-id=<NUM> | -n <NUM>]
 			[--lba=<LBA> | -l <LBA>]
-			[--timeout=<timeout> | -t <timeout>]
+			[--timeout=<timeout>]
 
 DESCRIPTION
 -----------
@@ -33,7 +33,6 @@ OPTIONS
 --lba=<lba>::
 	The LBA to flush up to.
 
--t <timeout>::
 --timeout=<timeout>::
 	Override default timeout value. In milliseconds.
 

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -389,7 +389,6 @@ _nvme () {
 				--output-format=':Output format: normal|json|binary'
 				-o ':alias for --output-format'
 				--timeout=':value for timeout'
-				-t ':alias for --timeout'
 				)
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp hardware-component-log options" _hardware_component_log
@@ -840,7 +839,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o':alias for --output-format'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme list-ns options" _listns
@@ -1022,7 +1020,6 @@ _nvme () {
 			--block-size=':target block size'
 			-b':alias of --block-size'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			--csi=':command set identifier'
 			-y':alias of --csi'
 			--lbstm=':logical block storage tag mask'
@@ -1052,7 +1049,6 @@ _nvme () {
 			--namespace-id=':namespace to delete'
 			-n':alias of --namespace-id'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme delete-ns options" _deletens
@@ -1280,7 +1276,6 @@ _nvme () {
 			--csi=':command set identifier'
 			-c':alias of --csi'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme effects-log options" _effects_log
@@ -1359,7 +1354,6 @@ _nvme () {
 			--raw-binary':dump infos in binary format'
 			-b':alias to --raw-binary'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			--human-readable':show feature in readable format'
 			-H':alias of --human-readable'
 			--changed':show feature changed'
@@ -1379,7 +1373,6 @@ _nvme () {
 			--wait':Wait for the test to finish'
 			-w':alias to --wait'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme device-self-test options" _device_self_test
@@ -1413,7 +1406,6 @@ _nvme () {
 			--uuid=':UUID Index field required aligned with Scope'
 			-U':alias of --uuid'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme lockdown options" _lockdown
@@ -1435,7 +1427,6 @@ _nvme () {
 			--uuid-index=':uuid index'
 			-U':alias for --uuid-index'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme set-feature options" _setf
@@ -1449,7 +1440,6 @@ _nvme () {
 			--value=':the value of the property to be set'
 			-V':alias to --value'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme set-property options" _set_property
@@ -1463,7 +1453,6 @@ _nvme () {
 			--human-readable':show infos in readable format'
 			-H':alias of --human-readable'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme get-property options" _get_property
@@ -1475,7 +1464,6 @@ _nvme () {
 			--namespace-id=':<nsid> of namespace to format (required)'
 			-n':alias of --namespace-id'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			--lbaf=':LBA format to apply to namespace (required)'
 			-l':alias of --lbaf'
 			--ses=':secure erase? 0 - no-op (default), 1 - user-data erase, 2 - cryptographic erase'
@@ -1499,7 +1487,6 @@ _nvme () {
 			--slot=':firmware slot to activate'
 			-s':alias of --slot'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme fw-commit options" _fw_commit
@@ -1515,7 +1502,6 @@ _nvme () {
 			--offset=':starting offset, in dwords (defaults to 0, only useful if download is split across multiple files)'
 			-O':alias of --offset'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme fw-download options" _fwd
@@ -1533,7 +1519,6 @@ _nvme () {
 			--cap-upper=':Most significant 32 bits of the capacity in bytes'
 			-u':alias of --cap-upper'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme capacity-mgmt options" _capacity_mgmt
@@ -1573,7 +1558,6 @@ _nvme () {
 			--namespace-zeroes':If set, then the controller clear all logical blocks to zero in the entire namespace'
 			-Z':alias of --namespace-zeroes'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme write-zeroes options" _write_zeroes
@@ -1593,7 +1577,6 @@ _nvme () {
 			--dir-spec':directive specific'
 			-S':alias of --dir-spec'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme write-uncor options" _write_uncor
@@ -1625,7 +1608,6 @@ _nvme () {
 			--storage-tag-check':Storage Tag field shall be checked as part of end-to-end data protection processing'
 			-C':alias of --storage-tag-check'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme verify options" _verify
@@ -1743,7 +1725,6 @@ _nvme () {
 			--metadata-len=':length for metadata buffer'
 			-m':alias of --metadata-len'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			--cdw2=':value for command dword 2'
 			-2':alias for --cdw2'
 			--cdw3=':value for command dword 3'
@@ -1793,7 +1774,6 @@ _nvme () {
 			--metadata-len=':length for metadata buffer'
 			-m':alias of --metadata-len'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			--cdw2=':value for command dword 2'
 			-2':alias for --cdw2'
 			--cdw3=':value for command dword 3'
@@ -1858,7 +1838,6 @@ _nvme () {
 			--raw-binary':dump output in binary format'
 			-b':alias for --raw-binary'
 			--timeout=':value for timeout'
-			-t':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme security-recv options" _srecv
@@ -1878,7 +1857,6 @@ _nvme () {
 			--range-len=':Range Length(RL) specifies the length of the range of contiguous LBAs beginning at SLBA'
 			-l':alias for --range-len'
 			--timeout':value for timeout'
-			-t':alias for --timeout'
 			--output-format=':Output format: normal|json|binary'
 			-o':alias for --output-format'
 			)
@@ -1936,7 +1914,6 @@ _nvme () {
 			--raw-binary':dump output in binary format'
 			-b':alias of --raw-binary'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme resv-report options" _rep
@@ -1958,7 +1935,6 @@ _nvme () {
 			--iekey':ignore existing reservation key'
 			-i':alias for --iekey'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme resv-register options" _reg
@@ -1984,7 +1960,6 @@ _nvme () {
 			--cdw11=':value for command dword 11'
 			-c':alias for --cdw11'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme dsm options" _dsm
@@ -2026,7 +2001,6 @@ _nvme () {
 			--format=':source range entry format'
 			-F':alias of --format'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme copy options" _copy
@@ -2161,7 +2135,6 @@ _nvme () {
 			_shor=(
 			/dev/nvme':supply a device to use (required)'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme show-regs options" _shor
@@ -2471,7 +2444,6 @@ _nvme () {
 			--human-readable':show infos in readable format'
 			-H':alias of --human-readable'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme dir-receive options" _dir_receive
@@ -2501,7 +2473,6 @@ _nvme () {
 			--input-file=':write/send file (default stdin)'
 			-i':alias of --input-file'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme dir-send options" _dir_send
@@ -2519,7 +2490,6 @@ _nvme () {
 			--nr=':Number of Controller Resources(NR)'
 			-n':alias of --nr'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme virt-mgmt options" _virt_mgmt
@@ -2646,7 +2616,6 @@ _nvme () {
 			--verbose':Increase the information detail in the output.'
 			-v':alias for --verbose'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme get-reg options" _get_reg
@@ -2681,7 +2650,6 @@ _nvme () {
 			--verbose':Increase the information detail in the output.'
 			-v':alias for --verbose'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme set-reg options" _set_reg
@@ -2705,7 +2673,6 @@ _nvme () {
 			--verbose':Increase the information detail in the output.'
 			-v':alias for --verbose'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme io-mgmt-recv-reg options" _io_mgmt_recv
@@ -2729,7 +2696,6 @@ _nvme () {
 			--verbose':Increase the information detail in the output.'
 			-v':alias for --verbose'
 			--timeout=':value for timeout'
-			-t':alias of --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme io-mgmt-send options" _io_mgmt_send
@@ -2743,7 +2709,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o ':alias for --output-format'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme mgmt-addr-list-log" _mal_log
@@ -2773,7 +2738,6 @@ _nvme () {
 			--verbose':Increase the information detail in the output.'
 			-v':alias for --verbose'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme changed-alloc-ns-list-log options" _changed_alloc_ns_list_log
@@ -2789,7 +2753,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o ':alias for --output-format'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme dispersed-ns-participating-nss-log" _dns_psub_log
@@ -2807,7 +2770,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o ':alias for --output-format'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme reachability-groups-log" _rg_log
@@ -2825,7 +2787,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o ':alias for --output-format'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme reachability-associationsroups-log" _ra_log
@@ -2843,7 +2804,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o ':alias for --output-format'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme host-discovery-log" _hd_log
@@ -2859,7 +2819,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o ':alias for --output-format'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme ave-discovery-log" _ad_log
@@ -2875,7 +2834,6 @@ _nvme () {
 			--output-format=':Output format: normal|json|binary'
 			-o ':alias for --output-format'
 			--timeout=':value for timeout'
-			-t ':alias for --timeout'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme pull-model-ddr-req-log" _pmdr_log

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -63,7 +63,7 @@ nvme_list_opts () {
 			;;
 		"list-ns")
 		opts+=" --namespace-id= -n --al -a --csi= -y \
-			--outputformat= -o --timeout= -t"
+			--outputformat= -o --timeout="
 			;;
 		"list-ctrl")
 		opts+=" --namespace-id= -n --cntid= -c \
@@ -112,12 +112,12 @@ nvme_list_opts () {
 		"create-ns")
 		opts+=" --nsze= -s --ncap= -c --flbas= -f \
 			--dps= -d --nmic= -m --anagrp-id= -a --nvmset-id= -i \
-			--block-size= -b --timeout= -t --csi= -y --lbstm= -l \
+			--block-size= -b --timeout= --csi= -y --lbstm= -l \
 			--nphndls= -n --nsze-si= -S --ncap-si= -C --azr -z --rar= -r \
 			--ror= -O --rnumzrwa= -u --phndls= -p --endg-id= -e"
 			;;
 		"delete-ns")
-		opts+=" -namespace-id= -n --timeout= -t"
+		opts+=" -namespace-id= -n --timeout="
 			;;
 		"attach-ns")
 		opts+=" --namespace-id= -n --controllers= -c"
@@ -163,7 +163,7 @@ nvme_list_opts () {
 			;;
 		"effects-log")
 		opts+=" --output-format= -o --human-readable -H \
-			--raw-binary -b --timeout= -t"
+			--raw-binary -b --timeout="
 			;;
 		"endurance-log")
 		opts+=" --output-format= -o --group-id -g"
@@ -205,10 +205,10 @@ nvme_list_opts () {
 		"get-feature")
 		opts+=" --namespace-id= -n --feature-id= -f --sel= -s \
 			--data-len= -l --cdw11= --c -uuid-index= -U --raw-binary -b \
-			--human-readable -H --timeout= -t --changed -C"
+			--human-readable -H --timeout= --changed -C"
 			;;
 		"device-self-test")
-		opts+=" --namespace-id= -n --self-test-code= -s --timeout= -t"
+		opts+=" --namespace-id= -n --self-test-code= -s --timeout="
 			;;
 		"self-test-log")
 		opts+=" --dst-entries= -e --output-format= -o \
@@ -217,20 +217,20 @@ nvme_list_opts () {
 		"set-feature")
 		opts+=" --namespace-id= -n --feature-id= -f --value= -v \
 			--data-len= -l -data= -d --value= -v --save -s --uuid-index= -U \
-			--cdw12= -c --timeout= -t"
+			--cdw12= -c --timeout="
 			;;
 		"set-property")
-		opts+=" --offset= -O --value= -V --timeout= -t"
+		opts+=" --offset= -O --value= -V --timeout="
 			;;
 		"get-property")
-		opts=+" --offset= -O --human-readable -H --timeout= -t"
+		opts=+" --offset= -O --human-readable -H --timeout="
 			;;
 		"format")
-		opts+=" --namespace-id= -n --timeout= -t --lbaf= -l \
+		opts+=" --namespace-id= -n --timeout= --lbaf= -l \
 			--ses= -s --pil= -p -pi= -i --ms= -m --reset -r"
 			;;
 		"fw-commit")
-		opts+=" --slot= -s --action= -a --bpid= -b --timeout= -t"
+		opts+=" --slot= -s --action= -a --bpid= -b --timeout="
 		case $opt in
 			--action|-a)
 			vals+=" replace replace-and-activate set-active \
@@ -240,20 +240,20 @@ nvme_list_opts () {
 		esac
 			;;
 		"fw-download")
-		opts+=" --fw= -f --xfer= -x --offset= -O --timeout= -t"
+		opts+=" --fw= -f --xfer= -x --offset= -O --timeout="
 			;;
 		"capacity-mgmt")
 		opts+=" --operation= -O --element-id= -i --cap-lower= -l \
-			--cap-upper= -u --timeout= -t"
+			--cap-upper= -u --timeout="
 			;;
 		"lockdown")
 		opts+=" --ofi= -O --ifc= -f --prhbt= -p --scp= -s --uuid -U \
-			--timeout= -t"
+			--timeout="
 			;;
 		"admin-passthru")
 		opts+=" --opcode= -O --flags= -f --prefil= -p --rsvd= -R \
 			--namespace-id= -n --data-len= -l --metadata-len= -m \
-			--timeout= -t --cdw2= -2 --cdw3= -3 --cdw10= -4 \
+			--timeout= --cdw2= -2 --cdw3= -3 --cdw10= -4 \
 			--cdw11= -5 --cdw12= -6 --cdw13= -7 --cdw14= -8 \
 			--cdw15= -9 --input-file= -i --raw-binary -b \
 			--show-command -s --dry-run -d --read -r --write -w \
@@ -262,7 +262,7 @@ nvme_list_opts () {
 		"io-passthru")
 		opts+=" --opcode= -O --flags= -f --prefill= -p --rsvd= -R \
 			--namespace-id= -n --data-len= -l --metadata-len= -m \
-			--timeout= -t --cdw2= -2 --cdw3= -3 --cdw10= -4 \
+			--timeout= --cdw2= -2 --cdw3= -3 --cdw10= -4 \
 			--cdw11= -5 --cdw12= -6 --cdw13= -7 --cdw14= -8 \
 			--cdw15= -9 --input-file= -i --raw-binary -b \
 			--show-command -s --dry-run -d --read -r --write -w \
@@ -278,7 +278,7 @@ nvme_list_opts () {
 			;;
 		"get-lba-status")
 		opts+=" --namespace-id= -n --start-lba= -s --max-dw= -m \
-			--action= -a --range-len= -l --timeout= -t \
+			--action= -a --range-len= -l --timeout= \
 			--output-format= -o"
 			;;
 		"resv-acquire")
@@ -287,7 +287,7 @@ nvme_list_opts () {
 			;;
 		"resv-register")
 		opts+=" --namespace-id= -n --crkey= -c --nrkey= -k \
-			--rrega= -r --cptpl= -p --iekey -i --timeout= -t"
+			--rrega= -r --cptpl= -p --iekey -i --timeout="
 			;;
 		"resv-release")
 		opts+=" --namespace-id= -n --crkey -c --rtype= -t \
@@ -295,12 +295,12 @@ nvme_list_opts () {
 			;;
 		"resv-report")
 		opts+=" --namespace-id= -n --numd= -d --eds -e \
-			--raw-binary= -b --output-format= -o --timeout= -t"
+			--raw-binary= -b --output-format= -o --timeout="
 			;;
 		"dsm")
 		opts+=" --namespace-id= -n --ctx-attrs= -a --blocks= -b \
 			--slbs= -s --ad -d --idw -w --idr -r --cdw11= -c \
-			--timeout= -t"
+			--timeout="
 			;;
 		"copy")
 		opts+=" --namespace-id= -n --sdlba= -d --blocks= -b --slbs= -s \
@@ -309,7 +309,7 @@ nvme_list_opts () {
 			--ref-tag= -r --expected-ref-tag= -R \
 			--app-tag= -a --expected-app-tag= -A \
 			--app-tag-mask= -m --expected-app-tag-mask= -M \
-			--dir-type= -T --dir-spec= -S --format= -F --timeout= -t"
+			--dir-type= -T --dir-spec= -S --format= -F --timeout="
 			;;
 		"flush")
 		opts+=" --namespace-id= -n"
@@ -348,19 +348,19 @@ nvme_list_opts () {
 			--app-tag-mask= -m --app-tag= -a \
 			--storage-tag= -S --storage-tag-check -C \
 			--dir-type= -T --dir-spec= -S --namespace-zeroes -Z \
-			--timeout= -t"
+			--timeout="
 			;;
 		"write-uncor")
 		opts+=" --namespace-id= -n --start-block= -s \
 			--block-count= -c --dir-type= -T --dir-spec= -S \
-			--timeout= -t"
+			--timeout="
 			;;
 		"verify")
 		opts+=" --namespace-id= -n --start-block= -s \
 			--block-count= -c --limited-retry -l \
 			--force-unit-access -f --prinfo= -p --ref-tag= -r \
 			--app-tag= -a --app-tag-mask= -m \
-			--storage-tag= -S --storage-tag-check -C --timeout= -t"
+			--storage-tag= -S --storage-tag-check -C --timeout="
 			;;
 		"sanitize")
 		opts+=" --no-dealloc -d --oipbp -i --owpass= -n \
@@ -386,7 +386,7 @@ nvme_list_opts () {
 		opts+=$NO_OPTS
 			;;
 		"show-regs")
-		opts+=" --output-format= -o --human-readable -H --timeout= -t"
+		opts+=" --output-format= -o --human-readable -H --timeout="
 			;;
 		"discover")
 		opts+=" --transport= -t -traddr= -a -trsvcid= -s \
@@ -444,16 +444,16 @@ nvme_list_opts () {
 		"dir-receive")
 		opts+=" --namespace-id= -n --data-len= -l --raw-binary -b \
 			--dir-type= -D --dir-spec= -S --dir-oper= -O \
-			--req-resource= -r --human-readable -H --timeout= -t"
+			--req-resource= -r --human-readable -H --timeout="
 			;;
 		"dir-send")
 		opts+=" --namespace-id= -n --data-len= -l --dir-type= -D \
 			--target-dir= -T --dir-spec= -S --dir-oper= -O \
 			--endir= -e --human-readable -H --raw-binary -b \
-			--timeout= -t"
+			--timeout="
 			;;
 		"virt-mgmt")
-		opts+=" --cntlid= -c --rt= -r --act= -a --nr= -n --timeout= -t"
+		opts+=" --cntlid= -c --rt= -r --act= -a --nr= -n --timeout="
 			;;
 		"rpmb")
 		opts+=" --cmd= -c --msgfile= -f --keyfile= -g \
@@ -477,59 +477,59 @@ nvme_list_opts () {
 			--pmrcap --pmrsts --pmrebs --pmrswtp --intms --intmc \
 			--cc --csts --nssr --aqa --asq --acq --bprsel --bpmbl \
 			--cmbmsc --nssd --pmrctl --pmrmscl --pmrmscu \
-			--output-format -o --verbose -v --timeout= -t"
+			--output-format -o --verbose -v --timeout="
 			;;
 		"set-reg")
 		opts+=" --offset= -O --value= -V --mmio32 -m --intms= --intmc= \
 			--cc= --csts= --nssr= --aqa= --asq= --acq= --bprsel= \
 			--bpmbl= --cmbmsc= --nssd= --pmrctl= --pmrmscl= \
 			--pmrmscu= --output-format= -o --verbose -v \
-			--timeout= -t"
+			--timeout="
 			;;
 		"io-mgmt-recv")
 		opts+=" --namespace-id= -n --mos= -s --mo= -m --data= -d \
 			--data-len= -l --output-format= -o --verbose -v \
-			--timeout= -t"
+			--timeout="
 			;;
 		"io-mgmt-send")
 		opts+=" --namespace-id= -n --mos= -s --mo= -m --data= -d \
 			--data-len= -l --output-format= -o --verbose -v \
-			--timeout= -t"
+			--timeout="
 			;;
 		"mgmt-addr-list-log")
-		opts+=" --verbose -v --output-format= -o --timeout= -t"
+		opts+=" --verbose -v --output-format= -o --timeout="
 			;;
 		"rotational-media-info-log")
 		opts+=" --endg-id= -e --verbose -v --output-format= -o \
-			--timeout= -t"
+			--timeout="
 			;;
 		"changed-alloc-cns-list-log")
 		opts+=" --output-format= -o --raw-binary -b  --verbose -v \
-			--timeout= -t"
+			--timeout="
 			;;
 		"dispersed-ns-participating-nss-log")
 		opts+=" --namespace-id= -n --verbose -v --output-format= -o \
-			--timeout= -t"
+			--timeout="
 			;;
 		"reachability-groups-log")
 		opts+=" --groups-only -g --rae -r --verbose -v \
-			--output-format= -o --timeout= -t"
+			--output-format= -o --timeout="
 			;;
 		"reachability-associations-log")
 		opts+=" --associations-only -a --rae -r --verbose -v \
-			--output-format= -o --timeout= -t"
+			--output-format= -o --timeout="
 			;;
 		"host-discovery-log")
 		opts+=" --all-host-entries -a --rae -r --verbose -v \
-			--output-format= -o --timeout= -t"
+			--output-format= -o --timeout="
 			;;
 		"ave-discovery-log")
 		opts+=" --rae -r --verbose -v --output-format= -o \
-			--timeout= -t"
+			--timeout="
 			;;
 		"pull--ddc-req-log")
 		opts+=" --rae -r --verbose -v --output-format= -o \
-			--timeout= -t"
+			--timeout="
 			;;
 		"version")
 		opts+=$NO_OPTS
@@ -1390,7 +1390,7 @@ plugin_zns_opts () {
 		"zone-mgmt-send")
 		opts+=" --namespace-id= -n --start-lba= -s --zsaso -o \
 			--select-all -a --zsa= -z --data-len= -l \
-			--data= -d --timeout= -t"
+			--data= -d --timeout="
 			;;
 		"report-zones")
 		opts+=" --namespace-id= -n --start-lba= -s \
@@ -1399,30 +1399,30 @@ plugin_zns_opts () {
 			;;
 		"close-zone")
 		opts+=" --namespace-id= -n --start-lba= -s \
-			--select-all -a --timeout= -t"
+			--select-all -a --timeout="
 			;;
 		"finish-zone")
 		opts+=" --namespace-id= -n --start-lba= -s \
-			--select-all -a --timeout= -t"
+			--select-all -a --timeout="
 			;;
 		"open-zone")
 		opts+=" --namespace-id= -n --start-lba= -s \
-			--select-all -a --timeout= -t --zrwa -r"
+			--select-all -a --timeout= --zrwa -r"
 			;;
 		"reset-zone")
 		opts+=" --namespace-id= -n --start-lba= -s \
-			--select-all -a --timeout= -t"
+			--select-all -a --timeout="
 			;;
 		"offline-zone")
 		opts+=" --namespace-id= -n --start-lba= -s \
-			--select-all -a --timeout= -t"
+			--select-all -a --timeout="
 			;;
 		"set-zone-desc")
 		opts+=" --namespace-id= -n --start-lba= -s \
-			--data= -d --timeout= -t --zrwa -r"
+			--data= -d --timeout= --zrwa -r"
 			;;
 		"flush-zone")
-		opts+=" --namespace-id= -n --last-lba= -l --timeout= -t"
+		opts+=" --namespace-id= -n --last-lba= -l --timeout="
 			;;
 		"zone-append")
 		opts+=" --namespace-id= -n --zslba= -s --data-size= -z \
@@ -1653,7 +1653,7 @@ plugin_ocp_opts () {
 			;;
 		"hardware-component-log")
 		opts+=" --comp-id= -i --list -l --verbose -v \
-			--output-format -o --timeout= -t"
+			--output-format -o --timeout="
 			;;
 		"get-latency-monitor")
 		opts+=" --sel= -s \

--- a/nvme.h
+++ b/nvme.h
@@ -79,7 +79,7 @@ struct nvme_args {
 		OPT_FMT("output-format", 'o', &nvme_args.output_format,                \
                          DESC_OUTPUT_FORMAT),                                          \
 		##__VA_ARGS__,                                                         \
-		OPT_UINT("timeout",      't', &nvme_args.timeout,                      \
+		OPT_UINT("timeout",        0, &nvme_args.timeout,                      \
                          "timeout value, in milliseconds"),                            \
 		OPT_FLAG("dry-run",        0, &nvme_args.dry_run,                      \
                          "show command instead of executing"),                         \


### PR DESCRIPTION
The -t option shadows a bunch of existing users, thus drop the shorthand for --timeout on global level:

nvme check-tls-key --keytype
nvme copy --storage-tag
nvme fdp set-events --event-types
nvme gen-tls-key --keytype
nvme intel set-bucket-thresholds --bucket-thresholds nvme lm migration-send --stype
nvme memblaze lat-set-feature-x --set-trim-threshold nvme micron latency-tracking --threshold
nvme micron vs-internal-log --type
nvme ocp internal-log --telemetry-type
nvme ocp set-error-injection --type
nvme ocp set-telemetry-profile --telemetry-profile-select nvme resv-acquire --rtype
nvme resv-release --rtype
nvme security-recv --al
nvme security-send --tl
nvme sndk vs-internal-log --type
nvme tls-key --keytype
nvme wdc vs-internal-log --type