### PR TITLE
AI docs: add Claude Code project configuration

### DIFF
--- a/.claude/rules/accessor-workflow.md
+++ b/.claude/rules/accessor-workflow.md
@@ -1,0 +1,63 @@
+# Accessor regeneration workflow
+
+libnvme exposes auto-generated getter/setter functions for its opaque structs.
+The generated files are committed to the tree and validated by CI
+(`check-accessors.yml`). They must be kept in sync with `private.h` and
+`private-fabrics.h`.
+
+## When to regenerate
+
+Regenerate whenever a struct annotated with `!generate-accessors` in
+`private.h` or `private-fabrics.h` has a member **added, removed, renamed,
+or has its `!access:` annotation changed**.
+
+## How to regenerate
+
+```shell
+# Regenerate both common and fabrics accessors in one step:
+meson compile -C .build update-accessors
+
+# Or regenerate only one set:
+meson compile -C .build update-common-accessors
+meson compile -C .build update-fabrics-accessors
+```
+
+The script updates `.h` and `.c` files atomically when their content changes.
+
+## Files touched by regeneration
+
+| Target | Input | Generated files |
+|---|---|---|
+| `update-common-accessors` | `libnvme/src/nvme/private.h` | `accessors.h`, `accessors.c`, `accessors.ld` |
+| `update-fabrics-accessors` | `libnvme/src/nvme/private-fabrics.h` | `accessors-fabrics.h`, `accessors-fabrics.c`, `accessors-fabrics.ld` |
+
+## Maintaining the `.ld` version-script files
+
+The `.ld` files are **not** updated automatically — each new exported symbol
+must be placed in the correct ABI version section by hand, because adding a
+symbol to an already-published section would break binary compatibility.
+
+When the generator detects drift it prints:
+```
+WARNING: accessors.ld needs manual attention.
+
+  Symbols to ADD (new version section, e.g. LIBNVME_ACCESSORS_X_Y):
+    libnvme_ctrl_get_new_field
+    libnvme_ctrl_set_new_field
+```
+
+Add the new symbols to a **new** version section that chains the previous one:
+```
+LIBNVME_ACCESSORS_4 {
+    global:
+        libnvme_ctrl_get_new_field;
+        libnvme_ctrl_set_new_field;
+} LIBNVME_ACCESSORS_3;
+```
+
+## Committing
+
+Commit the `private.h` change and the regenerated files together (or as a
+logical pair of commits). Do not commit regenerated files without the
+corresponding struct change, and do not commit the struct change without
+regenerating first.

--- a/.claude/rules/api-naming.md
+++ b/.claude/rules/api-naming.md
@@ -1,0 +1,33 @@
+# libnvme API naming conventions
+
+## Spec-mirroring definitions — `nvme_` / `nvmf_`
+
+Types, structs, and enums that directly mirror the NVMe specification use the
+short prefixes `nvme_` (base spec) and `nvmf_` (NVMe-oF spec). These live in
+`libnvme/src/nvme/types.h` and `libnvme/src/nvme/cmds.h` and are
+**data-layout definitions**, not library API.
+
+## Public library API — `libnvme_` / `libnvmf_`
+
+Every public symbol exported from `libnvme.so` must use one of these prefixes:
+
+| Prefix | Scope | Examples |
+|--------|-------|---------|
+| `libnvme_` | Common NVMe (PCIe **and** NVMe-oF) | `libnvme_open()`, `libnvme_first_host()`, `libnvme_ctrl_identify()` |
+| `libnvmf_` | NVMe-oF only (fabrics transport, discovery, connect) | `libnvmf_connect_ctrl()`, `libnvmf_get_discovery_log()` |
+
+**Rule**: choose `libnvmf_` only when the function is meaningless outside an
+NVMe-oF context. When in doubt, prefer `libnvme_`.
+
+The split is enforced by two linker version scripts:
+- `libnvme/src/libnvme.ld` — exports `libnvme_*` symbols
+- `libnvme/src/libnvmf.ld` — exports `libnvmf_*` symbols
+
+New public symbols must be added to the appropriate `.ld` file under a new
+version section (see `accessor-workflow.md` for the version-section rules).
+
+## Internal / private functions
+
+Functions that are not exported (used only within libnvme) need no special
+prefix constraint, but by convention use `libnvme_` or `libnvmf_` with a
+leading underscore or by keeping them `static`.

