### PR TITLE
python bindings: table-driven fabrics config dict parsing

### DIFF
--- a/libnvme/libnvme/fctx_field_tables.h
+++ b/libnvme/libnvme/fctx_field_tables.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+/*
+ * This file is part of libnvme.
+ *
+ * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ *
+ *   ____                           _           _    ____          _
+ *  / ___| ___ _ __   ___ _ __ __ _| |_ ___  __| |  / ___|___   __| | ___
+ * | |  _ / _ \ '_ \ / _ \ '__/ _` | __/ _ \/ _` | | |   / _ \ / _` |/ _ \
+ * | |_| |  __/ | | |  __/ | | (_| | ||  __/ (_| | | |__| (_) | (_| |  __/
+ *  \____|\___|_| |_|\___|_|  \__,_|\__\___|\__,_|  \____\___/ \__,_|\___|
+ *
+ * Auto-generated struct member accessors (setter/getter)
+ *
+ * To update run: meson compile -C [BUILD-DIR] update-accessors
+ * Or:            make update-accessors
+ */
+
+#ifndef _FCTX_FIELD_TABLES_H_
+#define _FCTX_FIELD_TABLES_H_
+
+#include <stddef.h>
+
+struct fctx_field {
+	const char *key;
+	size_t off;
+};
+
+/* Derived from struct libnvme_fabrics_config in private.h. */
+
+#define _OFF(m) offsetof(struct libnvme_fabrics_config, m)
+
+static const struct fctx_field libnvme_fabrics_config_int_fields[] = {
+	{ "queue_size", _OFF(queue_size) },
+	{ "nr_io_queues", _OFF(nr_io_queues) },
+	{ "reconnect_delay", _OFF(reconnect_delay) },
+	{ "ctrl_loss_tmo", _OFF(ctrl_loss_tmo) },
+	{ "fast_io_fail_tmo", _OFF(fast_io_fail_tmo) },
+	{ "keep_alive_tmo", _OFF(keep_alive_tmo) },
+	{ "nr_write_queues", _OFF(nr_write_queues) },
+	{ "nr_poll_queues", _OFF(nr_poll_queues) },
+	{ "tos", _OFF(tos) },
+	{ NULL, 0 },
+};
+
+static const struct fctx_field libnvme_fabrics_config_long_fields[] = {
+	{ "keyring_id", _OFF(keyring_id) },
+	{ "tls_key_id", _OFF(tls_key_id) },
+	{ "tls_configured_key_id", _OFF(tls_configured_key_id) },
+	{ NULL, 0 },
+};
+
+static const struct fctx_field libnvme_fabrics_config_bool_fields[] = {
+	{ "duplicate_connect", _OFF(duplicate_connect) },
+	{ "disable_sqflow", _OFF(disable_sqflow) },
+	{ "hdr_digest", _OFF(hdr_digest) },
+	{ "data_digest", _OFF(data_digest) },
+	{ "tls", _OFF(tls) },
+	{ "concat", _OFF(concat) },
+	{ NULL, 0 },
+};
+
+#undef _OFF
+
+static const char * const libnvme_fabrics_config_keys[] = {
+	"queue_size",
+	"nr_io_queues",
+	"reconnect_delay",
+	"ctrl_loss_tmo",
+	"fast_io_fail_tmo",
+	"keep_alive_tmo",
+	"nr_write_queues",
+	"nr_poll_queues",
+	"tos",
+	"keyring_id",
+	"tls_key_id",
+	"tls_configured_key_id",
+	"duplicate_connect",
+	"disable_sqflow",
+	"hdr_digest",
+	"data_digest",
+	"tls",
+	"concat",
+	NULL,
+};
+
+#endif /* _FCTX_FIELD_TABLES_H_ */

--- a/libnvme/libnvme/meson.build
+++ b/libnvme/libnvme/meson.build
@@ -27,6 +27,7 @@ if want_python
             'accessors.i',
             'accessors-fabrics.i',
             'nvme-manual-bridges.i',
+            'fctx_field_tables.h',
         ],
         install: true,
         install_dir: [python3.get_install_dir(pure: false, subdir: 'libnvme'), false],
@@ -38,6 +39,7 @@ if want_python
         '_nvme',
         nvme_wrap_c,
         dependencies: [config_dep, ccan_dep, libnvme_dep, py3_dep],
+        include_directories: include_directories('.'),
         install: true,
         subdir: 'libnvme',
     )

--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -97,18 +97,21 @@ static PyObject *NvmeDiscoverError     = NULL;
 static PyObject *NvmeNotConnectedError = NULL;
 static PyObject *fctx_known_keys       = NULL;
 
