### PR TITLE
libnvme: move fabrics-only helpers to util-fabrics.c

### DIFF
--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -44,6 +44,7 @@ if want_fabrics
         'nvme/accessors-fabrics.c',
         'nvme/fabrics.c',
         'nvme/nbft.c',
+        'nvme/util-fabrics.c',
     ]
     headers += [
         'nvme/accessors-fabrics.h',

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1542,12 +1542,12 @@ static __u32 nvmf_get_tel(const char *hostsymname)
 	__u16 len;
 
 	/* Host ID is mandatory */
-	tel += nvmf_exat_size(NVME_UUID_LEN);
+	tel += libnvmf_exat_size(NVME_UUID_LEN);
 
 	/* Symbolic name is optional */
 	len = hostsymname ? strlen(hostsymname) : 0;
 	if (len)
-		tel += nvmf_exat_size(len);
+		tel += libnvmf_exat_size(len);
 
 	return tel;
 }
@@ -1586,13 +1586,13 @@ static void nvmf_fill_die(struct nvmf_ext_die *die, struct libnvme_host *h,
 	numexat++;
 	exat = die->exat;
 	exat->exattype = cpu_to_le16(NVMF_EXATTYPE_HOSTID);
-	exat->exatlen  = cpu_to_le16(nvmf_exat_len(NVME_UUID_LEN));
+	exat->exatlen  = cpu_to_le16(libnvmf_exat_len(NVME_UUID_LEN));
 	libnvme_uuid_from_string(h->hostid, exat->exatval);
 
 	/* Extended Attribute for the Symbolic Name (optional) */
 	symname_len = h->hostsymname ? strlen(h->hostsymname) : 0;
 	if (symname_len) {
-		__u16 exatlen = nvmf_exat_len(symname_len);
+		__u16 exatlen = libnvmf_exat_len(symname_len);
 
 		numexat++;
 		exat = libnvmf_exat_ptr_next(exat);

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -7,6 +7,10 @@
  */
 #pragma once
 
+#if defined(HAVE_NETDB) || defined(CONFIG_FABRICS)
+#include <ifaddrs.h>
+#endif
+
 #include <nvme/fabrics.h>
 #include <nvme/tree.h>
 
@@ -105,6 +109,54 @@ struct libnvmf_uri { // !generate-accessors
 	char *query;
 	char *fragment;
 };
+
+/**
+ * libnvmf_exat_len() - Return length rounded up by 4
+ * @val_len: Value length
+ *
+ * Return the size in bytes, rounded to a multiple of 4 (e.g., size of
+ * __u32), of the buffer needed to hold the exat value of size
+ * @val_len.
+ *
+ * Return: Length rounded up by 4
+ */
+static inline __u16 libnvmf_exat_len(size_t val_len)
+{
+	return (__u16)round_up(val_len, sizeof(__u32));
+}
+
+/**
+ * libnvmf_exat_size - Return min aligned size to hold value
+ * @val_len: This is the length of the data to be copied to the "exatval"
+ *           field of a "struct nvmf_ext_attr".
+ *
+ * Return the size of the "struct nvmf_ext_attr" needed to hold
+ * a value of size @val_len.
+ *
+ * Return: The size in bytes, rounded to a multiple of 4 (i.e. size of
+ * __u32), of the "struct nvmf_ext_attr" required to hold a string of
+ * length @val_len.
+ */
+static inline __u16 libnvmf_exat_size(size_t val_len)
+{
+	return (__u16)(sizeof(struct nvmf_ext_attr) + libnvmf_exat_len(val_len));
+}
+
+#if defined(HAVE_NETDB) || defined(CONFIG_FABRICS)
+/**
+ * libnvmf_getifaddrs - Cached wrapper around getifaddrs()
+ * @ctx: pointer to the global context
+ *
+ * On the first call, this function invokes the POSIX getifaddrs()
+ * and caches the result in the global context. Subsequent calls
+ * return the cached data. The caller must NOT call freeifaddrs()
+ * on the returned data. The cache will be freed when the global
+ * context is freed.
+ *
+ * Return: Pointer to I/F data, NULL on error (with errno set).
+ */
+const struct ifaddrs *libnvmf_getifaddrs(struct libnvme_global_ctx *ctx);
+#endif /* HAVE_NETDB || CONFIG_FABRICS */
 
 bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
 		const char *transport, const char *traddr);

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -337,7 +337,7 @@ struct libnvme_global_ctx {
 	bool dry_run;
 #ifdef CONFIG_FABRICS
 	struct libnvme_fabric_options *options;
-	struct ifaddrs *ifaddrs_cache; /* init with libnvme_getifaddrs() */
+	struct ifaddrs *ifaddrs_cache; /* init with libnvmf_getifaddrs() */
 #endif
 
 	enum libnvme_io_uring_state uring_state;
@@ -418,20 +418,6 @@ static inline char *xstrdup(const char *s)
 }
 
 /**
- * libnvme_getifaddrs - Cached wrapper around getifaddrs()
- * @ctx: pointer to the global context
- *
- * On the first call, this function invokes the POSIX getifaddrs()
- * and caches the result in the global context. Subsequent calls
- * return the cached data. The caller must NOT call freeifaddrs()
- * on the returned data. The cache will be freed when the global
- * context is freed.
- *
- * Return: Pointer to I/F data, NULL on error (with errno set).
- */
-const struct ifaddrs *libnvme_getifaddrs(struct libnvme_global_ctx *ctx);
-
-/**
  * libnvme_ipaddrs_eq - Check if 2 IP addresses are equal.
  * @addr1: IP address (can be IPv4 or IPv6)
  * @addr2: IP address (can be IPv4 or IPv6)
@@ -440,6 +426,7 @@ const struct ifaddrs *libnvme_getifaddrs(struct libnvme_global_ctx *ctx);
  */
 bool libnvme_ipaddrs_eq(const char *addr1, const char *addr2);
 
+#if defined(HAVE_NETDB) || defined(CONFIG_FABRICS)
 /**
  * libnvme_iface_matching_addr - Get interface matching @addr
  * @iface_list: Interface list returned by getifaddrs()
@@ -469,6 +456,7 @@ const char *libnvme_iface_matching_addr(const struct ifaddrs *iface_list,
  */
 bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
 		const char *iface, const char *addr);
