### PR TITLE
CI: fix podman device permissions

### DIFF
--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -126,7 +126,7 @@ jobs:
             #command set.
 
             sudo podman run --privileged \
-            --device="${BDEV0}":"${BDEV0}":rwm \
+            -v /dev:/dev \
             -e BDEV0 \
             -v "${PWD}/test.sh":"/test.sh" \
             -v "${PWD}/nvme-cli":"/nvme-cli":z \


### PR DESCRIPTION
The nvme_create_max_ns_test test case is failing to create more than one namespace due to the lack of access permissions in the /dev tree within the test container.

Instead of passing only the default namespace of the testing device to the container we now bind mount the entire /dev tree, giving the container access to all devices within the test VM.