### PR TITLE
CI: Add host_devices list to kubevirt-action

### DIFF
--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -27,6 +27,7 @@ jobs:
         id: blktests
         uses: ./.github/actions/kubevirt-action
         with:
+          host_devices: "nvme-wdc-zn540,nvme-wdc-sn640"
           kernel_version: linus-master
           vm_artifact_upload_dir: blktests/results/
           run_cmds: |
@@ -85,6 +86,7 @@ jobs:
         if: success() || steps.blktests.conclusion == 'failure'
         uses: ./.github/actions/kubevirt-action
         with:
+          host_devices: "nvme-wdc-zn540,nvme-wdc-sn640"
           kernel_version: linus-master
           vm_artifact_upload_dir: nvme-cli/tests/nvmetests/
           run_cmds: |


### PR DESCRIPTION
We need to specify the devices that are passed though to the VM when running the tests. The kubevirt-action should not be responsible for picking the testing devices.