### PR TITLE
python bindings: exception hierarchy + PUBLISHING.md

### DIFF
--- a/libnvme/examples/discover-loop.py
+++ b/libnvme/examples/discover-loop.py
@@ -23,16 +23,16 @@ def discover(ctx, host, ctrl, iteration):
 
     try:
         ctrl.connect(host)
-    except Exception as e:
+    except nvme.ConnectError as e:
         print(f'Failed to connect: {e}')
         return
 
     print(f'{ctrl.name} connected to {ctrl.subsystem}')
 
-    slp = ctrl.supported_log_pages()
     try:
+        slp = ctrl.get_supported_log_pages()
         dlp_supp_opts = slp[nvme.NVME_LOG_LID_DISCOVERY] >> 16
-    except (TypeError, IndexError):
+    except (nvme.NvmeError, IndexError, TypeError):
         dlp_supp_opts = 0
 
     print(f"LID {nvme.NVME_LOG_LID_DISCOVERY}h (Discovery), supports: {disc_supp_str(dlp_supp_opts)}")
@@ -40,7 +40,7 @@ def discover(ctx, host, ctrl, iteration):
     try:
         lsp = nvme.NVMF_LOG_DISC_LSP_PLEO if dlp_supp_opts & nvme.NVMF_LOG_DISC_LID_PLEOS else 0
         disc_log = ctrl.discover(lsp=lsp)
-    except Exception as e:
+    except nvme.DiscoverError as e:
         print(f'Failed to discover: {e}')
         return
 
@@ -52,7 +52,7 @@ def discover(ctx, host, ctrl, iteration):
             continue
         print(f'{iteration}: {dlpe["subtype"]} {dlpe["subnqn"]}')
         with nvme.Ctrl(ctx, subsysnqn=dlpe['subnqn'], transport=dlpe['trtype'], traddr=dlpe['traddr'], trsvcid=dlpe['trsvcid']) as new_ctrl:
-            discover(host, new_ctrl, iteration + 1)
+            discover(ctx, host, new_ctrl, iteration + 1)
 
 ctx = nvme.GlobalCtx()
 host = nvme.Host(ctx)