+#endif /* HAVE_NETDB || CONFIG_FABRICS */
 
 int hostname2traddr(struct libnvme_global_ctx *ctx, const char *traddr,
 		char **hostname);
@@ -551,38 +539,6 @@ char *kv_keymatch(const char *kv, const char *key);
  * usage: int x = round_up(13, sizeof(__u32)); // 13 -> 16
  */
 #define round_up(val, mult)     ((((val)-1) | __round_mask((val), (mult)))+1)
-
-/**
- * nvmf_exat_len() - Return length rounded up by 4
- * @val_len: Value length
- *
- * Return the size in bytes, rounded to a multiple of 4 (e.g., size of
- * __u32), of the buffer needed to hold the exat value of size
- * @val_len.
- *
- * Return: Length rounded up by 4
- */
-static inline __u16 nvmf_exat_len(size_t val_len)
-{
-	return (__u16)round_up(val_len, sizeof(__u32));
-}
-
-/**
- * nvmf_exat_size - Return min aligned size to hold value
- * @val_len: This is the length of the data to be copied to the "exatval"
- *           field of a "struct nvmf_ext_attr".
- *
- * Return the size of the "struct nvmf_ext_attr" needed to hold
- * a value of size @val_len.
- *
- * Return: The size in bytes, rounded to a multiple of 4 (i.e. size of
- * __u32), of the "struct nvmf_ext_attr" required to hold a string of
- * length @val_len.
- */
-static inline __u16 nvmf_exat_size(size_t val_len)
-{
-	return (__u16)(sizeof(struct nvmf_ext_attr) + nvmf_exat_len(val_len));
-}
 
 /**
  * libnvme_ns_get_transport_handle() - Get associated transport handle

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1429,7 +1429,7 @@ static ctrl_match_t _candidate_init(struct libnvme_global_ctx *ctx,
 
 #ifdef CONFIG_FABRICS
 	if (streq0(fctx->transport, "tcp")) {
-		candidate->iface_list = libnvme_getifaddrs(ctx); /* TCP only */
+		candidate->iface_list = libnvmf_getifaddrs(ctx); /* TCP only */
 		candidate->addreq = libnvme_ipaddrs_eq;
 		return _tcp_match_ctrl;
 	}

