### PR TITLE
compat (fd): Adds cross-platform-compatible file descriptor type

### DIFF
--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -101,7 +101,7 @@ __libnvme_public int libnvme_update_block_size(
 		struct libnvme_transport_handle *hdl, int block_size)
 {
 	int ret;
-	int fd = libnvme_transport_handle_get_fd(hdl);
+	libnvme_fd_t fd = libnvme_transport_handle_get_fd(hdl);
 
 	ret = ioctl(fd, BLKBSZSET, &block_size);
 	if (ret < 0)

--- a/libnvme/src/nvme/lib-types.h
+++ b/libnvme/src/nvme/lib-types.h
@@ -101,3 +101,20 @@ struct libnvme_uring_cmd {
 	__u32	timeout_ms;
 	__u32   rsvd2;
 };
+
+#if defined(_WIN32)
+
+#define WIN32_LEAN_AND_MEAN	/* keeps windows.h from including winsock */
+#include <windows.h>
+
+typedef HANDLE libnvme_fd_t;
+#define LIBNVME_INVALID_FD INVALID_HANDLE_VALUE
+#define LIBNVME_TEST_FD ((HANDLE)0xFD)
+
+#else
+
+typedef int libnvme_fd_t;
+#define LIBNVME_INVALID_FD -1
+#define LIBNVME_TEST_FD 0xFD
+
+#endif

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -250,7 +250,7 @@ __libnvme_public int libnvme_open(
 
 	if (!strncmp(name, "NVME_TEST_FD", 12)) {
 		hdl->type = LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT;
-		hdl->fd = 0xFD;
+		hdl->fd = LIBNVME_TEST_FD;
 
 		if (!strcmp(name, "NVME_TEST_FD64"))
 			hdl->ioctl_admin64 = true;
@@ -294,7 +294,7 @@ __libnvme_public void libnvme_close(struct libnvme_transport_handle *hdl)
 	}
 }
 
-__libnvme_public int libnvme_transport_handle_get_fd(
+__libnvme_public libnvme_fd_t libnvme_transport_handle_get_fd(
 		struct libnvme_transport_handle *hdl)
 {
 	return hdl->fd;

--- a/libnvme/src/nvme/lib.h
+++ b/libnvme/src/nvme/lib.h
@@ -94,9 +94,10 @@ void libnvme_close(struct libnvme_transport_handle *hdl);
  * If the device handle is for a ioctl based device,
  * libnvme_transport_handle_get_fd will return a valid file descriptor.
  *
- * Return: File descriptor for an IOCTL based transport handle, otherwise -1.
+ * Return: File descriptor for an IOCTL based transport handle,
+ * otherwise LIBNVME_INVALID_FD.
  */
-int libnvme_transport_handle_get_fd(struct libnvme_transport_handle *hdl);
+libnvme_fd_t libnvme_transport_handle_get_fd(struct libnvme_transport_handle *hdl);
 
 /**
  * libnvme_transport_handle_get_name - Return name of the device

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -160,7 +160,7 @@ struct libnvme_transport_handle {
 	__u32 timeout;
 
 	/* direct */
-	int fd;
+	libnvme_fd_t fd;
 	struct stat stat;
 	bool ioctl_admin64;
 	bool ioctl_io64;

--- a/libnvme/test/ioctl/ana.c
+++ b/libnvme/test/ioctl/ana.c
@@ -13,7 +13,6 @@
 #include "mock.h"
 #include "util.h"
 
-#define TEST_FD 0xFD
 #define PDU_SIZE NVME_LOG_PAGE_PDU_SIZE
 
 static struct libnvme_transport_handle *test_hdl;
@@ -631,7 +630,7 @@ int main(void)
 	struct libnvme_global_ctx *ctx =
 		libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 
-	set_mock_fd(TEST_FD);
+	set_mock_fd(LIBNVME_TEST_FD);
 	check(!libnvme_open(ctx, "NVME_TEST_FD", &test_hdl),
 	      "opening test link failed");
 

--- a/libnvme/test/ioctl/discovery.c
+++ b/libnvme/test/ioctl/discovery.c
@@ -13,7 +13,6 @@
 #include "mock.h"
 #include "util.h"
 
-#define TEST_FD 0xFD
 #define HEADER_LEN 20
 
 static struct libnvme_transport_handle *test_hdl;
@@ -441,7 +440,7 @@ int main(void)
 	struct libnvme_global_ctx *ctx =
 		libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 
-	set_mock_fd(TEST_FD);
+	set_mock_fd(LIBNVME_TEST_FD);
 	check(!libnvme_open(ctx, "NVME_TEST_FD", &test_hdl),
 	      "opening test link failed");
 

--- a/libnvme/test/ioctl/features.c
+++ b/libnvme/test/ioctl/features.c
@@ -8,7 +8,6 @@
 #include "mock.h"
 #include "util.h"
 
-#define TEST_FD 0xFD
 #define TEST_TIMEOUT 1234
 #define TEST_NSID 0x89ABCDEF
 #define TEST_CDW11 0x11111111
@@ -1625,7 +1624,7 @@ int main(void)
 	struct libnvme_global_ctx *ctx =
 		libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 
-	set_mock_fd(TEST_FD);
+	set_mock_fd(LIBNVME_TEST_FD);
 	check(!libnvme_open(ctx, "NVME_TEST_FD64", &test_hdl),
 	      "opening test link failed");
 

--- a/libnvme/test/ioctl/identify.c
+++ b/libnvme/test/ioctl/identify.c
@@ -8,7 +8,6 @@
 #include "mock.h"
 #include "util.h"
 
-#define TEST_FD 0xFD
 #define TEST_NSID 0x12345678
 #define TEST_NVMSETID 0xABCD
 #define TEST_UUID 123
@@ -647,7 +646,7 @@ int main(void)
 	struct libnvme_global_ctx * ctx =
 		libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 
-	set_mock_fd(TEST_FD);
+	set_mock_fd(LIBNVME_TEST_FD);
 	check(!libnvme_open(ctx, "NVME_TEST_FD", &test_hdl),
 	      "opening test link failed");
 

--- a/libnvme/test/ioctl/logs.c
+++ b/libnvme/test/ioctl/logs.c
@@ -5,7 +5,6 @@
 #include "mock.h"
 #include "util.h"
 
-#define TEST_FD 0xFD
 #define TEST_NSID 0x12345678
 #define TEST_NVMSETID 0xABCD
 #define TEST_CSI NVME_CSI_KV
@@ -1105,7 +1104,7 @@ int main(void)
 	struct libnvme_global_ctx * ctx =
 		libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 
-	set_mock_fd(TEST_FD);
+	set_mock_fd(LIBNVME_TEST_FD);
 	check(!libnvme_open(ctx, "NVME_TEST_FD", &test_hdl),
 	      "opening test link failed");
 

--- a/libnvme/test/ioctl/misc.c
+++ b/libnvme/test/ioctl/misc.c
@@ -8,7 +8,6 @@
 #include "mock.h"
 #include "util.h"
 
-#define TEST_FD 0xFD
 #define TEST_NSID 0x12345678
 #define TEST_CSI NVME_CSI_KV
 #define TEST_COPY_NR 0x12
@@ -1464,7 +1463,7 @@ int main(void)
 	struct libnvme_global_ctx *ctx =
 		libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 
-	set_mock_fd(TEST_FD);
+	set_mock_fd(LIBNVME_TEST_FD);
 	check(!libnvme_open(ctx, "NVME_TEST_FD64", &test_hdl),
 	      "opening test link failed");
 

--- a/libnvme/test/ioctl/mock.c
+++ b/libnvme/test/ioctl/mock.c
@@ -21,7 +21,7 @@ struct mock_cmds {
 	size_t remaining_cmds;
 };
 
-static int mock_fd = -1;
+static libnvme_fd_t mock_fd = LIBNVME_INVALID_FD;
 static struct mock_cmds mock_admin_cmds = {.name = "admin"};
 static struct mock_cmds mock_io_cmds = {.name = "IO"};
 
@@ -39,7 +39,7 @@ static void mock_cmds_done(const struct mock_cmds *mock_cmds)
 	      mock_cmds->remaining_cmds, mock_cmds->name);
 }
 
-void set_mock_fd(int fd)
+void set_mock_fd(libnvme_fd_t fd)
 {
 	mock_fd = fd;
 }
@@ -122,11 +122,11 @@ void end_mock_cmds(void)
 })
 
 #if defined(HAVE_GLIBC_IOCTL) && HAVE_GLIBC_IOCTL == 1
