### PR TITLE
generate-accessors: fix invalid kdoc banners

### DIFF
--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-/**
+/*
  * This file is part of libnvme.
  *
  * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.

--- a/libnvme/src/nvme/accessors-fabrics.h
+++ b/libnvme/src/nvme/accessors-fabrics.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/**
+/*
  * This file is part of libnvme.
  *
  * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.

--- a/libnvme/src/nvme/accessors.c
+++ b/libnvme/src/nvme/accessors.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-/**
+/*
  * This file is part of libnvme.
  *
  * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.

--- a/libnvme/src/nvme/accessors.h
+++ b/libnvme/src/nvme/accessors.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/**
+/*
  * This file is part of libnvme.
  *
  * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.

--- a/libnvme/tools/generator/generate-accessors.py
+++ b/libnvme/tools/generator/generate-accessors.py
@@ -72,7 +72,7 @@ SPDX_H  = "/* SPDX-License-Identifier: LGPL-2.1-or-later */"
 SPDX_LD = "# SPDX-License-Identifier: LGPL-2.1-or-later"
 
 BANNER = (
-    "/**\n"
+    "/*\n"
     " * This file is part of libnvme.\n"
     " *\n"
     " * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.\n"
@@ -92,7 +92,7 @@ BANNER = (
 )
 
 LD_BANNER = (
-    "/**\n"
+    "/*\n"
     " * This file is part of libnvme.\n"
     " *\n"
     " * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.\n"


### PR DESCRIPTION
The banners are not kdoc documentation, so use normal comment style instead.