### PR TITLE
Makefile: add checkpatch targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,3 +91,21 @@ static:
 		-Dexamples=false
 
 	meson compile -C ${BUILD-DIR}
+
+CHECKPATCH     := /tmp/checkpatch.pl
+CHECKPATCH_URL := https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl
+BASE ?= master
+
+# make checkpatch              → check all commits on branch vs $(BASE)
+# make checkpatch BASE=HEAD~3  → check last 3 commits only
+.PHONY: checkpatch
+checkpatch:
+	@[ -f ${CHECKPATCH} ] || curl -sSf ${CHECKPATCH_URL} -o ${CHECKPATCH}
+	git format-patch --stdout ${BASE}..HEAD | perl ${CHECKPATCH} -
+
+# make checkpatch-diff  → check staged/unstaged changes + untracked files
+.PHONY: checkpatch-diff
+checkpatch-diff:
+	@[ -f ${CHECKPATCH} ] || curl -sSf ${CHECKPATCH_URL} -o ${CHECKPATCH}
+	git diff HEAD | perl ${CHECKPATCH} -
+	@git ls-files --others --exclude-standard | xargs -r -I{} perl ${CHECKPATCH} --file {}


### PR DESCRIPTION
Add two targets for running checkpatch locally before committing, mirroring the CI workflow.

`make checkpatch` checks all commits on the current branch not yet in the base. The base defaults to `master` but can be overridden via `BASE=`:

```
make checkpatch                       # compare vs local master
make checkpatch BASE=upstream/master  # for fork workflows where origin= personal fork
make checkpatch BASE=HEAD~3           # check only the last 3 commits
```

`make checkpatch-diff` checks uncommitted work — staged and unstaged changes to tracked files, plus any untracked files:

```
make checkpatch-diff
```

`checkpatch.pl` is fetched from `torvalds/linux` on first use and cached in `/tmp`, matching the CI fetch introduced in #3335.