--- a/libnvme/libnvme/PUBLISHING.md
+++ b/libnvme/libnvme/PUBLISHING.md
@@ -1,0 +1,29 @@
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+# Publishing the libnvme PyPI package
+
+Publishing is handled automatically by GitHub Actions workflows — no manual `twine` or `pip` commands are needed.
+
+## What gets published
+
+A **source distribution** (sdist) is published — not a binary wheel. The package contains the full source tree and builds libnvme and the Python bindings on the target machine at install time (via `pyproject.toml`).
+
+## Workflows
+
+### Test PyPI — on every push to `master`
+
+The `libnvme-release-python.yml` workflow runs on every push to `master`. It builds a dev sdist (version derived from `git describe`, e.g. `3.0.dev123`) and publishes it to [TestPyPI](https://test.pypi.org/).
+
+To install from TestPyPI:
+
+```bash
+pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  libnvme==<version>
+```
+
+### PyPI — on release tags
+
+When a tag matching `vX.Y` or `vX.Y.Z` is pushed, the same workflow publishes the release sdist to the official [PyPI](https://pypi.org/) registry.
+
+Publishing uses OIDC (`id-token: write`) — no API token is required.

--- a/libnvme/libnvme/README.md
+++ b/libnvme/libnvme/README.md
@@ -3,6 +3,84 @@
 
 We use [SWIG](http://www.swig.org/) to generate Python bindings for libnvme.
 
+## Classes
+
+Five classes are exposed, matching the NVMe topology:
+
+| Class | Description |
+|---|---|
+| `nvme.GlobalCtx` | Root context. Manages the NVMe device tree and logging. Create one instance per process. |
+| `nvme.Host` | Represents the local host: NQN, host ID, optional symbolic name (symname). |
+| `nvme.Subsystem` | An NVMe subsystem discovered under a host. |
+| `nvme.Ctrl` | An NVMe controller (physical or fabrics). Constructed from a configuration dict. |
+| `nvme.Namespace` | A namespace under a controller. |
+
+All five classes support the context manager protocol (`with` statement) for automatic cleanup.
+
+Topology can be traversed with iterators: `ctx.hosts()`, `host.subsystems()`,
+`subsystem.controllers()`, `ctrl.namespaces()`.
+
+### Ctrl configuration dict
+
+`nvme.Ctrl(ctx, cfg)` accepts a flat dict. Common keys:
+
+| Key | Description |
+|---|---|
+| `subsysnqn` | Subsystem NQN (required) |
+| `transport` | Transport type: `pcie`, `tcp`, `rdma`, `fc`, `loop`, `apple-nvme` (required) |
+| `traddr` | Target address |
+| `trsvcid` | Target service ID (port) |
+| `host_iface` | Local network interface to use |
+| `hostnqn` | Override the host NQN |
+| `hostid` | Override the host ID |
+| `hdr_digest` | Enable header digests (`bool`) |
+| `data_digest` | Enable data digests (`bool`) |
+| `persistent` | Keep the connection alive after the object is released (`bool`) |
+
+### Key Ctrl methods and properties
+
+| Name | Type | Description |
+|---|---|---|
+| `connected` | property | `True` if the controller is currently connected |
+| `registration_supported` | property | `True` if the target supports explicit host registration |
+| `name` | property | Kernel device name (e.g. `nvme0`), or `None` if not connected |
+| `transport`, `traddr`, `trsvcid` | properties | Connection parameters |
+| `connect(host)` | method | Establish the kernel connection |
+| `disconnect()` | method | Tear down the connection |
+| `discover()` | method | Retrieve the discovery log page (discovery controllers only) |
+| `get_supported_log_pages()` | method | Fetch the Supported Log Pages log |
+| `rescan()` | method | Rescan the controller and refresh its namespace list |
+| `registration_control(tas)` | method | Register / deregister / update with the DIM service |
+
+## Exceptions
+
+All libnvme errors are reported through a small exception hierarchy:
+
+```
+NvmeError                  base class — carries .errno (int) and .message (str)
+├── ConnectError            raised by ctrl.connect()
+├── DisconnectError         raised by ctrl.disconnect()
+├── DiscoverError           raised by ctrl.discover()
+└── NotConnectedError       raised when an operation requires a connected controller
+                            (.errno is always 0)
+```
+
+Import them directly from the `nvme` module:
+
+```python
+from libnvme import nvme
+
+try:
+    ctrl.connect(host)
+except nvme.ConnectError as e:
+    print(f"errno={e.errno}, message={e.message}")
+except nvme.NotConnectedError:
+    print("not connected")
+```
+
+`NvmeError` is also raised by `get_supported_log_pages()` and
+`registration_control()` on failure.
+
 ## How to use
 
 ```python
@@ -19,59 +97,75 @@ def disc_supp_str(dlp_supp_opts):
     }
     return [txt for msk, txt in bitmap.items() if dlp_supp_opts & msk]
 
-ctx = nvme.global_ctx()     # This is a singleton
-ctx.log_level('debug')      # Optional: extra debug info
+ctx = nvme.GlobalCtx()
+ctx.log_level('debug')  # Optional: extra debug info
 
-host = nvme.host(ctx)       # This "may be" a singleton.
-subsysnqn  = [string]       # e.g. nvme.NVME_DISC_SUBSYS_NAME, ...
-transport  = [string]       # One of: 'tcp', 'rdma', 'fc', 'loop'.
-traddr     = [IPv4 or IPv6] # e.g. '192.168.10.10', 'fd2e:853b:3cad:e135:506a:65ee:29f2:1b18', ...
-trsvcid    = [string]		# e.g. '8009', '4420', ...
-host_iface = [interface]    # e.g. 'eth1', ens256', ...
-ctrl = nvme.ctrl(ctx, subsysnqn=subsysnqn, transport=transport, traddr=traddr, trsvcid=trsvcid, host_iface=host_iface)
+host = nvme.Host(ctx)
+
+ctrl = nvme.Ctrl(ctx, {
+    'subsysnqn':  '...',    # e.g. nvme.NVME_DISC_SUBSYS_NAME
+    'transport':  '...',    # One of: 'tcp', 'rdma', 'fc', 'loop'
+    'traddr':     '...',    # e.g. '192.168.10.10'
+    'trsvcid':    '...',    # e.g. '8009', '4420'
+    'host_iface': '...',    # e.g. 'eth1', 'ens256'
+    'hdr_digest': True,     # Enable header digests
+    'data_digest': False,   # Disable data digests
+})
 
 try:
-    cfg = {
-        'hdr_digest': True,   # Enable header digests
-        'data_digest': False, # Disable data digests       
-    }
-    ctrl.connect(host, cfg)
+    ctrl.connect(host)
     print(f"connected to {ctrl.name} subsys {ctrl.subsystem.name}")
-except Exception as e:
+except nvme.ConnectError as e:
     sys.exit(f'Failed to connect: {e}')
 
-supported_log_pages = ctrl.supported_log_pages()
 try:
-    # Get the supported options for the Get Discovery Log Page command
-    dlp_supp_opts = supported_log_pages[nvme.NVME_LOG_LID_DISCOVERY] >> 16
-except (TypeError, IndexError):
+    slp = ctrl.get_supported_log_pages()
+    dlp_supp_opts = slp[nvme.NVME_LOG_LID_DISCOVERY] >> 16
+except (nvme.NvmeError, IndexError, TypeError):
     dlp_supp_opts = 0
 
 print(f"LID {nvme.NVME_LOG_LID_DISCOVERY:02x}h (Discovery), supports: {disc_supp_str(dlp_supp_opts)}")
+
 try:
     lsp = nvme.NVMF_LOG_DISC_LSP_PLEO if dlp_supp_opts & nvme.NVMF_LOG_DISC_LID_PLEOS else 0
     log_pages = ctrl.discover(lsp=lsp)
     print(pprint.pformat(log_pages))
-except Exception as e:
+except nvme.DiscoverError as e:
     sys.exit(f'Failed to retrieve log pages: {e}')
 
 try:
     ctrl.disconnect()
-except Exception as e:
+except nvme.DisconnectError as e:
     sys.exit(f'Failed to disconnect: {e}')
-
-ctrl = None
-host = None
-ctx = None
 ```
 
-## Testing PyPI package
+## Installation
 
-Use the following command to test installing the package from TestPyPI before publishing to the official PyPI registry.
+The package is available from most Linux distribution repositories and on PyPI.
+
+**From your distribution (recommended):**
 
 ```bash
-pip install \
-  --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple/ \
-  libnvme==[libnvme-version]
+# Debian / Ubuntu
+apt-get install python3-libnvme
+
+# Fedora
+dnf install python3-libnvme
+
+# openSUSE
+zypper install python3-libnvme
 ```
+
+**From PyPI:**
+
+```bash
+pip install libnvme
+```
+
+> **Note:** The PyPI package is a source distribution — it builds libnvme and
+> the Python bindings directly on your machine. Build dependencies (a C
+> compiler, Meson, Ninja, SWIG, and the libnvme C dependencies) must be
+> present. If any are missing, `pip install` will fail. Installing from your
+> distribution package manager is generally easier and avoids this requirement.
+
+See [PUBLISHING.md](PUBLISHING.md) for instructions on testing and publishing new releases.

--- a/libnvme/libnvme/_exceptions.py
+++ b/libnvme/libnvme/_exceptions.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# This file is part of libnvme.
+# Copyright (c) 2026, Dell Technologies Inc. or its subsidiaries.
+# Authors: Martin Belanger <Martin.Belanger@dell.com>
+
+
+class NvmeError(Exception):
+    """Base class for all libnvme errors.
+
+    Attributes:
+        errno:   OS error number (negative values are stored as-is).
+        message: Human-readable description from libnvme_errno_to_string().
+    """
+    def __init__(self, errno, message):
+        self.errno = errno
+        self.message = message
+        super().__init__(f"[Errno {errno}] {message}")
+
+
+class ConnectError(NvmeError):
+    """Raised when a controller connection attempt fails."""
+
+
+class DisconnectError(NvmeError):
+    """Raised when a controller disconnect attempt fails."""
+
+
+class DiscoverError(NvmeError):
+    """Raised when a discovery log retrieval fails."""
+
+
+class NotConnectedError(NvmeError):
+    """Raised when an operation requires a connected controller but none exists."""
+    def __init__(self, message="Not connected"):
+        super().__init__(0, message)

--- a/libnvme/libnvme/meson.build
+++ b/libnvme/libnvme/meson.build
@@ -60,19 +60,22 @@ if want_python
         },
     )
 
-    # Little hack to copy file __init__.py to the build directory. 
-    # This is needed to create the proper directory layout to run the tests.
-    # It's a hack because we don't really "configure" file __init__.py and we
-    # could simply install directly from the source tree with:
-    #   python3.install_sources(['__init__.py', ], pure:false, subdir:'libnvme')
-    # However, since we need __init__.py in the build directory to run the tests
-    # we resort to this hack to copy it.
-    configure_file(
-        input:  '__init__.py', 
-        output: '__init__.py',
-        configuration: conf,
-        install_dir: python3.get_install_dir(pure: false, subdir: 'libnvme'),
-    )
+    # Little hack to copy a list of files [__init__.py, etc.] to the build
+    # directory. This is needed to create the proper directory layout to run the
+    # tests. It's a hack because we don't really "configure" files and we could
+    # simply install directly from the source tree with:
+    #   python3.install_sources(files, pure:false, subdir:'libnvme')
+    # However, since we need these files in the build directory to run the tests
+    # we resort to this hack to copy them.
+    files = ['__init__.py', '_exceptions.py']
+    foreach file: files
+        configure_file(
+            input:  file,
+            output: file,
+            configuration: conf,
+            install_dir: python3.get_install_dir(pure: false, subdir: 'libnvme'),
+        )
+    endforeach
 
     # Set the PYTHONPATH so that we can run the 
     # tests directly from the build directory.

--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -89,8 +89,22 @@ PyObject *read_hostid();
 
 #define STR_OR_NONE(str) (!(str) ? "None" : str)
 
-static int connect_err = 0;
-static int discover_err = 0;
+static PyObject *NvmeError             = NULL;
+static PyObject *NvmeConnectError      = NULL;
+static PyObject *NvmeDisconnectError   = NULL;
+static PyObject *NvmeDiscoverError     = NULL;
+static PyObject *NvmeNotConnectedError = NULL;
+
+static void raise_nvme(PyObject *cls, int err) {
+	const char *s = libnvme_errno_to_string(err < 0 ? -err : err);
+	PyObject *args = Py_BuildValue("(is)", err, s ? s : "unknown");
+	PyErr_SetObject(cls, args);
+	Py_DECREF(args);
+}
+
+static void raise_not_connected(void) {
+	PyErr_SetString(NvmeNotConnectedError, "Not connected");
+}
 
 static void PyDict_SetItemStringDecRef(PyObject * p, const char *key, PyObject *val) {
 	PyDict_SetItemString(p, key, val); /* Does NOT steal reference to val .. */
@@ -510,6 +524,26 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char * filename)
 }
 %} /* --------- end C implementation block --------- */
 
