### PR TITLE
swig: guard against silent attribute typos on SWIG objects

### DIFF
--- a/libnvme/libnvme/meson.build
+++ b/libnvme/libnvme/meson.build
@@ -84,6 +84,7 @@ if want_python
         [ 'sigsegv-during-gc', [ files('tests/gc.py'), ] ],
         [ 'read-nbft-file', [ files('tests/test-nbft.py'), '--filename', join_paths(meson.current_source_dir(), 'tests', 'NBFT') ] ],
         [ 'object-properties-and-errors', [ files('tests/test-objects.py'), ] ],
+        [ 'setattr-guards', [ files('tests/test-setattr.py'), ] ],
     ]
     foreach test: py_tests
         description = test[0]

--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -105,6 +105,14 @@ static inline PyObject *Py_NewRef(PyObject *obj)
 		cfg = libnvmf_context_get_fabrics_config(fctx);
 
 		while (PyDict_Next(dict, &pos, &key, &value)) {
+			/* Already consumed above via dict_get_str() */
+			if (!PyUnicode_CompareWithASCIIString(key, "subsysnqn") ||
+			    !PyUnicode_CompareWithASCIIString(key, "transport") ||
+			    !PyUnicode_CompareWithASCIIString(key, "traddr") ||
+			    !PyUnicode_CompareWithASCIIString(key, "trsvcid") ||
+			    !PyUnicode_CompareWithASCIIString(key, "host_traddr") ||
+			    !PyUnicode_CompareWithASCIIString(key, "host_iface"))
+				continue;
 			if (!PyUnicode_CompareWithASCIIString(key, "queue_size")) {
 				libnvme_fabrics_config_set_queue_size(cfg, PyLong_AsLong(value));
 				continue;
@@ -216,7 +224,8 @@ static inline PyObject *Py_NewRef(PyObject *obj)
 				has_persistent = true;
 				continue;
 			}
-			/* Unknown keys are silently ignored */
+			PyErr_Format(PyExc_KeyError, "unknown ctrl config key: '%U'", key);
+			return -1;
 		}
 
 		if (hostnqn || hostid)
@@ -686,6 +695,20 @@ struct libnvme_ns {
 	    while h:
 	        yield h
 	        h = libnvme_next_host(self, h)
+	def __setattr__(self, name, value):
+	    if name == 'this' or name.startswith('_'):
+	        object.__setattr__(self, name, value)
+	        return
+	    for klass in type(self).__mro__:
+	        attr = klass.__dict__.get(name)
+	        if attr is not None:
+	            if isinstance(attr, property) and attr.fset is not None:
+	                attr.fset(self, value)
+	                return
+	            break
+	    raise AttributeError(
+	        f"'{type(self).__name__}' object has no writable attribute '{name}'"
+	    )
 	%}
 	void refresh_topology() {
 		libnvme_refresh_topology($self);
@@ -750,6 +773,20 @@ struct libnvme_ns {
 	    while s:
 	        yield s
 	        s = libnvme_next_subsystem(self, s)
+	def __setattr__(self, name, value):
+	    if name == 'this' or name.startswith('_'):
+	        object.__setattr__(self, name, value)
+	        return
+	    for klass in type(self).__mro__:
+	        attr = klass.__dict__.get(name)
+	        if attr is not None:
+	            if isinstance(attr, property) and attr.fset is not None:
+	                attr.fset(self, value)
+	                return
+	            break
+	    raise AttributeError(
+	        f"'{type(self).__name__}' object has no writable attribute '{name}'"
+	    )
 	%}
 }
 
@@ -806,6 +843,20 @@ struct libnvme_ns {
 	    while ns:
 	        yield ns
 	        ns = libnvme_subsystem_next_ns(self, ns)
+	def __setattr__(self, name, value):
+	    if name == 'this' or name.startswith('_'):
+	        object.__setattr__(self, name, value)
+	        return
+	    for klass in type(self).__mro__:
+	        attr = klass.__dict__.get(name)
+	        if attr is not None:
+	            if isinstance(attr, property) and attr.fset is not None:
+	                attr.fset(self, value)
+	                return
+	            break
+	    raise AttributeError(
+	        f"'{type(self).__name__}' object has no writable attribute '{name}'"
+	    )
 	%}
 	%immutable name;
 	const char *name;
@@ -1035,6 +1086,20 @@ struct libnvme_ns {
 	    while ns:
 	        yield ns
 	        ns = libnvme_ctrl_next_ns(self, ns)
+	def __setattr__(self, name, value):
+	    if name == 'this' or name.startswith('_'):
+	        object.__setattr__(self, name, value)
+	        return
+	    for klass in type(self).__mro__:
+	        attr = klass.__dict__.get(name)
+	        if attr is not None:
+	            if isinstance(attr, property) and attr.fset is not None:
+	                attr.fset(self, value)
+	                return
+	            break
+	    raise AttributeError(
+	        f"'{type(self).__name__}' object has no writable attribute '{name}'"
+	    )
 	%}
 }
 

