### PR TITLE
lib: Gave blkdev and chardev checks platform agnostic names.

### DIFF
--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -181,10 +181,10 @@ LIBNVME_3 {
 		libnvme_subsystem_release_fds;
 		libnvme_transport_handle_get_fd;
 		libnvme_transport_handle_get_name;
-		libnvme_transport_handle_is_blkdev;
-		libnvme_transport_handle_is_chardev;
+		libnvme_transport_handle_is_ctrl;
 		libnvme_transport_handle_is_direct;
 		libnvme_transport_handle_is_mi;
+		libnvme_transport_handle_is_ns;
 		libnvme_transport_handle_set_decide_retry;
 		libnvme_transport_handle_set_submit_entry;
 		libnvme_transport_handle_set_submit_exit;

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -291,14 +291,14 @@ __public const char *libnvme_transport_handle_get_name(struct libnvme_transport_
 	return basename(hdl->name);
 }
 
-__public bool libnvme_transport_handle_is_blkdev(struct libnvme_transport_handle *hdl)
-{
-	return S_ISBLK(hdl->stat.st_mode);
-}
-
-__public bool libnvme_transport_handle_is_chardev(struct libnvme_transport_handle *hdl)
+__public bool libnvme_transport_handle_is_ctrl(struct libnvme_transport_handle *hdl)
 {
 	return S_ISCHR(hdl->stat.st_mode);
+}
+
+__public bool libnvme_transport_handle_is_ns(struct libnvme_transport_handle *hdl)
+{
+	return S_ISBLK(hdl->stat.st_mode);
 }
 
 __public bool libnvme_transport_handle_is_direct(struct libnvme_transport_handle *hdl)

--- a/libnvme/src/nvme/lib.h
+++ b/libnvme/src/nvme/lib.h
@@ -109,29 +109,21 @@ const char *libnvme_transport_handle_get_name(
 		struct libnvme_transport_handle *hdl);
 
 /**
- * libnvme_transport_handle_is_blkdev - Check if transport handle is a
- * block device
+ * libnvme_transport_handle_is_ctrl - Check if transport handle is a
+ * controller device
  * @hdl:	Transport handle
  *
- * Return: Return true if transport handle is a block device, otherwise false.
+ * Return: Return true if transport handle is a controller device,
+ * otherwise false.
  */
-bool libnvme_transport_handle_is_blkdev(struct libnvme_transport_handle *hdl);
-
-/**
- * libnvme_transport_handle_is_chardev - Check if transport handle is a
- * char device
- * @hdl:	Transport handle
- *
- * Return: Return true if transport handle is a char device, otherwise false.
- */
-bool libnvme_transport_handle_is_chardev(struct libnvme_transport_handle *hdl);
+bool libnvme_transport_handle_is_ctrl(struct libnvme_transport_handle *hdl);
 
 /**
  * libnvme_transport_handle_is_direct - Check if transport handle is using IOCTL
  * interface
  * @hdl:	Transport handle
  *
- * Return: Return true if transport handle is using IOCTL itnerface,
+ * Return: Return true if transport handle is using IOCTL interface,
  * otherwise false.
  */
 bool libnvme_transport_handle_is_direct(struct libnvme_transport_handle *hdl);
@@ -145,6 +137,16 @@ bool libnvme_transport_handle_is_direct(struct libnvme_transport_handle *hdl);
  * otherwise false.
  */
 bool libnvme_transport_handle_is_mi(struct libnvme_transport_handle *hdl);
+
+/**
+ * libnvme_transport_handle_is_ns - Check if transport handle is a
+ * namespace device
+ * @hdl:	Transport handle
+ *
+ * Return: Return true if transport handle is a namespace device,
+ * otherwise false.
+ */
+bool libnvme_transport_handle_is_ns(struct libnvme_transport_handle *hdl);
 
 /**
  * libnvme_transport_handle_set_submit_entry() - Install a submit-entry callback

--- a/nvme.c
+++ b/nvme.c
@@ -174,8 +174,8 @@ static struct program nvme = {
 	.name = "nvme",
 	.version = nvme_version_string,
 	.usage = "<command> [<device>] [<args>]",
-	.desc = "The '<device>' may be either an NVMe character "
-		"device (ex: /dev/nvme0), an nvme block device "
+	.desc = "The '<device>' may be either an NVMe controller "
+		"device (ex: /dev/nvme0), an nvme namespace device "
 		"(ex: /dev/nvme0n1), or a mctp address in the form "
 		"mctp:<net>,<eid>[:ctrl-id]",
 	.extensions = &builtin,
@@ -212,7 +212,7 @@ static const char *mo = "management operation";
 static const char *namespace_desired = "desired namespace";
 static const char *namespace_id_optional = "optional namespace attached to controller";
 static const char *nssf = "NVMe Security Specific Field";
-static const char *only_char_dev = "Only character device is allowed";
+static const char *only_ctrl_dev = "Only controller device is allowed";
 static const char *prinfo = "PI and check field";
 static const char *rae = "Retain an Asynchronous Event";
 static const char *raw_directive = "show directive in binary format";
@@ -422,11 +422,11 @@ static int open_fallback_chardev(struct libnvme_global_ctx *ctx,
 	struct libnvme_transport_handle *hdl = *phdl;
 	int err;
 
-	if (libnvme_transport_handle_is_chardev(hdl)) {
+	if (libnvme_transport_handle_is_ctrl(hdl)) {
 		__cleanup_free char *cdev = NULL;
 
 		if (!nsid) {
-			nvme_show_error("char device not supported without --namespace-id");
+			nvme_show_error("controller device not supported without --namespace-id");
 			return -EINVAL;
 		}
 
@@ -1099,8 +1099,8 @@ static int get_effects_log(int argc, char **argv, struct command *acmd, struct p
 
 	if (cfg.csi < 0) {
 		__u64 cap;
-		if (libnvme_transport_handle_is_blkdev(hdl)) {
-			nvme_show_error("Block device isn't allowed without csi");
+		if (libnvme_transport_handle_is_ns(hdl)) {
+			nvme_show_error("Namespace device isn't allowed without csi");
 			return -EINVAL;
 		}
 		bar = mmap_registers(hdl, false);
@@ -3013,8 +3013,8 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 		return err;
 	}
 
-	if (libnvme_transport_handle_is_blkdev(hdl)) {
-		nvme_show_error("%s: a block device opened (dev: %s, nsid: %d)", acmd->name,
+	if (libnvme_transport_handle_is_ns(hdl)) {
+		nvme_show_error("%s: a namespace device opened (dev: %s, nsid: %d)", acmd->name,
 				libnvme_transport_handle_get_name(hdl), cfg.nsid);
 		return -EINVAL;
 	}
@@ -5437,8 +5437,8 @@ static int subsystem_reset(int argc, char **argv, struct command *acmd, struct p
 	if (err)
 		return err;
 
-	if (!libnvme_transport_handle_is_chardev(hdl)) {
-		nvme_show_error(only_char_dev);
+	if (!libnvme_transport_handle_is_ctrl(hdl)) {
+		nvme_show_error(only_ctrl_dev);
 		return -EINVAL;
 	}
 
@@ -5468,8 +5468,8 @@ static int reset(int argc, char **argv, struct command *acmd, struct plugin *plu
 	if (err)
 		return err;
 
-	if (!libnvme_transport_handle_is_chardev(hdl)) {
-		nvme_show_error(only_char_dev);
+	if (!libnvme_transport_handle_is_ctrl(hdl)) {
+		nvme_show_error(only_ctrl_dev);
 		return -EINVAL;
 	}
 
@@ -5497,8 +5497,8 @@ static int ns_rescan(int argc, char **argv, struct command *acmd, struct plugin 
 	if (err)
 		return err;
 
-	if (!libnvme_transport_handle_is_chardev(hdl)) {
-		nvme_show_error(only_char_dev);
+	if (!libnvme_transport_handle_is_ctrl(hdl)) {
+		nvme_show_error(only_ctrl_dev);
 		return -EINVAL;
 	}
 
@@ -5860,8 +5860,8 @@ static int show_registers(int argc, char **argv, struct command *acmd, struct pl
 	if (err)
 		return err;
 
-	if (libnvme_transport_handle_is_blkdev(hdl)) {
-		nvme_show_error(only_char_dev);
+	if (libnvme_transport_handle_is_ns(hdl)) {
+		nvme_show_error(only_ctrl_dev);
 		return -EINVAL;
 	}
 
@@ -6137,8 +6137,8 @@ static int get_register(int argc, char **argv, struct command *acmd, struct plug
 	if (err)
 		return err;
 
-	if (libnvme_transport_handle_is_blkdev(hdl)) {
-		nvme_show_error(only_char_dev);
+	if (libnvme_transport_handle_is_ns(hdl)) {
+		nvme_show_error(only_ctrl_dev);
 		return -EINVAL;
 	}
 
@@ -6441,8 +6441,8 @@ static int set_register(int argc, char **argv, struct command *acmd, struct plug
 	if (err)
 		return err;
 
-	if (libnvme_transport_handle_is_blkdev(hdl)) {
-		nvme_show_error(only_char_dev);
+	if (libnvme_transport_handle_is_ns(hdl)) {
+		nvme_show_error(only_ctrl_dev);
 		return -EINVAL;
 	}
 
@@ -6798,7 +6798,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 
 	printf("Success formatting namespace:%x\n", cfg.namespace_id);
 	if (libnvme_transport_handle_is_direct(hdl) && cfg.lbaf != prev_lbaf) {
-		if (libnvme_transport_handle_is_chardev(hdl)) {
+		if (libnvme_transport_handle_is_ctrl(hdl)) {
 			if (libnvme_rescan_ns(hdl) < 0) {
 				nvme_show_error("failed to rescan namespaces");
 				return -errno;
@@ -6830,7 +6830,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		}
 	}
 	if (libnvme_transport_handle_is_direct(hdl) && cfg.reset &&
-	    libnvme_transport_handle_is_chardev(hdl))
+	    libnvme_transport_handle_is_ctrl(hdl))
 		libnvme_reset_ctrl(hdl);
 
 	return err;

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1417,7 +1417,7 @@ static int nvme_expand_cap(struct libnvme_transport_handle *hdl, __u32 namespace
 		__u8  reserve1[5];
 	} __packed;
 
-	if (libnvme_transport_handle_is_chardev(hdl))
+	if (libnvme_transport_handle_is_ctrl(hdl))
 		snprintf(dev_name, 32, "%sn%u", libnvme_transport_handle_get_name(hdl), namespace_id);
 	else
 		strcpy(dev_name, libnvme_transport_handle_get_name(hdl));
@@ -1507,8 +1507,8 @@ static int sfx_expand_cap(int argc, char **argv, struct command *acmd, struct pl
 		return err;
 
 	if (cfg.namespace_id == NVME_NSID_ALL) {
-		if (libnvme_transport_handle_is_chardev(hdl)) {
-			fprintf(stderr, "namespace_id or blk device required\n");
+		if (libnvme_transport_handle_is_ctrl(hdl)) {
+			fprintf(stderr, "namespace_id or namespace device required\n");
 			return -EINVAL;
 		} else {
 			cfg.namespace_id = atoi(&libnvme_transport_handle_get_name(hdl)[strlen(libnvme_transport_handle_get_name(hdl)) - 1]);

--- a/plugins/sed/sed.c
+++ b/plugins/sed/sed.c
@@ -63,7 +63,7 @@ OPT_ARGS(discovery_opts) = {
 
 /*
  * Open the NVMe device specified on the command line. It must be the
- * NVMe block device (e.g. /dev/nvme0n1).
+ * NVMe namespace device (e.g. /dev/nvme0n1).
  */
 static int sed_opal_open_device(struct libnvme_global_ctx **ctx, struct libnvme_transport_handle **hdl, int argc, char **argv,
 		const char *desc, struct argconfig_commandline_options *opts)
@@ -74,9 +74,10 @@ static int sed_opal_open_device(struct libnvme_global_ctx **ctx, struct libnvme_
 	if (err)
 		return err;
 
-	if (!libnvme_transport_handle_is_blkdev(*hdl)) {
+	if (!libnvme_transport_handle_is_ns(*hdl)) {
 		fprintf(stderr,
-			"ERROR : The NVMe block device must be specified\n");
+			"ERROR : The NVMe namespace device (e.g. /dev/nvme0n1) "
+			"must be specified\n");
 		err = -EINVAL;
 	}
 


### PR DESCRIPTION
On Linux, controller devices are character devices, and namespace devices are block devices.  This is not true on platforms like Windows.
- Changed platform-specific libnvme_transport_handle_is_chardev and libnvme_transport_handle_is_blkdev to platform-agnostic libnvme_transport_handle_is_ctrl and libnvme_transport_handle_is_ns. This also helps to make the intent of the checks more clear.
- Changed error messages to use platform-agnostic controller/namespace wording as well.