### PR TITLE
tests: skip write-uncor test when not supported

### DIFF
--- a/tests/nvme_writeuncor_test.py
+++ b/tests/nvme_writeuncor_test.py
@@ -30,6 +30,7 @@ NVMe Write Compare Testcae:-
 
 """
 
+from nvme_test import to_decimal
 from nvme_test_io import TestNVMeIO
 
 
@@ -51,6 +52,9 @@ class TestNVMeUncor(TestNVMeIO):
         self.read_file = self.test_log_dir + "/" + self.read_file
         self.create_data_file(self.write_file, self.data_size, "15")
         open(self.read_file, 'a').close()
+        oncs = to_decimal(self.get_id_ctrl_field_value("oncs"))
+        if not oncs & (1 << 1):
+            self.skipTest("write-uncor is not supported by this controller")
 
     def tearDown(self):
         """ Post Section for TestNVMeUncor """


### PR DESCRIPTION
Make the write uncorrected test aware that this feature is not always supported.

Fixes: #3321

And with this fix the test all run on a Qemu controller without faililng:

```
61/80 nvme-cli - nvme_attach_detach_ns_test                              SKIP             0.50s   0 subtests passed
62/80 nvme-cli - nvme_compare_test                                       OK               0.70s   1 subtests passed
63/80 nvme-cli - nvme_create_max_ns_test                                 SKIP             0.51s   0 subtests passed
64/80 nvme-cli - nvme_error_log_test                                     OK               0.51s   1 subtests passed
65/80 nvme-cli - nvme_flush_test                                         OK               0.55s   1 subtests passed
66/80 nvme-cli - nvme_format_test                                        SKIP             0.52s   0 subtests passed
67/80 nvme-cli - nvme_fw_log_test                                        OK               0.51s   1 subtests passed
68/80 nvme-cli - nvme_get_features_test                                  OK               1.09s   1 subtests passed
69/80 nvme-cli - nvme_id_ctrl_test                                       OK               0.54s   1 subtests passed
70/80 nvme-cli - nvme_id_ns_test                                         OK               0.59s   1 subtests passed
71/80 nvme-cli - nvme_read_write_test                                    OK               0.59s   1 subtests passed
72/80 nvme-cli - nvme_smart_log_test                                     OK               0.61s   1 subtests passed
73/80 nvme-cli - nvme_writeuncor_test                                    SKIP             0.57s   0 subtests passed
74/80 nvme-cli - nvme_writezeros_test                                    OK               0.67s   1 subtests passed
75/80 nvme-cli - nvme_copy_test                                          OK               3.67s   3 subtests passed
76/80 nvme-cli - nvme_dsm_test                                           OK               0.54s   1 subtests passed
77/80 nvme-cli - nvme_verify_test                                        SKIP             0.55s   0 subtests passed
78/80 nvme-cli - nvme_lba_status_log_test                                SKIP             0.53s   0 subtests passed
79/80 nvme-cli - nvme_get_lba_status_test                                SKIP             0.56s   0 subtests passed
80/80 nvme-cli - nvme_ctrl_reset_test                                    OK               0.80s   1 subtests passed
```