-static void raise_nvme(PyObject *cls, int err) {
+static void raise_nvme(PyObject *cls, int err)
+{
 	const char *s = libnvme_errno_to_string(err < 0 ? -err : err);
 	PyObject *args = Py_BuildValue("(is)", err, s ? s : "unknown");
 	PyErr_SetObject(cls, args);
 	Py_DECREF(args);
 }
 
-static void raise_not_connected(void) {
+static void raise_not_connected(void)
+{
 	PyErr_SetString(NvmeNotConnectedError, "Not connected");
 }
 
-static void PyDict_SetItemStringDecRef(PyObject * p, const char *key, PyObject *val) {
+static void PyDict_SetItemStringDecRef(PyObject *p, const char *key, PyObject *val)
+{
 	PyDict_SetItemString(p, key, val); /* Does NOT steal reference to val .. */
 	Py_XDECREF(val);                   /* .. therefore decrement ref. count. */
 }

--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -86,6 +86,7 @@ PyObject *read_hostid();
 #include <libnvme.h>
 #include "nvme/private.h"
 #include "nvme/private-fabrics.h"
+#include "fctx_field_tables.h"
 
 #define STR_OR_NONE(str) (!(str) ? "None" : str)
 
@@ -94,6 +95,7 @@ static PyObject *NvmeConnectError      = NULL;
 static PyObject *NvmeDisconnectError   = NULL;
 static PyObject *NvmeDiscoverError     = NULL;
 static PyObject *NvmeNotConnectedError = NULL;
+static PyObject *fctx_known_keys       = NULL;
 
 static void raise_nvme(PyObject *cls, int err) {
 	const char *s = libnvme_errno_to_string(err < 0 ? -err : err);
@@ -110,18 +112,6 @@ static void PyDict_SetItemStringDecRef(PyObject * p, const char *key, PyObject *
 	PyDict_SetItemString(p, key, val); /* Does NOT steal reference to val .. */
 	Py_XDECREF(val);                   /* .. therefore decrement ref. count. */
 }
-PyObject *read_hostnqn() {
-	char * val = libnvme_read_hostnqn();
-	PyObject * obj = val ? PyUnicode_FromString(val) : Py_NewRef(Py_None);
-	free(val);
-	return obj;
-}
-PyObject *read_hostid() {
-	char * val = libnvme_read_hostid();
-	PyObject * obj = val ? PyUnicode_FromString(val) : Py_NewRef(Py_None);
-	free(val);
-	return obj;
-}
 
 static const char *dict_get_str(PyObject *dict, const char *key)
 {
@@ -132,17 +122,97 @@ static const char *dict_get_str(PyObject *dict, const char *key)
 	return PyUnicode_AsUTF8(val);
 }
 
-static int set_fctx_from_dict(struct libnvmf_context *fctx, PyObject *dict)
+/*
+ * Write scalar fields of libnvme_fabrics_config (queue sizes, timeouts,
+ * boolean flags) from the Python dict.  Field coverage is driven entirely
+ * by the auto-generated sentinel tables in fctx_field_tables.h, so adding
+ * a new scalar field to the struct requires no change here.
+ */
+static void set_fctx_fabrics_config(struct libnvmf_context *fctx,
+				    PyObject *dict)
 {
 	struct libnvme_fabrics_config *cfg;
-	const char *subsysnqn, *transport;
+	const struct fctx_field *fp;
+	PyObject *val;
+
+	cfg = libnvmf_context_get_fabrics_config(fctx);
+
+	for (fp = libnvme_fabrics_config_int_fields; fp->key; fp++) {
+		val = PyDict_GetItemString(dict, fp->key);
+		if (val)
+			*(int *)((char *)cfg + fp->off) =
+				(int)PyLong_AsLong(val);
+	}
+	for (fp = libnvme_fabrics_config_long_fields; fp->key; fp++) {
+		val = PyDict_GetItemString(dict, fp->key);
+		if (val)
+			*(long *)((char *)cfg + fp->off) =
+				PyLong_AsLong(val);
+	}
+	for (fp = libnvme_fabrics_config_bool_fields; fp->key; fp++) {
+		val = PyDict_GetItemString(dict, fp->key);
+		if (val)
+			*(bool *)((char *)cfg + fp->off) =
+				(bool)PyObject_IsTrue(val);
+	}
+}
+
+typedef struct { const char *key; const char **val; } str_fields_t;
+
+/*
+ * Set host identity and credential fields on fctx from the Python dict.
+ * This covers hostnqn, hostid, the TLS/crypto key names, and the persistent
+ * flag — fields that require higher-level libnvmf_context_set_*() helpers
+ * rather than direct struct assignment.
+ */
+static void set_fctx_host_params(struct libnvmf_context *fctx, PyObject *dict)
+{
 	const char *hostnqn = NULL, *hostid = NULL;
 	const char *hostkey = NULL, *ctrlkey = NULL;
 	const char *keyring = NULL, *tls_key = NULL, *tls_key_identity = NULL;
-	bool persistent = false;
-	bool has_persistent = false;
-	Py_ssize_t pos = 0;
-	PyObject *key, *value;
+	str_fields_t tbl[] = {
+		{"hostnqn",          &hostnqn},
+		{"hostid",           &hostid},
+		{"hostkey",          &hostkey},
+		{"ctrlkey",          &ctrlkey},
+		{"keyring",          &keyring},
+		{"tls_key",          &tls_key},
+		{"tls_key_identity", &tls_key_identity},
+		{NULL, NULL}, /* sentinel */
+	};
+	str_fields_t *p;
+	PyObject *val;
+
+	val = PyDict_GetItemString(dict, "persistent");
+	if (val)
+		fctx->persistent = (bool)PyObject_IsTrue(val);
+
+	for (p = tbl; p->key; p++)
+		*p->val = dict_get_str(dict, p->key);
+
+	/* hostnqn and hostid are passed together to a single setter */
+	if (hostnqn || hostid)
+		libnvmf_context_set_hostnqn(fctx, hostnqn, hostid);
+
+	if (hostkey || ctrlkey || keyring || tls_key || tls_key_identity)
+		libnvmf_context_set_crypto(fctx, hostkey, ctrlkey, keyring,
+					   tls_key, tls_key_identity);
+}
+
+/*
+ * Populate a libnvmf_context from a Python dict of ctrl config key/value pairs.
+ *
+ * Validates the two required keys ('subsysnqn' and 'transport'), sets the
+ * connection endpoint, then delegates field population to two helpers:
+ *   - set_fctx_fabrics_config(): scalar fields of libnvme_fabrics_config
+ *   - set_fctx_host_params():    host identity and credential fields
+ *
+ * Returns 0 on success, -1 with a Python exception set on error.
+ * Unknown keys are rejected via fctx_known_keys (built at module init).
+ */
+static int set_fctx_from_dict(struct libnvmf_context *fctx, PyObject *dict)
+{
+	const char *subsysnqn, *transport;
 
 	subsysnqn = dict_get_str(dict, "subsysnqn");
 	transport = dict_get_str(dict, "transport");
@@ -159,141 +229,50 @@ static int set_fctx_from_dict(struct libnvmf_context *fctx, PyObject *dict)
 				       dict_get_str(dict, "host_traddr"),
 				       dict_get_str(dict, "host_iface"));
 
-	cfg = libnvmf_context_get_fabrics_config(fctx);
+	set_fctx_host_params(fctx, dict);
+	set_fctx_fabrics_config(fctx, dict);
 
-	while (PyDict_Next(dict, &pos, &key, &value)) {
-		/* Already consumed above via dict_get_str() */
-		if (!PyUnicode_CompareWithASCIIString(key, "subsysnqn") ||
-		    !PyUnicode_CompareWithASCIIString(key, "transport") ||
-		    !PyUnicode_CompareWithASCIIString(key, "traddr") ||
-		    !PyUnicode_CompareWithASCIIString(key, "trsvcid") ||
-		    !PyUnicode_CompareWithASCIIString(key, "host_traddr") ||
-		    !PyUnicode_CompareWithASCIIString(key, "host_iface"))
-			continue;
-		if (!PyUnicode_CompareWithASCIIString(key, "queue_size")) {
-			cfg->queue_size = PyLong_AsLong(value);
-			continue;
+	/* Reject any key not present in fctx_known_keys (built at module init).
+	 * PySet_Contains() is O(1) per key via the frozen known-keys set.
+	 */
+	if (fctx_known_keys) {
+		Py_ssize_t pos = 0;
+		PyObject *key, *value;
+
+		while (PyDict_Next(dict, &pos, &key, &value)) {
+			if (!PySet_Contains(fctx_known_keys, key)) {
+				PyErr_Format(PyExc_KeyError,
+					     "unknown ctrl config key: '%U'",
+					     key);
+				return -1;
+			}
 		}
-		if (!PyUnicode_CompareWithASCIIString(key, "nr_io_queues")) {
-			cfg->nr_io_queues = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "reconnect_delay")) {
-			cfg->reconnect_delay = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "ctrl_loss_tmo")) {
-			cfg->ctrl_loss_tmo = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "fast_io_fail_tmo")) {
-			cfg->fast_io_fail_tmo = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "keep_alive_tmo")) {
-			cfg->keep_alive_tmo = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "nr_write_queues")) {
-			cfg->nr_write_queues = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "nr_poll_queues")) {
-			cfg->nr_poll_queues = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "tos")) {
-			cfg->tos = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "keyring_id")) {
-			cfg->keyring_id = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "tls_key_id")) {
-			cfg->tls_key_id = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "tls_configured_key_id")) {
-			cfg->tls_configured_key_id = PyLong_AsLong(value);
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "duplicate_connect")) {
-			cfg->duplicate_connect = PyObject_IsTrue(value) ? true : false;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "disable_sqflow")) {
-			cfg->disable_sqflow = PyObject_IsTrue(value) ? true : false;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "hdr_digest")) {
-			cfg->hdr_digest = PyObject_IsTrue(value) ? true : false;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "data_digest")) {
-			cfg->data_digest = PyObject_IsTrue(value) ? true : false;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "tls")) {
-			cfg->tls = PyObject_IsTrue(value) ? true : false;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "concat")) {
-			cfg->concat = PyObject_IsTrue(value) ? true : false;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "hostnqn")) {
-			hostnqn = (value != Py_None) ? PyUnicode_AsUTF8(value) : NULL;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "hostid")) {
-			hostid = (value != Py_None) ? PyUnicode_AsUTF8(value) : NULL;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "hostkey")) {
-			hostkey = (value != Py_None) ? PyUnicode_AsUTF8(value) : NULL;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "ctrlkey")) {
-			ctrlkey = (value != Py_None) ? PyUnicode_AsUTF8(value) : NULL;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "keyring")) {
-			keyring = (value != Py_None) ? PyUnicode_AsUTF8(value) : NULL;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "tls_key")) {
-			tls_key = (value != Py_None) ? PyUnicode_AsUTF8(value) : NULL;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "tls_key_identity")) {
-			tls_key_identity = (value != Py_None) ? PyUnicode_AsUTF8(value) : NULL;
-			continue;
-		}
-		if (!PyUnicode_CompareWithASCIIString(key, "persistent")) {
-			persistent = PyObject_IsTrue(value) ? true : false;
-			has_persistent = true;
-			continue;
-		}
-		PyErr_Format(PyExc_KeyError, "unknown ctrl config key: '%U'", key);
-		return -1;
 	}
