### PR TITLE
windows: added platform abstraction headers

### DIFF
--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -160,3 +160,14 @@ install_headers(
     subdir: 'nvme',
     install_mode: mode,
 )
+
+# Install platform abstraction headers
+install_headers([
+        'platform/includes.h',
+        'platform/linux.h',
+        'platform/windows.h',
+        'platform/types.h'
+    ],
+    subdir: 'platform',
+    install_mode: mode,
+)

--- a/libnvme/src/nvme/accessors.h
+++ b/libnvme/src/nvme/accessors.h
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <linux/types.h> /* __u32, __u64, etc. */
+#include <platform/types.h> /* __u32, __u64, etc. */
 
 /* Forward declarations. These are internal (opaque) structs. */
 struct nvme_path;

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -3,13 +3,10 @@
 #define __CLEANUP_H
 
 #include <dirent.h>
-#include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
-#include <sys/socket.h>
-#include <sys/types.h>
+#include <platform/includes.h>
 
 #include "fabrics.h"
 

--- a/libnvme/src/nvme/cmds.h
+++ b/libnvme/src/nvme/cmds.h
@@ -10,9 +10,10 @@
 
 #pragma once
 
-#include <endian.h>
 #include <errno.h>
 #include <string.h>
+
+#include <platform/includes.h>
 
 #include <nvme/ioctl.h>
 #include <nvme/types.h>

--- a/libnvme/src/nvme/lib-types.h
+++ b/libnvme/src/nvme/lib-types.h
@@ -8,7 +8,7 @@
  */
 #pragma once
 
-#include <linux/types.h>
+#include <platform/types.h>
 
 struct nvme_global_ctx;
 struct nvme_transport_handle;

--- a/libnvme/src/nvme/lib.h
+++ b/libnvme/src/nvme/lib.h
@@ -10,7 +10,8 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include <syslog.h>
+
+#include <platform/includes.h>
 
 #include <nvme/lib-types.h>
 

--- a/libnvme/src/nvme/log.c
+++ b/libnvme/src/nvme/log.c
@@ -10,10 +10,9 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
-#include <stdio.h>
-#include <syslog.h>
 #include <time.h>
-#include <unistd.h>
+
+#include <platform/includes.h>
 
 #include <libnvme.h>
 

--- a/libnvme/src/nvme/mi-mctp-compat.h
+++ b/libnvme/src/nvme/mi-mctp-compat.h
@@ -3,7 +3,7 @@
 #ifndef _MI_MCTP_COMPAT_H
 #define _MI_MCTP_COMPAT_H
 
-#include <linux/types.h>
+#include <platform/types.h>
 
 /* As of kernel v5.15, these AF_MCTP-related definitions are provided by
  * linux/mctp.h. However, we provide a set here while that header percolates

--- a/libnvme/src/nvme/mi-mctp.c
+++ b/libnvme/src/nvme/mi-mctp.c
@@ -12,12 +12,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/uio.h>
+#include <platform/includes.h>
 
 #if HAVE_LINUX_MCTP_H
 #include <linux/mctp.h>

--- a/libnvme/src/nvme/mi.h
+++ b/libnvme/src/nvme/mi.h
@@ -82,8 +82,9 @@
  */
 #pragma once
 
-#include <endian.h>
 #include <stdint.h>
+
+#include <platform/includes.h>
 
 #include <nvme/tree.h>
 

--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <arpa/inet.h>
+#include <platform/includes.h>
 
 #include <ccan/endian/endian.h>
 
@@ -18,8 +18,6 @@
 
 #include "private.h"
 #include "compiler_attributes.h"
