### PR TITLE
mmap_registers: Made mmap functionality conditional on mmap support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -416,6 +416,8 @@ conf.set(
 
 conf.set('NVME_HAVE_SENDFILE', cc.has_function('sendfile'))
 
+conf.set('NVME_HAVE_MMAP', cc.has_function('mmap'))
+
 project_config_file = 'nvme-config.h'
 nvme_config_h = configure_file(output: project_config_file, configuration: conf)
 config_dep = declare_dependency(

--- a/nvme.c
+++ b/nvme.c
@@ -41,8 +41,11 @@
 
 #include <linux/fs.h>
 
-#include <sys/ioctl.h>
+#ifdef NVME_HAVE_MMAP
 #include <sys/mman.h>
+#endif
+
+#include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -257,6 +260,7 @@ struct nvme_args nvme_args = {
 };
 
 static void *mmap_registers(struct libnvme_transport_handle *hdl, bool writable);
+static int munmap_registers(void *addr);
 
 static OPT_VALS(feature_name) = {
 	VAL_BYTE("arbitration", NVME_FEAT_FID_ARBITRATION),
@@ -1107,7 +1111,7 @@ static int get_effects_log(int argc, char **argv, struct command *acmd, struct p
 
 		if (bar) {
 			cap = mmio_read64(bar + NVME_REG_CAP);
-			munmap(bar, getpagesize());
+			munmap_registers(bar);
 		} else {
 			nvme_init_get_property(&cmd, NVME_REG_CAP);
 			err = libnvme_submit_admin_passthru(hdl, &cmd);
@@ -5802,8 +5806,9 @@ static int nvme_get_properties(struct libnvme_transport_handle *hdl, void **pbar
 
 static void *mmap_registers(struct libnvme_transport_handle *hdl, bool writable)
 {
+	void *membase = NULL;
+#ifdef NVME_HAVE_MMAP
 	char path[512];
-	void *membase;
 	int fd;
 	int prot = PROT_READ;
 
@@ -5832,7 +5837,17 @@ static void *mmap_registers(struct libnvme_transport_handle *hdl, bool writable)
 	}
 
 	close(fd);
+#endif
 	return membase;
+}
+
+static int munmap_registers(void *addr)
+{
+#ifdef NVME_HAVE_MMAP
+	return munmap(addr, getpagesize());
+#else
+	return 0;
+#endif
 }
 
 static int show_registers(int argc, char **argv, struct command *acmd, struct plugin *plugin)
@@ -5886,7 +5901,7 @@ static int show_registers(int argc, char **argv, struct command *acmd, struct pl
 	if (cfg.fabrics)
 		free(bar);
 	else
-		munmap(bar, getpagesize());
+		munmap_registers(bar);
 
 	return 0;
 }
@@ -6171,7 +6186,7 @@ static int get_register(int argc, char **argv, struct command *acmd, struct plug
 	if (fabrics)
 		free(bar);
 	else
-		munmap(bar, getpagesize());
+		munmap_registers(bar);
 
 	return err;
 }
@@ -6455,7 +6470,7 @@ static int set_register(int argc, char **argv, struct command *acmd, struct plug
 		err = set_register_names(hdl, bar, opts, &cfg);
 
 	if (bar)
-		munmap(bar, getpagesize());
+		munmap_registers(bar);
 
 	return err;
 }


### PR DESCRIPTION
Bypassed the mmap functionality in mmap_registers if the target platform doesn't support mmap.  Created munmap_registers for conditional unmap usage as well.

Used NVME_HAVE_MMAP to avoid conflict with python's HAVE_MMAP definition when building python wrappers.