+%init %{
+	PyObject *_exc = PyImport_ImportModule("libnvme._exceptions");
+	NvmeError             = PyObject_GetAttrString(_exc, "NvmeError");
+	NvmeConnectError      = PyObject_GetAttrString(_exc, "ConnectError");
+	NvmeDisconnectError   = PyObject_GetAttrString(_exc, "DisconnectError");
+	NvmeDiscoverError     = PyObject_GetAttrString(_exc, "DiscoverError");
+	NvmeNotConnectedError = PyObject_GetAttrString(_exc, "NotConnectedError");
+	Py_DECREF(_exc);
+%}
+
+%pythoncode %{
+from libnvme._exceptions import (
+	NvmeError,
+	ConnectError,
+	DisconnectError,
+	DiscoverError,
+	NotConnectedError,
+)
+%}
+
 //##############################################################################
 
 /* All typemaps must be defined before the %include statements below so that
@@ -749,48 +783,21 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char * filename)
 %include "accessors.i"
 %include "accessors-fabrics.i"
 
+/* Propagate any Python exception set inside the helper function.
+ * raise_nvme() sets the exception; SWIG_fail jumps to the fail: label
+ * in the wrapper (not in the extracted SWIGINTERN helper), so it must
+ * live here rather than inside the %extend function body. */
 %exception libnvme_ctrl::connect {
-	connect_err = 0;
-	$action  /* $action sets connect_err to non-zero value on failure */
-	if (connect_err) {
-		const char *errstr = libnvme_errno_to_string(-connect_err);
-		if (errstr) {
-			SWIG_exception(SWIG_RuntimeError, errstr);
-		} else {
-			SWIG_exception(SWIG_RuntimeError, "Connect failed");
-		}
-	}
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
 }