-
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
 static __u8 csum(const __u8 *buffer, ssize_t length)
 {

--- a/libnvme/src/nvme/nbft.h
+++ b/libnvme/src/nvme/nbft.h
@@ -10,7 +10,7 @@
 
 #include <stdbool.h>
 
-#include <linux/types.h>
+#include <platform/types.h>
 #include <sys/types.h>
 
 #include <nvme/lib-types.h>

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -7,14 +7,9 @@
  */
 #pragma once
 
-#include <errno.h>
-#include <ifaddrs.h>
-#include <poll.h>
-
-#include <sys/ioctl.h>
-#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <platform/includes.h>
 
 #include <ccan/list/list.h>
 

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -9,18 +9,16 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <ifaddrs.h>
 #include <libgen.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
-#include <arpa/inet.h>
-#include <netdb.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <platform/includes.h>
 
 #include <ccan/endian/endian.h>
 #include <ccan/list/list.h>

--- a/libnvme/src/nvme/types.h
+++ b/libnvme/src/nvme/types.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <linux/types.h>
+#include <platform/types.h>
 
 /**
  * DOC: types.h

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -16,11 +16,10 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <platform/includes.h>
 
 #include <ccan/endian/endian.h>
 #include <ccan/minmax/minmax.h>

--- a/libnvme/src/platform/includes.h
+++ b/libnvme/src/platform/includes.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2025 Micron Technology, Inc.
+ *
+ * Common platform-specific includes and definitions.
+ */
+
+#pragma once
+
+#include "platform/types.h"
+
+/* Platform-specific includes */
+#ifdef _WIN32
+    #include "platform/windows.h"
+#else
+    #include "platform/linux.h"
+#endif

--- a/libnvme/src/platform/linux.h
+++ b/libnvme/src/platform/linux.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Linux platform-specific definitions and includes.
+ */
+
+#pragma once
+
+/* Linux-specific includes */
+#include <dirent.h>
+#include <endian.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <syslog.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#include <netinet/in.h>

--- a/libnvme/src/platform/types.h
+++ b/libnvme/src/platform/types.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Platform compatibility for linux/types.h
+ */
+#ifndef _PLATFORM_TYPES_H
+#define _PLATFORM_TYPES_H
+
+#ifdef _WIN32
+
+#include <stdint.h>
+
+/* Standard type definitions for linux/types.h compatibility */
+typedef uint8_t  __u8;
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+typedef int8_t   __s8;
+typedef int16_t  __s16;
+typedef int32_t  __s32;
+typedef int64_t  __s64;
+
+/* Little-endian types (Windows is little-endian) */
+typedef __u16    __le16;
+typedef __u32    __le32;
+typedef __u64    __le64;
+typedef __s16    __le16s;
+typedef __s32    __le32s;
+typedef __s64    __le64s;
+
+/* Big-endian types for completeness */
+typedef __u16    __be16;
+typedef __u32    __be32;
+typedef __u64    __be64;
+typedef __s16    __be16s;
+typedef __s32    __be32s;
+typedef __s64    __be64s;
+
+#else
+
+#include <linux/types.h>
+
+#endif
+
+#endif /* _PLATFORM_TYPES_H */

--- a/libnvme/src/platform/windows.h
+++ b/libnvme/src/platform/windows.h
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Windows platform-specific definitions and includes.
+ */
+
+#pragma once
+
+/* Windows-specific includes - winsock2 before windows.h to avoid warnings */
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+
+#include <bcrypt.h>
+#include <direct.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <io.h>
+#include <process.h>
+#include <stdio.h>
+#include <time.h>
+
+
+/* endian.h compatibility */
+
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	#define htobe16(x) (x)
+	#define htobe32(x) (x)
+	#define htobe64(x) (x)
+	#define htole16(x) __builtin_bswap16(x)
+	#define htole32(x) __builtin_bswap32(x)
+	#define htole64(x) __builtin_bswap64(x)
+	#define le16toh(x) __builtin_bswap16(x)
+	#define le32toh(x) __builtin_bswap32(x)
+	#define le64toh(x) __builtin_bswap64(x)
+#else
+	/* Little-endian (most common case for Windows) */
+	#define htobe16(x) __builtin_bswap16(x)
+	#define htobe32(x) __builtin_bswap32(x)
+	#define htobe64(x) __builtin_bswap64(x)
+	#define htole16(x) (x)
+	#define htole32(x) (x)
+	#define htole64(x) (x)
+	#define le16toh(x) (x)
+	#define le32toh(x) (x)
+	#define le64toh(x) (x)
+#endif
+
+
+/* sys/param.h compatibility */
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+
+/*
+ * More compatibility definitions and method implementations will be needed
+ * as Windows support is developed. For now, this file serves as a base
+ * implementation and an example of the proposed structure.
+ */

--- a/libnvme/tools/generator/generate-accessors.md
+++ b/libnvme/tools/generator/generate-accessors.md
@@ -124,7 +124,7 @@ python3 generate-accessors.py person.h
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <linux/types.h> /* __u32, __u64, etc. */
+#include <platform/types.h> /* __u32, __u64, etc. */
 
 /* Forward declarations. These are internal (opaque) structs. */
 struct person;

--- a/libnvme/tools/generator/generate-accessors.py
+++ b/libnvme/tools/generator/generate-accessors.py
@@ -622,7 +622,7 @@ def main():
             f'#include <string.h>\n'
             f'#include <stdbool.h>\n'
             f'#include <stdint.h>\n'
-            f'#include <linux/types.h> /* __u32, __u64, etc. */\n'
+            f'#include <platform/types.h> /* __u32, __u64, etc. */\n'
             f'\n'
         )
         f.write('/* Forward declarations. These are internal (opaque) structs. */\n')

--- a/logging.c
+++ b/logging.c
@@ -6,11 +6,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <linux/types.h>
-
-#include <sys/ioctl.h>
-#include <sys/syslog.h>
-#include <sys/time.h>
+#include <platform/includes.h>
 
 #include <ccan/endian/endian.h>
 

--- a/nvme-dummy.c
+++ b/nvme-dummy.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <stdio.h>
+#include <platform/includes.h>
 
 int main(int argc, char **argv)
 {

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -4,10 +4,8 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
+#include <platform/includes.h>
 #include <ccan/compiler/compiler.h>
-
 #include <libnvme.h>
 
 #include "nvme-print.h"

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -7,8 +7,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
+#include <platform/includes.h>
 #include <ccan/strset/strset.h>
 #include <ccan/htable/htable_type.h>
 #include <ccan/htable/htable.h>

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -41,7 +41,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <linux/types.h>
+#include <platform/types.h>
 
 enum argconfig_types {
 	CFG_FLAG,

--- a/util/mem.c
+++ b/util/mem.c
@@ -3,7 +3,8 @@
 #include <unistd.h>
 #include <malloc.h>
 #include <string.h>
-#include <sys/mman.h>
+
+#include <platform/includes.h>
 
 #include "mem.h"
 

--- a/util/types.h
+++ b/util/types.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#include <linux/types.h>
+#include <platform/types.h>
 
 #include <libnvme.h>
 


### PR DESCRIPTION
Added Windows and Linux platform abstraction headers.  Updated files that include platform-specific files to include the new platform compatibility headers.

Platform abstraction headers get installed under the platform subfolder.