-typedef int (*ioctl_func_t)(int, unsigned long, void *);
-int ioctl(int fd, unsigned long request, ...)
+typedef int (*ioctl_func_t)(libnvme_fd_t, unsigned long, void *);
+int ioctl(libnvme_fd_t fd, unsigned long request, ...)
 #else
-typedef int (*ioctl_func_t)(int, int, void *);
-int ioctl(int fd, int request, ...)
+typedef int (*ioctl_func_t)(libnvme_fd_t, int, void *);
+int ioctl(libnvme_fd_t fd, int request, ...)
 #endif
 {
 	ioctl_func_t real_ioctl = NULL;

--- a/libnvme/test/ioctl/mock.h
+++ b/libnvme/test/ioctl/mock.h
@@ -61,7 +61,7 @@ struct mock_cmd {
  * set_mock_fd() - sets the expected file descriptor for NVMe passthru ioctls()
  * @fd: file descriptor expected to be passed to ioctl()
  */
-void set_mock_fd(int fd);
+void set_mock_fd(libnvme_fd_t fd);
 
 /**
  * set_mock_admin_cmds() - mocks NVMe admin passthru ioctl() invocations

--- a/libnvme/test/ioctl/zns.c
+++ b/libnvme/test/ioctl/zns.c
@@ -7,7 +7,6 @@
 #include "mock.h"
 #include "util.h"
 
-#define TEST_FD 0xFD
 #define TEST_NSID 0x12345678
 #define TEST_SLBA 0xffffffff12345678
 
@@ -165,7 +164,7 @@ int main(void)
 	struct libnvme_global_ctx *ctx =
 		libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 
-	set_mock_fd(TEST_FD);
+	set_mock_fd(LIBNVME_TEST_FD);
 	check(!libnvme_open(ctx, "NVME_TEST_FD", &test_hdl),
 	      "opening test link failed");
 


### PR DESCRIPTION
Creates and uses new libnvme_fd_t to handle differences in file descriptor types across platforms.  Also defines platform-specific values for invalid file descriptors and test file descriptors.