### PR TITLE
mi: fix nvme_mi_create_global_ctx removal

### DIFF
--- a/libnvme/examples/mi-conf.c
+++ b/libnvme/examples/mi-conf.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
 	if (rc)
 		errx(EXIT_FAILURE, "can't parse MI device string '%s'", devstr);
 
-	ctx = nvme_mi_create_global_ctx(stderr, DEFAULT_LOGLEVEL);
+	ctx = nvme_create_global_ctx(stderr, DEFAULT_LOGLEVEL);
 	if (!ctx)
 		err(EXIT_FAILURE, "can't create global context");
 
@@ -219,7 +219,7 @@ out_close_ep:
 	dbus_error_free(&berr);
 	nvme_mi_close(ep);
 out_free_ctx:
-	nvme_mi_free_global_ctx(ctx);
+	nvme_free_global_ctx(ctx);
 
 	return rc ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -132,14 +132,12 @@ LIBNVME_2_0 {
 		nvme_mi_close;
 		nvme_mi_close_transport_handle;
 		nvme_mi_control;
-		nvme_mi_create_global_ctx;
 		nvme_mi_ctrl_id;
 		nvme_mi_endpoint_desc;
 		nvme_mi_ep_get_timeout;
 		nvme_mi_ep_set_timeout;
 		nvme_mi_first_ctrl;
 		nvme_mi_first_endpoint;
-		nvme_mi_free_global_ctx;
 		nvme_mi_init_transport_handle;
 		nvme_mi_mi_config_get;
 		nvme_mi_mi_config_set;

--- a/libnvme/src/nvme/mi-mctp.c
+++ b/libnvme/src/nvme/mi-mctp.c
@@ -954,7 +954,7 @@ struct nvme_global_ctx *nvme_mi_scan_mctp(void)
 	dbus_bool_t drc;
 	DBusError berr;
 
-	ctx = nvme_mi_create_global_ctx(NULL, DEFAULT_LOGLEVEL);
+	ctx = nvme_create_global_ctx(NULL, DEFAULT_LOGLEVEL);
 	if (!ctx) {
 		errno = ENOMEM;
 		return NULL;
@@ -1028,7 +1028,7 @@ out:
 
 	if (rc < 0) {
 		if (ctx) {
-			nvme_mi_free_global_ctx(ctx);
+			nvme_free_global_ctx(ctx);
 		}
 		errno = errno_save;
 		ctx = NULL;


### PR DESCRIPTION
Not all users of nvme_mi_create_global_ctx and nvme_mi_free_global_ctx have been replaced.

Fixes: c645b0c39f77 ("mi: replace nvme_mi_*global_context with nvme_*_global_context")