--- a/libnvme/src/nvme/util-fabrics.c
+++ b/libnvme/src/nvme/util-fabrics.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026, Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ */
+
+#include <ccan/endian/endian.h>
+
+#include <libnvme.h>
+
+#include "compiler-attributes.h"
+#include "private-fabrics.h"
+#include "util.h"
+
+__public struct nvmf_ext_attr *libnvmf_exat_ptr_next(struct nvmf_ext_attr *p)
+{
+	__u16 size = libnvmf_exat_size(le16_to_cpu(p->exatlen));
+
+	return (struct nvmf_ext_attr *)((uintptr_t)p + (ptrdiff_t)size);
+}
+
+const struct ifaddrs *libnvmf_getifaddrs(struct libnvme_global_ctx *ctx)
+{
+	if (!ctx->ifaddrs_cache) {
+		struct ifaddrs *p;
+
+		if (!getifaddrs(&p))
+			ctx->ifaddrs_cache = p;
+	}
+
+	return ctx->ifaddrs_cache;
+}

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -716,12 +716,6 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 	return num_bytes;
 }
 
-__public struct nvmf_ext_attr *libnvmf_exat_ptr_next(struct nvmf_ext_attr *p)
-{
-	return (struct nvmf_ext_attr *)
-		((uintptr_t)p + (ptrdiff_t)nvmf_exat_size(le16_to_cpu(p->exatlen)));
-}
-
 __public const char *libnvme_get_version(enum libnvme_version type)
 {
 	switch(type) {
@@ -938,7 +932,7 @@ bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
 	return match_found;
 }
 
-#else /* HAVE_NETDB */
+#elif defined(CONFIG_FABRICS)
 
 const char *libnvme_iface_matching_addr(const struct ifaddrs *iface_list,
 		const char *addr)
@@ -958,7 +952,7 @@ bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
 	return false;
 }
 
-#endif /* HAVE_NETDB */
+#endif /* HAVE_NETDB || CONFIG_FABRICS */
 
 void *__libnvme_alloc(size_t len)
 {
@@ -985,20 +979,6 @@ void *__libnvme_realloc(void *p, size_t len)
 
 	return result;
 }
-
-#ifdef CONFIG_FABRICS
-const struct ifaddrs *libnvme_getifaddrs(struct libnvme_global_ctx *ctx)
-{
-	if (!ctx->ifaddrs_cache) {
-		struct ifaddrs *p;
-
-		if (!getifaddrs(&p))
-			ctx->ifaddrs_cache = p;
-	}
-
-	return ctx->ifaddrs_cache;
-}
-#endif
 
 /* This used instead of basename() due to behavioral differences between
  * the POSIX and the GNU version. This is the glibc implementation.


### PR DESCRIPTION
## Summary

- `libnvmf_exat_ptr_next()` and `libnvme_getifaddrs()` were compiled unconditionally even in PCIe-only/embedded builds that disable the fabrics layer. This patch moves them to a new `util-fabrics.c` which is only compiled when `want_fabrics` is set (in `meson.build`).
- `libnvme_getifaddrs()` is renamed to `libnvmf_getifaddrs()` to reflect that it is a fabrics-only function (consistent with the `libnvmf_` prefix convention).
- The `nvmf_exat_len()` and `nvmf_exat_size()` static inlines, along with the `libnvmf_getifaddrs()` declaration, are moved from `private.h` to `private-fabrics.h` for the same reason.
- The include guard in `util.c` is simplified from `#if defined(HAVE_NETDB) || defined(CONFIG_FABRICS)` to `#ifdef HAVE_NETDB` now that `CONFIG_FABRICS` is no longer needed there.

This is low-hanging fruit — a small, self-contained first step toward a cleaner fabrics/PCIe separation. More work is needed in `tree.c`, which still contains several `#ifdef CONFIG_FABRICS` blocks (TCP-specific match functions, `libnvme_iface_matching_addr()`, etc.) that belong in a future `tree-fabrics.c`. That follow-up is more invasive and will be handled separately.

## Test plan

- [x] Builds cleanly with `meson setup .build && meson compile -C .build`
- [x] Builds cleanly with fabrics disabled: `meson setup .build -Dfabrics=disabled`
- [x] Unit tests pass: `meson test -C .build`