### PR TITLE
ci: extend check-accessors to cover all generated files

### DIFF
--- a/.github/workflows/check-accessors.yml
+++ b/.github/workflows/check-accessors.yml
@@ -6,12 +6,18 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-# Verify that the committed accessor files (accessors.h, accessors.c) are
-# up to date with the generate-accessors tool and the structs in private.h.
+# Verify that all committed generated accessor files (.h, .c, .i, .ld) are
+# in sync with the generate-accessors tool and the annotated private*.h files.
 #
-# If this check fails, run the following command and commit the result:
+# .h, .c, and .i files must be byte-identical to what the generator produces.
+# .ld files are checked at the symbol level: the committed file may carry
+# different version-section labels but must export the same set of symbols.
 #
-#   meson compile -C <build-dir> update-accessors
+# If this check fails:
+#   - For .h/.c/.i: run 'meson compile -C <build-dir> update-accessors'
+#                   and commit the result.
+#   - For .ld:      manually add/remove the symbols listed in the WARNING and
+#                   commit the result.
 
 name: Check accessors
 
@@ -34,15 +40,6 @@ jobs:
       - name: Mark repo as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure
-        run: meson setup .build-ci
-      - name: Regenerate accessor files
+        run: meson setup .build-ci -Dcheck-accessors=true
+      - name: Check generated accessor files are in sync
         run: meson compile -C .build-ci update-accessors
-      - name: Check for uncommitted differences
-        run: |
-          if ! git diff --exit-code libnvme/src/nvme/accessors.h \
-                                    libnvme/src/nvme/accessors.c; then
-            echo ""
-            echo "ERROR: accessor files are out of date."
-            echo "Run 'meson compile -C <build-dir> update-accessors' and commit the result."
-            exit 1
-          fi

--- a/libnvme/tools/generator/meson.build
+++ b/libnvme/tools/generator/meson.build
@@ -29,6 +29,11 @@ libnvme_swig_dir = libnvme_srcroot / 'libnvme'
 
 _py3 = find_program('python3', required: true)
 
