### PR TITLE
Rename `_cleanup_NAME_` to `__cleanup_NAME`

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -958,7 +958,7 @@ int fabrics_config(const char *desc, int argc, char **argv)
 	}
 
 	if (update_config) {
-		_cleanup_fd_ int fd = -1;
+		__cleanup_fd int fd = -1;
 
 		fd = open(config_file, O_RDONLY, 0);
 		if (fd != -1)

--- a/fabrics.c
+++ b/fabrics.c
@@ -593,7 +593,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	char *context = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvmf_context_ struct libnvmf_context *fctx = NULL;
-	_cleanup_nvme_ctrl_ libnvme_ctrl_t c = NULL;
+	__cleanup_nvme_ctrl libnvme_ctrl_t c = NULL;
 	int ret;
 	nvme_print_flags_t flags;
 	struct libnvme_fabrics_config cfg = { 0 };

--- a/fabrics.c
+++ b/fabrics.c
@@ -480,7 +480,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	char *context = NULL;
 	nvme_print_flags_t flags;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvmf_context_ struct libnvmf_context *fctx = NULL;
+	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 	int ret;
 	struct libnvme_fabrics_config cfg;
 	struct nvmf_args fa = { .subsysnqn = NVME_DISC_SUBSYS_NAME };
@@ -592,7 +592,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	char *config_file = NULL;
 	char *context = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvmf_context_ struct libnvmf_context *fctx = NULL;
+	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 	__cleanup_nvme_ctrl libnvme_ctrl_t c = NULL;
 	int ret;
 	nvme_print_flags_t flags;
@@ -931,7 +931,7 @@ int fabrics_config(const char *desc, int argc, char **argv)
 	}
 
 	if (modify_config) {
-		_cleanup_nvmf_context_ struct libnvmf_context *fctx = NULL;
+		__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 
 		if (!fa.subsysnqn) {
 			fprintf(stderr,

--- a/fabrics.c
+++ b/fabrics.c
@@ -479,7 +479,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	char *config_file = PATH_NVMF_CONFIG;
 	char *context = NULL;
 	nvme_print_flags_t flags;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvmf_context_ struct libnvmf_context *fctx = NULL;
 	int ret;
 	struct libnvme_fabrics_config cfg;
@@ -591,7 +591,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	__cleanup_free char *hid = NULL;
 	char *config_file = NULL;
 	char *context = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvmf_context_ struct libnvmf_context *fctx = NULL;
 	__cleanup_nvme_ctrl libnvme_ctrl_t c = NULL;
 	int ret;
@@ -736,7 +736,7 @@ static void nvmf_disconnect_nqn(struct libnvme_global_ctx *ctx, char *nqn)
 int fabrics_disconnect(const char *desc, int argc, char **argv)
 {
 	const char *device = "nvme device handle";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	libnvme_ctrl_t c;
 	char *p;
 	int ret;
@@ -820,7 +820,7 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 
 int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	libnvme_host_t h;
 	libnvme_subsystem_t s;
 	libnvme_ctrl_t c;
@@ -887,7 +887,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 int fabrics_config(const char *desc, int argc, char **argv)
 {
 	bool scan_tree = false, modify_config = false, update_config = false;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	char *config_file = PATH_NVMF_CONFIG;
 	struct libnvme_fabrics_config cfg;
 	struct nvmf_args fa = { };
@@ -998,7 +998,7 @@ static int dim_operation(libnvme_ctrl_t c, enum nvmf_dim_tas tas, const char *na
 
 int fabrics_dim(const char *desc, int argc, char **argv)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	enum nvmf_dim_tas tas;
 	libnvme_ctrl_t c;
 	char *p;

--- a/fabrics.c
+++ b/fabrics.c
@@ -587,8 +587,8 @@ out_free:
 
 int fabrics_connect(const char *desc, int argc, char **argv)
 {
-	_cleanup_free_ char *hnqn = NULL;
-	_cleanup_free_ char *hid = NULL;
+	__cleanup_free char *hnqn = NULL;
+	__cleanup_free char *hid = NULL;
 	char *config_file = NULL;
 	char *context = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -35,7 +35,7 @@ static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)
 #define __cleanup_file __cleanup(cleanup_file)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_dir, DIR *, closedir)
-#define _cleanup_dir_ __cleanup(cleanup_dir)
+#define __cleanup_dir __cleanup(cleanup_dir)
 
 static inline void cleanup_fd(int *fd)
 {

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -32,7 +32,7 @@ static inline void freep(void *p)
 #define __cleanup_free __cleanup(freep)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)
-#define _cleanup_file_ __cleanup(cleanup_file)
+#define __cleanup_file __cleanup(cleanup_file)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_dir, DIR *, closedir)
 #define _cleanup_dir_ __cleanup(cleanup_dir)

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -45,7 +45,7 @@ static inline void cleanup_fd(int *fd)
 #define __cleanup_fd __cleanup(cleanup_fd)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_addrinfo, struct addrinfo *, freeaddrinfo)
-#define _cleanup_addrinfo_ __cleanup(cleanup_addrinfo)
+#define __cleanup_addrinfo __cleanup(cleanup_addrinfo)
 
 static inline void free_uri(struct libnvme_fabrics_uri **uri)
 {

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -52,6 +52,6 @@ static inline void free_uri(struct libnvme_fabrics_uri **uri)
 	if (*uri)
 		libnvmf_free_uri(*uri);
 }
-#define _cleanup_uri_ __cleanup(free_uri)
+#define __cleanup_uri __cleanup(free_uri)
 
 #endif

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -13,7 +13,7 @@
 
 #include "fabrics.h"
 
-#define __cleanup__(fn) __attribute__((cleanup(fn)))
+#define __cleanup(fn) __attribute__((cleanup(fn)))
 
 #define DECLARE_CLEANUP_FUNC(name, type) \
 	void name(type *__p)
@@ -29,29 +29,29 @@ static inline void freep(void *p)
 {
 	free(*(void **)p);
 }
-#define _cleanup_free_ __cleanup__(freep)
+#define _cleanup_free_ __cleanup(freep)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)
-#define _cleanup_file_ __cleanup__(cleanup_file)
+#define _cleanup_file_ __cleanup(cleanup_file)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_dir, DIR *, closedir)
-#define _cleanup_dir_ __cleanup__(cleanup_dir)
+#define _cleanup_dir_ __cleanup(cleanup_dir)
 
 static inline void cleanup_fd(int *fd)
 {
 	if (*fd >= 0)
 		close(*fd);
 }
-#define _cleanup_fd_ __cleanup__(cleanup_fd)
+#define _cleanup_fd_ __cleanup(cleanup_fd)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_addrinfo, struct addrinfo *, freeaddrinfo)
-#define _cleanup_addrinfo_ __cleanup__(cleanup_addrinfo)
+#define _cleanup_addrinfo_ __cleanup(cleanup_addrinfo)
 
 static inline void free_uri(struct libnvme_fabrics_uri **uri)
 {
 	if (*uri)
 		libnvmf_free_uri(*uri);
 }
-#define _cleanup_uri_ __cleanup__(free_uri)
+#define _cleanup_uri_ __cleanup(free_uri)
 
 #endif

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -42,7 +42,7 @@ static inline void cleanup_fd(int *fd)
 	if (*fd >= 0)
 		close(*fd);
 }
-#define _cleanup_fd_ __cleanup(cleanup_fd)
+#define __cleanup_fd __cleanup(cleanup_fd)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_addrinfo, struct addrinfo *, freeaddrinfo)
 #define _cleanup_addrinfo_ __cleanup(cleanup_addrinfo)

--- a/libnvme/src/nvme/cleanup.h
+++ b/libnvme/src/nvme/cleanup.h
@@ -29,7 +29,7 @@ static inline void freep(void *p)
 {
 	free(*(void **)p);
 }
-#define _cleanup_free_ __cleanup(freep)
+#define __cleanup_free __cleanup(freep)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)
 #define _cleanup_file_ __cleanup(cleanup_file)

--- a/libnvme/src/nvme/cmds.c
+++ b/libnvme/src/nvme/cmds.c
@@ -313,7 +313,7 @@ __public int libnvme_get_uuid_list(struct libnvme_transport_handle *hdl,
 __public int libnvme_get_telemetry_max(struct libnvme_transport_handle *hdl,
 		enum nvme_telemetry_da *da, size_t *data_tx)
 {
-	_cleanup_free_ struct nvme_id_ctrl *id_ctrl = NULL;
+	__cleanup_free struct nvme_id_ctrl *id_ctrl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 
@@ -354,7 +354,7 @@ __public int libnvme_get_telemetry_log(struct libnvme_transport_handle *hdl, boo
 	static const __u32 xfer = NVME_LOG_TELEM_BLOCK_SIZE;
 	struct nvme_telemetry_log *telem;
 	struct libnvme_passthru_cmd cmd;
-	_cleanup_free_ void *log = NULL;
+	__cleanup_free void *log = NULL;
 	void *tmp;
 	int err;
 	size_t dalb;
@@ -477,7 +477,7 @@ __public int libnvme_get_new_host_telemetry(struct libnvme_transport_handle *hdl
 int libnvme_get_lba_status_log(struct libnvme_transport_handle *hdl, bool rae,
 		struct nvme_lba_status_log **log)
 {
-	_cleanup_free_ struct nvme_lba_status_log *buf = NULL;
+	__cleanup_free struct nvme_lba_status_log *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 size;
 	void *tmp;
@@ -532,7 +532,7 @@ __public size_t libnvme_get_ana_log_len_from_id_ctrl(const struct nvme_id_ctrl *
 
 __public int libnvme_get_ana_log_len(struct libnvme_transport_handle *hdl, size_t *analen)
 {
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int ret;
 
@@ -552,7 +552,7 @@ __public int libnvme_get_ana_log_len(struct libnvme_transport_handle *hdl, size_
 __public int libnvme_get_logical_block_size(struct libnvme_transport_handle *hdl,
 		__u32 nsid, int *blksize)
 {
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u8 flbas;
 	int ret;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -862,7 +862,7 @@ static int build_options(libnvme_host_t h, libnvme_ctrl_t c, char **argstr)
 static int __nvmf_supported_options(struct libnvme_global_ctx *ctx)
 {
 	char buf[0x1000], *options, *p, *v;
-	_cleanup_fd_ int fd = -1;
+	__cleanup_fd int fd = -1;
 	ssize_t len;
 
 	if (ctx->options)
@@ -949,7 +949,7 @@ static int __nvmf_supported_options(struct libnvme_global_ctx *ctx)
 
 static int __nvmf_add_ctrl(struct libnvme_global_ctx *ctx, const char *argstr)
 {
-	_cleanup_fd_ int fd = -1;
+	__cleanup_fd int fd = -1;
 	int ret, len = strlen(argstr);
 	char buf[0x1000], *options, *p;
 

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -316,8 +316,8 @@ __public int libnvmf_context_set_crypto(struct libnvmf_context *fctx,
 		return 0;
 
 	if (!strncmp(tls_key, "pin:", 4)) {
-		_cleanup_free_ unsigned char *raw_secret = NULL;
-		_cleanup_free_ char *encoded_key = NULL;
+		__cleanup_free unsigned char *raw_secret = NULL;
+		__cleanup_free char *encoded_key = NULL;
 		int key_len = 32;
 
 		err = libnvme_create_raw_secret(fctx->ctx, tls_key,
@@ -629,7 +629,7 @@ static int inet6_pton(struct libnvme_global_ctx *ctx, const char *src, uint16_t 
 	if (strlen(src) > INET6_ADDRSTRLEN)
 		return -EINVAL;
 
-	_cleanup_free_ char *tmp = strdup(src);
+	__cleanup_free char *tmp = strdup(src);
 	if (!tmp) {
 		libnvme_msg(ctx, LOG_ERR, "cannot copy: %s\n", src);
 		return -ENOMEM;
@@ -1039,7 +1039,7 @@ __public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c,
 {
 	libnvme_subsystem_t s;
 	const char *root_app, *app;
-	_cleanup_free_ char *argstr = NULL;
+	__cleanup_free char *argstr = NULL;
 	int ret;
 
 	/* highest prio have configs from command line */
@@ -1132,7 +1132,7 @@ __public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c,
 
 __public int libnvmf_connect_ctrl(libnvme_ctrl_t c)
 {
-	_cleanup_free_ char *argstr = NULL;
+	__cleanup_free char *argstr = NULL;
 	int ret;
 
 	ret = build_options(c->s->h, c, &argstr);
@@ -1578,7 +1578,7 @@ static int nvmf_dim(libnvme_ctrl_t c, enum nvmf_dim_tas tas, __u8 trtype,
 		    __u32 *result)
 {
 	struct libnvme_global_ctx *ctx = c->s && c->s->h ? c->s->h->ctx : NULL;
-	_cleanup_free_ struct nvmf_dim_data *dim = NULL;
+	__cleanup_free struct nvmf_dim_data *dim = NULL;
 	struct libnvme_transport_handle *hdl = libnvme_ctrl_get_transport_handle(c);
 	struct libnvme_passthru_cmd cmd;
 	struct nvmf_ext_die  *die;
@@ -1709,7 +1709,7 @@ static const char *dctype_str[] = {
  */
 static int nvme_fetch_cntrltype_dctype_from_id(libnvme_ctrl_t c)
 {
-	_cleanup_free_ struct nvme_id_ctrl *id = NULL;
+	__cleanup_free struct nvme_id_ctrl *id = NULL;
 	int ret;
 
 	id = __libnvme_alloc(sizeof(*id));
@@ -1789,10 +1789,10 @@ static char *unescape_uri(const char *str, int len)
 __public int libnvme_parse_uri(const char *str, struct libnvme_fabrics_uri **urip)
 {
 	struct libnvme_fabrics_uri *uri;
-	_cleanup_free_ char *scheme = NULL;
-	_cleanup_free_ char *authority = NULL;
-	_cleanup_free_ char *path = NULL;
-	_cleanup_free_ char *h = NULL;
+	__cleanup_free char *scheme = NULL;
+	__cleanup_free char *authority = NULL;
+	__cleanup_free char *path = NULL;
+	__cleanup_free char *h = NULL;
 	const char *host;
 	int i;
 
@@ -1918,8 +1918,8 @@ static libnvme_ctrl_t lookup_ctrl(libnvme_host_t h, struct libnvmf_context *fctx
 static int lookup_host(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, struct libnvme_host **host)
 {
-	_cleanup_free_ char *hnqn = NULL;
-	_cleanup_free_ char *hid = NULL;
+	__cleanup_free char *hnqn = NULL;
+	__cleanup_free char *hid = NULL;
 	struct libnvme_host *h;
 	int err;
 
@@ -1998,7 +1998,7 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, bool connect,
 		struct libnvme_ctrl *c)
 {
-	_cleanup_free_ struct nvmf_discovery_log *log = NULL;
+	__cleanup_free struct nvmf_discovery_log *log = NULL;
 	libnvme_subsystem_t s = libnvme_ctrl_get_subsystem(c);
 	libnvme_host_t h = libnvme_subsystem_get_host(s);
 	uint64_t numrec;
@@ -2188,7 +2188,7 @@ static int nvmf_create_discovery_ctrl(struct libnvme_global_ctx *ctx,
 		struct libnvme_fabrics_config *cfg,
 		struct libnvme_ctrl **ctrl)
 {
-	_cleanup_free_ struct nvme_id_ctrl *id = NULL;
+	__cleanup_free struct nvme_id_ctrl *id = NULL;
 	struct libnvme_ctrl *c;
 	int ret;
 
@@ -2487,8 +2487,8 @@ __public int libnvmf_discovery_config_file(struct libnvme_global_ctx *ctx,
 __public int libnvmf_config_modify(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx)
 {
-	_cleanup_free_ char *hnqn = NULL;
-	_cleanup_free_ char *hid = NULL;
+	__cleanup_free char *hnqn = NULL;
+	__cleanup_free char *hid = NULL;
 	struct libnvme_host *h;
 	struct libnvme_subsystem *s;
 	struct libnvme_ctrl *c;
@@ -2896,7 +2896,7 @@ __public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 		/* Discovery Descriptor List */
 		for (dd = entry->nbft->discovery_list; dd && *dd; dd++) {
 			_cleanup_uri_ struct libnvme_fabrics_uri *uri = NULL;
-			_cleanup_free_ char *trsvcid = NULL;
+			__cleanup_free char *trsvcid = NULL;
 			struct libnvmf_context nfctx = *fctx;
 			bool persistent = false;
 			bool linked = false;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2895,7 +2895,7 @@ __public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 
 		/* Discovery Descriptor List */
 		for (dd = entry->nbft->discovery_list; dd && *dd; dd++) {
-			_cleanup_uri_ struct libnvme_fabrics_uri *uri = NULL;
+			__cleanup_uri struct libnvme_fabrics_uri *uri = NULL;
 			__cleanup_free char *trsvcid = NULL;
 			struct libnvmf_context nfctx = *fctx;
 			bool persistent = false;

--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -200,7 +200,7 @@ static struct json_object *parse_json(struct libnvme_global_ctx *ctx, int fd)
 	char *str = NULL;
 	_cleanup_tokener_ json_tokener *tok = NULL;
 	int ret;
-	_cleanup_free_ void *ptr = NULL;
+	__cleanup_free void *ptr = NULL;
 	int len = 0;
 
 	while ((ret = read(fd, buf, JSON_FILE_BUF_SIZE)) > 0) {

--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -191,14 +191,14 @@ static void json_parse_host(struct libnvme_global_ctx *ctx, struct json_object *
 }
 
 static DEFINE_CLEANUP_FUNC(cleanup_tokener, json_tokener *, json_tokener_free)
-#define _cleanup_tokener_ __cleanup(cleanup_tokener)
+#define __cleanup_tokener __cleanup(cleanup_tokener)
 
 static struct json_object *parse_json(struct libnvme_global_ctx *ctx, int fd)
 {
 	char buf[JSON_FILE_BUF_SIZE];
 	struct json_object *obj;
 	char *str = NULL;
-	_cleanup_tokener_ json_tokener *tok = NULL;
+	__cleanup_tokener json_tokener *tok = NULL;
 	int ret;
 	__cleanup_free void *ptr = NULL;
 	int len = 0;

--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -191,7 +191,7 @@ static void json_parse_host(struct libnvme_global_ctx *ctx, struct json_object *
 }
 
 static DEFINE_CLEANUP_FUNC(cleanup_tokener, json_tokener *, json_tokener_free)
-#define _cleanup_tokener_ __cleanup__(cleanup_tokener)
+#define _cleanup_tokener_ __cleanup(cleanup_tokener)
 
 static struct json_object *parse_json(struct libnvme_global_ctx *ctx, int fd)
 {

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -127,7 +127,7 @@ static int __nvme_transport_handle_open_direct(
 		struct libnvme_transport_handle *hdl, const char *devname)
 {
 	struct libnvme_passthru_cmd dummy = { 0 };
-	_cleanup_free_ char *path = NULL;
+	__cleanup_free char *path = NULL;
 	char *name;
 	int ret, id, ns;
 	bool c = true;

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -263,7 +263,7 @@ static const EVP_MD *select_hmac(int hmac, size_t *hmac_len)
 
 static DEFINE_CLEANUP_FUNC(
 	cleanup_evp_pkey_ctx, EVP_PKEY_CTX *, EVP_PKEY_CTX_free)
-#define _cleanup_evp_pkey_ctx_ __cleanup__(cleanup_evp_pkey_ctx)
+#define _cleanup_evp_pkey_ctx_ __cleanup(cleanup_evp_pkey_ctx)
 
 /* NVMe is using the TLS 1.3 HkdfLabel structure */
 #define HKDF_INFO_MAX_LEN 514
@@ -598,11 +598,11 @@ static int derive_tls_key_compat(struct libnvme_global_ctx *ctx,
 
 static DEFINE_CLEANUP_FUNC(
 	cleanup_ossl_lib_ctx, OSSL_LIB_CTX *, OSSL_LIB_CTX_free)
-#define _cleanup_ossl_lib_ctx_ __cleanup__(cleanup_ossl_lib_ctx)
+#define _cleanup_ossl_lib_ctx_ __cleanup(cleanup_ossl_lib_ctx)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac_ctx, EVP_MAC_CTX *, EVP_MAC_CTX_free)
-#define _cleanup_evp_mac_ctx_ __cleanup__(cleanup_evp_mac_ctx)
+#define _cleanup_evp_mac_ctx_ __cleanup(cleanup_evp_mac_ctx)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac, EVP_MAC *, EVP_MAC_free)
-#define _cleanup_evp_mac_ __cleanup__(cleanup_evp_mac)
+#define _cleanup_evp_mac_ __cleanup(cleanup_evp_mac)
 
 __public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 		char *hostnqn, enum libnvme_hmac_alg hmac,

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -602,7 +602,7 @@ static DEFINE_CLEANUP_FUNC(
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac_ctx, EVP_MAC_CTX *, EVP_MAC_CTX_free)
 #define __cleanup_evp_mac_ctx __cleanup(cleanup_evp_mac_ctx)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac, EVP_MAC *, EVP_MAC_free)
-#define _cleanup_evp_mac_ __cleanup(cleanup_evp_mac)
+#define __cleanup_evp_mac __cleanup(cleanup_evp_mac)
 
 __public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 		char *hostnqn, enum libnvme_hmac_alg hmac,
@@ -612,7 +612,7 @@ __public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 	const char hmac_seed[] = "NVMe-over-Fabrics";
 	_cleanup_ossl_lib_ctx_ OSSL_LIB_CTX *lib_ctx = NULL;
 	__cleanup_evp_mac_ctx EVP_MAC_CTX *mac_ctx = NULL;
-	_cleanup_evp_mac_ EVP_MAC *mac = NULL;
+	__cleanup_evp_mac EVP_MAC *mac = NULL;
 	OSSL_PARAM params[2], *p = params;
 	char *progq = NULL;
 	char *digest;
@@ -681,7 +681,7 @@ static int derive_psk_digest(struct libnvme_global_ctx *ctx,
 	_cleanup_ossl_lib_ctx_ OSSL_LIB_CTX *lib_ctx = NULL;
 	__cleanup_evp_mac_ctx EVP_MAC_CTX *mac_ctx = NULL;
 	__cleanup_free unsigned char *psk_ctx = NULL;
-	_cleanup_evp_mac_ EVP_MAC *mac = NULL;
+	__cleanup_evp_mac EVP_MAC *mac = NULL;
 	OSSL_PARAM params[2], *p = params;
 	size_t hmac_len;
 	char *progq = NULL;

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -74,7 +74,7 @@ static int __nvme_set_attr(const char *path, const char *value)
 
 int libnvme_set_attr(const char *dir, const char *attr, const char *value)
 {
-	_cleanup_free_ char *path = NULL;
+	__cleanup_free char *path = NULL;
 	int ret;
 
 	ret = asprintf(&path, "%s/%s", dir, attr);
@@ -115,7 +115,7 @@ static char *__nvme_get_attr(const char *path)
 
 __public char *libnvme_get_attr(const char *dir, const char *attr)
 {
-	_cleanup_free_ char *path = NULL;
+	__cleanup_free char *path = NULL;
 	int ret;
 
 	ret = asprintf(&path, "%s/%s", dir, attr);
@@ -304,7 +304,7 @@ static int derive_retained_key(struct libnvme_global_ctx *ctx,
 		size_t key_len)
 {
 	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
-	_cleanup_free_ uint8_t *hkdf_info = NULL;
+	__cleanup_free uint8_t *hkdf_info = NULL;
 	char *hkdf_label;
 	const EVP_MD *md;
 	size_t hmac_len;
@@ -373,7 +373,7 @@ static int derive_retained_key_compat(struct libnvme_global_ctx *ctx,
 		unsigned char *retained, size_t key_len)
 {
 	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
-	_cleanup_free_ uint8_t *hkdf_info = NULL;
+	__cleanup_free uint8_t *hkdf_info = NULL;
 	const EVP_MD *md;
 	size_t hmac_len;
 	char *pos;
@@ -454,7 +454,7 @@ static int derive_tls_key(struct libnvme_global_ctx *ctx,
 		unsigned char *retained, unsigned char *psk, size_t key_len)
 {
 	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
-	_cleanup_free_ uint8_t *hkdf_info = NULL;
+	__cleanup_free uint8_t *hkdf_info = NULL;
 	char *hkdf_label;
 	const EVP_MD *md;
 	size_t hmac_len;
@@ -531,7 +531,7 @@ static int derive_tls_key_compat(struct libnvme_global_ctx *ctx,
 		unsigned char *retained, unsigned char *psk, size_t key_len)
 {
 	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
-	_cleanup_free_ uint8_t *hkdf_info = NULL;
+	__cleanup_free uint8_t *hkdf_info = NULL;
 	const EVP_MD *md;
 	size_t hmac_len;
 	char *pos;
@@ -680,7 +680,7 @@ static int derive_psk_digest(struct libnvme_global_ctx *ctx,
 	static const char hmac_seed[] = "NVMe-over-Fabrics";
 	_cleanup_ossl_lib_ctx_ OSSL_LIB_CTX *lib_ctx = NULL;
 	_cleanup_evp_mac_ctx_ EVP_MAC_CTX *mac_ctx = NULL;
-	_cleanup_free_ unsigned char *psk_ctx = NULL;
+	__cleanup_free unsigned char *psk_ctx = NULL;
 	_cleanup_evp_mac_ EVP_MAC *mac = NULL;
 	OSSL_PARAM params[2], *p = params;
 	size_t hmac_len;
@@ -820,7 +820,7 @@ err:
 __public int libnvme_create_raw_secret(struct libnvme_global_ctx *ctx,
 		const char *secret, size_t key_len, unsigned char **raw_secret)
 {
-	_cleanup_free_ unsigned char *buf = NULL;
+	__cleanup_free unsigned char *buf = NULL;
 	int secret_len = 0, i, err;
 	unsigned int c;
 
@@ -904,8 +904,8 @@ static int derive_nvme_keys(struct libnvme_global_ctx *ctx,
 		int hmac, unsigned char *configured,
 		unsigned char *psk, int key_len, bool compat)
 {
-	_cleanup_free_ unsigned char *retained = NULL;
-	_cleanup_free_ char *digest = NULL;
+	__cleanup_free unsigned char *retained = NULL;
+	__cleanup_free char *digest = NULL;
 	char *context = identity;
 	unsigned char cipher;
 	int ret = -1;
@@ -981,8 +981,8 @@ __public int libnvme_generate_tls_key_identity(struct libnvme_global_ctx *ctx,
 		unsigned char *configured_key, int key_len,
 		char **ident)
 {
-	_cleanup_free_ unsigned char *psk = NULL;
-	_cleanup_free_ char *identity = NULL;
+	__cleanup_free unsigned char *psk = NULL;
+	__cleanup_free char *identity = NULL;
 	ssize_t identity_len;
 	int ret;
 
@@ -1018,8 +1018,8 @@ __public int libnvme_generate_tls_key_identity_compat(struct libnvme_global_ctx 
 		int version, int hmac, unsigned char *configured_key,
 		int key_len, char **ident)
 {
-	_cleanup_free_ unsigned char *psk = NULL;
-	_cleanup_free_ char *identity = NULL;
+	__cleanup_free unsigned char *psk = NULL;
+	__cleanup_free char *identity = NULL;
 	ssize_t identity_len;
 	int ret;
 
@@ -1068,7 +1068,7 @@ __public int libnvme_lookup_keyring(struct libnvme_global_ctx *ctx, const char *
 
 __public char *libnvme_describe_key_serial(struct libnvme_global_ctx *ctx, long key_id)
 {
-	_cleanup_free_ char *str = NULL;
+	__cleanup_free char *str = NULL;
 	char *last;
 
 	if (keyctl_describe_alloc(key_id, &str) < 0)
@@ -1224,8 +1224,8 @@ static int __nvme_insert_tls_key(struct libnvme_global_ctx *ctx,
 		int version, int hmac, unsigned char *configured_key,
 		int key_len, bool compat, long *keyp)
 {
-	_cleanup_free_ unsigned char *psk = NULL;
-	_cleanup_free_ char *identity = NULL;
+	__cleanup_free unsigned char *psk = NULL;
+	__cleanup_free char *identity = NULL;
 	ssize_t identity_len;
 	long key;
 	int ret;
@@ -1333,7 +1333,7 @@ static int __nvme_import_tls_key(struct libnvme_global_ctx *ctx, long keyring_id
 		const char *identity, const char *key,
 		long *keyp)
 {
-	_cleanup_free_ unsigned char *key_data = NULL;
+	__cleanup_free unsigned char *key_data = NULL;
 	unsigned char version;
 	unsigned char hmac;
 	size_t key_len;
@@ -1818,7 +1818,7 @@ static int uuid_from_product_uuid(char *system_uuid)
 {
 	_cleanup_file_ FILE *stream = NULL;
 	ssize_t nread;
-	_cleanup_free_ char *line = NULL;
+	__cleanup_free char *line = NULL;
 	size_t len = 0;
 
 	stream = fopen(PATH_DMI_PROD_UUID, "re");

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -1816,7 +1816,7 @@ static int uuid_from_dmi_entries(char *system_uuid)
  */
 static int uuid_from_product_uuid(char *system_uuid)
 {
-	_cleanup_file_ FILE *stream = NULL;
+	__cleanup_file FILE *stream = NULL;
 	ssize_t nread;
 	__cleanup_free char *line = NULL;
 	size_t len = 0;

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -59,7 +59,7 @@
 
 static int __nvme_set_attr(const char *path, const char *value)
 {
-	_cleanup_fd_ int fd = -1;
+	__cleanup_fd int fd = -1;
 
 	fd = open(path, O_WRONLY);
 	if (fd < 0) {
@@ -763,7 +763,7 @@ static ssize_t getrandom_bytes(void *buf, size_t buflen)
 #if HAVE_SYS_RANDOM
 	result = getrandom(buf, buflen, GRND_NONBLOCK);
 #else
-	_cleanup_fd_ int fd = -1;
+	__cleanup_fd int fd = -1;
 
 	fd = open("/dev/urandom", O_RDONLY);
 	if (fd < 0)
@@ -1706,7 +1706,7 @@ __public int libnvme_import_tls_key(struct libnvme_global_ctx *ctx, const char *
 
 static int uuid_from_device_tree(char *system_uuid)
 {
-	_cleanup_fd_ int f = -1;
+	__cleanup_fd int f = -1;
 	ssize_t len;
 
 	f = open(libnvme_uuid_ibm_filename(), O_RDONLY);
@@ -1901,7 +1901,7 @@ __public char *libnvme_generate_hostnqn(void)
 static char *nvmf_read_file(const char *f, int len)
 {
 	char buf[len];
-	_cleanup_fd_ int fd = -1;
+	__cleanup_fd int fd = -1;
 	int ret;
 
 	fd = open(f, O_RDONLY);

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -1748,7 +1748,7 @@ static bool is_dmi_uuid_valid(const char *buf, size_t len)
 
 static int uuid_from_dmi_entries(char *system_uuid)
 {
-	_cleanup_dir_ DIR *d = NULL;
+	__cleanup_dir DIR *d = NULL;
 	const char *entries_dir = libnvme_dmi_entries_dir();
 	int f;
 	struct dirent *de;

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -263,7 +263,7 @@ static const EVP_MD *select_hmac(int hmac, size_t *hmac_len)
 
 static DEFINE_CLEANUP_FUNC(
 	cleanup_evp_pkey_ctx, EVP_PKEY_CTX *, EVP_PKEY_CTX_free)
-#define _cleanup_evp_pkey_ctx_ __cleanup(cleanup_evp_pkey_ctx)
+#define __cleanup_evp_pkey_ctx __cleanup(cleanup_evp_pkey_ctx)
 
 /* NVMe is using the TLS 1.3 HkdfLabel structure */
 #define HKDF_INFO_MAX_LEN 514
@@ -303,7 +303,7 @@ static int derive_retained_key(struct libnvme_global_ctx *ctx,
 		unsigned char *configured, unsigned char *retained,
 		size_t key_len)
 {
-	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
+	__cleanup_evp_pkey_ctx EVP_PKEY_CTX *ectx = NULL;
 	__cleanup_free uint8_t *hkdf_info = NULL;
 	char *hkdf_label;
 	const EVP_MD *md;
@@ -372,7 +372,7 @@ static int derive_retained_key_compat(struct libnvme_global_ctx *ctx,
 		int hmac, const char *hostnqn, unsigned char *configured,
 		unsigned char *retained, size_t key_len)
 {
-	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
+	__cleanup_evp_pkey_ctx EVP_PKEY_CTX *ectx = NULL;
 	__cleanup_free uint8_t *hkdf_info = NULL;
 	const EVP_MD *md;
 	size_t hmac_len;
@@ -453,7 +453,7 @@ static int derive_tls_key(struct libnvme_global_ctx *ctx,
 		int version, unsigned char cipher, const char *context,
 		unsigned char *retained, unsigned char *psk, size_t key_len)
 {
-	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
+	__cleanup_evp_pkey_ctx EVP_PKEY_CTX *ectx = NULL;
 	__cleanup_free uint8_t *hkdf_info = NULL;
 	char *hkdf_label;
 	const EVP_MD *md;
@@ -530,7 +530,7 @@ static int derive_tls_key_compat(struct libnvme_global_ctx *ctx,
 		int version, unsigned char cipher, const char *context,
 		unsigned char *retained, unsigned char *psk, size_t key_len)
 {
-	_cleanup_evp_pkey_ctx_ EVP_PKEY_CTX *ectx = NULL;
+	__cleanup_evp_pkey_ctx EVP_PKEY_CTX *ectx = NULL;
 	__cleanup_free uint8_t *hkdf_info = NULL;
 	const EVP_MD *md;
 	size_t hmac_len;
@@ -598,7 +598,7 @@ static int derive_tls_key_compat(struct libnvme_global_ctx *ctx,
 
 static DEFINE_CLEANUP_FUNC(
 	cleanup_ossl_lib_ctx, OSSL_LIB_CTX *, OSSL_LIB_CTX_free)
-#define _cleanup_ossl_lib_ctx_ __cleanup(cleanup_ossl_lib_ctx)
+#define __cleanup_ossl_lib_ctx __cleanup(cleanup_ossl_lib_ctx)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac_ctx, EVP_MAC_CTX *, EVP_MAC_CTX_free)
 #define __cleanup_evp_mac_ctx __cleanup(cleanup_evp_mac_ctx)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac, EVP_MAC *, EVP_MAC_free)
@@ -610,7 +610,7 @@ __public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 		unsigned char *key)
 {
 	const char hmac_seed[] = "NVMe-over-Fabrics";
-	_cleanup_ossl_lib_ctx_ OSSL_LIB_CTX *lib_ctx = NULL;
+	__cleanup_ossl_lib_ctx OSSL_LIB_CTX *lib_ctx = NULL;
 	__cleanup_evp_mac_ctx EVP_MAC_CTX *mac_ctx = NULL;
 	__cleanup_evp_mac EVP_MAC *mac = NULL;
 	OSSL_PARAM params[2], *p = params;
@@ -678,7 +678,7 @@ static int derive_psk_digest(struct libnvme_global_ctx *ctx,
 		char *digest, size_t digest_len)
 {
 	static const char hmac_seed[] = "NVMe-over-Fabrics";
-	_cleanup_ossl_lib_ctx_ OSSL_LIB_CTX *lib_ctx = NULL;
+	__cleanup_ossl_lib_ctx OSSL_LIB_CTX *lib_ctx = NULL;
 	__cleanup_evp_mac_ctx EVP_MAC_CTX *mac_ctx = NULL;
 	__cleanup_free unsigned char *psk_ctx = NULL;
 	__cleanup_evp_mac EVP_MAC *mac = NULL;

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -600,7 +600,7 @@ static DEFINE_CLEANUP_FUNC(
 	cleanup_ossl_lib_ctx, OSSL_LIB_CTX *, OSSL_LIB_CTX_free)
 #define _cleanup_ossl_lib_ctx_ __cleanup(cleanup_ossl_lib_ctx)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac_ctx, EVP_MAC_CTX *, EVP_MAC_CTX_free)
-#define _cleanup_evp_mac_ctx_ __cleanup(cleanup_evp_mac_ctx)
+#define __cleanup_evp_mac_ctx __cleanup(cleanup_evp_mac_ctx)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac, EVP_MAC *, EVP_MAC_free)
 #define _cleanup_evp_mac_ __cleanup(cleanup_evp_mac)
 
@@ -611,7 +611,7 @@ __public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 {
 	const char hmac_seed[] = "NVMe-over-Fabrics";
 	_cleanup_ossl_lib_ctx_ OSSL_LIB_CTX *lib_ctx = NULL;
-	_cleanup_evp_mac_ctx_ EVP_MAC_CTX *mac_ctx = NULL;
+	__cleanup_evp_mac_ctx EVP_MAC_CTX *mac_ctx = NULL;
 	_cleanup_evp_mac_ EVP_MAC *mac = NULL;
 	OSSL_PARAM params[2], *p = params;
 	char *progq = NULL;
@@ -679,7 +679,7 @@ static int derive_psk_digest(struct libnvme_global_ctx *ctx,
 {
 	static const char hmac_seed[] = "NVMe-over-Fabrics";
 	_cleanup_ossl_lib_ctx_ OSSL_LIB_CTX *lib_ctx = NULL;
-	_cleanup_evp_mac_ctx_ EVP_MAC_CTX *mac_ctx = NULL;
+	__cleanup_evp_mac_ctx EVP_MAC_CTX *mac_ctx = NULL;
 	__cleanup_free unsigned char *psk_ctx = NULL;
 	_cleanup_evp_mac_ EVP_MAC *mac = NULL;
 	OSSL_PARAM params[2], *p = params;

--- a/libnvme/src/nvme/log.c
+++ b/libnvme/src/nvme/log.c
@@ -44,8 +44,8 @@ __libnvme_msg(struct libnvme_global_ctx *ctx, int level,
 		"[%s] <%s>%s ",
 		"[%s] <%s> %s: ",
 	};
-	_cleanup_free_ char *header = NULL;
-	_cleanup_free_ char *message = NULL;
+	__cleanup_free char *header = NULL;
+	__cleanup_free char *message = NULL;
 	int idx = 0;
 
 	if (level > l->level)

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -109,7 +109,7 @@ static void cleanup_dirents(struct dirents *ents)
 	free(ents->ents);
 }
 
-#define _cleanup_dirents_ __cleanup(cleanup_dirents)
+#define __cleanup_dirents __cleanup(cleanup_dirents)
 
 static char *nvme_hostid_from_hostnqn(const char *hostnqn)
 {
@@ -280,7 +280,7 @@ static void libnvme_filter_tree(struct libnvme_global_ctx *ctx,
 __public int libnvme_scan_topology(struct libnvme_global_ctx *ctx,
 		libnvme_scan_filter_t f, void *f_args)
 {
-	_cleanup_dirents_ struct dirents subsys = {}, ctrls = {};
+	__cleanup_dirents struct dirents subsys = {}, ctrls = {};
 	int i, ret;
 
 	if (!ctx)
@@ -686,7 +686,7 @@ struct libnvme_host *libnvme_lookup_host(struct libnvme_global_ctx *ctx,
 static int nvme_subsystem_scan_namespaces(struct libnvme_global_ctx *ctx,
 		libnvme_subsystem_t s)
 {
-	_cleanup_dirents_ struct dirents namespaces = {};
+	__cleanup_dirents struct dirents namespaces = {};
 	int i, ret;
 
 	if (ctx->create_only) {
@@ -1578,7 +1578,7 @@ libnvme_ctrl_t libnvme_lookup_ctrl(libnvme_subsystem_t s,
 static int libnvme_ctrl_scan_paths(struct libnvme_global_ctx *ctx,
 			struct libnvme_ctrl *c)
 {
-	_cleanup_dirents_ struct dirents paths = {};
+	__cleanup_dirents struct dirents paths = {};
 	int err, i;
 
 	if (ctx->create_only) {
@@ -1602,7 +1602,7 @@ static int libnvme_ctrl_scan_paths(struct libnvme_global_ctx *ctx,
 static int libnvme_ctrl_scan_namespaces(struct libnvme_global_ctx *ctx,
 		struct libnvme_ctrl *c)
 {
-	_cleanup_dirents_ struct dirents namespaces = {};
+	__cleanup_dirents struct dirents namespaces = {};
 	int err, i;
 
 	if (ctx->create_only) {
@@ -1625,7 +1625,7 @@ static int libnvme_ctrl_lookup_subsystem_name(struct libnvme_global_ctx *ctx,
 		const char *ctrl_name, char **name)
 {
 	const char *subsys_dir = libnvme_subsys_sysfs_dir();
-	_cleanup_dirents_ struct dirents subsys = {};
+	__cleanup_dirents struct dirents subsys = {};
 	int i;
 
 	subsys.num = libnvme_scan_subsystems(&subsys.ents);

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -109,7 +109,7 @@ static void cleanup_dirents(struct dirents *ents)
 	free(ents->ents);
 }
 
-#define _cleanup_dirents_ __cleanup__(cleanup_dirents)
+#define _cleanup_dirents_ __cleanup(cleanup_dirents)
 
 static char *nvme_hostid_from_hostnqn(const char *hostnqn)
 {

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1658,7 +1658,7 @@ static int libnvme_ctrl_lookup_phy_slot(struct libnvme_global_ctx *ctx,
 {
 	const char *slots_sysfs_dir = libnvme_slots_sysfs_dir();
 	__cleanup_free char *target_addr = NULL;
-	_cleanup_dir_ DIR *slots_dir = NULL;
+	__cleanup_dir DIR *slots_dir = NULL;
 	struct dirent *entry;
 	char *slot;
 	int ret;

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -126,9 +126,9 @@ __public int libnvme_host_get_ids(struct libnvme_global_ctx *ctx,
 		      const char *hostnqn_arg, const char *hostid_arg,
 		      char **hostnqn, char **hostid)
 {
-	_cleanup_free_ char *nqn = NULL;
-	_cleanup_free_ char *hid = NULL;
-	_cleanup_free_ char *hnqn = NULL;
+	__cleanup_free char *nqn = NULL;
+	__cleanup_free char *hid = NULL;
+	__cleanup_free char *hnqn = NULL;
 	libnvme_host_t h;
 
 	/* command line argumments */
@@ -195,8 +195,8 @@ __public int libnvme_host_get_ids(struct libnvme_global_ctx *ctx,
 __public int libnvme_get_host(struct libnvme_global_ctx *ctx, const char *hostnqn,
 		const char *hostid, libnvme_host_t *host)
 {
-	_cleanup_free_ char *hnqn = NULL;
-	_cleanup_free_ char *hid = NULL;
+	__cleanup_free char *hnqn = NULL;
+	__cleanup_free char *hid = NULL;
 	struct libnvme_host *h;
 	int err;
 
@@ -748,7 +748,7 @@ static int libnvme_scan_subsystem(struct libnvme_global_ctx *ctx,
 		const char *name)
 {
 	struct libnvme_subsystem *s = NULL, *_s;
-	_cleanup_free_ char *path = NULL, *subsysnqn = NULL;
+	__cleanup_free char *path = NULL, *subsysnqn = NULL;
 	libnvme_host_t h = NULL;
 	int ret;
 
@@ -813,7 +813,7 @@ __public libnvme_ns_t libnvme_path_get_ns(libnvme_path_t p)
 
 __public int libnvme_path_get_queue_depth(libnvme_path_t p)
 {
-	_cleanup_free_ char *queue_depth = NULL;
+	__cleanup_free char *queue_depth = NULL;
 
 	queue_depth = libnvme_get_path_attr(p, "queue_depth");
 	if (queue_depth) {
@@ -838,7 +838,7 @@ static int libnvme_ctrl_scan_path(struct libnvme_global_ctx *ctx,
 		struct libnvme_ctrl *c, char *name)
 {
 	struct libnvme_path *p;
-	_cleanup_free_ char *path = NULL, *grpid = NULL, *queue_depth = NULL;
+	__cleanup_free char *path = NULL, *grpid = NULL, *queue_depth = NULL;
 	int ret;
 
 	libnvme_msg(ctx, LOG_DEBUG, "scan controller %s path %s\n",
@@ -1634,7 +1634,7 @@ static int libnvme_ctrl_lookup_subsystem_name(struct libnvme_global_ctx *ctx,
 
 	for (i = 0; i < subsys.num; i++) {
 		struct stat st;
-		_cleanup_free_ char *path = NULL;
+		__cleanup_free char *path = NULL;
 
 		if (asprintf(&path, "%s/%s/%s", subsys_dir,
 			     subsys.ents[i]->d_name, ctrl_name) < 0)
@@ -1657,7 +1657,7 @@ static int libnvme_ctrl_lookup_phy_slot(struct libnvme_global_ctx *ctx,
 		libnvme_ctrl_t c)
 {
 	const char *slots_sysfs_dir = libnvme_slots_sysfs_dir();
-	_cleanup_free_ char *target_addr = NULL;
+	__cleanup_free char *target_addr = NULL;
 	_cleanup_dir_ DIR *slots_dir = NULL;
 	struct dirent *entry;
 	char *slot;
@@ -1678,8 +1678,8 @@ static int libnvme_ctrl_lookup_phy_slot(struct libnvme_global_ctx *ctx,
 		if (entry->d_type == DT_DIR &&
 		    strncmp(entry->d_name, ".", 1) != 0 &&
 		    strncmp(entry->d_name, "..", 2) != 0) {
-			_cleanup_free_ char *path = NULL;
-			_cleanup_free_ char *addr = NULL;
+			__cleanup_free char *path = NULL;
+			__cleanup_free char *addr = NULL;
 
 			ret = asprintf(&path, "%s/%s",
 				       slots_sysfs_dir, entry->d_name);
@@ -1769,7 +1769,7 @@ static void libnvme_read_sysfs_tls(struct libnvme_global_ctx *ctx,
 static void libnvme_read_sysfs_tls_mode(struct libnvme_global_ctx *ctx,
 		libnvme_ctrl_t c)
 {
-	_cleanup_free_ char *mode = NULL;
+	__cleanup_free char *mode = NULL;
 
 	mode = libnvme_get_ctrl_attr(c, "tls_mode");
 	if (!mode)
@@ -1836,7 +1836,7 @@ static int libnvme_reconfigure_ctrl(struct libnvme_global_ctx *ctx,
 
 __public int libnvme_init_ctrl(libnvme_host_t h, libnvme_ctrl_t c, int instance)
 {
-	_cleanup_free_ char *subsys_name = NULL, *name = NULL, *path = NULL;
+	__cleanup_free char *subsys_name = NULL, *name = NULL, *path = NULL;
 	libnvme_subsystem_t s;
 	int ret;
 
@@ -1880,7 +1880,7 @@ __public int libnvme_init_ctrl(libnvme_host_t h, libnvme_ctrl_t c, int instance)
 int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,
 		const char *path, const char *name, libnvme_ctrl_t *cp)
 {
-	_cleanup_free_ char *addr = NULL, *address = NULL, *transport = NULL;
+	__cleanup_free char *addr = NULL, *address = NULL, *transport = NULL;
 	char *host_traddr = NULL, *host_iface = NULL;
 	char *traddr = NULL, *trsvcid = NULL;
 	char *a = NULL, *e = NULL;
@@ -1894,7 +1894,7 @@ int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,
 	/* Parse 'address' string into components */
 	addr = libnvme_get_attr(path, "address");
 	if (!addr) {
-		_cleanup_free_ char *rpath = NULL;
+		__cleanup_free char *rpath = NULL;
 		char *p = NULL, *_a = NULL;
 
 		/* loop transport might not have an address */
@@ -1984,9 +1984,9 @@ skip_address:
 __public int libnvme_scan_ctrl(struct libnvme_global_ctx *ctx, const char *name,
 		   libnvme_ctrl_t *cp)
 {
-	_cleanup_free_ char *subsysnqn = NULL, *subsysname = NULL;
-	_cleanup_free_ char *hostnqn = NULL, *hostid = NULL;
-	_cleanup_free_ char *path = NULL;
+	__cleanup_free char *subsysnqn = NULL, *subsysname = NULL;
+	__cleanup_free char *hostnqn = NULL, *hostid = NULL;
+	__cleanup_free char *path = NULL;
 	char *host_key;
 	libnvme_host_t h;
 	libnvme_subsystem_t s;
@@ -2437,7 +2437,7 @@ static int parse_attrs(const char *path, struct sysfs_attr_table *tbl, int size)
 
 static int libnvme_ns_init(const char *path, struct libnvme_ns *ns)
 {
-	_cleanup_free_ char *attr = NULL;
+	__cleanup_free char *attr = NULL;
 	struct stat sb;
 	uint64_t size;
 	int ret;
@@ -2479,7 +2479,7 @@ static int libnvme_ns_init(const char *path, struct libnvme_ns *ns)
 		if (ret)
 			return ret;
 	} else {
-		_cleanup_free_ struct nvme_id_ns *id = NULL;
+		__cleanup_free struct nvme_id_ns *id = NULL;
 		uint8_t flbas;
 
 		id = __libnvme_alloc(sizeof(*ns));
@@ -2520,7 +2520,7 @@ static int libnvme_ns_open(struct libnvme_global_ctx *ctx, const char *sys_path,
 	struct libnvme_ns *n;
 	struct libnvme_ns_head *head;
 	struct stat arg;
-	_cleanup_free_ char *path = NULL;
+	__cleanup_free char *path = NULL;
 
 	n = calloc(1, sizeof(*n));
 	if (!n)
@@ -2605,8 +2605,8 @@ static char *libnvme_ns_generic_to_blkdev(const char *generic)
 static int __libnvme_scan_namespace(struct libnvme_global_ctx *ctx,
 		const char *sysfs_dir, const char *name, libnvme_ns_t *ns)
 {
-	_cleanup_free_ char *blkdev = NULL;
-	_cleanup_free_ char *path = NULL;
+	__cleanup_free char *blkdev = NULL;
+	__cleanup_free char *path = NULL;
 	struct libnvme_ns *n = NULL;
 	int ret;
 

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -752,7 +752,7 @@ __public int libnvme_uuid_from_string(const char *str, unsigned char uuid[NVME_U
 
 __public int libnvme_random_uuid(unsigned char uuid[NVME_UUID_LEN])
 {
-	_cleanup_fd_ int f = -1;
+	__cleanup_fd int f = -1;
 	ssize_t n;
 
 	f = open("/dev/urandom", O_RDONLY);

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -581,7 +581,7 @@ char *kv_keymatch(const char *kv, const char *key)
 static size_t read_file(const char * fname, char *buffer, size_t *bufsz)
 {
 	char   *p;
-	_cleanup_file_ FILE *file = NULL;
+	__cleanup_file FILE *file = NULL;
 	size_t len;
 
 	file = fopen(fname, "re");
@@ -630,7 +630,7 @@ size_t get_entity_name(char *buffer, size_t bufsz)
 
 size_t get_entity_version(char *buffer, size_t bufsz)
 {
-	_cleanup_file_ FILE *file = NULL;
+	__cleanup_file FILE *file = NULL;
 	size_t  num_bytes = 0;
 
 	/* /proc/sys/kernel/ostype typically contains the string "Linux" */

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -456,7 +456,7 @@ __public const char *libnvme_strerror(int errnum)
 int hostname2traddr(struct libnvme_global_ctx *ctx, const char *traddr,
 		    char **hostname)
 {
-	_cleanup_addrinfo_ struct addrinfo *host_info = NULL;
+	__cleanup_addrinfo struct addrinfo *host_info = NULL;
 	struct addrinfo hints = {.ai_family = AF_UNSPEC};
 	char addrstr[NVMF_TRADDR_SIZE];
 	const char *p;

--- a/libnvme/test/ioctl/misc.c
+++ b/libnvme/test/ioctl/misc.c
@@ -346,8 +346,8 @@ static void test_get_lba_status(void)
 	__u16 rl = 0x42;
 	int err;
 
-	_cleanup_free_ struct nvme_lba_status *lbas = NULL;
-	_cleanup_free_ struct nvme_lba_status *expected_lbas = NULL;
+	__cleanup_free struct nvme_lba_status *lbas = NULL;
+	__cleanup_free struct nvme_lba_status *expected_lbas = NULL;
 
 	lbas = malloc(lba_status_size);
 	check(lbas, "lbas: ENOMEM");
@@ -558,9 +558,9 @@ static void test_directive_recv_stream_status(void)
 		sizeof(struct nvme_streams_directive_status) +
 		nr_entries * sizeof(__le16);
 
-	_cleanup_free_ struct nvme_streams_directive_status *expected_status =
+	__cleanup_free struct nvme_streams_directive_status *expected_status =
 		NULL;
-	_cleanup_free_ struct nvme_streams_directive_status *status = NULL;
+	__cleanup_free struct nvme_streams_directive_status *status = NULL;
 
 	status = malloc(stream_status_size);
 	check(status, "status: ENOMEM");
@@ -955,7 +955,7 @@ static void test_dsm(void)
 	__u16 nr_ranges = 0xab;
 	int dsm_size = sizeof(struct nvme_dsm_range) * nr_ranges;
 
-	_cleanup_free_ struct nvme_dsm_range *dsm = NULL;
+	__cleanup_free struct nvme_dsm_range *dsm = NULL;
 
 	dsm = malloc(dsm_size);
 	check(dsm, "dsm: ENOMEM");
@@ -1002,7 +1002,7 @@ static void test_copy(void)
 		0xc, 0, 0, 0, 0, 0, 0, 0, 0x40, 0, 0, 0, 3, 0x33, 3, 0xff
 	};
 
-	_cleanup_free_ struct nvme_copy_range_f0 *copy = NULL;
+	__cleanup_free struct nvme_copy_range_f0 *copy = NULL;
 
 	copy = calloc(1, copy_size);
 	check(copy, "copy: ENOMEM");
@@ -1058,7 +1058,7 @@ static void test_copy_range_f1(void)
 		0x40, 0, 0, 0, 3, 0x33, 3, 0xff
 	};
 
-	_cleanup_free_ struct nvme_copy_range_f1 *copy = NULL;
+	__cleanup_free struct nvme_copy_range_f1 *copy = NULL;
 
 	copy = calloc(1, copy_size);
 	check(copy, "copy: ENOMEM");

--- a/libnvme/test/ioctl/util.h
+++ b/libnvme/test/ioctl/util.h
@@ -17,12 +17,12 @@ void arbitrary(void *buf, size_t len);
 
 size_t arbitrary_range(size_t max);
 
-#define __cleanup__(fn) __attribute__((cleanup(fn)))
+#define __cleanup(fn) __attribute__((cleanup(fn)))
 
 static inline void freep(void *p)
 {
 	free(*(void **)p);
 }
-#define _cleanup_free_ __cleanup__(freep)
+#define _cleanup_free_ __cleanup(freep)
 
 #endif /* #ifndef _LIBNVME_TEST_IOCTL_UTIL_H */

--- a/libnvme/test/ioctl/util.h
+++ b/libnvme/test/ioctl/util.h
@@ -23,6 +23,6 @@ static inline void freep(void *p)
 {
 	free(*(void **)p);
 }
-#define _cleanup_free_ __cleanup(freep)
+#define __cleanup_free __cleanup(freep)
 
 #endif /* #ifndef _LIBNVME_TEST_IOCTL_UTIL_H */

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -118,7 +118,7 @@ static void obj_add_result(struct json_object *o, const char *v, ...)
 {
 	va_list ap;
 
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 
 	va_start(ap, v);
 
@@ -134,7 +134,7 @@ static void obj_add_key(struct json_object *o, const char *k, const char *v, ...
 {
 	va_list ap;
 
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 
 	va_start(ap, v);
 
@@ -648,7 +648,7 @@ void json_changed_ns_list_log(struct nvme_ns_list *log, const char *devname, boo
 	__u32 nsid;
 	int i;
 
-	_cleanup_free_ char *k = NULL;
+	__cleanup_free char *k = NULL;
 
 	if (log->ns[0] == cpu_to_le32(0xffffffff))
 		return;
@@ -2288,7 +2288,7 @@ static void json_phy_rx_eom_descs(struct nvme_phy_rx_eom_log *log,
 
 	for (i = 0; i < num_descs; i++) {
 		struct nvme_eom_lane_desc *desc = p;
-		_cleanup_free_ char *hexstr = NULL;
+		__cleanup_free char *hexstr = NULL;
 		unsigned char *vsdata = NULL;
 		unsigned int vsdataoffset = 0;
 		uint16_t nrows, ncols, edlen;
@@ -2352,7 +2352,7 @@ static void json_phy_rx_eom_log(struct nvme_phy_rx_eom_log *log, __u16 controlle
 	int i;
 	struct json_object *r = json_create_object();
 
-	_cleanup_free_ char **allocated_eyes = NULL;
+	__cleanup_free char **allocated_eyes = NULL;
 
 	obj_add_uint(r, "lid", log->lid);
 	obj_add_uint(r, "eomip", log->eomip);
@@ -4117,7 +4117,7 @@ static void json_feature_show_fields_power_limit(struct json_object *r,
 {
 	__u8 field = NVME_FEAT_POWER_LIMIT_PLS(result);
 
-	_cleanup_free_ char *k =
+	__cleanup_free char *k =
 	    get_power_and_scale(NVME_FEAT_POWER_LIMIT_PLV(result), field);
 
 	obj_add_str(r, "Power Limit Scale (PLS)",
@@ -4132,7 +4132,7 @@ static void json_feature_show_fields_power_thresh(struct json_object *r,
 {
 	__u8 field;
 	__u16 ptv;
-	_cleanup_free_ char *k = NULL;
+	__cleanup_free char *k = NULL;
 
 	field = NVME_FEAT_POWER_THRESH_EPT(result);
 
@@ -5312,7 +5312,7 @@ static void json_output_error_status(int status, const char *msg, va_list ap)
 	int val;
 	int type;
 
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 
 	if (vasprintf(&value, msg, ap) < 0)
 		value = alloc_error;
@@ -5352,7 +5352,7 @@ static void json_output_message(bool error, const char *msg, va_list ap)
 {
 	struct json_object *r = json_r ? json_r : json_create_object();
 
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 
 	if (vasprintf(&value, msg, ap) < 0)
 		value = NULL;
@@ -5366,7 +5366,7 @@ static void json_output_perror(const char *msg, va_list ap)
 {
 	struct json_object *r = json_create_object();
 
-	_cleanup_free_ char *error = NULL;
+	__cleanup_free char *error = NULL;
 
 	if (vasprintf(&error, msg, ap) < 0)
 		error = NULL;
@@ -5407,8 +5407,8 @@ static void json_output_key_value(const char *key, const char *val, va_list ap)
 {
 	struct json_object *r = json_r ? json_r : json_create_object();
 
-	_cleanup_free_ char *value = NULL;
-	_cleanup_free_ char *key_trim = trim_white_space(strdup(key));
+	__cleanup_free char *value = NULL;
+	__cleanup_free char *key_trim = trim_white_space(strdup(key));
 
 	if (vasprintf(&value, val, ap) < 0)
 		value = NULL;

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -6421,7 +6421,7 @@ static void stdout_message(bool error, const char *msg, va_list ap)
 
 static void stdout_perror(const char *msg, va_list ap)
 {
-	_cleanup_free_ char *error = NULL;
+	__cleanup_free char *error = NULL;
 
 	if (vasprintf(&error, msg, ap) < 0)
 		error = NULL;
@@ -6431,7 +6431,7 @@ static void stdout_perror(const char *msg, va_list ap)
 
 static void stdout_key_value(const char *key, const char *val, va_list ap)
 {
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 
 	if (vasprintf(&value, val, ap) < 0)
 		value = NULL;

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -538,7 +538,7 @@ void nvme_show_err(int err, const char *fmt, ...)
 {
 	va_list ap;
 
-	_cleanup_free_ char *msg = NULL;
+	__cleanup_free char *msg = NULL;
 
 	va_start(ap, fmt);
 

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -869,8 +869,8 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 		OPT_UINT("blocks",    'b', &cfg.blocks,   blocks),
 		OPT_UINT("target",    't', &cfg.target,   target));
 	
-	_cleanup_free_ unsigned char *key_buf = NULL;
-	_cleanup_free_ unsigned char *msg_buf = NULL;
+	__cleanup_free unsigned char *key_buf = NULL;
+	__cleanup_free unsigned char *msg_buf = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	unsigned int write_cntr = 0;

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -872,7 +872,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 	__cleanup_free unsigned char *key_buf = NULL;
 	__cleanup_free unsigned char *msg_buf = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	unsigned int write_cntr = 0;
 	unsigned int msg_size = 0;
 	unsigned int key_size = 0;

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -871,7 +871,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 	
 	__cleanup_free unsigned char *key_buf = NULL;
 	__cleanup_free unsigned char *msg_buf = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	unsigned int write_cntr = 0;
 	unsigned int msg_size = 0;

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -210,7 +210,7 @@ static void write_file(unsigned char *data, size_t len, const char *dir,
 		       const char *file, const char *msg)
 {
 	char temp_folder[PATH_MAX] = { 0 };
-	_cleanup_file_ FILE *fp = NULL;
+	__cleanup_file FILE *fp = NULL;
 
 	if (dir != NULL)
 		sprintf(temp_folder, "%s/%s", dir, file);

--- a/nvme.c
+++ b/nvme.c
@@ -496,7 +496,7 @@ static int get_smart_log(int argc, char **argv, struct command *acmd, struct plu
 
 	__cleanup_free struct nvme_smart_log *smart_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	const char *namespace = "(optional) desired namespace";
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -558,7 +558,7 @@ static int get_ana_log(int argc, char **argv, struct command *acmd,
 	const char *groups = "Return ANA groups only.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free struct nvme_ana_log *ana_log = NULL;
 	size_t max_ana_log_len;
@@ -822,7 +822,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 	__cleanup_free struct nvme_telemetry_log *log = NULL;
 	__cleanup_free struct nvme_id_ctrl *id_ctrl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_fd int output = -1;
 	int err = 0;
 	size_t total_size = 0;
@@ -985,7 +985,7 @@ static int get_endurance_log(int argc, char **argv, struct command *acmd, struct
 
 	__cleanup_free struct nvme_endurance_group_log *endurance_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -1053,7 +1053,7 @@ static int get_effects_log(int argc, char **argv, struct command *acmd, struct p
 	const char *desc = "Retrieve command effects log page and print the table.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	struct list_head log_pages;
 	nvme_effects_log_node_t *node;
@@ -1150,7 +1150,7 @@ static int get_supported_log_pages(int argc, char **argv, struct command *acmd,
 
 	__cleanup_free struct nvme_supported_log_pages *supports = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -1195,7 +1195,7 @@ static int get_error_log(int argc, char **argv, struct command *acmd, struct plu
 
 	__cleanup_free struct nvme_error_log_page *err_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl ctrl = { 0 };
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -1265,7 +1265,7 @@ static int get_fw_log(int argc, char **argv, struct command *acmd, struct plugin
 
 	__cleanup_free struct nvme_firmware_slot *fw_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -1313,7 +1313,7 @@ static int get_changed_ns_list_log(int argc, char **argv, bool alloc)
 	__cleanup_free char *desc = NULL;
 	__cleanup_free struct nvme_ns_list *changed_ns_list_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -1391,7 +1391,7 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 
 	__cleanup_free struct nvme_nvmset_predictable_lat_log *plpns_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -1448,7 +1448,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 	const char *log_entries = "Number of pending NVM Set log Entries list";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free void *pea_log = NULL;
 	nvme_print_flags_t flags;
@@ -1534,7 +1534,7 @@ static int get_persistent_event_log(int argc, char **argv,
 	struct nvme_persistent_event_log *pevent_collected = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	void *pevent_log_info;
 	int err;
@@ -1644,7 +1644,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 	const char *log_entries = "Number of pending Endurance Group Event log Entries list";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free void *endurance_log = NULL;
 	nvme_print_flags_t flags;
@@ -1726,7 +1726,7 @@ static int get_lba_status_log(int argc, char **argv,
 		"for the given device in either decoded format(default),json or binary.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *lba_status = NULL;
 	nvme_print_flags_t flags;
 	__u32 lslplen;
@@ -1785,7 +1785,7 @@ static int get_resv_notif_log(int argc, char **argv,
 
 	__cleanup_free struct nvme_resv_notification_log *resv = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -1826,7 +1826,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *acmd, struct
 	const char *fname = "boot partition data output file name";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_boot_partition *boot = NULL;
 	__cleanup_free __u8 *bp_log = NULL;
 	nvme_print_flags_t flags;
@@ -1920,7 +1920,7 @@ static int get_phy_rx_eom_log(int argc, char **argv, struct command *acmd,
 	size_t phy_rx_eom_log_len;
 	nvme_print_flags_t flags;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = -1;
 	__u8 lsp_tmp;
 
@@ -2005,7 +2005,7 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *acmd,
 
 	__cleanup_free struct nvme_media_unit_stat_log *mus = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -2058,7 +2058,7 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *acmd,
 
 	__cleanup_free struct nvme_supported_cap_config_list_log *cap_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -2109,7 +2109,7 @@ static int io_mgmt_send(int argc, char **argv, struct command *acmd, struct plug
 	const char *desc = "I/O Management Send";
 	const char *data = "optional file for data (default stdin)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_fd int dfd = STDIN_FILENO;
 	__cleanup_free void *buf = NULL;
@@ -2185,7 +2185,7 @@ static int io_mgmt_recv(int argc, char **argv, struct command *acmd, struct plug
 	const char *desc = "I/O Management Receive";
 	const char *data = "optional file for data (default stdout)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -2274,7 +2274,7 @@ static int get_log(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *xfer_len = "read chunk size (default 4k)";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free unsigned char *log = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
@@ -2479,7 +2479,7 @@ static int sanitize_log(int argc, char **argv, struct command *acmd, struct plug
 
 	__cleanup_free struct nvme_sanitize_log_page *sanitize_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -2539,7 +2539,7 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *ac
 
 	__cleanup_free struct nvme_fid_supported_effects_log *fid_support_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -2591,7 +2591,7 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 
 	__cleanup_free struct nvme_mi_cmd_supported_effects_log *mi_cmd_support_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -2643,7 +2643,7 @@ static int list_ctrl(int argc, char **argv, struct command *acmd, struct plugin 
 
 	__cleanup_free struct nvme_ctrl_list *cntlist = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -2703,7 +2703,7 @@ static int list_ns(int argc, char **argv, struct command *acmd, struct plugin *p
 
 	__cleanup_free struct nvme_ns_list *ns_list = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	enum nvme_identify_cns cns;
 	nvme_print_flags_t flags;
 	int err;
@@ -2775,7 +2775,7 @@ static int id_ns_lba_format(int argc, char **argv, struct command *acmd, struct 
 		"LBA Format index in  various formats.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -2833,7 +2833,7 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *acmd,
 
 	__cleanup_free struct nvme_id_endurance_group_list *endgrp_list = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -2923,7 +2923,7 @@ static int delete_ns(int argc, char **argv, struct command *acmd, struct plugin 
 		"the namespace is not already inactive, once deleted.";
 	const char *namespace_id = "namespace to delete";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -2976,7 +2976,7 @@ static int delete_ns(int argc, char **argv, struct command *acmd, struct plugin 
 
 static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, struct command *acmd)
 {
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	__cleanup_free struct nvme_ctrl_list *cntlist = NULL;
@@ -3197,7 +3197,7 @@ static int create_ns(int argc, char **argv, struct command *acmd, struct plugin 
 	    "Requested Number of ZRWA Resources (RNUMZRWA) for Zoned Namespace Command Set";
 	const char *phndls = "Comma separated list of Placement Handle Associated RUH";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_ns_mgmt_host_sw_specified *data = NULL;
 	__cleanup_free struct nvme_id_ns_granularity_list *gr_list = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
@@ -3585,7 +3585,7 @@ int __id_ctrl(int argc, char **argv, struct command *acmd, struct plugin *plugin
 
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -3654,7 +3654,7 @@ static int nvm_id_ctrl(int argc, char **argv, struct command *acmd,
 
 	__cleanup_free struct nvme_id_ctrl_nvm *ctrl_nvm = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -3700,7 +3700,7 @@ static int nvm_id_ns(int argc, char **argv, struct command *acmd,
 	__cleanup_free struct nvme_nvm_id_ns *id_ns = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -3774,7 +3774,7 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *acmd, str
 	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -3841,7 +3841,7 @@ static int ns_descs(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *raw = "show descriptors in binary format";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *nsdescs = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -3909,7 +3909,7 @@ static int id_ns(int argc, char **argv, struct command *acmd, struct plugin *plu
 	const char *vendor_specific = "dump binary vendor fields";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -3995,7 +3995,7 @@ static int cmd_set_independent_id_ns(int argc, char **argv, struct command *acmd
 
 	__cleanup_free struct nvme_id_independent_id_ns *ns = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -4067,7 +4067,7 @@ static int id_ns_granularity(int argc, char **argv, struct command *acmd, struct
 
 	__cleanup_free struct nvme_id_ns_granularity_list *granularity_list = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -4108,7 +4108,7 @@ static int id_nvmset(int argc, char **argv, struct command *acmd, struct plugin 
 
 	__cleanup_free struct nvme_id_nvmset_list *nvmset = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -4161,7 +4161,7 @@ static int id_uuid(int argc, char **argv, struct command *acmd, struct plugin *p
 
 	__cleanup_free struct nvme_id_uuid_list *uuid_list = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -4219,7 +4219,7 @@ static int id_iocs(int argc, char **argv, struct command *acmd, struct plugin *p
 
 	__cleanup_free struct nvme_id_iocs *iocs = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -4274,7 +4274,7 @@ static int id_domain(int argc, char **argv, struct command *acmd, struct plugin 
 
 	__cleanup_free struct nvme_id_domain_list *id_domain = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -4323,7 +4323,7 @@ static int get_ns_id(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *desc = "Get namespace ID of a the block device.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	unsigned int nsid;
 	int err;
 	nvme_print_flags_t flags;
@@ -4369,7 +4369,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *acmd, struct plug
 		"9h: Secondary Online";
 	const char *nr = "Number of Controller Resources(NR)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
@@ -4420,7 +4420,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *acmd, struct
 
 	__cleanup_free struct nvme_primary_ctrl_cap *caps = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -4477,7 +4477,7 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *acmd, stru
 
 	__cleanup_free struct nvme_secondary_ctrl_list *sc_list = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -4643,7 +4643,7 @@ static int device_self_test(int argc, char **argv, struct command *acmd, struct 
 		"fh Abort the device self-test operation";
 	const char *wait = "Wait for the test to finish";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -4745,7 +4745,7 @@ static int self_test_log(int argc, char **argv, struct command *acmd, struct plu
 
 	__cleanup_free struct nvme_self_test_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -4945,7 +4945,7 @@ static int get_feature(int argc, char **argv, struct command *acmd,
 	nvme_print_flags_t flags = NORMAL;
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct feat_cfg cfg = {
@@ -5122,7 +5122,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 	const char *ignore_ovr = "ignore overwrite errors";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_fd int fw_fd = -1;
 	unsigned int fw_size, pos;
@@ -5331,7 +5331,7 @@ static int fw_commit(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *bpid = "[0,1]: boot partition identifier, if applicable (default: 0)";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 	nvme_print_flags_t flags;
@@ -5430,7 +5430,7 @@ static int subsystem_reset(int argc, char **argv, struct command *acmd, struct p
 	const char *desc = "Resets the NVMe subsystem";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	NVME_ARGS(opts);
@@ -5461,7 +5461,7 @@ static int reset(int argc, char **argv, struct command *acmd, struct plugin *plu
 	const char *desc = "Resets the NVMe controller\n";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	NVME_ARGS(opts);
@@ -5489,7 +5489,7 @@ static int ns_rescan(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *desc = "Rescans the NVMe namespaces\n";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	nvme_print_flags_t flags;
 
@@ -5531,7 +5531,7 @@ static int sanitize_cmd(int argc, char **argv, struct command *acmd, struct plug
 				"3 = Start overwrite, 4 = Start crypto erase, 5 = Exit media verification";
 	const char *ovrpat_desc = "Overwrite pattern.";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -5649,7 +5649,7 @@ static int sanitize_ns_cmd(int argc, char **argv, struct command *acmd,
 		"4 = Start a crypto erase namespace sanitize operation,\n"
 		"5 = Exit media verification state";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl =
 		NULL;
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
@@ -5845,7 +5845,7 @@ static int show_registers(int argc, char **argv, struct command *acmd, struct pl
 	    "show info in readable format in case of output_format == normal";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	void *bar;
 	int err;
@@ -6092,7 +6092,7 @@ static int get_register(int argc, char **argv, struct command *acmd, struct plug
 	const char *pmrmscu = "PMRMSCU=0xe18 register offset";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	nvme_print_flags_t flags;
 	bool fabrics = false;
@@ -6411,7 +6411,7 @@ static int set_register(int argc, char **argv, struct command *acmd, struct plug
 	const char *mmio32 = "Access 64-bit registers as 2 32-bit";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	void *bar;
 
@@ -6471,7 +6471,7 @@ static int get_property(int argc, char **argv, struct command *acmd, struct plug
 	const char *human_readable = "show property in readable format";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 value;
 	int err;
 	nvme_print_flags_t flags = NORMAL;
@@ -6519,7 +6519,7 @@ static int set_property(int argc, char **argv, struct command *acmd, struct plug
 	const char *value = "the value of the property to be set";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	nvme_print_flags_t flags;
 
@@ -6590,7 +6590,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	nvme_print_flags_t flags = NORMAL;
@@ -6859,7 +6859,7 @@ static int set_feature(int argc, char **argv, struct command *acmd, struct plugi
 	const char *sv = "specifies that the controller shall save the attribute";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	__cleanup_fd int ffd = STDIN_FILENO;
 	int err;
@@ -7004,7 +7004,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *tl = "transfer length (cf. SPC-4)";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__cleanup_free void *sec_buf = NULL;
 	__cleanup_fd int sec_fd = -1;
@@ -7116,7 +7116,7 @@ static int dir_send(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *input = "write/send file (default stdin)";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 dw12 = 0;
@@ -7249,7 +7249,7 @@ static int write_uncor(int argc, char **argv, struct command *acmd, struct plugi
 	    "The Write Uncorrectable command is used to set a range of logical blocks to invalid.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 
@@ -7464,7 +7464,7 @@ static int init_pi_tags(struct libnvme_transport_handle *hdl,
 static int write_zeroes(int argc, char **argv,
 	struct command *acmd, struct plugin *plugin)
 {
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u16 control = 0;
@@ -7604,7 +7604,7 @@ static int dsm(int argc, char **argv, struct command *acmd, struct plugin *plugi
 	const char *cdw11 = "All the command DWORD 11 attributes. Use instead of specifying individual attributes";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_dsm_range *dsm = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 ctx_attrs[256] = {0,};
@@ -7729,7 +7729,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *d_format = "source range entry format";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u16 nr, nb, ns, nrts, natms, nats, nids;
 	struct libnvme_passthru_cmd cmd;
 	__u16 nlbs[256] = { 0 };
@@ -7931,7 +7931,7 @@ static int flush_cmd(int argc, char **argv, struct command *acmd, struct plugin 
 		"associated namespace status.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -7982,7 +7982,7 @@ static int resv_acquire(int argc, char **argv, struct command *acmd, struct plug
 	const char *prkey = "pre-empt reservation key";
 	const char *racqa = "reservation acquire action";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -8059,7 +8059,7 @@ static int resv_register(int argc, char **argv, struct command *acmd, struct plu
 	const char *rrega = "reservation registration action";
 	const char *cptpl = "change persistence through power loss setting";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -8144,7 +8144,7 @@ static int resv_release(int argc, char **argv, struct command *acmd, struct plug
 		"the issuing controller are notified.";
 	const char *rrela = "reservation release action";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -8218,7 +8218,7 @@ static int resv_report(int argc, char **argv, struct command *acmd, struct plugi
 	const char *numd = "number of dwords to transfer";
 	const char *eds = "request extended data structure";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free struct nvme_resv_status *status = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
@@ -8313,7 +8313,7 @@ unsigned long long elapsed_utime(struct timeval start_time,
 
 static int submit_io(int opcode, char *command, const char *desc, int argc, char **argv)
 {
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	unsigned long long buffer_size = 0, mbuffer_size = 0;
 	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
@@ -8663,7 +8663,7 @@ static int write_cmd(int argc, char **argv, struct command *acmd, struct plugin 
 
 static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u16 control = 0;
@@ -8772,7 +8772,7 @@ static int sec_recv(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *size = "size of buffer (prints to stdout on success)";
 	const char *al = "allocation length (cf. SPC-4)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free void *sec_buf = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -8865,7 +8865,7 @@ static int get_lba_status(int argc, char **argv, struct command *acmd,
 	    "Range Length(RL) specifies the length of the range of contiguous LBAs beginning at SLBA";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__cleanup_free void *buf = NULL;
 	nvme_print_flags_t flags;
@@ -8951,7 +8951,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *acmd, struct plu
 	    "Most significant 32 bits of the capacity in bytes of the Endurance Group or NVM Set to be created";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
 	nvme_print_flags_t flags;
@@ -9029,7 +9029,7 @@ static int dir_receive(int argc, char **argv, struct command *acmd, struct plugi
 
 	nvme_print_flags_t flags = NORMAL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 dw12 = 0;
@@ -9161,7 +9161,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *acmd, struct plug
 		"then no UUID index is specified";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
 
@@ -9273,7 +9273,7 @@ static int passthru(int argc, char **argv, bool admin,
 
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_fd int dfd = -1, mfd = -1;
 	int flags;
 	int mode = 0644;
@@ -10430,7 +10430,7 @@ static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc
 	int flags;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u32 result;
 
 	struct config {
@@ -10562,7 +10562,7 @@ static int get_mgmt_addr_list_log(int argc, char **argv, struct command *acmd, s
 
 	__cleanup_free struct nvme_mgmt_addr_list_log *ma_log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts);
 
@@ -10600,7 +10600,7 @@ static int get_rotational_media_info_log(int argc, char **argv, struct command *
 
 	__cleanup_free struct nvme_rotational_media_info_log *info = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
 		__u16 endgid;
@@ -10686,7 +10686,7 @@ static int get_dispersed_ns_participating_nss_log(int argc, char **argv, struct 
 	int err;
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_dispersed_ns_participating_nss_log *log = NULL;
 
 	struct config {
@@ -10728,7 +10728,7 @@ static int get_power_measurement_log(int argc, char **argv, struct command *acmd
 		"json, or binary.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_power_meas_log *log = NULL;
 	nvme_print_flags_t flags;
 	__u32 min_log_size = sizeof(struct nvme_power_meas_log);
@@ -10909,7 +10909,7 @@ static int get_reachability_groups_log(int argc, char **argv, struct command *ac
 	__u64 len = 0;
 	__cleanup_free struct nvme_reachability_groups_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
 		bool rgo;
@@ -11020,7 +11020,7 @@ static int get_reachability_associations_log(int argc, char **argv, struct comma
 	__u64 len = 0;
 	__cleanup_free struct nvme_reachability_associations_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
 		bool rao;
@@ -11100,7 +11100,7 @@ static int get_host_discovery_log(int argc, char **argv, struct command *acmd, s
 	int err;
 	__cleanup_free struct nvme_host_discover_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
 		bool allhoste;
@@ -11179,7 +11179,7 @@ static int get_ave_discovery_log(int argc, char **argv, struct command *acmd, st
 
 	__cleanup_free struct nvme_ave_discover_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
 		bool rae;
@@ -11255,7 +11255,7 @@ static int get_pull_model_ddc_req_log(int argc, char **argv, struct command *acm
 
 	__cleanup_free struct nvme_pull_model_ddc_req_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
 		bool rae;

--- a/nvme.c
+++ b/nvme.c
@@ -823,7 +823,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 	__cleanup_free struct nvme_id_ctrl *id_ctrl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_fd_ int output = -1;
+	__cleanup_fd int output = -1;
 	int err = 0;
 	size_t total_size = 0;
 	__u8 *data_ptr = NULL;
@@ -1831,7 +1831,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *acmd, struct
 	__cleanup_free __u8 *bp_log = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
-	_cleanup_fd_ int output = -1;
+	__cleanup_fd int output = -1;
 	__u32 bpsz = 0;
 
 	struct config {
@@ -2111,7 +2111,7 @@ static int io_mgmt_send(int argc, char **argv, struct command *acmd, struct plug
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_fd_ int dfd = STDIN_FILENO;
+	__cleanup_fd int dfd = STDIN_FILENO;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
@@ -2189,7 +2189,7 @@ static int io_mgmt_recv(int argc, char **argv, struct command *acmd, struct plug
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
-	_cleanup_fd_ int dfd = -1;
+	__cleanup_fd int dfd = -1;
 	int err = -1;
 
 	struct config {
@@ -5124,7 +5124,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
-	_cleanup_fd_ int fw_fd = -1;
+	__cleanup_fd int fw_fd = -1;
 	unsigned int fw_size, pos;
 	int err;
 	struct stat sb;
@@ -6861,7 +6861,7 @@ static int set_feature(int argc, char **argv, struct command *acmd, struct plugi
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
-	_cleanup_fd_ int ffd = STDIN_FILENO;
+	__cleanup_fd int ffd = STDIN_FILENO;
 	int err;
 	__u64 result;
 	nvme_print_flags_t flags;
@@ -7007,7 +7007,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__cleanup_free void *sec_buf = NULL;
-	_cleanup_fd_ int sec_fd = -1;
+	__cleanup_fd int sec_fd = -1;
 	unsigned int sec_size;
 	int err;
 	nvme_print_flags_t flags;
@@ -7120,7 +7120,7 @@ static int dir_send(int argc, char **argv, struct command *acmd, struct plugin *
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 dw12 = 0;
-	_cleanup_fd_ int ffd = STDIN_FILENO;
+	__cleanup_fd int ffd = STDIN_FILENO;
 	int err;
 
 	struct config {
@@ -8322,7 +8322,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	unsigned int logical_block_size = 0;
 	struct timeval start_time, end_time;
 	__cleanup_free void *mbuffer = NULL;
-	_cleanup_fd_ int dfd = -1, mfd = -1;
+	__cleanup_fd int dfd = -1, mfd = -1;
 	__u16 control = 0, nblocks = 0;
 	struct libnvme_passthru_cmd cmd;
 	__u8 sts = 0, pif = 0;
@@ -9274,7 +9274,7 @@ static int passthru(int argc, char **argv, bool admin,
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_fd_ int dfd = -1, mfd = -1;
+	__cleanup_fd int dfd = -1, mfd = -1;
 	int flags;
 	int mode = 0644;
 	void *data = NULL;
@@ -10426,7 +10426,7 @@ static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc
 	void *data = NULL;
 	int err = 0;
 	bool send;
-	_cleanup_fd_ int fd = -1;
+	__cleanup_fd int fd = -1;
 	int flags;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;

--- a/nvme.c
+++ b/nvme.c
@@ -495,7 +495,7 @@ static int get_smart_log(int argc, char **argv, struct command *acmd, struct plu
 		"(default) or binary.";
 
 	__cleanup_free struct nvme_smart_log *smart_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	const char *namespace = "(optional) desired namespace";
 	nvme_print_flags_t flags;
@@ -557,7 +557,7 @@ static int get_ana_log(int argc, char **argv, struct command *acmd,
 		"decoded format (default), json or binary.";
 	const char *groups = "Return ANA groups only.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free struct nvme_ana_log *ana_log = NULL;
@@ -821,7 +821,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 
 	__cleanup_free struct nvme_telemetry_log *log = NULL;
 	__cleanup_free struct nvme_id_ctrl *id_ctrl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_fd int output = -1;
 	int err = 0;
@@ -984,7 +984,7 @@ static int get_endurance_log(int argc, char **argv, struct command *acmd, struct
 	const char *group_id = "The endurance group identifier";
 
 	__cleanup_free struct nvme_endurance_group_log *endurance_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -1052,7 +1052,7 @@ static int get_effects_log(int argc, char **argv, struct command *acmd, struct p
 {
 	const char *desc = "Retrieve command effects log page and print the table.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	struct list_head log_pages;
@@ -1149,7 +1149,7 @@ static int get_supported_log_pages(int argc, char **argv, struct command *acmd,
 	const char *desc = "Retrieve supported logs and print the table.";
 
 	__cleanup_free struct nvme_supported_log_pages *supports = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -1194,7 +1194,7 @@ static int get_error_log(int argc, char **argv, struct command *acmd, struct plu
 	const char *raw = "dump in binary format";
 
 	__cleanup_free struct nvme_error_log_page *err_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl ctrl = { 0 };
 	nvme_print_flags_t flags;
@@ -1264,7 +1264,7 @@ static int get_fw_log(int argc, char **argv, struct command *acmd, struct plugin
 		"specified device in either decoded format (default) or binary.";
 
 	__cleanup_free struct nvme_firmware_slot *fw_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -1312,7 +1312,7 @@ static int get_changed_ns_list_log(int argc, char **argv, bool alloc)
 {
 	__cleanup_free char *desc = NULL;
 	__cleanup_free struct nvme_ns_list *changed_ns_list_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -1390,7 +1390,7 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 	const char *nvmset_id = "NVM Set Identifier";
 
 	__cleanup_free struct nvme_nvmset_predictable_lat_log *plpns_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -1447,7 +1447,7 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 		"device in either decoded format(default), json or binary.";
 	const char *log_entries = "Number of pending NVM Set log Entries list";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free void *pea_log = NULL;
@@ -1533,7 +1533,7 @@ static int get_persistent_event_log(int argc, char **argv,
 	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
 	struct nvme_persistent_event_log *pevent_collected = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	void *pevent_log_info;
@@ -1643,7 +1643,7 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 		"device in either decoded format(default), json or binary.";
 	const char *log_entries = "Number of pending Endurance Group Event log Entries list";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free void *endurance_log = NULL;
@@ -1725,7 +1725,7 @@ static int get_lba_status_log(int argc, char **argv,
 	const char *desc = "Retrieve Get LBA Status Info Log and prints it, "
 		"for the given device in either decoded format(default),json or binary.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *lba_status = NULL;
 	nvme_print_flags_t flags;
@@ -1784,7 +1784,7 @@ static int get_resv_notif_log(int argc, char **argv,
 		"device in either decoded format(default), json or binary.";
 
 	__cleanup_free struct nvme_resv_notification_log *resv = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -1825,7 +1825,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *acmd, struct
 		"device in either decoded format(default), json or binary.";
 	const char *fname = "boot partition data output file name";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_boot_partition *boot = NULL;
 	__cleanup_free __u8 *bp_log = NULL;
@@ -1919,7 +1919,7 @@ static int get_phy_rx_eom_log(int argc, char **argv, struct command *acmd,
 	__cleanup_free struct nvme_phy_rx_eom_log *phy_rx_eom_log = NULL;
 	size_t phy_rx_eom_log_len;
 	nvme_print_flags_t flags;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = -1;
 	__u8 lsp_tmp;
@@ -2004,7 +2004,7 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *acmd,
 	const char *desc = "Retrieve the configuration and wear of media units and print it";
 
 	__cleanup_free struct nvme_media_unit_stat_log *mus = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -2057,7 +2057,7 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *acmd,
 	const char *desc = "Retrieve the list of Supported Capacity Configuration Descriptors";
 
 	__cleanup_free struct nvme_supported_cap_config_list_log *cap_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -2110,7 +2110,7 @@ static int io_mgmt_send(int argc, char **argv, struct command *acmd, struct plug
 	const char *data = "optional file for data (default stdin)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_fd int dfd = STDIN_FILENO;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -2186,7 +2186,7 @@ static int io_mgmt_recv(int argc, char **argv, struct command *acmd, struct plug
 	const char *data = "optional file for data (default stdout)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__cleanup_fd int dfd = -1;
@@ -2273,7 +2273,7 @@ static int get_log(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *offset_type = "offset type";
 	const char *xfer_len = "read chunk size (default 4k)";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free unsigned char *log = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -2478,7 +2478,7 @@ static int sanitize_log(int argc, char **argv, struct command *acmd, struct plug
 	const char *desc = "Retrieve sanitize log and show it.";
 
 	__cleanup_free struct nvme_sanitize_log_page *sanitize_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -2538,7 +2538,7 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *ac
 	const char *desc = "Retrieve FID Support and Effects log and show it.";
 
 	__cleanup_free struct nvme_fid_supported_effects_log *fid_support_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -2590,7 +2590,7 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 	const char *desc = "Retrieve NVMe-MI Command Support and Effects log and show it.";
 
 	__cleanup_free struct nvme_mi_cmd_supported_effects_log *mi_cmd_support_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -2642,7 +2642,7 @@ static int list_ctrl(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *controller = "controller to display";
 
 	__cleanup_free struct nvme_ctrl_list *cntlist = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -2702,7 +2702,7 @@ static int list_ns(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *all = "show all namespaces in the subsystem, whether attached or inactive";
 
 	__cleanup_free struct nvme_ns_list *ns_list = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	enum nvme_identify_cns cns;
 	nvme_print_flags_t flags;
@@ -2774,7 +2774,7 @@ static int id_ns_lba_format(int argc, char **argv, struct command *acmd, struct 
 		"device, returns capability field properties of the specified "
 		"LBA Format index in  various formats.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	nvme_print_flags_t flags;
@@ -2832,7 +2832,7 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *acmd,
 	const char *endurance_grp_id = "Endurance Group ID";
 
 	__cleanup_free struct nvme_id_endurance_group_list *endgrp_list = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -2924,7 +2924,7 @@ static int delete_ns(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *namespace_id = "namespace to delete";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -2977,7 +2977,7 @@ static int delete_ns(int argc, char **argv, struct command *acmd, struct plugin 
 static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, struct command *acmd)
 {
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	__cleanup_free struct nvme_ctrl_list *cntlist = NULL;
 	__u16 list[NVME_ID_CTRL_LIST_MAX];
@@ -3200,7 +3200,7 @@ static int create_ns(int argc, char **argv, struct command *acmd, struct plugin 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_ns_mgmt_host_sw_specified *data = NULL;
 	__cleanup_free struct nvme_id_ns_granularity_list *gr_list = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free struct nvme_id_ctrl *id = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	__u64 align_nsze = 1 << 20; /* Default 1 MiB */
@@ -3477,7 +3477,7 @@ static bool nvme_match_device_filter(libnvme_subsystem_t s,
 static int list_subsys(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	nvme_print_flags_t flags;
 	const char *desc = "Retrieve information for subsystems";
 	libnvme_scan_filter_t filter = NULL;
@@ -3539,7 +3539,7 @@ static int list(int argc, char **argv, struct command *acmd, struct plugin *plug
 {
 	const char *desc = "Retrieve basic information for all NVMe namespaces";
 	nvme_print_flags_t flags;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int err = 0;
 
 	NVME_ARGS(opts);
@@ -3584,7 +3584,7 @@ int __id_ctrl(int argc, char **argv, struct command *acmd, struct plugin *plugin
 	const char *vendor_specific = "dump binary vendor field";
 
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -3653,7 +3653,7 @@ static int nvm_id_ctrl(int argc, char **argv, struct command *acmd,
 		"the specified controller in various formats.";
 
 	__cleanup_free struct nvme_id_ctrl_nvm *ctrl_nvm = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -3699,7 +3699,7 @@ static int nvm_id_ns(int argc, char **argv, struct command *acmd,
 
 	__cleanup_free struct nvme_nvm_id_ns *id_ns = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -3773,7 +3773,7 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *acmd, str
 
 	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
@@ -3840,7 +3840,7 @@ static int ns_descs(int argc, char **argv, struct command *acmd, struct plugin *
 		"of the specific namespace in either human-readable or binary format.";
 	const char *raw = "show descriptors in binary format";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *nsdescs = NULL;
 	nvme_print_flags_t flags;
@@ -3908,7 +3908,7 @@ static int id_ns(int argc, char **argv, struct command *acmd, struct plugin *plu
 	const char *force = "Return this namespace, even if not attached (1.2 devices only)";
 	const char *vendor_specific = "dump binary vendor fields";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -3994,7 +3994,7 @@ static int cmd_set_independent_id_ns(int argc, char **argv, struct command *acmd
 		"specified namespace in human-readable or binary or json format.";
 
 	__cleanup_free struct nvme_id_independent_id_ns *ns = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -4066,7 +4066,7 @@ static int id_ns_granularity(int argc, char **argv, struct command *acmd, struct
 		"in either human-readable or binary format.";
 
 	__cleanup_free struct nvme_id_ns_granularity_list *granularity_list = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -4107,7 +4107,7 @@ static int id_nvmset(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *nvmset_id = "NVM Set Identify value";
 
 	__cleanup_free struct nvme_id_nvmset_list *nvmset = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -4160,7 +4160,7 @@ static int id_uuid(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *human_readable = "show uuid in readable format";
 
 	__cleanup_free struct nvme_id_uuid_list *uuid_list = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -4218,7 +4218,7 @@ static int id_iocs(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *controller_id = "identifier of desired controller";
 
 	__cleanup_free struct nvme_id_iocs *iocs = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -4273,7 +4273,7 @@ static int id_domain(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *domain_id = "identifier of desired domain";
 
 	__cleanup_free struct nvme_id_domain_list *id_domain = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -4322,7 +4322,7 @@ static int get_ns_id(int argc, char **argv, struct command *acmd, struct plugin 
 {
 	const char *desc = "Get namespace ID of a the block device.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	unsigned int nsid;
 	int err;
@@ -4370,7 +4370,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *acmd, struct plug
 	const char *nr = "Number of Controller Resources(NR)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 
@@ -4419,7 +4419,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *acmd, struct
 		"decoded format (default), json or binary.";
 
 	__cleanup_free struct nvme_primary_ctrl_cap *caps = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -4476,7 +4476,7 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *acmd, stru
 	const char *num_entries = "number of entries to retrieve";
 
 	__cleanup_free struct nvme_secondary_ctrl_list *sc_list = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -4644,7 +4644,7 @@ static int device_self_test(int argc, char **argv, struct command *acmd, struct 
 	const char *wait = "Wait for the test to finish";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -4744,7 +4744,7 @@ static int self_test_log(int argc, char **argv, struct command *acmd, struct plu
 		"by default all the 20 entries will be retrieved";
 
 	__cleanup_free struct nvme_self_test_log *log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -4944,7 +4944,7 @@ static int get_feature(int argc, char **argv, struct command *acmd,
 	const char *changed = "show feature changed";
 	nvme_print_flags_t flags = NORMAL;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -5121,7 +5121,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 	const char *progress = "display firmware transfer progress";
 	const char *ignore_ovr = "ignore overwrite errors";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_fd int fw_fd = -1;
@@ -5330,7 +5330,7 @@ static int fw_commit(int argc, char **argv, struct command *acmd, struct plugin 
 				"7 = activate boot partition";
 	const char *bpid = "[0,1]: boot partition identifier, if applicable (default: 0)";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
@@ -5429,7 +5429,7 @@ static int subsystem_reset(int argc, char **argv, struct command *acmd, struct p
 {
 	const char *desc = "Resets the NVMe subsystem";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -5460,7 +5460,7 @@ static int reset(int argc, char **argv, struct command *acmd, struct plugin *plu
 {
 	const char *desc = "Resets the NVMe controller\n";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -5488,7 +5488,7 @@ static int ns_rescan(int argc, char **argv, struct command *acmd, struct plugin 
 {
 	const char *desc = "Rescans the NVMe namespaces\n";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	nvme_print_flags_t flags;
@@ -5532,7 +5532,7 @@ static int sanitize_cmd(int argc, char **argv, struct command *acmd, struct plug
 	const char *ovrpat_desc = "Overwrite pattern.";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -5652,7 +5652,7 @@ static int sanitize_ns_cmd(int argc, char **argv, struct command *acmd,
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
 		NULL;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -5844,7 +5844,7 @@ static int show_registers(int argc, char **argv, struct command *acmd, struct pl
 	const char *human_readable =
 	    "show info in readable format in case of output_format == normal";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	void *bar;
@@ -6091,7 +6091,7 @@ static int get_register(int argc, char **argv, struct command *acmd, struct plug
 	const char *pmrmscl = "PMRMSCL=0xe14 register offset";
 	const char *pmrmscu = "PMRMSCU=0xe18 register offset";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	nvme_print_flags_t flags;
@@ -6410,7 +6410,7 @@ static int set_register(int argc, char **argv, struct command *acmd, struct plug
 	const char *value = "the value of the register to be set";
 	const char *mmio32 = "Access 64-bit registers as 2 32-bit";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	void *bar;
@@ -6470,7 +6470,7 @@ static int get_property(int argc, char **argv, struct command *acmd, struct plug
 	const char *offset = "offset of the requested property";
 	const char *human_readable = "show property in readable format";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 value;
 	int err;
@@ -6518,7 +6518,7 @@ static int set_property(int argc, char **argv, struct command *acmd, struct plug
 	const char *offset = "the offset of the property";
 	const char *value = "the value of the property to be set";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	nvme_print_flags_t flags;
@@ -6556,7 +6556,7 @@ static int set_property(int argc, char **argv, struct command *acmd, struct plug
 
 static void show_relatives(const char *name, nvme_print_flags_t flags)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx;
 	int err;
 
 	ctx = libnvme_create_global_ctx(stderr, log_level);
@@ -6589,7 +6589,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 	const char *bs = "target block size";
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	__cleanup_free struct nvme_id_ns *ns = NULL;
@@ -6858,7 +6858,7 @@ static int set_feature(int argc, char **argv, struct command *acmd, struct plugi
 	const char *cdw12 = "feature cdw12, if used";
 	const char *sv = "specifies that the controller shall save the attribute";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	__cleanup_fd int ffd = STDIN_FILENO;
@@ -7003,7 +7003,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *file = "transfer payload";
 	const char *tl = "transfer length (cf. SPC-4)";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__cleanup_free void *sec_buf = NULL;
@@ -7115,7 +7115,7 @@ static int dir_send(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *ttype = "target directive type to be enabled/disabled";
 	const char *input = "write/send file (default stdin)";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -7248,7 +7248,7 @@ static int write_uncor(int argc, char **argv, struct command *acmd, struct plugi
 	const char *desc =
 	    "The Write Uncorrectable command is used to set a range of logical blocks to invalid.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
@@ -7465,7 +7465,7 @@ static int write_zeroes(int argc, char **argv,
 	struct command *acmd, struct plugin *plugin)
 {
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u16 control = 0;
 	int err;
@@ -7603,7 +7603,7 @@ static int dsm(int argc, char **argv, struct command *acmd, struct plugin *plugi
 	const char *idr = "Attribute Integral Dataset for Read";
 	const char *cdw11 = "All the command DWORD 11 attributes. Use instead of specifying individual attributes";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_dsm_range *dsm = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -7728,7 +7728,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *d_dspec = "directive specific (write part)";
 	const char *d_format = "source range entry format";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u16 nr, nb, ns, nrts, natms, nats, nids;
 	struct libnvme_passthru_cmd cmd;
@@ -7930,7 +7930,7 @@ static int flush_cmd(int argc, char **argv, struct command *acmd, struct plugin 
 		"flushed by the controller, from any namespace, depending on controller and\n"
 		"associated namespace status.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -7983,7 +7983,7 @@ static int resv_acquire(int argc, char **argv, struct command *acmd, struct plug
 	const char *racqa = "reservation acquire action";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	__le64 payload[2];
@@ -8060,7 +8060,7 @@ static int resv_register(int argc, char **argv, struct command *acmd, struct plu
 	const char *cptpl = "change persistence through power loss setting";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	__le64 payload[2];
@@ -8145,7 +8145,7 @@ static int resv_release(int argc, char **argv, struct command *acmd, struct plug
 	const char *rrela = "reservation release action";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	__le64 payload[1];
@@ -8219,7 +8219,7 @@ static int resv_report(int argc, char **argv, struct command *acmd, struct plugi
 	const char *eds = "request extended data structure";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free struct nvme_resv_status *status = NULL;
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -8314,7 +8314,7 @@ unsigned long long elapsed_utime(struct timeval start_time,
 static int submit_io(int opcode, char *command, const char *desc, int argc, char **argv)
 {
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	unsigned long long buffer_size = 0, mbuffer_size = 0;
 	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
@@ -8664,7 +8664,7 @@ static int write_cmd(int argc, char **argv, struct command *acmd, struct plugin 
 static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u16 control = 0;
 	int err;
@@ -8773,7 +8773,7 @@ static int sec_recv(int argc, char **argv, struct command *acmd, struct plugin *
 	const char *al = "allocation length (cf. SPC-4)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free void *sec_buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -8864,7 +8864,7 @@ static int get_lba_status(int argc, char **argv, struct command *acmd,
 	const char *rl =
 	    "Range Length(RL) specifies the length of the range of contiguous LBAs beginning at SLBA";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__cleanup_free void *buf = NULL;
@@ -8950,7 +8950,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *acmd, struct plu
 	const char *cap_upper =
 	    "Most significant 32 bits of the capacity in bytes of the Endurance Group or NVM Set to be created";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
@@ -9028,7 +9028,7 @@ static int dir_receive(int argc, char **argv, struct command *acmd, struct plugi
 	const char *nsr = "namespace stream requested";
 
 	nvme_print_flags_t flags = NORMAL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -9160,7 +9160,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *acmd, struct plug
 		"List that is used by the command.If this field is cleared to 0h,\n"
 		"then no UUID index is specified";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
@@ -9272,7 +9272,7 @@ static int passthru(int argc, char **argv, bool admin,
 	const char *prefill = "prefill buffers with known byte-value, default 0";
 
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_fd int dfd = -1, mfd = -1;
 	int flags;
@@ -9543,7 +9543,7 @@ static int gen_dhchap_key(int argc, char **argv, struct command *acmd, struct pl
 	    "HMAC function to use for key transformation (0 = none, 1 = SHA-256, 2 = SHA-384, 3 = SHA-512).";
 	const char *nqn = "Host NQN to use for key transformation.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free unsigned char *raw_secret = NULL;
 	__cleanup_free char *hnqn = NULL;
 	unsigned char key[68];
@@ -9823,7 +9823,7 @@ static int gen_tls_key(int argc, char **argv, struct command *acmd, struct plugi
 	const char *keyfile = "Update key file with the derive TLS PSK.";
 	const char *compat = "Use non-RFC 8446 compliant algorithm for deriving TLS PSK for older implementations";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free unsigned char *raw_secret = NULL;
 	__cleanup_free char *encoded_key = NULL;
 	__cleanup_free char *hnqn = NULL;
@@ -9956,7 +9956,7 @@ static int check_tls_key(int argc, char **argv, struct command *acmd, struct plu
 	const char *keyfile = "Update key file with the derive TLS PSK.";
 	const char *compat = "Use non-RFC 8446 compliant algorithm for checking TLS PSK for older implementations.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free unsigned char *decoded_key = NULL;
 	__cleanup_free char *hnqn = NULL;
 	int decoded_len, err = 0;
@@ -10165,7 +10165,7 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *export = "Export all keys from the keyring.";
 	const char *revoke = "Revoke key from the keyring.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_file FILE *fd = NULL;
 	mode_t old_umask = 0;
 	int cnt, err = 0;
@@ -10285,7 +10285,7 @@ static int show_topology_cmd(int argc, char **argv, struct command *acmd, struct
 	const char *desc = "Show the topology\n";
 	const char *ranking = "Ranking order: namespace|ctrl|multipath";
 	nvme_print_flags_t flags;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	char *devname = NULL;
 	libnvme_scan_filter_t filter = NULL;
 	enum nvme_cli_topo_ranking rank;
@@ -10429,7 +10429,7 @@ static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc
 	__cleanup_fd int fd = -1;
 	int flags;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u32 result;
 
@@ -10561,7 +10561,7 @@ static int get_mgmt_addr_list_log(int argc, char **argv, struct command *acmd, s
 	int err = -1;
 
 	__cleanup_free struct nvme_mgmt_addr_list_log *ma_log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts);
@@ -10599,7 +10599,7 @@ static int get_rotational_media_info_log(int argc, char **argv, struct command *
 	int err = -1;
 
 	__cleanup_free struct nvme_rotational_media_info_log *info = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
@@ -10685,7 +10685,7 @@ static int get_dispersed_ns_participating_nss_log(int argc, char **argv, struct 
 	nvme_print_flags_t flags;
 	int err;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_dispersed_ns_participating_nss_log *log = NULL;
 
@@ -10727,7 +10727,7 @@ static int get_power_measurement_log(int argc, char **argv, struct command *acmd
 		"for the given device in either decoded format (default), "
 		"json, or binary.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_power_meas_log *log = NULL;
 	nvme_print_flags_t flags;
@@ -10908,7 +10908,7 @@ static int get_reachability_groups_log(int argc, char **argv, struct command *ac
 	int err;
 	__u64 len = 0;
 	__cleanup_free struct nvme_reachability_groups_log *log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
@@ -11019,7 +11019,7 @@ static int get_reachability_associations_log(int argc, char **argv, struct comma
 	int err;
 	__u64 len = 0;
 	__cleanup_free struct nvme_reachability_associations_log *log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
@@ -11099,7 +11099,7 @@ static int get_host_discovery_log(int argc, char **argv, struct command *acmd, s
 	nvme_print_flags_t flags;
 	int err;
 	__cleanup_free struct nvme_host_discover_log *log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
@@ -11178,7 +11178,7 @@ static int get_ave_discovery_log(int argc, char **argv, struct command *acmd, st
 	int err;
 
 	__cleanup_free struct nvme_ave_discover_log *log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
@@ -11254,7 +11254,7 @@ static int get_pull_model_ddc_req_log(int argc, char **argv, struct command *acm
 	int err;
 
 	__cleanup_free struct nvme_pull_model_ddc_req_log *log = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {

--- a/nvme.c
+++ b/nvme.c
@@ -425,7 +425,7 @@ static int open_fallback_chardev(struct libnvme_global_ctx *ctx,
 	int err;
 
 	if (libnvme_transport_handle_is_chardev(hdl)) {
-		_cleanup_free_ char *cdev = NULL;
+		__cleanup_free char *cdev = NULL;
 
 		if (!nsid) {
 			nvme_show_error("char device not supported without --namespace-id");
@@ -494,7 +494,7 @@ static int get_smart_log(int argc, char **argv, struct command *acmd, struct plu
 		"(or optionally a namespace) in either decoded format "
 		"(default) or binary.";
 
-	_cleanup_free_ struct nvme_smart_log *smart_log = NULL;
+	__cleanup_free struct nvme_smart_log *smart_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	const char *namespace = "(optional) desired namespace";
@@ -559,8 +559,8 @@ static int get_ana_log(int argc, char **argv, struct command *acmd,
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
-	_cleanup_free_ struct nvme_ana_log *ana_log = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_ana_log *ana_log = NULL;
 	size_t max_ana_log_len;
 	__u32 ana_log_len;
 	nvme_print_flags_t flags;
@@ -717,7 +717,7 @@ static int __create_telemetry_log_host(struct libnvme_transport_handle *hdl,
 				       struct nvme_telemetry_log **buf,
 				       bool da4_support)
 {
-	_cleanup_free_ struct nvme_telemetry_log *log = NULL;
+	__cleanup_free struct nvme_telemetry_log *log = NULL;
 	int err;
 
 	log = nvme_alloc(sizeof(*log));
@@ -789,7 +789,7 @@ static int __get_telemetry_log_host(struct libnvme_transport_handle *hdl,
 				    struct nvme_telemetry_log **buf,
 				    bool da4_support)
 {
-	_cleanup_free_ struct nvme_telemetry_log *log = NULL;
+	__cleanup_free struct nvme_telemetry_log *log = NULL;
 	int err;
 
 	log = nvme_alloc(sizeof(*log));
@@ -819,8 +819,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 	const char *mcda = "Host-init Maximum Created Data Area. Valid options are 0 ~ 4 "
 		"If given, This option will override dgen. 0 : controller determines data area";
 
-	_cleanup_free_ struct nvme_telemetry_log *log = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *id_ctrl = NULL;
+	__cleanup_free struct nvme_telemetry_log *log = NULL;
+	__cleanup_free struct nvme_id_ctrl *id_ctrl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_fd_ int output = -1;
@@ -983,7 +983,7 @@ static int get_endurance_log(int argc, char **argv, struct command *acmd, struct
 	const char *desc = "Retrieves endurance groups log page and prints the log.";
 	const char *group_id = "The endurance group identifier";
 
-	_cleanup_free_ struct nvme_endurance_group_log *endurance_log = NULL;
+	__cleanup_free struct nvme_endurance_group_log *endurance_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -1148,7 +1148,7 @@ static int get_supported_log_pages(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve supported logs and print the table.";
 
-	_cleanup_free_ struct nvme_supported_log_pages *supports = NULL;
+	__cleanup_free struct nvme_supported_log_pages *supports = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -1193,7 +1193,7 @@ static int get_error_log(int argc, char **argv, struct command *acmd, struct plu
 	const char *log_entries = "number of entries to retrieve";
 	const char *raw = "dump in binary format";
 
-	_cleanup_free_ struct nvme_error_log_page *err_log = NULL;
+	__cleanup_free struct nvme_error_log_page *err_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl ctrl = { 0 };
@@ -1263,7 +1263,7 @@ static int get_fw_log(int argc, char **argv, struct command *acmd, struct plugin
 	const char *desc = "Retrieve the firmware log for the "
 		"specified device in either decoded format (default) or binary.";
 
-	_cleanup_free_ struct nvme_firmware_slot *fw_log = NULL;
+	__cleanup_free struct nvme_firmware_slot *fw_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -1310,8 +1310,8 @@ static int get_fw_log(int argc, char **argv, struct command *acmd, struct plugin
 
 static int get_changed_ns_list_log(int argc, char **argv, bool alloc)
 {
-	_cleanup_free_ char *desc = NULL;
-	_cleanup_free_ struct nvme_ns_list *changed_ns_list_log = NULL;
+	__cleanup_free char *desc = NULL;
+	__cleanup_free struct nvme_ns_list *changed_ns_list_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -1389,7 +1389,7 @@ static int get_pred_lat_per_nvmset_log(int argc, char **argv,
 		"format(default),json or binary.";
 	const char *nvmset_id = "NVM Set Identifier";
 
-	_cleanup_free_ struct nvme_nvmset_predictable_lat_log *plpns_log = NULL;
+	__cleanup_free struct nvme_nvmset_predictable_lat_log *plpns_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -1449,8 +1449,8 @@ static int get_pred_lat_event_agg_log(int argc, char **argv,
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
-	_cleanup_free_ void *pea_log = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free void *pea_log = NULL;
 	nvme_print_flags_t flags;
 	__u32 log_size;
 	int err;
@@ -1530,7 +1530,7 @@ static int get_persistent_event_log(int argc, char **argv,
 		"processing this persistent log page command.";
 	const char *log_len = "number of bytes to retrieve";
 
-	_cleanup_free_ struct nvme_persistent_event_log *pevent = NULL;
+	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
 	struct nvme_persistent_event_log *pevent_collected = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
@@ -1645,8 +1645,8 @@ static int get_endurance_event_agg_log(int argc, char **argv,
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
-	_cleanup_free_ void *endurance_log = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free void *endurance_log = NULL;
 	nvme_print_flags_t flags;
 	__u32 log_size;
 	int err;
@@ -1727,7 +1727,7 @@ static int get_lba_status_log(int argc, char **argv,
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *lba_status = NULL;
+	__cleanup_free void *lba_status = NULL;
 	nvme_print_flags_t flags;
 	__u32 lslplen;
 	int err;
@@ -1783,7 +1783,7 @@ static int get_resv_notif_log(int argc, char **argv,
 		"log page and prints it, for the given "
 		"device in either decoded format(default), json or binary.";
 
-	_cleanup_free_ struct nvme_resv_notification_log *resv = NULL;
+	__cleanup_free struct nvme_resv_notification_log *resv = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -1827,8 +1827,8 @@ static int get_boot_part_log(int argc, char **argv, struct command *acmd, struct
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_boot_partition *boot = NULL;
-	_cleanup_free_ __u8 *bp_log = NULL;
+	__cleanup_free struct nvme_boot_partition *boot = NULL;
+	__cleanup_free __u8 *bp_log = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 	_cleanup_fd_ int output = -1;
@@ -1916,7 +1916,7 @@ static int get_phy_rx_eom_log(int argc, char **argv, struct command *acmd,
 		"Measurement log for the given device in decoded format "
 		"(default), json or binary.";
 	const char *controller = "Target Controller ID.";
-	_cleanup_free_ struct nvme_phy_rx_eom_log *phy_rx_eom_log = NULL;
+	__cleanup_free struct nvme_phy_rx_eom_log *phy_rx_eom_log = NULL;
 	size_t phy_rx_eom_log_len;
 	nvme_print_flags_t flags;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
@@ -2003,7 +2003,7 @@ static int get_media_unit_stat_log(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve the configuration and wear of media units and print it";
 
-	_cleanup_free_ struct nvme_media_unit_stat_log *mus = NULL;
+	__cleanup_free struct nvme_media_unit_stat_log *mus = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -2056,7 +2056,7 @@ static int get_supp_cap_config_log(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve the list of Supported Capacity Configuration Descriptors";
 
-	_cleanup_free_ struct nvme_supported_cap_config_list_log *cap_log = NULL;
+	__cleanup_free struct nvme_supported_cap_config_list_log *cap_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -2112,7 +2112,7 @@ static int io_mgmt_send(int argc, char **argv, struct command *acmd, struct plug
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_fd_ int dfd = STDIN_FILENO;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
 
@@ -2187,7 +2187,7 @@ static int io_mgmt_recv(int argc, char **argv, struct command *acmd, struct plug
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	_cleanup_fd_ int dfd = -1;
 	int err = -1;
@@ -2275,7 +2275,7 @@ static int get_log(int argc, char **argv, struct command *acmd, struct plugin *p
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ unsigned char *log = NULL;
+	__cleanup_free unsigned char *log = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 	nvme_print_flags_t flags;
@@ -2477,7 +2477,7 @@ static int sanitize_log(int argc, char **argv, struct command *acmd, struct plug
 {
 	const char *desc = "Retrieve sanitize log and show it.";
 
-	_cleanup_free_ struct nvme_sanitize_log_page *sanitize_log = NULL;
+	__cleanup_free struct nvme_sanitize_log_page *sanitize_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -2537,7 +2537,7 @@ static int get_fid_support_effects_log(int argc, char **argv, struct command *ac
 {
 	const char *desc = "Retrieve FID Support and Effects log and show it.";
 
-	_cleanup_free_ struct nvme_fid_supported_effects_log *fid_support_log = NULL;
+	__cleanup_free struct nvme_fid_supported_effects_log *fid_support_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -2589,7 +2589,7 @@ static int get_mi_cmd_support_effects_log(int argc, char **argv, struct command 
 {
 	const char *desc = "Retrieve NVMe-MI Command Support and Effects log and show it.";
 
-	_cleanup_free_ struct nvme_mi_cmd_supported_effects_log *mi_cmd_support_log = NULL;
+	__cleanup_free struct nvme_mi_cmd_supported_effects_log *mi_cmd_support_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -2641,7 +2641,7 @@ static int list_ctrl(int argc, char **argv, struct command *acmd, struct plugin 
 		"given device is part of, or optionally controllers attached to a specific namespace.";
 	const char *controller = "controller to display";
 
-	_cleanup_free_ struct nvme_ctrl_list *cntlist = NULL;
+	__cleanup_free struct nvme_ctrl_list *cntlist = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -2701,7 +2701,7 @@ static int list_ns(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *csi = "I/O command set identifier";
 	const char *all = "show all namespaces in the subsystem, whether attached or inactive";
 
-	_cleanup_free_ struct nvme_ns_list *ns_list = NULL;
+	__cleanup_free struct nvme_ns_list *ns_list = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	enum nvme_identify_cns cns;
@@ -2776,7 +2776,7 @@ static int id_ns_lba_format(int argc, char **argv, struct command *acmd, struct 
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 
@@ -2831,7 +2831,7 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *acmd,
 	const char *desc = "Show endurance group list information for the given endurance group id";
 	const char *endurance_grp_id = "Endurance Group ID";
 
-	_cleanup_free_ struct nvme_id_endurance_group_list *endgrp_list = NULL;
+	__cleanup_free struct nvme_id_endurance_group_list *endgrp_list = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -2880,7 +2880,7 @@ static bool is_ns_mgmt_support(struct libnvme_transport_handle *hdl)
 {
 	int err;
 
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = nvme_alloc(sizeof(*ctrl));
+	__cleanup_free struct nvme_id_ctrl *ctrl = nvme_alloc(sizeof(*ctrl));
 
 	if (ctrl)
 		return false;
@@ -2979,7 +2979,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 
-	_cleanup_free_ struct nvme_ctrl_list *cntlist = NULL;
+	__cleanup_free struct nvme_ctrl_list *cntlist = NULL;
 	__u16 list[NVME_ID_CTRL_LIST_MAX];
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -3092,9 +3092,9 @@ static int detach_ns(int argc, char **argv, struct command *acmd, struct plugin 
 static int parse_lba_num_si(struct libnvme_transport_handle *hdl, const char *opt,
 			    const char *val, __u8 flbas, __u64 *num, __u64 align)
 {
-	_cleanup_free_ struct nvme_ns_list *ns_list = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_ns_list *ns_list = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	__u32 nsid = 1;
 	__u8 lbaf;
 	unsigned int remainder;
@@ -3198,11 +3198,11 @@ static int create_ns(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *phndls = "Comma separated list of Placement Handle Associated RUH";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_ns_mgmt_host_sw_specified *data = NULL;
-	_cleanup_free_ struct nvme_id_ns_granularity_list *gr_list = NULL;
+	__cleanup_free struct nvme_ns_mgmt_host_sw_specified *data = NULL;
+	__cleanup_free struct nvme_id_ns_granularity_list *gr_list = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *id = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_id_ctrl *id = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	__u64 align_nsze = 1 << 20; /* Default 1 MiB */
 	__u64 align_ncap = align_nsze;
 	struct libnvme_passthru_cmd cmd;
@@ -3583,7 +3583,7 @@ int __id_ctrl(int argc, char **argv, struct command *acmd, struct plugin *plugin
 		"controller attributes in hex-dump if requested.";
 	const char *vendor_specific = "dump binary vendor field";
 
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -3652,7 +3652,7 @@ static int nvm_id_ctrl(int argc, char **argv, struct command *acmd,
 		"command to the given device and report information about "
 		"the specified controller in various formats.";
 
-	_cleanup_free_ struct nvme_id_ctrl_nvm *ctrl_nvm = NULL;
+	__cleanup_free struct nvme_id_ctrl_nvm *ctrl_nvm = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -3697,8 +3697,8 @@ static int nvm_id_ns(int argc, char **argv, struct command *acmd,
 		"command to the given device and report information about "
 		"the specified namespace in various formats.";
 
-	_cleanup_free_ struct nvme_nvm_id_ns *id_ns = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_nvm_id_ns *id_ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -3771,8 +3771,8 @@ static int nvm_id_ns_lba_format(int argc, char **argv, struct command *acmd, str
 		"command to the given device, returns capability field properties of "
 		"the specified LBA Format index in the specified namespace in various formats.";
 
-	_cleanup_free_ struct nvme_nvm_id_ns *nvm_ns = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -3842,7 +3842,7 @@ static int ns_descs(int argc, char **argv, struct command *acmd, struct plugin *
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *nsdescs = NULL;
+	__cleanup_free void *nsdescs = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -3910,7 +3910,7 @@ static int id_ns(int argc, char **argv, struct command *acmd, struct plugin *plu
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -3993,7 +3993,7 @@ static int cmd_set_independent_id_ns(int argc, char **argv, struct command *acmd
 		"Namespace command to the given device, returns properties of the "
 		"specified namespace in human-readable or binary or json format.";
 
-	_cleanup_free_ struct nvme_id_independent_id_ns *ns = NULL;
+	__cleanup_free struct nvme_id_independent_id_ns *ns = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -4065,7 +4065,7 @@ static int id_ns_granularity(int argc, char **argv, struct command *acmd, struct
 		"given device, returns namespace granularity list "
 		"in either human-readable or binary format.";
 
-	_cleanup_free_ struct nvme_id_ns_granularity_list *granularity_list = NULL;
+	__cleanup_free struct nvme_id_ns_granularity_list *granularity_list = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -4106,7 +4106,7 @@ static int id_nvmset(int argc, char **argv, struct command *acmd, struct plugin 
 		"in either binary format or json format";
 	const char *nvmset_id = "NVM Set Identify value";
 
-	_cleanup_free_ struct nvme_id_nvmset_list *nvmset = NULL;
+	__cleanup_free struct nvme_id_nvmset_list *nvmset = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -4159,7 +4159,7 @@ static int id_uuid(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *raw = "show uuid in binary format";
 	const char *human_readable = "show uuid in readable format";
 
-	_cleanup_free_ struct nvme_id_uuid_list *uuid_list = NULL;
+	__cleanup_free struct nvme_id_uuid_list *uuid_list = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -4217,7 +4217,7 @@ static int id_iocs(int argc, char **argv, struct command *acmd, struct plugin *p
 		"in either human-readable or binary format.";
 	const char *controller_id = "identifier of desired controller";
 
-	_cleanup_free_ struct nvme_id_iocs *iocs = NULL;
+	__cleanup_free struct nvme_id_iocs *iocs = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -4272,7 +4272,7 @@ static int id_domain(int argc, char **argv, struct command *acmd, struct plugin 
 		"in either normal|json|binary format.";
 	const char *domain_id = "identifier of desired domain";
 
-	_cleanup_free_ struct nvme_id_domain_list *id_domain = NULL;
+	__cleanup_free struct nvme_id_domain_list *id_domain = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -4418,7 +4418,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *acmd, struct
 		"command to the given device and report the information in a "
 		"decoded format (default), json or binary.";
 
-	_cleanup_free_ struct nvme_primary_ctrl_cap *caps = NULL;
+	__cleanup_free struct nvme_primary_ctrl_cap *caps = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -4475,7 +4475,7 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *acmd, stru
 	const char *controller = "lowest controller identifier to display";
 	const char *num_entries = "number of entries to retrieve";
 
-	_cleanup_free_ struct nvme_secondary_ctrl_list *sc_list = NULL;
+	__cleanup_free struct nvme_secondary_ctrl_list *sc_list = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -4544,8 +4544,8 @@ static int sleep_self_test(unsigned int seconds)
 static int wait_self_test(struct libnvme_transport_handle *hdl)
 {
 	static const char spin[] = {'-', '\\', '|', '/' };
-	_cleanup_free_ struct nvme_self_test_log *log = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_self_test_log *log = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	int err, i = 0, p = 0, cnt = 0;
 	int wthr;
 
@@ -4680,7 +4680,7 @@ static int device_self_test(int argc, char **argv, struct command *acmd, struct 
 	}
 
 	if (cfg.stc == NVME_ST_CODE_RESERVED) {
-		_cleanup_free_ struct nvme_self_test_log *log = NULL;
+		__cleanup_free struct nvme_self_test_log *log = NULL;
 
 		log = nvme_alloc(sizeof(*log));
 		if (!log)
@@ -4743,7 +4743,7 @@ static int self_test_log(int argc, char **argv, struct command *acmd, struct plu
 	const char *dst_entries = "Indicate how many DST log entries to be retrieved, "
 		"by default all the 20 entries will be retrieved";
 
-	_cleanup_free_ struct nvme_self_test_log *log = NULL;
+	__cleanup_free struct nvme_self_test_log *log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -4864,8 +4864,8 @@ static bool is_get_feature_result_set(enum nvme_features_id feature_id)
 static int get_feature_id_changed(struct libnvme_transport_handle *hdl, struct feat_cfg cfg,
 		nvme_print_flags_t flags)
 {
-	_cleanup_free_ void *buf_def = NULL;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf_def = NULL;
+	__cleanup_free void *buf = NULL;
 	__u64 result_def = 0;
 	__u64 result;
 	int err_def = 0;
@@ -5256,7 +5256,7 @@ static char *nvme_fw_status_reset_type(__u16 status)
 
 static bool fw_commit_support_mud(struct libnvme_transport_handle *hdl)
 {
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	int err;
 
 	ctrl = nvme_alloc(sizeof(*ctrl));
@@ -6591,8 +6591,8 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	nvme_print_flags_t flags = NORMAL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 timeout_ms = 600000;
@@ -6860,7 +6860,7 @@ static int set_feature(int argc, char **argv, struct command *acmd, struct plugi
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	_cleanup_fd_ int ffd = STDIN_FILENO;
 	int err;
 	__u64 result;
@@ -7006,7 +7006,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
-	_cleanup_free_ void *sec_buf = NULL;
+	__cleanup_free void *sec_buf = NULL;
 	_cleanup_fd_ int sec_fd = -1;
 	unsigned int sec_size;
 	int err;
@@ -7117,7 +7117,7 @@ static int dir_send(int argc, char **argv, struct command *acmd, struct plugin *
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 dw12 = 0;
 	_cleanup_fd_ int ffd = STDIN_FILENO;
@@ -7358,8 +7358,8 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 		__u32 nsid, __u8 prinfo, __u64 ilbrt, __u64 lbst,
 		unsigned int *logical_block_size, __u16 *metadata_size)
 {
-	_cleanup_free_ struct nvme_nvm_id_ns *nvm_ns = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	__u8 sts = 0, pif = 0;
 	unsigned int lbs = 0;
 	__u8 lba_index;
@@ -7421,8 +7421,8 @@ static int init_pi_tags(struct libnvme_transport_handle *hdl,
 	struct libnvme_passthru_cmd *cmd, __u32 nsid, __u64 ilbrt, __u64 lbst,
 	__u16 lbat, __u16 lbatm)
 {
-	_cleanup_free_ struct nvme_nvm_id_ns *nvm_ns = NULL;
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	__u8 sts = 0, pif = 0;
 	int err = 0;
 
@@ -7605,7 +7605,7 @@ static int dsm(int argc, char **argv, struct command *acmd, struct plugin *plugi
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_dsm_range *dsm = NULL;
+	__cleanup_free struct nvme_dsm_range *dsm = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 ctx_attrs[256] = {0,};
 	__u32 nlbs[256] = {0,};
@@ -7746,7 +7746,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 	__u16 elbatms[256] = { 0 };
 	__u16 elbats[256] = { 0 };
 
-	_cleanup_free_ union {
+	__cleanup_free union {
 		struct nvme_copy_range_f0 f0[256];
 		struct nvme_copy_range_f1 f1[256];
 		struct nvme_copy_range_f2 f2[256];
@@ -8220,8 +8220,8 @@ static int resv_report(int argc, char **argv, struct command *acmd, struct plugi
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ struct nvme_resv_status *status = NULL;
-	_cleanup_free_ struct nvme_id_ctrl *ctrl = NULL;
+	__cleanup_free struct nvme_resv_status *status = NULL;
+	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err, size;
@@ -8316,12 +8316,12 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	unsigned long long buffer_size = 0, mbuffer_size = 0;
-	_cleanup_free_ struct nvme_nvm_id_ns *nvm_ns = NULL;
+	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
-	_cleanup_free_ struct nvme_id_ns *ns = NULL;
+	__cleanup_free struct nvme_id_ns *ns = NULL;
 	unsigned int logical_block_size = 0;
 	struct timeval start_time, end_time;
-	_cleanup_free_ void *mbuffer = NULL;
+	__cleanup_free void *mbuffer = NULL;
 	_cleanup_fd_ int dfd = -1, mfd = -1;
 	__u16 control = 0, nblocks = 0;
 	struct libnvme_passthru_cmd cmd;
@@ -8774,7 +8774,7 @@ static int sec_recv(int argc, char **argv, struct command *acmd, struct plugin *
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ void *sec_buf = NULL;
+	__cleanup_free void *sec_buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;
@@ -8867,7 +8867,7 @@ static int get_lba_status(int argc, char **argv, struct command *acmd,
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	nvme_print_flags_t flags;
 	unsigned long buf_len;
 	int err;
@@ -9030,7 +9030,7 @@ static int dir_receive(int argc, char **argv, struct command *acmd, struct plugi
 	nvme_print_flags_t flags = NORMAL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	struct libnvme_passthru_cmd cmd;
 	__u32 dw12 = 0;
 	int err;
@@ -9278,7 +9278,7 @@ static int passthru(int argc, char **argv, bool admin,
 	int flags;
 	int mode = 0644;
 	void *data = NULL;
-	_cleanup_free_ void *mdata = NULL;
+	__cleanup_free void *mdata = NULL;
 	int err = 0;
 	const char *cmd_name = NULL;
 	struct timeval start_time, end_time;
@@ -9544,8 +9544,8 @@ static int gen_dhchap_key(int argc, char **argv, struct command *acmd, struct pl
 	const char *nqn = "Host NQN to use for key transformation.";
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ unsigned char *raw_secret = NULL;
-	_cleanup_free_ char *hnqn = NULL;
+	__cleanup_free unsigned char *raw_secret = NULL;
+	__cleanup_free char *hnqn = NULL;
 	unsigned char key[68];
 	char encoded_key[128];
 	unsigned long crc = crc32(0L, NULL, 0);
@@ -9740,9 +9740,9 @@ static int check_dhchap_key(int argc, char **argv, struct command *acmd, struct 
 static int append_keyfile(struct libnvme_global_ctx *ctx, const char *keyring,
 		long id, const char *keyfile)
 {
-	_cleanup_free_ unsigned char *key_data = NULL;
-	_cleanup_free_ char *exported_key = NULL;
-	_cleanup_free_ char *identity = NULL;
+	__cleanup_free unsigned char *key_data = NULL;
+	__cleanup_free char *exported_key = NULL;
+	__cleanup_free char *identity = NULL;
 	_cleanup_file_ FILE *fd = NULL;
 	int err, ver, hmac, key_len;
 	mode_t old_umask;
@@ -9824,9 +9824,9 @@ static int gen_tls_key(int argc, char **argv, struct command *acmd, struct plugi
 	const char *compat = "Use non-RFC 8446 compliant algorithm for deriving TLS PSK for older implementations";
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ unsigned char *raw_secret = NULL;
-	_cleanup_free_ char *encoded_key = NULL;
-	_cleanup_free_ char *hnqn = NULL;
+	__cleanup_free unsigned char *raw_secret = NULL;
+	__cleanup_free char *encoded_key = NULL;
+	__cleanup_free char *hnqn = NULL;
 	int key_len = 32;
 	int err;
 	long tls_key;
@@ -9957,8 +9957,8 @@ static int check_tls_key(int argc, char **argv, struct command *acmd, struct plu
 	const char *compat = "Use non-RFC 8446 compliant algorithm for checking TLS PSK for older implementations.";
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ unsigned char *decoded_key = NULL;
-	_cleanup_free_ char *hnqn = NULL;
+	__cleanup_free unsigned char *decoded_key = NULL;
+	__cleanup_free char *hnqn = NULL;
 	int decoded_len, err = 0;
 	unsigned int hmac;
 	long tls_key;
@@ -10063,7 +10063,7 @@ static int check_tls_key(int argc, char **argv, struct command *acmd, struct plu
 				return err;
 		}
 	} else {
-		_cleanup_free_ char *tls_id = NULL;
+		__cleanup_free char *tls_id = NULL;
 
 		if (cfg.compat)
 			err = libnvme_generate_tls_key_identity_compat(ctx,
@@ -10089,8 +10089,8 @@ static void __scan_tls_key(struct libnvme_global_ctx *ctx, long keyring_id,
 		long key_id, char *desc, int desc_len, void *data)
 {
 	FILE *fd = data;
-	_cleanup_free_ unsigned char *key_data = NULL;
-	_cleanup_free_ char *encoded_key = NULL;
+	__cleanup_free unsigned char *key_data = NULL;
+	__cleanup_free char *encoded_key = NULL;
 	int key_len;
 	int ver, hmac;
 	char type;
@@ -10560,7 +10560,7 @@ static int get_mgmt_addr_list_log(int argc, char **argv, struct command *acmd, s
 	nvme_print_flags_t flags;
 	int err = -1;
 
-	_cleanup_free_ struct nvme_mgmt_addr_list_log *ma_log = NULL;
+	__cleanup_free struct nvme_mgmt_addr_list_log *ma_log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
@@ -10598,7 +10598,7 @@ static int get_rotational_media_info_log(int argc, char **argv, struct command *
 	nvme_print_flags_t flags;
 	int err = -1;
 
-	_cleanup_free_ struct nvme_rotational_media_info_log *info = NULL;
+	__cleanup_free struct nvme_rotational_media_info_log *info = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
@@ -10687,7 +10687,7 @@ static int get_dispersed_ns_participating_nss_log(int argc, char **argv, struct 
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_dispersed_ns_participating_nss_log *log = NULL;
+	__cleanup_free struct nvme_dispersed_ns_participating_nss_log *log = NULL;
 
 	struct config {
 		__u32 namespace_id;
@@ -10729,7 +10729,7 @@ static int get_power_measurement_log(int argc, char **argv, struct command *acmd
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_power_meas_log *log = NULL;
+	__cleanup_free struct nvme_power_meas_log *log = NULL;
 	nvme_print_flags_t flags;
 	__u32 min_log_size = sizeof(struct nvme_power_meas_log);
 	__u32 log_size;
@@ -10907,7 +10907,7 @@ static int get_reachability_groups_log(int argc, char **argv, struct command *ac
 	nvme_print_flags_t flags;
 	int err;
 	__u64 len = 0;
-	_cleanup_free_ struct nvme_reachability_groups_log *log = NULL;
+	__cleanup_free struct nvme_reachability_groups_log *log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
@@ -11018,7 +11018,7 @@ static int get_reachability_associations_log(int argc, char **argv, struct comma
 	nvme_print_flags_t flags;
 	int err;
 	__u64 len = 0;
-	_cleanup_free_ struct nvme_reachability_associations_log *log = NULL;
+	__cleanup_free struct nvme_reachability_associations_log *log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
@@ -11098,7 +11098,7 @@ static int get_host_discovery_log(int argc, char **argv, struct command *acmd, s
 	const char *allhoste = "All Host Entries";
 	nvme_print_flags_t flags;
 	int err;
-	_cleanup_free_ struct nvme_host_discover_log *log = NULL;
+	__cleanup_free struct nvme_host_discover_log *log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
@@ -11177,7 +11177,7 @@ static int get_ave_discovery_log(int argc, char **argv, struct command *acmd, st
 	nvme_print_flags_t flags;
 	int err;
 
-	_cleanup_free_ struct nvme_ave_discover_log *log = NULL;
+	__cleanup_free struct nvme_ave_discover_log *log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
@@ -11253,7 +11253,7 @@ static int get_pull_model_ddc_req_log(int argc, char **argv, struct command *acm
 	nvme_print_flags_t flags;
 	int err;
 
-	_cleanup_free_ struct nvme_pull_model_ddc_req_log *log = NULL;
+	__cleanup_free struct nvme_pull_model_ddc_req_log *log = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 

--- a/nvme.c
+++ b/nvme.c
@@ -1532,7 +1532,7 @@ static int get_persistent_event_log(int argc, char **argv,
 
 	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
 	struct nvme_persistent_event_log *pevent_collected = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
@@ -5123,7 +5123,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_fd int fw_fd = -1;
 	unsigned int fw_size, pos;
 	int err;
@@ -8317,7 +8317,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	unsigned long long buffer_size = 0, mbuffer_size = 0;
 	__cleanup_free struct nvme_nvm_id_ns *nvm_ns = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	unsigned int logical_block_size = 0;
 	struct timeval start_time, end_time;
@@ -9271,7 +9271,7 @@ static int passthru(int argc, char **argv, bool admin,
 	const char *wr = "set dataflow direction to send";
 	const char *prefill = "prefill buffers with known byte-value, default 0";
 
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_fd int dfd = -1, mfd = -1;
@@ -10428,7 +10428,7 @@ static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc
 	bool send;
 	__cleanup_fd int fd = -1;
 	int flags;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u32 result;

--- a/nvme.c
+++ b/nvme.c
@@ -9743,7 +9743,7 @@ static int append_keyfile(struct libnvme_global_ctx *ctx, const char *keyring,
 	__cleanup_free unsigned char *key_data = NULL;
 	__cleanup_free char *exported_key = NULL;
 	__cleanup_free char *identity = NULL;
-	_cleanup_file_ FILE *fd = NULL;
+	__cleanup_file FILE *fd = NULL;
 	int err, ver, hmac, key_len;
 	mode_t old_umask;
 	long kr_id;
@@ -10166,7 +10166,7 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 	const char *revoke = "Revoke key from the keyring.";
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_file_ FILE *fd = NULL;
+	__cleanup_file FILE *fd = NULL;
 	mode_t old_umask = 0;
 	int cnt, err = 0;
 

--- a/nvme.h
+++ b/nvme.h
@@ -117,7 +117,7 @@ int parse_and_open(struct libnvme_global_ctx **ctx,
 // TODO: unsure if we need a double ptr here
 static inline DEFINE_CLEANUP_FUNC(
 	cleanup_nvme_transport_handle, struct libnvme_transport_handle *, libnvme_close)
-#define _cleanup_nvme_transport_handle_ __cleanup(cleanup_nvme_transport_handle)
+#define __cleanup_nvme_transport_handle __cleanup(cleanup_nvme_transport_handle)
 
 extern const char *uuid_index;
 extern const char *namespace_id_desired;

--- a/nvme.h
+++ b/nvme.h
@@ -117,7 +117,7 @@ int parse_and_open(struct libnvme_global_ctx **ctx,
 // TODO: unsure if we need a double ptr here
 static inline DEFINE_CLEANUP_FUNC(
 	cleanup_nvme_transport_handle, struct libnvme_transport_handle *, libnvme_close)
-#define _cleanup_nvme_transport_handle_ __cleanup__(cleanup_nvme_transport_handle)
+#define _cleanup_nvme_transport_handle_ __cleanup(cleanup_nvme_transport_handle)
 
 extern const char *uuid_index;
 extern const char *namespace_id_desired;

--- a/plugins/amzn/amzn-nvme.c
+++ b/plugins/amzn/amzn-nvme.c
@@ -562,7 +562,7 @@ static int get_stats(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "display command latency statistics";
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct amzn_latency_log_page log = { 0 };
 	nvme_print_flags_t flags = 0;
 	struct libnvme_passthru_cmd cmd;

--- a/plugins/amzn/amzn-nvme.c
+++ b/plugins/amzn/amzn-nvme.c
@@ -561,7 +561,7 @@ static int get_stats(int argc, char **argv, struct command *acmd,
 		     struct plugin *plugin)
 {
 	const char *desc = "display command latency statistics";
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct amzn_latency_log_page log = { 0 };
 	nvme_print_flags_t flags = 0;

--- a/plugins/dapustor/dapustor-nvme.c
+++ b/plugins/dapustor/dapustor-nvme.c
@@ -513,7 +513,7 @@ static int dapustor_additional_smart_log(int argc, char **argv, struct command *
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_extended_additional_smart_log ext_smart_log;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct nvme_additional_smart_log smart_log;
 	nvme_print_flags_t flags;
 	bool has_ext = false;

--- a/plugins/dapustor/dapustor-nvme.c
+++ b/plugins/dapustor/dapustor-nvme.c
@@ -511,7 +511,7 @@ static int dapustor_additional_smart_log(int argc, char **argv, struct command *
 	const char *json = "Dump output in json format";
 #endif /* CONFIG_JSONC */
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_extended_additional_smart_log ext_smart_log;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct nvme_additional_smart_log smart_log;

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -119,7 +119,7 @@ static int get_status(int argc, char **argv, struct command *acmd, struct plugin
 {
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	enum dera_device_status state = DEVICE_STATUS_FATAL_ERROR;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	char *desc = "Get the Dera device status";
 	struct nvme_dera_smart_info_log log;
 	int err;

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -117,7 +117,7 @@ static int nvme_dera_get_device_status(struct libnvme_transport_handle *hdl, enu
 
 static int get_status(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	enum dera_device_status state = DEVICE_STATUS_FATAL_ERROR;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	char *desc = "Get the Dera device status";

--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -28,7 +28,7 @@ static int fdp_configs(int argc, char **argv, struct command *acmd,
 	const char *raw = "use binary output";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *log = NULL;
 	struct nvme_fdp_config_log hdr;
 	nvme_print_flags_t flags;
@@ -98,7 +98,7 @@ static int fdp_usage(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *raw = "use binary output";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *log = NULL;
 	struct nvme_fdp_ruhu_log hdr;
 	nvme_print_flags_t flags;
@@ -162,7 +162,7 @@ static int fdp_stats(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *raw = "use binary output";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_fdp_stats_log stats;
 	nvme_print_flags_t flags;
 	int err;
@@ -220,7 +220,7 @@ static int fdp_events(int argc, char **argv, struct command *acmd, struct plugin
 	const char *raw = "use binary output";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_fdp_events_log events;
 	nvme_print_flags_t flags;
 	int err;
@@ -278,7 +278,7 @@ static int fdp_status(int argc, char **argv, struct command *acmd, struct plugin
 	const char *namespace_id = "Namespace identifier";
 	const char *raw = "use binary output";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free void *buf = NULL;
 	struct nvme_fdp_ruh_status hdr;
@@ -351,7 +351,7 @@ static int fdp_update(int argc, char **argv, struct command *acmd, struct plugin
 	const char *namespace_id = "Namespace identifier";
 	const char *_pids = "Comma-separated list of placement identifiers to update";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	unsigned short pids[256];
@@ -418,7 +418,7 @@ static int fdp_set_events(int argc, char **argv, struct command *acmd, struct pl
 	const char *sv = "specifies that the controller shall save the attribute";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	unsigned short evts[255];
 	__u8 buf[255];
 	int err = -1;
@@ -496,7 +496,7 @@ static int fdp_feature(int argc, char **argv, struct command *acmd, struct plugi
 	const char *disable = "Disable current FDP configuration";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	bool enabling_conf_idx = false;
 	__u64 result;
 	int err = -1;

--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -29,7 +29,7 @@ static int fdp_configs(int argc, char **argv, struct command *acmd,
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *log = NULL;
+	__cleanup_free void *log = NULL;
 	struct nvme_fdp_config_log hdr;
 	nvme_print_flags_t flags;
 	int err;
@@ -99,7 +99,7 @@ static int fdp_usage(int argc, char **argv, struct command *acmd, struct plugin 
 
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *log = NULL;
+	__cleanup_free void *log = NULL;
 	struct nvme_fdp_ruhu_log hdr;
 	nvme_print_flags_t flags;
 	size_t len;
@@ -280,7 +280,7 @@ static int fdp_status(int argc, char **argv, struct command *acmd, struct plugin
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	struct nvme_fdp_ruh_status hdr;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;

--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -27,7 +27,7 @@ static int fdp_configs(int argc, char **argv, struct command *acmd,
 	const char *human_readable = "show log in readable format";
 	const char *raw = "use binary output";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *log = NULL;
 	struct nvme_fdp_config_log hdr;
@@ -97,7 +97,7 @@ static int fdp_usage(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *egid = "Endurance group identifier";
 	const char *raw = "use binary output";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *log = NULL;
 	struct nvme_fdp_ruhu_log hdr;
@@ -161,7 +161,7 @@ static int fdp_stats(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *egid = "Endurance group identifier";
 	const char *raw = "use binary output";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_fdp_stats_log stats;
 	nvme_print_flags_t flags;
@@ -219,7 +219,7 @@ static int fdp_events(int argc, char **argv, struct command *acmd, struct plugin
 	const char *host_events = "Get host events";
 	const char *raw = "use binary output";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_fdp_events_log events;
 	nvme_print_flags_t flags;
@@ -279,7 +279,7 @@ static int fdp_status(int argc, char **argv, struct command *acmd, struct plugin
 	const char *raw = "use binary output";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free void *buf = NULL;
 	struct nvme_fdp_ruh_status hdr;
 	struct libnvme_passthru_cmd cmd;
@@ -352,7 +352,7 @@ static int fdp_update(int argc, char **argv, struct command *acmd, struct plugin
 	const char *_pids = "Comma-separated list of placement identifiers to update";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	unsigned short pids[256];
 	__u16 buf[256];
@@ -417,7 +417,7 @@ static int fdp_set_events(int argc, char **argv, struct command *acmd, struct pl
 	const char *ph = "Placement Handle";
 	const char *sv = "specifies that the controller shall save the attribute";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	unsigned short evts[255];
 	__u8 buf[255];
@@ -495,7 +495,7 @@ static int fdp_feature(int argc, char **argv, struct command *acmd, struct plugi
 	const char *endurance_group = "Endurance group ID";
 	const char *disable = "Disable current FDP configuration";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	bool enabling_conf_idx = false;
 	__u64 result;

--- a/plugins/feat/feat-nvme.c
+++ b/plugins/feat/feat-nvme.c
@@ -139,7 +139,7 @@ static int feat_power_mgmt(int argc, char **argv, struct command *acmd, struct p
 	const char *wh = "workload hint";
 	const __u8 fid = NVME_FEAT_FID_POWER_MGMT;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -234,7 +234,7 @@ static int feat_perfc(int argc, char **argv, struct command *acmd, struct plugin
 	const char *attrl = "attribute length";
 	const char *vs_data = "vendor specific data";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	__u8 fid = NVME_FEAT_FID_PERF_CHARACTERISTICS;
@@ -298,7 +298,7 @@ static int feat_hctm(int argc, char **argv, struct command *acmd, struct plugin 
 {
 	const __u8 fid = NVME_FEAT_FID_HCTM;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -361,7 +361,7 @@ static int feat_timestamp(int argc, char **argv, struct command *acmd, struct pl
 	const __u8 fid = NVME_FEAT_FID_TIMESTAMP;
 	const char *tstmp = "timestamp";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -445,7 +445,7 @@ static int feat_temp_thresh(int argc, char **argv, struct command *acmd, struct 
 	const char *thsel = "threshold type select";
 	const char *tmpthh = "temperature threshold hysteresis";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -533,7 +533,7 @@ static int feat_arbitration(int argc, char **argv, struct command *acmd, struct 
 	const char *mpw = "medium priority weight";
 	const char *hpw = "high priority weight";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -585,7 +585,7 @@ static int feat_volatile_wc(int argc, char **argv, struct command *acmd, struct 
 	const __u8 fid = NVME_FEAT_FID_VOLATILE_WC;
 	const char *wce = "volatile write cache enable";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -644,7 +644,7 @@ static int feat_power_limit(int argc, char **argv, struct command *acmd,
 	const char *pls = "power limit scale";
 	const __u8 fid = NVME_FEAT_FID_POWER_LIMIT;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
 	    NULL;
@@ -716,7 +716,7 @@ static int feat_power_thresh(int argc, char **argv, struct command *acmd,
 	const char *ept = "enable power threshold";
 	const __u8 fid = NVME_FEAT_FID_POWER_THRESH;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
 	    NULL;
@@ -793,7 +793,7 @@ static int feat_power_meas(int argc, char **argv, struct command *cmd,
 	const char *smt = "stop measurement time";
 	const __u8 fid = NVME_FEAT_FID_POWER_MEASUREMENT;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
 	    NULL;
@@ -862,7 +862,7 @@ static int feat_err_recovery(int argc, char **argv, struct command *acmd,
 {
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
 	    NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	const char *dulbe =
 	    "deallocated or unwritten logical block error enable";
@@ -947,7 +947,7 @@ static int feat_num_queues(int argc, char **argv, struct command *acmd,
 {
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
 	    NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	const char *ncqr = "number of I/O completion queues requested";
 	const char *nsqr = "number of I/O submission queues requested";

--- a/plugins/feat/feat-nvme.c
+++ b/plugins/feat/feat-nvme.c
@@ -140,7 +140,7 @@ static int feat_power_mgmt(int argc, char **argv, struct command *acmd, struct p
 	const __u8 fid = NVME_FEAT_FID_POWER_MGMT;
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -235,7 +235,7 @@ static int feat_perfc(int argc, char **argv, struct command *acmd, struct plugin
 	const char *vs_data = "vendor specific data";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	__u8 fid = NVME_FEAT_FID_PERF_CHARACTERISTICS;
 	__u32 cdw11;
@@ -299,7 +299,7 @@ static int feat_hctm(int argc, char **argv, struct command *acmd, struct plugin 
 	const __u8 fid = NVME_FEAT_FID_HCTM;
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -362,7 +362,7 @@ static int feat_timestamp(int argc, char **argv, struct command *acmd, struct pl
 	const char *tstmp = "timestamp";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -446,7 +446,7 @@ static int feat_temp_thresh(int argc, char **argv, struct command *acmd, struct 
 	const char *tmpthh = "temperature threshold hysteresis";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct temp_thresh_config cfg = { 0 };
@@ -534,7 +534,7 @@ static int feat_arbitration(int argc, char **argv, struct command *acmd, struct 
 	const char *hpw = "high priority weight";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct arbitration_config cfg = { 0 };
@@ -586,7 +586,7 @@ static int feat_volatile_wc(int argc, char **argv, struct command *acmd, struct 
 	const char *wce = "volatile write cache enable";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -646,7 +646,7 @@ static int feat_power_limit(int argc, char **argv, struct command *acmd,
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl =
 	    NULL;
 	int err;
 
@@ -718,7 +718,7 @@ static int feat_power_thresh(int argc, char **argv, struct command *acmd,
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl =
 	    NULL;
 	int err;
 
@@ -795,7 +795,7 @@ static int feat_power_meas(int argc, char **argv, struct command *cmd,
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl =
 	    NULL;
 	int err;
 
@@ -860,7 +860,7 @@ static int err_recovery_set(struct libnvme_transport_handle *hdl, const __u8 fid
 static int feat_err_recovery(int argc, char **argv, struct command *acmd,
 			     struct plugin *plugin)
 {
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl =
 	    NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
@@ -945,7 +945,7 @@ static int num_queues_set(struct libnvme_transport_handle *hdl, const __u8 fid,
 static int feat_num_queues(int argc, char **argv, struct command *acmd,
 			     struct plugin *plugin)
 {
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl =
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl =
 	    NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 

--- a/plugins/feat/feat-nvme.c
+++ b/plugins/feat/feat-nvme.c
@@ -70,7 +70,7 @@ static int feat_get_nsid(struct libnvme_transport_handle *hdl, __u32 nsid,
 	int err;
 	__u32 len = 0;
 
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 
 	if (!NVME_CHECK(sel, GET_FEATURES_SEL, SUPPORTED))
 		libnvme_get_feature_length(fid, cdw11, NVME_DATA_TFR_CTRL_TO_HOST, &len);

--- a/plugins/feat/feat-nvme.c
+++ b/plugins/feat/feat-nvme.c
@@ -174,7 +174,7 @@ static int perfc_set(struct libnvme_transport_handle *hdl, __u8 fid, __u32 cdw11
 	__u64 result;
 	int err;
 
-	_cleanup_fd_ int ffd = STDIN_FILENO;
+	__cleanup_fd int ffd = STDIN_FILENO;
 
 	struct nvme_perf_characteristics data = {
 		.attr_buf = { 0 },

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -331,7 +331,7 @@ static int huawei_list(int argc, char **argv, struct command *acmd,
 	}
 
 	for (i = 0; i < n; i++) {
-		_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+		__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 		snprintf(path, sizeof(path), "/dev/%s", devices[i]->d_name);
 		ret = libnvme_open(ctx, path, &hdl);

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -296,7 +296,7 @@ static void huawei_print_list_items(struct huawei_list_item *list_items, unsigne
 static int huawei_list(int argc, char **argv, struct command *acmd,
 		       struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx =
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx =
 		libnvme_create_global_ctx(stdout, DEFAULT_LOGLEVEL);
 	char path[264];
 	struct dirent **devices;

--- a/plugins/ibm/ibm-nvme.c
+++ b/plugins/ibm/ibm-nvme.c
@@ -225,7 +225,7 @@ static int get_ibm_addi_smart_log(int argc, char **argv, struct command *cmd, st
 	const char *desc = "Get IBM specific additional smart log and show it.";
 	const char *raw = "Dump output in binary format";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_ibm_additional_smart_log smart_log;
 	int err;
@@ -352,7 +352,7 @@ static void show_ibm_vpd_log(struct nvme_ibm_vpd_log *vpd, const char *devname)
 
 static int get_ibm_vpd_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_ibm_vpd_log vpd_log;
 	int err;
@@ -525,7 +525,7 @@ static int get_ibm_persistent_event_log(int argc, char **argv,
 	const char *action = "action the controller shall take during "
 		"processing this persistent log page command.";
 	const char *log_len = "number of bytes to retrieve";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_persistent_event_log pevent_log;
 	void *pevent_log_info = NULL;

--- a/plugins/ibm/ibm-nvme.c
+++ b/plugins/ibm/ibm-nvme.c
@@ -226,7 +226,7 @@ static int get_ibm_addi_smart_log(int argc, char **argv, struct command *cmd, st
 	const char *raw = "Dump output in binary format";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_ibm_additional_smart_log smart_log;
 	int err;
 
@@ -353,7 +353,7 @@ static void show_ibm_vpd_log(struct nvme_ibm_vpd_log *vpd, const char *devname)
 static int get_ibm_vpd_log(int argc, char **argv, struct command *cmd, struct plugin *plugin)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_ibm_vpd_log vpd_log;
 	int err;
 
@@ -526,7 +526,7 @@ static int get_ibm_persistent_event_log(int argc, char **argv,
 		"processing this persistent log page command.";
 	const char *log_len = "number of bytes to retrieve";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_persistent_event_log pevent_log;
 	void *pevent_log_info = NULL;
 	enum nvme_print_flags flags;

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -174,7 +174,7 @@ static int innogrit_geteventlog(int argc, char **argv,
 				struct plugin *plugin)
 {
 	const char *desc = "Recrieve event log for the given device ";
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_file FILE *fp = NULL;
 	char currentdir[128], filename[512];
@@ -215,7 +215,7 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *acmd,
 	const char *desc = "Recrieve cdump data for the given device ";
 	char currentdir[128], filename[512], fname[128];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	unsigned int itotal, icur, ivsctype;
 	unsigned int ipackcount, ipackindex;
 	unsigned char busevsc = false;

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -175,7 +175,7 @@ static int innogrit_geteventlog(int argc, char **argv,
 {
 	const char *desc = "Recrieve event log for the given device ";
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_file FILE *fp = NULL;
 	char currentdir[128], filename[512];
 	struct tm *logtime;
@@ -214,7 +214,7 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Recrieve cdump data for the given device ";
 	char currentdir[128], filename[512], fname[128];
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	unsigned int itotal, icur, ivsctype;
 	unsigned int ipackcount, ipackindex;

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -176,7 +176,7 @@ static int innogrit_geteventlog(int argc, char **argv,
 	const char *desc = "Recrieve event log for the given device ";
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_file_ FILE *fp = NULL;
+	__cleanup_file FILE *fp = NULL;
 	char currentdir[128], filename[512];
 	struct tm *logtime;
 	time_t timep;

--- a/plugins/inspur/inspur-nvme.c
+++ b/plugins/inspur/inspur-nvme.c
@@ -210,7 +210,7 @@ static int nvme_get_vendor_log(int argc, char **argv, struct command *acmd, stru
 {
 	char *desc = "Get the Inspur vendor log";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u8 local_mem[BYTE_OF_4K];
 	int err;
 

--- a/plugins/inspur/inspur-nvme.c
+++ b/plugins/inspur/inspur-nvme.c
@@ -209,7 +209,7 @@ void show_r1_media_err_log(r1_cli_vendor_log_t *vendorlog)
 static int nvme_get_vendor_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	char *desc = "Get the Inspur vendor log";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u8 local_mem[BYTE_OF_4K];
 	int err;

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -344,7 +344,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 
 	struct nvme_additional_smart_log smart_log;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -394,7 +394,7 @@ static int get_market_log(int argc, char **argv, struct command *acmd, struct pl
 	const char *desc = "Get Intel Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	char log[512];
 	int err;
 
@@ -453,7 +453,7 @@ static int get_temp_stats_log(int argc, char **argv, struct command *acmd, struc
 {
 	struct intel_temp_stats stats;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	const char *desc = "Get Temperature Statistics log and show it.";
@@ -1031,7 +1031,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *acmd, struct
 {
 	__u8 data[NAND_LAT_STATS_LEN];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
 
@@ -1348,7 +1348,7 @@ static int get_internal_log(int argc, char **argv, struct command *acmd,
 	struct intel_assert_dump *ad = (struct intel_assert_dump *) intel->reserved;
 	struct intel_event_header *ehdr = (struct intel_event_header *)intel->reserved;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	const char *desc = "Get Intel Firmware Log and save it.";
 	const char *log = "Log type: 0, 1, or 2 for nlog, event log, and assert log, respectively.";
@@ -1540,7 +1540,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	const __u32 data_len = 32;
 	const __u32 sv = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	void *buf = NULL;
 	__u64 result;
 	int err;
@@ -1624,7 +1624,7 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 	const __u32 cdw12 = 0x0;
 	const __u32 sv = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err, num;
 

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -343,7 +343,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 #endif /* CONFIG_JSONC */
 
 	struct nvme_additional_smart_log smart_log;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -393,7 +393,7 @@ static int get_market_log(int argc, char **argv, struct command *acmd, struct pl
 {
 	const char *desc = "Get Intel Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	char log[512];
 	int err;
@@ -452,7 +452,7 @@ static void show_temp_stats(struct intel_temp_stats *stats)
 static int get_temp_stats_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	struct intel_temp_stats stats;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -1030,7 +1030,7 @@ static void show_lat_stats(int write)
 static int get_lat_stats_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	__u8 data[NAND_LAT_STATS_LEN];
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err;
@@ -1347,7 +1347,7 @@ static int get_internal_log(int argc, char **argv, struct command *acmd,
 	struct intel_vu_nlog *intel_nlog = (struct intel_vu_nlog *)buf;
 	struct intel_assert_dump *ad = (struct intel_assert_dump *) intel->reserved;
 	struct intel_event_header *ehdr = (struct intel_event_header *)intel->reserved;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	const char *desc = "Get Intel Firmware Log and save it.";
@@ -1539,7 +1539,7 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 	const __u32 cdw12 = 0x0;
 	const __u32 data_len = 32;
 	const __u32 sv = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	void *buf = NULL;
 	__u64 result;
@@ -1623,7 +1623,7 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 	const __u8 fid = 0xf7;
 	const __u32 cdw12 = 0x0;
 	const __u32 sv = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err, num;

--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -61,7 +61,7 @@ static int lm_create_cdq(int argc, char **argv, struct command *acmd, struct plu
 			      "worse.";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct lba_migration_queue_entry_type_0 *queue = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	struct libnvme_passthru_cmd cmd;
@@ -127,7 +127,7 @@ static int lm_delete_cdq(int argc, char **argv, struct command *acmd, struct plu
 	const char *cdqid = "Controller Data Queue ID";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
 
@@ -177,7 +177,7 @@ static int lm_track_send(int argc, char **argv, struct command *acmd, struct plu
 
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
 
@@ -275,7 +275,7 @@ static int lm_migration_send(int argc, char **argv, struct command *acmd, struct
 	const char *input = "Controller State Data input file";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_file FILE *file = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -407,7 +407,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *acmd, struct
 	const char *human_readable_info = "show info in readable format";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_file FILE *fd = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -525,7 +525,7 @@ static int lm_set_cdq(int argc, char **argv, struct command *acmd, struct plugin
 	const char *tpt = "If specified, the slot that causes the controller "
 			  " to issue a CDQ Tail Pointer event";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = -1;
 
@@ -569,7 +569,7 @@ static int lm_get_cdq(int argc, char **argv, struct command *acmd, struct plugin
 			   "of a CDQ and specify the configuration of a CDQ Tail event.";
 	const char *cdqid = "Controller Data Queue ID";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;

--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -60,7 +60,7 @@ static int lm_create_cdq(int argc, char **argv, struct command *acmd, struct plu
 			      "will write to invalid memory, inevitably leading to MMU faults or "
 			      "worse.";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct lba_migration_queue_entry_type_0 *queue = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
@@ -126,7 +126,7 @@ static int lm_delete_cdq(int argc, char **argv, struct command *acmd, struct plu
 	const char *desc = "Delete Controller Data Queue";
 	const char *cdqid = "Controller Data Queue ID";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
@@ -176,7 +176,7 @@ static int lm_track_send(int argc, char **argv, struct command *acmd, struct plu
 	const char *stop = "Equivalent to stop tracking with defaults";
 
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
@@ -274,7 +274,7 @@ static int lm_migration_send(int argc, char **argv, struct command *acmd, struct
 	const char *numd = "Number of Dwords (NUMD)";
 	const char *input = "Controller State Data input file";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_file FILE *file = NULL;
@@ -406,7 +406,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *acmd, struct
 	const char *output = "Controller State Data output file";
 	const char *human_readable_info = "show info in readable format";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_file FILE *fd = NULL;
@@ -526,7 +526,7 @@ static int lm_set_cdq(int argc, char **argv, struct command *acmd, struct plugin
 			  " to issue a CDQ Tail Pointer event";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = -1;
 
 	struct config {
@@ -570,7 +570,7 @@ static int lm_get_cdq(int argc, char **argv, struct command *acmd, struct plugin
 	const char *cdqid = "Controller Data Queue ID";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err = -1;
 

--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -277,7 +277,7 @@ static int lm_migration_send(int argc, char **argv, struct command *acmd, struct
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
-	_cleanup_file_ FILE *file = NULL;
+	__cleanup_file FILE *file = NULL;
 	struct libnvme_passthru_cmd cmd;
 	void *data = NULL;
 	int err = -1;
@@ -409,7 +409,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *acmd, struct
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
-	_cleanup_file_ FILE *fd = NULL;
+	__cleanup_file FILE *fd = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	void *data = NULL;

--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -63,7 +63,7 @@ static int lm_create_cdq(int argc, char **argv, struct command *acmd, struct plu
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	struct lba_migration_queue_entry_type_0 *queue = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	struct libnvme_passthru_cmd cmd;
 	int err = -1;
 
@@ -276,7 +276,7 @@ static int lm_migration_send(int argc, char **argv, struct command *acmd, struct
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_file FILE *file = NULL;
 	struct libnvme_passthru_cmd cmd;
 	void *data = NULL;
@@ -408,7 +408,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *acmd, struct
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_file FILE *fd = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -422,7 +422,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *ac
 	    "Get Memblaze vendor specific additional smart log, and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		__u32 namespace_id;
@@ -478,7 +478,7 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *acm
 	const char *desc = "Get Memblaze power management ststus\n	(value 0 - 25w, 1 - 20w, 2 - 15w)";
 	__u64 result;
 	__u32 feature_id = MB_FEAT_POWER_MGMT;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -506,7 +506,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *acm
 	const char *desc = "Set Memblaze power management status\n	(value 0 - 25w, 1 - 20w, 2 - 15w)";
 	const char *value = "new value of feature (required)";
 	const char *save = "specifies that the controller shall save the attribute";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;
@@ -556,7 +556,7 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *acmd,
 			   "	p2 value: 1 .. 5000 ms";
 	const char *param = "input parameters";
 	int param1 = 0, param2 = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
@@ -696,7 +696,7 @@ static int mb_high_latency_log_print(int argc, char **argv, struct command *acmd
 {
 	const char *desc = "Get Memblaze high latency log";
 	char buf[LOG_PAGE_SIZE];
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	FILE *fdi = NULL;
@@ -753,7 +753,7 @@ static int mb_selective_download(int argc, char **argv, struct command *acmd, st
 	const char *select = "FW Select (e.g., --select=OOB, EEP, ALL)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	int selectNo, fw_fd, fw_size, err, offset = 0;
 	struct libnvme_passthru_cmd cmd;
@@ -959,7 +959,7 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *acmd, s
 	char stats[LOG_PAGE_SIZE];
 	char f1[] = FID_C1_LOG_FILENAME;
 	char f2[] = FID_C2_LOG_FILENAME;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	int err;
@@ -996,7 +996,7 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	char *desc = "Clear Memblaze devices error log.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	int err;
@@ -1048,7 +1048,7 @@ static int mb_set_lat_stats(int argc, char **argv, struct command *acmd, struct 
 	const __u32 cdw12 = 0x0;
 	const __u32 data_len = 32;
 	const __u32 save = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	void *buf = NULL;
@@ -1552,7 +1552,7 @@ static int mb_get_smart_log_add(int argc, char **argv, struct command *acmd, str
 	NVME_ARGS(opts,
 		OPT_FLAG("raw-binary", 'b', &cfg.raw_binary, "dump the whole log buffer in binary format"));
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 
@@ -1713,7 +1713,7 @@ static int mb_set_latency_feature(int argc, char **argv, struct command *acmd, s
 		OPT_UINT("set-trim-threshold", 't', &cfg.de_allocate_trim_threshold,
 		  "set trim high latency log threshold, it's a 0-based value and unit is 10ms"));
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 
@@ -1752,7 +1752,7 @@ static int mb_get_latency_feature(int argc, char **argv, struct command *acmd, s
 
 	NVME_ARGS(opts);
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
@@ -1903,7 +1903,7 @@ static int mb_get_latency_stats(int argc, char **argv, struct command *acmd, str
 			&cfg.raw_binary,
 			"dump the whole log buffer in binary format"));
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	int err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
@@ -2008,7 +2008,7 @@ static int mb_get_high_latency_log(int argc, char **argv, struct command *acmd,
 			&cfg.raw_binary,
 			"dump the whole log buffer in binary format"));
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	int err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
@@ -2254,7 +2254,7 @@ static int mb_get_performance_stats(int argc, char **argv, struct command *acmd,
 			&cfg.raw_binary,
 			"dump the whole log buffer in binary format"));
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	int err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -423,7 +423,7 @@ static int mb_get_additional_smart_log(int argc, char **argv, struct command *ac
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		__u32 namespace_id;
 		bool  raw_binary;
@@ -479,7 +479,7 @@ static int mb_get_powermanager_status(int argc, char **argv, struct command *acm
 	__u64 result;
 	__u32 feature_id = MB_FEAT_POWER_MGMT;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	NVME_ARGS(opts);
@@ -507,7 +507,7 @@ static int mb_set_powermanager_status(int argc, char **argv, struct command *acm
 	const char *value = "new value of feature (required)";
 	const char *save = "specifies that the controller shall save the attribute";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;
 
@@ -557,7 +557,7 @@ static int mb_set_high_latency_log(int argc, char **argv, struct command *acmd,
 	const char *param = "input parameters";
 	int param1 = 0, param2 = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
 	int err;
@@ -697,7 +697,7 @@ static int mb_high_latency_log_print(int argc, char **argv, struct command *acmd
 	const char *desc = "Get Memblaze high latency log";
 	char buf[LOG_PAGE_SIZE];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	FILE *fdi = NULL;
 	int err;
@@ -752,7 +752,7 @@ static int mb_selective_download(int argc, char **argv, struct command *acmd, st
 	const char *fw = "firmware file (required)";
 	const char *select = "FW Select (e.g., --select=OOB, EEP, ALL)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	int selectNo, fw_fd, fw_size, err, offset = 0;
@@ -960,7 +960,7 @@ static int mb_lat_stats_log_print(int argc, char **argv, struct command *acmd, s
 	char f1[] = FID_C1_LOG_FILENAME;
 	char f2[] = FID_C2_LOG_FILENAME;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	int err;
 
@@ -997,7 +997,7 @@ static int memblaze_clear_error_log(int argc, char **argv, struct command *acmd,
 {
 	char *desc = "Clear Memblaze devices error log.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	int err;
 
@@ -1049,7 +1049,7 @@ static int mb_set_lat_stats(int argc, char **argv, struct command *acmd, struct 
 	const __u32 data_len = 32;
 	const __u32 save = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	void *buf = NULL;
 	__u64 result;
@@ -1553,7 +1553,7 @@ static int mb_get_smart_log_add(int argc, char **argv, struct command *acmd, str
 		OPT_FLAG("raw-binary", 'b', &cfg.raw_binary, "dump the whole log buffer in binary format"));
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
@@ -1714,7 +1714,7 @@ static int mb_set_latency_feature(int argc, char **argv, struct command *acmd, s
 		  "set trim high latency log threshold, it's a 0-based value and unit is 10ms"));
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
@@ -1753,7 +1753,7 @@ static int mb_get_latency_feature(int argc, char **argv, struct command *acmd, s
 	NVME_ARGS(opts);
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
 	if (err)
@@ -1904,7 +1904,7 @@ static int mb_get_latency_stats(int argc, char **argv, struct command *acmd, str
 			"dump the whole log buffer in binary format"));
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	int err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
 
@@ -2009,7 +2009,7 @@ static int mb_get_high_latency_log(int argc, char **argv, struct command *acmd,
 			"dump the whole log buffer in binary format"));
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	int err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
 	if (err)
@@ -2255,7 +2255,7 @@ static int mb_get_performance_stats(int argc, char **argv, struct command *acmd,
 			"dump the whole log buffer in binary format"));
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	int err = parse_and_open(&ctx, &hdl, argc, argv, acmd->help, opts);
 

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -577,7 +577,7 @@ static int micron_selective_download(int argc, char **argv,
 	const char *fw = "firmware file (required)";
 	const char *select = "FW Select (e.g., --select=ALL)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	int selectNo, fw_fd, fw_size, err, offset = 0;
@@ -704,7 +704,7 @@ static int micron_smbus_option(int argc, char **argv,
 	int fid = MICRON_FEATURE_SMBUS_OPTION;
 	enum eDriveModel model = UNKNOWN_MODEL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
 	struct {
@@ -786,7 +786,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	struct json_object *root;
 	struct json_object *logPages;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	NVME_ARGS(opts,
 		OPT_FMT("format", 'f', &cfg.fmt, fmt));
 
@@ -911,7 +911,7 @@ static int micron_pcie_stats(int argc, char **argv,
 	int  i, err = 0, bus = 0, domain = 0, device = 0, function = 0, ctrlIdx;
 	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	char *businfo = NULL;
 	char *devicename = NULL;
@@ -1100,7 +1100,7 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 	int err = -EINVAL, bus, domain, device, function;
 	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	char *businfo = NULL;
 	char *devicename = NULL;
 	char tdevice[PATH_MAX] = { 0 };
@@ -1811,7 +1811,7 @@ static int micron_nand_stats(int argc, char **argv,
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	struct nvme_id_ctrl ctrl;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err, ctrlIdx;
 	__u8 nsze;
 	bool has_d0_log = true;
@@ -1960,7 +1960,7 @@ static int micron_smart_ext_log(int argc, char **argv,
 	int err = 0, ctrlIdx = 0;
 	__u8 log_id;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	bool is_json = true;
 	struct format {
 		char *fmt;
@@ -2009,7 +2009,7 @@ static int micron_work_load_log(int argc, char **argv, struct command *acmd, str
 	unsigned int micronWorkLoadLog[C5_MicronWorkLoad_log_size/sizeof(int)] = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	int err = 0, ctrlIdx = 0;
 	bool is_json = true;
@@ -2061,7 +2061,7 @@ static int micron_vendor_telemetry_log(int argc, char **argv,
 	int err = 0, ctrlIdx = 0;
 	bool is_json = true;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct format {
 		char *fmt;
@@ -2464,7 +2464,7 @@ static int micron_drive_info(int argc, char **argv, struct command *acmd,
 	struct json_object *root;
 	struct json_object *driveInfo;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct format {
 		char *fmt;
 	};
@@ -2778,7 +2778,7 @@ static int micron_fw_activation_history(int argc, char **argv, struct command *a
 	unsigned int logC2[C2_log_size/sizeof(int)] = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	bool is_json = false;
 	struct json_object *root, *fw_act, *element;
@@ -2887,7 +2887,7 @@ static int micron_latency_stats_track(int argc, char **argv, struct command *acm
 	uint32_t timing_mask = 0x08080800; /* R[31-24]:W[23:16]:T[15:8]:0 */
 	uint32_t enable = 2;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct {
 		char *option;
 		char *command;
@@ -3024,7 +3024,7 @@ static int micron_latency_stats_logs(int argc, char **argv, struct command *acmd
 	} log[LATENCY_LOG_ENTRIES];
 	enum eDriveModel model = UNKNOWN_MODEL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = -1;
 	const char *desc = "Display Latency tracking log information";
 
@@ -3060,7 +3060,7 @@ static int micron_latency_stats_info(int argc, char **argv, struct command *acmd
 	const char *cmdstr = "command to display stats - all|read|write|trim, default is all";
 	int err = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	enum eDriveModel model = UNKNOWN_MODEL;
 	#define LATENCY_BUCKET_COUNT 32
 	#define LATENCY_BUCKET_RSVD  32
@@ -3156,7 +3156,7 @@ static int micron_ocp_smart_health_logs(int argc, char **argv, struct command *a
 	struct nvme_id_ctrl ctrl;
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	bool is_json = true;
 	nsze_from_oacs = false;
 	struct format {
@@ -3226,7 +3226,7 @@ static int micron_clr_fw_activation_history(int argc, char **argv,
 	__u8 fid = MICRON_FEATURE_CLEAR_FW_ACTIVATION_HISTORY;
 	enum eDriveModel model = UNKNOWN_MODEL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts);
 	int err = 0;
@@ -3265,7 +3265,7 @@ static int micron_telemetry_cntrl_option(int argc, char **argv,
 	enum eDriveModel model = UNKNOWN_MODEL;
 	struct nvme_id_ctrl ctrl = { 0 };
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct {
 		char *option;
@@ -3589,7 +3589,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 	char msg[256] = { 0 };
 	int  c_logs_index = 8; /* should be current size of aVendorLogs */
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct {
 		unsigned char ucLogPage;
 		const char *strFileName;
@@ -3947,7 +3947,7 @@ static int micron_logpage_dir(int argc, char **argv, struct command *acmd,
 	enum eDriveModel model = UNKNOWN_MODEL;
 	char logbuf[MIN_LOG_SIZE];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int i;
 
 	NVME_ARGS(opts);
@@ -4013,7 +4013,7 @@ static int micron_cloud_boot_SSD_version(int argc, char **argv,
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct format {
 	char *fmt;
 	};
@@ -4069,7 +4069,7 @@ static int micron_device_waf(int argc, char **argv, struct command *acmd,
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	long double tlc_units_written, slc_units_written;
 	long double data_units_written, write_amplification_factor;
@@ -4133,7 +4133,7 @@ static int micron_cloud_log(int argc, char **argv, struct command *acmd,
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	bool is_json = true;
 	struct format {
 		char *fmt;
@@ -4365,7 +4365,7 @@ static int micron_health_info(int argc, char **argv, struct command *acmd,
 			      struct plugin *plugin)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	const char *desc = "Retrieve SMART/Health log for Micron drives";
 	const char *fmt = "output format normal|json";
 	enum eDriveModel eModel = UNKNOWN_MODEL;
@@ -4459,7 +4459,7 @@ static int micron_id_ctrl(int argc, char **argv, struct command *acmd,
 			  struct plugin *plugin)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	const char *desc = "Identify Controller with Micron vendor fields";
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	struct nvme_id_ctrl ctrl = { 0 };

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -2213,7 +2213,7 @@ static void GetGenericLogs(struct libnvme_transport_handle *hdl, const char *dir
 	struct nvme_firmware_slot fw_log;
 	struct nvme_cmd_effects_log effects;
 	struct nvme_persistent_event_log pevent_log;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	void *pevent_log_info = NULL;
 	__u32 log_len = 0;
 	int err = 0;

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -578,7 +578,7 @@ static int micron_selective_download(int argc, char **argv,
 	const char *select = "FW Select (e.g., --select=ALL)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 
 	int selectNo, fw_fd, fw_size, err, offset = 0;
 	struct libnvme_passthru_cmd cmd;
@@ -703,7 +703,7 @@ static int micron_smbus_option(int argc, char **argv,
 	const char *save = "1 - persistent, 0 - non-persistent (default)";
 	int fid = MICRON_FEATURE_SMBUS_OPTION;
 	enum eDriveModel model = UNKNOWN_MODEL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
@@ -785,7 +785,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	bool is_json = false;
 	struct json_object *root;
 	struct json_object *logPages;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	NVME_ARGS(opts,
 		OPT_FMT("format", 'f', &cfg.fmt, fmt));
@@ -910,7 +910,7 @@ static int micron_pcie_stats(int argc, char **argv,
 {
 	int  i, err = 0, bus = 0, domain = 0, device = 0, function = 0, ctrlIdx;
 	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	char *businfo = NULL;
@@ -1099,7 +1099,7 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 {
 	int err = -EINVAL, bus, domain, device, function;
 	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	char *businfo = NULL;
 	char *devicename = NULL;
@@ -1810,7 +1810,7 @@ static int micron_nand_stats(int argc, char **argv,
 	unsigned char logC0[C0_log_size] = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	struct nvme_id_ctrl ctrl;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err, ctrlIdx;
 	__u8 nsze;
@@ -1959,7 +1959,7 @@ static int micron_smart_ext_log(int argc, char **argv,
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0, ctrlIdx = 0;
 	__u8 log_id;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	bool is_json = true;
 	struct format {
@@ -2008,7 +2008,7 @@ static int micron_work_load_log(int argc, char **argv, struct command *acmd, str
 	const char *desc = "Retrieve Micron Workload logs for the given device ";
 	unsigned int micronWorkLoadLog[C5_MicronWorkLoad_log_size/sizeof(int)] = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	int err = 0, ctrlIdx = 0;
@@ -2060,7 +2060,7 @@ static int micron_vendor_telemetry_log(int argc, char **argv,
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0, ctrlIdx = 0;
 	bool is_json = true;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct format {
@@ -2463,7 +2463,7 @@ static int micron_drive_info(int argc, char **argv, struct command *acmd,
 	bool is_json = false;
 	struct json_object *root;
 	struct json_object *driveInfo;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct format {
 		char *fmt;
@@ -2777,7 +2777,7 @@ static int micron_fw_activation_history(int argc, char **argv, struct command *a
 	int count = 0;
 	unsigned int logC2[C2_log_size/sizeof(int)] = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	bool is_json = false;
@@ -2886,7 +2886,7 @@ static int micron_latency_stats_track(int argc, char **argv, struct command *acm
 	uint32_t command_mask = 0x7;	   /* 1:read 2:write 4:trim 7:all */
 	uint32_t timing_mask = 0x08080800; /* R[31-24]:W[23:16]:T[15:8]:0 */
 	uint32_t enable = 2;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct {
 		char *option;
@@ -3023,7 +3023,7 @@ static int micron_latency_stats_logs(int argc, char **argv, struct command *acmd
 		uint32_t   rfu[6];
 	} log[LATENCY_LOG_ENTRIES];
 	enum eDriveModel model = UNKNOWN_MODEL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = -1;
 	const char *desc = "Display Latency tracking log information";
@@ -3059,7 +3059,7 @@ static int micron_latency_stats_info(int argc, char **argv, struct command *acmd
 	const char *desc = "display command latency statistics";
 	const char *cmdstr = "command to display stats - all|read|write|trim, default is all";
 	int err = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	enum eDriveModel model = UNKNOWN_MODEL;
 	#define LATENCY_BUCKET_COUNT 32
@@ -3155,7 +3155,7 @@ static int micron_ocp_smart_health_logs(int argc, char **argv, struct command *a
 	unsigned int logFB[FB_log_size/sizeof(int)] = { 0 };
 	struct nvme_id_ctrl ctrl;
 	enum eDriveModel eModel = UNKNOWN_MODEL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	bool is_json = true;
 	nsze_from_oacs = false;
@@ -3225,7 +3225,7 @@ static int micron_clr_fw_activation_history(int argc, char **argv,
 	__u64 result = 0;
 	__u8 fid = MICRON_FEATURE_CLEAR_FW_ACTIVATION_HISTORY;
 	enum eDriveModel model = UNKNOWN_MODEL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts);
@@ -3264,7 +3264,7 @@ static int micron_telemetry_cntrl_option(int argc, char **argv,
 	int fid = MICRON_FEATURE_TELEMETRY_CONTROL_OPTION;
 	enum eDriveModel model = UNKNOWN_MODEL;
 	struct nvme_id_ctrl ctrl = { 0 };
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct {
@@ -3588,7 +3588,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 	char sn[20] = { 0 };
 	char msg[256] = { 0 };
 	int  c_logs_index = 8; /* should be current size of aVendorLogs */
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct {
 		unsigned char ucLogPage;
@@ -3946,7 +3946,7 @@ static int micron_logpage_dir(int argc, char **argv, struct command *acmd,
 	const char *desc = "List the supported log pages";
 	enum eDriveModel model = UNKNOWN_MODEL;
 	char logbuf[MIN_LOG_SIZE];
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int i;
 
@@ -4012,7 +4012,7 @@ static int micron_cloud_boot_SSD_version(int argc, char **argv,
 	struct nvme_id_ctrl ctrl;
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct format {
 	char *fmt;
@@ -4068,7 +4068,7 @@ static int micron_device_waf(int argc, char **argv, struct command *acmd,
 	struct nvme_smart_log smart_log;
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	long double tlc_units_written, slc_units_written;
@@ -4132,7 +4132,7 @@ static int micron_cloud_log(int argc, char **argv, struct command *acmd,
 	struct nvme_id_ctrl ctrl;
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	int err = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	bool is_json = true;
 	struct format {
@@ -4364,7 +4364,7 @@ static void print_micron_health_log_json(struct nvme_smart_log *smart,
 static int micron_health_info(int argc, char **argv, struct command *acmd,
 			      struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	const char *desc = "Retrieve SMART/Health log for Micron drives";
 	const char *fmt = "output format normal|json";
@@ -4458,7 +4458,7 @@ static void micron_id_ctrl_vs(__u8 *vs, struct json_object *root)
 static int micron_id_ctrl(int argc, char **argv, struct command *acmd,
 			  struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	const char *desc = "Identify Controller with Micron vendor fields";
 	enum eDriveModel eModel = UNKNOWN_MODEL;

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -536,7 +536,7 @@ int show_nbft(int argc, char **argv, struct command *acmd, struct plugin *plugin
 {
 	const char *desc = "Display contents of the ACPI NBFT files.";
 	bool show_subsys = false, show_hfi = false, show_discovery = false;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct nbft_file_entry *head = NULL;
 	struct list_head nbft_list;
 	char *nbft_path = NBFT_SYSFS_PATH;

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -893,7 +893,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 			    struct plugin *plugin)
 {
 	const char *desc = "Display information about E-Series volumes.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = libnvme_create_global_ctx(stdout, DEFAULT_LOGLEVEL);
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = libnvme_create_global_ctx(stdout, DEFAULT_LOGLEVEL);
 	struct dirent **devices;
 	int num, i, ret, fmt;
 	struct smdevice_info *smdevices;
@@ -991,7 +991,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = libnvme_create_global_ctx(stdout, DEFAULT_LOGLEVEL);
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = libnvme_create_global_ctx(stdout, DEFAULT_LOGLEVEL);
 	const char *desc = "Display information about ONTAP devices.";
 	struct dirent **devices;
 	int num, i, ret, fmt;

--- a/plugins/ocp/ocp-clear-features.c
+++ b/plugins/ocp/ocp-clear-features.c
@@ -17,7 +17,7 @@
 
 static int ocp_clear_feature(int argc, char **argv, const char *desc, const __u8 fid)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result = 0;
 	__u32 clear = 1 << 31;
@@ -66,7 +66,7 @@ int get_ocp_error_counters(int argc, char **argv, struct command *acmd,
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 	const char *no_uuid = "Do not try to automatically detect UUID index";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;

--- a/plugins/ocp/ocp-clear-features.c
+++ b/plugins/ocp/ocp-clear-features.c
@@ -18,7 +18,7 @@
 static int ocp_clear_feature(int argc, char **argv, const char *desc, const __u8 fid)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result = 0;
 	__u32 clear = 1 << 31;
 	__u8 uuid_index = 0;
@@ -67,7 +67,7 @@ int get_ocp_error_counters(int argc, char **argv, struct command *acmd,
 	const char *no_uuid = "Do not try to automatically detect UUID index";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;
 	bool uuid;

--- a/plugins/ocp/ocp-fw-activation-history.c
+++ b/plugins/ocp/ocp-fw-activation-history.c
@@ -30,7 +30,7 @@ int ocp_fw_activation_history_log(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts);
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct fw_activation_history fw_history = { 0 };
 	struct libnvme_passthru_cmd cmd;
 	__u8 uuid_index = 0;

--- a/plugins/ocp/ocp-fw-activation-history.c
+++ b/plugins/ocp/ocp-fw-activation-history.c
@@ -29,7 +29,7 @@ int ocp_fw_activation_history_log(int argc, char **argv, struct command *acmd,
 
 	NVME_ARGS(opts);
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct fw_activation_history fw_history = { 0 };
 	struct libnvme_passthru_cmd cmd;

--- a/plugins/ocp/ocp-hardware-component-log.c
+++ b/plugins/ocp/ocp-hardware-component-log.c
@@ -271,7 +271,7 @@ static int get_hwcomp_log(struct libnvme_transport_handle *hdl, __u32 id, bool l
 int ocp_hwcomp_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	const char *desc = "retrieve hardware component log";
 	struct config {

--- a/plugins/ocp/ocp-hardware-component-log.c
+++ b/plugins/ocp/ocp-hardware-component-log.c
@@ -270,7 +270,7 @@ static int get_hwcomp_log(struct libnvme_transport_handle *hdl, __u32 id, bool l
 
 int ocp_hwcomp_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	const char *desc = "retrieve hardware component log";

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -265,7 +265,7 @@ static int ocp_latency_monitor_log(int argc, char **argv,
 {
 	const char *desc = "Retrieve latency monitor log data.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	NVME_ARGS(opts);
@@ -287,7 +287,7 @@ int ocp_set_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 {
 	int err = -1;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	struct feature_latency_monitor buf = { 0 };
 	__u32  nsid = NVME_NSID_ALL;
@@ -408,7 +408,7 @@ static int ocp_get_latency_monitor_feature(int argc, char **argv, struct command
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
 	int err;
@@ -556,7 +556,7 @@ static int eol_plp_failure_mode(int argc, char **argv, struct command *acmd,
 	const __u32 nsid = 0;
 	const __u8 fid = OCP_FID_ROWTM;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -1432,7 +1432,7 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *acmd, struct
 	const char *telemetry_type = "Telemetry Type; 'host', 'host0', 'host1' or 'controller'";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 	__u32  nsid = NVME_NSID_ALL;
 	struct stat nvme_stat;
@@ -1685,7 +1685,7 @@ static int ocp_unsupported_requirements_log(int argc, char **argv, struct comman
 {
 	const char *desc = "Retrieve unsupported requirements log data.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -1786,7 +1786,7 @@ static int ocp_error_recovery_log(int argc, char **argv, struct command *acmd, s
 {
 	const char *desc = "Retrieve C1h Error Recovery Log data.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -1886,7 +1886,7 @@ static int ocp_device_capabilities_log(int argc, char **argv, struct command *ac
 {
 	const char *desc = "Retrieve C4h Device Capabilities Log data.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -1950,7 +1950,7 @@ static int ocp_set_telemetry_profile_feature(int argc, char **argv, struct comma
 	const char *desc = "Set Telemetry Profile (Feature Identifier C8h) Set Feature.";
 	const char *tps = "Telemetry Profile Select for device debug data collection";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -1989,7 +1989,7 @@ static int ocp_get_telemetry_profile_feature(int argc, char **argv, struct comma
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
 	int err;
@@ -2090,7 +2090,7 @@ static int set_dssd_power_state_feature(int argc, char **argv, struct command *a
 	const char *save = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -2164,7 +2164,7 @@ static int get_dssd_power_state_feature(int argc, char **argv, struct command *a
 	const __u32 nsid = 0;
 	const __u8 fid = OCP_FID_DSSDPS;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int i, err;
 
 	struct config {
@@ -2217,7 +2217,7 @@ static int set_plp_health_check_interval(int argc, char **argv, struct command *
 	const char *sv = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	__u64 result;
 	__u8 uidx = 0;
@@ -2275,7 +2275,7 @@ static int get_plp_health_check_interval(int argc, char **argv, struct command *
 	const __u32 nsid = 0;
 	const __u8 fid = 0xc6;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;
 
@@ -2324,7 +2324,7 @@ static int set_dssd_async_event_config(int argc, char **argv, struct command *ac
 	const char *sv = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	__u64 result;
 	__u8 uidx = 0;
@@ -2378,7 +2378,7 @@ static int get_dssd_async_event_config(int argc, char **argv, struct command *ac
 	const __u32 nsid = 0;
 	const __u8 fid = OCP_FID_DAEC;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;
 
@@ -2449,7 +2449,7 @@ static int ocp_telemetry_str_log_format(int argc, char **argv, struct command *a
 					struct plugin *plugin)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	char file_path[PATH_MAX];
 	const char *string_suffix = ".bin";
@@ -2567,7 +2567,7 @@ static int ocp_tcg_configuration_log(int argc, char **argv, struct command *acmd
 {
 	const char *desc = "Retrieve TCG Configuration Log Page Data";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -2681,7 +2681,7 @@ static int get_error_injection(int argc, char **argv, struct command *acmd, stru
 {
 	const char *desc = "Return set of error injection";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	struct config {
 		__u8 sel;
@@ -2775,7 +2775,7 @@ static int set_error_injection(int argc, char **argv, struct command *acmd, stru
 {
 	const char *desc = "Inject error conditions";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u32 nsid;
 	int err;
 
@@ -2849,7 +2849,7 @@ static int get_enable_ieee1667_silo(int argc, char **argv, struct command *acmd,
 	struct config cfg = { 0 };
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts,
 		OPT_BYTE("sel", 's', &cfg.sel, sel),
@@ -2907,7 +2907,7 @@ static int set_enable_ieee1667_silo(int argc, char **argv, struct command *acmd,
 	int err;
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts,
 		OPT_FLAG("enable", 'e', NULL, no_uuid),
@@ -2939,7 +2939,7 @@ static int ocp_get_persistent_event_log(int argc, char **argv,
 	struct nvme_persistent_event_log *pevent_collected = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	nvme_print_flags_t flags;
 	void *pevent_log_info;
@@ -3062,7 +3062,7 @@ static int ocp_get_idle_wakeup_time_config_feature(int argc, char **argv,
 	const char *nsid = "Byte[04-07]: NSID Valid/Invalid/Inactive";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 
 	__u64 result;

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -2937,7 +2937,7 @@ static int ocp_get_persistent_event_log(int argc, char **argv,
 
 	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
 	struct nvme_persistent_event_log *pevent_collected = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -2629,7 +2629,7 @@ static int fw_activation_history_log(int argc, char **argv, struct command *acmd
 
 static int error_injection_get(struct libnvme_transport_handle *hdl, const __u8 sel, bool uuid, __u32 nsid)
 {
-	_cleanup_free_ struct erri_entry *entry = NULL;
+	__cleanup_free struct erri_entry *entry = NULL;
 	struct erri_get_cq_entry cq_entry;
 	const __u8 fid = OCP_FID_ERRI;
 	__u64 result;
@@ -2712,7 +2712,7 @@ static int get_error_injection(int argc, char **argv, struct command *acmd, stru
 
 static int error_injection_set(struct libnvme_transport_handle *hdl, struct erri_config *cfg, bool uuid, __u32 nsid)
 {
-	_cleanup_free_ struct erri_entry *entry = NULL;
+	__cleanup_free struct erri_entry *entry = NULL;
 	_cleanup_fd_ int ffd = -1;
 	__u32 data_len;
 	__u8 uidx = 0;
@@ -2935,7 +2935,7 @@ static int ocp_get_persistent_event_log(int argc, char **argv,
 		"processing this persistent log page command.";
 	const char *log_len = "number of bytes to retrieve";
 
-	_cleanup_free_ struct nvme_persistent_event_log *pevent = NULL;
+	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
 	struct nvme_persistent_event_log *pevent_collected = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -1280,7 +1280,7 @@ static int get_c9_log_page_data(struct libnvme_transport_handle *hdl,
 	__le64 vu_event_str_table_ofst = 0;
 	__le64 ascii_table_ofst = 0;
 
-	_cleanup_fd_ int fd = STDIN_FILENO;
+	__cleanup_fd int fd = STDIN_FILENO;
 
 	header_data = (__u8 *)malloc(sizeof(__u8) * C9_TELEMETRY_STR_LOG_LEN);
 	if (!header_data) {
@@ -2713,7 +2713,7 @@ static int get_error_injection(int argc, char **argv, struct command *acmd, stru
 static int error_injection_set(struct libnvme_transport_handle *hdl, struct erri_config *cfg, bool uuid, __u32 nsid)
 {
 	__cleanup_free struct erri_entry *entry = NULL;
-	_cleanup_fd_ int ffd = -1;
+	__cleanup_fd int ffd = -1;
 	__u32 data_len;
 	__u8 uidx = 0;
 	int err;

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -264,7 +264,7 @@ static int ocp_latency_monitor_log(int argc, char **argv,
 				   struct plugin *plugin)
 {
 	const char *desc = "Retrieve latency monitor log data.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -286,7 +286,7 @@ static int ocp_latency_monitor_log(int argc, char **argv,
 int ocp_set_latency_monitor_feature(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	int err = -1;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	struct feature_latency_monitor buf = { 0 };
@@ -407,7 +407,7 @@ static int ocp_get_latency_monitor_feature(int argc, char **argv, struct command
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
@@ -555,7 +555,7 @@ static int eol_plp_failure_mode(int argc, char **argv, struct command *acmd,
 	const char *mode = "[0-3]: default/rom/wtm/normal";
 	const __u32 nsid = 0;
 	const __u8 fid = OCP_FID_ROWTM;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -1431,7 +1431,7 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *acmd, struct
 
 	const char *telemetry_type = "Telemetry Type; 'host', 'host0', 'host1' or 'controller'";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 	__u32  nsid = NVME_NSID_ALL;
@@ -1684,7 +1684,7 @@ static int ocp_unsupported_requirements_log(int argc, char **argv, struct comman
 					    struct plugin *plugin)
 {
 	const char *desc = "Retrieve unsupported requirements log data.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -1785,7 +1785,7 @@ out:
 static int ocp_error_recovery_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Retrieve C1h Error Recovery Log data.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -1885,7 +1885,7 @@ out:
 static int ocp_device_capabilities_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Retrieve C4h Device Capabilities Log data.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -1949,7 +1949,7 @@ static int ocp_set_telemetry_profile_feature(int argc, char **argv, struct comma
 {
 	const char *desc = "Set Telemetry Profile (Feature Identifier C8h) Set Feature.";
 	const char *tps = "Telemetry Profile Select for device debug data collection";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -1988,7 +1988,7 @@ static int ocp_get_telemetry_profile_feature(int argc, char **argv, struct comma
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
@@ -2089,7 +2089,7 @@ static int set_dssd_power_state_feature(int argc, char **argv, struct command *a
 	const char *power_state = "DSSD Power State to set in watts";
 	const char *save = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -2163,7 +2163,7 @@ static int get_dssd_power_state_feature(int argc, char **argv, struct command *a
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const __u32 nsid = 0;
 	const __u8 fid = OCP_FID_DSSDPS;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int i, err;
 
@@ -2216,7 +2216,7 @@ static int set_plp_health_check_interval(int argc, char **argv, struct command *
 	const char *plp_health_interval = "[31:16]:PLP Health Check Interval";
 	const char *sv = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	__u64 result;
@@ -2274,7 +2274,7 @@ static int get_plp_health_check_interval(int argc, char **argv, struct command *
 	const char *desc = "Define Issue Get Feature command (FID : 0xC6) PLP Health Check Interval";
 	const __u32 nsid = 0;
 	const __u8 fid = 0xc6;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;
@@ -2323,7 +2323,7 @@ static int set_dssd_async_event_config(int argc, char **argv, struct command *ac
 	const char *epn = "[0]:Enable Panic Notices";
 	const char *sv = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	__u64 result;
@@ -2377,7 +2377,7 @@ static int get_dssd_async_event_config(int argc, char **argv, struct command *ac
 	const char *sel = "[0-3]: current/default/saved/supported";
 	const __u32 nsid = 0;
 	const __u8 fid = OCP_FID_DAEC;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int err;
@@ -2448,7 +2448,7 @@ static int get_c9_log_page(struct libnvme_transport_handle *hdl,
 static int ocp_telemetry_str_log_format(int argc, char **argv, struct command *acmd,
 					struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	char file_path[PATH_MAX];
@@ -2566,7 +2566,7 @@ static int ocp_tcg_configuration_log(int argc, char **argv, struct command *acmd
 					    struct plugin *plugin)
 {
 	const char *desc = "Retrieve TCG Configuration Log Page Data";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -2680,7 +2680,7 @@ static int error_injection_get(struct libnvme_transport_handle *hdl, const __u8 
 static int get_error_injection(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Return set of error injection";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 	struct config {
@@ -2774,7 +2774,7 @@ static int error_injection_set(struct libnvme_transport_handle *hdl, struct erri
 static int set_error_injection(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Inject error conditions";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u32 nsid;
 	int err;
@@ -2848,7 +2848,7 @@ static int get_enable_ieee1667_silo(int argc, char **argv, struct command *acmd,
 	};
 	struct config cfg = { 0 };
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts,
@@ -2906,7 +2906,7 @@ static int set_enable_ieee1667_silo(int argc, char **argv, struct command *acmd,
 {
 	int err;
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts,
@@ -2938,7 +2938,7 @@ static int ocp_get_persistent_event_log(int argc, char **argv,
 	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
 	struct nvme_persistent_event_log *pevent_collected = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	nvme_print_flags_t flags;
@@ -3061,7 +3061,7 @@ static int ocp_get_idle_wakeup_time_config_feature(int argc, char **argv,
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const char *nsid = "Byte[04-07]: NSID Valid/Invalid/Inactive";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 

--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -63,7 +63,7 @@ static void obj_add_result(struct json_object *o, const char *v, ...)
 {
 	va_list ap;
 
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 
 	va_start(ap, v);
 
@@ -92,7 +92,7 @@ static void print_hwcomp_desc_json(struct hwcomp_desc_entry *e, struct json_obje
 static void print_hwcomp_desc_list_json(struct json_object *r, struct hwcomp_desc_entry *e,
 					bool list, int num)
 {
-	_cleanup_free_ char *k = NULL;
+	__cleanup_free char *k = NULL;
 
 	if (asprintf(&k, "Component %d", num) < 0)
 		return;

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -100,7 +100,7 @@ int ocp_smart_add_log(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve the extended SMART health data.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	NVME_ARGS(opts);

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -99,7 +99,7 @@ int ocp_smart_add_log(int argc, char **argv, struct command *acmd,
 		      struct plugin *plugin)
 {
 	const char *desc = "Retrieve the extended SMART health data.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 

--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -404,7 +404,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 	__u64 capabilities = 0;
 	__u32 device_id, read_vendor_id;
 	int ret = -1;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
@@ -643,7 +643,7 @@ static int sndk_drive_resize(int argc, char **argv,
 {
 	const char *desc = "Send a Resize command.";
 	const char *size = "The new size (in GB) to resize the drive to.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
@@ -994,7 +994,7 @@ static int sndk_vs_fw_activate_history(int argc, char **argv,
 		struct plugin *plugin)
 {
 	const char *desc = "Retrieve FW activate history table.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
@@ -1050,7 +1050,7 @@ static int sndk_clear_fw_activate_history(int argc, char **argv,
 		struct plugin *plugin)
 {
 	const char *desc = "Clear FW activate history table.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	int ret;
@@ -1120,7 +1120,7 @@ static int sndk_capabilities(int argc, char **argv,
 		struct plugin *plugin)
 {
 	const char *desc = "Send a capabilities command.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;

--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -405,7 +405,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 	__u32 device_id, read_vendor_id;
 	int ret = -1;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct config {
 		char *file;
@@ -644,7 +644,7 @@ static int sndk_drive_resize(int argc, char **argv,
 	const char *desc = "Send a Resize command.";
 	const char *size = "The new size (in GB) to resize the drive to.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 	uint32_t device_id = -1, vendor_id = -1;
@@ -995,7 +995,7 @@ static int sndk_vs_fw_activate_history(int argc, char **argv,
 {
 	const char *desc = "Retrieve FW activate history table.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 
@@ -1051,7 +1051,7 @@ static int sndk_clear_fw_activate_history(int argc, char **argv,
 {
 	const char *desc = "Clear FW activate history table.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	int ret;
 
@@ -1121,7 +1121,7 @@ static int sndk_capabilities(int argc, char **argv,
 {
 	const char *desc = "Send a capabilities command.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1202,7 +1202,7 @@ ret:
 static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespace_id, __u32 storage_medium,
 			    char *file, bool parse, char *output)
 {
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	struct nvme_persistent_event_log *pevent;
 	void *pevent_log_info;
 	__u8  lsp_base, lsp;

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -336,7 +336,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 #ifdef CONFIG_JSONC
 	const char *json = "Dump output in json format";
 #endif /* CONFIG_JSONC */
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	struct config {
@@ -509,7 +509,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *acmd, struct
 	char *desc = "Get ScaleFlux Latency Statistics log and show it.";
 	const char *raw = "dump output in binary format";
 	const char *write = "Get write statistics (read default)";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		bool raw_binary;
@@ -653,7 +653,7 @@ static int sfx_get_bad_block(int argc, char **argv, struct command *acmd, struct
 {
 	const __u64 buf_size = 256*4096*sizeof(unsigned char);
 	unsigned char *data_buf;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
@@ -705,7 +705,7 @@ static int query_cap_info(int argc, char **argv, struct command *acmd, struct pl
 	struct sfx_freespace_ctx sfctx = { 0 };
 	char *desc = "query current capacity info";
 	const char *raw = "dump output in binary format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		bool  raw_binary;
@@ -822,7 +822,7 @@ static int change_cap(int argc, char **argv, struct command *acmd, struct plugin
 	const char *cap_gb = "cap size in GB";
 	const char *cap_byte = "cap size in byte";
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 cap_in_4k = 0;
 	__u64 cap_in_sec = 0;
@@ -933,7 +933,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *acmd, struct p
 	const char *feature_id = "hex feature name (required)";
 	const char *namespace_id = "desired namespace";
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ns ns;
 	int err = 0;
@@ -1029,7 +1029,7 @@ static int sfx_get_feature(int argc, char **argv, struct command *acmd, struct p
 				 "feature id 1: ATOMIC";
 	const char *feature_id = "hex feature name (required)";
 	const char *namespace_id = "desired namespace";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u32 result = 0;
 	int err = 0;
@@ -1355,7 +1355,7 @@ static int sfx_dump_evtlog(int argc, char **argv, struct command *acmd, struct p
 				     "0: nand(default) 1: nor";
 	const char *parse = "parse error & warning evtlog from evtlog file";
 	const char *output = "parse result output file";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
@@ -1478,7 +1478,7 @@ static int sfx_expand_cap(int argc, char **argv, struct command *acmd, struct pl
 			   "0: 512(default) 1: 4096";
 	const char *units = "namespace size/capacity units\n"
 			    "0: GB(default) 1: LBA";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
@@ -1538,7 +1538,7 @@ static int sfx_status(int argc, char **argv, struct command *acmd, struct plugin
 {
 	const char *desc				= "Get ScaleFlux specific status information and print it";
 	const char *json_desc			= "Print output in JSON format, otherwise human readable";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl id_ctrl = { 0 };
 	struct extended_health_info_myrtle sfx_smart = { 0 };

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -337,7 +337,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 	const char *json = "Dump output in json format";
 #endif /* CONFIG_JSONC */
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	struct config {
 		__u32 namespace_id;
@@ -510,7 +510,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *acmd, struct
 	const char *raw = "dump output in binary format";
 	const char *write = "Get write statistics (read default)";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		bool raw_binary;
 		bool write;
@@ -654,7 +654,7 @@ static int sfx_get_bad_block(int argc, char **argv, struct command *acmd, struct
 	const __u64 buf_size = 256*4096*sizeof(unsigned char);
 	unsigned char *data_buf;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
 	char *desc = "Get bad block table of sfx block device.";
@@ -706,7 +706,7 @@ static int query_cap_info(int argc, char **argv, struct command *acmd, struct pl
 	char *desc = "query current capacity info";
 	const char *raw = "dump output in binary format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		bool  raw_binary;
 	};
@@ -823,7 +823,7 @@ static int change_cap(int argc, char **argv, struct command *acmd, struct plugin
 	const char *cap_byte = "cap size in byte";
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 cap_in_4k = 0;
 	__u64 cap_in_sec = 0;
 	int shrink = 0;
@@ -934,7 +934,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *acmd, struct p
 	const char *namespace_id = "desired namespace";
 	const char *force = "The \"I know what I'm doing\" flag, skip confirmation before sending command";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ns ns;
 	int err = 0;
 
@@ -1030,7 +1030,7 @@ static int sfx_get_feature(int argc, char **argv, struct command *acmd, struct p
 	const char *feature_id = "hex feature name (required)";
 	const char *namespace_id = "desired namespace";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u32 result = 0;
 	int err = 0;
 
@@ -1356,7 +1356,7 @@ static int sfx_dump_evtlog(int argc, char **argv, struct command *acmd, struct p
 	const char *parse = "parse error & warning evtlog from evtlog file";
 	const char *output = "parse result output file";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
 	struct config {
@@ -1479,7 +1479,7 @@ static int sfx_expand_cap(int argc, char **argv, struct command *acmd, struct pl
 	const char *units = "namespace size/capacity units\n"
 			    "0: GB(default) 1: LBA";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err = 0;
 
 	struct config {
@@ -1539,7 +1539,7 @@ static int sfx_status(int argc, char **argv, struct command *acmd, struct plugin
 	const char *desc				= "Get ScaleFlux specific status information and print it";
 	const char *json_desc			= "Print output in JSON format, otherwise human readable";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl id_ctrl = { 0 };
 	struct extended_health_info_myrtle sfx_smart = { 0 };
 	struct nvme_smart_log smart_log = { 0 };

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -154,7 +154,7 @@ static int log_pages_supp(int argc, char **argv, struct command *acmd,
 	log_page_map logPageMap;
 	const char *desc = "Retrieve Seagate Supported Log-Page information for the given device ";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int fmt;
 
@@ -897,7 +897,7 @@ static int vs_smart_log(int argc, char **argv, struct command *acmd, struct plug
 
 	const char *desc = "Retrieve the Firmware Activation History for Seagate NVMe drives";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err, index = 0;
 
@@ -1076,7 +1076,7 @@ static int temp_stats(int argc, char **argv, struct command *acmd, struct plugin
 	unsigned int temperature = 0, PcbTemp = 0, SocTemp = 0, scCurrentTemp = 0, scMaxTemp = 0;
 	unsigned long long maxTemperature = 0, MaxSocTemp = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts);
 
@@ -1235,7 +1235,7 @@ static int vs_pcie_error_log(int argc, char **argv, struct command *acmd, struct
 {
 	pcie_error_log_page pcieErrorLog;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	const char *desc = "Retrieve Seagate PCIe error counters for the given device ";
 	int err;
@@ -1370,7 +1370,7 @@ static int stx_vs_fw_activate_history(int argc, char **argv, struct command *acm
 {
 	stx_fw_activ_history_log_page fwActivHis;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	const char *desc = "Retrieve FW Activate History for Seagate device ";
 	int err;
@@ -1414,7 +1414,7 @@ static int clear_fw_activate_history(int argc, char **argv, struct command *acmd
 	const char *save = "specifies that the controller shall save the attribute";
 	int err;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl ctrl;
 	char modelNo[40];
 	__u64 result;
@@ -1472,7 +1472,7 @@ static int vs_clr_pcie_correctable_errs(int argc, char **argv, struct command *a
 	char modelNo[40];
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
 	int err;
@@ -1534,7 +1534,7 @@ static int get_host_tele(int argc, char **argv, struct command *acmd, struct plu
 	struct nvme_temetry_log_hdr tele_log;
 	int blkCnt, maxBlk = 0, blksToGet;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	unsigned char  *log;
 	__le64  offset = 0;
@@ -1641,7 +1641,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *acmd, struct plu
 	const char *namespace_id = "desired namespace";
 	const char *raw = "output in raw format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err, dump_fd;
 	struct nvme_temetry_log_hdr tele_log;
@@ -1754,7 +1754,7 @@ static int vs_internal_log(int argc, char **argv, struct command *acmd, struct p
 
 	const char *file = "dump file";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err, dump_fd;
 	int flags = O_WRONLY | O_CREAT;

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -153,7 +153,7 @@ static int log_pages_supp(int argc, char **argv, struct command *acmd,
 	__u32 i = 0;
 	log_page_map logPageMap;
 	const char *desc = "Retrieve Seagate Supported Log-Page information for the given device ";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int fmt;
@@ -896,7 +896,7 @@ static int vs_smart_log(int argc, char **argv, struct command *acmd, struct plug
 	struct json_object *lbafs_ExtSmart, *lbafs_DramSmart;
 
 	const char *desc = "Retrieve the Firmware Activation History for Seagate NVMe drives";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	int err, index = 0;
@@ -1075,7 +1075,7 @@ static int temp_stats(int argc, char **argv, struct command *acmd, struct plugin
 	nvme_print_flags_t flags;
 	unsigned int temperature = 0, PcbTemp = 0, SocTemp = 0, scCurrentTemp = 0, scMaxTemp = 0;
 	unsigned long long maxTemperature = 0, MaxSocTemp = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(opts);
@@ -1234,7 +1234,7 @@ static void json_vs_pcie_error_log(pcie_error_log_page pcieErrorLog)
 static int vs_pcie_error_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	pcie_error_log_page pcieErrorLog;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	const char *desc = "Retrieve Seagate PCIe error counters for the given device ";
@@ -1369,7 +1369,7 @@ static void json_stx_vs_fw_activate_history(stx_fw_activ_history_log_page fwActi
 static int stx_vs_fw_activate_history(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	stx_fw_activ_history_log_page fwActivHis;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	const char *desc = "Retrieve FW Activate History for Seagate device ";
@@ -1413,7 +1413,7 @@ static int clear_fw_activate_history(int argc, char **argv, struct command *acmd
 	const char *desc = "Clear FW Activation History for the given Seagate device ";
 	const char *save = "specifies that the controller shall save the attribute";
 	int err;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl ctrl;
 	char modelNo[40];
@@ -1471,7 +1471,7 @@ static int vs_clr_pcie_correctable_errs(int argc, char **argv, struct command *a
 	struct nvme_id_ctrl ctrl;
 	char modelNo[40];
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	__u64 result;
@@ -1533,7 +1533,7 @@ static int get_host_tele(int argc, char **argv, struct command *acmd, struct plu
 	const char *raw = "output in raw format";
 	struct nvme_temetry_log_hdr tele_log;
 	int blkCnt, maxBlk = 0, blksToGet;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	unsigned char  *log;
@@ -1640,7 +1640,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *acmd, struct plu
 	    "Capture the Telemetry Controller-Initiated Data in either hex-dump (default) or binary format";
 	const char *namespace_id = "desired namespace";
 	const char *raw = "output in raw format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err, dump_fd;
@@ -1753,7 +1753,7 @@ static int vs_internal_log(int argc, char **argv, struct command *acmd, struct p
 	const char *namespace_id = "desired namespace";
 
 	const char *file = "dump file";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err, dump_fd;

--- a/plugins/sed/sed.c
+++ b/plugins/sed/sed.c
@@ -87,7 +87,7 @@ static int sed_opal_discover(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Query SED device and display locking features";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -104,7 +104,7 @@ static int sed_opal_initialize(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Initialize a SED device for locking";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -124,7 +124,7 @@ static int sed_opal_revert(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Revert a SED device from locking state";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -144,7 +144,7 @@ static int sed_opal_lock(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Lock a SED device";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -164,7 +164,7 @@ static int sed_opal_unlock(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Unlock a SED device";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -185,7 +185,7 @@ static int sed_opal_password(int argc, char **argv, struct command *acmd,
 {
 	int err;
 	const char *desc = "Change the locking password of a SED device";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	err = sed_opal_open_device(&ctx, &hdl, argc, argv, desc, no_opts);

--- a/plugins/sed/sed.c
+++ b/plugins/sed/sed.c
@@ -88,7 +88,7 @@ static int sed_opal_discover(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Query SED device and display locking features";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	err = sed_opal_open_device(&ctx, &hdl, argc, argv, desc, discovery_opts);
@@ -105,7 +105,7 @@ static int sed_opal_initialize(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Initialize a SED device for locking";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	err = sed_opal_open_device(&ctx, &hdl, argc, argv, desc, init_opts);
@@ -125,7 +125,7 @@ static int sed_opal_revert(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Revert a SED device from locking state";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	err = sed_opal_open_device(&ctx, &hdl, argc, argv, desc, revert_opts);
@@ -145,7 +145,7 @@ static int sed_opal_lock(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Lock a SED device";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	err = sed_opal_open_device(&ctx, &hdl, argc, argv, desc, lock_opts);
@@ -165,7 +165,7 @@ static int sed_opal_unlock(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Unlock a SED device";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	err = sed_opal_open_device(&ctx, &hdl, argc, argv, desc, lock_opts);
@@ -186,7 +186,7 @@ static int sed_opal_password(int argc, char **argv, struct command *acmd,
 	int err;
 	const char *desc = "Change the locking password of a SED device";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	err = sed_opal_open_device(&ctx, &hdl, argc, argv, desc, no_opts);
 	if (err)

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -255,7 +255,7 @@ static int set_additional_feature(int argc, char **argv, struct command *acmd, s
 	const char *save = "specifies that the controller shall save the attribute";
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ void *buf = NULL;
+	__cleanup_free void *buf = NULL;
 	int ffd = STDIN_FILENO;
 	__u64 result;
 	int err;

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -120,7 +120,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 	    "Get Shannon vendor specific additional smart log (optionally, for the specified namespace), and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		__u32 namespace_id;
@@ -175,7 +175,7 @@ static int get_additional_feature(int argc, char **argv, struct command *acmd, s
 	const char *data_len = "buffer len (if) data is returned";
 	const char *cdw11 = "dword 11 for interrupt vector config";
 	const char *human_readable = "show infos in readable format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	void *buf = NULL;
 	__u64 result;
@@ -253,7 +253,7 @@ static int set_additional_feature(int argc, char **argv, struct command *acmd, s
 	const char *data = "optional file for feature data (default stdin)";
 	const char *value = "new value of feature (required)";
 	const char *save = "specifies that the controller shall save the attribute";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	int ffd = STDIN_FILENO;

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -121,7 +121,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		__u32 namespace_id;
 		bool  raw_binary;
@@ -176,7 +176,7 @@ static int get_additional_feature(int argc, char **argv, struct command *acmd, s
 	const char *cdw11 = "dword 11 for interrupt vector config";
 	const char *human_readable = "show infos in readable format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	void *buf = NULL;
 	__u64 result;
 	int err;
@@ -254,7 +254,7 @@ static int set_additional_feature(int argc, char **argv, struct command *acmd, s
 	const char *value = "new value of feature (required)";
 	const char *save = "specifies that the controller shall save the attribute";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free void *buf = NULL;
 	int ffd = STDIN_FILENO;
 	__u64 result;

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -70,7 +70,7 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *a
 {
 	const char *desc = "Get and parse Solidigm vendor specific garbage collection event log.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	int err;

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -69,7 +69,7 @@ static void vu_gc_log_show(struct garbage_control_collection_log *payload, const
 int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Get and parse Solidigm vendor specific garbage collection event log.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;

--- a/plugins/solidigm/solidigm-get-drive-info.c
+++ b/plugins/solidigm/solidigm-get-drive-info.c
@@ -13,7 +13,7 @@ int sldgm_get_drive_info(int argc, char **argv, struct command *acmd, struct plu
 {
 	const char *desc = "Get drive HW information";
 	const char *FTL_unit_size_str = "FTL_unit_size";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	libnvme_ctrl_t c;

--- a/plugins/solidigm/solidigm-get-drive-info.c
+++ b/plugins/solidigm/solidigm-get-drive-info.c
@@ -14,7 +14,7 @@ int sldgm_get_drive_info(int argc, char **argv, struct command *acmd, struct plu
 	const char *desc = "Get drive HW information";
 	const char *FTL_unit_size_str = "FTL_unit_size";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	libnvme_ctrl_t c;
 	libnvme_ns_t n;

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -839,7 +839,7 @@ int solidigm_get_internal_log(int argc, char **argv, struct command *acmd,
 	__cleanup_free char *unique_folder = NULL;
 	__cleanup_free char *zip_name = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	char *initial_folder;
 	char *output_path;
 	struct ilog ilog = {0};

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -465,7 +465,7 @@ struct log {
 static int log_save(struct log *log, const char *parent_dir_name, const char *subdir_name,
 		    const char *file_name, __u8 *buffer, size_t buf_size)
 {
-	_cleanup_fd_ int output = -1;
+	__cleanup_fd int output = -1;
 	__cleanup_free char *file_path = NULL;
 	size_t bytes_remaining = 0;
 

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -838,7 +838,7 @@ int solidigm_get_internal_log(int argc, char **argv, struct command *acmd,
 	__cleanup_free char *full_folder = NULL;
 	__cleanup_free char *unique_folder = NULL;
 	__cleanup_free char *zip_name = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	char *initial_folder;
 	char *output_path;

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -777,7 +777,7 @@ static int ilog_dump_no_lsp_log_pages(struct libnvme_transport_handle *hdl, stru
 static int ilog_dump_pel(struct libnvme_transport_handle *hdl, struct ilog *ilog)
 {
 	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = {0};
+	__cleanup_huge struct nvme_mem_huge mh = {0};
 	void *pevent_log_full;
 	size_t max_data_tx;
 	struct log lp = {

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -236,7 +236,7 @@ static int ilog_dump_assert_logs(struct libnvme_transport_handle *hdl, struct il
 {
 	__u8 buf[INTERNAL_LOG_MAX_BYTE_TRANSFER];
 	__u8 head_buf[INTERNAL_LOG_MAX_BYTE_TRANSFER];
-	_cleanup_free_ char *file_path = NULL;
+	__cleanup_free char *file_path = NULL;
 	char file_name[] = "AssertLog.bin";
 	struct assert_dump_header *ad = (struct assert_dump_header *) head_buf;
 	struct libnvme_passthru_cmd cmd = {
@@ -294,7 +294,7 @@ static int ilog_dump_event_logs(struct libnvme_transport_handle *hdl, struct ilo
 {
 	__u8 buf[INTERNAL_LOG_MAX_BYTE_TRANSFER];
 	__u8 head_buf[INTERNAL_LOG_MAX_BYTE_TRANSFER];
-	_cleanup_free_ char *file_path = NULL;
+	__cleanup_free char *file_path = NULL;
 	struct event_dump_header *ehdr = (struct event_dump_header *) head_buf;
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
@@ -369,7 +369,7 @@ static int ilog_dump_nlogs(struct libnvme_transport_handle *hdl, struct ilog *il
 	int err = 0;
 	__u32 count, core_num;
 	__u8 buf[INTERNAL_LOG_MAX_BYTE_TRANSFER];
-	_cleanup_free_ char *file_path = NULL;
+	__cleanup_free char *file_path = NULL;
 	struct nlog_dump_header_common *nlog_header = (struct nlog_dump_header_common *)buf;
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
@@ -439,7 +439,7 @@ static int ilog_dump_nlogs(struct libnvme_transport_handle *hdl, struct ilog *il
 
 int ensure_dir(const char *parent_dir_name, const char *name)
 {
-	_cleanup_free_ char *file_path = NULL;
+	__cleanup_free char *file_path = NULL;
 	struct stat sb;
 
 	if (asprintf(&file_path, "%s/%s", parent_dir_name, name) < 0)
@@ -466,7 +466,7 @@ static int log_save(struct log *log, const char *parent_dir_name, const char *su
 		    const char *file_name, __u8 *buffer, size_t buf_size)
 {
 	_cleanup_fd_ int output = -1;
-	_cleanup_free_ char *file_path = NULL;
+	__cleanup_free char *file_path = NULL;
 	size_t bytes_remaining = 0;
 
 	ensure_dir(parent_dir_name, subdir_name);
@@ -498,7 +498,7 @@ static int ilog_dump_identify_page(struct libnvme_transport_handle *hdl,
 {
 	__u8 data[NVME_IDENTIFY_DATA_SIZE];
 	__u8 *buff = cns->buffer ? cns->buffer : data;
-	_cleanup_free_ char *filename = NULL;
+	__cleanup_free char *filename = NULL;
 	int err;
 
 	err = nvme_identify(hdl, nsid, NVME_CSI_NVM, cns->id, buff,
@@ -685,7 +685,7 @@ static int ilog_dump_identify_pages(struct libnvme_transport_handle *hdl, struct
 static int ilog_dump_log_page(struct libnvme_transport_handle *hdl, struct ilog *ilog, struct log *lp, __u32 nsid)
 {
 	__u8 *buff = lp->buffer;
-	_cleanup_free_ char *filename = NULL;
+	__cleanup_free char *filename = NULL;
 
 	int err;
 	if (!lp->buffer_size)
@@ -776,7 +776,7 @@ static int ilog_dump_no_lsp_log_pages(struct libnvme_transport_handle *hdl, stru
 
 static int ilog_dump_pel(struct libnvme_transport_handle *hdl, struct ilog *ilog)
 {
-	_cleanup_free_ struct nvme_persistent_event_log *pevent = NULL;
+	__cleanup_free struct nvme_persistent_event_log *pevent = NULL;
 	_cleanup_huge_ struct nvme_mem_huge mh = {0};
 	void *pevent_log_full;
 	size_t max_data_tx;
@@ -835,9 +835,9 @@ int solidigm_get_internal_log(int argc, char **argv, struct command *acmd,
 {
 	char sn_prefix[sizeof(((struct nvme_id_ctrl *)0)->sn)+1];
 	char date_str[sizeof("-YYYYMMDDHHMMSS")];
-	_cleanup_free_ char *full_folder = NULL;
-	_cleanup_free_ char *unique_folder = NULL;
-	_cleanup_free_ char *zip_name = NULL;
+	__cleanup_free char *full_folder = NULL;
+	__cleanup_free char *unique_folder = NULL;
+	__cleanup_free char *zip_name = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	char *initial_folder;
@@ -970,7 +970,7 @@ int solidigm_get_internal_log(int argc, char **argv, struct command *acmd,
 
 	if (ilog.count > 0) {
 		int ret_cmd;
-		_cleanup_free_ char *cmd = NULL;
+		__cleanup_free char *cmd = NULL;
 		char *quiet = nvme_args.verbose ? "" : " -q";
 
 		if (asprintf(&zip_name, "%s.zip", unique_folder) < 0)

--- a/plugins/solidigm/solidigm-latency-tracking.c
+++ b/plugins/solidigm/solidigm-latency-tracking.c
@@ -350,7 +350,7 @@ int solidigm_get_latency_tracking_log(int argc, char **argv, struct command *acm
 {
 	const char *desc = "Get and Parse Solidigm Latency Tracking Statistics log.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 enabled;
 	int err;
 

--- a/plugins/solidigm/solidigm-latency-tracking.c
+++ b/plugins/solidigm/solidigm-latency-tracking.c
@@ -349,7 +349,7 @@ int solidigm_get_latency_tracking_log(int argc, char **argv, struct command *acm
 				      struct plugin *plugin)
 {
 	const char *desc = "Get and Parse Solidigm Latency Tracking Statistics log.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 enabled;
 	int err;

--- a/plugins/solidigm/solidigm-log-page-dir.c
+++ b/plugins/solidigm/solidigm-log-page-dir.c
@@ -186,7 +186,7 @@ int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *a
 	const char *description = "Retrieves list of supported log pages for each UUID index.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(options);
 

--- a/plugins/solidigm/solidigm-log-page-dir.c
+++ b/plugins/solidigm/solidigm-log-page-dir.c
@@ -185,7 +185,7 @@ int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *a
 	const int NO_UUID_INDEX = 0;
 	const char *description = "Retrieves list of supported log pages for each UUID index.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	NVME_ARGS(options);

--- a/plugins/solidigm/solidigm-market-log.c
+++ b/plugins/solidigm/solidigm-market-log.c
@@ -30,7 +30,7 @@ int sldgm_get_market_log(int argc, char **argv, struct command *acmd,
 	const char *desc = "Get Solidigm Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	char log[MARKET_LOG_MAX_SIZE];
 	int err;

--- a/plugins/solidigm/solidigm-market-log.c
+++ b/plugins/solidigm/solidigm-market-log.c
@@ -29,7 +29,7 @@ int sldgm_get_market_log(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Get Solidigm Marketing Name log and show it.";
 	const char *raw = "dump output in binary format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	char log[MARKET_LOG_MAX_SIZE];

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -230,7 +230,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *acm
 	const int solidigm_vu_smart_log_id = 0xCA;
 	struct vu_smart_log smart_log_payload;
 	nvme_print_flags_t flags;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -231,7 +231,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *acm
 	struct vu_smart_log smart_log_payload;
 	nvme_print_flags_t flags;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 	__u8 uuid_index;

--- a/plugins/solidigm/solidigm-telemetry.c
+++ b/plugins/solidigm/solidigm-telemetry.c
@@ -72,7 +72,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *acmd, stru
 	const char *sfile = "binary file containing log dump";
 	const char *jqfilt = "JSON config entry name containing jq filter";
 	bool has_binary_file = false;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_telemetry_log *tlog = NULL;
 

--- a/plugins/solidigm/solidigm-telemetry.c
+++ b/plugins/solidigm/solidigm-telemetry.c
@@ -73,7 +73,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *acmd, stru
 	const char *jqfilt = "JSON config entry name containing jq filter";
 	bool has_binary_file = false;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_free struct nvme_telemetry_log *tlog = NULL;
 
 	__attribute__((cleanup(cleanup_json_object))) struct json_object *configuration = NULL;

--- a/plugins/solidigm/solidigm-telemetry.c
+++ b/plugins/solidigm/solidigm-telemetry.c
@@ -74,7 +74,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *acmd, stru
 	bool has_binary_file = false;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_free_ struct nvme_telemetry_log *tlog = NULL;
+	__cleanup_free struct nvme_telemetry_log *tlog = NULL;
 
 	__attribute__((cleanup(cleanup_json_object))) struct json_object *configuration = NULL;
 
@@ -142,7 +142,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *acmd, stru
 	}
 
 	if (argconfig_parse_seen(opts, "config-file")) {
-		_cleanup_free_ char *conf_str = NULL;
+		__cleanup_free char *conf_str = NULL;
 		size_t length = 0;
 		enum json_tokener_error jerr;
 

--- a/plugins/solidigm/solidigm-temp-stats.c
+++ b/plugins/solidigm/solidigm-temp-stats.c
@@ -41,7 +41,7 @@ static void show_temp_stats(struct temp_stats *stats)
 int sldgm_get_temp_stats_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	unsigned char buffer[4096] = {0};
 	struct libnvme_passthru_cmd cmd;
 	__u8 uuid_idx;

--- a/plugins/solidigm/solidigm-temp-stats.c
+++ b/plugins/solidigm/solidigm-temp-stats.c
@@ -40,7 +40,7 @@ static void show_temp_stats(struct temp_stats *stats)
 
 int sldgm_get_temp_stats_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	unsigned char buffer[4096] = {0};
 	struct libnvme_passthru_cmd cmd;

--- a/plugins/solidigm/solidigm-workload-tracker.c
+++ b/plugins/solidigm/solidigm-workload-tracker.c
@@ -493,7 +493,7 @@ int sldgm_get_workload_tracker(int argc, char **argv, struct command *acmd, stru
 	const char *run_time = "Limit runtime capture time in seconds";
 	const char *flush_frequency =
 		"Samples (1 to 126) to wait for extracting data. Default 100 samples";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct wltracker wlt = {0};
 	union WorkloadLogEnable we = {0};

--- a/plugins/solidigm/solidigm-workload-tracker.c
+++ b/plugins/solidigm/solidigm-workload-tracker.c
@@ -494,7 +494,7 @@ int sldgm_get_workload_tracker(int argc, char **argv, struct command *acmd, stru
 	const char *flush_frequency =
 		"Samples (1 to 126) to wait for extracting data. Default 100 samples";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct wltracker wlt = {0};
 	union WorkloadLogEnable we = {0};
 	char type_options[80] = {0};

--- a/plugins/ssstc/ssstc-nvme.c
+++ b/plugins/ssstc/ssstc-nvme.c
@@ -390,7 +390,7 @@ int ssstc_get_add_smart_log(int argc, char **argv, struct command *acmd, struct 
 
 	struct nvme_additional_smart_log smart_log_add;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {

--- a/plugins/ssstc/ssstc-nvme.c
+++ b/plugins/ssstc/ssstc-nvme.c
@@ -389,7 +389,7 @@ int ssstc_get_add_smart_log(int argc, char **argv, struct command *acmd, struct 
 #endif /* CONFIG_JSONC */
 
 	struct nvme_additional_smart_log smart_log_add;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -422,7 +422,7 @@ static int vendor_log(int argc, char **argv, struct command *acmd, struct plugin
 	const char *output_file = "(optional) binary output filename";
 	const char *log = "(optional) log ID (0xC0, or 0xCA), default 0xCA";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -471,7 +471,7 @@ static int internal_log(int argc, char **argv, struct command *acmd, struct plug
 	const char *output_file = "(optional) binary output filename";
 	const char *prev_log = "(optional) use previous log. Otherwise uses current log.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
 	struct config {
@@ -514,7 +514,7 @@ static int clear_correctable_errors(int argc, char **argv, struct command *acmd,
 {
 	char *desc = "Clear PCIe correctable error count.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	const __u32 namespace_id = 0xFFFFFFFF;
 	const __u32 feature_id = 0xCA;
 	const __u32 value = 1; /* Bit0 - reset clear PCIe correctable count */

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -421,7 +421,7 @@ static int vendor_log(int argc, char **argv, struct command *acmd, struct plugin
 	const char *namespace = "(optional) desired namespace";
 	const char *output_file = "(optional) binary output filename";
 	const char *log = "(optional) log ID (0xC0, or 0xCA), default 0xCA";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -470,7 +470,7 @@ static int internal_log(int argc, char **argv, struct command *acmd, struct plug
 	char *desc = "Get internal status log and show it.";
 	const char *output_file = "(optional) binary output filename";
 	const char *prev_log = "(optional) use previous log. Otherwise uses current log.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int err;
 
@@ -513,7 +513,7 @@ static int clear_correctable_errors(int argc, char **argv, struct command *acmd,
 				    struct plugin *plugin)
 {
 	char *desc = "Clear PCIe correctable error count.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	const __u32 namespace_id = 0xFFFFFFFF;
 	const __u32 feature_id = 0xCA;

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -24,7 +24,7 @@ static int getHealthValue(int argc, char **argv, struct command *acmd, struct pl
 	struct nvme_smart_log smart_log;
 	char *desc = "Get nvme health percentage.";
 	int  percent_used = 0, healthvalue = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int result;
 
@@ -55,7 +55,7 @@ static int getBadblock(int argc, char **argv, struct command *acmd, struct plugi
 {
 
 	char *desc = "Get nvme bad block number.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd nvmecmd;
 	unsigned char data[1] = {0};

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -25,7 +25,7 @@ static int getHealthValue(int argc, char **argv, struct command *acmd, struct pl
 	char *desc = "Get nvme health percentage.";
 	int  percent_used = 0, healthvalue = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int result;
 
 	NVME_ARGS(opts);
@@ -56,7 +56,7 @@ static int getBadblock(int argc, char **argv, struct command *acmd, struct plugi
 
 	char *desc = "Get nvme bad block number.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd nvmecmd;
 	unsigned char data[1] = {0};
 	int result;

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -950,7 +950,7 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv,
 	const char *output_file = "(optional) Name of the log file (give it a name that easy for you to remember what the test is). You can leave it blank too, we will take care it for you.";
 	const char *test_name = "(optional) Name of the test you are doing. We use this as part of the name of the log file.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
 	struct vtview_save_log_settings cfg = {
 		.run_time_hrs = 20,
@@ -1027,7 +1027,7 @@ static int vt_show_identify(int argc, char **argv, struct command *acmd, struct 
 		"Typical usages:\n\n"
 		"virtium show-identify /dev/yourDevice\n";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl ctrl;
 	int ret, err = 0;
 

--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -949,7 +949,7 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv,
 	const char *freq = "(optional) How often you want to log SMART data (0.25 = 15' , 0.5 = 30' , 1 = 1 hour, 2 = 2 hours, etc.). Default = 10 hours.";
 	const char *output_file = "(optional) Name of the log file (give it a name that easy for you to remember what the test is). You can leave it blank too, we will take care it for you.";
 	const char *test_name = "(optional) Name of the test you are doing. We use this as part of the name of the log file.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 
 	struct vtview_save_log_settings cfg = {
@@ -1026,7 +1026,7 @@ static int vt_show_identify(int argc, char **argv, struct command *acmd, struct 
 	char *desc = "Parse identify data to json format\n\n"
 		"Typical usages:\n\n"
 		"virtium show-identify /dev/yourDevice\n";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_id_ctrl ctrl;
 	int ret, err = 0;

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -2873,7 +2873,7 @@ static bool wdc_nvme_check_supported_log_page(struct libnvme_global_ctx *ctx,
 	int err = -1;
 	struct wdc_c2_cbs_data *cbs_data = NULL;
 
-	_cleanup_free_ struct nvme_supported_log_pages *supports = NULL;
+	__cleanup_free struct nvme_supported_log_pages *supports = NULL;
 
 	/* Check log page id 0 (supported log pages) first */
 	supports = nvme_alloc(sizeof(*supports));

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -3901,7 +3901,7 @@ out:
 static int wdc_cap_diag(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	const char *desc = "Capture Diagnostics Log.";
 	const char *file = "Output file pathname.";
@@ -4317,7 +4317,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 	char f[PATH_MAX] = {0};
 	char fb[PATH_MAX/2] = {0};
 	char fileSuffix[PATH_MAX] = {0};
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u32 xfer_size = 0;
 	int telemetry_type = 0, telemetry_data_area = 0;
@@ -4713,7 +4713,7 @@ static int wdc_drive_log(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Capture Drive Log.";
 	const char *file = "Output file pathname.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	char f[PATH_MAX] = {0};
 	int ret;
@@ -4760,7 +4760,7 @@ static int wdc_get_crash_dump(int argc, char **argv, struct command *acmd,
 	const char *desc = "Get Crash Dump.";
 	const char *file = "Output file pathname.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 
@@ -4801,7 +4801,7 @@ static int wdc_get_pfail_dump(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Get Pfail Crash Dump.";
 	const char *file = "Output file pathname.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	struct config {
@@ -4886,7 +4886,7 @@ static int wdc_purge(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
 	const char *desc = "Send a Purge command.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd admin_cmd;
 	__u64 capabilities = 0;
@@ -4937,7 +4937,7 @@ static int wdc_purge_monitor(int argc, char **argv,
 {
 	const char *desc = "Send a Purge Monitor command.";
 	__u8 output[WDC_NVME_PURGE_MONITOR_DATA_LEN];
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	double progress_percent;
 	struct libnvme_passthru_cmd admin_cmd;
@@ -8296,7 +8296,7 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 	const char *log_page_mask = "Log Page Mask, comma separated list: 0xC0, 0xC1, 0xCA, 0xD0";
 	const char *namespace_id = "desired namespace id";
 	nvme_print_flags_t fmt;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	int uuid_index = 0;
@@ -8437,7 +8437,7 @@ static int wdc_cu_smart_log(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve customer unique smart log statistics.";
 	const char *uuid_index = "The uuid index to select the correct log page implementation.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int ret = 0;
@@ -8547,7 +8547,7 @@ static int wdc_vs_cloud_log(int argc, char **argv, struct command *acmd,
 	const char *namespace_id = "desired namespace id";
 	nvme_print_flags_t fmt;
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 	__u8 *data;
@@ -8692,7 +8692,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve Device Write Amplication Factor";
 	const char *namespace_id = "desired namespace id";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_smart_log smart_log;
 	nvme_print_flags_t fmt;
@@ -8810,7 +8810,7 @@ static int wdc_get_latency_monitor_log(int argc, char **argv, struct command *ac
 {
 	const char *desc = "Retrieve latency monitor log data.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -8852,7 +8852,7 @@ static int wdc_get_error_recovery_log(int argc, char **argv, struct command *acm
 {
 	const char *desc = "Retrieve error recovery log data.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -8895,7 +8895,7 @@ static int wdc_get_dev_capabilities_log(int argc, char **argv, struct command *a
 {
 	const char *desc = "Retrieve device capabilities log data.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -8938,7 +8938,7 @@ static int wdc_get_unsupported_reqs_log(int argc, char **argv, struct command *a
 {
 	const char *desc = "Retrieve unsupported requirements log data.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
@@ -9021,7 +9021,7 @@ static int wdc_clear_pcie_correctable_errors(int argc, char **argv, struct comma
 		struct plugin *plugin)
 {
 	const char *desc = "Clear PCIE Correctable Errors.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	int ret;
@@ -9058,7 +9058,7 @@ static int wdc_drive_status(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Get Drive Status.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	int uuid_index;
@@ -9209,7 +9209,7 @@ static int wdc_clear_assert_dump(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Clear Assert Dump Present Status.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = -1;
 	__le32 assert_status = cpu_to_le32(0xFFFFFFFF);
@@ -9427,7 +9427,7 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *acm
 {
 	const char *desc = "Retrieve FW activate history table.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret = -1;
 
@@ -9518,7 +9518,7 @@ static int wdc_clear_fw_activate_history(int argc, char **argv, struct command *
 {
 	const char *desc = "Clear FW activate history table.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 
@@ -9557,7 +9557,7 @@ static int wdc_vs_telemetry_controller_option(int argc, char **argv, struct comm
 	const char *enable = "Enable controller option of the telemetry log page.";
 	const char *status = "Displays the current state of the controller initiated log page.";
 	__u64 capabilities = 0;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int ret = -1;
@@ -10350,7 +10350,7 @@ static int wdc_drive_essentials(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Capture Drive Essentials.";
 	const char *dirName = "Output directory pathname.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	char d[PATH_MAX] = {0};
 	char k[PATH_MAX] = {0};
@@ -10450,7 +10450,7 @@ static int wdc_drive_resize(int argc, char **argv,
 {
 	const char *desc = "Send a Resize command.";
 	const char *size = "The new size (in GB) to resize the drive to.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
@@ -10496,7 +10496,7 @@ static int wdc_namespace_resize(int argc, char **argv,
 	const char *desc = "Send a Namespace Resize command.";
 	const char *namespace_id = "The namespace id to resize.";
 	const char *op_option = "The over provisioning option to set for namespace.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
@@ -10552,7 +10552,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 	const char *desc = "Retrieve telemetry log reason identifier.";
 	const char *log_id = "Log ID to retrieve - host - 7 or controller - 8";
 	const char *fname = "File name to save raw binary identifier";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 	uint64_t capabilities = 0;
@@ -10811,7 +10811,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Retrieve Log Page Directory.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t fmt;
 	int ret = 0;
@@ -11567,7 +11567,7 @@ static int wdc_vs_nand_stats(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Retrieve NAND statistics.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	uint32_t read_device_id = 0, read_vendor_id = 0;
@@ -11641,7 +11641,7 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	const char *desc = "Retrieve PCIE statistics.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t fmt;
 	int ret;
@@ -11714,7 +11714,7 @@ static int wdc_vs_drive_info(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
 	const char *desc = "Send a vs-drive-info command.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t fmt;
 	uint64_t capabilities = 0;
@@ -11977,7 +11977,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 		struct command *command, struct plugin *plugin)
 {
 	const char *desc = "Send a vs-temperature-stats command.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_smart_log smart_log;
 	struct nvme_id_ctrl id_ctrl;
@@ -12092,7 +12092,7 @@ out:
 static int wdc_capabilities(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Send a capabilities command.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
@@ -12197,7 +12197,7 @@ static int wdc_cloud_ssd_plugin_version(int argc, char **argv, struct command *a
 					struct plugin *plugin)
 {
 	const char *desc = "Get Cloud SSD Plugin Version command.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
@@ -12230,7 +12230,7 @@ static int wdc_cloud_boot_SSD_version(int argc, char **argv, struct command *acm
 {
 	const char *desc = "Get Cloud Boot SSD Version command.";
 	const char *namespace_id = "desired namespace id";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
@@ -12291,7 +12291,7 @@ static int wdc_enc_get_log(int argc, char **argv, struct command *acmd, struct p
 	const char *file = "Output file pathname.";
 	const char *size = "Data retrieval transfer size.";
 	const char *log = "Enclosure Log Page ID.";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	FILE *output_fd;
 	int xfer_size = 0;
@@ -12554,7 +12554,7 @@ int wdc_set_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 
 	struct feature_latency_monitor buf = {0,};
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	uint64_t capabilities = 0;
 	__u64 result;
 	int ret;

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -11646,7 +11646,7 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *acmd,
 	nvme_print_flags_t fmt;
 	int ret;
 	__u64 capabilities = 0;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	struct wdc_vs_pcie_stats *pcieStatsPtr = NULL;
 	int pcie_stats_size = sizeof(struct wdc_vs_pcie_stats);
 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -3902,7 +3902,7 @@ static int wdc_cap_diag(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	const char *desc = "Capture Diagnostics Log.";
 	const char *file = "Output file pathname.";
 	const char *size = "Data retrieval transfer size.";
@@ -4318,7 +4318,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 	char fb[PATH_MAX/2] = {0};
 	char fileSuffix[PATH_MAX] = {0};
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u32 xfer_size = 0;
 	int telemetry_type = 0, telemetry_data_area = 0;
 	UtilsTimeInfo             timeInfo;
@@ -4714,7 +4714,7 @@ static int wdc_drive_log(int argc, char **argv, struct command *acmd,
 	const char *desc = "Capture Drive Log.";
 	const char *file = "Output file pathname.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	char f[PATH_MAX] = {0};
 	int ret;
 	__u64 capabilities = 0;
@@ -4761,7 +4761,7 @@ static int wdc_get_crash_dump(int argc, char **argv, struct command *acmd,
 	const char *file = "Output file pathname.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 
 	struct config {
@@ -4802,7 +4802,7 @@ static int wdc_get_pfail_dump(int argc, char **argv, struct command *acmd,
 	const char *desc = "Get Pfail Crash Dump.";
 	const char *file = "Output file pathname.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	struct config {
 		char *file;
@@ -4887,7 +4887,7 @@ static int wdc_purge(int argc, char **argv,
 {
 	const char *desc = "Send a Purge command.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd admin_cmd;
 	__u64 capabilities = 0;
 	char *err_str;
@@ -4938,7 +4938,7 @@ static int wdc_purge_monitor(int argc, char **argv,
 	const char *desc = "Send a Purge Monitor command.";
 	__u8 output[WDC_NVME_PURGE_MONITOR_DATA_LEN];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	double progress_percent;
 	struct libnvme_passthru_cmd admin_cmd;
 	struct wdc_nvme_purge_monitor_data *mon;
@@ -8297,7 +8297,7 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 	const char *namespace_id = "desired namespace id";
 	nvme_print_flags_t fmt;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	int uuid_index = 0;
 	int page_mask = 0, num, i;
@@ -8438,7 +8438,7 @@ static int wdc_cu_smart_log(int argc, char **argv, struct command *acmd,
 	const char *desc = "Retrieve customer unique smart log statistics.";
 	const char *uuid_index = "The uuid index to select the correct log page implementation.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int ret = 0;
 	__u64 capabilities = 0;
@@ -8548,7 +8548,7 @@ static int wdc_vs_cloud_log(int argc, char **argv, struct command *acmd,
 	nvme_print_flags_t fmt;
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 	__u8 *data;
 
@@ -8693,7 +8693,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *acmd,
 	const char *desc = "Retrieve Device Write Amplication Factor";
 	const char *namespace_id = "desired namespace id";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_smart_log smart_log;
 	nvme_print_flags_t fmt;
 	__u8 *data;
@@ -8811,7 +8811,7 @@ static int wdc_get_latency_monitor_log(int argc, char **argv, struct command *ac
 	const char *desc = "Retrieve latency monitor log data.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -8853,7 +8853,7 @@ static int wdc_get_error_recovery_log(int argc, char **argv, struct command *acm
 	const char *desc = "Retrieve error recovery log data.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -8896,7 +8896,7 @@ static int wdc_get_dev_capabilities_log(int argc, char **argv, struct command *a
 	const char *desc = "Retrieve device capabilities log data.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -8939,7 +8939,7 @@ static int wdc_get_unsupported_reqs_log(int argc, char **argv, struct command *a
 	const char *desc = "Retrieve unsupported requirements log data.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 
 	struct config {
@@ -9022,7 +9022,7 @@ static int wdc_clear_pcie_correctable_errors(int argc, char **argv, struct comma
 {
 	const char *desc = "Clear PCIE Correctable Errors.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	int ret;
 
@@ -9059,7 +9059,7 @@ static int wdc_drive_status(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Get Drive Status.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = 0;
 	int uuid_index;
 	void *dev_mng_log = NULL;
@@ -9210,7 +9210,7 @@ static int wdc_clear_assert_dump(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Clear Assert Dump Present Status.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = -1;
 	__le32 assert_status = cpu_to_le32(0xFFFFFFFF);
 	__u64 capabilities = 0;
@@ -9428,7 +9428,7 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *acm
 	const char *desc = "Retrieve FW activate history table.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret = -1;
 
 	struct config {
@@ -9519,7 +9519,7 @@ static int wdc_clear_fw_activate_history(int argc, char **argv, struct command *
 	const char *desc = "Clear FW activate history table.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 
 	NVME_ARGS(opts);
@@ -9558,7 +9558,7 @@ static int wdc_vs_telemetry_controller_option(int argc, char **argv, struct comm
 	const char *status = "Displays the current state of the controller initiated log page.";
 	__u64 capabilities = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 result;
 	int ret = -1;
 
@@ -10351,7 +10351,7 @@ static int wdc_drive_essentials(int argc, char **argv, struct command *acmd,
 	const char *desc = "Capture Drive Essentials.";
 	const char *dirName = "Output directory pathname.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	char d[PATH_MAX] = {0};
 	char k[PATH_MAX] = {0};
 	__u64 capabilities = 0;
@@ -10451,7 +10451,7 @@ static int wdc_drive_resize(int argc, char **argv,
 	const char *desc = "Send a Resize command.";
 	const char *size = "The new size (in GB) to resize the drive to.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 
@@ -10497,7 +10497,7 @@ static int wdc_namespace_resize(int argc, char **argv,
 	const char *namespace_id = "The namespace id to resize.";
 	const char *op_option = "The over provisioning option to set for namespace.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 
@@ -10553,7 +10553,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 	const char *log_id = "Log ID to retrieve - host - 7 or controller - 8";
 	const char *fname = "File name to save raw binary identifier";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int ret;
 	uint64_t capabilities = 0;
 	char f[PATH_MAX] = {0};
@@ -10812,7 +10812,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve Log Page Directory.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t fmt;
 	int ret = 0;
 	__u64 capabilities = 0;
@@ -11568,7 +11568,7 @@ static int wdc_vs_nand_stats(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve NAND statistics.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__u64 capabilities = 0;
 	uint32_t read_device_id = 0, read_vendor_id = 0;
 	int ret;
@@ -11642,7 +11642,7 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Retrieve PCIE statistics.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t fmt;
 	int ret;
 	__u64 capabilities = 0;
@@ -11715,7 +11715,7 @@ static int wdc_vs_drive_info(int argc, char **argv,
 {
 	const char *desc = "Send a vs-drive-info command.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t fmt;
 	uint64_t capabilities = 0;
 	int ret;
@@ -11978,7 +11978,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 {
 	const char *desc = "Send a vs-temperature-stats command.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_smart_log smart_log;
 	struct nvme_id_ctrl id_ctrl;
 	nvme_print_flags_t fmt;
@@ -12093,7 +12093,7 @@ static int wdc_capabilities(int argc, char **argv, struct command *acmd, struct 
 {
 	const char *desc = "Send a capabilities command.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 
@@ -12198,7 +12198,7 @@ static int wdc_cloud_ssd_plugin_version(int argc, char **argv, struct command *a
 {
 	const char *desc = "Get Cloud SSD Plugin Version command.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 
@@ -12231,7 +12231,7 @@ static int wdc_cloud_boot_SSD_version(int argc, char **argv, struct command *acm
 	const char *desc = "Get Cloud Boot SSD Version command.";
 	const char *namespace_id = "desired namespace id";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	uint64_t capabilities = 0;
 	int ret;
 	int major = 0, minor = 0;
@@ -12292,7 +12292,7 @@ static int wdc_enc_get_log(int argc, char **argv, struct command *acmd, struct p
 	const char *size = "Data retrieval transfer size.";
 	const char *log = "Enclosure Log Page ID.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	FILE *output_fd;
 	int xfer_size = 0;
 	int len;
@@ -12553,7 +12553,7 @@ int wdc_set_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 	const char *desc = "Set Latency Monitor feature.";
 
 	struct feature_latency_monitor buf = {0,};
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	uint64_t capabilities = 0;
 	__u64 result;

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -125,7 +125,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		__u32 namespace_id;
 		bool  raw_binary;

--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -124,7 +124,7 @@ static int get_additional_smart_log(int argc, char **argv, struct command *acmd,
 	    "Get Ymtc vendor specific additional smart log (optionally, for the specified namespace), and show it.";
 	const char *namespace = "(optional) desired namespace";
 	const char *raw = "dump output in binary format";
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct config {
 		__u32 namespace_id;

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -92,7 +92,7 @@ static int print_zns_list(struct libnvme_global_ctx *ctx, struct table *t)
 static int list(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int err;
 	struct table_column columns[] = {
 		{ "Node", LEFT, 21 },
@@ -133,7 +133,7 @@ static int id_ctrl(int argc, char **argv, struct command *acmd, struct plugin *p
 			   "the given device and report information about the specified\n"
 			   "controller in various formats.";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	struct nvme_zns_id_ctrl ctrl;
@@ -170,7 +170,7 @@ static int id_ns(int argc, char **argv, struct command *acmd, struct plugin *plu
 	const char *vendor_specific = "dump binary vendor fields";
 	const char *human_readable = "show identify in readable format";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	struct nvme_zns_id_ns ns;
@@ -233,7 +233,7 @@ static int zns_mgmt_send(int argc, char **argv, struct command *acmd, struct plu
 	const char *zslba = "starting LBA of the zone for this command";
 	const char *select_all = "send command to all zones";
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err, zcapc = 0;
 	char *cmdstr;
@@ -328,7 +328,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 	const char *data = "optional file for data (default stdin)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int ffd = STDIN_FILENO, err = -1;
 	struct libnvme_passthru_cmd cmd;
 	void *buf = NULL;
@@ -451,7 +451,7 @@ static int open_zone(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *zrwaa = "Allocate Zone Random Write Area to zone";
 	const char *select_all = "send command to all zones";
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 
@@ -520,7 +520,7 @@ static int set_zone_desc(int argc, char **argv, struct command *acmd, struct plu
 	const char *data = "optional file for zone extension data (default stdin)";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int ffd = STDIN_FILENO, err;
 	void *buf = NULL;
@@ -608,7 +608,7 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *acmd, struct p
 	const char *desc = "Flush Explicit ZRWA Range";
 	const char *slba = "LBA to flush up to";
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
 
@@ -659,7 +659,7 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *acmd, struct pl
 	const char *data_len = "length of data in bytes";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
 	void *data = NULL;
@@ -739,7 +739,7 @@ static int report_zones(int argc, char **argv, struct command *acmd, struct plug
 	const char *verbose = "show report zones verbosity";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	struct nvme_zone_report *report, *buff;
 	struct libnvme_passthru_cmd cmd;
@@ -915,7 +915,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 	const char *latency = "output latency statistics";
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int err = -1, dfd = STDIN_FILENO, mfd = STDIN_FILENO;
 	struct timeval start_time, end_time;
 	unsigned int lba_size, meta_size;
@@ -1094,7 +1094,7 @@ static int changed_zone_list(int argc, char **argv, struct command *acmd, struct
 	const char *desc = "Retrieve Changed Zone log for the given device";
 	const char *rae = "retain an asynchronous event";
 
-	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_zns_changed_zone_log log;
 	nvme_print_flags_t flags;

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -740,7 +740,7 @@ static int report_zones(int argc, char **argv, struct command *acmd, struct plug
 
 	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
 	_cleanup_nvme_global_ctx_ struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_huge_ struct nvme_mem_huge mh = { 0, };
+	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	struct nvme_zone_report *report, *buff;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -134,7 +134,7 @@ static int id_ctrl(int argc, char **argv, struct command *acmd, struct plugin *p
 			   "controller in various formats.";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct libnvme_passthru_cmd cmd;
 	struct nvme_zns_id_ctrl ctrl;
 	nvme_print_flags_t flags;
@@ -171,7 +171,7 @@ static int id_ns(int argc, char **argv, struct command *acmd, struct plugin *plu
 	const char *human_readable = "show identify in readable format";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
 	struct nvme_zns_id_ns ns;
 	struct nvme_id_ns id_ns;
@@ -232,7 +232,7 @@ static int zns_mgmt_send(int argc, char **argv, struct command *acmd, struct plu
 {
 	const char *zslba = "starting LBA of the zone for this command";
 	const char *select_all = "send command to all zones";
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err, zcapc = 0;
@@ -327,7 +327,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 	const char *data_len = "buffer length if data required";
 	const char *data = "optional file for data (default stdin)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int ffd = STDIN_FILENO, err = -1;
 	struct libnvme_passthru_cmd cmd;
@@ -450,7 +450,7 @@ static int open_zone(int argc, char **argv, struct command *acmd, struct plugin 
 	const char *zslba = "starting LBA of the zone for this command";
 	const char *zrwaa = "Allocate Zone Random Write Area to zone";
 	const char *select_all = "send command to all zones";
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
@@ -519,7 +519,7 @@ static int set_zone_desc(int argc, char **argv, struct command *acmd, struct plu
 	const char *zrwaa = "Allocate Zone Random Write Area to zone";
 	const char *data = "optional file for zone extension data (default stdin)";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int ffd = STDIN_FILENO, err;
@@ -607,7 +607,7 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *acmd, struct p
 {
 	const char *desc = "Flush Explicit ZRWA Range";
 	const char *slba = "LBA to flush up to";
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	int err;
@@ -658,7 +658,7 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *acmd, struct pl
 	const char *partial = "Zone Receive Action Specific Features(Partial Report)";
 	const char *data_len = "length of data in bytes";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t flags;
@@ -738,7 +738,7 @@ static int report_zones(int argc, char **argv, struct command *acmd, struct plug
 	const char *part = "set to use the partial report";
 	const char *verbose = "show report zones verbosity";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_huge struct nvme_mem_huge mh = { 0, };
 	struct nvme_zone_report *report, *buff;
@@ -914,7 +914,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 	const char *data_size = "size of data in bytes";
 	const char *latency = "output latency statistics";
 
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int err = -1, dfd = STDIN_FILENO, mfd = STDIN_FILENO;
 	struct timeval start_time, end_time;
@@ -1095,7 +1095,7 @@ static int changed_zone_list(int argc, char **argv, struct command *acmd, struct
 	const char *rae = "retain an asynchronous event";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	_cleanup_nvme_transport_handle_ struct libnvme_transport_handle *hdl = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	struct nvme_zns_changed_zone_log log;
 	nvme_print_flags_t flags;
 	int err = -1;

--- a/unit/test-argconfig-parse.c
+++ b/unit/test-argconfig-parse.c
@@ -189,7 +189,7 @@ const struct comma_sep_array_test comma_sep_array_tests[] = {
 
 void comma_sep_array_test(const struct comma_sep_array_test *test)
 {
-	_cleanup_free_ char *input = strdup(test->input);
+	__cleanup_free char *input = strdup(test->input);
 	__u32 values[COMMA_SEP_ARRAY_MAX_VALUES] = {};
 	int ret = argconfig_parse_comma_sep_array_u32(
 		input, values, COMMA_SEP_ARRAY_MAX_VALUES);

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -303,8 +303,8 @@ static bool argconfig_check_human_readable(struct argconfig_commandline_options 
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		    struct argconfig_commandline_options *options)
 {
-	_cleanup_free_ char *short_opts = NULL;
-	_cleanup_free_ struct option *long_opts = NULL;
+	__cleanup_free char *short_opts = NULL;
+	__cleanup_free struct option *long_opts = NULL;
 	struct argconfig_commandline_options *s;
 	int c, option_index = 0, short_index = 0, options_count = 0;
 	int ret = 0;

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -40,7 +40,7 @@ static inline void cleanup_nvme_global_ctx(struct libnvme_global_ctx **ctx)
 {
 	libnvme_free_global_ctx(*ctx);
 }
-#define _cleanup_nvme_global_ctx_ __cleanup(cleanup_nvme_global_ctx)
+#define __cleanup_nvme_global_ctx __cleanup(cleanup_nvme_global_ctx)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_nvme_ctrl, libnvme_ctrl_t, libnvme_free_ctrl)
 #define __cleanup_nvme_ctrl __cleanup(cleanup_nvme_ctrl)

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -57,7 +57,7 @@ static inline void cleanup_nvmf_context(struct libnvmf_context **fctx)
 {
 	libnvmf_context_free(*fctx);
 }
-#define _cleanup_nvmf_context_ __cleanup(cleanup_nvmf_context)
+#define __cleanup_nvmf_context __cleanup(cleanup_nvmf_context)
 #endif
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -34,7 +34,7 @@ static inline void cleanup_fd(int *fd)
 	if (*fd > STDERR_FILENO)
 		close(*fd);
 }
-#define _cleanup_fd_ __cleanup(cleanup_fd)
+#define __cleanup_fd __cleanup(cleanup_fd)
 
 static inline void cleanup_nvme_global_ctx(struct libnvme_global_ctx **ctx)
 {

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -43,7 +43,7 @@ static inline void cleanup_nvme_global_ctx(struct libnvme_global_ctx **ctx)
 #define _cleanup_nvme_global_ctx_ __cleanup(cleanup_nvme_global_ctx)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_nvme_ctrl, libnvme_ctrl_t, libnvme_free_ctrl)
-#define _cleanup_nvme_ctrl_ __cleanup(cleanup_nvme_ctrl)
+#define __cleanup_nvme_ctrl __cleanup(cleanup_nvme_ctrl)
 
 #ifdef CONFIG_FABRICS
 static inline void free_uri(struct libnvme_fabrics_uri **uri)

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -61,6 +61,6 @@ static inline void cleanup_nvmf_context(struct libnvmf_context **fctx)
 #endif
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)
-#define _cleanup_file_ __cleanup(cleanup_file)
+#define __cleanup_file __cleanup(cleanup_file)
 
 #endif /* __CLEANUP_H */

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -51,7 +51,7 @@ static inline void free_uri(struct libnvme_fabrics_uri **uri)
 	if (*uri)
 		libnvmf_free_uri(*uri);
 }
-#define _cleanup_uri_ __cleanup(free_uri)
+#define __cleanup_uri __cleanup(free_uri)
 
 static inline void cleanup_nvmf_context(struct libnvmf_context **fctx)
 {

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -25,7 +25,7 @@ static inline void freep(void *p)
 {
 	free(*(void **)p);
 }
-#define _cleanup_free_ __cleanup(freep)
+#define __cleanup_free __cleanup(freep)
 
 #define _cleanup_huge_ __cleanup(nvme_free_huge)
 

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -27,7 +27,7 @@ static inline void freep(void *p)
 }
 #define __cleanup_free __cleanup(freep)
 
-#define _cleanup_huge_ __cleanup(nvme_free_huge)
+#define __cleanup_huge __cleanup(nvme_free_huge)
 
 static inline void cleanup_fd(int *fd)
 {

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -9,7 +9,7 @@
 
 #include "util/mem.h"
 
-#define __cleanup__(fn) __attribute__((cleanup(fn)))
+#define __cleanup(fn) __attribute__((cleanup(fn)))
 
 #define DECLARE_CLEANUP_FUNC(name, type) \
 	void name(type *__p)
@@ -25,25 +25,25 @@ static inline void freep(void *p)
 {
 	free(*(void **)p);
 }
-#define _cleanup_free_ __cleanup__(freep)
+#define _cleanup_free_ __cleanup(freep)
 
-#define _cleanup_huge_ __cleanup__(nvme_free_huge)
+#define _cleanup_huge_ __cleanup(nvme_free_huge)
 
 static inline void cleanup_fd(int *fd)
 {
 	if (*fd > STDERR_FILENO)
 		close(*fd);
 }
-#define _cleanup_fd_ __cleanup__(cleanup_fd)
+#define _cleanup_fd_ __cleanup(cleanup_fd)
 
 static inline void cleanup_nvme_global_ctx(struct libnvme_global_ctx **ctx)
 {
 	libnvme_free_global_ctx(*ctx);
 }
-#define _cleanup_nvme_global_ctx_ __cleanup__(cleanup_nvme_global_ctx)
+#define _cleanup_nvme_global_ctx_ __cleanup(cleanup_nvme_global_ctx)
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_nvme_ctrl, libnvme_ctrl_t, libnvme_free_ctrl)
-#define _cleanup_nvme_ctrl_ __cleanup__(cleanup_nvme_ctrl)
+#define _cleanup_nvme_ctrl_ __cleanup(cleanup_nvme_ctrl)
 
 #ifdef CONFIG_FABRICS
 static inline void free_uri(struct libnvme_fabrics_uri **uri)
@@ -51,16 +51,16 @@ static inline void free_uri(struct libnvme_fabrics_uri **uri)
 	if (*uri)
 		libnvmf_free_uri(*uri);
 }
-#define _cleanup_uri_ __cleanup__(free_uri)
+#define _cleanup_uri_ __cleanup(free_uri)
 
 static inline void cleanup_nvmf_context(struct libnvmf_context **fctx)
 {
 	libnvmf_context_free(*fctx);
 }
-#define _cleanup_nvmf_context_ __cleanup__(cleanup_nvmf_context)
+#define _cleanup_nvmf_context_ __cleanup(cleanup_nvmf_context)
 #endif
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)
-#define _cleanup_file_ __cleanup__(cleanup_file)
+#define _cleanup_file_ __cleanup(cleanup_file)
 
 #endif /* __CLEANUP_H */

--- a/util/json.c
+++ b/util/json.c
@@ -92,7 +92,7 @@ void json_object_add_byte_array(struct json_object *o, const char *k, unsigned c
 {
 	int i;
 
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 
 	if (!buf || !len) {
 		json_object_add_value_string(o, k, "No information provided");
@@ -139,7 +139,7 @@ void json_object_add_0nprix64(struct json_object *o, const char *k, uint64_t v, 
 
 void json_object_add_string(struct json_object *o, const char *k, const char *format, ...)
 {
-	_cleanup_free_ char *value = NULL;
+	__cleanup_free char *value = NULL;
 	va_list ap;
 
 	va_start(ap, format);


### PR DESCRIPTION
Follow the new naming pattern of the compiler attributes which is just `__NAME`. This is what the kernel is using as well and started also using in `compiler_attributes.h`