--- a/libnvme/libnvme/tests/test-setattr.py
+++ b/libnvme/libnvme/tests/test-setattr.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# This file is part of libnvme.
+# Copyright (c) 2026, Dell Technologies Inc. or its subsidiaries.
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+"""Tests that __setattr__ guards on SWIG-generated classes raise on bad names."""
+
+import unittest
+from libnvme import nvme
+
+
+class TestCtrlSetattr(unittest.TestCase):
+
+    def setUp(self):
+        self.ctx = nvme.global_ctx()
+        self.ctrl = nvme.ctrl(self.ctx, {
+            'subsysnqn': nvme.NVME_DISC_SUBSYS_NAME,
+            'transport': 'loop',
+        })
+
+    def test_valid_writable_property(self):
+        """Writing a valid writable property must not raise."""
+        self.ctrl.discovery_ctrl = True
+
+    def test_typo_raises(self):
+        """A typo in a property name must raise AttributeError immediately."""
+        with self.assertRaises(AttributeError):
+            self.ctrl.dhchap_key = 'somekey'   # correct name is dhchap_ctrl_key
+
+    def test_readonly_raises(self):
+        """Writing a read-only (%immutable) property must raise AttributeError."""
+        with self.assertRaises(AttributeError):
+            self.ctrl.transport = 'tcp'
+
+    def test_unknown_attr_raises(self):
+        """A completely unknown attribute name must raise AttributeError."""
+        with self.assertRaises(AttributeError):
+            self.ctrl.does_not_exist = 42
+
+
+class TestCtrlDictValidation(unittest.TestCase):
+
+    def setUp(self):
+        self.ctx = nvme.global_ctx()
+
+    def test_unknown_dict_key_raises(self):
+        """An unknown key in the constructor dict must raise KeyError."""
+        with self.assertRaises(KeyError):
+            nvme.ctrl(self.ctx, {
+                'subsysnqn': nvme.NVME_DISC_SUBSYS_NAME,
+                'transport': 'loop',
+                'typo_key': 'value',
+            })
+
+    def test_missing_required_key_raises(self):
+        """Omitting a required key (subsysnqn or transport) must raise KeyError."""
+        with self.assertRaises(KeyError):
+            nvme.ctrl(self.ctx, {'transport': 'loop'})
+        with self.assertRaises(KeyError):
+            nvme.ctrl(self.ctx, {'subsysnqn': nvme.NVME_DISC_SUBSYS_NAME})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Problem

SWIG-generated Python classes allow assigning arbitrary attributes on instances. A caller writing:

```python
ctrl.dhchap_key = x        # typo — correct name is dhchap_ctrl_key
```
silently creates a new Python instance attribute instead of calling the C-level property setter. The value is discarded and the bug is invisible at runtime. This has already caused a real bug in `nvme-stas` where `dhchap_key` was written instead of `dhchap_ctrl_key`, meaning the controller DHCHAP key was never actually set. What actually happened is that the property `dhchap_key` had been renamed to `dhchap_ctrl_key` in libnvme's python bindings, but had not been changed in `nvme-stas` causing a silent failure.

The same silent-failure applies to the ctrl constructor dict: a typo in a key such as `subsysnqn_typo` was previously ignored without error.

**Changes**

#### `libnvme/libnvme/nvme.i`

Add a `__setattr__` guard (via `%pythoncode`) to four classes:
`libnvme_global_ctx`, `libnvme_host`, `libnvme_subsystem`, and `libnvme_ctrl`.

The guard:
- Passes through this (SWIG's raw C pointer) and `_`-prefixed names (GC-anchoring refs set by `%pythonappend` blocks such as `self.__host`) via `object.__setattr__`, bypassing property lookup.
- Walks the MRO to find a `property` with an `fset` and calls it directly, equivalent to Python's default machinery but without allowing fallback to instance-dict creation.
- Raises `AttributeError` for everything else — covering both unknown names and `%immutable` properties (which have no `fset`).

Note: `thisown` has an `fset`, so it is handled correctly by the MRO walk without any special case.

In `set_fctx_from_dict()`, replace the silent fall-through at the end of the key-dispatch `while` loop with a `PyErr_Format(PyExc_KeyError) - return -1`. Every known key already hits `continue`; any key that falls through is therefore unknown. This avoids a second pass over the dict.

#### `libnvme/libnvme/tests/test-setattr.py` (new file)

Six test cases:
- Valid writable property assignment does not raise.
- Typo on a property name raises `AttributeError` immediately.
- Assignment to a `%immutable` (read-only) property raises `AttributeError`.
- Completely unknown attribute name raises `AttributeError`.
- Unknown key in the constructor dict raises `KeyError`.
- Missing required key (`subsysnqn` or `transport`) raises `KeyError`.

Testing
```bash
meson test -C .build
```