### PR TITLE
mi: make private-mi.h include conditional on MI support

### DIFF
--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -24,7 +24,11 @@
 #include "cleanup.h"
 #include "cleanup-linux.h"
 #include "private.h"
+
+#ifdef CONFIG_MI
 #include "private-mi.h"
+#endif
+
 #include "compiler-attributes.h"
 
 static bool libnvme_mi_probe_enabled_default(void)


### PR DESCRIPTION
MI support was made optional, but lib.c still included private-mi.h unconditionally.  Made include contitional based on MI support.