### PR TITLE
python: add combat shim for older distros

### DIFF
--- a/libnvme/libnvme/meson.build
+++ b/libnvme/libnvme/meson.build
@@ -6,6 +6,10 @@
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
 if want_python
+    if not cc.has_header_symbol('Python.h', 'Py_NewRef', dependencies: py3_dep)
+       warning('Python < 3.10 detected: providing Py_NewRef compatibility shim')
+    endif
+
     r = run_command(swig, ['-version'], check: true)  # Returns: "\nSWIG Version 4.1.1\n\nCompiled with ..."
     swig_version = r.stdout().split('\n')[1].split()[2].strip()
     if swig_version.version_compare('<4.1.0')

--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -10,6 +10,20 @@
                clashes with the same macro defined in Python.h.
  */
 #undef fallthrough
+
+#include <Python.h>
+
+/*
+ * Py_NewRef was added in Python 3.10; provide a compat shim for
+ * older versions
+ */
+#if PY_VERSION_HEX < 0x030a0000
+static inline PyObject *Py_NewRef(PyObject *obj)
+{
+    Py_INCREF(obj);
+    return obj;
+}
+#endif
 %}
 
 %module(docstring="Python bindings for libnvme") nvme


### PR DESCRIPTION
Newer SWIG started generating Py_NewRef() calls in its own runtime boilerplate, but Py_NewRef wasn't added until Python 3.10. The mismatch hits any distro with SWIG ≥ 4.1 but Python < 3.10.

Suggested-by: Martin Belanger <Martin.Belanger@dell.com>