### PR TITLE
nbft: Moves public nbft methods from libnvme to libnvmf

### DIFF
--- a/libnvme/doc/man/libnvmf_free_nbft.2
+++ b/libnvme/doc/man/libnvmf_free_nbft.2
@@ -1,8 +1,8 @@
-.TH "libnvme_free_nbft" 9 "libnvme_free_nbft" "April 2026" "libnvme API manual" LINUX
+.TH "libnvmf_free_nbft" 9 "libnvmf_free_nbft" "April 2026" "libnvme API manual" LINUX
 .SH NAME
-libnvme_free_nbft \- Free the struct libnbft_info and its contents
+libnvmf_free_nbft \- Free the struct libnbft_info and its contents
 .SH SYNOPSIS
-.B "void" libnvme_free_nbft
+.B "void" libnvmf_free_nbft
 .BI "(struct libnvme_global_ctx *ctx "  ","
 .BI "struct libnbft_info *nbft "  ");"
 .SH ARGUMENTS

--- a/libnvme/doc/man/libnvmf_read_nbft.2
+++ b/libnvme/doc/man/libnvmf_read_nbft.2
@@ -1,8 +1,8 @@
-.TH "libnvme_read_nbft" 9 "libnvme_read_nbft" "April 2026" "libnvme API manual" LINUX
+.TH "libnvmf_read_nbft" 9 "libnvmf_read_nbft" "April 2026" "libnvme API manual" LINUX
 .SH NAME
-libnvme_read_nbft \- Read and parse contents of an ACPI NBFT table
+libnvmf_read_nbft \- Read and parse contents of an ACPI NBFT table
 .SH SYNOPSIS
-.B "int" libnvme_read_nbft
+.B "int" libnvmf_read_nbft
 .BI "(struct libnvme_global_ctx *ctx "  ","
 .BI "struct libnbft_info **nbft "  ","
 .BI "const char *filename "  ");"

--- a/libnvme/doc/rst/nbft.rst
+++ b/libnvme/doc/rst/nbft.rst
@@ -431,7 +431,7 @@
 
 
 
-.. c:function:: int libnvme_read_nbft (struct libnvme_global_ctx *ctx, struct libnbft_info **nbft, const char *filename)
+.. c:function:: int libnvmf_read_nbft (struct libnvme_global_ctx *ctx, struct libnbft_info **nbft, const char *filename)
 
    Read and parse contents of an ACPI NBFT table
 
@@ -449,14 +449,14 @@
 **Description**
 
 Read and parse the specified NBFT file into a struct libnbft_info.
-Free with libnvme_free_nbft().
+Free with libnvmf_free_nbft().
 
 **Return**
 
 0 on success, errno otherwise.
 
 
-.. c:function:: void libnvme_free_nbft (struct libnvme_global_ctx *ctx, struct libnbft_info *nbft)
+.. c:function:: void libnvmf_free_nbft (struct libnvme_global_ctx *ctx, struct libnbft_info *nbft)
 
    Free the struct libnbft_info and its contents
 

--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -495,13 +495,13 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char *filename)
 	PyObject *output;
 	int ret;
 
-	ret = libnvme_read_nbft(ctx, &nbft, filename);
+	ret = libnvmf_read_nbft(ctx, &nbft, filename);
 	if (ret) {
 		Py_RETURN_NONE;
 	}
 
 	output = nbft_to_pydict(nbft);
