### PR TITLE
fabrics: sanitize traddr & trsvcid handling during connect-all

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2083,6 +2083,8 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 		int tmo = fctx->cfg.keep_alive_tmo;
 		struct libnvmf_context nfctx = *fctx;
 
+		sanitize_discovery_log_entry(c->ctx, e);
+
 		nfctx.subsysnqn = e->subnqn;
 		nfctx.transport = libnvmf_trtype_str(e->trtype);
 		nfctx.traddr = e->traddr;
@@ -2746,6 +2748,8 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context nfctx = *fctx;
 		libnvme_ctrl_t cl;
 		int tmo = fctx->cfg.keep_alive_tmo;
+
+		sanitize_discovery_log_entry(c->ctx, e);
 
 		nfctx.subsysnqn = e->subnqn;
 		nfctx.transport = libnvmf_trtype_str(e->trtype);


### PR DESCRIPTION
During a connect-all using the JSON config file, there are instances where traddr and trsvcid end up with garbage values eventually leading to connect invalid failures:

nvme connect-all -J /usr/local/etc/nvme/config.json.gen.psk.orig -vv ...
connect ctrl, 'nqn=nqn.1992-08.com.netapp:sn.48391d66c0a611ecaaa5d039ea165514:subsystem.subsys_CLIENT116_0,transport=tcp,traddr=▒o,host_traddr=192.168.1.6,trsvcid=4420                            ,hostnqn=nqn.2014-08.org.nvmexpress:uuid:e6550026-173e-4959-ba74-be367844bd8a,hostid=e6550026-173e-4959-ba74-be367844bd8a,dhchap_secret=DHHC-1:01:gTtZdM+d+SjkxHcCcJKuI0OQKEnIJiXFASAlNDQP94FD/lKe:,ctrl_loss_tmo=600,concat'
Failed to write to /dev/nvme-fabrics: Invalid argument
free(): double free detected in tcache 2
Aborted (core dumped)
...