+# When -Dcheck-accessors=true the script runs in read-only CI mode: it exits
+# non-zero if any generated file is out of sync with the source tree rather
+# than updating it.
+_check_flag = get_option('check-accessors') ? ['--check'] : []
+
 _tgt_common = run_target(
     'update-common-accessors',
     command: [
@@ -38,6 +43,7 @@ _tgt_common = run_target(
         libnvme_src_nvme / 'accessors.h',
         libnvme_src_nvme / 'accessors.c',
         libnvme_src / 'accessors.ld',
+    ] + _check_flag + [
         '--swig-out', libnvme_swig_dir / 'accessors.i',
         libnvme_src_nvme / 'private.h',
     ],
@@ -52,10 +58,11 @@ _tgt_fabrics = run_target(
         libnvme_src_nvme / 'accessors-fabrics.h',
         libnvme_src_nvme / 'accessors-fabrics.c',
         libnvme_src / 'accessors-fabrics.ld',
+    ] + _check_flag + [
         '--swig-out', libnvme_swig_dir / 'accessors-fabrics.i',
         libnvme_src_nvme / 'private-fabrics.h',
     ],
 )
 
-# This alias allows generating all accessors in one shot.
+# This alias allows generating/checking all accessors in one shot.
 alias_target('update-accessors', _tgt_common, _tgt_fabrics)

--- a/libnvme/tools/generator/update-accessors.sh
+++ b/libnvme/tools/generator/update-accessors.sh
@@ -7,16 +7,23 @@
 # Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-# This script is invoked via: meson compile -C <build-dir> update-accessors
+# Invoked via:
+#   meson compile -C <build-dir> update-accessors   (developer, updates files)
+#   meson compile -C <build-dir> check-accessors    (CI, read-only)
+#
 # It is NOT run during a normal build.
 #
-# The .h and .c files are updated automatically when the generator produces
-# different output.
+# The .h, .c, and .i files are updated automatically when the generator
+# produces different output.
 #
 # The .ld file is NOT updated automatically because its version section
 # label (e.g. LIBNVME_ACCESSORS_3, LIBNVMF_ACCESSORS_3) must be assigned by
 # the maintainer.  Instead, this script reports which symbols have been added
 # or removed so the maintainer knows exactly what to change.
+#
+# With --check (used by CI), the script is read-only: it never modifies the
+# source tree.  It exits non-zero if any .h/.c/.i file is out of date or if
+# the .ld symbol list has drifted.
 #
 # Arguments (supplied by the Meson run_target):
 #   $1             path to the python3 interpreter
@@ -24,6 +31,7 @@
 #   $3             full path of the output .h file
 #   $4             full path of the output .c file
 #   $5             full path of the output .ld file
+#   [--check]      optional: CI mode — read-only, exit non-zero on any drift
 #   [--swig-out F] optional: full path of the output SWIG fragment (.i file)
 #   $6 (or $8) ... one or more input headers scanned for
 #                  // !generate-accessors and // !generate-python structs
@@ -36,6 +44,12 @@ H_OUT="${3:?missing .h output path}"
 C_OUT="${4:?missing .c output path}"
 LD_OUT="${5:?missing .ld output path}"
 shift 5
+
+CHECK_MODE=0
+if [ "${1-}" = "--check" ]; then
+    CHECK_MODE=1
+    shift
+fi
 
 SWIG_OUT=""
 if [ "${1-}" = "--swig-out" ]; then
@@ -79,7 +93,24 @@ update_if_changed() {
 }
 
 # ---------------------------------------------------------------------------
+# Helper (check mode): report whether a source file is current.
+# Sets DRIFT to a non-zero value if the file is stale.
+# ---------------------------------------------------------------------------
+check_if_current() {
+    local src="$1"   # newly generated file in TMPDIR_WORK
+    local dest="$2"  # committed file in the source tree
+
+    if [ -f "$dest" ] && cmp -s "$src" "$dest"; then
+        printf "  up to date: %s\n" "$(basename "$dest")"
+    else
+        printf "  STALE:      %s\n" "$(basename "$dest")"
+        DRIFT=$((DRIFT + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # Helper: compare symbol lists and report ld drift.
+# Returns 1 if drift is detected, 0 if the symbol list is current.
 # ---------------------------------------------------------------------------
 extract_syms() {
     grep -E '^\s+[a-zA-Z_][a-zA-Z0-9_]*;' "$1" \
@@ -102,19 +133,21 @@ check_ld_drift() {
 
     if [ -z "$added" ] && [ -z "$removed" ]; then
         echo "${ld_name}: symbol list is up to date."
-    else
-        echo "WARNING: $(realpath --relative-to=.. ${old_ld}) needs manual attention."
-        echo ""
-        if [ -n "$added" ]; then
-            echo "  Symbols to ADD (new version section, e.g. <PREFIX>_ACCESSORS_X_Y):"
-            printf '%s\n' "$added" | sed 's/^/\t\t/' | sed 's/$/;/'
-        fi
-        if [ -n "$removed" ]; then
-            echo ""
-            echo "  Symbols to REMOVE from ${ld_name}:"
-            printf '%s\n' "$removed" | sed 's/^/    /'
-        fi
+        return 0
     fi
+
+    echo "WARNING: $(realpath --relative-to=.. "$old_ld") needs manual attention."
+    echo ""
+    if [ -n "$added" ]; then
+        echo "  Symbols to ADD (new version section, e.g. <PREFIX>_ACCESSORS_X_Y):"
+        printf '%s\n' "$added" | sed 's/^/\t\t/' | sed 's/$/;/'
+    fi
+    if [ -n "$removed" ]; then
+        echo ""
+        echo "  Symbols to REMOVE from ${ld_name}:"
+        printf '%s\n' "$removed" | sed 's/^/    /'
+    fi
+    return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -134,19 +167,48 @@ SWIG_ARGS=()
     "${SWIG_ARGS[@]}"  \
     "$@"
 
-CHANGED=0
-update_if_changed "$TMP_H" "$H_OUT"
-update_if_changed "$TMP_C" "$C_OUT"
-[ -n "$SWIG_OUT" ] && update_if_changed "$TMP_I" "$SWIG_OUT"
-echo ""
-if [ "$CHANGED" -gt 0 ]; then
-    printf "%d file(s) updated in %s\n" "$CHANGED" "$(dirname "$H_OUT")"
-    echo "Don't forget to commit the updated files."
+if [ "$CHECK_MODE" -eq 1 ]; then
+    # ------------------------------------------------------------------
+    # Check mode: read-only.  Report all drift, then exit non-zero if
+    # anything is out of sync.
+    # ------------------------------------------------------------------
+    DRIFT=0
+    check_if_current "$TMP_H" "$H_OUT"
+    check_if_current "$TMP_C" "$C_OUT"
+    [ -n "$SWIG_OUT" ] && check_if_current "$TMP_I" "$SWIG_OUT"
+    echo ""
+    check_ld_drift "$TMP_LD" "$LD_OUT" || DRIFT=$((DRIFT + 1))
+    echo ""
+    if [ "$DRIFT" -gt 0 ]; then
+        echo "ERROR: generated files are out of sync with the source."
+        echo "Run 'meson compile -C <build-dir> update-accessors' and commit."
+        echo "(.ld symbol changes require manual version-script edits; see WARNING above.)"
+        echo ""
+        echo "--- ${BASE}: check FAILED ---"
+        echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+        echo ""
+        exit 1
+    fi
+    echo "All generated files are up to date."
 else
-    echo "All accessor source files are up to date."
+    # ------------------------------------------------------------------
+    # Update mode: auto-update .h/.c/.i; report .ld drift as advisory.
+    # ------------------------------------------------------------------
+    CHANGED=0
+    update_if_changed "$TMP_H" "$H_OUT"
+    update_if_changed "$TMP_C" "$C_OUT"
+    [ -n "$SWIG_OUT" ] && update_if_changed "$TMP_I" "$SWIG_OUT"
+    echo ""
+    if [ "$CHANGED" -gt 0 ]; then
+        printf "%d file(s) updated in %s\n" "$CHANGED" "$(dirname "$H_OUT")"
+        echo "Don't forget to commit the updated files."
+    else
+        echo "All accessor source files are up to date."
+    fi
+    echo ""
+    check_ld_drift "$TMP_LD" "$LD_OUT" || true
 fi
-echo ""
-check_ld_drift "$TMP_LD" "$LD_OUT"
+
 echo ""
 echo "--- ${BASE}: generation complete ---"
 echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -161,6 +161,12 @@ option(
   description : 'building for PyPI (use short soversion, e.g. libnvme.so.3)'
 )
 option(
+  'check-accessors',
+  type : 'boolean',
+  value : false,
+  description : 'CI mode: verify generated accessor files are in sync instead of updating them'
+)
+option(
   'plugins',
   type : 'array',
   choices: ['amzn', 'dapustor', 'dell', 'dera',


### PR DESCRIPTION
### Problem

The `check-accessors` CI workflow only verified two of the eight files produced by `generate-accessors.py`:
|File|CI coverage (before)|
|:---|:---|
| libnvme/src/nvme/accessors.h | ✓ checked |
| libnvme/src/nvme/accessors.c | ✓ checked |
| libnvme/src/accessors.ld              | ✗ not checked |
| libnvme/src/nvme/accessors-fabrics.h  | ✗ not checked |
| libnvme/src/nvme/accessors-fabrics.c  | ✗ not checked |
| libnvme/src/accessors-fabrics.ld      | ✗ not checked |
| libnvme/libnvme/accessors.i           | ✗ not checked |
| libnvme/libnvme/accessors-fabrics.i   | ✗ not checked |

A developer could modify `private.h` or `private-fabrics.h`, regenerate, and push with any of those six files stale — and CI would pass silently.

The `.ld` files have an additional wrinkle: they cannot be checked with a simple `git diff` because their version-section labels (`LIBNVME_ACCESSORS_3`, etc.) are assigned manually by the maintainer. The right check is whether the **symbol set** has drifted, not whether the file is byte-identical.

### Solution

Add a `-Dcheck-accessors=true` meson option. When set, `update-accessors.sh` runs in read-only CI mode (`--check` flag):

- `.h`, `.c`, `.i` — byte-compared against the source tree; any mismatch is reported as STALE and causes a non-zero exit.
- `.ld` — symbol sets extracted and compared via `comm`; added or removed symbols are reported as drift and cause a non-zero exit. The file itself is not compared (version labels are intentionally different).

The existing `update-common-accessors` and `update-fabrics-accessors` targets receive `--check` when the option is enabled — no new targets needed. The CI workflow passes `-Dcheck-accessors=true` to `meson setup` and replaces the old two-step (regenerate + `git diff`) with a single `meson compile update-accessors`.

The developer workflow (`meson compile update-accessors` without the option) is unchanged: `.h`/`.c`/`.i` are updated in place, `.ld` drift is reported as an advisory warning, and the script always exits 0.

### Files changed

| File | Change |
|---|---|
| `meson_options.txt` | Add `check-accessors` boolean option (default `false`) |
| `libnvme/tools/generator/meson.build` | Splice `--check` into both targets when option is set |
| `libnvme/tools/generator/update-accessors.sh` | Add `--check` mode: read-only, exits non-zero on any drift |
| `.github/workflows/check-accessors.yml` | Pass `-Dcheck-accessors=true`; drop separate `git diff` step |