-
 %exception libnvme_ctrl::disconnect {
-	connect_err = 0;
-	errno = 0;
-	$action  /* $action sets connect_err to non-zero value on failure */
-	if (connect_err == 1) {
-		SWIG_exception(SWIG_AttributeError, "No controller connection");
-	} else if (connect_err) {
-		const char *errstr = libnvme_errno_to_string(-connect_err);
-		if (errstr) {
-			SWIG_exception(SWIG_RuntimeError, errstr);
-		} else {
-			SWIG_exception(SWIG_RuntimeError, "Disconnect failed");
-		}
-	}
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
 }
-
 %exception libnvme_ctrl::discover {
-	discover_err = 0;
-	$action  /* $action sets discover_err to non-zero value on failure */
-	if (discover_err == 1) {
-		SWIG_exception(SWIG_AttributeError, "No controller connection");
-	} else if (discover_err) {
-		const char *errstr = libnvme_errno_to_string(-discover_err);
-		if (errstr) {
-			SWIG_exception(SWIG_RuntimeError, errstr);
-		} else {
-			SWIG_exception(SWIG_RuntimeError, "Discover failed");
-		}
-	}
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
 }
 
 #include "tree.h"
@@ -1137,7 +1144,7 @@ struct libnvme_ns * libnvme_ctrl_next_ns(struct libnvme_ctrl * c, struct libnvme
 		"    h: Host object to associate with the connection.\n"
 		"\n"
 		"Raises:\n"
-		"    RuntimeError: Connection failed.") connect;
+		"    ConnectError: Connection failed.") connect;
 	void connect(struct libnvme_host *h) {
 		int ret;
 
@@ -1146,7 +1153,7 @@ struct libnvme_ns * libnvme_ctrl_next_ns(struct libnvme_ctrl * c, struct libnvme
 		Py_END_ALLOW_THREADS    /* Reacquire Python GIL */
 
 		if (ret) {
-			connect_err = ret;
+			raise_nvme(NvmeConnectError, ret);
 			return;
 		}
 	}
@@ -1157,22 +1164,24 @@ struct libnvme_ns * libnvme_ctrl_next_ns(struct libnvme_ctrl * c, struct libnvme
 	%feature("autodoc", "Disconnect this controller from the NVMe-oF target.\n"
 		"\n"
 		"Raises:\n"
-		"    AttributeError: Controller is not currently connected.\n"
-		"    RuntimeError: Disconnect failed.") disconnect;
+		"    NotConnectedError: Controller is not currently connected.\n"
+		"    DisconnectError: Disconnect failed.") disconnect;
 	void disconnect() {
 		int ret;
 		const char *dev;
 
 		dev = libnvme_ctrl_get_name($self);
 		if (!dev) {
-			connect_err = 1;
+			raise_not_connected();
 			return;
 		}
 		Py_BEGIN_ALLOW_THREADS  /* Release Python GIL */
 		ret = libnvmf_disconnect_ctrl($self);
 		Py_END_ALLOW_THREADS    /* Reacquire Python GIL */
-		if (ret < 0)
-			connect_err = 2;
+		if (ret < 0) {
+			raise_nvme(NvmeDisconnectError, ret);
+			return;
+		}
 	}
 
 	bool _registration_supported() {
@@ -1231,28 +1240,34 @@ struct libnvme_ns * libnvme_ctrl_next_ns(struct libnvme_ctrl * c, struct libnvme
 		"    ``subtype``.\n"
 		"\n"
 		"Raises:\n"
-		"    AttributeError: Controller is not connected.\n"
-		"    RuntimeError: Discovery failed.") discover;
+		"    NotConnectedError: Controller is not connected.\n"
+		"    DiscoverError: Discovery failed.") discover;
 	%newobject discover;
 	struct nvmf_discovery_log *discover(int lsp = 0, int max_retries = 6) {
 		struct nvmf_discovery_log *logp = NULL;
 		struct libnvmf_discovery_args *args = NULL;
+		int ret;
 
 		if (!libnvme_ctrl_get_name($self)) {
-			discover_err = 1;
+			raise_not_connected();
 			return NULL;
 		}
-		discover_err = libnvmf_discovery_args_new(&args);
-		if (discover_err)
+		ret = libnvmf_discovery_args_new(&args);
+		if (ret) {
+			raise_nvme(NvmeDiscoverError, ret);
 			return NULL;
+		}
 		libnvmf_discovery_args_set_lsp(args, lsp);
 		libnvmf_discovery_args_set_max_retries(args, max_retries);
 		Py_BEGIN_ALLOW_THREADS  /* Release Python GIL */
-		    discover_err = libnvmf_get_discovery_log($self, args, &logp);
+		    ret = libnvmf_get_discovery_log($self, args, &logp);
 		Py_END_ALLOW_THREADS    /* Reacquire Python GIL */
 		libnvmf_discovery_args_free(args);
 
-		if (logp == NULL) discover_err = 2;
+		if (ret || logp == NULL) {
+			raise_nvme(NvmeDiscoverError, ret);
+			return NULL;
+		}
 		return logp;
 	}
 
@@ -1263,8 +1278,11 @@ struct libnvme_ns * libnvme_ctrl_next_ns(struct libnvme_ctrl * c, struct libnvme
 		"\n"
 		"Returns:\n"
 		"    A list of integers, one per Log Identifier, encoding its\n"
-		"    supported features. Returns None if the command fails.") supported_log_pages;
-	PyObject *supported_log_pages(bool rae = true) {
+		"    supported features.\n"
+		"\n"
+		"Raises:\n"
+		"    NvmeError: The command failed.") get_supported_log_pages;
+	PyObject *get_supported_log_pages(bool rae = true) {
 		struct nvme_supported_log_pages log;
 		struct libnvme_passthru_cmd cmd;
 		PyObject *obj = NULL;
@@ -1276,11 +1294,12 @@ struct libnvme_ns * libnvme_ctrl_next_ns(struct libnvme_ctrl * c, struct libnvme
 		Py_END_ALLOW_THREADS    /* Reacquire Python GIL */
 
 		if (ret) {
-			Py_RETURN_NONE;
+			raise_nvme(NvmeError, ret);
+			return NULL;
 		}
 
 		obj = PyList_New(NVME_LOG_SUPPORTED_LOG_PAGES_MAX);
-		if (!obj) Py_RETURN_NONE;
+		if (!obj) return NULL;
 
 		for (int i = 0; i < NVME_LOG_SUPPORTED_LOG_PAGES_MAX; i++)
 			PyList_SetItem(obj, i, PyLong_FromLong(le32_to_cpu(log.lid_support[i]))); /* steals ref. to object - no need to decref */

--- a/libnvme/libnvme/tests/test-objects.py
+++ b/libnvme/libnvme/tests/test-objects.py
@@ -239,6 +239,47 @@ class TestCtrl(unittest.TestCase):
             self.assertFalse(c.connected)
 
 
+class TestExceptions(unittest.TestCase):
+    """Exception hierarchy exposed via the nvme module."""
+
+    def test_nvme_error_importable(self):
+        self.assertTrue(hasattr(nvme, 'NvmeError'))
+
+    def test_connect_error_importable(self):
+        self.assertTrue(hasattr(nvme, 'ConnectError'))
+
+    def test_disconnect_error_importable(self):
+        self.assertTrue(hasattr(nvme, 'DisconnectError'))
+
+    def test_discover_error_importable(self):
+        self.assertTrue(hasattr(nvme, 'DiscoverError'))
+
+    def test_not_connected_error_importable(self):
+        self.assertTrue(hasattr(nvme, 'NotConnectedError'))
+
+    def test_subclasses_inherit_from_nvme_error(self):
+        for cls in (nvme.ConnectError, nvme.DisconnectError,
+                    nvme.DiscoverError, nvme.NotConnectedError):
+            with self.subTest(cls=cls):
+                self.assertTrue(issubclass(cls, nvme.NvmeError))
+
+    def test_nvme_error_is_exception(self):
+        self.assertTrue(issubclass(nvme.NvmeError, Exception))
+
+    def test_nvme_error_has_errno_and_message(self):
+        e = nvme.NvmeError(5, 'test message')
+        self.assertEqual(e.errno, 5)
+        self.assertEqual(e.message, 'test message')
+
+    def test_not_connected_error_no_errno_arg(self):
+        e = nvme.NotConnectedError()
+        self.assertEqual(e.errno, 0)
+
+    def test_not_connected_error_custom_message(self):
+        e = nvme.NotConnectedError("custom msg")
+        self.assertEqual(e.message, "custom msg")
+
+
 class TestCtrlErrorHandling(unittest.TestCase):
     """Error paths that can be exercised without real hardware."""
 
@@ -254,12 +295,12 @@ class TestCtrlErrorHandling(unittest.TestCase):
         self.ctx = None
         gc.collect()
 
-    def test_disconnect_unconnected_raises_attribute_error(self):
-        with self.assertRaises(AttributeError):
+    def test_disconnect_unconnected_raises_not_connected_error(self):
+        with self.assertRaises(nvme.NotConnectedError):
             self.ctrl.disconnect()
 
-    def test_discover_unconnected_raises_attribute_error(self):
-        with self.assertRaises(AttributeError):
+    def test_discover_unconnected_raises_not_connected_error(self):
+        with self.assertRaises(nvme.NotConnectedError):
             self.ctrl.discover()
 
 


### PR DESCRIPTION
### Exception hierarchy

Replaces the `connect_err` / `discover_err` globals and `%exception` shims with a proper exception hierarchy in `libnvme/_exceptions.py`:

```
NvmeError              base class — carries .errno (int) and .message (str)
├── ConnectError       raised by ctrl.connect()
├── DisconnectError    raised by ctrl.disconnect()
├── DiscoverError      raised by ctrl.discover()
└── NotConnectedError  raised when a connected controller is required (.errno is always 0)
```

Exceptions are imported into the `nvme` module namespace at init time so callers can use `nvme.ConnectError` etc. directly.

On the C side, `raise_nvme(cls, err)` sets the exception; `raise_not_connected()` handles the no-errno case. One subtlety worth noting: `SWIG_fail` (`goto fail;`) cannot be used inside `%extend` function bodies because SWIG extracts those into `SWIGINTERN` helper functions where the `fail:` label is absent. Minimal `%exception` blocks are used instead to propagate any pending exception from the helper back into the wrapper where `fail:` is defined.

`supported_log_pages()` is renamed to `get_supported_log_pages()` and now raises `NvmeError` on failure instead of returning `None`.

`discover-loop.py` and `README.md` are updated to match the new API.

### PUBLISHING.md

Documents the PyPI publishing workflow: source distribution only (no wheels), GitHub Actions handles both TestPyPI (on every master push) and PyPI (on release tags) using OIDC authentication.