-
-	if (hostnqn || hostid)
-		libnvmf_context_set_hostnqn(fctx, hostnqn, hostid);
-	if (hostkey || ctrlkey || keyring || tls_key || tls_key_identity)
-		libnvmf_context_set_crypto(fctx, hostkey, ctrlkey,
-					   keyring, tls_key,
-					   tls_key_identity);
-	if (has_persistent)
-		libnvmf_context_set_persistent(fctx, persistent);
 
 	return 0;
 }
 
-/******
-NBFT
-******/
+/*============================================================================*/
+
+PyObject *read_hostnqn()
+{
+	char *val = libnvme_read_hostnqn();
+	PyObject *obj = val ? PyUnicode_FromString(val) : Py_NewRef(Py_None);
+	free(val);
+	return obj;
+}
+
+PyObject *read_hostid()
+{
+	char *val = libnvme_read_hostid();
+	PyObject *obj = val ? PyUnicode_FromString(val) : Py_NewRef(Py_None);
+	free(val);
+	return obj;
+}
+
+/*============================================================================*/
+
+/* ---- NBFT ---- */
 static PyObject *ssns_to_dict(struct libnbft_subsystem_ns *ss)
 {
 	unsigned int i;
@@ -507,7 +486,7 @@ static PyObject *nbft_to_pydict(struct libnbft_info *nbft)
 	return output;
 }
 
-PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char * filename)
+PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char *filename)
 {
 	struct libnbft_info *nbft;
 	PyObject *output;
@@ -524,6 +503,8 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char * filename)
 }
 %} /* --------- end C implementation block --------- */
 
+/*============================================================================*/
+
 %init %{
 	PyObject *_exc = PyImport_ImportModule("libnvme._exceptions");
 	NvmeError             = PyObject_GetAttrString(_exc, "NvmeError");
@@ -532,6 +513,32 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char * filename)
 	NvmeDiscoverError     = PyObject_GetAttrString(_exc, "DiscoverError");
 	NvmeNotConnectedError = PyObject_GetAttrString(_exc, "NotConnectedError");
 	Py_DECREF(_exc);
+
+	/* Build the frozenset of all known ctrl config dict keys. */
+	static const char * const _hand_written_keys[] = {
+		"subsysnqn", "transport", "traddr", "trsvcid",
+		"host_traddr", "host_iface",
+		"hostnqn", "hostid",
+		"hostkey", "ctrlkey", "keyring", "tls_key", "tls_key_identity",
+		"persistent",
+		NULL,
+	};
+	{
+		const char * const *kp;
+		PyObject *_tmp = PySet_New(NULL);
+		for (kp = libnvme_fabrics_config_keys; *kp; kp++) {
+			PyObject *_s = PyUnicode_FromString(*kp);
+			PySet_Add(_tmp, _s);
+			Py_DECREF(_s);
+		}
+		for (kp = _hand_written_keys; *kp; kp++) {
+			PyObject *_s = PyUnicode_FromString(*kp);
+			PySet_Add(_tmp, _s);
+			Py_DECREF(_s);
+		}
+		fctx_known_keys = PyFrozenSet_New(_tmp);
+		Py_DECREF(_tmp);
+	}
 %}
 
 %pythoncode %{
@@ -544,7 +551,7 @@ from libnvme._exceptions import (
 )
 %}
 
