### PR TITLE
fabrics: add helper to update tls and concat

### DIFF
--- a/nbft.c
+++ b/nbft.c
@@ -103,6 +103,34 @@ static bool validate_uri(struct nbft_info_discovery *dd,
 	return true;
 }
 
+static void update_tls_concat(struct nvmf_disc_log_entry *e,
+		struct nvme_fabrics_config *cfg)
+{
+	if (e->trtype != NVMF_TRTYPE_TCP ||
+	    e->tsas.tcp.sectype == NVMF_TCP_SECTYPE_NONE)
+		return;
+
+	if (e->treq & NVMF_TREQ_REQUIRED) {
+		fprintf(stderr,
+			"setting --tls due to treq %s and sectype %s\n",
+			nvmf_treq_str(e->treq),
+			nvmf_sectype_str(e->tsas.tcp.sectype));
+
+		cfg->tls = true;
+		return;
+	}
+
+	if (e->treq & NVMF_TREQ_NOT_REQUIRED) {
+		fprintf(stderr,
+			"setting --concat due to treq %s and sectype %s\n",
+			nvmf_treq_str(e->treq),
+			nvmf_sectype_str(e->tsas.tcp.sectype));
+
+		cfg->concat = true;
+		return;
+	}
+}
+
 /* returns 0 for success or negative errno otherwise */
 static int do_connect(nvme_root_t r,
 		      nvme_host_t h,
@@ -138,11 +166,8 @@ static int do_connect(nvme_root_t r,
 		nvme_init_logging(r, -1, false, false);
 	}
 
-	if (e) {
-		if (e->trtype == NVMF_TRTYPE_TCP &&
-		    e->tsas.tcp.sectype != NVMF_TCP_SECTYPE_NONE)
-			cfg->tls = true;
-	}
+	/* Update tls or concat */
+	update_tls_concat(e, cfg);
 
 	errno = 0;
 	ret = nvmf_add_ctrl(h, c, cfg);


### PR DESCRIPTION
Only --tls was properly updated in nbft_connect(), and not --concat. But this is properly done in nvmf_connect_disc_entry() already. So add a helper function to update both --tls and --concat and invoke the same from nvmf_connect_disc_entry() and nbft_connect() respectively.


[wagi: reformated the function to improve readability] (cherry picked from 99dd46fdff25)