### PR TITLE
doc: add error-log command description for fields and ordering

### DIFF
--- a/Documentation/nvme-error-log.txt
+++ b/Documentation/nvme-error-log.txt
@@ -15,7 +15,8 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Retrieves NVMe Error log page from an NVMe device and provides the
-returned structure.
+returned structure. All the returned structure fields including the
+ordering of the entries are described in the spec.
 
 The <device> parameter is mandatory and may be either the NVMe character
 device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).

--- a/nvme-print-binary.c
+++ b/nvme-print-binary.c
@@ -216,7 +216,7 @@ static void binary_id_domain_list(struct nvme_id_domain_list *id_dom)
 }
 
 static void binary_error_log(struct nvme_error_log_page *err_log, int entries,
-	const char *devname)
+	const char *devname, struct nvme_error_log_filter *flt)
 {
 	d_raw((unsigned char *)err_log, entries * sizeof(*err_log));
 }

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -521,16 +521,21 @@ void json_nvme_id_ctrl(struct nvme_id_ctrl *ctrl,
 }
 
 static void json_error_log(struct nvme_error_log_page *err_log, int entries,
-			   const char *devname)
+			   const char *devname,
+			   struct nvme_error_log_filter *flt)
 {
 	struct json_object *r = json_create_object();
 	struct json_object *errors = json_create_array();
+	struct json_object *error;
 	int i;
 
 	obj_add_array(r, "errors", errors);
 
 	for (i = 0; i < entries; i++) {
-		struct json_object *error = json_create_object();
+		if (nvme_is_error_log_filter(&err_log[i], flt))
+			continue;
+
+		error = json_create_object();
 
 		obj_add_uint64(error, "error_count", le64_to_cpu(err_log[i].error_count));
 		obj_add_int(error, "sqid", le16_to_cpu(err_log[i].sqid));

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -548,8 +548,12 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries,
 		obj_add_uint(error, "nsid", le32_to_cpu(err_log[i].nsid));
 		obj_add_int(error, "vs", err_log[i].vs);
 		obj_add_int(error, "trtype", err_log[i].trtype);
+		obj_add_int(error, "csi", err_log[i].csi);
+		obj_add_int(error, "opcode", err_log[i].opcode);
 		obj_add_uint64(error, "cs", le64_to_cpu(err_log[i].cs));
 		obj_add_int(error, "trtype_spec_info", le16_to_cpu(err_log[i].trtype_spec_info));
+		obj_add_int(error, "log_page_version",
+			    err_log[i].log_page_version);
 
 		array_add_obj(errors, error);
 	}

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -537,11 +537,14 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries,
 
 		error = json_create_object();
 
-		obj_add_uint64(error, "error_count", le64_to_cpu(err_log[i].error_count));
+		obj_add_uint64(error, "error_count",
+			       le64_to_cpu(err_log[i].error_count));
 		obj_add_int(error, "sqid", le16_to_cpu(err_log[i].sqid));
 		obj_add_int(error, "cmdid", le16_to_cpu(err_log[i].cmdid));
-		obj_add_int(error, "status_field", le16_to_cpu(err_log[i].status_field) >> 0x1);
-		obj_add_int(error, "phase_tag", le16_to_cpu(err_log[i].status_field) & 0x1);
+		obj_add_int(error, "status_field",
+			    le16_to_cpu(err_log[i].status_field) >> 0x1);
+		obj_add_int(error, "phase_tag",
+			    le16_to_cpu(err_log[i].status_field) & 0x1);
 		obj_add_int(error, "parm_error_location",
 			    le16_to_cpu(err_log[i].parm_error_location));
 		obj_add_uint64(error, "lba", le64_to_cpu(err_log[i].lba));
@@ -551,7 +554,8 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries,
 		obj_add_int(error, "csi", err_log[i].csi);
 		obj_add_int(error, "opcode", err_log[i].opcode);
 		obj_add_uint64(error, "cs", le64_to_cpu(err_log[i].cs));
-		obj_add_int(error, "trtype_spec_info", le16_to_cpu(err_log[i].trtype_spec_info));
+		obj_add_int(error, "trtype_spec_info",
+			    le16_to_cpu(err_log[i].trtype_spec_info));
 		obj_add_int(error, "log_page_version",
 			    err_log[i].log_page_version);
 

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -527,6 +527,7 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries,
 	struct json_object *r = json_create_object();
 	struct json_object *errors = json_create_array();
 	struct json_object *error;
+	__u16 sts;
 	int i;
 
 	obj_add_array(r, "errors", errors);
@@ -536,15 +537,15 @@ static void json_error_log(struct nvme_error_log_page *err_log, int entries,
 			continue;
 
 		error = json_create_object();
+		sts = le16_to_cpu(err_log[i].status_field);
 
 		obj_add_uint64(error, "error_count",
 			       le64_to_cpu(err_log[i].error_count));
 		obj_add_int(error, "sqid", le16_to_cpu(err_log[i].sqid));
 		obj_add_int(error, "cmdid", le16_to_cpu(err_log[i].cmdid));
 		obj_add_int(error, "status_field",
-			    le16_to_cpu(err_log[i].status_field) >> 0x1);
-		obj_add_int(error, "phase_tag",
-			    le16_to_cpu(err_log[i].status_field) & 0x1);
+			    NVME_ERR_SF_STATUS_FIELD(sts));
+		obj_add_int(error, "phase_tag", NVME_ERR_SF_PHASE_TAG(sts));
 		obj_add_int(error, "parm_error_location",
 			    le16_to_cpu(err_log[i].parm_error_location));
 		obj_add_uint64(error, "lba", le64_to_cpu(err_log[i].lba));

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4230,7 +4230,7 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 	__u16 status;
 
 	printf("Error Log Entries for device:%s entries:%d\n", devname,
-								entries);
+	       entries);
 	printf(".................\n");
 	for (i = 0; i < entries; i++) {
 		if (nvme_is_error_log_filter(&err_log[i], flt)) {
@@ -4243,21 +4243,22 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 		printf(" Entry[%2d]\n", i);
 		printf(".................\n");
 		printf("error_count	: %"PRIu64"\n",
-			le64_to_cpu(err_log[i].error_count));
+		       le64_to_cpu(err_log[i].error_count));
 		printf("sqid		: %d\n", le16_to_cpu(err_log[i].sqid));
 		printf("cmdid		: %#x\n",
 		       le16_to_cpu(err_log[i].cmdid));
 		printf("status_field	: %#x (%s)\n", status,
-			libnvme_status_to_string(status, false));
-		printf("phase_tag	: %#x\n", le16_to_cpu(err_log[i].status_field) & 0x1);
+		       libnvme_status_to_string(status, false));
+		printf("phase_tag	: %#x\n",
+		       le16_to_cpu(err_log[i].status_field) & 0x1);
 		printf("parm_err_loc	: %#x\n",
 		       le16_to_cpu(err_log[i].parm_error_location));
 		printf("lba		: %#"PRIx64"\n",
-			le64_to_cpu(err_log[i].lba));
+		       le64_to_cpu(err_log[i].lba));
 		printf("nsid		: %#x\n", le32_to_cpu(err_log[i].nsid));
 		printf("vs		: %d\n", err_log[i].vs);
 		printf("trtype		: %#x (%s)\n", err_log[i].trtype,
-			nvme_trtype_to_string(err_log[i].trtype));
+		       nvme_trtype_to_string(err_log[i].trtype));
 		printf("csi		: %d\n", err_log[i].csi);
 		printf("opcode		: %#x\n", err_log[i].opcode);
 		printf("cs		: %#"PRIx64"\n",

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4228,6 +4228,7 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 	int filtered = 0;
 	int i;
 	__u16 status;
+	__u16 sts;
 
 	printf("Error Log Entries for device:%s entries:%d\n", devname,
 	       entries);
@@ -4238,7 +4239,8 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 			continue;
 		}
 
