### PR TITLE
compat (errno): Adds cross-platform compatibility for errno values.

### DIFF
--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -43,6 +43,17 @@
 #define LINE_MAX 2048
 #endif
 
+/* Some error codes aren't defined on all platforms. Use best equivalents. */
+#ifndef EREMOTEIO
+#define EREMOTEIO ENXIO
+#endif
+#ifndef EDQUOT
+#define EDQUOT    ENOSPC
+#endif
+#ifndef ERESTART
+#define ERESTART  EAGAIN
+#endif
+
 /* Source Code Control System, query version of binary with 'what' */
 const char sccsid[] = "@(#)libnvme " GIT_VERSION;
 

--- a/nvme.c
+++ b/nvme.c
@@ -7466,7 +7466,7 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 		 * Keep the I/O commands behavior same as before.
 		 * Since the error returned by drives unsupported.
 		 */
-		return -ENAVAIL;
+		return NVME_SC_INVALID_FIELD;
 
 	pi_size = (pif == NVME_NVM_PIF_16B_GUARD) ? 8 : 16;
 	if (NVME_FLBAS_META_EXT(ns->flbas)) {
@@ -7521,7 +7521,7 @@ static int init_pi_tags(struct libnvme_transport_handle *hdl,
 		 * Keep the I/O commands behavior same as before.
 		 * Since the error returned by drives unsupported.
 		 */
-		return -ENAVAIL;
+		return NVME_SC_INVALID_FIELD;
 
 	if (invalid_tags(lbst, ilbrt, sts, pif))
 		return -EINVAL;
@@ -7637,7 +7637,7 @@ static int write_zeroes(int argc, char **argv,
 
 	err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst, cfg.lbat,
 			   cfg.lbatm);
-	if (err && err != -ENAVAIL)
+	if (err && err != NVME_SC_INVALID_FIELD)
 		return err;
 
 	err = libnvme_exec_io_passthru(hdl, &cmd);
@@ -7980,7 +7980,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 		       cfg.fua, cfg.lr, 0, cfg.dspec, copy->f0);
 	err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst, cfg.lbat,
 		cfg.lbatm);
-	if (err != 0 && err != -ENAVAIL)
+	if (err != 0 && err != NVME_SC_INVALID_FIELD)
 		return err;
 	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
@@ -8819,7 +8819,7 @@ static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		cfg.block_count, control, 0, NULL, 0, NULL, 0);
 	err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst,
 		cfg.lbat, cfg.lbatm);
-	if (err != 0 && err != -ENAVAIL)
+	if (err != 0 && err != NVME_SC_INVALID_FIELD)
 		return err;
 	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {


### PR DESCRIPTION
Some errno values used in the code are only available on Linux. Adds compatible handling of errno values not available on all platforms.
- Substitutes good equivalent errno value for unsupported values used by nvme/util.c when converting status to errno.
- Replaces ENAVAIL usage in nvme.c with a local error code. It is only used internally within nvme.c to signal that an "invalid field" error was returned and should be ignored.