### PR TITLE
mi: fix build with MI support disabled

### DIFF
--- a/libnvme/src/nvme/no-mi.c
+++ b/libnvme/src/nvme/no-mi.c
@@ -10,7 +10,9 @@
 
 #include <libnvme.h>
 
-const char *libnvme_mi_status_to_string(int status)
+#include "compiler-attributes.h"
+
+__public const char *libnvme_mi_status_to_string(int status)
 {
 	return "MI support disabled";
 }

--- a/libnvme/src/nvme/private-mi.h
+++ b/libnvme/src/nvme/private-mi.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#ifdef CONFIG_MI
+
 #include <poll.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -115,6 +117,8 @@ void __libnvme_mi_mctp_set_ops(const struct __mi_mctp_socket_ops *newops);
  * endpoint to use this with these devices should return an error
  */
 #define LIBNVME_QUIRK_CSI_1_NOT_SUPPORTED		(1 << 1)
+
+#endif
 
 int __libnvme_transport_handle_open_mi(struct libnvme_transport_handle *hdl,
 		const char *devname);

--- a/libnvme/test/meson.build
+++ b/libnvme/test/meson.build
@@ -77,29 +77,31 @@ zns = executable(
     ],
 )
 
-mi = executable(
-    'test-mi',
-    ['mi.c', 'utils.c'],
-    dependencies: [
-        config_dep,
-        ccan_dep,
-        libnvme_test_dep,
-    ],
-)
+if want_mi
+    mi = executable(
+        'test-mi',
+        ['mi.c', 'utils.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_test_dep,
+        ],
+    )
 
-test('libnvme - mi', mi)
+    test('libnvme - mi', mi)
 
-mi_mctp = executable(
-    'test-mi-mctp',
-    ['mi-mctp.c', 'utils.c'],
-    dependencies: [
-        config_dep,
-        ccan_dep,
-        libnvme_test_dep,
-    ],
-)
+    mi_mctp = executable(
+        'test-mi-mctp',
+        ['mi-mctp.c', 'utils.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_test_dep,
+        ],
+    )
 
-test('libnvme - mi-mctp', mi_mctp)
+    test('libnvme - mi-mctp', mi_mctp)
+endif
 
 uuid = executable(
     'test-uuid',


### PR DESCRIPTION
MI support was made optional, but building with mi=disabled currently fails.  Fixed build issues and made inclusion of Linux-specific code in private-mi.h conditional on CONFIG_MI.