### PR TITLE
libnvme: internalize uring dispatch and fix NULL hdl dereference

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -28,3 +28,8 @@
 
 # Avoid "Does not appear to be a unified-diff format patch" message
 --ignore NOT_UNIFIED_DIFF
+
+# compiler-attributes.h defines __unused via __attribute__((__unused__)).
+# checkpatch prefers __always_unused/__maybe_unused but those are kernel
+# macros not available in userspace — this file IS their definition.
+--ignore PREFER_DEFINED_ATTRIBUTE_MACRO

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -205,7 +205,9 @@ LIBNVME_3 {
 		libnvme_status_to_string;
 		libnvme_strerror;
 		libnvme_submit_admin_passthru;
+		libnvme_wait_admin_passthru;
 		libnvme_submit_io_passthru;
+		libnvme_wait_io_passthru;
 		libnvme_subsystem_first_ctrl;
 		libnvme_subsystem_first_ns;
 		libnvme_subsystem_get_host;

--- a/libnvme/src/nvme/compiler-attributes.h
+++ b/libnvme/src/nvme/compiler-attributes.h
@@ -24,3 +24,11 @@
  * optional overrides and platform hooks.
  */
 #define __weak __attribute__((weak))
+
+/**
+ * __unused - Mark a symbol or parameter as intentionally unused.
+ *
+ * Suppresses compiler warnings for symbols or parameters that are unused
+ * by design (e.g. no-op stubs that must match a specific signature).
+ */
+#define __unused __attribute__((__unused__))

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1713,7 +1713,7 @@ static int nvmf_dim(libnvme_ctrl_t c, enum nvmf_dim_tas tas, __u8 trtype,
 	nvmf_fill_die(die, c->s->h, tel, trtype, adrfam, reg_addr, tsas);
 
 	nvme_init_dim_send(&cmd, tas, dim, tdl);
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**

--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -193,6 +193,9 @@ out:
 __public int libnvme_submit_io_passthru(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd)
 {
+	if (!hdl)
+		return -ENODEV;
+
 	if (!cmd->timeout_ms && hdl->timeout)
 		cmd->timeout_ms = hdl->timeout;
 
@@ -205,6 +208,9 @@ __public int libnvme_submit_io_passthru(struct libnvme_transport_handle *hdl,
 __public int libnvme_submit_admin_passthru(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd)
 {
+	if (!hdl)
+		return -ENODEV;
+
 	if (hdl->uring_enabled)
 		return libnvme_submit_admin_passthru_async(hdl, cmd);
 

--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -205,6 +205,9 @@ __public int libnvme_submit_io_passthru(struct libnvme_transport_handle *hdl,
 __public int libnvme_submit_admin_passthru(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd)
 {
+	if (hdl->uring_enabled)
+		return libnvme_submit_admin_passthru_async(hdl, cmd);
+
 	if (!cmd->timeout_ms && hdl->timeout)
 		cmd->timeout_ms = hdl->timeout;
 

--- a/libnvme/src/nvme/ioctl.h
+++ b/libnvme/src/nvme/ioctl.h
@@ -40,6 +40,41 @@ int libnvme_submit_admin_passthru(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd);
 
 /**
+ * libnvme_wait_admin_passthru() - Wait for pending admin passthru completions
+ * @hdl:	Transport handle
+ *
+ * When io_uring is enabled, libnvme_submit_admin_passthru() queues commands
+ * asynchronously. Call this function after one or more submits to drain all
+ * pending completions before inspecting response data.
+ *
+ * This is a no-op when io_uring is not available.
+ *
+ * Return: 0 on success or a negative error code otherwise.
+ */
+int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl);
+
+/**
+ * libnvme_exec_admin_passthru() - Submit an admin passthru command and wait
+ * @hdl:	Transport handle
+ * @cmd:	The nvme admin command to send
+ *
+ * Convenience wrapper that combines libnvme_submit_admin_passthru() and
+ * libnvme_wait_admin_passthru() into a single synchronous call. Use this
+ * for the common case where commands are sent one at a time. Use the
+ * split-phase API directly when batching multiple commands with io_uring.
+ *
+ * Return: 0 on success, the nvme command status if a response was
+ * received (see &enum nvme_status_field) or a negative error otherwise.
+ */
+static inline int libnvme_exec_admin_passthru(
+		struct libnvme_transport_handle *hdl,
+		struct libnvme_passthru_cmd *cmd)
+{
+	int err = libnvme_submit_admin_passthru(hdl, cmd);
+	return err ? err : libnvme_wait_admin_passthru(hdl);
+}
+
+/**
  * libnvme_submit_io_passthru() - Submit an nvme passthrough command
  * @hdl:	Transport handle
  * @cmd:	The nvme io command to send
@@ -51,6 +86,36 @@ int libnvme_submit_admin_passthru(struct libnvme_transport_handle *hdl,
  */
 int libnvme_submit_io_passthru(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd);
+
+/**
+ * libnvme_wait_io_passthru() - Wait for pending IO passthru completions
+ * @hdl:	Transport handle
+ *
+ * Counterpart to libnvme_submit_io_passthru() for the split-phase API.
+ * Currently a no-op as the IO passthru path does not yet use io_uring.
+ *
+ * Return: 0 on success or a negative error code otherwise.
+ */
+int libnvme_wait_io_passthru(struct libnvme_transport_handle *hdl);
+
+/**
+ * libnvme_exec_io_passthru() - Submit an IO passthru command and wait
+ * @hdl:	Transport handle
+ * @cmd:	The nvme IO command to send
+ *
+ * Convenience wrapper combining libnvme_submit_io_passthru() and
+ * libnvme_wait_io_passthru() into a single synchronous call.
+ *
+ * Return: 0 on success, the nvme command status if a response was
+ * received (see &enum nvme_status_field) or a negative error otherwise.
+ */
+static inline int libnvme_exec_io_passthru(
+		struct libnvme_transport_handle *hdl,
+		struct libnvme_passthru_cmd *cmd)
+{
+	int err = libnvme_submit_io_passthru(hdl, cmd);
+	return err ? err : libnvme_wait_io_passthru(hdl);
+}
 
 /**
  * libnvme_reset_subsystem() - Initiate a subsystem reset

--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -195,7 +195,7 @@ void libnvme_mi_ep_probe(struct libnvme_mi_ep *ep)
 	 */
 	nvme_init_identify_ctrl(&cmd, &id);
 	cmd.data_len = offsetof(struct nvme_id_ctrl, rab);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (rc) {
 		libnvme_msg(ep->ctx, LIBNVME_LOG_WARN,
 			 "Identify Controller failed, no quirks applied\n");

--- a/libnvme/src/nvme/no-uring.c
+++ b/libnvme/src/nvme/no-uring.c
@@ -12,6 +12,7 @@
 #include <libnvme.h>
 
 #include "private.h"
+#include "compiler-attributes.h"
 
 int libnvme_open_uring(struct libnvme_global_ctx *ctx)
 {
@@ -33,7 +34,12 @@ int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 	return -ENOTSUP;
 }
 
-int libnvme_wait_complete_passthru(struct libnvme_transport_handle *hdl)
+__public int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl)
 {
-	return -ENOTSUP;
+	return 0;
+}
+
+__public int libnvme_wait_io_passthru(struct libnvme_transport_handle *hdl)
+{
+	return 0;
 }

--- a/libnvme/src/nvme/no-uring.c
+++ b/libnvme/src/nvme/no-uring.c
@@ -34,12 +34,14 @@ int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 	return -ENOTSUP;
 }
 
-__public int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl)
+__public int libnvme_wait_admin_passthru(
+		__unused struct libnvme_transport_handle *hdl)
 {
 	return 0;
 }
 
-__public int libnvme_wait_io_passthru(struct libnvme_transport_handle *hdl)
+__public int libnvme_wait_io_passthru(
+		__unused struct libnvme_transport_handle *hdl)
 {
 	return 0;
 }

--- a/libnvme/src/nvme/nvme-cmds.c
+++ b/libnvme/src/nvme/nvme-cmds.c
@@ -85,10 +85,7 @@ __public int libnvme_get_log(struct libnvme_transport_handle *hdl,
 		cmd->data_len = xfer;
 		cmd->addr = (__u64)(uintptr_t)ptr;
 
-		if (hdl->uring_enabled)
-			ret = libnvme_submit_admin_passthru_async(hdl, cmd);
-		else
-			ret = libnvme_submit_admin_passthru(hdl, cmd);
+		ret = libnvme_submit_admin_passthru(hdl, cmd);
 		if (ret)
 			return ret;
 
@@ -96,13 +93,7 @@ __public int libnvme_get_log(struct libnvme_transport_handle *hdl,
 		ptr += xfer;
 	} while (offset < data_len);
 
-	if (hdl->uring_enabled) {
-		ret = libnvme_wait_complete_passthru(hdl);
-		if (ret)
-			return ret;
-	}
-
-	return 0;
+	return libnvme_wait_admin_passthru(hdl);
 }
 
 static int read_ana_chunk(struct libnvme_transport_handle *hdl,
@@ -239,7 +230,7 @@ __public int libnvme_set_etdas(struct libnvme_transport_handle *hdl, bool *chang
 	int err;
 
 	nvme_init_get_features_host_behavior(&cmd, 0, &da4);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err)
 		return err;
 
@@ -251,7 +242,7 @@ __public int libnvme_set_etdas(struct libnvme_transport_handle *hdl, bool *chang
 	da4.etdas = 1;
 
 	nvme_init_set_features_host_behavior(&cmd, false, &da4);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err)
 		return err;
 
@@ -266,7 +257,7 @@ __public int libnvme_clear_etdas(struct libnvme_transport_handle *hdl, bool *cha
 	int err;
 
 	nvme_init_get_features_host_behavior(&cmd, 0, &da4);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err)
 		return err;
 
@@ -277,7 +268,7 @@ __public int libnvme_clear_etdas(struct libnvme_transport_handle *hdl, bool *cha
 
 	da4.etdas = 0;
 	nvme_init_set_features_host_behavior(&cmd, false, &da4);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err)
 		return err;
 
@@ -294,7 +285,7 @@ __public int libnvme_get_uuid_list(struct libnvme_transport_handle *hdl,
 
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	nvme_init_identify_ctrl(&cmd, &ctrl);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		libnvme_msg(hdl->ctx, LIBNVME_LOG_ERR,
 			 "ERROR: nvme_identify_ctrl() failed 0x%x\n", err);
@@ -304,7 +295,7 @@ __public int libnvme_get_uuid_list(struct libnvme_transport_handle *hdl,
 	if ((ctrl.ctratt & NVME_CTRL_CTRATT_UUID_LIST) ==
 			NVME_CTRL_CTRATT_UUID_LIST) {
 		nvme_init_identify_uuid_list(&cmd, uuid_list);
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 	}
 
 	return err;
@@ -322,7 +313,7 @@ __public int libnvme_get_telemetry_max(struct libnvme_transport_handle *hdl,
 		return -ENOMEM;
 
 	nvme_init_identify_ctrl(&cmd, id_ctrl);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err)
 		return err;
 
@@ -541,7 +532,7 @@ __public int libnvme_get_ana_log_len(struct libnvme_transport_handle *hdl, size_
 		return -ENOMEM;
 
 	nvme_init_identify_ctrl(&cmd, ctrl);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (ret)
 		return ret;
 
@@ -562,7 +553,7 @@ __public int libnvme_get_logical_block_size(struct libnvme_transport_handle *hdl
 		return -ENOMEM;
 
 	nvme_init_identify_ns(&cmd, nsid, ns);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (ret)
 		return ret;
 

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -651,5 +651,4 @@ void libnvme_close_uring(struct libnvme_global_ctx *ctx);
 int __libnvme_transport_handle_open_uring(struct libnvme_transport_handle *hdl);
 int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd);
-int libnvme_wait_complete_passthru(struct libnvme_transport_handle *hdl);
 

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1498,7 +1498,7 @@ __public int libnvme_ctrl_identify(libnvme_ctrl_t c, struct nvme_id_ctrl *id)
 	struct libnvme_passthru_cmd cmd;
 
 	nvme_init_identify_ctrl(&cmd, id);
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 __public libnvme_ns_t libnvme_ctrl_first_ns(libnvme_ctrl_t c)
@@ -2679,7 +2679,7 @@ __public int libnvme_ns_identify(libnvme_ns_t n, struct nvme_id_ns *ns)
 		return err;
 
 	nvme_init_identify_ns(&cmd, libnvme_ns_get_nsid(n), ns);
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 int libnvme_ns_identify_descs(libnvme_ns_t n, struct nvme_ns_id_desc *descs)
@@ -2693,7 +2693,7 @@ int libnvme_ns_identify_descs(libnvme_ns_t n, struct nvme_ns_id_desc *descs)
 		return err;
 
 	nvme_init_identify_ns_descs_list(&cmd, libnvme_ns_get_nsid(n), descs);
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 __public int libnvme_ns_verify(libnvme_ns_t n, off_t offset, size_t count)

--- a/libnvme/src/nvme/uring.c
+++ b/libnvme/src/nvme/uring.c
@@ -12,6 +12,7 @@
 #include <libnvme.h>
 
 #include "private.h"
+#include "compiler-attributes.h"
 
 /*
  * should not exceed CAP.MQES, 16 is rational for most ssd
@@ -99,7 +100,7 @@ static int nvme_submit_uring_cmd(struct io_uring *ring, int fd,
 	return 0;
 }
 
-int libnvme_wait_complete_passthru(struct libnvme_transport_handle *hdl)
+__public int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl)
 {
 	struct io_uring_cqe *cqe;
 	struct io_uring *ring;
@@ -124,7 +125,7 @@ int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 	int err;
 
 	if (hdl->ctx->ring_cmds >= NVME_URING_ENTRIES) {
-		err = libnvme_wait_complete_passthru(hdl);
+		err = libnvme_wait_admin_passthru(hdl);
 		if (err)
 			return err;
 	}
@@ -134,5 +135,10 @@ int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 		return err;
 
 	hdl->ctx->ring_cmds += 1;
+	return 0;
+}
+
+__public int libnvme_wait_io_passthru(struct libnvme_transport_handle *hdl)
+{
 	return 0;
 }

--- a/libnvme/src/nvme/uring.c
+++ b/libnvme/src/nvme/uring.c
@@ -104,7 +104,7 @@ __public int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl)
 {
 	struct io_uring_cqe *cqe;
 	struct io_uring *ring;
-	int err;
+	int err, ret = 0;
 
 	if (!hdl)
 		return -ENODEV;
@@ -113,13 +113,17 @@ __public int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl)
 
 	for (int i = 0; i < hdl->ctx->ring_cmds; i++) {
 		err = io_uring_wait_cqe(ring, &cqe);
-		if (err < 0)
+		if (err < 0) {
+			hdl->ctx->ring_cmds = 0;
 			return -errno;
+		}
+		if (!ret && cqe->res)
+			ret = cqe->res;
 		io_uring_cqe_seen(ring, cqe);
 	}
 
 	hdl->ctx->ring_cmds = 0;
-	return 0;
+	return ret;
 }
 
 int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,

--- a/libnvme/src/nvme/uring.c
+++ b/libnvme/src/nvme/uring.c
@@ -106,6 +106,9 @@ __public int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl)
 	struct io_uring *ring;
 	int err;
 
+	if (!hdl)
+		return -ENODEV;
+
 	ring = hdl->ctx->ring;
 
 	for (int i = 0; i < hdl->ctx->ring_cmds; i++) {

--- a/libnvme/src/nvme/uring.c
+++ b/libnvme/src/nvme/uring.c
@@ -68,8 +68,11 @@ int __libnvme_transport_handle_open_uring(struct libnvme_transport_handle *hdl)
 	}
 
 	err = libnvme_open_uring(hdl->ctx);
-	if (err)
+	if (err) {
+		hdl->ctx->uring_state = LIBNVME_IO_URING_STATE_NOT_AVAILABLE;
 		return err;
+	}
+	hdl->ctx->uring_state = LIBNVME_IO_URING_STATE_AVAILABLE;
 
 uring_enabled:
 	hdl->uring_enabled = true;

--- a/libnvme/src/nvme/uring.c
+++ b/libnvme/src/nvme/uring.c
@@ -145,7 +145,8 @@ int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 	return 0;
 }
 
-__public int libnvme_wait_io_passthru(struct libnvme_transport_handle *hdl)
+__public int libnvme_wait_io_passthru(
+		__unused struct libnvme_transport_handle *hdl)
 {
 	return 0;
 }

--- a/libnvme/src/nvme/util-fabrics.c
+++ b/libnvme/src/nvme/util-fabrics.c
@@ -10,9 +10,10 @@
 
 #include <libnvme.h>
 
-#include "compiler-attributes.h"
 #include "private-fabrics.h"
 #include "util.h"
+
+#include "compiler-attributes.h"
 
 __public struct nvmf_ext_attr *libnvmf_exat_ptr_next(struct nvmf_ext_attr *p)
 {

--- a/libnvme/test/ioctl/features.c
+++ b/libnvme/test/ioctl/features.c
@@ -57,7 +57,7 @@ static void test_set_features(void)
 	cmd.data_len = sizeof(data);
 	cmd.addr = (__u64)(uintptr_t)data;
 	cmd.timeout_ms = TEST_TIMEOUT;
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -91,7 +91,7 @@ static void test_get_features(void)
 	cmd.data_len = sizeof(get_data);
 	cmd.addr = (__u64)(uintptr_t)get_data;
 	cmd.timeout_ms = TEST_TIMEOUT;
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -120,7 +120,7 @@ static void test_get_features_data(void)
 	cmd.nsid = TEST_NSID;
 	cmd.data_len = sizeof(get_data);
 	cmd.addr = (__u64)(uintptr_t)get_data;
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -143,7 +143,7 @@ static void test_set_arbitration(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_arbitration(&cmd, false, AB, LPW, MPW, HPW);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -163,7 +163,7 @@ static void test_get_arbitration(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_arbitration(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -186,7 +186,7 @@ static void test_set_power_mgmt(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_power_mgmt(&cmd, true, PS, WH);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -206,7 +206,7 @@ static void test_get_power_mgmt(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_power_mgmt(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -234,7 +234,7 @@ static void test_set_lba_range(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_lba_range(&cmd, TEST_NSID, false,
 		NUM, &range_types);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -260,7 +260,7 @@ static void test_get_lba_range(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_lba_range(&cmd, TEST_NSID, TEST_SEL,
 		&get_range_types);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -288,7 +288,7 @@ static void test_set_temp_thresh(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_temp_thresh(&cmd, true, TMPTH, TMPSEL, THSEL, 0);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -313,7 +313,7 @@ static void test_get_temp_thresh(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_temp_thresh(&cmd, TEST_SEL, 0, 0);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -337,7 +337,7 @@ static void test_set_err_recovery(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_err_recovery(&cmd, TEST_NSID, false, TLER, true);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -358,7 +358,7 @@ static void test_get_err_recovery(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_err_recovery(&cmd, TEST_NSID, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -380,7 +380,7 @@ static void test_set_volatile_wc(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_volatile_wc(&cmd, true, true);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -401,7 +401,7 @@ static void test_get_volatile_wc(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_volatile_wc(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -421,7 +421,7 @@ static void test_get_num_queues(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_num_queues(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -443,7 +443,7 @@ static void test_set_irq_coalesce(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_irq_coalesce(&cmd, false, THR, TIME);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -463,7 +463,7 @@ static void test_get_irq_coalesce(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_irq_coalesce(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -487,7 +487,7 @@ static void test_set_irq_config(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_irq_config(&cmd, true, IV, true);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -509,7 +509,7 @@ static void test_get_irq_config(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_irq_config(&cmd, TEST_SEL, IV, false);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -530,7 +530,7 @@ static void test_set_write_atomic(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_write_atomic(&cmd, false, true);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -550,7 +550,7 @@ static void test_get_write_atomic(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_write_atomic(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -573,7 +573,7 @@ static void test_set_async_event(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_async_event(&cmd, true, EVENTS);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -593,7 +593,7 @@ static void test_get_async_event(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_async_event(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -618,7 +618,7 @@ static void test_set_auto_pst(void)
 	arbitrary(&apst, sizeof(apst));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_auto_pst(&cmd, false, true, &apst);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -642,7 +642,7 @@ static void test_get_auto_pst(void)
 	arbitrary(&apst, sizeof(apst));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_auto_pst(&cmd, TEST_SEL, &get_apst);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -667,7 +667,7 @@ static void test_get_host_mem_buf(void)
 	arbitrary(&attrs, sizeof(attrs));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_host_mem_buf(&cmd, TEST_SEL, &get_attrs);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -698,7 +698,7 @@ static void test_set_timestamp(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_timestamp(&cmd, true, timestamp, &buf);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 }
@@ -718,7 +718,7 @@ static void test_get_timestamp(void)
 	arbitrary(&ts, sizeof(ts));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_timestamp(&cmd, TEST_SEL, &get_ts);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	cmp(&get_ts, &ts, sizeof(ts), "incorrect timestamp");
@@ -736,7 +736,7 @@ static void test_get_kato(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_kato(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -758,7 +758,7 @@ static void test_set_hctm(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_hctm(&cmd, false, TMT2, TMT1);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -778,7 +778,7 @@ static void test_get_hctm(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_hctm(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -800,7 +800,7 @@ static void test_set_nopsc(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_nopsc(&cmd, true, true);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -820,7 +820,7 @@ static void test_get_nopsc(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_nopsc(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -844,7 +844,7 @@ static void test_set_rrl(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_rrl(&cmd, false, NVMSETID, RRL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -865,7 +865,7 @@ static void test_get_rrl(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_rrl(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -893,7 +893,7 @@ static void test_set_plm_config(void)
 	arbitrary(&config, sizeof(config));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_plm_config(&cmd, true, NVMSETID, true,  &config);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -920,7 +920,7 @@ static void test_get_plm_config(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_plm_config(&cmd, TEST_SEL, NVMSETID,
 		&get_config);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -945,7 +945,7 @@ static void test_set_plm_window(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_plm_window(&cmd, false, NVMSETID, SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -967,7 +967,7 @@ static void test_get_plm_window(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_plm_window(&cmd, TEST_SEL, NVMSETID);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -990,7 +990,7 @@ static void test_set_lba_sts_interval(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_lba_sts_interval(&cmd, true, LSIRI, LSIPI);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1010,7 +1010,7 @@ static void test_get_lba_sts_interval(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_lba_sts_interval(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1034,7 +1034,7 @@ static void test_set_host_behavior(void)
 	arbitrary(&behavior, sizeof(behavior));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_host_behavior(&cmd, false, &behavior);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 }
@@ -1055,7 +1055,7 @@ static void test_get_host_behavior(void)
 	arbitrary(&behavior, sizeof(behavior));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_host_behavior(&cmd, TEST_SEL, &get_behavior);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1077,7 +1077,7 @@ static void test_set_sanitize(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_sanitize(&cmd, false, true);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1097,7 +1097,7 @@ static void test_get_sanitize(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_sanitize(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1121,7 +1121,7 @@ static void test_set_endurance_evt_cfg(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_endurance_evt_cfg(&cmd, true, ENDGID, EGWARN);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1143,7 +1143,7 @@ static void test_get_endurance_event_cfg(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_endurance_event_cfg(&cmd, TEST_SEL, ENDGID);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1164,7 +1164,7 @@ static void test_set_iocs_profile(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_iocs_profile(&cmd, false, IOCSI);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 }
@@ -1181,7 +1181,7 @@ static void test_get_iocs_profile(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_iocs_profile(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1204,7 +1204,7 @@ static void test_set_sw_progress(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_sw_progress(&cmd, true, PBSLC);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1224,7 +1224,7 @@ static void test_get_sw_progress(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_sw_progress(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1249,7 +1249,7 @@ static void test_set_host_id(void)
 	arbitrary(hostid, sizeof(hostid));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_host_id(&cmd, true, false,hostid);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 }
@@ -1271,7 +1271,7 @@ static void test_set_host_id_extended(void)
 	arbitrary(hostid, sizeof(hostid));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_host_id(&cmd, false, true, hostid);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 }
@@ -1293,7 +1293,7 @@ static void test_get_host_id(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_host_id(&cmd, TEST_SEL, false,
 		get_hostid, sizeof(hostid));
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	cmp(get_hostid, hostid, sizeof(hostid), "incorrect host identifier");
@@ -1317,7 +1317,7 @@ static void test_get_host_id_extended(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_host_id(&cmd, TEST_SEL, true,
 		get_hostid, sizeof(hostid));
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	cmp(get_hostid, hostid, sizeof(hostid), "incorrect host identifier");
@@ -1339,7 +1339,7 @@ static void test_set_resv_mask(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_resv_mask(&cmd, TEST_NSID, true, MASK);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1360,7 +1360,7 @@ static void test_get_resv_mask(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_resv_mask(&cmd, TEST_NSID, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1382,7 +1382,7 @@ static void test_set_resv_persist(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_resv_persist(&cmd, TEST_NSID, false, true);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1403,7 +1403,7 @@ static void test_get_resv_persist(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_resv_persist(&cmd, TEST_NSID, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1429,7 +1429,7 @@ static void test_set_write_protect(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_write_protect(&cmd, TEST_NSID, true, STATE);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1450,7 +1450,7 @@ static void test_get_write_protect(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_write_protect(&cmd, TEST_NSID, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d", err);
 	check(cmd.result == TEST_RESULT,
@@ -1478,7 +1478,7 @@ static void test_set_status_code_error(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_async_event(&cmd, false, EVENTS);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == TEST_SC, "got error %d, expected %d", err, TEST_SC);
 	check(cmd.result == TEST_RESULT,
@@ -1502,7 +1502,7 @@ static void test_set_kernel_error(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_features_resv_mask(&cmd, TEST_NSID, false, MASK);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == -EIO, "got error %d, expected -EIO", err);
 	check(!cmd.result,
@@ -1527,7 +1527,7 @@ static void test_get_status_code_error(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_kato(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == TEST_SC, "got error %d, expected %d", err, TEST_SC);
 	check(cmd.result == TEST_RESULT,
@@ -1548,7 +1548,7 @@ static void test_get_kernel_error(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_features_num_queues(&cmd, TEST_SEL);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == -EBUSY, "got error %d, expected -EBUSY", err);
 	check(!cmd.result,
@@ -1574,7 +1574,7 @@ static void test_lm_set_features_ctrl_data_queue(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_lm_set_features_ctrl_data_queue(&cmd, TEST_CDQID,
 		hp, tpt, etpt);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "set features returned error %d, errno %m", err);
 	check(cmd.result == TEST_RESULT,
@@ -1601,7 +1601,7 @@ static void test_lm_get_features_ctrl_data_queue(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_lm_get_features_ctrl_data_queue(&cmd, TEST_SEL,
 		TEST_CDQID, &data);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "get features returned error %d, errno %m", err);
 	check(cmd.result == TEST_RESULT,

--- a/libnvme/test/ioctl/identify.c
+++ b/libnvme/test/ioctl/identify.c
@@ -37,7 +37,7 @@ static void test_ns(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ns(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d, errno %m", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -58,7 +58,7 @@ static void test_ctrl(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ctrl(&cmd, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -80,7 +80,7 @@ static void test_active_ns_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_active_ns_list(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -105,7 +105,7 @@ static void test_ns_descs(void)
 	check(id, "memory allocation failed");
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ns_descs_list(&cmd, TEST_NSID, id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(id, expected_id, sizeof(expected_id), "incorrect identify data");
@@ -128,7 +128,7 @@ static void test_nvmset_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_nvmset_list(&cmd, NVME_NSID_NONE, TEST_NVMSETID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -153,7 +153,7 @@ static void test_ns_csi(void)
 	arbitrary(expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_csi_ns(&cmd, TEST_NSID, TEST_CSI, TEST_UUID, id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(id, expected_id, sizeof(id), "incorrect identify data");
@@ -176,7 +176,7 @@ static void test_zns_identify_ns(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_zns_identify_ns(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -198,7 +198,7 @@ static void test_nvm_identify_ctrl(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_csi_ctrl(&cmd, NVME_CSI_NVM, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -220,7 +220,7 @@ static void test_zns_identify_ctrl(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_zns_identify_ctrl(&cmd, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -243,7 +243,7 @@ static void test_active_ns_list_csi(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_csi_active_ns_list(&cmd, TEST_NSID, TEST_CSI, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -266,7 +266,7 @@ static void test_independent_identify_ns(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	/* That's a mouthful! */
 	nvme_init_identify_csi_independent_identify_id_ns(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -288,7 +288,7 @@ static void test_allocated_ns_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_allocated_ns_list(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -310,7 +310,7 @@ static void test_allocated_ns(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_allocated_ns(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -333,7 +333,7 @@ static void test_nsid_ctrl_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ns_ctrl_list(&cmd, TEST_NSID, TEST_CNTID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -355,7 +355,7 @@ static void test_ctrl_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ctrl_list(&cmd, TEST_CNTID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -377,7 +377,7 @@ static void test_primary_ctrl(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_primary_ctrl_cap(&cmd, TEST_CNTID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -399,7 +399,7 @@ static void test_secondary_ctrl_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_secondary_ctrl_list(&cmd, TEST_CNTID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -420,7 +420,7 @@ static void test_ns_granularity(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ns_granularity(&cmd, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -441,7 +441,7 @@ static void test_uuid(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_uuid_list(&cmd, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -463,7 +463,7 @@ static void test_domain_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_domain_list(&cmd, TEST_DOMID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -485,7 +485,7 @@ static void test_endurance_group_list(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_endurance_group_id(&cmd, TEST_ENDGID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -508,7 +508,7 @@ static void test_allocated_ns_list_csi(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_csi_allocated_ns_list(&cmd, TEST_NSID, TEST_CSI, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -530,7 +530,7 @@ static void test_iocs(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_command_set_structure(&cmd, TEST_CNTID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -556,7 +556,7 @@ static void test_status_code_error(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_nvmset_list(&cmd, NVME_NSID_NONE, TEST_NVMSETID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == TEST_SC, "got error %d, expected TEST_SC", err);
 }
@@ -576,7 +576,7 @@ static void test_kernel_error(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ns(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == -EIO, "got error %d, expected -EIO", err);
 }
@@ -601,7 +601,7 @@ static void test_identify_ns_csi_user_data_format(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_ns_user_data_format(&cmd, NVME_CSI_NVM,
 		TEST_FIDX, TEST_UUID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d, errno %m", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");
@@ -626,7 +626,7 @@ static void test_identify_iocs_ns_csi_user_data_format(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_identify_csi_ns_user_data_format(&cmd, TEST_CSI,
 		TEST_FIDX, TEST_UUID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "identify returned error %d, errno %m", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect identify data");

--- a/libnvme/test/ioctl/misc.c
+++ b/libnvme/test/ioctl/misc.c
@@ -35,7 +35,7 @@ static void test_format_nvm(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_format_nvm(&cmd, nsid, lbaf, mset, pi, pil, ses);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -62,7 +62,7 @@ static void test_ns_mgmt(void)
 	arbitrary(&expected_data, sizeof(expected_data));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_ns_mgmt(&cmd, nsid, sel, csi, &data);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -90,7 +90,7 @@ static void test_ns_mgmt_create(void)
 	arbitrary(&expected_data, sizeof(expected_data));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_ns_mgmt_create(&cmd, NVME_CSI_ZNS, &data);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == TEST_NSID,
@@ -110,7 +110,7 @@ static void test_ns_mgmt_delete(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_ns_mgmt_delete(&cmd, TEST_NSID);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 }
@@ -131,7 +131,7 @@ static void test_get_property(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_property(&cmd, NVME_REG_ACQ);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == expected_result, "returned wrong result");
@@ -153,7 +153,7 @@ static void test_set_property(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_set_property(&cmd, NVME_REG_BPMBL, value);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -177,7 +177,7 @@ static void test_ns_attach(void)
 	arbitrary(&expected_ctrlist, sizeof(expected_ctrlist));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_ns_attach(&cmd, nsid, sel, &ctrlist);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -201,7 +201,7 @@ static void test_ns_attach_ctrls(void)
 	arbitrary(&ctrlist, sizeof(ctrlist));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_ns_attach_ctrls(&cmd, TEST_NSID, &ctrlist);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 }
@@ -222,7 +222,7 @@ static void test_ns_detach_ctrls(void)
 	arbitrary(&ctrlist, sizeof(ctrlist));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_ns_detach_ctrls(&cmd, TEST_NSID, &ctrlist);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 }
@@ -247,7 +247,7 @@ static void test_fw_download(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	err = nvme_init_fw_download(&cmd, data, data_len, offset);
 	check(err == 0, "download initializing error %d", err);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -268,7 +268,7 @@ static void test_fw_commit(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_fw_commit(&cmd, slot, action, bpid);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -299,7 +299,7 @@ static void test_security_send(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_security_send(&cmd, nsid, nssf, spsp, secp, tl,
 		data, data_len);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -328,7 +328,7 @@ static void test_security_receive(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_security_receive(&cmd, TEST_NSID, nssf, spsp, secp, al,
 		data, sizeof(data));
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -370,7 +370,7 @@ static void test_get_lba_status(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_get_lba_status(&cmd, TEST_NSID, slba, mndw, atype,
 		rl, lbas);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned wrong result");
@@ -401,7 +401,7 @@ static void test_directive_send(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_send(&cmd, TEST_NSID, doper, dtype, dspec,
 		expected_data, data_len);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned wrong result");
@@ -429,7 +429,7 @@ static void test_directive_send_id_endir(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_send_id_endir(&cmd, TEST_NSID, true,
 		NVME_DIRECTIVE_DTYPE_STREAMS, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect id");
@@ -451,7 +451,7 @@ static void test_directive_send_stream_release_identifier(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_send_stream_release_identifier(&cmd, TEST_NSID,
 		stream_id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 }
@@ -469,7 +469,7 @@ static void test_directive_send_stream_release_resource(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_send_stream_release_resource(&cmd, TEST_NSID);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 }
@@ -496,7 +496,7 @@ static void test_directive_recv(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_recv(&cmd, TEST_NSID, doper, dtype, dspec,
 		data, data_len);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned wrong result");
@@ -521,7 +521,7 @@ static void test_directive_recv_identify_parameters(void)
 	arbitrary(&expected_id, sizeof(expected_id));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_recv_identify_parameters(&cmd, TEST_NSID, &id);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	cmp(&id, &expected_id, sizeof(id), "incorrect id");
@@ -545,7 +545,7 @@ static void test_directive_recv_stream_parameters(void)
 	arbitrary(&expected_params, sizeof(expected_params));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_recv_stream_parameters(&cmd, TEST_NSID, &params);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	cmp(&params, &expected_params, sizeof(params), "incorrect params");
@@ -583,7 +583,7 @@ static void test_directive_recv_stream_status(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_recv_stream_status(&cmd, TEST_NSID, nr_entries,
 		status);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	cmp(status, expected_status, stream_status_size, "incorrect status");
@@ -606,7 +606,7 @@ static void test_directive_recv_stream_allocate(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_directive_recv_stream_allocate(&cmd, TEST_NSID, nsr);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == expected_result, "wrong result");
@@ -631,7 +631,7 @@ void test_capacity_mgmt(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_capacity_mgmt(&cmd, op, elid, cap);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == expected_result, "wrong result");
@@ -657,7 +657,7 @@ static void test_lockdown(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_lockdown(&cmd, scp, prhbt, ifc, ofi, uuidx);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == expected_result, "wrong result");
@@ -687,7 +687,7 @@ static void test_sanitize_nvm(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_sanitize_nvm(&cmd, sanact, ause, owpass, oipbp, ndas,
 		emvs, ovrpat);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == expected_result, "wrong result");
@@ -707,7 +707,7 @@ static void test_dev_self_test(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_dev_self_test(&cmd, TEST_NSID, NVME_DST_STC_ABORT);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == expected_result, "wrong result");
@@ -731,7 +731,7 @@ static void test_virtual_mgmt(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_virtual_mgmt(&cmd, act, rt, cntlid, nr);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == expected_result, "wrong result");
@@ -748,7 +748,7 @@ static void test_flush(void)
 
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_flush(&cmd, TEST_NSID);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 }
@@ -781,7 +781,7 @@ static void test_read(void)
 	nvme_init_read(&cmd, TEST_NSID, slba, nlb, control, dsm, 0,
 		data, sizeof(data), NULL, 0);
 	nvme_init_app_tag(&cmd, apptag, appmask);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -816,7 +816,7 @@ static void test_write(void)
 	nvme_init_write(&cmd, TEST_NSID, slba, nlb, control, dspec, dsm, 0,
 		expected_data, sizeof(expected_data), NULL, 0);
 	nvme_init_app_tag(&cmd, apptag, appmask);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -850,7 +850,7 @@ static void test_compare(void)
 	nvme_init_compare(&cmd, TEST_NSID, slba, nlb, control, cev, data,
 		sizeof(data), NULL, 0);
 	nvme_init_app_tag(&cmd, apptag, appmask);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -882,7 +882,7 @@ static void test_write_zeros(void)
 	nvme_init_write_zeros(&cmd, TEST_NSID, slba, nlb, control,
 		dspec, dsm, cev);
 	nvme_init_app_tag(&cmd, apptag, appmask);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -913,7 +913,7 @@ static void test_write_uncorrectable(void)
 	nvme_init_write_uncorrectable(&cmd, TEST_NSID, slba, nlb,
 		control, dspec);
 	nvme_init_app_tag(&cmd, apptag, appmask);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -943,7 +943,7 @@ static void test_verify(void)
 	nvme_init_verify(&cmd, TEST_NSID, slba, nlb, control, cev,
 		NULL, 0, NULL, 0);
 	nvme_init_app_tag(&cmd, apptag, appmask);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -974,7 +974,7 @@ static void test_dsm(void)
 	arbitrary(dsm, dsm_size);
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_dsm(&cmd, TEST_NSID, nr_ranges, 0, 0, 1, dsm, dsm_size);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1028,7 +1028,7 @@ static void test_copy(void)
 	nvme_init_copy(&cmd, TEST_NSID, sdlba, nr, desfmt,
 		prinfor, prinfow, cetype, dtype, stcw, stcr,
 		fua, lr, cev, dspec, (void *)copy);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1084,7 +1084,7 @@ static void test_copy_range_f1(void)
 	nvme_init_copy(&cmd, TEST_NSID, sdlba, nr, desfmt,
 		prinfor, prinfow, cetype, dtype, stcw, stcr,
 		fua, lr, cev, dspec, (void *)copy);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64,
@@ -1112,7 +1112,7 @@ static void test_resv_acquire(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_resv_acquire(&cmd, TEST_NSID, racqa, iekey, false, rtype,
 		1, 2, payload);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1139,7 +1139,7 @@ static void test_resv_register(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_resv_register(&cmd, TEST_NSID, rrega, iekey, false, cptpl,
 		0xffffffffffffffff, 0, payload);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1166,7 +1166,7 @@ static void test_resv_release(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_resv_release(&cmd, TEST_NSID, rrela, iekey, false, rtype,
 		0xffffffffffffffff, payload);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1192,7 +1192,7 @@ static void test_resv_report(void)
 	arbitrary(&expected_status, sizeof(expected_status));
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_resv_report(&cmd, TEST_NSID, eds, disnsrs, &status, len);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1219,7 +1219,7 @@ static void test_io_mgmt_recv(void)
 	arbitrary(&expected_data, sizeof(expected_data));
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_io_mgmt_recv(&cmd, TEST_NSID, mo, mos, data, data_len);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	cmp(&data, &expected_data, sizeof(data), "incorrect data");
@@ -1245,7 +1245,7 @@ static void test_io_mgmt_send(void)
 	memcpy(&data, &expected_data, sizeof(expected_data));
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_io_mgmt_send(&cmd, TEST_NSID, mo, mos, data, data_len);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	cmp(&data, &expected_data, sizeof(data), "incorrect data");
@@ -1270,7 +1270,7 @@ static void test_fdp_reclaim_unit_handle_status(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_fdp_reclaim_unit_handle_status(&cmd, TEST_NSID,
 		&data, data_len);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	cmp(&data, &expected_data, sizeof(data), "incorrect data");
@@ -1293,7 +1293,7 @@ static void test_fdp_reclaim_unit_handle_update(void)
 	arbitrary(&pids, sizeof(pids));
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_fdp_reclaim_unit_handle_update(&cmd, TEST_NSID, &pids, npids);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 }
@@ -1316,7 +1316,7 @@ static void test_dim_send(void)
 	memcpy(&data, &expected_data, sizeof(expected_data));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_dim_send(&cmd, tas, data, data_len);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1345,7 +1345,7 @@ static void test_lm_cdq_delete(void)
 	memcpy(&data, &expected_data, sizeof(expected_data));
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_lm_cdq_delete(&cmd, mos, cdqid);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1367,7 +1367,7 @@ static void test_lm_track_send(void)
 
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_lm_track_send(&cmd, sel, mos, cdqid);
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1405,7 +1405,7 @@ static void test_lm_migration_send(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_lm_migration_send(&cmd, sel, mos, cntlid, stype, dudmq,
 		csvi, csuuidi, offset, uidx, &data, sizeof(data));
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);
@@ -1442,7 +1442,7 @@ static void test_lm_migration_recv(void)
 	set_mock_admin_cmds(&mock_admin_cmd, 1);
 	nvme_init_lm_migration_recv(&cmd, offset, mos, cntlid, csuuidi, sel,
 		uidx, csuidxp, data, sizeof(data));
-	err = libnvme_submit_admin_passthru(test_hdl, &cmd);
+	err = libnvme_exec_admin_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(cmd.result == 0, "returned result %" PRIu64, (uint64_t)cmd.result);

--- a/libnvme/test/ioctl/zns.c
+++ b/libnvme/test/ioctl/zns.c
@@ -51,7 +51,7 @@ static void test_zns_append(void)
 	if (elbas)
 		nvme_init_var_size_tags(&cmd, pif, sts, reftag, storage_tag);
 	nvme_init_app_tag(&cmd, lbat, lbatm);
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(result == 0, "wrong result");
@@ -82,7 +82,7 @@ static void test_zns_report_zones(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_zns_report_zones(&cmd, TEST_NSID, TEST_SLBA, opts,
 		extended, partial, &data, sizeof(data));
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(result == 0, "returned result %"PRIu64, (uint64_t)result);
@@ -114,7 +114,7 @@ static void test_zns_mgmt_send(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_zns_mgmt_send(&cmd, TEST_NSID, slba, zsa, select_all, zsaso,
 		false, data, sizeof(data));
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(result == 0, "returned result %"PRIu64, (uint64_t)result);
@@ -143,7 +143,7 @@ static void test_zns_mgmt_recv(void)
 	set_mock_io_cmds(&mock_io_cmd, 1);
 	nvme_init_zns_mgmt_recv(&cmd, TEST_NSID, 0, zra, zrasf, zras_feat,
 		data, sizeof(data));
-	err = libnvme_submit_io_passthru(test_hdl, &cmd);
+	err = libnvme_exec_io_passthru(test_hdl, &cmd);
 	end_mock_cmds();
 	check(err == 0, "returned error %d", err);
 	check(result == 0, "returned result %"PRIu64, (uint64_t)result);

--- a/libnvme/test/mi-mctp.c
+++ b/libnvme/test/mi-mctp.c
@@ -429,7 +429,7 @@ static void test_admin_resp_err(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->tx_buf_len = 8;
 
 	nvme_init_identify_ctrl(&cmd, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
 	assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
 }
@@ -456,7 +456,7 @@ static void test_admin_resp_sizes(libnvme_mi_ep_t ep, struct test_peer *peer)
 	for (i = 8; i <= 4096 + 8; i+=4) {
 		peer->tx_buf_len = i;
 		nvme_init_identify_ctrl(&cmd, &id);
-		rc = libnvme_submit_admin_passthru(hdl, &cmd);
+		rc = libnvme_exec_admin_passthru(hdl, &cmd);
 		assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
 		assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
 	}
@@ -581,7 +581,7 @@ static void test_mpr_admin(libnvme_mi_ep_t ep, struct test_peer *peer)
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
 
 	nvme_init_identify_ctrl(&cmd, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc == 0);
 
 	libnvme_close(hdl);
@@ -608,7 +608,7 @@ static void test_mpr_admin_quirked(libnvme_mi_ep_t ep, struct test_peer *peer)
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
 
 	nvme_init_identify_ctrl(&cmd, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc == 0);
 
 	libnvme_close(hdl);

--- a/libnvme/test/mi.c
+++ b/libnvme/test/mi.c
@@ -450,7 +450,7 @@ static void test_admin_id(libnvme_mi_ep_t ep)
 	assert(hdl);
 
 	nvme_init_identify_ctrl(&cmd, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc == 0);
 }
 
@@ -506,7 +506,7 @@ static void test_admin_err_mi_resp(libnvme_mi_ep_t ep)
 	assert(hdl);
 
 	nvme_init_identify_ctrl(&cmd, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc != 0);
 	assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
 	assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
@@ -570,7 +570,7 @@ static void test_admin_err_nvme_resp(libnvme_mi_ep_t ep)
 	assert(hdl);
 
 	nvme_init_identify_ctrl(&cmd, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc != 0);
 	assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_NVME);
 	assert(nvme_status_get_value(rc) ==
@@ -978,7 +978,7 @@ static void test_get_features(libnvme_mi_ep_t ep)
 	assert(hdl);
 
 	nvme_init_get_features(&cmd, NVME_FEAT_FID_ARBITRATION, 0);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc == 0);
 	assert(cmd.result == 0x04030201);
 }
@@ -1048,7 +1048,7 @@ static void test_set_features(libnvme_mi_ep_t ep)
 	assert(hdl);
 
 	nvme_init_set_features_timestamp(&cmd, true, 0x050403020100, &tstmp);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc == 0);
 }
 
@@ -1118,7 +1118,7 @@ static void test_admin_id_alloc_ns_list(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_identify_allocated_ns_list(&cmd, 1, &list);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	assert(le32_to_cpu(list.ns[0]) == 2);
@@ -1141,7 +1141,7 @@ static void test_admin_id_active_ns_list(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_identify_active_ns_list(&cmd, 1, &list);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	assert(le32_to_cpu(list.ns[0]) == 4);
@@ -1206,7 +1206,7 @@ static void test_admin_id_alloc_ns(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_identify_allocated_ns(&cmd, 1, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 	assert(le64_to_cpu(id.nsze) == 1);
 }
@@ -1226,7 +1226,7 @@ static void test_admin_id_active_ns(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_identify_ns(&cmd, 1, &id);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 	assert(le64_to_cpu(id.nsze) == 1);
 }
@@ -1273,7 +1273,7 @@ static void test_admin_id_ns_ctrl_list(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_identify_ns_ctrl_list(&cmd, 0x01020304, 5, &list);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1316,7 +1316,7 @@ static void test_admin_id_secondary_ctrl_list(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_identify_secondary_ctrl_list(&cmd, 5, &list);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1389,14 +1389,14 @@ static void test_admin_ns_mgmt_create(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_ns_mgmt_create(&cmd, NVME_CSI_NVM, &data);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 	ns = cmd.result;
 	assert(ns == 0x01020304);
 
 	data.nsze = cpu_to_le64(42);
 	nvme_init_ns_mgmt_create(&cmd, NVME_CSI_NVM, &data);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(rc);
 }
 
@@ -1412,7 +1412,7 @@ static void test_admin_ns_mgmt_delete(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_ns_mgmt_delete(&cmd, 0x05060708);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1481,7 +1481,7 @@ static void test_admin_ns_attach(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_ns_attach_ctrls(&cmd, 0x02030405, &list);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1506,7 +1506,7 @@ static void test_admin_ns_detach(struct libnvme_mi_ep *ep)
 	assert(hdl);
 
 	nvme_init_ns_detach_ctrls(&cmd, 0x02030405, &list);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1587,7 +1587,7 @@ static void test_admin_fw_download(struct libnvme_mi_ep *ep)
 	info.offset = 0;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
 	assert(!rc);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	/* largest len */
@@ -1595,7 +1595,7 @@ static void test_admin_fw_download(struct libnvme_mi_ep *ep)
 	info.offset = 0;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
 	assert(!rc);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	/* offset value */
@@ -1603,7 +1603,7 @@ static void test_admin_fw_download(struct libnvme_mi_ep *ep)
 	info.offset = 4096;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
 	assert(!rc);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1657,7 +1657,7 @@ static void test_admin_fw_commit(struct libnvme_mi_ep *ep)
 	info.slot = 0;
 	info.action = 0;
 	nvme_init_fw_commit(&cmd, info.slot, info.action, info.bpid);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	/* all ones */
@@ -1665,7 +1665,7 @@ static void test_admin_fw_commit(struct libnvme_mi_ep *ep)
 	info.slot = 0x7;
 	info.action = 0x7;
 	nvme_init_fw_commit(&cmd, info.slot, info.action, info.bpid);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	/* correct fields */
@@ -1673,7 +1673,7 @@ static void test_admin_fw_commit(struct libnvme_mi_ep *ep)
 	info.slot = 2;
 	info.action = 3;
 	nvme_init_fw_commit(&cmd, info.slot, info.action, info.bpid);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1743,7 +1743,7 @@ static void test_admin_format_nvm(struct libnvme_mi_ep *ep)
 
 	nvme_init_format_nvm(&cmd, args.nsid, args.lbaf, args.mset,
 			     args.pi, args.pil, args.ses);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	args.nsid = ~args.nsid;
@@ -1755,7 +1755,7 @@ static void test_admin_format_nvm(struct libnvme_mi_ep *ep)
 
 	nvme_init_format_nvm(&cmd, args.nsid, args.lbaf, args.mset,
 			     args.pi, args.pil, args.ses);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 
@@ -1821,7 +1821,7 @@ static void test_admin_sanitize_nvm(struct libnvme_mi_ep *ep)
 
 	nvme_init_sanitize_nvm(&cmd, args.sanact, args.ause, args.owpass,
 		args.oipbp, args.ndas, args.emvs, args.ovrpat);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 
 	args.sanact = 0x0;
@@ -1833,7 +1833,7 @@ static void test_admin_sanitize_nvm(struct libnvme_mi_ep *ep)
 
 	nvme_init_sanitize_nvm(&cmd, args.sanact, args.ause, args.owpass,
 		args.oipbp, args.ndas, args.emvs, args.ovrpat);
-	rc = libnvme_submit_admin_passthru(hdl, &cmd);
+	rc = libnvme_exec_admin_passthru(hdl, &cmd);
 	assert(!rc);
 }
 

--- a/libnvme/test/test.c
+++ b/libnvme/test/test.c
@@ -64,7 +64,7 @@ static int test_ctrl(libnvme_ctrl_t c)
 	struct nvme_id_ctrl id = { 0 };
 
 	nvme_init_identify_ctrl(&cmd, &id);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (ret) {
 		printf("ERROR: no identify for:%s\n", libnvme_ctrl_get_name(c));
 		return ret;
@@ -94,49 +94,49 @@ static int test_ctrl(libnvme_ctrl_t c)
 	printf("  model:%-.40s\n", id.mn);
 
 	nvme_init_identify_allocated_ns_list(&cmd, 0, &ns_list);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: Allocated NS List\n");
 	else
 		printf("  ERROR: Allocated NS List:%x\n", ret);
 	nvme_init_identify_active_ns_list(&cmd, 0, &ns_list);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: Active NS List\n");
 	else
 		printf("  ERROR: Active NS List:%x\n", ret);
 	nvme_init_identify_ctrl_list(&cmd, 0, &ctrlist);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: Ctrl List\n");
 	else
 		printf("  ERROR: CtrlList:%x\n", ret);
 	nvme_init_identify_ctrl_list(&cmd, 1, &ctrlist);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: NSID Ctrl List\n");
 	else
 		printf("  ERROR: NSID CtrlList:%x\n", ret);
 	nvme_init_identify_primary_ctrl_cap(&cmd, 0, &prim);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: Identify Primary\n");
 	else
 		printf("  ERROR: Identify Primary:%x\n", ret);
 	nvme_init_identify_secondary_ctrl_list(&cmd, 0, &sec);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: Identify Secondary\n");
 	else
 		printf("  ERROR: Identify Secondary:%x\n", ret);
 	nvme_init_identify_ns_granularity(&cmd, &gran);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: Identify NS granularity\n");
 	else
 		printf("  ERROR: Identify NS granularity:%x\n", ret);
 	nvme_init_identify_uuid_list(&cmd, &uuid);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  PASSED: Identify UUID List\n");
 	else
@@ -207,111 +207,111 @@ static int test_ctrl(libnvme_ctrl_t c)
 		printf("  ERROR: Error Log:%x\n", ret);
 	printf("\nFeatures\n");
 	nvme_init_get_features_arbitration(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Arbitration:%" PRIu64 "\n", (uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Arbitration:%x\n", ret);
 	nvme_init_get_features_power_mgmt(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Power Management:%" PRIu64 "x\n", (uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Power Management:%x\n", ret);
 
 	nvme_init_get_features_temp_thresh(&cmd, sel, 0, 0);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Temperature Threshold:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Temperature Threshold:%x\n", ret);
 	nvme_init_get_features_volatile_wc(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Volatile Write Cache:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Volatile Write Cache:%x\n", ret);
 	nvme_init_get_features_num_queues(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Number of Queues:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Number of Queues:%x\n", ret);
 	nvme_init_get_features_irq_coalesce(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  IRQ Coalescing:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: IRQ Coalescing:%x\n", ret);
 	nvme_init_get_features_write_atomic(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Write Atomic:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Write Atomic:%x\n", ret);
 	nvme_init_get_features_async_event(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Asycn Event Config:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Asycn Event Config:%x\n", ret);
 	nvme_init_get_features_hctm(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  HCTM:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: HCTM:%x\n", ret);
 	nvme_init_get_features_nopsc(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  NOP Power State Config:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: NOP Power State Configrbitration:%x\n", ret);
 	nvme_init_get_features_rrl(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Read Recover Levels:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Read Recover Levels:%x\n", ret);
 	nvme_init_get_features_lba_sts_interval(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  LBA Status Interval:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: LBA Status Interval:%x\n", ret);
 	nvme_init_get_features_sanitize(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Sanitize:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: SW Progress Marker:%x\n", ret);
 	nvme_init_get_features_sw_progress(&cmd, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  SW Progress Marker:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Sanitize:%x\n", ret);
 	nvme_init_get_features_resv_mask(&cmd, 0, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Reservation Mask:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
 	else if (ret > 0)
 		printf("  ERROR: Reservation Mask:%x\n", ret);
 	nvme_init_get_features_resv_persist(&cmd, 0, sel);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Reservation Persistence:%" PRIu64 "\n",
 			(uint64_t)cmd.result);
@@ -344,7 +344,7 @@ static int test_namespace(libnvme_ns_t n)
 		1 << ns.lbaf[flbas].ds);
 
 	nvme_init_identify_allocated_ns(&cmd, nsid, &allocated);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Identify allocated ns\n");
 	else
@@ -354,7 +354,7 @@ static int test_namespace(libnvme_ns_t n)
 		return -1;
 
 	nvme_init_identify_ns_descs_list(&cmd, nsid, descs);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Identify NS Descriptors\n");
 	else
@@ -362,7 +362,7 @@ static int test_namespace(libnvme_ns_t n)
 	free(descs);
 	nvme_init_get_features_write_protect(&cmd, nsid,
 		NVME_GET_FEATURES_SEL_CURRENT);
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!ret)
 		printf("  Write Protect:%" PRIu64 "\n", (uint64_t)result);
 	else if (ret > 0)

--- a/libnvme/test/zns.c
+++ b/libnvme/test/zns.c
@@ -39,7 +39,7 @@ static void show_zns_properties(libnvme_ns_t n)
 		return;
 
 	nvme_init_zns_identify_ns(&cmd, libnvme_ns_get_nsid(n), &zns_ns);
-	if (libnvme_submit_admin_passthru(hdl, &cmd)) {
+	if (libnvme_exec_admin_passthru(hdl, &cmd)) {
 		fprintf(stderr, "failed to identify zns ns, result %" PRIx64 "\n",
 			(uint64_t)cmd.result);
 		free(zr);
@@ -51,7 +51,7 @@ static void show_zns_properties(libnvme_ns_t n)
 		le32_to_cpu(zns_ns.mor));
 
 	nvme_init_zns_identify_ctrl(&cmd, &zns_ctrl);
-	if (libnvme_submit_admin_passthru(hdl, &cmd)) {
+	if (libnvme_exec_admin_passthru(hdl, &cmd)) {
 		fprintf(stderr, "failed to identify zns ctrl\n");;
 		free(zr);
 		return;
@@ -61,7 +61,7 @@ static void show_zns_properties(libnvme_ns_t n)
 	nvme_init_zns_report_zones(&cmd, libnvme_ns_get_nsid(n), 0,
 				  NVME_ZNS_ZRAS_REPORT_ALL, false,
 				  true, (void *)zr, 0x1000);
-	if (libnvme_submit_io_passthru(hdl, &cmd)) {
+	if (libnvme_exec_io_passthru(hdl, &cmd)) {
 		fprintf(stderr, "failed to report zones, result %" PRIx64"\n",
 			(uint64_t)cmd.result);
 		free(zr);

--- a/nvme-cmds.c
+++ b/nvme-cmds.c
@@ -26,7 +26,7 @@ static int nvme_ns_attachment(struct libnvme_transport_handle *hdl, bool ish,
 	else
 		nvme_init_ns_detach_ctrls(&cmd, nsid, &cntlist);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 int nvme_namespace_attach_ctrls(struct libnvme_transport_handle *hdl, bool ish,

--- a/nvme-cmds.h
+++ b/nvme-cmds.h
@@ -32,7 +32,7 @@ static inline int nvme_flush(struct libnvme_transport_handle *hdl, __u32 nsid)
 	cmd.opcode = nvme_cmd_flush;
 	cmd.nsid = nsid;
 
-	return libnvme_submit_io_passthru(hdl, &cmd);
+	return libnvme_exec_io_passthru(hdl, &cmd);
 }
 
 /**
@@ -60,7 +60,7 @@ nvme_identify(struct libnvme_transport_handle *hdl, __u32 nsid, enum nvme_csi cs
 
 	nvme_init_identify(&cmd, nsid, csi, cns, data, len);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -84,7 +84,7 @@ nvme_identify_ctrl(struct libnvme_transport_handle *hdl,
 
 	nvme_init_identify_ctrl(&cmd, id);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -108,7 +108,7 @@ nvme_identify_active_ns_list(struct libnvme_transport_handle *hdl,
 
 	nvme_init_identify_active_ns_list(&cmd, nsid, ns_list);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -133,7 +133,7 @@ nvme_identify_ns(struct libnvme_transport_handle *hdl,
 
 	nvme_init_identify_ns(&cmd, nsid, ns);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -159,7 +159,7 @@ nvme_identify_csi_ns(struct libnvme_transport_handle *hdl, __u32 nsid,
 
 	nvme_init_identify_csi_ns(&cmd, nsid, csi, uidx, id_ns);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -182,7 +182,7 @@ nvme_identify_uuid_list(struct libnvme_transport_handle *hdl,
 
 	nvme_init_identify_uuid_list(&cmd, uuid_list);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -208,7 +208,7 @@ nvme_identify_csi_ns_user_data_format(struct libnvme_transport_handle *hdl,
 
 	nvme_init_identify_csi_ns_user_data_format(&cmd, csi, fidx, uidx, data);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -231,7 +231,7 @@ nvme_identify_ns_granularity(struct libnvme_transport_handle *hdl,
 
 	nvme_init_identify_ns_granularity(&cmd, gr_list);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -256,7 +256,7 @@ nvme_identify_ns_descs_list(struct libnvme_transport_handle *hdl,
 
 	nvme_init_identify_ns_descs_list(&cmd, nsid, descs);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -280,7 +280,7 @@ nvme_zns_identify_ns(struct libnvme_transport_handle *hdl,
 
 	nvme_init_zns_identify_ns(&cmd, nsid, data);
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -1634,7 +1634,7 @@ nvme_set_features(struct libnvme_transport_handle *hdl, __u32 nsid, __u8 fid,
 	cmd.data_len = len;
 	cmd.addr = (__u64)(uintptr_t)data;
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (result)
 		*result = cmd.result;
 	return err;
@@ -1667,7 +1667,7 @@ nvme_set_features_simple(struct libnvme_transport_handle *hdl,
 	cmd.nsid = nsid;
 	cmd.cdw11 = cdw11;
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (result)
 		*result = cmd.result;
 	return err;
@@ -1708,7 +1708,7 @@ nvme_get_features(struct libnvme_transport_handle *hdl, __u32 nsid,
 	cmd.data_len = len;
 	cmd.addr = (__u64)(uintptr_t)data;
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (result)
 		*result = cmd.result;
 	return err;
@@ -1737,7 +1737,7 @@ nvme_get_features_simple(struct libnvme_transport_handle *hdl, __u8 fid,
 
 	nvme_init_get_features(&cmd, fid, sel);
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (result)
 		*result = cmd.result;
 	return err;

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -282,7 +282,7 @@ static int send_rpmb_req(struct libnvme_transport_handle *hdl, unsigned char tgt
 
 	nvme_init_security_send(&cmd, NVME_NSID_NONE, tgt, RPMB_NVME_SPSP,
 			        RPMB_NVME_SECP, 0, req, size);
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 static int recv_rpmb_rsp(struct libnvme_transport_handle *hdl, int tgt, int size,
@@ -292,7 +292,7 @@ static int recv_rpmb_rsp(struct libnvme_transport_handle *hdl, int tgt, int size
 
 	nvme_init_security_receive(&cmd, 0, tgt, RPMB_NVME_SPSP,
 				   RPMB_NVME_SECP, 0, rsp, size);
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /* Initialize nonce value in rpmb request frame */

--- a/nvme.c
+++ b/nvme.c
@@ -1127,7 +1127,7 @@ static int get_effects_log(int argc, char **argv, struct command *acmd, struct p
 			munmap_registers(bar);
 		} else {
 			nvme_init_get_property(&cmd, NVME_REG_CAP);
-			err = libnvme_submit_admin_passthru(hdl, &cmd);
+			err = libnvme_exec_admin_passthru(hdl, &cmd);
 			if (err)
 				goto cleanup_list;
 			cap = cmd.result;
@@ -2183,7 +2183,7 @@ static int io_mgmt_send(int argc, char **argv, struct command *acmd, struct plug
 	}
 
 	nvme_init_io_mgmt_send(&cmd, cfg.nsid, cfg.mo, cfg.mos, buf, cfg.data_len);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "io-mgmt-send");
 		return err;
@@ -2246,7 +2246,7 @@ static int io_mgmt_recv(int argc, char **argv, struct command *acmd, struct plug
 
 	nvme_init_io_mgmt_recv(&cmd, cfg.nsid, cfg.mo, cfg.mos, buf,
 		cfg.data_len);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "io-mgmt-recv");
 		return err;
@@ -2697,7 +2697,7 @@ static int list_ctrl(int argc, char **argv, struct command *acmd, struct plugin 
 		nvme_init_identify_ns_ctrl_list(&cmd, cfg.namespace_id,
 						cfg.cntid, cntlist);
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "id controller list");
 		return err;
@@ -2880,7 +2880,7 @@ static int id_endurance_grp_list(int argc, char **argv, struct command *acmd,
 
 	nvme_init_identify_endurance_group_id(&cmd, cfg.endgrp_id,
 					      endgrp_list);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "Id endurance group list");
 		return err;
@@ -2983,7 +2983,7 @@ static int delete_ns(int argc, char **argv, struct command *acmd, struct plugin 
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	ns_mgmt_show_status(hdl, err, acmd->name, cfg.namespace_id);
 
 	return err;
@@ -3077,7 +3077,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	ns_mgmt_show_status(hdl, err, acmd->name, cfg.nsid);
 
 	return err;
@@ -3444,7 +3444,7 @@ parse_lba:
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	nsid = cmd.result;
 	ns_mgmt_show_status(hdl, err, acmd->name, nsid);
 
@@ -3694,7 +3694,7 @@ static int nvm_id_ctrl(int argc, char **argv, struct command *acmd,
 		return -ENOMEM;
 
 	nvme_init_identify_csi_ctrl(&cmd, NVME_CSI_NVM, ctrl_nvm);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "nvm identify controller");
 		return err;
@@ -3986,7 +3986,7 @@ static int id_ns(int argc, char **argv, struct command *acmd, struct plugin *plu
 
 	if (cfg.force) {
 		nvme_init_identify_allocated_ns(&cmd, cfg.namespace_id, ns);
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 	} else {
 		err = nvme_identify_ns(hdl, cfg.namespace_id, ns);
 	}
@@ -4062,7 +4062,7 @@ static int cmd_set_independent_id_ns(int argc, char **argv, struct command *acmd
 
 	nvme_init_identify_csi_independent_identify_id_ns(&cmd,
 							  cfg.namespace_id, ns);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err,
 			      "I/O command set independent identify namespace");
@@ -4155,7 +4155,7 @@ static int id_nvmset(int argc, char **argv, struct command *acmd, struct plugin 
 
 	nvme_init_identify_nvmset_list(&cmd, NVME_NSID_NONE,
 				       cfg.nvmset_id, nvmset);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "identify nvm set list");
 		return err;
@@ -4268,7 +4268,7 @@ static int id_iocs(int argc, char **argv, struct command *acmd, struct plugin *p
 		return -ENOMEM;
 
 	nvme_init_identify_command_set_structure(&cmd, cfg.cntid, iocs);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "NVMe Identify I/O Command Set");
 		return err;
@@ -4320,7 +4320,7 @@ static int id_domain(int argc, char **argv, struct command *acmd, struct plugin 
 		return -ENOMEM;
 
 	nvme_init_identify_domain_list(&cmd, cfg.dom_id, id_domain);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "NVMe Identify Domain List");
 		return err;
@@ -4414,7 +4414,7 @@ static int virtual_mgmt(int argc, char **argv, struct command *acmd, struct plug
 		return err;
 
 	nvme_init_virtual_mgmt(&cmd, cfg.act, cfg.rt, cfg.cntlid, cfg.nr);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "virt-mgmt");
 		return err;
@@ -4472,7 +4472,7 @@ static int primary_ctrl_caps(int argc, char **argv, struct command *acmd, struct
 		return -ENOMEM;
 
 	nvme_init_identify_primary_ctrl_cap(&cmd, cfg.cntlid, caps);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "identify primary controller capabilities");
 		return err;
@@ -4531,7 +4531,7 @@ static int list_secondary_ctrl(int argc, char **argv, struct command *acmd, stru
 		return -ENOMEM;
 
 	nvme_init_identify_secondary_ctrl_list(&cmd, cfg.cntid, sc_list);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "id secondary controller list");
 		return err;
@@ -4633,7 +4633,7 @@ static void abort_self_test(struct libnvme_transport_handle *hdl, bool ish,
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "Device self-test");
 		return;
@@ -4726,7 +4726,7 @@ static int device_self_test(int argc, char **argv, struct command *acmd, struct 
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "Device self-test");
 		goto check_abort;
@@ -5050,7 +5050,7 @@ static int fw_download_single(struct libnvme_transport_handle *hdl, void *fw_buf
 		if (err)
 			return err;
 
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 		if (!err)
 			return 0;
 
@@ -5415,7 +5415,7 @@ static int fw_commit(int argc, char **argv, struct command *acmd, struct plugin 
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		fw_commit_err(err, cfg.action, cfg.slot, cfg.bpid);
 		return err;
@@ -5636,7 +5636,7 @@ static int sanitize_cmd(int argc, char **argv, struct command *acmd, struct plug
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "sanitize");
 		return err;
@@ -5731,7 +5731,7 @@ static int sanitize_ns_cmd(int argc, char **argv, struct command *acmd,
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_admin_cmd_err("sanitize ns", cmd.opcode, err);
 		return err;
@@ -5747,7 +5747,7 @@ static int nvme_get_single_property(struct libnvme_transport_handle *hdl,
 	int err;
 
 	nvme_init_get_property(&cmd, cfg->offset);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err) {
 		*value = cmd.result;
 		return 0;
@@ -6001,7 +6001,7 @@ static int get_register_properties(struct libnvme_transport_handle *hdl, void **
 			continue;
 
 		nvme_init_get_property(&cmd, offset);
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 		if (nvme_status_equals(err, NVME_STATUS_TYPE_NVME, NVME_SC_INVALID_FIELD)) {
 			value = -1;
 		} else if (err) {
@@ -6201,7 +6201,7 @@ static int nvme_set_single_property(struct libnvme_transport_handle *hdl, int of
 	int err;
 
 	nvme_init_set_property(&cmd, offset, value);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "set-property");
 		return err;
@@ -6807,7 +6807,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "format");
 		return err;
@@ -7105,7 +7105,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "security-send");
 		return err;
@@ -7230,7 +7230,7 @@ static int dir_send(int argc, char **argv, struct command *acmd, struct plugin *
 	nvme_init_directive_send(&cmd, cfg.namespace_id, cfg.doper, cfg.dtype,
 		cfg.dspec, buf, cfg.data_len);
 	cmd.cdw12 = dw12;
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "dir-send");
 		return err;
@@ -7303,7 +7303,7 @@ static int write_uncor(int argc, char **argv, struct command *acmd, struct plugi
 
 	nvme_init_write_uncorrectable(&cmd, cfg.namespace_id, cfg.start_block,
 		cfg.block_count, cfg.dtype << 4, cfg.dspec);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "write uncorrectable");
 		return err;
@@ -7577,7 +7577,7 @@ static int write_zeroes(int argc, char **argv,
 	if (err && err != -ENAVAIL)
 		return err;
 
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "write-zeroes");
 		return err;
@@ -7701,7 +7701,7 @@ static int dsm(int argc, char **argv, struct command *acmd, struct plugin *plugi
 	nvme_init_dsm_range(dsm, ctx_attrs, nlbs, slbas, nb);
 	nvme_init_dsm(&cmd, cfg.namespace_id, nb, cfg.idr, cfg.idw, cfg.ad, dsm,
 		      sizeof(*dsm) * nb);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "data-set management");
 		return err;
@@ -7919,7 +7919,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 		cfg.lbatm);
 	if (err != 0 && err != -ENAVAIL)
 		return err;
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "NVMe Copy");
 		return err;
@@ -8047,7 +8047,7 @@ static int resv_acquire(int argc, char **argv, struct command *acmd, struct plug
 
 	nvme_init_resv_acquire(&cmd, cfg.namespace_id, cfg.racqa, cfg.iekey,
 			       false, cfg.rtype, cfg.crkey, cfg.prkey, payload);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "reservation acquire");
 		return err;
@@ -8129,7 +8129,7 @@ static int resv_register(int argc, char **argv, struct command *acmd, struct plu
 	nvme_init_resv_register(&cmd, cfg.namespace_id, cfg.rrega, cfg.iekey,
 				false, cfg.cptpl, cfg.crkey, cfg.nrkey,
 				payload);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "reservation register");
 		return err;
@@ -8206,7 +8206,7 @@ static int resv_release(int argc, char **argv, struct command *acmd, struct plug
 
 	nvme_init_resv_release(&cmd, cfg.nsid, cfg.rrela, cfg.iekey, false,
 		cfg.rtype, cfg.crkey, payload);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "reservation release");
 		return err;
@@ -8300,7 +8300,7 @@ static int resv_report(int argc, char **argv, struct command *acmd, struct plugi
 		return -ENOMEM;
 
 	nvme_init_resv_report(&cmd, cfg.nsid, cfg.eds, false, status, size);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "reservation report");
 		return err;
@@ -8617,7 +8617,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 			return err;
 	}
 	gettimeofday(&start_time, NULL);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	gettimeofday(&end_time, NULL);
 	if (cfg.latency)
 		printf(" latency: %s: %llu us\n", command, elapsed_utime(start_time, end_time));
@@ -8758,7 +8758,7 @@ static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		cfg.lbat, cfg.lbatm);
 	if (err != 0 && err != -ENAVAIL)
 		return err;
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "verify");
 		return err;
@@ -8844,7 +8844,7 @@ static int sec_recv(int argc, char **argv, struct command *acmd, struct plugin *
 
 	nvme_init_security_receive(&cmd, cfg.namespace_id, cfg.nssf, cfg.spsp,
 				   cfg.secp, cfg.al, sec_buf, cfg.size);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "security receive");
 		return err;
@@ -8934,7 +8934,7 @@ static int get_lba_status(int argc, char **argv, struct command *acmd,
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "get lba status");
 		return err;
@@ -9011,7 +9011,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *acmd, struct plu
 		else
 			printf("ISH is supported only for NVMe-MI\n");
 	}
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "capacity management");
 		return err;
@@ -9128,7 +9128,7 @@ static int dir_receive(int argc, char **argv, struct command *acmd, struct plugi
 	nvme_init_directive_recv(&cmd, cfg.namespace_id, cfg.doper, cfg.dtype,
 		cfg.dspec, buf, cfg.data_len);
 	cmd.cdw12 = dw12;
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "dir-receive");
 		return err;
@@ -9220,7 +9220,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *acmd, struct plug
 
 	nvme_init_lockdown(&cmd, cfg.scp, cfg.prhbt, cfg.ifc, cfg.ofi,
 			   cfg.uuid);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "lockdown");
 		return err;
@@ -9463,9 +9463,9 @@ static int passthru(int argc, char **argv, bool admin,
 		.timeout_ms 	= nvme_args.timeout,
 	};
 	if (admin)
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 	else
-		err = libnvme_submit_io_passthru(hdl, &cmd);
+		err = libnvme_exec_io_passthru(hdl, &cmd);
 
 	gettimeofday(&end_time, NULL);
 	cmd_name = nvme_cmd_to_string(admin, cfg.opcode);
@@ -10524,7 +10524,7 @@ static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc
 		.data_len	= cfg.data_len,
 	};
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "nmi_recv");
 		return err;

--- a/plugins/dera/dera-nvme.c
+++ b/plugins/dera/dera-nvme.c
@@ -108,7 +108,7 @@ static int nvme_dera_get_device_status(struct libnvme_transport_handle *hdl, enu
 		.cdw12 = 0x104,
 	};
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err && result)
 		*result = cmd.result;
 

--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -321,7 +321,7 @@ static int fdp_status(int argc, char **argv, struct command *acmd, struct plugin
 
 	nvme_init_fdp_reclaim_unit_handle_status(&cmd, cfg.nsid, &hdr,
 		sizeof(hdr));
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_status(err);
 		return err;
@@ -334,7 +334,7 @@ static int fdp_status(int argc, char **argv, struct command *acmd, struct plugin
 		return -ENOMEM;
 
 	nvme_init_fdp_reclaim_unit_handle_status(&cmd, cfg.nsid, buf, len);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_status(err);
 		return err;
@@ -397,7 +397,7 @@ static int fdp_update(int argc, char **argv, struct command *acmd, struct plugin
 		buf[i] = cpu_to_le16(pids[i]);
 
 	nvme_init_fdp_reclaim_unit_handle_status(&cmd, cfg.nsid, buf, npids);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_status(err);
 		return err;

--- a/plugins/feat/feat-nvme.c
+++ b/plugins/feat/feat-nvme.c
@@ -411,7 +411,7 @@ static int temp_thresh_set(struct libnvme_transport_handle *hdl, const __u8 fid,
 		sel = NVME_GET_FEATURES_SEL_SAVED;
 
 	nvme_init_get_features_temp_thresh(&cmd, sel, cfg->tmpsel, cfg->thsel);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err) {
 		nvme_feature_decode_temp_threshold(cmd.result, &tmpth,
 						   &tmpsel, &thsel, &tmpthh);
@@ -423,7 +423,7 @@ static int temp_thresh_set(struct libnvme_transport_handle *hdl, const __u8 fid,
 
 	nvme_init_set_features_temp_thresh(&cmd, sv, cfg->tmpth, cfg->tmpsel,
 					   cfg->thsel, cfg->tmpthh);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "Set %s", temp_thresh_feat);
 		return err;
@@ -493,7 +493,7 @@ static int arbitration_set(struct libnvme_transport_handle *hdl, const __u8 fid,
 		sel = NVME_GET_FEATURES_SEL_SAVED;
 
 	nvme_init_get_features_arbitration(&cmd, sel);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err) {
 		nvme_feature_decode_arbitration(cmd.result, &ab,
 						&lpw, &mpw, &hpw);
@@ -509,7 +509,7 @@ static int arbitration_set(struct libnvme_transport_handle *hdl, const __u8 fid,
 
 	nvme_init_set_features_arbitration(&cmd, sv, cfg->ab, cfg->lpw,
 					   cfg->mpw, cfg->hpw);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "Set %s", arbitration_feat);
 		return err;
@@ -921,7 +921,7 @@ static int num_queues_set(struct libnvme_transport_handle *hdl, const __u8 fid,
 		sel = NVME_GET_FEATURES_SEL_SAVED;
 
 	nvme_init_get_features_num_queues(&cmd, sel);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err) {
 		nvme_feature_decode_number_of_queues(cmd.result, &nsqr, &ncqr);
 		if (!argconfig_parse_seen(opts, "nsqr"))
@@ -999,7 +999,7 @@ static int host_behavior_set(struct libnvme_transport_handle *hdl, __u8 fid,
 		gsel = NVME_GET_FEATURES_SEL_SAVED;
 
 	nvme_init_get_features_host_behavior(&cmd, gsel, &data);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "Get %s", host_behavior_feat);
 		return err;
@@ -1017,7 +1017,7 @@ static int host_behavior_set(struct libnvme_transport_handle *hdl, __u8 fid,
 		data.cdfe = cpu_to_le16(cfg->cdfe);
 
 	nvme_init_set_features_host_behavior(&cmd, sv, &data);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "Set %s", host_behavior_feat);
 		return err;

--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -36,7 +36,7 @@ static int nvme_vucmd(struct libnvme_transport_handle *hdl, unsigned char opcode
 	cmd.nsid = 0xffffffff;
 	cmd.addr = (__u64)(__u64)(uintptr_t)data;
 	cmd.data_len = data_len;
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 static int getlogpage(struct libnvme_transport_handle *hdl, unsigned char ilogid,

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1234,7 +1234,7 @@ static int read_entire_cmd(struct libnvme_passthru_cmd *cmd, int total_size,
 
 	dword_tfer = min(max_tfer, total_size);
 	while (total_size > 0) {
-		err = libnvme_submit_admin_passthru(hdl, cmd);
+		err = libnvme_exec_admin_passthru(hdl, cmd);
 		if (err) {
 			fprintf(stderr,
 				"failed on cmd.data_len %u cmd.cdw13 %u cmd.cdw12 %x cmd.cdw10 %u err %x remaining size %d\n",

--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -109,7 +109,7 @@ static int lm_create_cdq(int argc, char **argv, struct command *acmd, struct plu
 
 	nvme_init_lm_cdq_create(&cmd, NVME_SET(cfg.qt, LM_QT),
 			 cfg.cntlid, cfg.sz, queue);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err < 0)
 		nvme_show_error("ERROR: nvme_lm_cdq() failed: %s", libnvme_strerror(errno));
 	else if (err)
@@ -147,7 +147,7 @@ static int lm_delete_cdq(int argc, char **argv, struct command *acmd, struct plu
 		return err;
 
 	nvme_init_lm_cdq_delete(&cmd, 0, cfg.cdqid);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err < 0)
 		nvme_show_error("ERROR: nvme_lm_cdq() failed: %s", libnvme_strerror(errno));
 	else if (err > 0)
@@ -230,7 +230,7 @@ static int lm_track_send(int argc, char **argv, struct command *acmd, struct plu
 	}
 
 	nvme_init_lm_track_send(&cmd, cfg.sel, cfg.mos, cfg.cdqid);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err < 0)
 		nvme_show_error("ERROR: nvme_lm_track_send() failed %s", libnvme_strerror(errno));
 	else if (err)
@@ -377,7 +377,7 @@ static int lm_migration_send(int argc, char **argv, struct command *acmd, struct
 				    cfg.stype, cfg.dudmq, cfg.csvi, cfg.csuuidi,
 				    cfg.offset, cfg.uidx, data,
 				    (cfg.numd << 2));
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err < 0)
 		nvme_show_error("ERROR: nvme_lm_migration_send() failed %s", libnvme_strerror(errno));
 	else if (err > 0)
@@ -485,7 +485,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *acmd, struct
 	nvme_init_lm_migration_recv(&cmd, cfg.offset, mos, cfg.cntlid,
 				    cfg.csuuidi, cfg.sel, cfg.uidx, 0, data,
 				    (cfg.numd + 1) << 2);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err < 0)
 		nvme_show_error("ERROR: nvme_lm_migration_recv() failed %s", libnvme_strerror(errno));
 	else if (err)

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -736,7 +736,7 @@ static int memblaze_fw_commit(struct libnvme_transport_handle *hdl, int select)
 		.cdw12		= select,
 	};
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 static int mb_selective_download(int argc, char **argv, struct command *acmd, struct plugin *plugin)
@@ -840,7 +840,7 @@ static int mb_selective_download(int argc, char **argv, struct command *acmd, st
 			perror("fw-download");
 			goto out_free;
 		}
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 		if (err < 0) {
 			perror("fw-download");
 			goto out_free;

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -472,7 +472,7 @@ static int NVMEGetLogPage(struct libnvme_transport_handle *hdl, unsigned char uc
 		cmd.addr = (__u64) (uintptr_t) pTempPtr;
 		cmd.nsid = 0xFFFFFFFF;
 		cmd.data_len = uiXferDwords * 4;
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 		ullBytesRead += uiXferDwords * 4;
 		if (ucLogID == 0x07 || ucLogID == 0x08 || ucLogID == 0xE9)
 			pTempPtr = pBuffer + (ullBytesRead - offset);
@@ -561,7 +561,7 @@ static int micron_fw_commit(struct libnvme_transport_handle *hdl, int select)
 		.cdw12 = select,
 	};
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 static int micron_selective_download(int argc, char **argv,
@@ -662,7 +662,7 @@ static int micron_selective_download(int argc, char **argv,
 			perror("fw-download");
 			goto out_free;
 		}
-		err = libnvme_submit_admin_passthru(hdl, &cmd);
+		err = libnvme_exec_admin_passthru(hdl, &cmd);
 		if (err < 0) {
 			perror("fw-download");
 			goto out_free;
@@ -969,7 +969,7 @@ static int micron_pcie_stats(int argc, char **argv,
 		admin_cmd.addr = (__u64)(uintptr_t)&pcie_error_counters;
 		admin_cmd.data_len = sizeof(pcie_error_counters);
 		admin_cmd.cdw10 = 1;
-		err = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		err = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (!err) {
 			counters = true;
 			correctable_errors = 10;
@@ -1137,7 +1137,7 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 		admin_cmd.opcode = 0xD6;
 		admin_cmd.addr = 0;
 		admin_cmd.cdw10 = 0;
-		err = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		err = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (!err) {
 			printf("Device correctable error counters are cleared!\n");
 			goto out;
@@ -2500,7 +2500,7 @@ static int micron_drive_info(int argc, char **argv, struct command *acmd,
 		admin_cmd.addr = (__u64) (uintptr_t) &dinfo;
 		admin_cmd.data_len = (__u32)sizeof(dinfo);
 		admin_cmd.cdw12 = 3;
-		err = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		err = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (err) {
 			fprintf(stderr, "ERROR : drive-info opcode failed with 0x%x\n", err);
 			return -1;

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -746,7 +746,7 @@ static int nvme_get_ontap_c2_log(struct libnvme_transport_handle *hdl, __u32 nsi
 	get_log.cdw10 |= ONTAP_C2_LOG_NSINFO_LSP << 8;
 	get_log.cdw11 = numdu;
 
-	err = libnvme_submit_admin_passthru(hdl, &get_log);
+	err = libnvme_exec_admin_passthru(hdl, &get_log);
 	if (err) {
 		fprintf(stderr, "ioctl error %0x\n", err);
 		return 1;

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -675,7 +675,7 @@ static int get_telemetry_data(struct libnvme_transport_handle *hdl, __u32 ns, __
 	cmd.cdw12 = (__u32)(0x00000000FFFFFFFF & offset);
 	cmd.cdw13 = (__u32)((0xFFFFFFFF00000000 & offset) >> 8);
 	cmd.cdw14 = 0;
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 static void print_telemetry_data_area_1(struct telemetry_data_area_1 *da1,

--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -267,7 +267,7 @@ static __u32 sndk_dump_udui_data(struct libnvme_transport_handle *hdl,
 	admin_cmd.data_len = dataLen;
 	admin_cmd.cdw10 = ((dataLen >> 2) - 1);
 	admin_cmd.cdw12 = offset;
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
 		fprintf(stderr, "ERROR: SNDK: reading DUI data failed\n");
 		nvme_show_status(ret);
@@ -631,7 +631,7 @@ static int sndk_do_sn861_drive_resize(struct libnvme_transport_handle *hdl,
 	admin_cmd.addr = (__u64)(uintptr_t)buffer;
 	admin_cmd.data_len = SNDK_NVME_SN861_DRIVE_RESIZE_BUFFER_SIZE;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (result)
 		*result = admin_cmd.result;
 	return ret;

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -59,7 +59,7 @@ int nvme_query_cap(struct libnvme_transport_handle *hdl, __u32 nsid, __u32 data_
 	};
 
 	rc = ioctl(libnvme_transport_handle_get_fd(hdl), SFX_GET_FREESPACE, data);
-	return rc ? libnvme_submit_admin_passthru(hdl, &cmd) : 0;
+	return rc ? libnvme_exec_admin_passthru(hdl, &cmd) : 0;
 }
 
 int nvme_change_cap(struct libnvme_transport_handle *hdl, __u32 nsid, __u64 capacity)
@@ -71,7 +71,7 @@ int nvme_change_cap(struct libnvme_transport_handle *hdl, __u32 nsid, __u64 capa
 		.cdw11	= (capacity >> 32),
 	};
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 int nvme_sfx_set_features(struct libnvme_transport_handle *hdl, __u32 nsid, __u32 fid, __u32 value)
@@ -83,7 +83,7 @@ int nvme_sfx_set_features(struct libnvme_transport_handle *hdl, __u32 nsid, __u3
 		.cdw11	= value,
 	};
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 int nvme_sfx_get_features(struct libnvme_transport_handle *hdl, __u32 nsid, __u32 fid, __u32 *result)
@@ -95,7 +95,7 @@ int nvme_sfx_get_features(struct libnvme_transport_handle *hdl, __u32 nsid, __u3
 		.cdw10	= fid,
 	};
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err && result)
 		*result = cmd.result;
 
@@ -565,7 +565,7 @@ int sfx_nvme_get_log(struct libnvme_transport_handle *hdl, __u32 nsid, __u8 log_
 	cmd.cdw10 = log_id | (numdl << 16);
 	cmd.cdw11 = numdu;
 
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 /**
@@ -1453,7 +1453,7 @@ static int nvme_expand_cap(struct libnvme_transport_handle *hdl, __u32 namespace
 		.cdw10       = 0x0e,
 	};
 
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		fprintf(stderr, "Create ns failed\n");
 		nvme_show_status(err);

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -185,7 +185,7 @@ static int cmd_dump_repeat(struct libnvme_passthru_cmd *cmd, __u32 total_dw_size
 
 		cmd->cdw10 = force_max_transfer ? INTERNAL_LOG_MAX_DWORD_TRANSFER : dword_tfer;
 		cmd->data_len = dword_tfer * 4;
-		err = libnvme_submit_admin_passthru(hdl, cmd);
+		err = libnvme_exec_admin_passthru(hdl, cmd);
 		if (err)
 			return err;
 
@@ -577,14 +577,14 @@ static int ilog_dump_telemetry(struct libnvme_transport_handle *hdl, struct ilog
 
 	if (da == 4) {
 		nvme_init_get_features_host_behavior(&cmd, 0, &prev);
-		int err = libnvme_submit_admin_passthru(hdl, &cmd);
+		int err = libnvme_exec_admin_passthru(hdl, &cmd);
 
 		if (!err && !prev.etdas) {
 			struct nvme_feat_host_behavior da4_enable = prev;
 
 			da4_enable.etdas = 1;
 			nvme_init_set_features_host_behavior(&cmd, 0, &da4_enable);
-			libnvme_submit_admin_passthru(hdl, &cmd);
+			libnvme_exec_admin_passthru(hdl, &cmd);
 			host_behavior_changed = true;
 		}
 	}
@@ -612,7 +612,7 @@ static int ilog_dump_telemetry(struct libnvme_transport_handle *hdl, struct ilog
 
 	if (host_behavior_changed) {
 		nvme_init_set_features_host_behavior(&cmd, 0, &prev);
-		libnvme_submit_admin_passthru(hdl, &cmd);
+		libnvme_exec_admin_passthru(hdl, &cmd);
 	}
 
 	if (err)

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -59,7 +59,7 @@ static int nvme_sct_op(struct libnvme_transport_handle *hdl, __u32 opcode,
 		.data_len	= data_len,
 		.addr		= (__u64)(uintptr_t)data,
 	};
-	return libnvme_submit_admin_passthru(hdl, &cmd);
+	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
 static int nvme_get_sct_status(struct libnvme_transport_handle *hdl, __u32 device_mask)

--- a/plugins/transcend/transcend-nvme.c
+++ b/plugins/transcend/transcend-nvme.c
@@ -76,7 +76,7 @@ static int getBadblock(int argc, char **argv, struct command *acmd, struct plugi
 	nvmecmd.addr = (__u64)(uintptr_t)data;
 	nvmecmd.data_len = 0x1;
 
-	result = libnvme_submit_admin_passthru(hdl, &nvmecmd);
+	result = libnvme_exec_admin_passthru(hdl, &nvmecmd);
 	if (!result) {
 		int badblock  = data[0];
 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -2995,7 +2995,7 @@ static int wdc_do_clear_dump(struct libnvme_transport_handle *hdl, __u8 opcode, 
 	memset(&admin_cmd, 0, sizeof(struct libnvme_passthru_cmd));
 	admin_cmd.opcode = opcode;
 	admin_cmd.cdw12 = cdw12;
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret)
 		fprintf(stdout, "ERROR: WDC: Crash dump erase failed\n");
 	nvme_show_status(ret);
@@ -3017,7 +3017,7 @@ static __u32 wdc_dump_length(struct libnvme_transport_handle *link, __u32 opcode
 	admin_cmd.cdw10 = cdw10;
 	admin_cmd.cdw12 = cdw12;
 
-	ret = libnvme_submit_admin_passthru(link, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(link, &admin_cmd);
 	if (ret) {
 		l->log_size = 0;
 		ret = -1;
@@ -3045,7 +3045,7 @@ static __u32 wdc_dump_length_e6(struct libnvme_transport_handle *hdl, __u32 opco
 	admin_cmd.cdw10 = cdw10;
 	admin_cmd.cdw12 = cdw12;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
 		fprintf(stderr, "ERROR: WDC: reading dump length failed\n");
 		nvme_show_status(ret);
@@ -3072,7 +3072,7 @@ static __u32 wdc_dump_dui_data(struct libnvme_transport_handle *hdl, __u32 dataL
 		admin_cmd.cdw14 = WDC_NVME_CAP_DUI_DISABLE_IO;
 
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
 		fprintf(stderr, "ERROR: WDC: reading DUI data failed\n");
 		nvme_show_status(ret);
@@ -3103,7 +3103,7 @@ static __u32 wdc_dump_dui_data_v2(struct libnvme_transport_handle *hdl, __u32 da
 	else
 		admin_cmd.cdw14 = WDC_NVME_CAP_DUI_DISABLE_IO;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
 		fprintf(stderr, "ERROR: WDC: reading DUI data V2 failed\n");
 		nvme_show_status(ret);
@@ -3141,7 +3141,7 @@ static int wdc_do_dump(struct libnvme_transport_handle *hdl, __u32 opcode, __u32
 	admin_cmd.cdw13 = curr_data_offset;
 
 	while (curr_data_offset < data_len) {
-		ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (ret) {
 			nvme_show_status(ret);
 			fprintf(stderr, "%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx\n",
@@ -3216,7 +3216,7 @@ static int wdc_do_dump_e6(struct libnvme_transport_handle *hdl, __u32 opcode, __
 		admin_cmd.cdw10 = xfer_size >> 2;
 		admin_cmd.cdw13 = curr_data_offset >> 2;
 
-		ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (ret) {
 			nvme_show_status(ret);
 			fprintf(stderr, "%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx\n",
@@ -3978,7 +3978,7 @@ static int wdc_do_get_sn730_log_len(struct libnvme_transport_handle *hdl, uint32
 	admin_cmd.cdw12 = subopcode;
 	admin_cmd.cdw10 = SN730_LOG_CHUNK_SIZE / 4;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (!ret)
 		*len_buf = *output;
 	free(output);
@@ -4004,7 +4004,7 @@ static int wdc_do_get_sn730_log(struct libnvme_transport_handle *hdl, void *log_
 	admin_cmd.cdw13 = offset;
 	admin_cmd.cdw10 = SN730_LOG_CHUNK_SIZE / 4;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (!ret)
 		memcpy(log_buf, output, SN730_LOG_CHUNK_SIZE);
 	return ret;
@@ -4700,7 +4700,7 @@ static int wdc_do_drive_log(struct libnvme_transport_handle *hdl, const char *fi
 	admin_cmd.cdw12 = ((WDC_NVME_DRIVE_LOG_SUBCMD <<
 				WDC_NVME_SUBCMD_SHIFT) | WDC_NVME_DRIVE_LOG_SIZE_CMD);
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	nvme_show_status(ret);
 	if (!ret)
 		ret = wdc_create_log_file(file, drive_log_data, drive_log_length);
@@ -4912,7 +4912,7 @@ static int wdc_purge(int argc, char **argv,
 		memset(&admin_cmd, 0, sizeof(admin_cmd));
 		admin_cmd.opcode = WDC_NVME_PURGE_CMD_OPCODE;
 
-		ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (ret > 0) {
 			switch (ret) {
 			case WDC_NVME_PURGE_CMD_SEQ_ERR:
@@ -4968,7 +4968,7 @@ static int wdc_purge_monitor(int argc, char **argv,
 		admin_cmd.cdw10 = WDC_NVME_PURGE_MONITOR_CMD_CDW10;
 		admin_cmd.timeout_ms = WDC_NVME_PURGE_MONITOR_TIMEOUT;
 
-		ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (!ret) {
 			mon = (struct wdc_nvme_purge_monitor_data *) output;
 			printf("Purge state = 0x%0"PRIx64"\n",
@@ -8986,7 +8986,7 @@ static int wdc_do_clear_pcie_correctable_errors(struct libnvme_transport_handle 
 	admin_cmd.cdw12 = ((WDC_NVME_CLEAR_PCIE_CORR_SUBCMD << WDC_NVME_SUBCMD_SHIFT) |
 			WDC_NVME_CLEAR_PCIE_CORR_CMD);
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	nvme_show_status(ret);
 	return ret;
 }
@@ -8999,7 +8999,7 @@ static int wdc_do_clear_pcie_correctable_errors_vuc(struct libnvme_transport_han
 	memset(&admin_cmd, 0, sizeof(admin_cmd));
 	admin_cmd.opcode = WDC_NVME_CLEAR_PCIE_CORR_OPCODE_VUC;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	nvme_show_status(ret);
 	return ret;
 }
@@ -9247,7 +9247,7 @@ static int wdc_clear_assert_dump(int argc, char **argv, struct command *acmd,
 		admin_cmd.cdw12 = ((WDC_NVME_CLEAR_ASSERT_DUMP_SUBCMD << WDC_NVME_SUBCMD_SHIFT) |
 				WDC_NVME_CLEAR_ASSERT_DUMP_CMD);
 
-		ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		nvme_show_status(ret);
 	} else
 		fprintf(stderr, "INFO: WDC: No Assert Dump Present\n");
@@ -9494,7 +9494,7 @@ static int wdc_do_clear_fw_activate_history_vuc(struct libnvme_transport_handle 
 	admin_cmd.cdw12 = ((WDC_NVME_CLEAR_FW_ACT_HIST_SUBCMD << WDC_NVME_SUBCMD_SHIFT) |
 			WDC_NVME_CLEAR_FW_ACT_HIST_CMD);
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	nvme_show_status(ret);
 
 	return ret;
@@ -9703,7 +9703,7 @@ static int wdc_de_VU_read_size(struct libnvme_transport_handle *hdl, __u32 fileI
 	cmd.cdw13 = fileId << 16;
 	cmd.cdw14 = spiDestn;
 
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 
 	if (!ret && logSize)
 		*logSize = cmd.result;
@@ -9740,7 +9740,7 @@ static int wdc_de_VU_read_buffer(struct libnvme_transport_handle *hdl, __u32 fil
 	cmd.addr = (__u64)(__u64)(uintptr_t)dataBuffer;
 	cmd.data_len = *bufferSize;
 
-	ret = libnvme_submit_admin_passthru(hdl, &cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 
 	if (ret != WDC_STATUS_SUCCESS) {
 		fprintf(stderr, "ERROR: WDC: VUReadBuffer() failed, ");
@@ -10409,7 +10409,7 @@ static int wdc_do_drive_resize(struct libnvme_transport_handle *hdl, uint64_t ne
 			    WDC_NVME_DRIVE_RESIZE_CMD);
 	admin_cmd.cdw13 = new_size;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	return ret;
 }
 
@@ -10423,7 +10423,7 @@ static int wdc_do_namespace_resize(struct libnvme_transport_handle *hdl, __u32 n
 	admin_cmd.nsid = nsid;
 	admin_cmd.cdw10 = op_option;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	return ret;
 }
 
@@ -10437,7 +10437,7 @@ static int wdc_do_drive_info(struct libnvme_transport_handle *hdl, __u32 *result
 	admin_cmd.cdw12 = ((WDC_NVME_DRIVE_INFO_SUBCMD << WDC_NVME_SUBCMD_SHIFT) |
 			    WDC_NVME_DRIVE_INFO_CMD);
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 
 	if (!ret && result)
 		*result = admin_cmd.result;
@@ -10954,7 +10954,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 				.data_len	= 32,
 			};
 
-			ret = libnvme_submit_admin_passthru(hdl, &cmd);
+			ret = libnvme_exec_admin_passthru(hdl, &cmd);
 			if (!ret) {
 				switch (fmt) {
 				case BINARY:
@@ -11632,7 +11632,7 @@ static int wdc_do_vs_pcie_stats(struct libnvme_transport_handle *hdl,
 	admin_cmd.addr = (__u64)(uintptr_t)pcieStatsPtr;
 	admin_cmd.data_len = pcie_stats_size;
 
-	ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 
 	return ret;
 }
@@ -11926,7 +11926,7 @@ static int wdc_vs_drive_info(int argc, char **argv,
 				.addr		= (__u64)(uintptr_t)&info,
 				.data_len	= data_len,
 			};
-			ret = libnvme_submit_admin_passthru(hdl, &cmd);
+			ret = libnvme_exec_admin_passthru(hdl, &cmd);
 			if (!ret) {
 				__u16 hw_rev_major, hw_rev_minor;
 
@@ -12430,7 +12430,7 @@ static int wdc_enc_submit_move_data(struct libnvme_transport_handle *hdl, char *
 	       nvme_cmd.timeout_ms, nvme_cmd.result, md, d);
 #endif
 	nvme_cmd.result = 0;
-	err = libnvme_submit_admin_passthru(hdl, &nvme_cmd);
+	err = libnvme_exec_admin_passthru(hdl, &nvme_cmd);
 	if (nvme_status_equals(err, NVME_STATUS_TYPE_NVME, NVME_SC_INTERNAL)) {
 		fprintf(stderr, "%s: WARNING : WDC: No log ID:x%x available\n", __func__, log_id);
 	} else if (err) {
@@ -12455,7 +12455,7 @@ static int wdc_enc_submit_move_data(struct libnvme_transport_handle *hdl, char *
 			nvme_cmd.cdw14 = cdw14;
 			nvme_cmd.cdw15 = cdw15;
 			nvme_cmd.result = 0;  /* returned result !=0 indicates more data available */
-			err = libnvme_submit_admin_passthru(hdl, &nvme_cmd);
+			err = libnvme_exec_admin_passthru(hdl, &nvme_cmd);
 			if (err) {
 				more = 0;
 				fprintf(stderr, "%s: ERROR: WDC: NVMe Rcv Mgmt ", __func__);
@@ -12515,7 +12515,7 @@ static int wdc_enc_get_nic_log(struct libnvme_transport_handle *hdl, __u8 log_id
 			admin_cmd.nsid, admin_cmd.addr, admin_cmd.data_len, admin_cmd.cdw10,
 			admin_cmd.cdw11, admin_cmd.cdw12, admin_cmd.cdw13, admin_cmd.cdw14);
 #endif
-		ret = libnvme_submit_admin_passthru(hdl, &admin_cmd);
+		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (ret) {
 			nvme_show_status(ret);
 			fprintf(stderr, "%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx\n",

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -151,7 +151,7 @@ static int id_ctrl(int argc, char **argv, struct command *acmd, struct plugin *p
 		return err;
 
 	nvme_init_zns_identify_ctrl(&cmd, &ctrl);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
 		nvme_show_zns_id_ctrl(&ctrl, flags);
 	else if (err > 0)
@@ -269,7 +269,7 @@ static int zns_mgmt_send(int argc, char **argv, struct command *acmd, struct plu
 
 	nvme_init_zns_mgmt_send(&cmd, cfg.namespace_id, cfg.zslba, zsa,
 				cfg.select_all, 0, 0, NULL, 0);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err) {
 		if (zsa == NVME_ZNS_ZSA_RESET)
 			zcapc = cmd.result & 0x1;
@@ -413,7 +413,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 	nvme_init_zns_mgmt_send(&cmd, cfg.namespace_id, cfg.zslba, cfg.zsa,
 				cfg.select_all, cfg.zsaso, 0, buf,
 				cfg.data_len);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
 		printf("zone-mgmt-send: Success, action:%d zone:%"PRIx64" all:%d nsid:%d\n",
 		       cfg.zsa, (uint64_t)cfg.zslba, (int)cfg.select_all, cfg.namespace_id);
@@ -486,7 +486,7 @@ static int open_zone(int argc, char **argv, struct command *acmd, struct plugin 
 	nvme_init_zns_mgmt_send(&cmd, cfg.namespace_id, cfg.zslba,
 				NVME_ZNS_ZSA_OPEN, cfg.select_all, cfg.zrwaa, 0,
 				NULL, 0);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
 		printf("zns-open-zone: Success zone slba:%"PRIx64" nsid:%d\n",
 		       (uint64_t)cfg.zslba, cfg.namespace_id);
@@ -585,7 +585,7 @@ static int set_zone_desc(int argc, char **argv, struct command *acmd, struct plu
 	nvme_init_zns_mgmt_send(&cmd, cfg.namespace_id, cfg.zslba,
 				NVME_ZNS_ZSA_SET_DESC_EXT, 0, cfg.zrwaa, 0, buf,
 				data_len);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
 		printf("set-zone-desc: Success, zone:%"PRIx64" nsid:%d\n",
 		       (uint64_t)cfg.zslba, cfg.namespace_id);
@@ -637,7 +637,7 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *acmd, struct p
 
 	nvme_init_zns_mgmt_send(&cmd, cfg.namespace_id, cfg.lba,
 				NVME_ZNS_ZSA_ZRWA_FLUSH, 0, 0, 0, NULL, 0);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
 		printf("zrwa-flush-zone: Success, lba:%"PRIx64" nsid:%d\n",
 		       (uint64_t)cfg.lba, cfg.namespace_id);
@@ -714,7 +714,7 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *acmd, struct pl
 
 	nvme_init_zns_mgmt_recv(&cmd, cfg.namespace_id, cfg.zslba, cfg.zra,
 				cfg.zrasf, cfg.partial, data, cfg.data_len);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
 		printf("zone-mgmt-recv: Success, action:%d zone:%"PRIx64" nsid:%d\n",
 		       cfg.zra, (uint64_t)cfg.zslba, cfg.namespace_id);
@@ -830,7 +830,7 @@ static int report_zones(int argc, char **argv, struct command *acmd, struct plug
 
 	nvme_init_zns_report_zones(&cmd, cfg.namespace_id, 0, cfg.state, false,
 				   false, buff, log_len);
-	err = libnvme_submit_io_passthru(hdl, &cmd);
+	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err > 0) {
 		nvme_show_status(err);
 		goto free_buff;
@@ -873,7 +873,7 @@ static int report_zones(int argc, char **argv, struct command *acmd, struct plug
 		nvme_init_zns_report_zones(&cmd, cfg.namespace_id, offset,
 					   cfg.state, cfg.extended, cfg.partial,
 					   report, log_len);
-		err = libnvme_submit_io_passthru(hdl, &cmd);
+		err = libnvme_exec_io_passthru(hdl, &cmd);
 		if (err > 0) {
 			nvme_show_status(err);
 			break;
@@ -1061,7 +1061,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 	nvme_init_zns_append(&cmd, cfg.namespace_id, cfg.zslba, nblocks,
 			     control, cev, dspec, buf, cfg.data_size, mbuf,
 			     cfg.metadata_size);
-	err = libnvme_submit_admin_passthru(hdl, &cmd);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	gettimeofday(&end_time, NULL);
 	if (cfg.latency)
 		printf(" latency: zone append: %llu us\n",


### PR DESCRIPTION
### Problem

`libnvme_ctrl_get_transport_handle()` uses lazy-open semantics: it opens `/dev/nvmeX` on first use. When the device is mid-teardown (kernel returns `EAGAIN`), `libnvme_open()` fails and the handle stays NULL. Three callers passed that NULL directly into `libnvme_submit_admin_passthru()`, which dereferenced it immediately at the `hdl->uring_enabled` check — causing a segfault reproducible with nvme-stas under rapid device create/delete cycling.

### Fix

Per your suggestion, the NULL guard is now centralized in `ioctl.c` rather than scattered across call sites.

While moving it there, the io_uring vs. ioctl routing was also pulled out of callers and into `libnvme_submit_admin_passthru()` itself. `libnvme_wait_complete_passthru()` is now a true no-op (`return 0`) in the no-uring build, so all callers can pair submit + wait unconditionally. The batching behaviour in `libnvme_get_log()` is preserved.

### Question 

@igaw - Should we also add `if (!hdl) return -ENODEV;` with a `LIBNVME_LOG_DEBUG` message at the three call sites that obtain `hdl` from `libnvme_ctrl_get_transport_handle()` (`nvme_discovery_log`, `nvmf_dim`, `libnvme_ctrl_identify`)? This would provide a traceable log entry identifying the exact code path that hit the NULL, which is useful for diagnosing the race. Happy to add that as a follow-up commit if you think it's worthwhile.

### Testing

Verified with nvme-stas tests that rapidly create and delete NVMe devices — no crash after this patch.

