### PR TITLE
lib: fix uninitialized value created by stack allocation

### DIFF
--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -149,7 +149,7 @@ static int __nvme_transport_handle_open_direct(
 	struct libnvme_passthru_cmd dummy = { 0 };
 	__cleanup_free char *path = NULL;
 	char *name;
-	int ret, id, ns;
+	int ret, id, ns = 0;
 	bool c = true;
 
 	name = libnvme_basename(devname);


### PR DESCRIPTION
Valgrind complained of an uninitialized value created by stack allocation warning while running nvme discover:

==8257== Syscall param ioctl(generic) points to uninitialised byte(s)
==8257==    at 0x49E582B: ioctl (in /lib64/libc.so.6)
==8257==    by 0x4876C96: __nvme_transport_handle_open_direct (lib.c:192)
==8257==    by 0x4876C96: libnvme_open (lib.c:258)
==8257==    by 0x488579A: nvmf_create_discovery_ctrl (fabrics.c:2257)
==8257==    by 0x4888372: libnvmf_discovery (fabrics.c:3108)
==8257==    by 0x456FCE: fabrics_discovery (fabrics.c:675)
==8257==    by 0x4451A8: handle_plugin (plugin.c:190)
==8257==    by 0x407F40: main (nvme.c:11330)
==8257==  Address 0x1ffeffeef4 is on thread 1's stack
==8257==  in frame #1, created by libnvme_open (lib.c:230)
==8257==  Uninitialised value was created by a stack allocation
==8257==    at 0x48769E0: libnvme_open (lib.c:230)

Fix the same.