### PR TITLE
ci: replace webispy/checkpatch-action with upstream checkpatch.pl

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,11 +13,17 @@ jobs:
     name: checkpatch review
     runs-on: ubuntu-latest
     steps:
-    - name: 'Calculate PR commits + 1'
-      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> $GITHUB_ENV
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
+    - name: Fetch checkpatch.pl
+      run: |
+        curl -sSf \
+          https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl \
+          -o checkpatch.pl
+
     - name: Run checkpatch review
-      uses: webispy/checkpatch-action@58374fe5bb03358b23d3d6871e2ff290ce77fcd2 # v9
+      run: |
+        git format-patch --stdout origin/${{ github.base_ref }}..HEAD \
+          | perl checkpatch.pl -


### PR DESCRIPTION
## Summary

- Drops the `webispy/checkpatch-action` third-party action (frozen at 2022) in favour of fetching `checkpatch.pl` directly from `torvalds/linux` at workflow runtime
- Eliminates supply chain risk from a pinned, unmaintained third-party action
- Picks up current kernel checkpatch improvements, including proper support for the `Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL]` signature format
- All project-specific settings remain in `.checkpatch.conf` and are auto-read by `checkpatch.pl` — no behaviour change there

## Notes

The old action had an unused `Calculate PR commits + 1` step left over from an earlier `fetch-depth` strategy; removed as part of this cleanup since `fetch-depth: 0` is hardcoded in the checkout step.

Tested locally by running the new pipeline against this branch and against a branch with known `Assisted-by` commits — 0 errors, 0 warnings on both.