-		status = le16_to_cpu(err_log[i].status_field) >> 0x1;
+		sts = le16_to_cpu(err_log[i].status_field);
+		status = NVME_ERR_SF_STATUS_FIELD(sts);
 
 		printf(" Entry[%2d]\n", i);
 		printf(".................\n");
@@ -4249,8 +4251,7 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 		       le16_to_cpu(err_log[i].cmdid));
 		printf("status_field	: %#x (%s)\n", status,
 		       libnvme_status_to_string(status, false));
-		printf("phase_tag	: %#x\n",
-		       le16_to_cpu(err_log[i].status_field) & 0x1);
+		printf("phase_tag	: %#x\n", NVME_ERR_SF_PHASE_TAG(sts));
 		printf("parm_err_loc	: %#x\n",
 		       le16_to_cpu(err_log[i].parm_error_location));
 		printf("lba		: %#"PRIx64"\n",

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4222,15 +4222,23 @@ static void stdout_id_iocs(struct nvme_id_iocs *iocs)
 }
 
 static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
-			     const char *devname)
+			     const char *devname,
+			     struct nvme_error_log_filter *flt)
 {
+	int filtered = 0;
 	int i;
+	__u16 status;
 
 	printf("Error Log Entries for device:%s entries:%d\n", devname,
 								entries);
 	printf(".................\n");
 	for (i = 0; i < entries; i++) {
-		__u16 status = le16_to_cpu(err_log[i].status_field) >> 0x1;
+		if (nvme_is_error_log_filter(&err_log[i], flt)) {
+			filtered++;
+			continue;
+		}
+
+		status = le16_to_cpu(err_log[i].status_field) >> 0x1;
 
 		printf(" Entry[%2d]\n", i);
 		printf(".................\n");
@@ -4257,6 +4265,9 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 		printf("log_page_version: %d\n", err_log[i].log_page_version);
 		printf(".................\n");
 	}
+
+	if (entries == filtered)
+		printf("all entries filtered\n");
 }
 
 static void stdout_resv_report(struct nvme_resv_status *status, int bytes,
@@ -6878,7 +6889,8 @@ static void stdout_log(const char *devname, struct nvme_get_log_args *args)
 		break;
 	case NVME_LOG_LID_ERROR:
 		stdout_error_log((struct nvme_error_log_page *)args->log,
-				 args->len / sizeof(struct nvme_error_log_page), devname);
+				 args->len / sizeof(struct nvme_error_log_page),
+				 devname, NULL);
 		break;
 	case NVME_LOG_LID_SMART:
 		stdout_smart_log((struct nvme_smart_log *)args->log, args->nsid, devname);

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -4244,16 +4244,17 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 		printf(".................\n");
 		printf("error_count	: %"PRIu64"\n",
 			le64_to_cpu(err_log[i].error_count));
