### PR TITLE
libnvme: make free functions null-pointer safe

### DIFF
--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -110,7 +110,7 @@ PyObject *read_hostid();
 };
 
 %typemap(newfree) struct nvmf_discovery_log * {
-	if ($1) free($1);
+	free($1);
 }
 
 %typemap(out) struct nvmf_discovery_log * {

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -44,8 +44,7 @@ const char *nvmf_dev = "/dev/nvme-fabrics";
 
 static inline void free_uri(struct libnvmf_uri **uri)
 {
-	if (*uri)
-		libnvmf_uri_free(*uri);
+	libnvmf_uri_free(*uri);
 }
 #define __cleanup_uri __cleanup(free_uri)
 
@@ -1517,6 +1516,9 @@ __public int libnvmf_discovery_args_create(struct libnvmf_discovery_args **argsp
 
 __public void libnvmf_discovery_args_free(struct libnvmf_discovery_args *args)
 {
+	if (!args)
+		return;
+
 	free(args);
 }
 
@@ -2642,6 +2644,9 @@ __public int libnvmf_nbft_read_files(struct libnvme_global_ctx *ctx, char *path,
 
 __public void libnvmf_nbft_free(struct libnvme_global_ctx *ctx, struct nbft_file_entry *head)
 {
+	if (!head)
+		return;
+
 	while (head) {
 		struct nbft_file_entry *next = head->next;
 

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -508,6 +508,9 @@ static void __nvme_free_ns(struct libnvme_ns *n)
 /* Stub for SWIG */
 __public void libnvme_free_ns(struct libnvme_ns *n)
 {
+	if (!n)
+		return;
+
 	__nvme_free_ns(n);
 }
 
@@ -552,6 +555,10 @@ __public void libnvme_subsystem_release_fds(struct libnvme_subsystem *s)
  */
 __public void libnvme_free_subsystem(libnvme_subsystem_t s)
 {
+	if (!s)
+		return;
+
+	__nvme_free_subsystem(s);
 }
 
 struct libnvme_subsystem *nvme_alloc_subsystem(struct libnvme_host *h,
@@ -637,6 +644,9 @@ __public void libnvme_host_release_fds(struct libnvme_host *h)
 /* Stub for SWIG */
 __public void libnvme_free_host(struct libnvme_host *h)
 {
+	if (!h)
+		return;
+
 	__libnvme_free_host(h);
 }
 
@@ -831,6 +841,9 @@ __public int libnvme_path_get_queue_depth(libnvme_path_t p)
 
 void nvme_free_path(struct libnvme_path *p)
 {
+	if (!p)
+		return;
+
 	list_del_init(&p->entry);
 	list_del_init(&p->nentry);
 	free(p->name);
@@ -1043,6 +1056,9 @@ static void __libnvme_free_ctrl(libnvme_ctrl_t c)
 
 __public void libnvme_free_ctrl(libnvme_ctrl_t c)
 {
+	if (!c)
+		return;
+
 	__libnvme_free_ctrl(c);
 }
 

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -42,14 +42,16 @@ static inline void cleanup_nvme_global_ctx(struct libnvme_global_ctx **ctx)
 }
 #define __cleanup_nvme_global_ctx __cleanup(cleanup_nvme_global_ctx)
 
-static inline DEFINE_CLEANUP_FUNC(cleanup_nvme_ctrl, libnvme_ctrl_t, libnvme_free_ctrl)
+static inline void cleanup_nvme_ctrl(libnvme_ctrl_t *__p)
+{
+	libnvme_free_ctrl(*__p);
+}
 #define __cleanup_nvme_ctrl __cleanup(cleanup_nvme_ctrl)
 
 #ifdef CONFIG_FABRICS
 static inline void free_uri(struct libnvmf_uri **uri)
 {
-	if (*uri)
-		libnvmf_uri_free(*uri);
+	libnvmf_uri_free(*uri);
 }
 #define __cleanup_uri __cleanup(free_uri)
 


### PR DESCRIPTION
Currently, some free functions check for null pointers, while others do not. Update all free functions to be null-pointer safe.