-	libnvme_free_nbft(ctx, nbft);
+	libnvmf_free_nbft(ctx, nbft);
 	return output;
 }
 %} /* --------- end C implementation block --------- */

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -38,7 +38,6 @@ LIBNVME_3 {
 		libnvme_free_ctrl;
 		libnvme_free_global_ctx;
 		libnvme_free_host;
-		libnvme_free_nbft;
 		libnvme_free_ns;
 		libnvme_free_subsystem;
 		libnvme_gen_dhchap_key;
@@ -178,7 +177,6 @@ LIBNVME_3 {
 		libnvme_read_hostid;
 		libnvme_read_hostnqn;
 		libnvme_read_key;
-		libnvme_read_nbft;
 		libnvme_refresh_topology;
 		libnvme_rescan_ctrl;
 		libnvme_rescan_ns;

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -29,6 +29,7 @@ LIBNVMF_3 {
 		libnvmf_discovery_nbft;
 		libnvmf_eflags_str;
 		libnvmf_exat_ptr_next;
+		libnvmf_free_nbft;
 		libnvmf_get_default_trsvcid;
 		libnvmf_get_discovery_log;
 		libnvmf_is_registration_supported;
@@ -36,6 +37,7 @@ LIBNVMF_3 {
 		libnvmf_nbft_read_files;
 		libnvmf_prtype_str;
 		libnvmf_qptype_str;
+		libnvmf_read_nbft;
 		libnvmf_register_ctrl;
 		libnvmf_sectype_str;
 		libnvmf_subtype_str;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2603,7 +2603,7 @@ __public int libnvmf_nbft_read_files(struct libnvme_global_ctx *ctx, char *path,
 		snprintf(filename, sizeof(filename), "%s/%s", path,
 			dent[i]->d_name);
 
-		ret = libnvme_read_nbft(ctx, &nbft, filename);
+		ret = libnvmf_read_nbft(ctx, &nbft, filename);
 		if (!ret) {
 			struct nbft_file_entry *new;
 
@@ -2633,7 +2633,7 @@ __public void libnvmf_nbft_free(struct libnvme_global_ctx *ctx, struct nbft_file
 	while (head) {
 		struct nbft_file_entry *next = head->next;
 
-		libnvme_free_nbft(ctx, head->nbft);
+		libnvmf_free_nbft(ctx, head->nbft);
 		free(head);
 
 		head = next;

--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -710,7 +710,7 @@ static int parse_raw_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info *n
 	return 0;
 }
 
-__public void libnvme_free_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info *nbft)
+__public void libnvmf_free_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info *nbft)
 {
 	struct libnbft_hfi **hfi;
 	struct libnbft_security **sec;
@@ -736,7 +736,7 @@ __public void libnvme_free_nbft(struct libnvme_global_ctx *ctx, struct libnbft_i
 	free(nbft);
 }
 
-__public int libnvme_read_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info **nbft,
+__public int libnvmf_read_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info **nbft,
 		const char *filename)
 {
 	__u8 *raw_nbft = NULL;
@@ -800,7 +800,7 @@ __public int libnvme_read_nbft(struct libnvme_global_ctx *ctx, struct libnbft_in
 
 	if (parse_raw_nbft(ctx, *nbft)) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to parse %s\n", filename);
-		libnvme_free_nbft(ctx, *nbft);
+		libnvmf_free_nbft(ctx, *nbft);
 		return -EINVAL;
 	}
 	return 0;

--- a/libnvme/src/nvme/nbft.h
+++ b/libnvme/src/nvme/nbft.h
@@ -246,26 +246,26 @@ struct libnbft_info {
 };
 
 /**
- * libnvme_read_nbft() - Read and parse contents of an ACPI NBFT table
+ * libnvmf_read_nbft() - Read and parse contents of an ACPI NBFT table
  *
  * @ctx:      struct libnvme_global_ctx object
  * @nbft:     Parsed NBFT table data.
  * @filename: Filename of the raw NBFT table to read.
  *
  * Read and parse the specified NBFT file into a struct libnbft_info.
- * Free with libnvme_free_nbft().
+ * Free with libnvmf_free_nbft().
  *
  * Return: 0 on success, errno otherwise.
  */
-int libnvme_read_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info **nbft,
+int libnvmf_read_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info **nbft,
 		const char *filename);
 
 /**
- * libnvme_free_nbft() - Free the struct libnbft_info and its contents
+ * libnvmf_free_nbft() - Free the struct libnbft_info and its contents
  * @ctx: struct libnvme_global_ctx object
  * @nbft: Parsed NBFT table data.
  */
-void libnvme_free_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info *nbft);
+void libnvmf_free_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info *nbft);
 
 /**
  * struct nbft_file_entry - Linked list entry for NBFT files

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -10,6 +10,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#if defined(HAVE_NETDB) || defined(CONFIG_FABRICS)
+#include <ifaddrs.h>
+#endif
+
 #include <ccan/list/list.h>
 
 #include "nvme/nvme-types.h"

--- a/libnvme/test/nbft/nbft-dump.c
+++ b/libnvme/test/nbft/nbft-dump.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if (libnvme_read_nbft(ctx, &table, argv[1]) != 0) {
+	if (libnvmf_read_nbft(ctx, &table, argv[1]) != 0) {
 		fprintf(stderr, "Error parsing the NBFT table %s: %m\n",
 			argv[1]);
 		libnvme_free_global_ctx(ctx);
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
 
 	print_nbft(table);
 
-	libnvme_free_nbft(ctx, table);
+	libnvmf_free_nbft(ctx, table);
 	libnvme_free_global_ctx(ctx);
 	return 0;
 }


### PR DESCRIPTION
Fixes check-public-headers test with fabrics disabed.  Since nbft is not included when fabrics is disabled, moves public nbft methods from libnvme.ld to libnvmf.ld and renames them with the libnvmf prefix.

Also fixes build warnings in private.h when building with fabrics disables but netdb available.  Includes ifaddrs in private.h if needed.