-		printf("sqid		: %d\n", err_log[i].sqid);
-		printf("cmdid		: %#x\n", err_log[i].cmdid);
+		printf("sqid		: %d\n", le16_to_cpu(err_log[i].sqid));
+		printf("cmdid		: %#x\n",
+		       le16_to_cpu(err_log[i].cmdid));
 		printf("status_field	: %#x (%s)\n", status,
 			libnvme_status_to_string(status, false));
 		printf("phase_tag	: %#x\n", le16_to_cpu(err_log[i].status_field) & 0x1);
 		printf("parm_err_loc	: %#x\n",
-			err_log[i].parm_error_location);
+		       le16_to_cpu(err_log[i].parm_error_location));
 		printf("lba		: %#"PRIx64"\n",
 			le64_to_cpu(err_log[i].lba));
-		printf("nsid		: %#x\n", err_log[i].nsid);
+		printf("nsid		: %#x\n", le32_to_cpu(err_log[i].nsid));
 		printf("vs		: %d\n", err_log[i].vs);
 		printf("trtype		: %#x (%s)\n", err_log[i].trtype,
 			nvme_trtype_to_string(err_log[i].trtype));
@@ -4261,7 +4262,8 @@ static void stdout_error_log(struct nvme_error_log_page *err_log, int entries,
 		printf("opcode		: %#x\n", err_log[i].opcode);
 		printf("cs		: %#"PRIx64"\n",
 		       le64_to_cpu(err_log[i].cs));
-		printf("trtype_spec_info: %#x\n", err_log[i].trtype_spec_info);
+		printf("trtype_spec_info: %#x\n",
+		       le16_to_cpu(err_log[i].trtype_spec_info));
 		printf("log_page_version: %d\n", err_log[i].log_page_version);
 		printf(".................\n");
 	}

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -778,9 +778,32 @@ const char *nvme_trtype_to_string(__u8 trtype)
 }
 
 void nvme_show_error_log(struct nvme_error_log_page *err_log, int entries,
-			 const char *devname, nvme_print_flags_t flags)
+			 const char *devname, struct nvme_error_log_filter *flt,
+			 nvme_print_flags_t flags)
 {
-	nvme_print(error_log, flags, err_log, entries, devname);
+	nvme_print(error_log, flags, err_log, entries, devname, flt);
+}
+
+bool nvme_is_error_log_filter(struct nvme_error_log_page *err_log,
+			      struct nvme_error_log_filter *flt)
+{
+	__u16 sts = le16_to_cpu(err_log->status_field);
+	__u16 status = NVME_ERR_SF_STATUS_FIELD(sts);
+	__u16 sqid = le16_to_cpu(err_log->sqid);
+	__u32 nsid = le32_to_cpu(err_log->nsid);
+	__u64 lba = le64_to_cpu(err_log->lba);
+
+	if (flt && ((flt->valid && !err_log->error_count) ||
+	    (flt->sqid && flt->sqid != sqid) ||
+	    (flt->status && flt->status != status) ||
+	    (flt->lba && flt->lba != lba) ||
+	    (flt->nsid && flt->nsid != nsid) ||
+	    (flt->trtype && flt->trtype != err_log->trtype) ||
+	    (flt->csi && flt->csi != err_log->csi) ||
+	    (flt->opcode && flt->opcode != err_log->opcode)))
+		return true;
+
+	return false;
 }
 
 void nvme_show_resv_report(struct nvme_resv_status *status, int bytes,

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -24,6 +24,17 @@ typedef struct nvme_effects_log_node {
 void d(unsigned char *buf, int len, int width, int group);
 void d_raw(unsigned char *buf, unsigned len);
 
+struct nvme_error_log_filter {
+	bool valid;
+	__u16 sqid;
+	__u16 status;
+	__u64 lba;
+	__u32 nsid;
+	__u8 trtype;
+	__u8 csi;
+	__u8 opcode;
+};
+
 struct print_ops {
 	/* libnvme types.h print functions */
 	void (*ana_log)(struct nvme_ana_log *ana_log, const char *devname, size_t len);
@@ -38,7 +49,9 @@ struct print_ops {
 	void (*endurance_group_event_agg_log)(struct nvme_aggregate_endurance_group_event *endurance_log, __u64 log_entries, __u32 size, const char *devname);
 	void (*endurance_group_list)(struct nvme_id_endurance_group_list *endgrp_list);
 	void (*endurance_log)(struct nvme_endurance_group_log *endurance_group, __u16 group_id, const char *devname);
-	void (*error_log)(struct nvme_error_log_page *err_log, int entries, const char *devname);
+	void (*error_log)(struct nvme_error_log_page *err_log, int entries,
+			  const char *devname,
+			  struct nvme_error_log_filter *flt);
 	void (*fdp_config_log)(struct nvme_fdp_config_log *log, size_t len);
 	void (*fdp_event_log)(struct nvme_fdp_events_log *log);
 	void (*fdp_ruh_status)(struct nvme_fdp_ruh_status *status, size_t len);
@@ -185,7 +198,10 @@ void nvme_show_lba_range(struct nvme_lba_range_type *lbrt, int nr_ranges,
 void nvme_show_supported_log(struct nvme_supported_log_pages *support,
 	const char *devname, nvme_print_flags_t flags);
 void nvme_show_error_log(struct nvme_error_log_page *err_log, int entries,
-	const char *devname, nvme_print_flags_t flags);
+	const char *devname, struct nvme_error_log_filter *flt,
+	nvme_print_flags_t flags);
+bool nvme_is_error_log_filter(struct nvme_error_log_page *err_log,
+			      struct nvme_error_log_filter *flt);
 void nvme_show_smart_log(struct nvme_smart_log *smart, unsigned int nsid, const char *devname,
 			 nvme_print_flags_t flags);
 void nvme_show_ana_log(struct nvme_ana_log *ana_log, const char *devname,

--- a/nvme.c
+++ b/nvme.c
@@ -1206,6 +1206,14 @@ static int get_error_log(int argc, char **argv, struct command *acmd, struct plu
 		"error log entries from a given device "
 		"in either decoded format (default) or binary.";
 	const char *log_entries = "number of entries to retrieve";
+	const char *status = "output specified STATUS entry only";
+	const char *nsid = "output specified NSID entry only";
+	const char *trtype = "output specified TRTYPE entry only";
+	const char *opcode = "output specified OPC entry only";
+	const char *sqid = "output specified SQID entry only";
+	const char *valid_entry = "output valid entry only";
+	const char *lba = "output specified LBA entry only";
+	const char *csi = "output specified CSI entry only";
 	const char *raw = "dump in binary format";
 
 	__cleanup_free struct nvme_error_log_page *err_log = NULL;
@@ -1218,6 +1226,7 @@ static int get_error_log(int argc, char **argv, struct command *acmd, struct plu
 	struct config {
 		__u32	log_entries;
 		bool	raw_binary;
+		struct nvme_error_log_filter flt;
 	};
 
 	struct config cfg = {
@@ -1226,8 +1235,16 @@ static int get_error_log(int argc, char **argv, struct command *acmd, struct plu
 	};
 
 	NVME_ARGS(opts,
-		  OPT_UINT("log-entries",  'e', &cfg.log_entries,   log_entries),
-		  OPT_FLAG("raw-binary",   'b', &cfg.raw_binary,    raw));
+		  OPT_UINT("log-entries",  'e', &cfg.log_entries, log_entries),
+		  OPT_FLAG("raw-binary",   'b', &cfg.raw_binary,  raw),
+		  OPT_FLAG("valid-entry",  'V', &cfg.flt.valid,   valid_entry),
+		  OPT_SHRT("sqid",         'S', &cfg.flt.sqid,    sqid),
+		  OPT_SHRT("status",       's', &cfg.flt.status,  status),
+		  OPT_SUFFIX("lba",        'l', &cfg.flt.lba,     lba),
+		  OPT_UINT("namespace-id", 'n', &cfg.flt.nsid,    nsid),
+		  OPT_BYTE("trtype",       't', &cfg.flt.trtype,  trtype),
+		  OPT_BYTE("csi",          'c', &cfg.flt.csi,     csi),
+		  OPT_BYTE("opcode",       'O', &cfg.flt.opcode,  opcode));
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (err)
@@ -1268,7 +1285,8 @@ static int get_error_log(int argc, char **argv, struct command *acmd, struct plu
 	}
 
 	nvme_show_error_log(err_log, cfg.log_entries,
-			    libnvme_transport_handle_get_name(hdl), flags);
+			    libnvme_transport_handle_get_name(hdl), &cfg.flt,
+			    flags);
 
 	return err;
 }


### PR DESCRIPTION
As all fields including the ordering described in the spec.