-//##############################################################################
+/*############################################################################*/
 
 /* All typemaps must be defined before the %include statements below so that
  * they are in scope when SWIG processes the struct and method declarations.
@@ -604,7 +611,8 @@ from libnvme._exceptions import (
 
 %typemap(out) struct nvmf_discovery_log * {
 	struct nvmf_discovery_log *log = $1;
-	int numrec = log ? log->numrec : 0, i;
+	int numrec = log ? log->numrec : 0;
+	int i;
 	PyObject *obj = PyList_New(numrec);
 	if (!obj) return NULL;
 
@@ -694,7 +702,7 @@ from libnvme._exceptions import (
 		}
 		PyDict_SetItemStringDecRef(entry, "treq", val);
 
-		if (e->trtype ==  NVMF_TRTYPE_TCP) {
+		if (e->trtype == NVMF_TRTYPE_TCP) {
 			PyObject *tsas = PyDict_New();
 
 			switch (e->tsas.tcp.sectype) {
@@ -776,9 +784,10 @@ from libnvme._exceptions import (
 	$result = obj;
 };
 
-// These %include statements must be located after the main %{...%} block and
-// all %typemap directives above, so that typemaps are in scope when SWIG
-// processes the struct and method declarations in the included files.
+/* These %include statements must be located after the main %{...%} block and
+ * all %typemap directives above, so that typemaps are in scope when SWIG
+ * processes the struct and method declarations in the included files.
+ */
 %include "nvme-manual-bridges.i"
 %include "accessors.i"
 %include "accessors-fabrics.i"
@@ -810,7 +819,7 @@ from libnvme._exceptions import (
 		"\n"
 		"Returns:\n"
 		"    A dict containing the NBFT data, or None on failure.") nbft_get;
-PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char * filename);
+PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char *filename);
 
 %rename(_libnvme_first_host)        libnvme_first_host;
 %rename(_libnvme_next_host)         libnvme_next_host;
@@ -822,16 +831,16 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char * filename);
 %rename(_libnvme_subsystem_next_ns)    libnvme_subsystem_next_ns;
 %rename(_libnvme_ctrl_first_ns)     libnvme_ctrl_first_ns;
 %rename(_libnvme_ctrl_next_ns)      libnvme_ctrl_next_ns;
