### PR TITLE
nvme-print: fix traddr transformation for ave discovery log

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -5632,16 +5632,22 @@ static void json_host_discovery_log(struct nvme_host_discover_log *log)
 
 static void obj_add_traddr(struct json_object *o, const char *k, __u8 adrfam, __u8 *traddr)
 {
-	int af = AF_INET;
-	socklen_t size = INET_ADDRSTRLEN;
 	char dst[INET6_ADDRSTRLEN];
+	socklen_t size;
+	int af;
 
-	if (adrfam == NVMF_ADDR_FAMILY_IP6) {
+	if (adrfam == NVMF_ADDR_FAMILY_IP4) {
+		af = AF_INET;
+		size = INET_ADDRSTRLEN;
+	} else if (adrfam == NVMF_ADDR_FAMILY_IP6) {
 		af = AF_INET6;
 		size = INET6_ADDRSTRLEN;
+	} else {
+		obj_add_str(o, k, "<invalid>");
+		return;
 	}
 
-	if (inet_ntop(af, libnvmf_adrfam_str(adrfam), dst, size))
+	if (inet_ntop(af, traddr, dst, size))
 		obj_add_str(o, k, dst);
 }
 

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -6642,16 +6642,22 @@ static void stdout_host_discovery_log(struct nvme_host_discover_log *log)
 
 static void print_traddr(char *field, __u8 adrfam, __u8 *traddr)
 {
-	int af = AF_INET;
-	socklen_t size = INET_ADDRSTRLEN;
 	char dst[INET6_ADDRSTRLEN];
+	socklen_t size;
+	int af;
 
-	if (adrfam == NVMF_ADDR_FAMILY_IP6) {
+	if (adrfam == NVMF_ADDR_FAMILY_IP4) {
+		af = AF_INET;
+		size = INET_ADDRSTRLEN;
+	} else if (adrfam == NVMF_ADDR_FAMILY_IP6) {
 		af = AF_INET6;
 		size = INET6_ADDRSTRLEN;
+	} else {
+		printf("%s: <invalid>\n", field);
+		return;
 	}
 
-	if (inet_ntop(af, libnvmf_adrfam_str(adrfam), dst, size))
+	if (inet_ntop(af, traddr, dst, size))
 		printf("%s: %s\n", field, dst);
 }
 


### PR DESCRIPTION
inet_ntop wants the network address structure as input not converted string.

Fixes: 1571543dcd9b ("nvme: add ave-discovery-log command")

@ikegami-t did you tests the original implementation? If so, can you try this one too?