### PR TITLE
fabrics: do not re-initialize nvmf_args

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -166,7 +166,6 @@ struct nvmf_args {
 
 static void nvmf_default_args(struct nvmf_args *fa)
 {
-	memset(fa, 0, sizeof(*fa));
 	fa->tos = -1;
 	fa->ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO;
 }


### PR DESCRIPTION
The memset clears all other pre-initialized values such as subsysnqn in fabrics_discovery.

Fixes: 72dce2d368af ("fabrics: add missing common arguments to nvmf_args")


bug: `nvme discover` fails when no subsnqnq is provided