-struct libnvme_host * libnvme_first_host(struct libnvme_global_ctx * ctx);
-struct libnvme_host * libnvme_next_host(struct libnvme_global_ctx *ctx, struct libnvme_host * h);
-struct libnvme_subsystem * libnvme_first_subsystem(struct libnvme_host * h);
-struct libnvme_subsystem * libnvme_next_subsystem(struct libnvme_host * h, struct libnvme_subsystem * s);
-struct libnvme_ctrl * libnvme_subsystem_first_ctrl(struct libnvme_subsystem * s);
-struct libnvme_ctrl * libnvme_subsystem_next_ctrl(struct libnvme_subsystem * s, struct libnvme_ctrl * c);
-struct libnvme_ns * libnvme_subsystem_first_ns(struct libnvme_subsystem * s);
-struct libnvme_ns * libnvme_subsystem_next_ns(struct libnvme_subsystem * s, struct libnvme_ns * n);
-struct libnvme_ns * libnvme_ctrl_first_ns(struct libnvme_ctrl * c);
-struct libnvme_ns * libnvme_ctrl_next_ns(struct libnvme_ctrl * c, struct libnvme_ns * n);
+struct libnvme_host *libnvme_first_host(struct libnvme_global_ctx *ctx);
+struct libnvme_host *libnvme_next_host(struct libnvme_global_ctx *ctx, struct libnvme_host *h);
+struct libnvme_subsystem *libnvme_first_subsystem(struct libnvme_host *h);
+struct libnvme_subsystem *libnvme_next_subsystem(struct libnvme_host *h, struct libnvme_subsystem *s);
+struct libnvme_ctrl *libnvme_subsystem_first_ctrl(struct libnvme_subsystem *s);
+struct libnvme_ctrl *libnvme_subsystem_next_ctrl(struct libnvme_subsystem *s, struct libnvme_ctrl *c);
+struct libnvme_ns *libnvme_subsystem_first_ns(struct libnvme_subsystem *s);
+struct libnvme_ns *libnvme_subsystem_next_ns(struct libnvme_subsystem *s, struct libnvme_ns *n);
+struct libnvme_ns *libnvme_ctrl_first_ns(struct libnvme_ctrl *c);
+struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_ns *n);
 
 %extend libnvme_global_ctx {
 	%feature("autodoc", "__init__(self, config_file=None)\n"

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -104,7 +104,7 @@ struct linux_passthru_cmd64 {
  * @tls:		Start TLS on the connection (TCP)
  * @concat:		Enable secure concatenation (TCP)
  */
-struct libnvme_fabrics_config { // !generate-accessors
+struct libnvme_fabrics_config { // !generate-accessors !generate-dict-table
 	int queue_size;
 	int nr_io_queues;
 	int reconnect_delay;

--- a/libnvme/tools/generator/generate-accessors.md
+++ b/libnvme/tools/generator/generate-accessors.md
@@ -2,6 +2,24 @@
 
 This tool generates **setter and getter functions** for C structs automatically. It also optionally generates a **constructor and destructor** (`foo_new` / `foo_free`) and a **defaults initialiser** (`foo_init_defaults`). It supports dynamic strings, fixed-size char arrays, `char **` arrays, and `const` fields, with control over which structs and members participate via **in-source annotations**.
 
+Beyond C code, the tool can also emit **SWIG fragments** that expose the generated accessors to the Python bindings, and **dict-table headers** used by the Python layer to populate structs from Python dictionaries.
+
+------
+
+## Design model
+
+### C public API
+
+The structs processed by this tool are **private** — defined in internal headers such as `private.h` and never exposed directly to external callers. The generated accessor functions form the stable public ABI: external code accesses struct fields only through them.
+
+Internal C code within libnvme is free to read and write struct members directly. Accessor functions are required even for internal code only when a member has **special handling** — for example, two fields that must always be written together, or a field whose value must be validated or derived from another. Those cases are hand-written and annotated with `custom`; everything else is `generated` and accessed directly.
+
+### Python bindings
+
+The same opaqueness applies to the Python layer: C structs are invisible to Python callers and are instead surfaced as properties of Python classes (`GlobalCtx`, `Host`, `Ctrl`, etc.). The public Python API is dict-based for configuration; users never see the underlying C structs.
+
+The SWIG-generated glue code, however, is not subject to this restriction — it has full access to the private headers and reads/writes struct members directly (`p->member`) for any axis annotated `generated`. A hand-written (custom) accessor is called only when a member requires special handling, making `custom` annotations the exception rather than the rule.
+
 ------
 
 ## Usage
@@ -17,9 +35,27 @@ python3 generate-accessors.py [options] <header-files>
 | `-h`  | `--h-out`  | `<file>` | Full path of the `*.h` file to generate. Default: `accessors.h` |
 | `-c`  | `--c-out`  | `<file>` | Full path of the `*.c` file to generate. Default: `accessors.c` |
 | `-l`  | `--ld-out` | `<file>` | Full path of the `*.ld` file to generate. Default: `accessors.ld` |
+| `-s`  | `--swig-out`       | `<file>` | Generated SWIG fragment (`*.i`). Omit to skip.           |
+| `-d`  | `--dict-table-out` | `<file>` | Generated dict-table header (`*.h`). Omit to skip.       |
 | `-p`  | `--prefix` | `<str>`  | Prefix prepended to every generated function name        |
 | `-v`  | `--verbose`| none     | Verbose output showing which structs are being processed |
 | `-H`  | `--help`   | none     | Show this help message                                   |
+
+------
+
+## Generated files
+
+Each output file is produced only when the corresponding command-line flag is supplied. The table below shows which annotation in the header source drives that file's content.
+
+| Flag               | Generated file        | Controlling annotation | Purpose                                                      |
+| ------------------ | --------------------- | ---------------------- | ------------------------------------------------------------ |
+| `--h-out`          | `accessors.h`         | `!generate-accessors`  | C header — accessor function declarations                    |
+| `--c-out`          | `accessors.c`         | `!generate-accessors`  | C implementation — accessor function bodies                  |
+| `--ld-out`         | `accessors.ld`        | `!generate-accessors`  | Linker version-script — exports accessor symbols in the shared library ABI |
+| `--swig-out`       | `accessors.i`         | `!generate-python`     | SWIG fragment — typemaps that expose accessors and accessible structs to the Python bindings |
+| `--dict-table-out` | `fctx_field_tables.h` | `!generate-dict-table` | C header — sentinel-terminated field offset tables used for dict parsing in the Python bindings |
+
+The first three flags share the same annotation (`!generate-accessors`) and are typically generated together in one invocation. The SWIG fragment (`--swig-out`) uses a separate annotation (`!generate-python`) and the dict-table header (`--dict-table-out`) uses yet another (`!generate-dict-table`); both may be passed to the same invocation as the other flags or to a separate one.
 
 ------
 
@@ -159,6 +195,104 @@ The value is emitted verbatim, so any valid C expression — integer literals, m
 
 `init_defaults()` can be used independently of `generate-lifecycle`.
 
+### Python SWIG fragment — `generate-python`
+
+Place the annotation on the same line as the struct's opening brace to include that struct in the SWIG output file (`--swig-out`). This annotation is independent of `!generate-accessors` — a struct may carry either or both:
+
+```c
+struct libnvme_ctrl { // !generate-accessors !generate-python
+    /* C accessors + SWIG Python fragment both generated */
+};
+
+struct libnvme_ctrl { // !generate-python
+    /* SWIG fragment only — public accessors (if any) are hand-written */
+};
+```
+
+The optional `alias=NAME` metadata renames the struct in Python without changing the C identifier:
+
+```c
+struct libnvme_fabrics_config { // !generate-accessors !generate-python:alias=FabricsConfig
+    /* Python class will be FabricsConfig, not libnvme_fabrics_config */
+};
+```
+
+For each struct carrying this annotation the generator emits into `accessors.i`:
+
+- `%rename(NAME) struct_name;` when `alias=NAME` is set.
+- `%rename` directives and `#define` bridges for any member whose `read` or `write` axis is `custom` — these map SWIG's expected `struct_member_get/set` naming to libnvme's `struct_get/set_member` convention.
+- A `struct { ... };` declaration body containing plain field entries for generated members and a `%extend { ... }` block for custom members. Read-only members (`write=none`) are preceded by `%immutable`.
+- A `%pythoncode` block that installs a strict `__setattr__` guard, causing Python to raise `AttributeError` for any attribute name not already present on the class.
+
+`!generate-python` is scanned separately from `!generate-accessors`. A struct without `!generate-accessors` is still parsed for SWIG purposes, treating all member axes as `generated` by default.
+
+### Python member visibility — `python:none`
+
+Place the annotation on a member's declaration line to exclude it from the SWIG fragment entirely. The member's C accessors (controlled by `!access`) are unaffected:
+
+```c
+struct libnvme_ctrl { // !generate-accessors !generate-python
+    char *name;
+    char *internal_tag;  // !python:none   /* not exposed to Python */
+};
+```
+
+### Python member renaming — `python:alias=NAME`
+
+Place the annotation on a member's declaration line to give it a different Python attribute name while keeping the C member name unchanged:
+
+```c
+struct libnvme_ctrl { // !generate-accessors !generate-python
+    char *subsysnqn;
+    int   kato_ms;      // !python:alias=kato   /* Python sees .kato */
+};
+```
+
+`!python:alias=NAME` can be combined with `!access` and `!python:none` (though combining with `!python:none` is pointless since the member is excluded anyway).
+
+### Dict-table generation — `generate-dict-table`
+
+Place the annotation on the same line as the struct's opening brace to include that struct in the dict-table output file (`--dict-table-out`). This annotation takes **no metadata** — its presence means "generate," its absence means "don't":
+
+```c
+struct libnvme_fabrics_config { // !generate-accessors !generate-dict-table
+    int  queue_size;
+    bool duplicate_connect;
+    char *hostnqn;   // !dict-table:none   /* excluded from the table */
+};
+```
+
+The generator buckets each eligible member by C type and emits:
+
+- One sentinel-terminated `fctx_field_t` array per bucket (`int`, `long`, `bool`, `char *`), using `offsetof` to record the field's byte offset.
+- A flat `NULL`-terminated `const char * const` array listing all included field names.
+
+These tables are consumed exclusively by the Python binding layer (`nvme.i`) to fill a `struct libnvme_fabrics_config` from a Python `dict` without a long chain of `strcmp` comparisons.
+
+**Supported member types:**
+
+| C type(s)                                              | Bucket     | Written via         |
+| ------------------------------------------------------ | ---------- | ------------------- |
+| `int`, `unsigned int`, `int32_t`, `__s32`, `uint32_t`, `__u32` | `int`  | `*(int *)ptr`       |
+| `long`, `unsigned long`, `long long`, …, `int64_t`, `__s64`, `uint64_t`, `__u64` | `long` | `*(long *)ptr` |
+| `bool`, `_Bool`                                        | `bool`     | `*(bool *)ptr`      |
+| `char *`                                               | `char *`   | key array only — values handled by hand-written code |
+
+`const`-qualified members and members with unsupported types (narrow integers, `void *`, nested structs, …) are skipped; the generator prints a warning for unknown scalars or multi-level pointers. Annotate those members with `// !dict-table:none` to suppress the warning.
+
+### Dict-table member exclusion — `dict-table:none`
+
+Place the annotation on a member's declaration line to exclude it from the dict-table output silently:
+
+```c
+struct libnvme_fabrics_config { // !generate-dict-table
+    int  queue_size;
+    char *hostnqn;   // !dict-table:none   /* handled by hand-written code */
+};
+```
+
+This annotation has no effect on accessor generation. It is independent of `!access` and `!lifecycle`.
+
 ### Annotation summary
 
 | Annotation                                             | Where        | Effect                                                                                  |
@@ -167,10 +301,16 @@ The value is emitted verbatim, so any valid C expression — integer literals, m
 | `// !generate-accessors:read=M,write=M`                | struct brace | Include struct; set struct-level default for each axis                                  |
 | `// !generate-accessors:read=M`                        | struct brace | Partial metadata; other axis inherits the built-in default (`generated`)                |
 | `// !generate-lifecycle`                               | struct brace | Generate constructor + destructor (no metadata)                                         |
+| `// !generate-python`                                  | struct brace | Include struct in the SWIG fragment output file (no metadata)                           |
+| `// !generate-python:alias=NAME`                       | struct brace | Same, and rename the struct to NAME in Python                                           |
+| `// !generate-dict-table`                              | struct brace | Include struct in the dict-table output file (no metadata)                              |
 | `// !access:read=M,write=M`                            | member line  | Override struct-level defaults for this member                                          |
 | `// !access:read=M`                                    | member line  | Partial metadata; other axis is inherited from the struct-level default                 |
 | `// !lifecycle:none`                                   | member line  | Exclude member from destructor free logic                                               |
 | `// !default:VALUE`                                    | member line  | Set field to VALUE in `init_defaults()`                                                 |
+| `// !python:none`                                      | member line  | Exclude member from SWIG fragment; C accessors unaffected                               |
+| `// !python:alias=NAME`                                | member line  | Rename Python attribute to NAME; C member name unchanged                                |
+| `// !dict-table:none`                                  | member line  | Exclude member from dict-table output; silences unsupported-type warnings               |
 | `const` qualifier on member                            | member type  | Force `write=none`; suppress free in destructor                                         |
 
 In the table above, `M` is one of `generated`, `custom`, or `none`.
@@ -179,10 +319,7 @@ In the table above, `M` is one of `generated`, `custom`, or `none`.
 
 ## Example
 
-The following example is based on `struct libnvmf_uri` from
-`libnvme/src/nvme/private-fabrics.h`. The struct as defined in that file carries
-only `// !generate-accessors`; `!generate-lifecycle` and `// !default:4420` are
-added here to illustrate all features in one place.
+The following example is based on `struct libnvmf_uri` from `libnvme/src/nvme/private-fabrics.h`. The struct as defined in that file carries only `// !generate-accessors`; `!generate-lifecycle` and `// !default:4420` are added here to illustrate all features in one place.
 
 ### Annotated header
 

--- a/libnvme/tools/generator/generate-accessors.py
+++ b/libnvme/tools/generator/generate-accessors.py
@@ -639,6 +639,135 @@ def parse_generate_python(raw_body):
     return False, None
 
 
+_GEN_DICT_TABLE_RE = re.compile(r'!generate-dict-table(?=[\s!]|$)')
+
+
+def parse_generate_dict_table(raw_body):
+    """Return True if ``!generate-dict-table`` is present on any line."""
+    for line in raw_body.splitlines():
+        comment = _comment_text(line)
+        if comment is None:
+            continue
+        if _GEN_DICT_TABLE_RE.search(comment):
+            return True
+    return False
+
+
+def parse_dict_table_none(raw_line):
+    """Return True if ``!dict-table:none`` is present on *raw_line*."""
+    comment = _comment_text(raw_line)
+    if comment is None:
+        return False
+    return bool(re.search(r'!dict-table:none(?=[\s!]|$)', comment))
+
+
+# Types that map to the 'int' bucket (4-byte signed/unsigned integers).
+# The table loop writes them via *(int *)ptr, which is safe for same-sized
+# types.  Smaller types (__u8, short, etc.) are intentionally excluded —
+# writing 4 bytes to a 1- or 2-byte field would corrupt adjacent memory.
+_DICT_TABLE_INT_TYPES = frozenset({
+    'int', 'unsigned int',
+    'int32_t', '__s32',
+    'uint32_t', '__u32',
+})
+
+# Types that map to the 'long' bucket (8-byte integers on 64-bit Linux).
+_DICT_TABLE_LONG_TYPES = frozenset({
+    'long', 'unsigned long',
+    'long long', 'unsigned long long',
+    'int64_t', '__s64',
+    'uint64_t', '__u64',
+})
+
+# Types that map to the 'bool' bucket.
+_DICT_TABLE_BOOL_TYPES = frozenset({'bool', '_Bool'})
+
+# Scalar types that are KNOWN but not yet supported (wrong width or need
+# special handling).  A member with one of these types will trigger a
+# warning instead of being silently dropped.
+_DICT_TABLE_UNSUPPORTED_SCALAR = frozenset({
+    'short', 'unsigned short',
+    'int8_t',  'int16_t',
+    'uint8_t', 'uint16_t',
+    '__s8',  '__s16',
+    '__u8',  '__u16',
+    'signed char', 'unsigned char', 'char',
+    'float', 'double',
+})
+
+
+def parse_members_for_dict_table(raw_body, struct_name='<unknown>'):
+    """Bucket members by C type for dict-table generation.
+
+    Returns ``{'int': [...], 'long': [...], 'bool': [...], 'char *': [...]}``,
+    where each list holds the member names belonging to that type.
+
+    Members annotated ``// !dict-table:none`` are skipped silently.
+    Members of unsupported scalar types produce a warning on stderr.
+    Members of unrecognised non-scalar types (pointers, enums, structs)
+    also produce a warning.
+    """
+    buckets = {'int': [], 'long': [], 'bool': [], 'char *': []}
+
+    for raw_line in raw_body.splitlines():
+        if parse_dict_table_none(raw_line):
+            continue
+
+        clean = strip_inline_comment(strip_block_comments(raw_line)).strip()
+
+        if not clean or ';' not in clean:
+            continue
+        if 'static' in clean or 'struct' in clean:
+            continue
+
+        # Fixed-size scalar arrays (e.g. uint8_t eui64[8]) and char arrays
+        # are not supported; CHAR_ARRAY_RE / SCALAR_ARRAY_RE would match
+        # them, but we only run MEMBER_RE here.  Skip array declarations
+        # so they do not fall through to the warning path.
+        if CHAR_ARRAY_RE.match(clean) or SCALAR_ARRAY_RE.match(clean):
+            continue
+
+        m = MEMBER_RE.match(clean)
+        if not m:
+            continue
+
+        if bool(m.group(1)):    # const — skip silently
+            continue
+
+        type_base = m.group(2)
+        ptr_part  = m.group(3)
+        name      = m.group(4)
+
+        ptr_depth = ptr_part.count('*')
+
+        if ptr_depth == 1 and type_base == 'char':
+            buckets['char *'].append(name)
+        elif ptr_depth == 0:
+            if type_base in _DICT_TABLE_INT_TYPES:
+                buckets['int'].append(name)
+            elif type_base in _DICT_TABLE_LONG_TYPES:
+                buckets['long'].append(name)
+            elif type_base in _DICT_TABLE_BOOL_TYPES:
+                buckets['bool'].append(name)
+            else:
+                print(
+                    f"warning: struct {struct_name}: member '{name}' has "
+                    f"type '{type_base}' which is not supported by "
+                    f"!generate-dict-table; annotate with "
+                    f"// !dict-table:none to silence this warning.",
+                    file=sys.stderr)
+        else:
+            # Multi-level pointer (char **, void *, struct foo *, …)
+            print(
+                f"warning: struct {struct_name}: member '{name}' has "
+                f"pointer type '{type_base} {"*" * ptr_depth}' which is "
+                f"not supported by !generate-dict-table; annotate with "
+                f"// !dict-table:none to silence this warning.",
+                file=sys.stderr)
+
+    return buckets
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle member: name + whether it is a char** (string array)
 # ---------------------------------------------------------------------------
@@ -1586,6 +1715,102 @@ def generate_swig_fragment(f, prefix, struct_name, members, errors,
 
 
 # ---------------------------------------------------------------------------
+# Dict-table emitters
+# ---------------------------------------------------------------------------
+
+_DICT_TABLE_SUFFIXES = (
+    ('int',    'int_fields'),
+    ('long',   'long_fields'),
+    ('bool',   'bool_fields'),
+    ('char *', 'str_fields'),
+)
+
+
+def emit_dict_table(f, struct_name, buckets, source_header):
+    """Emit field tables and key array for *struct_name* into *f*."""
+    f.write(f'/* Derived from struct {struct_name} in {source_header}. */\n\n')
+    f.write(f'#define _OFF(m) offsetof(struct {struct_name}, m)\n\n')
+
+    for type_key, suffix in _DICT_TABLE_SUFFIXES:
+        names = buckets.get(type_key, [])
+        if not names:
+            continue
+        arr_name = f'{struct_name}_{suffix}'
+        f.write(f'static const struct fctx_field {arr_name}[] = {{\n')
+        for mname in names:
+            f.write(f'\t{{ "{mname}", _OFF({mname}) }},\n')
+        f.write('\t{ NULL, 0 },\n')
+        f.write('};\n\n')
+
+    f.write('#undef _OFF\n\n')
+
+    all_names = [n for type_key, _ in _DICT_TABLE_SUFFIXES
+                 for n in buckets.get(type_key, [])]
+    if all_names:
+        f.write(f'static const char * const {struct_name}_keys[] = {{\n')
+        for mname in all_names:
+            f.write(f'\t"{mname}",\n')
+        f.write('\tNULL,\n')
+        f.write('};\n\n')
+
+
+def generate_dict_table_file(header_files, out_path, verbose):
+    """Write the dict-table header for all ``!generate-dict-table`` structs."""
+    results = []
+
+    for in_hdr in header_files:
+        try:
+            with open(in_hdr) as f:
+                text = f.read()
+        except OSError as e:
+            print(f"error: cannot read '{in_hdr}': {e}", file=sys.stderr)
+            sys.exit(1)
+
+        for match in STRUCT_RE.finditer(text):
+            struct_name = match.group(1)
+            raw_body    = match.group(2)
+
+            if not parse_generate_dict_table(raw_body):
+                continue
+
+            buckets = parse_members_for_dict_table(raw_body, struct_name)
+            results.append((struct_name, buckets, in_hdr))
+
+            if verbose:
+                total = sum(len(v) for v in buckets.values())
+                print(f"  dict-table: {struct_name} — {total} fields")
+
+    guard = '_' + sanitize_identifier(
+        os.path.basename(out_path).upper().replace('.', '_')) + '_'
+
+    makedirs_for(out_path)
+    with open(out_path, 'w') as f:
+        f.write(
+            f'{SPDX_H}\n'
+            f'\n'
+            f'{BANNER}\n'
+            f'\n'
+            f'#ifndef {guard}\n'
+            f'#define {guard}\n'
+            f'\n'
+            f'#include <stddef.h>\n'
+            f'\n'
+            f'struct fctx_field {{\n'
+            f'\tconst char *key;\n'
+            f'\tsize_t off;\n'
+            f'}};\n'
+            f'\n'
+        )
+        for struct_name, buckets, source_header in results:
+            emit_dict_table(f, struct_name, buckets,
+                            os.path.basename(source_header))
+        f.write(f'#endif /* {guard} */\n')
+
+    if verbose and results:
+        print(f"Generated {out_path}")
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1606,6 +1831,9 @@ def main():
     parser.add_argument('-s', '--swig-out', default=None,
                         dest='s_fname',   metavar='FILE',
                         help='Generated SWIG fragment (*.i). Omit to skip.')
+    parser.add_argument('-d', '--dict-table-out', default=None,
+                        dest='d_fname',   metavar='FILE',
+                        help='Generated dict-table header (*.h). Omit to skip.')
     parser.add_argument('-p', '--prefix',  default='',
                         dest='prefix',    metavar='STR',
                         help='Prefix prepended to every generated function name.')
@@ -1813,6 +2041,10 @@ def main():
         print(f"\nGenerated {args.h_fname} and {args.c_fname}")
         if emit_swig and args.s_fname:
             print(f"Generated {args.s_fname}")
+
+    # --- fctx_field_tables.h (dict-table) ----------------------------------
+    if args.d_fname:
+        generate_dict_table_file(header_files, args.d_fname, args.verbose)
 
 
 if __name__ == '__main__':

--- a/libnvme/tools/generator/meson.build
+++ b/libnvme/tools/generator/meson.build
@@ -22,7 +22,8 @@
 
 # Generated source files go to src/nvme/ (alongside the library sources).
 # The generated version script goes to src/ (alongside the other .ld files).
-# The generated SWIG include goes to libnvme/ (alongside nvme.i).
+# The generated SWIG includes and Python-only headers go to libnvme/ alongside
+# nvme.i.
 libnvme_src = libnvme_srcroot / 'src'
 libnvme_src_nvme = libnvme_src / 'nvme'
 libnvme_swig_dir = libnvme_srcroot / 'libnvme'
@@ -45,6 +46,7 @@ _tgt_common = run_target(
         libnvme_src / 'accessors.ld',
     ] + _check_flag + [
         '--swig-out', libnvme_swig_dir / 'accessors.i',
+        '--dict-table-out', libnvme_swig_dir / 'fctx_field_tables.h',
         libnvme_src_nvme / 'private.h',
     ],
 )

--- a/libnvme/tools/generator/update-accessors.sh
+++ b/libnvme/tools/generator/update-accessors.sh
@@ -31,9 +31,10 @@
 #   $3             full path of the output .h file
 #   $4             full path of the output .c file
 #   $5             full path of the output .ld file
-#   [--check]      optional: CI mode — read-only, exit non-zero on any drift
-#   [--swig-out F] optional: full path of the output SWIG fragment (.i file)
-#   $6 (or $8) ... one or more input headers scanned for
+#   [--check]             optional: CI mode; read-only, exit non-zero on drift
+#   [--swig-out F]        optional: full path of the SWIG fragment (.i file)
+#   [--dict-table-out F]  optional: full path of the dict-table header (.h file)
+#   $6 (or $8/10) ... one or more input headers scanned for
 #                  // !generate-accessors and // !generate-python structs
 
 set -euo pipefail
@@ -57,6 +58,12 @@ if [ "${1-}" = "--swig-out" ]; then
     shift 2
 fi
 
+DICT_TABLE_OUT=""
+if [ "${1-}" = "--dict-table-out" ]; then
+    DICT_TABLE_OUT="${2:?--dict-table-out requires a path argument}"
+    shift 2
+fi
+
 if [ $# -eq 0 ]; then
     echo "error: no input headers provided" >&2
     exit 1
@@ -72,6 +79,11 @@ TMP_H="$TMPDIR_WORK/${BASE}.h"
 TMP_C="$TMPDIR_WORK/${BASE}.c"
 TMP_LD="$TMPDIR_WORK/${BASE}.ld"
 TMP_I="$TMPDIR_WORK/${BASE}.i"
+if [ -n "$DICT_TABLE_OUT" ]; then
+    TMP_DT="$TMPDIR_WORK/$(basename "$DICT_TABLE_OUT")"
+else
+    TMP_DT="$TMPDIR_WORK/dict_table.h"
+fi
 
 # ---------------------------------------------------------------------------
 # Helper: update a source file atomically when content changes.
@@ -160,11 +172,15 @@ echo ""
 SWIG_ARGS=()
 [ -n "$SWIG_OUT" ] && SWIG_ARGS=(--swig-out "$TMP_I")
 
+DICT_TABLE_ARGS=()
+[ -n "$DICT_TABLE_OUT" ] && DICT_TABLE_ARGS=(--dict-table-out "$TMP_DT")
+
 "$PYTHON" "$GENERATOR" \
     --h-out  "$TMP_H"  \
     --c-out  "$TMP_C"  \
     --ld-out "$TMP_LD" \
     "${SWIG_ARGS[@]}"  \
+    "${DICT_TABLE_ARGS[@]}" \
     "$@"
 
 if [ "$CHECK_MODE" -eq 1 ]; then
@@ -175,7 +191,8 @@ if [ "$CHECK_MODE" -eq 1 ]; then
     DRIFT=0
     check_if_current "$TMP_H" "$H_OUT"
     check_if_current "$TMP_C" "$C_OUT"
-    [ -n "$SWIG_OUT" ] && check_if_current "$TMP_I" "$SWIG_OUT"
+    [ -n "$SWIG_OUT" ]       && check_if_current "$TMP_I"  "$SWIG_OUT"
+    [ -n "$DICT_TABLE_OUT" ] && check_if_current "$TMP_DT" "$DICT_TABLE_OUT"
     echo ""
     check_ld_drift "$TMP_LD" "$LD_OUT" || DRIFT=$((DRIFT + 1))
     echo ""
@@ -197,7 +214,8 @@ else
     CHANGED=0
     update_if_changed "$TMP_H" "$H_OUT"
     update_if_changed "$TMP_C" "$C_OUT"
-    [ -n "$SWIG_OUT" ] && update_if_changed "$TMP_I" "$SWIG_OUT"
+    [ -n "$SWIG_OUT" ]       && update_if_changed "$TMP_I"  "$SWIG_OUT"
+    [ -n "$DICT_TABLE_OUT" ] && update_if_changed "$TMP_DT" "$DICT_TABLE_OUT"
     echo ""
     if [ "$CHANGED" -gt 0 ]; then
         printf "%d file(s) updated in %s\n" "$CHANGED" "$(dirname "$H_OUT")"


### PR DESCRIPTION
## python bindings: table-driven fabrics config dict parsing

Replace the hand-written if-chain in set_fctx_from_dict() with a table-driven approach. The new design splits the function into two focused helpers:

- set_fctx_fabrics_config() — iterates auto-generated sentinel tables to write int/long/bool scalar fields directly by offset; adding a new scalar field to libnvme_fabrics_config requires no change here.
- set_fctx_host_params() — handles fields that need libnvmf_context_set_*() helpers (hostnqn, hostid, TLS keys, persistent flag).

The sentinel tables are generated into fctx_field_tables.h by a new `!generate-dict-table` struct annotation processed by generate-accessors.py. Members annotated `!dict-table:none` are excluded from the tables.

Changes:
| File | Change |
| :--- | :--- |
| `libnvme/libnvme/fctx_field_tables.h`           | new generated header |
| `libnvme/libnvme/nvme.i`                        | table-driven `set_fctx_from_dict()` |
| `libnvme/libnvme/meson.build`                   | depend_files + include_directories |
| `libnvme/src/nvme/private.h`                    | `!generate-dict-table` annotation |
| `libnvme/tools/generator/generate-accessors.py` | `!generate-dict-table` support |
| `libnvme/tools/generator/generate-accessors.md` | updated docs |
| `libnvme/tools/generator/update-accessors.sh`   | `--dict-table-out` in both branches |
| `libnvme/tools/generator/meson.build`           | `--dict-table-out` wired in |

