### PR TITLE
min: Cleaned up usage of MIN in favor of safer CCAN min.

### DIFF
--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -19,8 +19,6 @@
 #include "private.h"
 #include "compiler_attributes.h"
 
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-
 static __u8 csum(const __u8 *buffer, ssize_t length)
 {
 	int n;

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -613,7 +613,7 @@ static size_t copy_value(char *buf, size_t buflen, const char *value)
 	 /* Remove trailing " */
 	val_len = strcspn(value, "\"");
 
-	memcpy(buf, value, MIN(val_len, buflen-1));
+	memcpy(buf, value, min(val_len, buflen-1));
 
 	return val_len;
 }
@@ -684,7 +684,7 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 		if (name_len) {
 			/* Append a space */
 			buffer[num_bytes++] = ' ';
-			name_len = MIN(name_len, bufsz);
+			name_len = min(name_len, bufsz);
 			memcpy(&buffer[num_bytes], name, name_len);
 			bufsz -= name_len;
 			num_bytes += name_len;
@@ -693,7 +693,7 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 		if (ver_id_len) {
 			/* Append a space */
 			buffer[num_bytes++] = ' ';
-			ver_id_len = MIN(ver_id_len, bufsz);
+			ver_id_len = min(ver_id_len, bufsz);
 			memcpy(&buffer[num_bytes], ver_id, ver_id_len);
 			bufsz -= ver_id_len;
 			num_bytes += ver_id_len;


### PR DESCRIPTION
Libnvme's util.c uses a combination of CCAN's min from minmax.h and the MIN defined in param.h.  The CCAN implementation has typechecking and is more portable, whereas the param.h definition of MIN only exists on Linux.
- Updating util.c to use CCAN's min implementation consistently.
- Removing unused MIN definition in nbft.c.