--- a/.claude/rules/commit-messages.md
+++ b/.claude/rules/commit-messages.md
@@ -1,0 +1,49 @@
+# Commit message format
+
+Follow the Linux kernel mailing-list convention used by this project.
+
+## Structure
+
+```
+<subject>: <short summary>
+
+<body — wrap at 72 columns>
+
+Signed-off-by: Full Name <email@example.com>
+Assisted-by: Claude Model <noreply@anthropic.com>   # if AI-assisted
+```
+
+- **Subject prefix**: use the subsystem or file being changed
+  (`libnvme`, `nvme`, `fabrics`, `plugins/ocp`, `doc`, `tests`, …).
+- **Summary line**: imperative mood, lowercase after the colon, no trailing
+  period, ≤ 72 characters total.
+- **Body**: explain *why*, not just *what*. Omit if the summary is
+  self-explanatory for a trivial fix.
+- **Signed-off-by**: required on every commit (Developer Certificate of
+  Origin). Use the author's real name and email.
+- **Assisted-by**: required whenever an AI assistant contributed to the
+  commit (wrote code, generated a patch, drafted the message, etc.).
+  Use the model name and `noreply@anthropic.com` as the address.
+  Examples:
+  - `Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>`
+  - `Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>`
+
+## Example
+
+```
+libnvme: add libnvme_ctrl_get_address() accessor
+
+The ctrl address field is built from multiple sysfs attributes and
+requires custom formatting, so a hand-written getter is provided
+instead of a generated one.
+
+Signed-off-by: Jane Developer <jane@example.com>
+Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+## What to avoid
+
+- Merge commits in a PR branch — rebase instead.
+- Vague summaries like "fix bug" or "update code".
+- Committing generated files (accessors.{h,c}) without also committing
+  the private.h change that triggered the regeneration.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,30 @@
+# Git workflow — commits and PRs
+
+## Never commit or create PRs without explicit user approval
+
+Claude must **never** run `git commit`, `git push`, or `gh pr create`
+autonomously. Always stop and ask the user before taking any of these actions,
+even if the user has said "go ahead" for earlier steps in the same session.
+
+This applies to:
+- `git commit` (any form, including `--amend`)
+- `git push` (any form, including `--force`)
+- `gh pr create` / `gh pr edit`
+- Any other command that writes to the remote repository or creates/modifies
+  a GitHub object (issues, PR comments, labels, etc.)
+
+## Correct behaviour
+
+When work is ready to commit or submit:
+1. Show the user a `git diff --stat` or the proposed commit message.
+2. **Ask explicitly**: "Shall I commit this?" or "Ready to open the PR —
+   shall I proceed?"
+3. Wait for the user to confirm before running the command.
+
+## PR branch hygiene
+
+When preparing a PR branch:
+- No merge commits — rebase on `master` instead.
+- Every individual commit in the series must build cleanly on its own.
+- Run `meson compile -C .build` (or `./scripts/build.sh`) to verify before
+  declaring the branch ready.

--- a/.claude/rules/license-headers.md
+++ b/.claude/rules/license-headers.md
@@ -1,0 +1,28 @@
+# License headers
+
+This repository contains two components with different licenses. Every new
+source file must carry the correct SPDX identifier as its first line.
+
+| Directory / component | License | SPDX identifier |
+|-----------------------|---------|-----------------|
+| `libnvme/` (library) | GNU Lesser General Public License v2.1 or later | `LGPL-2.1-or-later` |
+| `nvme.c`, `nvme.h`, plugins, CLI utilities | GNU General Public License v2.0 or later | `GPL-2.0-or-later` |
+
+## Format
+
+C source and header files:
+```c
+// SPDX-License-Identifier: LGPL-2.1-or-later
+```
+or the block-comment form used by some existing files:
+```c
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+```
+
+Python, shell, and meson files:
+```python
+# SPDX-License-Identifier: LGPL-2.1-or-later
+```
+
+The SPDX line must be the very first line of the file (before any other
+comment or include).

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,17 @@ tests/*.pyc
 dist/
 
 .vscode/
+
+# Claude Code - ignore personal/local overrides
+CLAUDE.local.md
+.claude/settings.local.json
+
+# Claude Code - ignore global session data if ~/.claude is ever inside the project
+.claude/memory/
+.claude/todos/
+
+# Claude Code - the following are intentionally NOT ignored (shared with team)
+# CLAUDE.md
+# .claude/settings.json
+# .claude/commands/
+# .claude/rules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,283 @@
+# nvme-cli — Project Guide for Claude
+
+## Project overview
+
+nvme-cli is the Linux command-line utility for NVM-Express (NVMe) SSDs. As of version 3.x, the libnvme library is fully integrated into this repository (not an external dependency, not a git submodule — the complete source lives in `libnvme/`). The project is dual-licensed: GPL-2.0-only for the CLI and plugins, LGPL-2.1-or-later for libnvme.
+
+Current version: **3.0-a.3** (alpha). Installed to `/usr/local/sbin/nvme` by default.
+
+---
+
+## Repository layout
+
+```
+nvme.c                  Main CLI entry point + built-in command implementations (~11K lines)
+nvme.h                  Top-level public header: nvme_args struct, print flags, NVME_ARGS macro
+nvme-builtin.h          Registry of 118 built-in commands via ENTRY() macros
+nvme-cmds.c/.h          NVMe command/response structs mirroring the spec
+nvme-print-stdout.c     Human-readable output (~7K lines)
+nvme-print-json.c       JSON output (~5.8K lines)
+nvme-print-binary.c     Raw binary output
+nvme-print.h            Print function declarations
+nvme-models.c           Device model database
+fabrics.c/h             NVMe-oF (Fabrics) implementation
+plugin.c/h              Plugin loading, command dispatch, help system
+logging.c/h             Logging infrastructure
+util/                   argconfig, json wrapper, base64, crc32, suffix, table, cleanup, mem
+plugins/                32 vendor plugins (see below)
+libnvme/                Integrated libnvme library (NOT a submodule)
+unit/                   C unit tests (argconfig, suffix, uint128)
+tests/                  Python functional tests (real hardware)
+Documentation/          Man pages in AsciiDoc format
+scripts/                build.sh, release.sh, gen-hostnqn.sh
+ccan/                   Embedded utility library
+nvmf-autoconnect/       Systemd integration for NVMe-oF auto-connect
+completions/            Shell completion files
+.github/workflows/      12 CI workflows
+```
+
+---
+
+## Build system (Meson)
+
+```bash
+meson setup .build              # Configure (default: debugoptimized)
+meson compile -C .build         # Build
+meson test -C .build            # Run unit tests
+meson install -C .build         # Install
+
+# Common option overrides
+meson setup .build -Dplugins=intel,wdc,ocp   # Subset of plugins
+meson setup .build -Ddocs=man                # Build man pages
+meson setup .build -Db_sanitize=address      # AddressSanitizer
+meson setup .build --default-library=static  # Static libnvme
+
+# CI-style build (used by GitHub Actions)
+./scripts/build.sh               # meson + ninja, default settings
+./scripts/build.sh -c clang      # Use clang
+./scripts/build.sh -b release    # Release build type
+
+# Legacy Make wrapper (still supported)
+make && make install
+```
+
+**Key meson_options.txt options:**
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `nvme` | enabled | Build the nvme CLI binary |
+| `libnvme` | enabled | Build libnvme |
+| `fabrics` | enabled | NVMe-oF support; can disable for embedded/PCIe-only builds |
+| `json-c` | auto | Required in practice for all plugins |
+| `openssl` | auto | TLS/auth for NVMe-TCP (requires ≥3.0) |
+| `keyutils` | auto | Key management for NVMe-oF auth |
+| `plugins` | all | Comma-separated list or "all" |
+| `docs` | false | man / html / rst / all |
+| `tests` | true | Build unit tests |
+
+Generated header `nvme-config.h` carries git version string, feature flags (`CONFIG_JSONC`, `CONFIG_OPENSSL`, etc.), and directory paths.
+
+---
+
+## Command and plugin architecture
+
+### Built-in commands
+
+`nvme-builtin.h` lists 118 built-in commands via the X-macro pattern:
+
+```c
+ENTRY("id-ctrl",    "Send NVMe Identify Controller",   id_ctrl)
+ENTRY("smart-log",  "Retrieve SMART / Health Info log", smart_log)
+// ...
+```
+
+The macro expands (in `cmd_handler.h`) through 4 passes to generate:
+1. Function prototypes
+2. `struct command` instances
+3. `commands[]` array
+4. Plugin `struct` + `__attribute__((constructor))` registration
+
+Implementations live in `nvme.c` (most built-ins) and `nvme-cmds.c`.
+
+### Vendor plugins
+
+32 plugins under `plugins/<name>/`:
+
+```
+amzn  dapustor  dell  dera  fdp  feat  huawei  ibm  innogrit  inspur  intel
+lm  mangoboost  memblaze  micron  nbft  netapp  nvidia  ocp  sandisk
+scaleflux  seagate  sed  shannon  solidigm  ssstc  toshiba  transcend
+virtium  wdc  ymtc  zns
+```
+
+Each plugin is two files:
+- `{name}-nvme.h` — PLUGIN / COMMAND_LIST / ENTRY macro declarations
+- `{name}-nvme.c` — `#define CREATE_CMD` then `#include "{name}-nvme.h"` + implementations
+
+Plugins are linked statically (not dlopen). Each plugin's constructor calls `register_extension(&plugin)`.
+
+Command callback signature:
+```c
+int cmd_func(int argc, char **argv, struct command *acmd, struct plugin *plugin);
+```
+
+### Adding a new built-in command
+
+1. Add `ENTRY("name", "help text", function_name)` to `nvme-builtin.h`
+2. Implement `static int function_name(int argc, char **argv, struct command *cmd, struct plugin *plugin)` in `nvme.c`
+3. Declare local option struct, use `NVME_ARGS(opts, ...)` for standard args + extras
+4. Call `argconfig_parse(argc, argv, desc, opts)` to parse
+5. Use libnvme functions for device interaction
+6. Use `nvme_print_*` / `json_*` for output
+
+### Adding a vendor plugin
+
+1. Create `plugins/{vendor}/{vendor}-nvme.h` — PLUGIN/COMMAND_LIST/ENTRY
+2. Create `plugins/{vendor}/{vendor}-nvme.c` — `#define CREATE_CMD`, `#include "{vendor}-nvme.h"`, implementations
+3. Add plugin name to `meson_options.txt` choices list
+4. Add to `plugins/meson.build`
+
+---
+
+## Argument parsing (util/argconfig.h)
+
+Options are declared as arrays of `struct argconfig_commandline_options` using macros:
+
+```c
+OPT_FLAG("verbose",      'v', &cfg.verbose,      "increase verbosity")
+OPT_UINT("namespace-id", 'n', &cfg.namespace_id, "namespace identifier")
+OPT_STRING("input-file", 'i', "FILE", &cfg.input_file, "input file path")
+OPT_SUFFIX("data-len",   'z', &cfg.data_len,     "data length (supports suffixes)")
+OPT_FMT("output-format", 'o', &cfg.output_format,"output format: normal|json|binary")
+OPT_END()
+```
+
+The `NVME_ARGS(opts, ...)` macro auto-injects standard global options:
+- **Before**: `--verbose`/`-v`, `--output-format`/`-o`
+- **After**: `--timeout`, `--dry-run`, `--no-retries`, `--no-ioctl-probing`, `--output-format-version`
+
+---
+
+## Output / print flags
+
+```c
+enum nvme_print_flags {
+    NORMAL  = 0,
+    VERBOSE = 1 << 0,   // detailed field decoding
+    JSON    = 1 << 1,   // JSON output
+    VS      = 1 << 2,   // vendor-specific hex dump
+    BINARY  = 1 << 3,   // raw binary
+    TABULAR = 1 << 4,   // aligned table columns
+};
+```
+
+Select output mode with `validate_output_format(cfg.output_format, &flags)`.
+
+---
+
+## Code style
+
+- **Indentation**: tabs (kernel style, 8-space display)
+- **Line length**: 80 characters max (enforced by `.checkpatch.conf`)
+- **Brace style**: Linux kernel — same line for `if`/`for`/`while`, next line for functions
+- **Naming**:
+  - NVMe spec data layout types: `nvme_*`, `nvmf_*`
+  - libnvme public API: `nvme_*` (lib functions), `nvmf_*` (fabrics)
+  - CLI command functions: lowercase snake_case (`id_ctrl`, `smart_log`)
+  - Macros: `UPPER_CASE`
+- **Error handling**: return negative `errno` on error; use `nvme_strerror()` / `perror()`
+- **No `.clang-format`** — kernel style by convention + checkpatch CI enforcement
+- **Cleanup macros**: RAII-like cleanup via `__cleanup_*` macros in `util/cleanup.h`
+
+---
+
+## libnvme (integrated library)
+
+`libnvme/` is **not** a git submodule — it is the full source, maintained in sync with nvme-cli. Key structure:
+
+```
+libnvme/src/nvme/
+  types.h       NVMe spec-mirrored C types
+  cmds.h        Command definitions + send functions
+  lib.h         Public API (device tree, namespaces, paths)
+  accessors.h   Auto-generated getters/setters (do not edit by hand)
+  private.h     Internal structs (used by accessor generator)
+  fabrics.h     NVMe-oF specific API
+  ioctl.h       Raw IOCTL wrappers
+libnvme/src/
+  lib.c         Core implementation
+  ioctl.c       IOCTL implementation
+  fabrics.c     Fabrics/discovery implementation
+  accessors.c   Auto-generated accessor implementations
+libnvme/src/libnvme.ld      Hand-maintained ABI version script
+libnvme/src/nvme/accessors.ld  Auto-generated accessor ABI version script
+```
+
+**Important**: `accessors.h` and `accessors.c` are generated — do not edit by hand. The generator lives in `libnvme/` tree (Python scripts). The CI workflow `check-accessors.yml` validates they are up to date.
+
+**NVMe-oF footprint constraint**: The `fabrics` build option can be disabled for embedded/PCIe-only targets. Anything fabrics-specific must remain in `fabrics.c` / `nvmf-*` files, not bleed into core nvme.c.
+
+---
+
+## Testing
+
+```bash
+# Unit tests (fast, no hardware needed)
+meson test -C .build
+meson test -C .build --verbose
+
+# Functional tests (real hardware, configured in tests/config.json)
+cd tests && pytest
+
+# CI containers (for reproducible builds)
+# Images: ghcr.io/linux-nvme/{debian,fedora,tumbleweed}:latest
+# Cross-build: ghcr.io/linux-nvme/ubuntu-cross-{target}:latest
+```
+
+Unit tests live in `unit/` (C). Functional tests live in `tests/` (Python/pytest).
+
+---
+
+## Documentation
+
+Man pages are in `Documentation/` as AsciiDoc (`.txt`) files. Build with:
+
+```bash
+meson setup .build -Ddocs=man
+meson compile -C .build
+```
+
+Each subcommand should have a corresponding `Documentation/nvme-{cmd}.txt`.
+Plugin commands: `Documentation/nvme-{vendor}-{cmd}.txt`.
+
+---
+
+## CI
+
+12 GitHub Actions workflows. Key ones:
+- **build.yml** — matrix: Debian/Fedora/Tumbleweed × gcc/clang × debug/release
+- **checkpatch.yml** — Linux kernel style (runs on every PR)
+- **coverage.yml** — codecov integration
+- **codeql.yml** — security scanning
+- **check-accessors.yml** — validates accessor generation is current
+
+Pre-built static binary: `https://monom.org/linux-nvme/upload/nvme-cli-latest-x86_64`
+
+---
+
+## Key files quick-reference
+
+| File | Why it matters |
+|------|---------------|
+| `nvme.c` | Main implementation; start here for any built-in command |
+| `nvme-builtin.h` | Command registry; ENTRY() macros → function names |
+| `plugin.c` | Dispatch logic; how argv[1] resolves to a handler |
+| `util/argconfig.h` | All OPT_* macros; how options are declared |
+| `nvme.h` | nvme_args struct, NVME_ARGS macro, print flags |
+| `nvme-print-stdout.c` | Human output; add new print functions here |
+| `nvme-print-json.c` | JSON output counterpart |
+| `libnvme/src/nvme/lib.h` | libnvme public API declarations |
+| `libnvme/src/nvme/types.h` | Spec-mirrored NVMe data types |
+| `meson.build` | Build targets, dependencies, version |
+| `meson_options.txt` | All configurable build knobs |
+| `CONTRIBUTING.md` | Conventions for new commands and plugins |


