### PR TITLE
lib: Added libnvme wrapper for updating block size after format.

### DIFF
--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -189,6 +189,7 @@ LIBNVME_3 {
 		libnvme_transport_handle_set_submit_entry;
 		libnvme_transport_handle_set_submit_exit;
 		libnvme_unlink_ctrl;
+		libnvme_update_block_size;
 		libnvme_update_key;
 		libnvme_uuid_from_string;
 		libnvme_uuid_to_string;

--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -13,6 +13,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <linux/fs.h>
+
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
@@ -90,6 +92,23 @@ __public int libnvme_get_nsid(struct libnvme_transport_handle *hdl, __u32 *nsid)
 		return -errno;
 
 	*nsid = tmp;
+	return 0;
+}
+
+__public int libnvme_update_block_size(struct libnvme_transport_handle *hdl,
+		int block_size)
+{
+	int ret;
+	int fd = libnvme_transport_handle_get_fd(hdl);
+
+	ret = ioctl(fd, BLKBSZSET, &block_size);
+	if (ret < 0)
+		return -errno;
+
+	ret = ioctl(fd, BLKRRPART);
+	if (ret < 0)
+		return -errno;
+
 	return 0;
 }
 

--- a/libnvme/src/nvme/ioctl.h
+++ b/libnvme/src/nvme/ioctl.h
@@ -96,3 +96,16 @@ int libnvme_rescan_ns(struct libnvme_transport_handle *hdl);
  * Return: 0 if @nsid was set successfully or -1 with errno set otherwise.
  */
 int libnvme_get_nsid(struct libnvme_transport_handle *hdl, __u32 *nsid);
+
+/**
+ * libnvme_update_block_size() - Update the block size
+ * @hdl:	Transport handle
+ * @block_size:	New block size
+ *
+ * Notify the kernel blkdev to update its block size after a block size change.
+ * This should only be used for namespace handles, not controllers.
+ *
+ * Return: 0 if the block size was updated or a negative error code otherwise.
+ */
+int libnvme_update_block_size(struct libnvme_transport_handle *hdl,
+		int block_size);

--- a/nvme.c
+++ b/nvme.c
@@ -39,13 +39,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <linux/fs.h>
-
-#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
 
 #include <libnvme.h>
 
@@ -6813,19 +6809,12 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 			 * to the given one because blkdev will not
 			 * update by itself without re-opening fd.
 			 */
-			if (ioctl(libnvme_transport_handle_get_fd(hdl), BLKBSZSET,
-				  &block_size) < 0) {
+			err = libnvme_update_block_size(hdl, block_size);
+			if (err < 0) {
 				nvme_show_error(
 				    "failed to set block size to %d",
 				    block_size);
-				return -errno;
-			}
-
-			if (ioctl(libnvme_transport_handle_get_fd(hdl),
-				  BLKRRPART) < 0) {
-				nvme_show_error(
-				    "failed to re-read partition table");
-				return -errno;
+				return err;
 			}
 		}
 	}


### PR DESCRIPTION
Moved the linux-specific ioctl calls used to update the block size after it is changed by a format command into a wrapper function in libnvme. Consolidates ioctl calls into ioctl.c, and allows for platform-specific implementations in the future as needed.