### PR TITLE
fabrics: avoid connect segfault for invalid param

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -219,6 +219,9 @@ __public int libnvmf_context_create(struct libnvme_global_ctx *ctx,
 
 __public void libnvmf_context_free(struct libnvmf_context *fctx)
 {
+	if (!fctx)
+		return;
+
 	free(fctx->tls_key);
 	free(fctx);
 }


### PR DESCRIPTION
The connect command segfaults if one passes an invalid param to it. For e.g.

nvme connect disconnect
required argument [--nqn | -n] not specified
Segmentation fault (core dumped)

Running gdb on the core revealed the segfault was due to dereferencing the fctx NULL pointer:

Core was generated by `nvme connect disconnect'.
Program terminated with signal SIGSEGV, Segmentation fault. libnvmf_context_free (fctx=0x0) at ../libnvme/src/nvme/fabrics.c:222
222             free(fctx->tls_key);
(gdb) where
libnvmf_context_free (fctx=0x0) at ../libnvme/src/nvme/fabrics.c:222
cleanup_nvmf_context (fctx=0x7ffd6f16ddf8) at ../util/cleanup.h:58
fabrics_connect (desc=<optimized out>, argc=<optimized out>, argv=0x7ffd6f16ee10) at ../fabrics.c:595
handle_plugin (argc=argc@entry=2, argv=argv@entry=0x7ffd6f16ee10, plugin=0x558480 <builtin>) at ../plugin.c:190
main (argc=3, argv=0x7ffd6f16ee08) at ../nvme.c:11313

Fix the same.

Fixes: 27af156ed09a ("fabrics: allow tls key to be a pin")