### PR DESCRIPTION
## Summary

Add project-scoped Claude Code configuration so that AI coding assistants get consistent, accurate context about this repository out of the box. These files are intentionally committed and shared with all contributors — anyone using Claude Code (CLI, IDE extension, or web) will benefit automatically.

### What is added

**`CLAUDE.md`** — a project guide loaded by Claude at the start of every session. Covers:
- Repository layout and key files
- Build system (Meson commands and options)
- Command and plugin architecture
- Argument parsing conventions (`OPT_*` macros, `NVME_ARGS`)
- Output/print flags
- Code style (tabs, 80-column limit, Linux kernel brace style, naming)
- libnvme internals (accessors, ABI version scripts, NVMe-oF footprint)
- Testing and CI overview

**`.claude/rules/`** — five rule files with actionable constraints that go beyond background knowledge:

| File | Content |
|---|---|
| `commit-messages.md` | `<subject>: <summary>` format; `Signed-off-by` requirement; `Assisted-by` tag when AI-assisted |
| `license-headers.md` | `LGPL-2.1-or-later` for `libnvme/`; `GPL-2.0-or-later` for CLI and plugins |
| `api-naming.md` | `libnvme_` vs `libnvmf_` prefix rules and their ABI consequences |
| `accessor-workflow.md` | When and how to regenerate accessors; manual `.ld` version-section rules |
| `git-workflow.md` | Never commit or push without explicit user approval |

**`.gitignore`** — extended to track the shared files above while excluding personal/local overrides that must not be committed:
CLAUDE.local.md
.claude/settings.local.json
.claude/memory/
.claude/todos/

### What is intentionally NOT included

- Personal preferences or per-user settings (`settings.local.json` stays in the parent directory, outside the repo)
- Session data (`memory/`, `todos/`) — ephemeral and user-specific
- Anything that encodes one contributor's workflow over another's