### PR TITLE
json: Enables json printing and ocp plugin without fabrics

### DIFF
--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -79,7 +79,7 @@ else
     sources += 'nvme/no-uring.c'
 endif
 
-if json_c_dep.found()
+if json_c_dep.found() and want_fabrics
     sources += 'nvme/json.c'
 else
     sources += 'nvme/no-json.c'

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ want_nvme = get_option('nvme').disabled() == false
 want_libnvme = get_option('libnvme').disabled() == false
 want_fabrics = get_option('fabrics').disabled() == false and host_system != 'windows'
 want_mi = get_option('mi').disabled() == false and host_system != 'windows'
-want_json_c = get_option('json-c').disabled() == false and want_fabrics
+want_json_c = get_option('json-c').disabled() == false
 want_libkmod = get_option('libkmod').disabled() == false and host_system != 'windows'
 want_tests = get_option('tests') and host_system != 'windows'
 want_examples = get_option('examples') and host_system != 'windows'


### PR DESCRIPTION
Enables non fabrics-specific json functionality like printing and the ocp plugin when json-c is available, even if fabrics is disabled. Only nvme/json.c functionality is excluded when fabrics is disabled.