### PR TITLE
tests: don't run Python tests in parallel

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,6 +54,7 @@ foreach t : tests
         env: ['PATH=' + meson.project_build_root() + ':/usr/bin:/usr/sbin'],
         timeout: 500,
         protocol: 'tap',
+        is_parallel: false,
     )
 endforeach
 


### PR DESCRIPTION
The Python tests are reconfigurating the hardware, thus it's not possible to run them in parallel.