### PR TITLE
libnvme: add __libnvme_ prefix to all compiler attributes

### DIFF
--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -29,7 +29,8 @@
  * Accessors for: struct libnvmf_discovery_args
  ****************************************************************************/
 
-__public int libnvmf_discovery_args_new(struct libnvmf_discovery_args **pp)
+__libnvme_public int libnvmf_discovery_args_new(
+		struct libnvmf_discovery_args **pp)
 {
 	if (!pp)
 		return -EINVAL;
@@ -40,12 +41,13 @@ __public int libnvmf_discovery_args_new(struct libnvmf_discovery_args **pp)
 	return 0;
 }
 
-__public void libnvmf_discovery_args_free(struct libnvmf_discovery_args *p)
+__libnvme_public void libnvmf_discovery_args_free(
+		struct libnvmf_discovery_args *p)
 {
 	free(p);
 }
 
-__public void libnvmf_discovery_args_init_defaults(
+__libnvme_public void libnvmf_discovery_args_init_defaults(
 		struct libnvmf_discovery_args *p)
 {
 	if (!p)
@@ -54,27 +56,27 @@ __public void libnvmf_discovery_args_init_defaults(
 	p->lsp = NVMF_LOG_DISC_LSP_NONE;
 }
 
-__public void libnvmf_discovery_args_set_max_retries(
+__libnvme_public void libnvmf_discovery_args_set_max_retries(
 		struct libnvmf_discovery_args *p,
 		int max_retries)
 {
 	p->max_retries = max_retries;
 }
 
-__public int libnvmf_discovery_args_get_max_retries(
+__libnvme_public int libnvmf_discovery_args_get_max_retries(
 		const struct libnvmf_discovery_args *p)
 {
 	return p->max_retries;
 }
 
-__public void libnvmf_discovery_args_set_lsp(
+__libnvme_public void libnvmf_discovery_args_set_lsp(
 		struct libnvmf_discovery_args *p,
 		__u8 lsp)
 {
 	p->lsp = lsp;
 }
 
-__public __u8 libnvmf_discovery_args_get_lsp(
+__libnvme_public __u8 libnvmf_discovery_args_get_lsp(
 		const struct libnvmf_discovery_args *p)
 {
 	return p->lsp;
@@ -84,18 +86,20 @@ __public __u8 libnvmf_discovery_args_get_lsp(
  * Accessors for: struct libnvmf_uri
  ****************************************************************************/
 
-__public void libnvmf_uri_set_scheme(struct libnvmf_uri *p, const char *scheme)
+__libnvme_public void libnvmf_uri_set_scheme(
+		struct libnvmf_uri *p,
+		const char *scheme)
 {
 	free(p->scheme);
 	p->scheme = scheme ? strdup(scheme) : NULL;
 }
 
-__public const char *libnvmf_uri_get_scheme(const struct libnvmf_uri *p)
+__libnvme_public const char *libnvmf_uri_get_scheme(const struct libnvmf_uri *p)
 {
 	return p->scheme;
 }
 
-__public void libnvmf_uri_set_protocol(
+__libnvme_public void libnvmf_uri_set_protocol(
 		struct libnvmf_uri *p,
 		const char *protocol)
 {
@@ -103,12 +107,13 @@ __public void libnvmf_uri_set_protocol(
 	p->protocol = protocol ? strdup(protocol) : NULL;
 }
 
-__public const char *libnvmf_uri_get_protocol(const struct libnvmf_uri *p)
+__libnvme_public const char *libnvmf_uri_get_protocol(
+		const struct libnvmf_uri *p)
 {
 	return p->protocol;
 }
 
-__public void libnvmf_uri_set_userinfo(
+__libnvme_public void libnvmf_uri_set_userinfo(
 		struct libnvmf_uri *p,
 		const char *userinfo)
 {
@@ -116,33 +121,36 @@ __public void libnvmf_uri_set_userinfo(
 	p->userinfo = userinfo ? strdup(userinfo) : NULL;
 }
 
-__public const char *libnvmf_uri_get_userinfo(const struct libnvmf_uri *p)
+__libnvme_public const char *libnvmf_uri_get_userinfo(
+		const struct libnvmf_uri *p)
 {
 	return p->userinfo;
 }
 
-__public void libnvmf_uri_set_host(struct libnvmf_uri *p, const char *host)
+__libnvme_public void libnvmf_uri_set_host(
+		struct libnvmf_uri *p,
+		const char *host)
 {
 	free(p->host);
 	p->host = host ? strdup(host) : NULL;
 }
 
-__public const char *libnvmf_uri_get_host(const struct libnvmf_uri *p)
+__libnvme_public const char *libnvmf_uri_get_host(const struct libnvmf_uri *p)
 {
 	return p->host;
 }
 
-__public void libnvmf_uri_set_port(struct libnvmf_uri *p, int port)
+__libnvme_public void libnvmf_uri_set_port(struct libnvmf_uri *p, int port)
 {
 	p->port = port;
 }
 
-__public int libnvmf_uri_get_port(const struct libnvmf_uri *p)
+__libnvme_public int libnvmf_uri_get_port(const struct libnvmf_uri *p)
 {
 	return p->port;
 }
 
-__public void libnvmf_uri_set_path_segments(
+__libnvme_public void libnvmf_uri_set_path_segments(
 		struct libnvmf_uri *p,
 		const char *const *path_segments)
 {
@@ -174,24 +182,26 @@ __public void libnvmf_uri_set_path_segments(
 	p->path_segments = new_array;
 }
 
-__public const char *const *libnvmf_uri_get_path_segments(
+__libnvme_public const char *const *libnvmf_uri_get_path_segments(
 		const struct libnvmf_uri *p)
 {
 	return (const char *const *)p->path_segments;
 }
 
-__public void libnvmf_uri_set_query(struct libnvmf_uri *p, const char *query)
+__libnvme_public void libnvmf_uri_set_query(
+		struct libnvmf_uri *p,
+		const char *query)
 {
 	free(p->query);
 	p->query = query ? strdup(query) : NULL;
 }
 
-__public const char *libnvmf_uri_get_query(const struct libnvmf_uri *p)
+__libnvme_public const char *libnvmf_uri_get_query(const struct libnvmf_uri *p)
 {
 	return p->query;
 }
 
-__public void libnvmf_uri_set_fragment(
+__libnvme_public void libnvmf_uri_set_fragment(
 		struct libnvmf_uri *p,
 		const char *fragment)
 {
@@ -199,7 +209,8 @@ __public void libnvmf_uri_set_fragment(
 	p->fragment = fragment ? strdup(fragment) : NULL;
 }
 
-__public const char *libnvmf_uri_get_fragment(const struct libnvmf_uri *p)
+__libnvme_public const char *libnvmf_uri_get_fragment(
+		const struct libnvmf_uri *p)
 {
 	return p->fragment;
 }

--- a/libnvme/src/nvme/accessors.c
+++ b/libnvme/src/nvme/accessors.c
@@ -29,235 +29,235 @@
  * Accessors for: struct libnvme_fabrics_config
  ****************************************************************************/
 
-__public void libnvme_fabrics_config_set_queue_size(
+__libnvme_public void libnvme_fabrics_config_set_queue_size(
 		struct libnvme_fabrics_config *p,
 		int queue_size)
 {
 	p->queue_size = queue_size;
 }
 
-__public int libnvme_fabrics_config_get_queue_size(
+__libnvme_public int libnvme_fabrics_config_get_queue_size(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->queue_size;
 }
 
-__public void libnvme_fabrics_config_set_nr_io_queues(
+__libnvme_public void libnvme_fabrics_config_set_nr_io_queues(
 		struct libnvme_fabrics_config *p,
 		int nr_io_queues)
 {
 	p->nr_io_queues = nr_io_queues;
 }
 
-__public int libnvme_fabrics_config_get_nr_io_queues(
+__libnvme_public int libnvme_fabrics_config_get_nr_io_queues(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->nr_io_queues;
 }
 
-__public void libnvme_fabrics_config_set_reconnect_delay(
+__libnvme_public void libnvme_fabrics_config_set_reconnect_delay(
 		struct libnvme_fabrics_config *p,
 		int reconnect_delay)
 {
 	p->reconnect_delay = reconnect_delay;
 }
 
-__public int libnvme_fabrics_config_get_reconnect_delay(
+__libnvme_public int libnvme_fabrics_config_get_reconnect_delay(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->reconnect_delay;
 }
 
-__public void libnvme_fabrics_config_set_ctrl_loss_tmo(
+__libnvme_public void libnvme_fabrics_config_set_ctrl_loss_tmo(
 		struct libnvme_fabrics_config *p,
 		int ctrl_loss_tmo)
 {
 	p->ctrl_loss_tmo = ctrl_loss_tmo;
 }
 
-__public int libnvme_fabrics_config_get_ctrl_loss_tmo(
+__libnvme_public int libnvme_fabrics_config_get_ctrl_loss_tmo(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->ctrl_loss_tmo;
 }
 
-__public void libnvme_fabrics_config_set_fast_io_fail_tmo(
+__libnvme_public void libnvme_fabrics_config_set_fast_io_fail_tmo(
 		struct libnvme_fabrics_config *p,
 		int fast_io_fail_tmo)
 {
 	p->fast_io_fail_tmo = fast_io_fail_tmo;
 }
 
-__public int libnvme_fabrics_config_get_fast_io_fail_tmo(
+__libnvme_public int libnvme_fabrics_config_get_fast_io_fail_tmo(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->fast_io_fail_tmo;
 }
 
-__public void libnvme_fabrics_config_set_keep_alive_tmo(
+__libnvme_public void libnvme_fabrics_config_set_keep_alive_tmo(
 		struct libnvme_fabrics_config *p,
 		int keep_alive_tmo)
 {
 	p->keep_alive_tmo = keep_alive_tmo;
 }
 
-__public int libnvme_fabrics_config_get_keep_alive_tmo(
+__libnvme_public int libnvme_fabrics_config_get_keep_alive_tmo(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->keep_alive_tmo;
 }
 
-__public void libnvme_fabrics_config_set_nr_write_queues(
+__libnvme_public void libnvme_fabrics_config_set_nr_write_queues(
 		struct libnvme_fabrics_config *p,
 		int nr_write_queues)
 {
 	p->nr_write_queues = nr_write_queues;
 }
 
-__public int libnvme_fabrics_config_get_nr_write_queues(
+__libnvme_public int libnvme_fabrics_config_get_nr_write_queues(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->nr_write_queues;
 }
 
-__public void libnvme_fabrics_config_set_nr_poll_queues(
+__libnvme_public void libnvme_fabrics_config_set_nr_poll_queues(
 		struct libnvme_fabrics_config *p,
 		int nr_poll_queues)
 {
 	p->nr_poll_queues = nr_poll_queues;
 }
 
-__public int libnvme_fabrics_config_get_nr_poll_queues(
+__libnvme_public int libnvme_fabrics_config_get_nr_poll_queues(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->nr_poll_queues;
 }
 
-__public void libnvme_fabrics_config_set_tos(
+__libnvme_public void libnvme_fabrics_config_set_tos(
 		struct libnvme_fabrics_config *p,
 		int tos)
 {
 	p->tos = tos;
 }
 
-__public int libnvme_fabrics_config_get_tos(
+__libnvme_public int libnvme_fabrics_config_get_tos(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->tos;
 }
 
-__public void libnvme_fabrics_config_set_keyring_id(
+__libnvme_public void libnvme_fabrics_config_set_keyring_id(
 		struct libnvme_fabrics_config *p,
 		long keyring_id)
 {
 	p->keyring_id = keyring_id;
 }
 
-__public long libnvme_fabrics_config_get_keyring_id(
+__libnvme_public long libnvme_fabrics_config_get_keyring_id(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->keyring_id;
 }
 
-__public void libnvme_fabrics_config_set_tls_key_id(
+__libnvme_public void libnvme_fabrics_config_set_tls_key_id(
 		struct libnvme_fabrics_config *p,
 		long tls_key_id)
 {
 	p->tls_key_id = tls_key_id;
 }
 
-__public long libnvme_fabrics_config_get_tls_key_id(
+__libnvme_public long libnvme_fabrics_config_get_tls_key_id(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->tls_key_id;
 }
 
-__public void libnvme_fabrics_config_set_tls_configured_key_id(
+__libnvme_public void libnvme_fabrics_config_set_tls_configured_key_id(
 		struct libnvme_fabrics_config *p,
 		long tls_configured_key_id)
 {
 	p->tls_configured_key_id = tls_configured_key_id;
 }
 
-__public long libnvme_fabrics_config_get_tls_configured_key_id(
+__libnvme_public long libnvme_fabrics_config_get_tls_configured_key_id(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->tls_configured_key_id;
 }
 
-__public void libnvme_fabrics_config_set_duplicate_connect(
+__libnvme_public void libnvme_fabrics_config_set_duplicate_connect(
 		struct libnvme_fabrics_config *p,
 		bool duplicate_connect)
 {
 	p->duplicate_connect = duplicate_connect;
 }
 
-__public bool libnvme_fabrics_config_get_duplicate_connect(
+__libnvme_public bool libnvme_fabrics_config_get_duplicate_connect(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->duplicate_connect;
 }
 
-__public void libnvme_fabrics_config_set_disable_sqflow(
+__libnvme_public void libnvme_fabrics_config_set_disable_sqflow(
 		struct libnvme_fabrics_config *p,
 		bool disable_sqflow)
 {
 	p->disable_sqflow = disable_sqflow;
 }
 
-__public bool libnvme_fabrics_config_get_disable_sqflow(
+__libnvme_public bool libnvme_fabrics_config_get_disable_sqflow(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->disable_sqflow;
 }
 
-__public void libnvme_fabrics_config_set_hdr_digest(
+__libnvme_public void libnvme_fabrics_config_set_hdr_digest(
 		struct libnvme_fabrics_config *p,
 		bool hdr_digest)
 {
 	p->hdr_digest = hdr_digest;
 }
 
-__public bool libnvme_fabrics_config_get_hdr_digest(
+__libnvme_public bool libnvme_fabrics_config_get_hdr_digest(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->hdr_digest;
 }
 
-__public void libnvme_fabrics_config_set_data_digest(
+__libnvme_public void libnvme_fabrics_config_set_data_digest(
 		struct libnvme_fabrics_config *p,
 		bool data_digest)
 {
 	p->data_digest = data_digest;
 }
 
-__public bool libnvme_fabrics_config_get_data_digest(
+__libnvme_public bool libnvme_fabrics_config_get_data_digest(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->data_digest;
 }
 
-__public void libnvme_fabrics_config_set_tls(
+__libnvme_public void libnvme_fabrics_config_set_tls(
 		struct libnvme_fabrics_config *p,
 		bool tls)
 {
 	p->tls = tls;
 }
 
-__public bool libnvme_fabrics_config_get_tls(
+__libnvme_public bool libnvme_fabrics_config_get_tls(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->tls;
 }
 
-__public void libnvme_fabrics_config_set_concat(
+__libnvme_public void libnvme_fabrics_config_set_concat(
 		struct libnvme_fabrics_config *p,
 		bool concat)
 {
 	p->concat = concat;
 }
 
-__public bool libnvme_fabrics_config_get_concat(
+__libnvme_public bool libnvme_fabrics_config_get_concat(
 		const struct libnvme_fabrics_config *p)
 {
 	return p->concat;
@@ -267,18 +267,20 @@ __public bool libnvme_fabrics_config_get_concat(
  * Accessors for: struct libnvme_path
  ****************************************************************************/
 
-__public void libnvme_path_set_name(struct libnvme_path *p, const char *name)
+__libnvme_public void libnvme_path_set_name(
+		struct libnvme_path *p,
+		const char *name)
 {
 	free(p->name);
 	p->name = name ? strdup(name) : NULL;
 }
 
-__public const char *libnvme_path_get_name(const struct libnvme_path *p)
+__libnvme_public const char *libnvme_path_get_name(const struct libnvme_path *p)
 {
 	return p->name;
 }
 
-__public void libnvme_path_set_sysfs_dir(
+__libnvme_public void libnvme_path_set_sysfs_dir(
 		struct libnvme_path *p,
 		const char *sysfs_dir)
 {
@@ -286,17 +288,18 @@ __public void libnvme_path_set_sysfs_dir(
 	p->sysfs_dir = sysfs_dir ? strdup(sysfs_dir) : NULL;
 }
 
-__public const char *libnvme_path_get_sysfs_dir(const struct libnvme_path *p)
+__libnvme_public const char *libnvme_path_get_sysfs_dir(
+		const struct libnvme_path *p)
 {
 	return p->sysfs_dir;
 }
 
-__public void libnvme_path_set_grpid(struct libnvme_path *p, int grpid)
+__libnvme_public void libnvme_path_set_grpid(struct libnvme_path *p, int grpid)
 {
 	p->grpid = grpid;
 }
 
-__public int libnvme_path_get_grpid(const struct libnvme_path *p)
+__libnvme_public int libnvme_path_get_grpid(const struct libnvme_path *p)
 {
 	return p->grpid;
 }
@@ -305,27 +308,28 @@ __public int libnvme_path_get_grpid(const struct libnvme_path *p)
  * Accessors for: struct libnvme_ns
  ****************************************************************************/
 
-__public void libnvme_ns_set_nsid(struct libnvme_ns *p, __u32 nsid)
+__libnvme_public void libnvme_ns_set_nsid(struct libnvme_ns *p, __u32 nsid)
 {
 	p->nsid = nsid;
 }
 
-__public __u32 libnvme_ns_get_nsid(const struct libnvme_ns *p)
+__libnvme_public __u32 libnvme_ns_get_nsid(const struct libnvme_ns *p)
 {
 	return p->nsid;
 }
 
-__public const char *libnvme_ns_get_name(const struct libnvme_ns *p)
+__libnvme_public const char *libnvme_ns_get_name(const struct libnvme_ns *p)
 {
 	return p->name;
 }
 
-__public const char *libnvme_ns_get_generic_name(const struct libnvme_ns *p)
+__libnvme_public const char *libnvme_ns_get_generic_name(
+		const struct libnvme_ns *p)
 {
 	return p->generic_name;
 }
 
-__public void libnvme_ns_set_sysfs_dir(
+__libnvme_public void libnvme_ns_set_sysfs_dir(
 		struct libnvme_ns *p,
 		const char *sysfs_dir)
 {
@@ -333,72 +337,83 @@ __public void libnvme_ns_set_sysfs_dir(
 	p->sysfs_dir = sysfs_dir ? strdup(sysfs_dir) : NULL;
 }
 
-__public const char *libnvme_ns_get_sysfs_dir(const struct libnvme_ns *p)
+__libnvme_public const char *libnvme_ns_get_sysfs_dir(
+		const struct libnvme_ns *p)
 {
 	return p->sysfs_dir;
 }
 
-__public void libnvme_ns_set_lba_shift(struct libnvme_ns *p, int lba_shift)
+__libnvme_public void libnvme_ns_set_lba_shift(
+		struct libnvme_ns *p,
+		int lba_shift)
 {
 	p->lba_shift = lba_shift;
 }
 
-__public int libnvme_ns_get_lba_shift(const struct libnvme_ns *p)
+__libnvme_public int libnvme_ns_get_lba_shift(const struct libnvme_ns *p)
 {
 	return p->lba_shift;
 }
 
-__public void libnvme_ns_set_lba_size(struct libnvme_ns *p, int lba_size)
+__libnvme_public void libnvme_ns_set_lba_size(
+		struct libnvme_ns *p,
+		int lba_size)
 {
 	p->lba_size = lba_size;
 }
 
-__public int libnvme_ns_get_lba_size(const struct libnvme_ns *p)
+__libnvme_public int libnvme_ns_get_lba_size(const struct libnvme_ns *p)
 {
 	return p->lba_size;
 }
 
-__public void libnvme_ns_set_meta_size(struct libnvme_ns *p, int meta_size)
+__libnvme_public void libnvme_ns_set_meta_size(
+		struct libnvme_ns *p,
+		int meta_size)
 {
 	p->meta_size = meta_size;
 }
 
-__public int libnvme_ns_get_meta_size(const struct libnvme_ns *p)
+__libnvme_public int libnvme_ns_get_meta_size(const struct libnvme_ns *p)
 {
 	return p->meta_size;
 }
 
-__public void libnvme_ns_set_lba_count(struct libnvme_ns *p, uint64_t lba_count)
+__libnvme_public void libnvme_ns_set_lba_count(
+		struct libnvme_ns *p,
+		uint64_t lba_count)
 {
 	p->lba_count = lba_count;
 }
 
-__public uint64_t libnvme_ns_get_lba_count(const struct libnvme_ns *p)
+__libnvme_public uint64_t libnvme_ns_get_lba_count(const struct libnvme_ns *p)
 {
 	return p->lba_count;
 }
 
-__public void libnvme_ns_set_lba_util(struct libnvme_ns *p, uint64_t lba_util)
+__libnvme_public void libnvme_ns_set_lba_util(
+		struct libnvme_ns *p,
+		uint64_t lba_util)
 {
 	p->lba_util = lba_util;
 }
 
-__public uint64_t libnvme_ns_get_lba_util(const struct libnvme_ns *p)
+__libnvme_public uint64_t libnvme_ns_get_lba_util(const struct libnvme_ns *p)
 {
 	return p->lba_util;
 }
 
-__public const uint8_t *libnvme_ns_get_eui64(const struct libnvme_ns *p)
+__libnvme_public const uint8_t *libnvme_ns_get_eui64(const struct libnvme_ns *p)
 {
 	return p->eui64;
 }
 
-__public const uint8_t *libnvme_ns_get_nguid(const struct libnvme_ns *p)
+__libnvme_public const uint8_t *libnvme_ns_get_nguid(const struct libnvme_ns *p)
 {
 	return p->nguid;
 }
 
-__public enum nvme_csi libnvme_ns_get_csi(const struct libnvme_ns *p)
+__libnvme_public enum nvme_csi libnvme_ns_get_csi(const struct libnvme_ns *p)
 {
 	return p->csi;
 }
@@ -407,72 +422,84 @@ __public enum nvme_csi libnvme_ns_get_csi(const struct libnvme_ns *p)
  * Accessors for: struct libnvme_ctrl
  ****************************************************************************/
 
-__public const char *libnvme_ctrl_get_name(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_name(const struct libnvme_ctrl *p)
 {
 	return p->name;
 }
 
-__public const char *libnvme_ctrl_get_sysfs_dir(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_sysfs_dir(
+		const struct libnvme_ctrl *p)
 {
 	return p->sysfs_dir;
 }
 
-__public const char *libnvme_ctrl_get_address(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_address(
+		const struct libnvme_ctrl *p)
 {
 	return p->address;
 }
 
-__public const char *libnvme_ctrl_get_firmware(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_firmware(
+		const struct libnvme_ctrl *p)
 {
 	return p->firmware;
 }
 
-__public const char *libnvme_ctrl_get_model(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_model(
+		const struct libnvme_ctrl *p)
 {
 	return p->model;
 }
 
-__public const char *libnvme_ctrl_get_numa_node(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_numa_node(
+		const struct libnvme_ctrl *p)
 {
 	return p->numa_node;
 }
 
-__public const char *libnvme_ctrl_get_queue_count(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_queue_count(
+		const struct libnvme_ctrl *p)
 {
 	return p->queue_count;
 }
 
-__public const char *libnvme_ctrl_get_serial(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_serial(
+		const struct libnvme_ctrl *p)
 {
 	return p->serial;
 }
 
-__public const char *libnvme_ctrl_get_sqsize(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_sqsize(
+		const struct libnvme_ctrl *p)
 {
 	return p->sqsize;
 }
 
-__public const char *libnvme_ctrl_get_transport(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_transport(
+		const struct libnvme_ctrl *p)
 {
 	return p->transport;
 }
 
-__public const char *libnvme_ctrl_get_subsysnqn(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_subsysnqn(
+		const struct libnvme_ctrl *p)
 {
 	return p->subsysnqn;
 }
 
-__public const char *libnvme_ctrl_get_traddr(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_traddr(
+		const struct libnvme_ctrl *p)
 {
 	return p->traddr;
 }
 
-__public const char *libnvme_ctrl_get_trsvcid(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_trsvcid(
+		const struct libnvme_ctrl *p)
 {
 	return p->trsvcid;
 }
 
-__public void libnvme_ctrl_set_dhchap_host_key(
+__libnvme_public void libnvme_ctrl_set_dhchap_host_key(
 		struct libnvme_ctrl *p,
 		const char *dhchap_host_key)
 {
@@ -480,13 +507,13 @@ __public void libnvme_ctrl_set_dhchap_host_key(
 	p->dhchap_host_key = dhchap_host_key ? strdup(dhchap_host_key) : NULL;
 }
 
-__public const char *libnvme_ctrl_get_dhchap_host_key(
+__libnvme_public const char *libnvme_ctrl_get_dhchap_host_key(
 		const struct libnvme_ctrl *p)
 {
 	return p->dhchap_host_key;
 }
 
-__public void libnvme_ctrl_set_dhchap_ctrl_key(
+__libnvme_public void libnvme_ctrl_set_dhchap_ctrl_key(
 		struct libnvme_ctrl *p,
 		const char *dhchap_ctrl_key)
 {
@@ -494,13 +521,13 @@ __public void libnvme_ctrl_set_dhchap_ctrl_key(
 	p->dhchap_ctrl_key = dhchap_ctrl_key ? strdup(dhchap_ctrl_key) : NULL;
 }
 
-__public const char *libnvme_ctrl_get_dhchap_ctrl_key(
+__libnvme_public const char *libnvme_ctrl_get_dhchap_ctrl_key(
 		const struct libnvme_ctrl *p)
 {
 	return p->dhchap_ctrl_key;
 }
 
-__public void libnvme_ctrl_set_keyring(
+__libnvme_public void libnvme_ctrl_set_keyring(
 		struct libnvme_ctrl *p,
 		const char *keyring)
 {
@@ -508,12 +535,13 @@ __public void libnvme_ctrl_set_keyring(
 	p->keyring = keyring ? strdup(keyring) : NULL;
 }
 
-__public const char *libnvme_ctrl_get_keyring(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_keyring(
+		const struct libnvme_ctrl *p)
 {
 	return p->keyring;
 }
 
-__public void libnvme_ctrl_set_tls_key_identity(
+__libnvme_public void libnvme_ctrl_set_tls_key_identity(
 		struct libnvme_ctrl *p,
 		const char *tls_key_identity)
 {
@@ -522,13 +550,13 @@ __public void libnvme_ctrl_set_tls_key_identity(
 		tls_key_identity ? strdup(tls_key_identity) : NULL;
 }
 
-__public const char *libnvme_ctrl_get_tls_key_identity(
+__libnvme_public const char *libnvme_ctrl_get_tls_key_identity(
 		const struct libnvme_ctrl *p)
 {
 	return p->tls_key_identity;
 }
 
-__public void libnvme_ctrl_set_tls_key(
+__libnvme_public void libnvme_ctrl_set_tls_key(
 		struct libnvme_ctrl *p,
 		const char *tls_key)
 {
@@ -536,86 +564,94 @@ __public void libnvme_ctrl_set_tls_key(
 	p->tls_key = tls_key ? strdup(tls_key) : NULL;
 }
 
-__public const char *libnvme_ctrl_get_tls_key(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_tls_key(
+		const struct libnvme_ctrl *p)
 {
 	return p->tls_key;
 }
 
-__public const char *libnvme_ctrl_get_cntrltype(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_cntrltype(
+		const struct libnvme_ctrl *p)
 {
 	return p->cntrltype;
 }
 
-__public const char *libnvme_ctrl_get_cntlid(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_cntlid(
+		const struct libnvme_ctrl *p)
 {
 	return p->cntlid;
 }
 
-__public const char *libnvme_ctrl_get_dctype(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_dctype(
+		const struct libnvme_ctrl *p)
 {
 	return p->dctype;
 }
 
-__public const char *libnvme_ctrl_get_phy_slot(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_phy_slot(
+		const struct libnvme_ctrl *p)
 {
 	return p->phy_slot;
 }
 
-__public const char *libnvme_ctrl_get_host_traddr(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_host_traddr(
+		const struct libnvme_ctrl *p)
 {
 	return p->host_traddr;
 }
 
-__public const char *libnvme_ctrl_get_host_iface(const struct libnvme_ctrl *p)
+__libnvme_public const char *libnvme_ctrl_get_host_iface(
+		const struct libnvme_ctrl *p)
 {
 	return p->host_iface;
 }
 
-__public void libnvme_ctrl_set_discovery_ctrl(
+__libnvme_public void libnvme_ctrl_set_discovery_ctrl(
 		struct libnvme_ctrl *p,
 		bool discovery_ctrl)
 {
 	p->discovery_ctrl = discovery_ctrl;
 }
 
-__public bool libnvme_ctrl_get_discovery_ctrl(const struct libnvme_ctrl *p)
+__libnvme_public bool libnvme_ctrl_get_discovery_ctrl(
+		const struct libnvme_ctrl *p)
 {
 	return p->discovery_ctrl;
 }
 
-__public void libnvme_ctrl_set_unique_discovery_ctrl(
+__libnvme_public void libnvme_ctrl_set_unique_discovery_ctrl(
 		struct libnvme_ctrl *p,
 		bool unique_discovery_ctrl)
 {
 	p->unique_discovery_ctrl = unique_discovery_ctrl;
 }
 
-__public bool libnvme_ctrl_get_unique_discovery_ctrl(
+__libnvme_public bool libnvme_ctrl_get_unique_discovery_ctrl(
 		const struct libnvme_ctrl *p)
 {
 	return p->unique_discovery_ctrl;
 }
 
-__public void libnvme_ctrl_set_discovered(
+__libnvme_public void libnvme_ctrl_set_discovered(
 		struct libnvme_ctrl *p,
 		bool discovered)
 {
 	p->discovered = discovered;
 }
 
-__public bool libnvme_ctrl_get_discovered(const struct libnvme_ctrl *p)
+__libnvme_public bool libnvme_ctrl_get_discovered(const struct libnvme_ctrl *p)
 {
 	return p->discovered;
 }
 
-__public void libnvme_ctrl_set_persistent(
+__libnvme_public void libnvme_ctrl_set_persistent(
 		struct libnvme_ctrl *p,
 		bool persistent)
 {
 	p->persistent = persistent;
 }
 
-__public bool libnvme_ctrl_get_persistent(const struct libnvme_ctrl *p)
+__libnvme_public bool libnvme_ctrl_get_persistent(const struct libnvme_ctrl *p)
 {
 	return p->persistent;
 }
@@ -624,49 +660,49 @@ __public bool libnvme_ctrl_get_persistent(const struct libnvme_ctrl *p)
  * Accessors for: struct libnvme_subsystem
  ****************************************************************************/
 
-__public const char *libnvme_subsystem_get_name(
+__libnvme_public const char *libnvme_subsystem_get_name(
 		const struct libnvme_subsystem *p)
 {
 	return p->name;
 }
 
-__public const char *libnvme_subsystem_get_sysfs_dir(
+__libnvme_public const char *libnvme_subsystem_get_sysfs_dir(
 		const struct libnvme_subsystem *p)
 {
 	return p->sysfs_dir;
 }
 
-__public const char *libnvme_subsystem_get_subsysnqn(
+__libnvme_public const char *libnvme_subsystem_get_subsysnqn(
 		const struct libnvme_subsystem *p)
 {
 	return p->subsysnqn;
 }
 
-__public const char *libnvme_subsystem_get_model(
+__libnvme_public const char *libnvme_subsystem_get_model(
 		const struct libnvme_subsystem *p)
 {
 	return p->model;
 }
 
-__public const char *libnvme_subsystem_get_serial(
+__libnvme_public const char *libnvme_subsystem_get_serial(
 		const struct libnvme_subsystem *p)
 {
 	return p->serial;
 }
 
-__public const char *libnvme_subsystem_get_firmware(
+__libnvme_public const char *libnvme_subsystem_get_firmware(
 		const struct libnvme_subsystem *p)
 {
 	return p->firmware;
 }
 
-__public const char *libnvme_subsystem_get_subsystype(
+__libnvme_public const char *libnvme_subsystem_get_subsystype(
 		const struct libnvme_subsystem *p)
 {
 	return p->subsystype;
 }
 
-__public void libnvme_subsystem_set_application(
+__libnvme_public void libnvme_subsystem_set_application(
 		struct libnvme_subsystem *p,
 		const char *application)
 {
@@ -674,7 +710,7 @@ __public void libnvme_subsystem_set_application(
 	p->application = application ? strdup(application) : NULL;
 }
 
-__public const char *libnvme_subsystem_get_application(
+__libnvme_public const char *libnvme_subsystem_get_application(
 		const struct libnvme_subsystem *p)
 {
 	return p->application;
@@ -684,17 +720,19 @@ __public const char *libnvme_subsystem_get_application(
  * Accessors for: struct libnvme_host
  ****************************************************************************/
 
-__public const char *libnvme_host_get_hostnqn(const struct libnvme_host *p)
+__libnvme_public const char *libnvme_host_get_hostnqn(
+		const struct libnvme_host *p)
 {
 	return p->hostnqn;
 }
 
-__public const char *libnvme_host_get_hostid(const struct libnvme_host *p)
+__libnvme_public const char *libnvme_host_get_hostid(
+		const struct libnvme_host *p)
 {
 	return p->hostid;
 }
 
-__public void libnvme_host_set_dhchap_host_key(
+__libnvme_public void libnvme_host_set_dhchap_host_key(
 		struct libnvme_host *p,
 		const char *dhchap_host_key)
 {
@@ -702,13 +740,13 @@ __public void libnvme_host_set_dhchap_host_key(
 	p->dhchap_host_key = dhchap_host_key ? strdup(dhchap_host_key) : NULL;
 }
 
-__public const char *libnvme_host_get_dhchap_host_key(
+__libnvme_public const char *libnvme_host_get_dhchap_host_key(
 		const struct libnvme_host *p)
 {
 	return p->dhchap_host_key;
 }
 
-__public void libnvme_host_set_hostsymname(
+__libnvme_public void libnvme_host_set_hostsymname(
 		struct libnvme_host *p,
 		const char *hostsymname)
 {
@@ -716,7 +754,8 @@ __public void libnvme_host_set_hostsymname(
 	p->hostsymname = hostsymname ? strdup(hostsymname) : NULL;
 }
 
-__public const char *libnvme_host_get_hostsymname(const struct libnvme_host *p)
+__libnvme_public const char *libnvme_host_get_hostsymname(
+		const struct libnvme_host *p)
 {
 	return p->hostsymname;
 }
@@ -725,391 +764,391 @@ __public const char *libnvme_host_get_hostsymname(const struct libnvme_host *p)
  * Accessors for: struct libnvme_fabric_options
  ****************************************************************************/
 
-__public void libnvme_fabric_options_set_cntlid(
+__libnvme_public void libnvme_fabric_options_set_cntlid(
 		struct libnvme_fabric_options *p,
 		bool cntlid)
 {
 	p->cntlid = cntlid;
 }
 
-__public bool libnvme_fabric_options_get_cntlid(
+__libnvme_public bool libnvme_fabric_options_get_cntlid(
 		const struct libnvme_fabric_options *p)
 {
 	return p->cntlid;
 }
 
-__public void libnvme_fabric_options_set_concat(
+__libnvme_public void libnvme_fabric_options_set_concat(
 		struct libnvme_fabric_options *p,
 		bool concat)
 {
 	p->concat = concat;
 }
 
-__public bool libnvme_fabric_options_get_concat(
+__libnvme_public bool libnvme_fabric_options_get_concat(
 		const struct libnvme_fabric_options *p)
 {
 	return p->concat;
 }
 
-__public void libnvme_fabric_options_set_ctrl_loss_tmo(
+__libnvme_public void libnvme_fabric_options_set_ctrl_loss_tmo(
 		struct libnvme_fabric_options *p,
 		bool ctrl_loss_tmo)
 {
 	p->ctrl_loss_tmo = ctrl_loss_tmo;
 }
 
-__public bool libnvme_fabric_options_get_ctrl_loss_tmo(
+__libnvme_public bool libnvme_fabric_options_get_ctrl_loss_tmo(
 		const struct libnvme_fabric_options *p)
 {
 	return p->ctrl_loss_tmo;
 }
 
-__public void libnvme_fabric_options_set_data_digest(
+__libnvme_public void libnvme_fabric_options_set_data_digest(
 		struct libnvme_fabric_options *p,
 		bool data_digest)
 {
 	p->data_digest = data_digest;
 }
 
-__public bool libnvme_fabric_options_get_data_digest(
+__libnvme_public bool libnvme_fabric_options_get_data_digest(
 		const struct libnvme_fabric_options *p)
 {
 	return p->data_digest;
 }
 
-__public void libnvme_fabric_options_set_dhchap_ctrl_secret(
+__libnvme_public void libnvme_fabric_options_set_dhchap_ctrl_secret(
 		struct libnvme_fabric_options *p,
 		bool dhchap_ctrl_secret)
 {
 	p->dhchap_ctrl_secret = dhchap_ctrl_secret;
 }
 
-__public bool libnvme_fabric_options_get_dhchap_ctrl_secret(
+__libnvme_public bool libnvme_fabric_options_get_dhchap_ctrl_secret(
 		const struct libnvme_fabric_options *p)
 {
 	return p->dhchap_ctrl_secret;
 }
 
-__public void libnvme_fabric_options_set_dhchap_secret(
+__libnvme_public void libnvme_fabric_options_set_dhchap_secret(
 		struct libnvme_fabric_options *p,
 		bool dhchap_secret)
 {
 	p->dhchap_secret = dhchap_secret;
 }
 
-__public bool libnvme_fabric_options_get_dhchap_secret(
+__libnvme_public bool libnvme_fabric_options_get_dhchap_secret(
 		const struct libnvme_fabric_options *p)
 {
 	return p->dhchap_secret;
 }
 
-__public void libnvme_fabric_options_set_disable_sqflow(
+__libnvme_public void libnvme_fabric_options_set_disable_sqflow(
 		struct libnvme_fabric_options *p,
 		bool disable_sqflow)
 {
 	p->disable_sqflow = disable_sqflow;
 }
 
-__public bool libnvme_fabric_options_get_disable_sqflow(
+__libnvme_public bool libnvme_fabric_options_get_disable_sqflow(
 		const struct libnvme_fabric_options *p)
 {
 	return p->disable_sqflow;
 }
 
-__public void libnvme_fabric_options_set_discovery(
+__libnvme_public void libnvme_fabric_options_set_discovery(
 		struct libnvme_fabric_options *p,
 		bool discovery)
 {
 	p->discovery = discovery;
 }
 
-__public bool libnvme_fabric_options_get_discovery(
+__libnvme_public bool libnvme_fabric_options_get_discovery(
 		const struct libnvme_fabric_options *p)
 {
 	return p->discovery;
 }
 
-__public void libnvme_fabric_options_set_duplicate_connect(
+__libnvme_public void libnvme_fabric_options_set_duplicate_connect(
 		struct libnvme_fabric_options *p,
 		bool duplicate_connect)
 {
 	p->duplicate_connect = duplicate_connect;
 }
 
-__public bool libnvme_fabric_options_get_duplicate_connect(
+__libnvme_public bool libnvme_fabric_options_get_duplicate_connect(
 		const struct libnvme_fabric_options *p)
 {
 	return p->duplicate_connect;
 }
 
-__public void libnvme_fabric_options_set_fast_io_fail_tmo(
+__libnvme_public void libnvme_fabric_options_set_fast_io_fail_tmo(
 		struct libnvme_fabric_options *p,
 		bool fast_io_fail_tmo)
 {
 	p->fast_io_fail_tmo = fast_io_fail_tmo;
 }
 
-__public bool libnvme_fabric_options_get_fast_io_fail_tmo(
+__libnvme_public bool libnvme_fabric_options_get_fast_io_fail_tmo(
 		const struct libnvme_fabric_options *p)
 {
 	return p->fast_io_fail_tmo;
 }
 
-__public void libnvme_fabric_options_set_hdr_digest(
+__libnvme_public void libnvme_fabric_options_set_hdr_digest(
 		struct libnvme_fabric_options *p,
 		bool hdr_digest)
 {
 	p->hdr_digest = hdr_digest;
 }
 
-__public bool libnvme_fabric_options_get_hdr_digest(
+__libnvme_public bool libnvme_fabric_options_get_hdr_digest(
 		const struct libnvme_fabric_options *p)
 {
 	return p->hdr_digest;
 }
 
-__public void libnvme_fabric_options_set_host_iface(
+__libnvme_public void libnvme_fabric_options_set_host_iface(
 		struct libnvme_fabric_options *p,
 		bool host_iface)
 {
 	p->host_iface = host_iface;
 }
 
-__public bool libnvme_fabric_options_get_host_iface(
+__libnvme_public bool libnvme_fabric_options_get_host_iface(
 		const struct libnvme_fabric_options *p)
 {
 	return p->host_iface;
 }
 
-__public void libnvme_fabric_options_set_host_traddr(
+__libnvme_public void libnvme_fabric_options_set_host_traddr(
 		struct libnvme_fabric_options *p,
 		bool host_traddr)
 {
 	p->host_traddr = host_traddr;
 }
 
-__public bool libnvme_fabric_options_get_host_traddr(
+__libnvme_public bool libnvme_fabric_options_get_host_traddr(
 		const struct libnvme_fabric_options *p)
 {
 	return p->host_traddr;
 }
 
-__public void libnvme_fabric_options_set_hostid(
+__libnvme_public void libnvme_fabric_options_set_hostid(
 		struct libnvme_fabric_options *p,
 		bool hostid)
 {
 	p->hostid = hostid;
 }
 
-__public bool libnvme_fabric_options_get_hostid(
+__libnvme_public bool libnvme_fabric_options_get_hostid(
 		const struct libnvme_fabric_options *p)
 {
 	return p->hostid;
 }
 
-__public void libnvme_fabric_options_set_hostnqn(
+__libnvme_public void libnvme_fabric_options_set_hostnqn(
 		struct libnvme_fabric_options *p,
 		bool hostnqn)
 {
 	p->hostnqn = hostnqn;
 }
 
-__public bool libnvme_fabric_options_get_hostnqn(
+__libnvme_public bool libnvme_fabric_options_get_hostnqn(
 		const struct libnvme_fabric_options *p)
 {
 	return p->hostnqn;
 }
 
-__public void libnvme_fabric_options_set_instance(
+__libnvme_public void libnvme_fabric_options_set_instance(
 		struct libnvme_fabric_options *p,
 		bool instance)
 {
 	p->instance = instance;
 }
 
-__public bool libnvme_fabric_options_get_instance(
+__libnvme_public bool libnvme_fabric_options_get_instance(
 		const struct libnvme_fabric_options *p)
 {
 	return p->instance;
 }
 
-__public void libnvme_fabric_options_set_keep_alive_tmo(
+__libnvme_public void libnvme_fabric_options_set_keep_alive_tmo(
 		struct libnvme_fabric_options *p,
 		bool keep_alive_tmo)
 {
 	p->keep_alive_tmo = keep_alive_tmo;
 }
 
-__public bool libnvme_fabric_options_get_keep_alive_tmo(
+__libnvme_public bool libnvme_fabric_options_get_keep_alive_tmo(
 		const struct libnvme_fabric_options *p)
 {
 	return p->keep_alive_tmo;
 }
 
-__public void libnvme_fabric_options_set_keyring(
+__libnvme_public void libnvme_fabric_options_set_keyring(
 		struct libnvme_fabric_options *p,
 		bool keyring)
 {
 	p->keyring = keyring;
 }
 
-__public bool libnvme_fabric_options_get_keyring(
+__libnvme_public bool libnvme_fabric_options_get_keyring(
 		const struct libnvme_fabric_options *p)
 {
 	return p->keyring;
 }
 
-__public void libnvme_fabric_options_set_nqn(
+__libnvme_public void libnvme_fabric_options_set_nqn(
 		struct libnvme_fabric_options *p,
 		bool nqn)
 {
 	p->nqn = nqn;
 }
 
-__public bool libnvme_fabric_options_get_nqn(
+__libnvme_public bool libnvme_fabric_options_get_nqn(
 		const struct libnvme_fabric_options *p)
 {
 	return p->nqn;
 }
 
-__public void libnvme_fabric_options_set_nr_io_queues(
+__libnvme_public void libnvme_fabric_options_set_nr_io_queues(
 		struct libnvme_fabric_options *p,
 		bool nr_io_queues)
 {
 	p->nr_io_queues = nr_io_queues;
 }
 
-__public bool libnvme_fabric_options_get_nr_io_queues(
+__libnvme_public bool libnvme_fabric_options_get_nr_io_queues(
 		const struct libnvme_fabric_options *p)
 {
 	return p->nr_io_queues;
 }
 
-__public void libnvme_fabric_options_set_nr_poll_queues(
+__libnvme_public void libnvme_fabric_options_set_nr_poll_queues(
 		struct libnvme_fabric_options *p,
 		bool nr_poll_queues)
 {
 	p->nr_poll_queues = nr_poll_queues;
 }
 
-__public bool libnvme_fabric_options_get_nr_poll_queues(
+__libnvme_public bool libnvme_fabric_options_get_nr_poll_queues(
 		const struct libnvme_fabric_options *p)
 {
 	return p->nr_poll_queues;
 }
 
-__public void libnvme_fabric_options_set_nr_write_queues(
+__libnvme_public void libnvme_fabric_options_set_nr_write_queues(
 		struct libnvme_fabric_options *p,
 		bool nr_write_queues)
 {
 	p->nr_write_queues = nr_write_queues;
 }
 
-__public bool libnvme_fabric_options_get_nr_write_queues(
+__libnvme_public bool libnvme_fabric_options_get_nr_write_queues(
 		const struct libnvme_fabric_options *p)
 {
 	return p->nr_write_queues;
 }
 
-__public void libnvme_fabric_options_set_queue_size(
+__libnvme_public void libnvme_fabric_options_set_queue_size(
 		struct libnvme_fabric_options *p,
 		bool queue_size)
 {
 	p->queue_size = queue_size;
 }
 
-__public bool libnvme_fabric_options_get_queue_size(
+__libnvme_public bool libnvme_fabric_options_get_queue_size(
 		const struct libnvme_fabric_options *p)
 {
 	return p->queue_size;
 }
 
-__public void libnvme_fabric_options_set_reconnect_delay(
+__libnvme_public void libnvme_fabric_options_set_reconnect_delay(
 		struct libnvme_fabric_options *p,
 		bool reconnect_delay)
 {
 	p->reconnect_delay = reconnect_delay;
 }
 
-__public bool libnvme_fabric_options_get_reconnect_delay(
+__libnvme_public bool libnvme_fabric_options_get_reconnect_delay(
 		const struct libnvme_fabric_options *p)
 {
 	return p->reconnect_delay;
 }
 
-__public void libnvme_fabric_options_set_tls(
+__libnvme_public void libnvme_fabric_options_set_tls(
 		struct libnvme_fabric_options *p,
 		bool tls)
 {
 	p->tls = tls;
 }
 
-__public bool libnvme_fabric_options_get_tls(
+__libnvme_public bool libnvme_fabric_options_get_tls(
 		const struct libnvme_fabric_options *p)
 {
 	return p->tls;
 }
 
-__public void libnvme_fabric_options_set_tls_key(
+__libnvme_public void libnvme_fabric_options_set_tls_key(
 		struct libnvme_fabric_options *p,
 		bool tls_key)
 {
 	p->tls_key = tls_key;
 }
 
-__public bool libnvme_fabric_options_get_tls_key(
+__libnvme_public bool libnvme_fabric_options_get_tls_key(
 		const struct libnvme_fabric_options *p)
 {
 	return p->tls_key;
 }
 
-__public void libnvme_fabric_options_set_tos(
+__libnvme_public void libnvme_fabric_options_set_tos(
 		struct libnvme_fabric_options *p,
 		bool tos)
 {
 	p->tos = tos;
 }
 
-__public bool libnvme_fabric_options_get_tos(
+__libnvme_public bool libnvme_fabric_options_get_tos(
 		const struct libnvme_fabric_options *p)
 {
 	return p->tos;
 }
 
-__public void libnvme_fabric_options_set_traddr(
+__libnvme_public void libnvme_fabric_options_set_traddr(
 		struct libnvme_fabric_options *p,
 		bool traddr)
 {
 	p->traddr = traddr;
 }
 
-__public bool libnvme_fabric_options_get_traddr(
+__libnvme_public bool libnvme_fabric_options_get_traddr(
 		const struct libnvme_fabric_options *p)
 {
 	return p->traddr;
 }
 
-__public void libnvme_fabric_options_set_transport(
+__libnvme_public void libnvme_fabric_options_set_transport(
 		struct libnvme_fabric_options *p,
 		bool transport)
 {
 	p->transport = transport;
 }
 
-__public bool libnvme_fabric_options_get_transport(
+__libnvme_public bool libnvme_fabric_options_get_transport(
 		const struct libnvme_fabric_options *p)
 {
 	return p->transport;
 }
 
-__public void libnvme_fabric_options_set_trsvcid(
+__libnvme_public void libnvme_fabric_options_set_trsvcid(
 		struct libnvme_fabric_options *p,
 		bool trsvcid)
 {
 	p->trsvcid = trsvcid;
 }
 
-__public bool libnvme_fabric_options_get_trsvcid(
+__libnvme_public bool libnvme_fabric_options_get_trsvcid(
 		const struct libnvme_fabric_options *p)
 {
 	return p->trsvcid;

--- a/libnvme/src/nvme/compiler-attributes.h
+++ b/libnvme/src/nvme/compiler-attributes.h
@@ -8,27 +8,27 @@
 #pragma once
 
 /**
- * __public - mark a symbol as part of the public API.
+ * __libnvme_public - mark a symbol as part of the public API.
  *
  * When the library is built with -fvisibility=hidden all symbols are hidden
- * by default.  Annotating a function with __public overrides that and makes
- * the symbol visible in the shared library ABI.
+ * by default.  Annotating a function with __libnvme_public overrides that
+ * and makes the symbol visible in the shared library ABI.
  */
-#define __public __attribute__((visibility("default")))
+#define __libnvme_public __attribute__((visibility("default")))
 
 /**
- * __weak - Declares a symbol as "weak"
+ * __libnvme_weak - Declares a symbol as "weak"
  *
  * A weak symbol provides a default implementation that can be
  * replaced by another (strong) definition during linking. Useful for
  * optional overrides and platform hooks.
  */
-#define __weak __attribute__((weak))
+#define __libnvme_weak __attribute__((weak))
 
 /**
- * __unused - Mark a symbol or parameter as intentionally unused.
+ * __libnvme_unused - Mark a symbol or parameter as intentionally unused.
  *
  * Suppresses compiler warnings for symbols or parameters that are unused
  * by design (e.g. no-op stubs that must match a specific signature).
  */
-#define __unused __attribute__((__unused__))
+#define __libnvme_unused __attribute__((__unused__))

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -77,7 +77,7 @@ const char * const trtypes[] = {
 	[NVMF_TRTYPE_LOOP]	= "loop",
 };
 
-__public const char *libnvmf_trtype_str(__u8 trtype)
+__libnvme_public const char *libnvmf_trtype_str(__u8 trtype)
 {
 	return arg_str(trtypes, ARRAY_SIZE(trtypes), trtype);
 }
@@ -90,7 +90,7 @@ static const char * const adrfams[] = {
 	[NVMF_ADDR_FAMILY_FC]	= "fibre-channel",
 };
 
-__public const char *libnvmf_adrfam_str(__u8 adrfam)
+__libnvme_public const char *libnvmf_adrfam_str(__u8 adrfam)
 {
 	return arg_str(adrfams, ARRAY_SIZE(adrfams), adrfam);
 }
@@ -101,7 +101,7 @@ static const char * const subtypes[] = {
 	[NVME_NQN_CURR]		= "current discovery subsystem",
 };
 
-__public const char *libnvmf_subtype_str(__u8 subtype)
+__libnvme_public const char *libnvmf_subtype_str(__u8 subtype)
 {
 	return arg_str(subtypes, ARRAY_SIZE(subtypes), subtype);
 }
@@ -121,7 +121,7 @@ static const char * const treqs[] = {
 				"sq flow control disable supported",
 };
 
-__public const char *libnvmf_treq_str(__u8 treq)
+__libnvme_public const char *libnvmf_treq_str(__u8 treq)
 {
 	return arg_str(treqs, ARRAY_SIZE(treqs), treq);
 }
@@ -147,7 +147,7 @@ static const char * const eflags_strings[] = {
 					  "no cdc connectivity",
 };
 
-__public const char *libnvmf_eflags_str(__u16 eflags)
+__libnvme_public const char *libnvmf_eflags_str(__u16 eflags)
 {
 	return arg_str(eflags_strings, ARRAY_SIZE(eflags_strings), eflags);
 }
@@ -158,7 +158,7 @@ static const char * const sectypes[] = {
 	[NVMF_TCP_SECTYPE_TLS13]	= "tls13",
 };
 
-__public const char *libnvmf_sectype_str(__u8 sectype)
+__libnvme_public const char *libnvmf_sectype_str(__u8 sectype)
 {
 	return arg_str(sectypes, ARRAY_SIZE(sectypes), sectype);
 }
@@ -171,7 +171,7 @@ static const char * const prtypes[] = {
 	[NVMF_RDMA_PRTYPE_IWARP]		= "iwarp",
 };
 
-__public const char *libnvmf_prtype_str(__u8 prtype)
+__libnvme_public const char *libnvmf_prtype_str(__u8 prtype)
 {
 	return arg_str(prtypes, ARRAY_SIZE(prtypes), prtype);
 }
@@ -181,7 +181,7 @@ static const char * const qptypes[] = {
 	[NVMF_RDMA_QPTYPE_DATAGRAM]	= "datagram",
 };
 
-__public const char *libnvmf_qptype_str(__u8 qptype)
+__libnvme_public const char *libnvmf_qptype_str(__u8 qptype)
 {
 	return arg_str(qptypes, ARRAY_SIZE(qptypes), qptype);
 }
@@ -190,7 +190,7 @@ static const char * const cms[] = {
 	[NVMF_RDMA_CMS_RDMA_CM]	= "rdma-cm",
 };
 
-__public const char *libnvmf_cms_str(__u8 cm)
+__libnvme_public const char *libnvmf_cms_str(__u8 cm)
 {
 	return arg_str(cms, ARRAY_SIZE(cms), cm);
 }
@@ -201,7 +201,7 @@ void libnvmf_default_config(struct libnvme_fabrics_config *cfg)
 	cfg->ctrl_loss_tmo = NVMF_DEF_CTRL_LOSS_TMO;
 }
 
-__public int libnvmf_context_create(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvmf_context_create(struct libnvme_global_ctx *ctx,
 		bool (*decide_retry)(struct libnvmf_context *fctx, int err,
 			void *user_data),
 		void (*connected)(struct libnvmf_context *fctx,
@@ -232,7 +232,7 @@ __public int libnvmf_context_create(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public void libnvmf_context_free(struct libnvmf_context *fctx)
+__libnvme_public void libnvmf_context_free(struct libnvmf_context *fctx)
 {
 	if (!fctx)
 		return;
@@ -241,7 +241,8 @@ __public void libnvmf_context_free(struct libnvmf_context *fctx)
 	free(fctx);
 }
 
-__public int libnvmf_context_set_discovery_cbs(struct libnvmf_context *fctx,
+__libnvme_public int libnvmf_context_set_discovery_cbs(
+		struct libnvmf_context *fctx,
 		void (*discovery_log)(struct libnvmf_context *fctx,
 			bool connect,
 			struct nvmf_discovery_log *log,
@@ -261,8 +262,9 @@ __public int libnvmf_context_set_discovery_cbs(struct libnvmf_context *fctx,
 	return 0;
 }
 
-__public int libnvmf_context_set_discovery_defaults(struct libnvmf_context *fctx,
-		int max_discovery_retries, int keep_alive_timeout)
+__libnvme_public int libnvmf_context_set_discovery_defaults(
+		struct libnvmf_context *fctx, int max_discovery_retries,
+		int keep_alive_timeout)
 {
 	fctx->default_max_discovery_retries = max_discovery_retries;
 	fctx->default_keep_alive_timeout = keep_alive_timeout;
@@ -270,7 +272,8 @@ __public int libnvmf_context_set_discovery_defaults(struct libnvmf_context *fctx
 	return 0;
 }
 
-__public int libnvmf_context_set_fabrics_config(struct libnvmf_context *fctx,
+__libnvme_public int libnvmf_context_set_fabrics_config(
+		struct libnvmf_context *fctx,
 		struct libnvme_fabrics_config *cfg)
 {
 	fctx->cfg.queue_size = cfg->queue_size;
@@ -295,9 +298,9 @@ __public int libnvmf_context_set_fabrics_config(struct libnvmf_context *fctx,
 	return 0;
 }
 
-__public int libnvmf_context_set_connection(struct libnvmf_context *fctx,
-		const char *subsysnqn, const char *transport,
-		const char *traddr, const char *trsvcid,
+__libnvme_public int libnvmf_context_set_connection(
+		struct libnvmf_context *fctx, const char *subsysnqn,
+		const char *transport, const char *traddr, const char *trsvcid,
 		const char *host_traddr, const char *host_iface)
 {
 	fctx->subsysnqn = subsysnqn;
@@ -324,7 +327,7 @@ static const char *hostid_from_hostnqn(const char *hostnqn)
 	return match + strlen("uuid:");
 }
 
-__public int libnvmf_context_set_hostnqn(struct libnvmf_context *fctx,
+__libnvme_public int libnvmf_context_set_hostnqn(struct libnvmf_context *fctx,
 		const char *hostnqn, const char *hostid)
 {
 	fctx->hostnqn = hostnqn;
@@ -335,7 +338,7 @@ __public int libnvmf_context_set_hostnqn(struct libnvmf_context *fctx,
 	return 0;
 }
 
-__public int libnvmf_context_set_crypto(struct libnvmf_context *fctx,
+__libnvme_public int libnvmf_context_set_crypto(struct libnvmf_context *fctx,
 		const char *hostkey, const char *ctrlkey,
 		const char *keyring, const char *tls_key,
 		const char *tls_key_identity)
@@ -374,27 +377,29 @@ __public int libnvmf_context_set_crypto(struct libnvmf_context *fctx,
 	return 0;
 }
 
-__public int libnvmf_context_set_persistent(struct libnvmf_context *fctx, bool persistent)
+__libnvme_public int libnvmf_context_set_persistent(
+		struct libnvmf_context *fctx, bool persistent)
 {
 	fctx->persistent = persistent;
 
 	return 0;
 }
 
-__public int libnvmf_context_set_device(struct libnvmf_context *fctx, const char *device)
+__libnvme_public int libnvmf_context_set_device(
+		struct libnvmf_context *fctx, const char *device)
 {
 	fctx->device = device;
 
 	return 0;
 }
 
-__public struct libnvme_fabrics_config *libnvmf_context_get_fabrics_config(
+__libnvme_public struct libnvme_fabrics_config *libnvmf_context_get_fabrics_config(
 		struct libnvmf_context *fctx)
 {
 	return &fctx->cfg;
 }
 
-__public struct libnvme_fabrics_config *libnvmf_ctrl_get_fabrics_config(
+__libnvme_public struct libnvme_fabrics_config *libnvmf_ctrl_get_fabrics_config(
 		libnvme_ctrl_t c)
 {
 	return &c->cfg;
@@ -1089,13 +1094,13 @@ static const char *lookup_context(struct libnvme_global_ctx *ctx, libnvme_ctrl_t
 	return NULL;
 }
 
-__public int libnvmf_create_ctrl(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvmf_create_ctrl(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, libnvme_ctrl_t *cp)
 {
 	return _libnvme_create_ctrl(ctx, fctx, cp);
 }
 
-__public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
+__libnvme_public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
 {
 	libnvme_subsystem_t s;
 	const char *root_app, *app;
@@ -1191,7 +1196,7 @@ __public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
 	return libnvme_init_ctrl(h, c, ret);
 }
 
-__public int libnvmf_connect_ctrl(libnvme_ctrl_t c)
+__libnvme_public int libnvmf_connect_ctrl(libnvme_ctrl_t c)
 {
 	__cleanup_free char *argstr = NULL;
 	int ret;
@@ -1207,7 +1212,7 @@ __public int libnvmf_connect_ctrl(libnvme_ctrl_t c)
 	return 0;
 }
 
-__public int libnvmf_disconnect_ctrl(libnvme_ctrl_t c)
+__libnvme_public int libnvmf_disconnect_ctrl(libnvme_ctrl_t c)
 {
 	struct libnvme_global_ctx *ctx = c->s && c->s->h ? c->s->h->ctx : NULL;
 	int ret;
@@ -1503,7 +1508,7 @@ static void sanitize_discovery_log_entry(struct libnvme_global_ctx *ctx,
 	}
 }
 
-__public int libnvmf_get_discovery_log(libnvme_ctrl_t ctrl,
+__libnvme_public int libnvmf_get_discovery_log(libnvme_ctrl_t ctrl,
 				    const struct libnvmf_discovery_args *args,
 				    struct nvmf_discovery_log **logp)
 {
@@ -1794,7 +1799,7 @@ static int nvme_fetch_cntrltype_dctype_from_id(libnvme_ctrl_t c)
 	return 0;
 }
 
-__public bool libnvmf_is_registration_supported(libnvme_ctrl_t c)
+__libnvme_public bool libnvmf_is_registration_supported(libnvme_ctrl_t c)
 {
 	if (!c->cntrltype || !c->dctype)
 		if (nvme_fetch_cntrltype_dctype_from_id(c))
@@ -1803,7 +1808,8 @@ __public bool libnvmf_is_registration_supported(libnvme_ctrl_t c)
 	return !strcmp(c->dctype, "ddc") || !strcmp(c->dctype, "cdc");
 }
 
-__public int libnvmf_register_ctrl(libnvme_ctrl_t c, enum nvmf_dim_tas tas, __u32 *result)
+__libnvme_public int libnvmf_register_ctrl(
+		libnvme_ctrl_t c, enum nvmf_dim_tas tas, __u32 *result)
 {
 	if (!libnvmf_is_registration_supported(c))
 		return -ENOTSUP;
@@ -1844,7 +1850,8 @@ static char *unescape_uri(const char *str, int len)
 	return dst;
 }
 
-__public int libnvmf_uri_parse(const char *str, struct libnvmf_uri **urip)
+__libnvme_public int libnvmf_uri_parse(
+		const char *str, struct libnvmf_uri **urip)
 {
 	__cleanup_uri struct libnvmf_uri *uri = NULL;
 	__cleanup_free char *scheme = NULL;
@@ -1937,7 +1944,7 @@ __public int libnvmf_uri_parse(const char *str, struct libnvmf_uri **urip)
 	return 0;
 }
 
-__public void libnvmf_uri_free(struct libnvmf_uri *uri)
+__libnvme_public void libnvmf_uri_free(struct libnvmf_uri *uri)
 {
 	char **s;
 
@@ -2161,7 +2168,7 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public const char *libnvmf_get_default_trsvcid(const char *transport,
+__libnvme_public const char *libnvmf_get_default_trsvcid(const char *transport,
 		bool discovery_ctrl)
 {
 	if (!transport)
@@ -2372,8 +2379,9 @@ int _discovery_config_json(struct libnvme_global_ctx *ctx,
 	return ret;
 }
 
-__public int libnvmf_discovery_config_json(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, bool connect, bool force)
+__libnvme_public int libnvmf_discovery_config_json(
+		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
+		bool connect, bool force)
 {
 	const char *hnqn, *hid;
 	struct libnvme_subsystem *s;
@@ -2420,7 +2428,7 @@ __public int libnvmf_discovery_config_json(struct libnvme_global_ctx *ctx,
 	return ret;
 }
 
-__public int libnvmf_connect_config_json(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvmf_connect_config_json(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx)
 {
 	const char *hnqn, *hid;
@@ -2479,8 +2487,9 @@ __public int libnvmf_connect_config_json(struct libnvme_global_ctx *ctx,
 	return ret;
 }
 
-__public int libnvmf_discovery_config_file(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, bool connect, bool force)
+__libnvme_public int libnvmf_discovery_config_file(
+		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
+		bool connect, bool force)
 {
 	struct libnvme_host *h;
 	struct libnvme_ctrl *c;
@@ -2532,7 +2541,7 @@ __public int libnvmf_discovery_config_file(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvmf_config_modify(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvmf_config_modify(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx)
 {
 	__cleanup_free char *hnqn = NULL;
@@ -2586,7 +2595,8 @@ static int nbft_filter(const struct dirent *dent)
 	return !fnmatch(NBFT_SYSFS_FILENAME, dent->d_name, FNM_PATHNAME);
 }
 
-__public int libnvmf_nbft_read_files(struct libnvme_global_ctx *ctx, char *path,
+__libnvme_public int libnvmf_nbft_read_files(
+		struct libnvme_global_ctx *ctx, char *path,
 		struct nbft_file_entry **head)
 {
 	struct nbft_file_entry *entry = NULL;
@@ -2625,7 +2635,8 @@ __public int libnvmf_nbft_read_files(struct libnvme_global_ctx *ctx, char *path,
 	return 0;
 }
 
-__public void libnvmf_nbft_free(struct libnvme_global_ctx *ctx, struct nbft_file_entry *head)
+__libnvme_public void libnvmf_nbft_free(
+		struct libnvme_global_ctx *ctx, struct nbft_file_entry *head)
 {
 	if (!head)
 		return;
@@ -2820,7 +2831,7 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, bool connect, char *nbft_path)
 {
 	const char *hostnqn = NULL, *hostid = NULL, *host_traddr = NULL;
@@ -3035,7 +3046,8 @@ out_free:
 	return ret;
 }
 
-__public int libnvmf_discovery(struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
+__libnvme_public int libnvmf_discovery(
+		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
 		bool connect, bool force)
 {
 	struct libnvme_ctrl *c = NULL;
@@ -3130,7 +3142,8 @@ __public int libnvmf_discovery(struct libnvme_global_ctx *ctx, struct libnvmf_co
 	return ret;
 }
 
-__public int libnvmf_connect(struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx)
+__libnvme_public int libnvmf_connect(
+		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx)
 {
 	struct libnvme_host *h;
 	struct libnvme_ctrl *c;

--- a/libnvme/src/nvme/filters.c
+++ b/libnvme/src/nvme/filters.c
@@ -15,7 +15,7 @@
 #include "private.h"
 #include "compiler-attributes.h"
 
-__public int libnvme_filter_namespace(const struct dirent *d)
+__libnvme_public int libnvme_filter_namespace(const struct dirent *d)
 {
 	int i, n;
 
@@ -29,7 +29,7 @@ __public int libnvme_filter_namespace(const struct dirent *d)
 	return 0;
 }
 
-__public int libnvme_filter_paths(const struct dirent *d)
+__libnvme_public int libnvme_filter_paths(const struct dirent *d)
 {
 	int i, c, n;
 
@@ -43,7 +43,7 @@ __public int libnvme_filter_paths(const struct dirent *d)
 	return 0;
 }
 
-__public int libnvme_filter_ctrls(const struct dirent *d)
+__libnvme_public int libnvme_filter_ctrls(const struct dirent *d)
 {
 	int i, c, n;
 
@@ -62,7 +62,7 @@ __public int libnvme_filter_ctrls(const struct dirent *d)
 	return 0;
 }
 
-__public int libnvme_filter_subsys(const struct dirent *d)
+__libnvme_public int libnvme_filter_subsys(const struct dirent *d)
 {
 	int i;
 
@@ -76,7 +76,7 @@ __public int libnvme_filter_subsys(const struct dirent *d)
 	return 0;
 }
 
-__public int libnvme_scan_subsystems(struct dirent ***subsys)
+__libnvme_public int libnvme_scan_subsystems(struct dirent ***subsys)
 {
 	const char *dir = libnvme_subsys_sysfs_dir();
 	int ret;
@@ -88,7 +88,7 @@ __public int libnvme_scan_subsystems(struct dirent ***subsys)
 	return ret;
 }
 
-__public int libnvme_scan_subsystem_namespaces(libnvme_subsystem_t s,
+__libnvme_public int libnvme_scan_subsystem_namespaces(libnvme_subsystem_t s,
 		struct dirent ***ns)
 {
 	int ret;
@@ -101,7 +101,7 @@ __public int libnvme_scan_subsystem_namespaces(libnvme_subsystem_t s,
 	return ret;
 }
 
-__public int libnvme_scan_ctrls(struct dirent ***ctrls)
+__libnvme_public int libnvme_scan_ctrls(struct dirent ***ctrls)
 {
 	const char *dir = libnvme_ctrl_sysfs_dir();
 	int ret;
@@ -113,7 +113,7 @@ __public int libnvme_scan_ctrls(struct dirent ***ctrls)
 	return ret;
 }
 
-__public int libnvme_scan_ctrl_namespace_paths(libnvme_ctrl_t c,
+__libnvme_public int libnvme_scan_ctrl_namespace_paths(libnvme_ctrl_t c,
 		struct dirent ***paths)
 {
 	int ret;
@@ -126,7 +126,8 @@ __public int libnvme_scan_ctrl_namespace_paths(libnvme_ctrl_t c,
 	return ret;
 }
 
-__public int libnvme_scan_ctrl_namespaces(libnvme_ctrl_t c, struct dirent ***ns)
+__libnvme_public int libnvme_scan_ctrl_namespaces(
+		libnvme_ctrl_t c, struct dirent ***ns)
 {
 	int ret;
 
@@ -138,7 +139,7 @@ __public int libnvme_scan_ctrl_namespaces(libnvme_ctrl_t c, struct dirent ***ns)
 	return ret;
 }
 
-__public int libnvme_scan_ns_head_paths(libnvme_ns_head_t head,
+__libnvme_public int libnvme_scan_ns_head_paths(libnvme_ns_head_t head,
 		struct dirent ***paths)
 {
 	int ret;

--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -40,7 +40,8 @@ static int nvme_verify_chr(struct libnvme_transport_handle *hdl)
 	return 0;
 }
 
-__public int libnvme_reset_subsystem(struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_reset_subsystem(
+		struct libnvme_transport_handle *hdl)
 {
 	int ret;
 
@@ -54,7 +55,7 @@ __public int libnvme_reset_subsystem(struct libnvme_transport_handle *hdl)
 	return ret;
 }
 
-__public int libnvme_reset_ctrl(struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_reset_ctrl(struct libnvme_transport_handle *hdl)
 {
 	int ret;
 
@@ -68,7 +69,7 @@ __public int libnvme_reset_ctrl(struct libnvme_transport_handle *hdl)
 	return ret;
 }
 
-__public int libnvme_rescan_ns(struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_rescan_ns(struct libnvme_transport_handle *hdl)
 {
 	int ret;
 
@@ -82,7 +83,8 @@ __public int libnvme_rescan_ns(struct libnvme_transport_handle *hdl)
 	return ret;
 }
 
-__public int libnvme_get_nsid(struct libnvme_transport_handle *hdl, __u32 *nsid)
+__libnvme_public int libnvme_get_nsid(
+		struct libnvme_transport_handle *hdl, __u32 *nsid)
 {
 	__u32 tmp;
 
@@ -95,8 +97,8 @@ __public int libnvme_get_nsid(struct libnvme_transport_handle *hdl, __u32 *nsid)
 	return 0;
 }
 
-__public int libnvme_update_block_size(struct libnvme_transport_handle *hdl,
-		int block_size)
+__libnvme_public int libnvme_update_block_size(
+		struct libnvme_transport_handle *hdl, int block_size)
 {
 	int ret;
 	int fd = libnvme_transport_handle_get_fd(hdl);
@@ -190,7 +192,8 @@ out:
 	return err;
 }
 
-__public int libnvme_submit_io_passthru(struct libnvme_transport_handle *hdl,
+__libnvme_public int libnvme_submit_io_passthru(
+		struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd)
 {
 	if (!hdl)
@@ -205,7 +208,8 @@ __public int libnvme_submit_io_passthru(struct libnvme_transport_handle *hdl,
 	return libnvme_submit_passthru32(hdl, LIBNVME_IOCTL_IO_CMD, cmd);
 }
 
-__public int libnvme_submit_admin_passthru(struct libnvme_transport_handle *hdl,
+__libnvme_public int libnvme_submit_admin_passthru(
+		struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd)
 {
 	if (!hdl)

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -41,7 +41,8 @@ static bool libnvme_mi_probe_enabled_default(void)
 
 }
 
-__public struct libnvme_global_ctx *libnvme_create_global_ctx(FILE *fp, int log_level)
+__libnvme_public struct libnvme_global_ctx *libnvme_create_global_ctx(
+		FILE *fp, int log_level)
 {
 	struct libnvme_global_ctx *ctx;
 	int fd;
@@ -71,7 +72,7 @@ __public struct libnvme_global_ctx *libnvme_create_global_ctx(FILE *fp, int log_
 	return ctx;
 }
 
-__public void libnvme_free_global_ctx(struct libnvme_global_ctx *ctx)
+__libnvme_public void libnvme_free_global_ctx(struct libnvme_global_ctx *ctx)
 {
 	struct libnvme_host *h, *_h;
 #ifdef CONFIG_MI
@@ -99,17 +100,20 @@ __public void libnvme_free_global_ctx(struct libnvme_global_ctx *ctx)
 	free(ctx);
 }
 
-__public void libnvme_set_dry_run(struct libnvme_global_ctx *ctx, bool enable)
+__libnvme_public void libnvme_set_dry_run(
+		struct libnvme_global_ctx *ctx, bool enable)
 {
 	ctx->dry_run = enable;
 }
 
-__public void libnvme_set_ioctl_probing(struct libnvme_global_ctx *ctx, bool enable)
+__libnvme_public void libnvme_set_ioctl_probing(
+		struct libnvme_global_ctx *ctx, bool enable)
 {
 	ctx->ioctl_probing = enable;
 }
 
-__public void libnvme_transport_handle_set_submit_entry(struct libnvme_transport_handle *hdl,
+__libnvme_public void libnvme_transport_handle_set_submit_entry(
+		struct libnvme_transport_handle *hdl,
 		void *(*submit_entry)(struct libnvme_transport_handle *hdl,
 				struct libnvme_passthru_cmd *cmd))
 {
@@ -118,7 +122,8 @@ __public void libnvme_transport_handle_set_submit_entry(struct libnvme_transport
 		hdl->submit_exit = __libnvme_submit_exit;
 }
 
-__public void libnvme_transport_handle_set_submit_exit(struct libnvme_transport_handle *hdl,
+__libnvme_public void libnvme_transport_handle_set_submit_exit(
+		struct libnvme_transport_handle *hdl,
 		void (*submit_exit)(struct libnvme_transport_handle *hdl,
 				struct libnvme_passthru_cmd *cmd,
 				int err, void *user_data))
@@ -128,7 +133,8 @@ __public void libnvme_transport_handle_set_submit_exit(struct libnvme_transport_
 		hdl->submit_exit = __libnvme_submit_exit;
 }
 
-__public void libnvme_transport_handle_set_decide_retry(struct libnvme_transport_handle *hdl,
+__libnvme_public void libnvme_transport_handle_set_decide_retry(
+		struct libnvme_transport_handle *hdl,
 		bool (*decide_retry)(struct libnvme_transport_handle *hdl,
 				struct libnvme_passthru_cmd *cmd, int err))
 {
@@ -137,7 +143,7 @@ __public void libnvme_transport_handle_set_decide_retry(struct libnvme_transport
 		hdl->decide_retry = __libnvme_decide_retry;
 }
 
-__public void libnvme_transport_handle_set_timeout(
+__libnvme_public void libnvme_transport_handle_set_timeout(
 		struct libnvme_transport_handle *hdl, __u32 timeout_ms)
 {
 	hdl->timeout = timeout_ms;
@@ -225,8 +231,9 @@ struct libnvme_transport_handle *__libnvme_create_transport_handle(
 	return hdl;
 }
 
-__public int libnvme_open(struct libnvme_global_ctx *ctx, const char *name,
-	      struct libnvme_transport_handle **hdlp)
+__libnvme_public int libnvme_open(
+		struct libnvme_global_ctx *ctx, const char *name,
+		struct libnvme_transport_handle **hdlp)
 {
 	struct libnvme_transport_handle *hdl;
 	int ret;
@@ -267,7 +274,7 @@ __public int libnvme_open(struct libnvme_global_ctx *ctx, const char *name,
 	return 0;
 }
 
-__public void libnvme_close(struct libnvme_transport_handle *hdl)
+__libnvme_public void libnvme_close(struct libnvme_transport_handle *hdl)
 {
 	if (!hdl)
 		return;
@@ -287,32 +294,38 @@ __public void libnvme_close(struct libnvme_transport_handle *hdl)
 	}
 }
 
-__public int libnvme_transport_handle_get_fd(struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_transport_handle_get_fd(
+		struct libnvme_transport_handle *hdl)
 {
 	return hdl->fd;
 }
 
-__public const char *libnvme_transport_handle_get_name(struct libnvme_transport_handle *hdl)
+__libnvme_public const char *libnvme_transport_handle_get_name(
+		struct libnvme_transport_handle *hdl)
 {
 	return basename(hdl->name);
 }
 
-__public bool libnvme_transport_handle_is_ctrl(struct libnvme_transport_handle *hdl)
+__libnvme_public bool libnvme_transport_handle_is_ctrl(
+		struct libnvme_transport_handle *hdl)
 {
 	return S_ISCHR(hdl->stat.st_mode);
 }
 
-__public bool libnvme_transport_handle_is_ns(struct libnvme_transport_handle *hdl)
+__libnvme_public bool libnvme_transport_handle_is_ns(
+		struct libnvme_transport_handle *hdl)
 {
 	return S_ISBLK(hdl->stat.st_mode);
 }
 
-__public bool libnvme_transport_handle_is_direct(struct libnvme_transport_handle *hdl)
+__libnvme_public bool libnvme_transport_handle_is_direct(
+		struct libnvme_transport_handle *hdl)
 {
 	return hdl->type == LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT;
 }
 
-__public bool libnvme_transport_handle_is_mi(struct libnvme_transport_handle *hdl)
+__libnvme_public bool libnvme_transport_handle_is_mi(
+		struct libnvme_transport_handle *hdl)
 {
 	return hdl->type == LIBNVME_TRANSPORT_HANDLE_TYPE_MI;
 }

--- a/libnvme/src/nvme/linux.c
+++ b/libnvme/src/nvme/linux.c
@@ -115,7 +115,7 @@ static char *__nvme_get_attr(const char *path)
 	return strlen(value) ? strdup(value) : NULL;
 }
 
-__public char *libnvme_get_attr(const char *dir, const char *attr)
+__libnvme_public char *libnvme_get_attr(const char *dir, const char *attr)
 {
 	__cleanup_free char *path = NULL;
 	int ret;
@@ -127,22 +127,23 @@ __public char *libnvme_get_attr(const char *dir, const char *attr)
 	return __nvme_get_attr(path);
 }
 
-__public char *libnvme_get_subsys_attr(libnvme_subsystem_t s, const char *attr)
+__libnvme_public char *libnvme_get_subsys_attr(
+		libnvme_subsystem_t s, const char *attr)
 {
 	return libnvme_get_attr(libnvme_subsystem_get_sysfs_dir(s), attr);
 }
 
-__public char *libnvme_get_ctrl_attr(libnvme_ctrl_t c, const char *attr)
+__libnvme_public char *libnvme_get_ctrl_attr(libnvme_ctrl_t c, const char *attr)
 {
 	return libnvme_get_attr(libnvme_ctrl_get_sysfs_dir(c), attr);
 }
 
-__public char *libnvme_get_ns_attr(libnvme_ns_t n, const char *attr)
+__libnvme_public char *libnvme_get_ns_attr(libnvme_ns_t n, const char *attr)
 {
 	return libnvme_get_attr(libnvme_ns_get_sysfs_dir(n), attr);
 }
 
-__public char *libnvme_get_path_attr(libnvme_path_t p, const char *attr)
+__libnvme_public char *libnvme_get_path_attr(libnvme_path_t p, const char *attr)
 {
 	return libnvme_get_attr(libnvme_path_get_sysfs_dir(p), attr);
 }
@@ -153,7 +154,7 @@ static unsigned char default_hmac(size_t key_len)
 	return LIBNVME_HMAC_ALG_NONE;
 }
 
-__public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 		char *hostnqn, enum libnvme_hmac_alg hmac,
 		unsigned int key_len, unsigned char *secret,
 		unsigned char *key)
@@ -168,7 +169,7 @@ __public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_create_raw_secret(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_create_raw_secret(struct libnvme_global_ctx *ctx,
 		const char *secret, size_t key_len, unsigned char **raw_secret)
 {
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "NVMe TLS 2.0 is not supported; "
@@ -606,7 +607,7 @@ static DEFINE_CLEANUP_FUNC(cleanup_evp_mac_ctx, EVP_MAC_CTX *, EVP_MAC_CTX_free)
 static DEFINE_CLEANUP_FUNC(cleanup_evp_mac, EVP_MAC *, EVP_MAC_free)
 #define __cleanup_evp_mac __cleanup(cleanup_evp_mac)
 
-__public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_gen_dhchap_key(struct libnvme_global_ctx *ctx,
 		char *hostnqn, enum libnvme_hmac_alg hmac,
 		unsigned int key_len, unsigned char *secret,
 		unsigned char *key)
@@ -819,7 +820,7 @@ err:
 	return -EIO;
 }
 
-__public int libnvme_create_raw_secret(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_create_raw_secret(struct libnvme_global_ctx *ctx,
 		const char *secret, size_t key_len, unsigned char **raw_secret)
 {
 	__cleanup_free unsigned char *buf = NULL;
@@ -977,11 +978,10 @@ static ssize_t nvme_identity_len(int hmac, int version, const char *hostnqn,
 	return len;
 }
 
-__public int libnvme_generate_tls_key_identity(struct libnvme_global_ctx *ctx,
-		const char *hostnqn, const char *subsysnqn,
-		int version, int hmac,
-		unsigned char *configured_key, int key_len,
-		char **ident)
+__libnvme_public int libnvme_generate_tls_key_identity(
+		struct libnvme_global_ctx *ctx, const char *hostnqn,
+		const char *subsysnqn, int version, int hmac,
+		unsigned char *configured_key, int key_len, char **ident)
 {
 	__cleanup_free unsigned char *psk = NULL;
 	__cleanup_free char *identity = NULL;
@@ -1015,10 +1015,10 @@ __public int libnvme_generate_tls_key_identity(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_generate_tls_key_identity_compat(struct libnvme_global_ctx *ctx,
-		const char *hostnqn, const char *subsysnqn,
-		int version, int hmac, unsigned char *configured_key,
-		int key_len, char **ident)
+__libnvme_public int libnvme_generate_tls_key_identity_compat(
+		struct libnvme_global_ctx *ctx, const char *hostnqn,
+		const char *subsysnqn, int version, int hmac,
+		unsigned char *configured_key, int key_len, char **ident)
 {
 	__cleanup_free unsigned char *psk = NULL;
 	__cleanup_free char *identity = NULL;
@@ -1053,8 +1053,8 @@ __public int libnvme_generate_tls_key_identity_compat(struct libnvme_global_ctx 
 }
 
 #ifdef CONFIG_KEYUTILS
-__public int libnvme_lookup_keyring(struct libnvme_global_ctx *ctx, const char *keyring,
-		long *key)
+__libnvme_public int libnvme_lookup_keyring(
+		struct libnvme_global_ctx *ctx, const char *keyring, long *key)
 {
 	key_serial_t keyring_id;
 
@@ -1068,7 +1068,8 @@ __public int libnvme_lookup_keyring(struct libnvme_global_ctx *ctx, const char *
 	return 0;
 }
 
-__public char *libnvme_describe_key_serial(struct libnvme_global_ctx *ctx, long key_id)
+__libnvme_public char *libnvme_describe_key_serial(
+		struct libnvme_global_ctx *ctx, long key_id)
 {
 	__cleanup_free char *str = NULL;
 	char *last;
@@ -1087,7 +1088,8 @@ __public char *libnvme_describe_key_serial(struct libnvme_global_ctx *ctx, long 
 	return strdup(last);
 }
 
-__public int libnvme_lookup_key(struct libnvme_global_ctx *ctx, const char *type,
+__libnvme_public int libnvme_lookup_key(
+		struct libnvme_global_ctx *ctx, const char *type,
 		const char *identity, long *keyp)
 {
 	key_serial_t key;
@@ -1100,7 +1102,8 @@ __public int libnvme_lookup_key(struct libnvme_global_ctx *ctx, const char *type
 	return 0;
 }
 
-__public int libnvme_set_keyring(struct libnvme_global_ctx *ctx, long key_id)
+__libnvme_public int libnvme_set_keyring(
+		struct libnvme_global_ctx *ctx, long key_id)
 {
 	long err;
 
@@ -1115,8 +1118,9 @@ __public int libnvme_set_keyring(struct libnvme_global_ctx *ctx, long key_id)
 	return 0;
 }
 
-__public int libnvme_read_key(struct libnvme_global_ctx *ctx, long keyring_id,
-		long key_id, int *len, unsigned char **key)
+__libnvme_public int libnvme_read_key(
+		struct libnvme_global_ctx *ctx, long keyring_id, long key_id,
+		int *len, unsigned char **key)
 {
 	void *buffer;
 	int ret;
@@ -1134,7 +1138,8 @@ __public int libnvme_read_key(struct libnvme_global_ctx *ctx, long keyring_id,
 	return 0;
 }
 
-__public int libnvme_update_key(struct libnvme_global_ctx *ctx, long keyring_id,
+__libnvme_public int libnvme_update_key(
+		struct libnvme_global_ctx *ctx, long keyring_id,
 		const char *key_type, const char *identity,
 		unsigned char *key_data, int key_len, long *keyp)
 {
@@ -1194,7 +1199,8 @@ int __scan_keys_cb(key_serial_t parent, key_serial_t key, char *desc,
 	return 1;
 }
 
-__public int libnvme_scan_tls_keys(struct libnvme_global_ctx *ctx, const char *keyring,
+__libnvme_public int libnvme_scan_tls_keys(
+		struct libnvme_global_ctx *ctx, const char *keyring,
 		libnvme_scan_tls_keys_cb_t cb, void *data)
 {
 	struct __scan_keys_data d;
@@ -1262,7 +1268,8 @@ static int __nvme_insert_tls_key(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_insert_tls_key_versioned(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_insert_tls_key_versioned(
+		struct libnvme_global_ctx *ctx,
 		const char *keyring, const char *key_type,
 		const char *hostnqn, const char *subsysnqn,
 		int version, int hmac,
@@ -1285,7 +1292,8 @@ __public int libnvme_insert_tls_key_versioned(struct libnvme_global_ctx *ctx,
 		configured_key, key_len, false, key);
 }
 
-__public int libnvme_insert_tls_key_compat(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_insert_tls_key_compat(
+		struct libnvme_global_ctx *ctx,
 		const char *keyring, const char *key_type,
 		const char *hostnqn, const char *subsysnqn,
 		int version, int hmac,
@@ -1308,7 +1316,7 @@ __public int libnvme_insert_tls_key_compat(struct libnvme_global_ctx *ctx,
 		configured_key, key_len, true, key);
 }
 
-__public int libnvme_revoke_tls_key(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_revoke_tls_key(struct libnvme_global_ctx *ctx,
 		const char *keyring, const char *key_type,
 		const char *identity)
 {
@@ -1434,22 +1442,24 @@ out:
 	return 0;
 }
 #else
-__public int libnvme_lookup_keyring(struct libnvme_global_ctx *ctx, const char *keyring,
-		long *key)
+__libnvme_public int libnvme_lookup_keyring(
+		struct libnvme_global_ctx *ctx, const char *keyring, long *key)
 {
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "key operations not supported; "
 		 "recompile with keyutils support.\n");
 	return -ENOTSUP;
 }
 
-__public char *libnvme_describe_key_serial(struct libnvme_global_ctx *ctx, long key_id)
+__libnvme_public char *libnvme_describe_key_serial(
+		struct libnvme_global_ctx *ctx, long key_id)
 {
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "key operations not supported; "
 		 "recompile with keyutils support.\n");
 	return NULL;
 }
 
-__public int libnvme_lookup_key(struct libnvme_global_ctx *ctx, const char *type,
+__libnvme_public int libnvme_lookup_key(
+		struct libnvme_global_ctx *ctx, const char *type,
 		const char *identity, long *key)
 {
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "key operations not supported; "
@@ -1457,22 +1467,25 @@ __public int libnvme_lookup_key(struct libnvme_global_ctx *ctx, const char *type
 	return -ENOTSUP;
 }
 
-__public int libnvme_set_keyring(struct libnvme_global_ctx *ctx, long key_id)
+__libnvme_public int libnvme_set_keyring(
+		struct libnvme_global_ctx *ctx, long key_id)
 {
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "key operations not supported; "
 		 "recompile with keyutils support.\n");
 	return -ENOTSUP;
 }
 
-__public int libnvme_read_key(struct libnvme_global_ctx *ctx, long keyring_id,
-		long key_id, int *len, unsigned char **key)
+__libnvme_public int libnvme_read_key(
+		struct libnvme_global_ctx *ctx, long keyring_id, long key_id,
+		int *len, unsigned char **key)
 {
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "key operations not supported; "
 		 "recompile with keyutils support.\n");
 	return -ENOTSUP;
 }
 
-__public int libnvme_update_key(struct libnvme_global_ctx *ctx, long keyring_id,
+__libnvme_public int libnvme_update_key(
+		struct libnvme_global_ctx *ctx, long keyring_id,
 		const char *key_type, const char *identity,
 		unsigned char *key_data, int key_len, long *key)
 {
@@ -1481,7 +1494,8 @@ __public int libnvme_update_key(struct libnvme_global_ctx *ctx, long keyring_id,
 	return -ENOTSUP;
 }
 
-__public int libnvme_scan_tls_keys(struct libnvme_global_ctx *ctx, const char *keyring,
+__libnvme_public int libnvme_scan_tls_keys(
+		struct libnvme_global_ctx *ctx, const char *keyring,
 		libnvme_scan_tls_keys_cb_t cb, void *data)
 {
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "key operations not supported; "
@@ -1489,7 +1503,8 @@ __public int libnvme_scan_tls_keys(struct libnvme_global_ctx *ctx, const char *k
 	return -ENOTSUP;
 }
 
-__public int libnvme_insert_tls_key_versioned(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_insert_tls_key_versioned(
+		struct libnvme_global_ctx *ctx,
 		const char *keyring, const char *key_type,
 		const char *hostnqn, const char *subsysnqn,
 		int version, int hmac,
@@ -1501,7 +1516,8 @@ __public int libnvme_insert_tls_key_versioned(struct libnvme_global_ctx *ctx,
 	return -ENOTSUP;
 }
 
-__public int libnvme_insert_tls_key_compat(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_insert_tls_key_compat(
+		struct libnvme_global_ctx *ctx,
 		const char *keyring, const char *key_type,
 		const char *hostnqn, const char *subsysnqn,
 		int version, int hmac,
@@ -1513,7 +1529,7 @@ __public int libnvme_insert_tls_key_compat(struct libnvme_global_ctx *ctx,
 	return -ENOTSUP;
 }
 
-__public int libnvme_revoke_tls_key(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_revoke_tls_key(struct libnvme_global_ctx *ctx,
 		const char *keyring, const char *key_type,
 		const char *identity)
 {
@@ -1532,7 +1548,7 @@ int __libnvme_import_keys_from_config(libnvme_host_t h, libnvme_ctrl_t c,
 }
 #endif
 
-__public int libnvme_insert_tls_key(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_insert_tls_key(struct libnvme_global_ctx *ctx,
 		const char *keyring, const char *key_type,
 		const char *hostnqn, const char *subsysnqn, int hmac,
 		unsigned char *configured_key, int key_len, long *key)
@@ -1554,9 +1570,9 @@ __public int libnvme_insert_tls_key(struct libnvme_global_ctx *ctx,
  * s:  32 or 48 bytes binary followed by a CRC-32 of the configured PSK
  *     (4 bytes) encoded as base64
  */
-__public int libnvme_export_tls_key_versioned(struct libnvme_global_ctx *ctx,
-		unsigned char version, unsigned char hmac,
-		const unsigned char *key_data,
+__libnvme_public int libnvme_export_tls_key_versioned(
+		struct libnvme_global_ctx *ctx, unsigned char version,
+		unsigned char hmac, const unsigned char *key_data,
 		size_t key_len, char **encoded_keyp)
 {
 	unsigned int raw_len, encoded_len, len;
@@ -1604,7 +1620,7 @@ __public int libnvme_export_tls_key_versioned(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_export_tls_key(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_export_tls_key(struct libnvme_global_ctx *ctx,
 		const unsigned char *key_data, int key_len, char **key)
 {
 	unsigned char hmac;
@@ -1618,9 +1634,9 @@ __public int libnvme_export_tls_key(struct libnvme_global_ctx *ctx,
 		key_len, key);
 }
 
-__public int libnvme_import_tls_key_versioned(struct libnvme_global_ctx *ctx,
-		const char *encoded_key, unsigned char *version,
-		unsigned char *hmac, size_t *key_len,
+__libnvme_public int libnvme_import_tls_key_versioned(
+		struct libnvme_global_ctx *ctx, const char *encoded_key,
+		unsigned char *version, unsigned char *hmac, size_t *key_len,
 		unsigned char **keyp)
 {
 	unsigned char decoded_key[128], *key_data;
@@ -1687,7 +1703,8 @@ __public int libnvme_import_tls_key_versioned(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_import_tls_key(struct libnvme_global_ctx *ctx, const char *encoded_key,
+__libnvme_public int libnvme_import_tls_key(
+		struct libnvme_global_ctx *ctx, const char *encoded_key,
 		int *key_len, unsigned int *hmac, unsigned char **keyp)
 {
 	unsigned char version, _hmac;
@@ -1862,7 +1879,7 @@ static int uuid_from_dmi(char *system_uuid)
 	return ret;
 }
 
-__public char *libnvme_generate_hostid(void)
+__libnvme_public char *libnvme_generate_hostid(void)
 {
 	int ret;
 	char uuid_str[NVME_UUID_LEN_STRING];
@@ -1880,7 +1897,7 @@ __public char *libnvme_generate_hostid(void)
 	return strdup(uuid_str);
 }
 
-__public char *libnvme_generate_hostnqn_from_hostid(char *hostid)
+__libnvme_public char *libnvme_generate_hostnqn_from_hostid(char *hostid)
 {
 	char *hid = NULL;
 	char *hostnqn;
@@ -1895,7 +1912,7 @@ __public char *libnvme_generate_hostnqn_from_hostid(char *hostid)
 	return (ret < 0) ? NULL : hostnqn;
 }
 
-__public char *libnvme_generate_hostnqn(void)
+__libnvme_public char *libnvme_generate_hostnqn(void)
 {
 	return libnvme_generate_hostnqn_from_hostid(NULL);
 }
@@ -1918,7 +1935,7 @@ static char *nvmf_read_file(const char *f, int len)
 	return strndup(buf, strcspn(buf, "\n"));
 }
 
-__public char *libnvme_read_hostnqn(void)
+__libnvme_public char *libnvme_read_hostnqn(void)
 {
 	char *hostnqn = getenv("LIBNVME_HOSTNQN");
 
@@ -1931,7 +1948,7 @@ __public char *libnvme_read_hostnqn(void)
 	return nvmf_read_file(NVMF_HOSTNQN_FILE, NVMF_NQN_SIZE);
 }
 
-__public char *libnvme_read_hostid(void)
+__libnvme_public char *libnvme_read_hostid(void)
 {
 	char *hostid = getenv("LIBNVME_HOSTID");
 

--- a/libnvme/src/nvme/log.c
+++ b/libnvme/src/nvme/log.c
@@ -83,15 +83,16 @@ __libnvme_msg(struct libnvme_global_ctx *ctx, int level,
 		message ? message : "<error>");
 }
 
-__public void libnvme_set_logging_level(struct libnvme_global_ctx *ctx, int log_level,
-		bool log_pid, bool log_tstamp)
+__libnvme_public void libnvme_set_logging_level(
+		struct libnvme_global_ctx *ctx, int log_level, bool log_pid,
+		bool log_tstamp)
 {
 	ctx->log.level = log_level;
 	ctx->log.pid = log_pid;
 	ctx->log.timestamp = log_tstamp;
 }
 
-__public int libnvme_get_logging_level(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_get_logging_level(struct libnvme_global_ctx *ctx,
 		bool *log_pid, bool *log_tstamp)
 {
 	if (log_pid)

--- a/libnvme/src/nvme/mi-mctp.c
+++ b/libnvme/src/nvme/mi-mctp.c
@@ -677,8 +677,8 @@ int libnvme_mi_aem_open(libnvme_mi_ep_t ep)
 	return 0;
 }
 
-__public libnvme_mi_ep_t libnvme_mi_open_mctp(struct libnvme_global_ctx *ctx,
-			       unsigned int netid, __u8 eid)
+__libnvme_public libnvme_mi_ep_t libnvme_mi_open_mctp(
+		struct libnvme_global_ctx *ctx, unsigned int netid, __u8 eid)
 {
 	struct libnvme_mi_transport_mctp *mctp;
 	struct libnvme_mi_ep *ep;
@@ -947,7 +947,7 @@ static int handle_mctp_obj(struct libnvme_global_ctx *ctx, DBusMessageIter *obj)
 	return 0;
 }
 
-__public struct libnvme_global_ctx *libnvme_mi_scan_mctp(void)
+__libnvme_public struct libnvme_global_ctx *libnvme_mi_scan_mctp(void)
 {
 	DBusMessage *msg, *resp = NULL;
 	DBusConnection *bus = NULL;
@@ -1041,7 +1041,7 @@ out:
 
 #else /* CONFIG_DBUS */
 
-__public struct libnvme_global_ctx *libnvme_mi_scan_mctp(void)
+__libnvme_public struct libnvme_global_ctx *libnvme_mi_scan_mctp(void)
 {
 	return NULL;
 }

--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -298,7 +298,8 @@ struct libnvme_mi_ep *libnvme_mi_init_ep(struct libnvme_global_ctx *ctx)
 	return ep;
 }
 
-__public int libnvme_mi_ep_set_timeout(libnvme_mi_ep_t ep, unsigned int timeout_ms)
+__libnvme_public int libnvme_mi_ep_set_timeout(
+		libnvme_mi_ep_t ep, unsigned int timeout_ms)
 {
 	if (ep->transport->check_timeout) {
 		int rc;
@@ -316,7 +317,7 @@ void libnvme_mi_ep_set_mprt_max(libnvme_mi_ep_t ep, unsigned int mprt_max_ms)
 	ep->mprt_max = mprt_max_ms;
 }
 
-__public unsigned int libnvme_mi_ep_get_timeout(libnvme_mi_ep_t ep)
+__libnvme_public unsigned int libnvme_mi_ep_get_timeout(libnvme_mi_ep_t ep)
 {
 	return ep->timeout;
 }
@@ -326,7 +327,8 @@ static bool libnvme_mi_ep_has_quirk(libnvme_mi_ep_t ep, unsigned long quirk)
 	return ep->quirks & quirk;
 }
 
-__public struct libnvme_transport_handle *libnvme_mi_init_transport_handle(libnvme_mi_ep_t ep, __u16 ctrl_id)
+__libnvme_public struct libnvme_transport_handle *libnvme_mi_init_transport_handle(
+		libnvme_mi_ep_t ep, __u16 ctrl_id)
 {
 	struct libnvme_transport_handle *hdl;
 
@@ -344,12 +346,12 @@ __public struct libnvme_transport_handle *libnvme_mi_init_transport_handle(libnv
 	return hdl;
 }
 
-__public __u16 libnvme_mi_ctrl_id(struct libnvme_transport_handle *hdl)
+__libnvme_public __u16 libnvme_mi_ctrl_id(struct libnvme_transport_handle *hdl)
 {
 	return hdl->id;
 }
 
-__public int libnvme_mi_scan_ep(libnvme_mi_ep_t ep, bool force_rescan)
+__libnvme_public int libnvme_mi_scan_ep(libnvme_mi_ep_t ep, bool force_rescan)
 {
 	struct nvme_ctrl_list list;
 	unsigned int i, n_ctrl;
@@ -422,15 +424,18 @@ static int libnvme_mi_verify_resp_mic(struct libnvme_mi_resp *resp)
 	return resp->mic != ~crc;
 }
 
-__public __weak void *libnvme_mi_submit_entry(__u8 type, const struct nvme_mi_msg_hdr *hdr,
-					   size_t hdr_len, const void *data, size_t data_len)
+__libnvme_public __libnvme_weak void *libnvme_mi_submit_entry(
+		__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
+		const void *data, size_t data_len)
 {
 	return NULL;
 }
 
-__public __weak void libnvme_mi_submit_exit(__u8 type, const struct nvme_mi_msg_hdr *hdr,
-					 size_t hdr_len, const void *data, size_t data_len,
-					 void *user_data) { }
+__libnvme_public __libnvme_weak void libnvme_mi_submit_exit(
+		__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
+		const void *data, size_t data_len, void *user_data)
+{
+}
 
 
 int libnvme_mi_async_read(libnvme_mi_ep_t ep, struct libnvme_mi_resp *resp)
@@ -570,7 +575,7 @@ int libnvme_mi_submit(libnvme_mi_ep_t ep, struct libnvme_mi_req *req,
 	return 0;
 }
 
-__public int libnvme_mi_set_csi(libnvme_mi_ep_t ep, uint8_t csi)
+__libnvme_public int libnvme_mi_set_csi(libnvme_mi_ep_t ep, uint8_t csi)
 {
 	uint8_t csi_bit = (csi) ? 1 : 0;
 
@@ -723,7 +728,7 @@ static int libnvme_mi_get_async_message(libnvme_mi_ep_t ep,
 }
 
 
-__public int libnvme_mi_admin_xfer(struct libnvme_transport_handle *hdl,
+__libnvme_public int libnvme_mi_admin_xfer(struct libnvme_transport_handle *hdl,
 		       struct nvme_mi_admin_req_hdr *admin_req,
 		       size_t req_data_size,
 		       struct nvme_mi_admin_resp_hdr *admin_resp,
@@ -889,7 +894,7 @@ int libnvme_mi_admin_admin_passthru(struct libnvme_transport_handle *hdl,
 	return 0;
 }
 
-__public int libnvme_mi_control(libnvme_mi_ep_t ep, __u8 opcode,
+__libnvme_public int libnvme_mi_control(libnvme_mi_ep_t ep, __u8 opcode,
 		    __u16 cpsp, __u16 *result_cpsr)
 {
 	struct nvme_mi_control_resp control_resp;
@@ -961,7 +966,7 @@ static int libnvme_mi_read_data(libnvme_mi_ep_t ep, __u32 cdw0,
 	return 0;
 }
 
-__public int libnvme_mi_mi_xfer(libnvme_mi_ep_t ep,
+__libnvme_public int libnvme_mi_mi_xfer(libnvme_mi_ep_t ep,
 		       struct nvme_mi_mi_req_hdr *mi_req,
 		       size_t req_data_size,
 		       struct nvme_mi_mi_resp_hdr *mi_resp,
@@ -1011,7 +1016,7 @@ __public int libnvme_mi_mi_xfer(libnvme_mi_ep_t ep,
 	return 0;
 }
 
-__public int libnvme_mi_mi_read_mi_data_subsys(libnvme_mi_ep_t ep,
+__libnvme_public int libnvme_mi_mi_read_mi_data_subsys(libnvme_mi_ep_t ep,
 				   struct nvme_mi_read_nvm_ss_info *s)
 {
 	size_t len;
@@ -1036,8 +1041,9 @@ __public int libnvme_mi_mi_read_mi_data_subsys(libnvme_mi_ep_t ep,
 	return 0;
 }
 
-__public int libnvme_mi_mi_read_mi_data_port(libnvme_mi_ep_t ep, __u8 portid,
-				 struct nvme_mi_read_port_info *p)
+__libnvme_public int libnvme_mi_mi_read_mi_data_port(
+		libnvme_mi_ep_t ep, __u8 portid,
+		struct nvme_mi_read_port_info *p)
 {
 	size_t len;
 	__u32 cdw0;
@@ -1056,8 +1062,9 @@ __public int libnvme_mi_mi_read_mi_data_port(libnvme_mi_ep_t ep, __u8 portid,
 	return 0;
 }
 
-__public int libnvme_mi_mi_read_mi_data_ctrl_list(libnvme_mi_ep_t ep, __u8 start_ctrlid,
-				       struct nvme_ctrl_list *list)
+__libnvme_public int libnvme_mi_mi_read_mi_data_ctrl_list(
+		libnvme_mi_ep_t ep, __u8 start_ctrlid,
+		struct nvme_ctrl_list *list)
 {
 	size_t len;
 	__u32 cdw0;
@@ -1073,8 +1080,9 @@ __public int libnvme_mi_mi_read_mi_data_ctrl_list(libnvme_mi_ep_t ep, __u8 start
 	return 0;
 }
 
-__public int libnvme_mi_mi_read_mi_data_ctrl(libnvme_mi_ep_t ep, __u16 ctrl_id,
-				       struct nvme_mi_read_ctrl_info *ctrl)
+__libnvme_public int libnvme_mi_mi_read_mi_data_ctrl(
+		libnvme_mi_ep_t ep, __u16 ctrl_id,
+		struct nvme_mi_read_ctrl_info *ctrl)
 {
 	size_t len;
 	__u32 cdw0;
@@ -1093,8 +1101,9 @@ __public int libnvme_mi_mi_read_mi_data_ctrl(libnvme_mi_ep_t ep, __u16 ctrl_id,
 	return 0;
 }
 
-__public int libnvme_mi_mi_subsystem_health_status_poll(libnvme_mi_ep_t ep, bool clear,
-					    struct nvme_mi_nvm_ss_health_status *sshs)
+__libnvme_public int libnvme_mi_mi_subsystem_health_status_poll(
+		libnvme_mi_ep_t ep, bool clear,
+		struct nvme_mi_nvm_ss_health_status *sshs)
 {
 	struct nvme_mi_mi_resp_hdr resp_hdr;
 	struct nvme_mi_mi_req_hdr req_hdr;
@@ -1169,8 +1178,8 @@ int libnvme_mi_mi_config_set_get_ex(libnvme_mi_ep_t ep, __u8 opcode, __u32 dw0,
 	return 0;
 }
 
-__public int libnvme_mi_mi_config_get(libnvme_mi_ep_t ep, __u32 dw0, __u32 dw1,
-			  __u32 *nmresp)
+__libnvme_public int libnvme_mi_mi_config_get(
+		libnvme_mi_ep_t ep, __u32 dw0, __u32 dw1, __u32 *nmresp)
 {
 	size_t data_in_len = 0;
 
@@ -1185,7 +1194,8 @@ __public int libnvme_mi_mi_config_get(libnvme_mi_ep_t ep, __u32 dw0, __u32 dw1,
 					nmresp);
 }
 
-__public int libnvme_mi_mi_config_set(libnvme_mi_ep_t ep, __u32 dw0, __u32 dw1)
+__libnvme_public int libnvme_mi_mi_config_set(
+		libnvme_mi_ep_t ep, __u32 dw0, __u32 dw1)
 {
 	size_t data_in_len = 0;
 
@@ -1269,7 +1279,7 @@ int libnvme_mi_mi_config_set_async_event(libnvme_mi_ep_t ep,
 }
 
 
-__public void libnvme_mi_close(libnvme_mi_ep_t ep)
+__libnvme_public void libnvme_mi_close(libnvme_mi_ep_t ep)
 {
 	struct libnvme_transport_handle *hdl, *tmp;
 
@@ -1285,7 +1295,7 @@ __public void libnvme_mi_close(libnvme_mi_ep_t ep)
 	free(ep);
 }
 
-__public char *libnvme_mi_endpoint_desc(libnvme_mi_ep_t ep)
+__libnvme_public char *libnvme_mi_endpoint_desc(libnvme_mi_ep_t ep)
 {
 	char tsbuf[101], *s = NULL;
 	size_t tslen;
@@ -1315,12 +1325,14 @@ __public char *libnvme_mi_endpoint_desc(libnvme_mi_ep_t ep)
 	return s;
 }
 
-__public libnvme_mi_ep_t libnvme_mi_first_endpoint(struct libnvme_global_ctx *ctx)
+__libnvme_public libnvme_mi_ep_t libnvme_mi_first_endpoint(
+		struct libnvme_global_ctx *ctx)
 {
 	return list_top(&ctx->endpoints, struct libnvme_mi_ep, root_entry);
 }
 
-__public libnvme_mi_ep_t libnvme_mi_next_endpoint(struct libnvme_global_ctx *ctx, libnvme_mi_ep_t ep)
+__libnvme_public libnvme_mi_ep_t libnvme_mi_next_endpoint(
+		struct libnvme_global_ctx *ctx, libnvme_mi_ep_t ep)
 {
 	return ep ? list_next(&ctx->endpoints, ep, root_entry) : NULL;
 }
@@ -1359,7 +1371,7 @@ static const char *const mi_status[] = {
 
 /* kept in mi.c while we have a split libnvme/libnvme-mi; consider moving
  * to utils.c (with libnvme_status_to_string) if we ever merge. */
-__public const char *libnvme_mi_status_to_string(int status)
+__libnvme_public const char *libnvme_mi_status_to_string(int status)
 {
 	const char *s = "Unknown status";
 
@@ -1527,7 +1539,7 @@ err_cleanup:
 	return err;
 }
 
-__public int libnvme_mi_aem_get_fd(libnvme_mi_ep_t ep)
+__libnvme_public int libnvme_mi_aem_get_fd(libnvme_mi_ep_t ep)
 {
 	if (!ep || !ep->aem_ctx || !ep->transport || !ep->transport->aem_fd)
 		return -1;
@@ -1636,7 +1648,7 @@ static int aem_disable_enabled(libnvme_mi_ep_t ep)
 	return rc;
 }
 
-__public int libnvme_mi_aem_enable(libnvme_mi_ep_t ep,
+__libnvme_public int libnvme_mi_aem_enable(libnvme_mi_ep_t ep,
 	struct libnvme_mi_aem_config *config,
 	void *userdata)
 {
@@ -1710,7 +1722,7 @@ cleanup_ctx:
 	return rc;
 }
 
-__public int libnvme_mi_aem_get_enabled(libnvme_mi_ep_t ep,
+__libnvme_public int libnvme_mi_aem_get_enabled(libnvme_mi_ep_t ep,
 	struct libnvme_mi_aem_enabled_map *enabled_map)
 {
 	if (!ep || !enabled_map)
@@ -1751,7 +1763,7 @@ cleanup:
 	return rc;
 }
 
-__public int libnvme_mi_aem_disable(libnvme_mi_ep_t ep)
+__libnvme_public int libnvme_mi_aem_disable(libnvme_mi_ep_t ep)
 {
 	if (!ep)
 		return -1;
@@ -1769,7 +1781,8 @@ __public int libnvme_mi_aem_disable(libnvme_mi_ep_t ep)
  *spec_info and vend_spec_info must be copied to persist as they will not be valid after
  *the aem_handler has returned.
  */
-__public struct libnvme_mi_event *libnvme_mi_aem_get_next_event(libnvme_mi_ep_t ep)
+__libnvme_public struct libnvme_mi_event *libnvme_mi_aem_get_next_event(
+		libnvme_mi_ep_t ep)
 {
 	if (!ep || !ep->aem_ctx ||
 		!ep->aem_ctx->list_current ||
@@ -1806,7 +1819,7 @@ __public struct libnvme_mi_event *libnvme_mi_aem_get_next_event(libnvme_mi_ep_t 
 /* POLLIN has indicated events.  This function reads and processes them.
  * A callback will likely be invoked.
  */
-__public int libnvme_mi_aem_process(libnvme_mi_ep_t ep, void *userdata)
+__libnvme_public int libnvme_mi_aem_process(libnvme_mi_ep_t ep, void *userdata)
 {
 	int rc = 0;
 	uint8_t response_buffer[4096];

--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -710,7 +710,8 @@ static int parse_raw_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info *n
 	return 0;
 }
 
-__public void libnvme_free_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info *nbft)
+__libnvme_public void libnvme_free_nbft(
+		struct libnvme_global_ctx *ctx, struct libnbft_info *nbft)
 {
 	struct libnbft_hfi **hfi;
 	struct libnbft_security **sec;
@@ -736,7 +737,8 @@ __public void libnvme_free_nbft(struct libnvme_global_ctx *ctx, struct libnbft_i
 	free(nbft);
 }
 
-__public int libnvme_read_nbft(struct libnvme_global_ctx *ctx, struct libnbft_info **nbft,
+__libnvme_public int libnvme_read_nbft(
+		struct libnvme_global_ctx *ctx, struct libnbft_info **nbft,
 		const char *filename)
 {
 	__u8 *raw_nbft = NULL;

--- a/libnvme/src/nvme/no-mi.c
+++ b/libnvme/src/nvme/no-mi.c
@@ -12,7 +12,7 @@
 
 #include "compiler-attributes.h"
 
-__public const char *libnvme_mi_status_to_string(int status)
+__libnvme_public const char *libnvme_mi_status_to_string(int status)
 {
 	return "MI support disabled";
 }

--- a/libnvme/src/nvme/no-uring.c
+++ b/libnvme/src/nvme/no-uring.c
@@ -34,14 +34,14 @@ int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 	return -ENOTSUP;
 }
 
-__public int libnvme_wait_admin_passthru(
-		__unused struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_wait_admin_passthru(
+		__libnvme_unused struct libnvme_transport_handle *hdl)
 {
 	return 0;
 }
 
-__public int libnvme_wait_io_passthru(
-		__unused struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_wait_io_passthru(
+		__libnvme_unused struct libnvme_transport_handle *hdl)
 {
 	return 0;
 }

--- a/libnvme/src/nvme/nvme-cmds.c
+++ b/libnvme/src/nvme/nvme-cmds.c
@@ -32,7 +32,7 @@ static void nvme_init_env(void)
 		force_4k = true;
 }
 
-__public int libnvme_get_log(struct libnvme_transport_handle *hdl,
+__libnvme_public int libnvme_get_log(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd, bool rae,
 		__u32 xfer_len)
 {
@@ -167,9 +167,9 @@ static int try_read_ana(struct libnvme_transport_handle *hdl,
 	return 0;
 }
 
-__public int libnvme_get_ana_log_atomic(struct libnvme_transport_handle *hdl,
-		bool rae, bool rgo, struct nvme_ana_log *log, __u32 *len,
-		unsigned int retries)
+__libnvme_public int libnvme_get_ana_log_atomic(
+		struct libnvme_transport_handle *hdl, bool rae, bool rgo,
+		struct nvme_ana_log *log, __u32 *len, unsigned int retries)
 {
 	const enum nvme_log_ana_lsp lsp =
 		rgo ? NVME_LOG_ANA_LSP_RGO_GROUPS_ONLY : 0;
@@ -223,7 +223,8 @@ __public int libnvme_get_ana_log_atomic(struct libnvme_transport_handle *hdl,
 	return -EAGAIN;
 }
 
-__public int libnvme_set_etdas(struct libnvme_transport_handle *hdl, bool *changed)
+__libnvme_public int libnvme_set_etdas(
+		struct libnvme_transport_handle *hdl, bool *changed)
 {
 	struct nvme_feat_host_behavior da4;
 	struct libnvme_passthru_cmd cmd;
@@ -250,7 +251,8 @@ __public int libnvme_set_etdas(struct libnvme_transport_handle *hdl, bool *chang
 	return 0;
 }
 
-__public int libnvme_clear_etdas(struct libnvme_transport_handle *hdl, bool *changed)
+__libnvme_public int libnvme_clear_etdas(
+		struct libnvme_transport_handle *hdl, bool *changed)
 {
 	struct nvme_feat_host_behavior da4;
 	struct libnvme_passthru_cmd cmd;
@@ -276,7 +278,7 @@ __public int libnvme_clear_etdas(struct libnvme_transport_handle *hdl, bool *cha
 	return 0;
 }
 
-__public int libnvme_get_uuid_list(struct libnvme_transport_handle *hdl,
+__libnvme_public int libnvme_get_uuid_list(struct libnvme_transport_handle *hdl,
 		struct nvme_id_uuid_list *uuid_list)
 {
 	struct libnvme_passthru_cmd cmd;
@@ -301,7 +303,8 @@ __public int libnvme_get_uuid_list(struct libnvme_transport_handle *hdl,
 	return err;
 }
 
-__public int libnvme_get_telemetry_max(struct libnvme_transport_handle *hdl,
+__libnvme_public int libnvme_get_telemetry_max(
+		struct libnvme_transport_handle *hdl,
 		enum nvme_telemetry_da *da, size_t *data_tx)
 {
 	__cleanup_free struct nvme_id_ctrl *id_ctrl = NULL;
@@ -337,10 +340,10 @@ __public int libnvme_get_telemetry_max(struct libnvme_transport_handle *hdl,
 	return err;
 }
 
-__public int libnvme_get_telemetry_log(struct libnvme_transport_handle *hdl, bool create,
-		bool ctrl, bool rae, size_t max_data_tx,
-		enum nvme_telemetry_da da, struct nvme_telemetry_log **buf,
-		size_t *size)
+__libnvme_public int libnvme_get_telemetry_log(
+		struct libnvme_transport_handle *hdl, bool create, bool ctrl,
+		bool rae, size_t max_data_tx, enum nvme_telemetry_da da,
+		struct nvme_telemetry_log **buf, size_t *size)
 {
 	static const __u32 xfer = NVME_LOG_TELEM_BLOCK_SIZE;
 	struct nvme_telemetry_log *telem;
@@ -441,25 +444,28 @@ static int nvme_check_get_telemetry_log(struct libnvme_transport_handle *hdl,
 }
 
 
-__public int libnvme_get_ctrl_telemetry(struct libnvme_transport_handle *hdl, bool rae,
-		struct nvme_telemetry_log **log,
-		enum nvme_telemetry_da da, size_t *size)
+__libnvme_public int libnvme_get_ctrl_telemetry(
+		struct libnvme_transport_handle *hdl, bool rae,
+		struct nvme_telemetry_log **log, enum nvme_telemetry_da da,
+		size_t *size)
 {
 	return nvme_check_get_telemetry_log(hdl, false, true, rae, log,
 		da, size);
 }
 
-__public int libnvme_get_host_telemetry(struct libnvme_transport_handle *hdl,
-		struct nvme_telemetry_log **log,
-		enum nvme_telemetry_da da, size_t *size)
+__libnvme_public int libnvme_get_host_telemetry(
+		struct libnvme_transport_handle *hdl,
+		struct nvme_telemetry_log **log, enum nvme_telemetry_da da,
+		size_t *size)
 {
 	return nvme_check_get_telemetry_log(hdl, false, false, false, log,
 		da, size);
 }
 
-__public int libnvme_get_new_host_telemetry(struct libnvme_transport_handle *hdl,
-		struct nvme_telemetry_log **log,
-		enum nvme_telemetry_da da, size_t *size)
+__libnvme_public int libnvme_get_new_host_telemetry(
+		struct libnvme_transport_handle *hdl,
+		struct nvme_telemetry_log **log, enum nvme_telemetry_da da,
+		size_t *size)
 {
 	return nvme_check_get_telemetry_log(hdl, true, false, false, log,
 		da, size);
@@ -511,8 +517,8 @@ int libnvme_get_lba_status_log(struct libnvme_transport_handle *hdl, bool rae,
 	return 0;
 }
 
-__public size_t libnvme_get_ana_log_len_from_id_ctrl(const struct nvme_id_ctrl *id_ctrl,
-					 bool rgo)
+__libnvme_public size_t libnvme_get_ana_log_len_from_id_ctrl(
+		const struct nvme_id_ctrl *id_ctrl, bool rgo)
 {
 	__u32 nanagrpid = le32_to_cpu(id_ctrl->nanagrpid);
 	size_t size = sizeof(struct nvme_ana_log) +
@@ -521,7 +527,8 @@ __public size_t libnvme_get_ana_log_len_from_id_ctrl(const struct nvme_id_ctrl *
 	return rgo ? size : size + le32_to_cpu(id_ctrl->mnan) * sizeof(__le32);
 }
 
-__public int libnvme_get_ana_log_len(struct libnvme_transport_handle *hdl, size_t *analen)
+__libnvme_public int libnvme_get_ana_log_len(
+		struct libnvme_transport_handle *hdl, size_t *analen)
 {
 	__cleanup_free struct nvme_id_ctrl *ctrl = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -540,8 +547,8 @@ __public int libnvme_get_ana_log_len(struct libnvme_transport_handle *hdl, size_
 	return 0;
 }
 
-__public int libnvme_get_logical_block_size(struct libnvme_transport_handle *hdl,
-		__u32 nsid, int *blksize)
+__libnvme_public int libnvme_get_logical_block_size(
+		struct libnvme_transport_handle *hdl, __u32 nsid, int *blksize)
 {
 	__cleanup_free struct nvme_id_ns *ns = NULL;
 	struct libnvme_passthru_cmd cmd;
@@ -563,8 +570,8 @@ __public int libnvme_get_logical_block_size(struct libnvme_transport_handle *hdl
 	return 0;
 }
 
-__public int libnvme_get_feature_length(int fid, __u32 cdw11, enum nvme_data_tfr dir,
-			     __u32 *len)
+__libnvme_public int libnvme_get_feature_length(
+		int fid, __u32 cdw11, enum nvme_data_tfr dir, __u32 *len)
 {
 	switch (fid) {
 	case NVME_FEAT_FID_LBA_RANGE:
@@ -636,7 +643,8 @@ __public int libnvme_get_feature_length(int fid, __u32 cdw11, enum nvme_data_tfr
 	return 0;
 }
 
-__public int libnvme_get_directive_receive_length(enum nvme_directive_dtype dtype,
+__libnvme_public int libnvme_get_directive_receive_length(
+		enum nvme_directive_dtype dtype,
 		enum nvme_directive_receive_doper doper, __u32 *len)
 {
 	switch (dtype) {

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -129,7 +129,7 @@ static char *nvme_hostid_from_hostnqn(const char *hostnqn)
 	return strdup(uuid + strlen("uuid:"));
 }
 
-__public int libnvme_host_get_ids(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_host_get_ids(struct libnvme_global_ctx *ctx,
 		      const char *hostnqn_arg, const char *hostid_arg,
 		      char **hostnqn, char **hostid)
 {
@@ -199,7 +199,8 @@ __public int libnvme_host_get_ids(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_get_host(struct libnvme_global_ctx *ctx, const char *hostnqn,
+__libnvme_public int libnvme_get_host(
+		struct libnvme_global_ctx *ctx, const char *hostnqn,
 		const char *hostid, libnvme_host_t *host)
 {
 	__cleanup_free char *hnqn = NULL;
@@ -284,7 +285,7 @@ static void libnvme_filter_tree(struct libnvme_global_ctx *ctx,
 	}
 }
 
-__public int libnvme_scan_topology(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_scan_topology(struct libnvme_global_ctx *ctx,
 		libnvme_scan_filter_t f, void *f_args)
 {
 	__cleanup_dirents struct dirents subsys = {}, ctrls = {};
@@ -338,7 +339,7 @@ __public int libnvme_scan_topology(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_read_config(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_read_config(struct libnvme_global_ctx *ctx,
 		const char *config_file)
 {
 	int err;
@@ -361,22 +362,23 @@ __public int libnvme_read_config(struct libnvme_global_ctx *ctx,
 	return err;
 }
 
-__public int libnvme_dump_config(struct libnvme_global_ctx *ctx, int fd)
+__libnvme_public int libnvme_dump_config(struct libnvme_global_ctx *ctx, int fd)
 {
 	return json_update_config(ctx, fd);
 }
 
-__public int libnvme_dump_tree(struct libnvme_global_ctx *ctx)
+__libnvme_public int libnvme_dump_tree(struct libnvme_global_ctx *ctx)
 {
 	return json_dump_tree(ctx);
 }
 
-__public const char *libnvme_get_application(struct libnvme_global_ctx *ctx)
+__libnvme_public const char *libnvme_get_application(
+		struct libnvme_global_ctx *ctx)
 {
 	return ctx->application;
 }
 
-__public void libnvme_set_application(struct libnvme_global_ctx *ctx,
+__libnvme_public void libnvme_set_application(struct libnvme_global_ctx *ctx,
 		const char *a)
 {
 	free(ctx->application);
@@ -386,53 +388,56 @@ __public void libnvme_set_application(struct libnvme_global_ctx *ctx,
 		ctx->application = strdup(a);
 }
 
-__public void libnvme_skip_namespaces(struct libnvme_global_ctx *ctx)
+__libnvme_public void libnvme_skip_namespaces(struct libnvme_global_ctx *ctx)
 {
 	ctx->create_only = true;
 }
 
-__public libnvme_host_t libnvme_first_host(struct libnvme_global_ctx *ctx)
+__libnvme_public libnvme_host_t libnvme_first_host(
+		struct libnvme_global_ctx *ctx)
 {
 	return list_top(&ctx->hosts, struct libnvme_host, entry);
 }
 
-__public libnvme_host_t libnvme_next_host(struct libnvme_global_ctx *ctx,
-		libnvme_host_t h)
+__libnvme_public libnvme_host_t libnvme_next_host(
+		struct libnvme_global_ctx *ctx, libnvme_host_t h)
 {
 	return h ? list_next(&ctx->hosts, h, entry) : NULL;
 }
 
-__public struct libnvme_global_ctx *libnvme_host_get_global_ctx(
+__libnvme_public struct libnvme_global_ctx *libnvme_host_get_global_ctx(
 		libnvme_host_t h)
 {
 	return h->ctx;
 }
 
-__public void libnvme_host_set_pdc_enabled(libnvme_host_t h, bool enabled)
+__libnvme_public void libnvme_host_set_pdc_enabled(
+		libnvme_host_t h, bool enabled)
 {
 	h->pdc_enabled_valid = true;
 	h->pdc_enabled = enabled;
 }
 
-__public bool libnvme_host_is_pdc_enabled(libnvme_host_t h, bool fallback)
+__libnvme_public bool libnvme_host_is_pdc_enabled(
+		libnvme_host_t h, bool fallback)
 {
 	if (h->pdc_enabled_valid)
 		return h->pdc_enabled;
 	return fallback;
 }
 
-__public libnvme_subsystem_t libnvme_first_subsystem(libnvme_host_t h)
+__libnvme_public libnvme_subsystem_t libnvme_first_subsystem(libnvme_host_t h)
 {
 	return list_top(&h->subsystems, struct libnvme_subsystem, entry);
 }
 
-__public libnvme_subsystem_t libnvme_next_subsystem(libnvme_host_t h,
+__libnvme_public libnvme_subsystem_t libnvme_next_subsystem(libnvme_host_t h,
 		libnvme_subsystem_t s)
 {
 	return s ? list_next(&h->subsystems, s, entry) : NULL;
 }
 
-__public void libnvme_refresh_topology(struct libnvme_global_ctx *ctx)
+__libnvme_public void libnvme_refresh_topology(struct libnvme_global_ctx *ctx)
 {
 	struct libnvme_host *h, *_h;
 
@@ -449,23 +454,25 @@ void nvme_root_release_fds(struct libnvme_global_ctx *ctx)
 		libnvme_host_release_fds(h);
 }
 
-__public libnvme_ctrl_t libnvme_subsystem_first_ctrl(libnvme_subsystem_t s)
+__libnvme_public libnvme_ctrl_t libnvme_subsystem_first_ctrl(
+		libnvme_subsystem_t s)
 {
 	return list_top(&s->ctrls, struct libnvme_ctrl, entry);
 }
 
-__public libnvme_ctrl_t libnvme_subsystem_next_ctrl(libnvme_subsystem_t s,
-		libnvme_ctrl_t c)
+__libnvme_public libnvme_ctrl_t libnvme_subsystem_next_ctrl(
+		libnvme_subsystem_t s, libnvme_ctrl_t c)
 {
 	return c ? list_next(&s->ctrls, c, entry) : NULL;
 }
 
-__public libnvme_host_t libnvme_subsystem_get_host(libnvme_subsystem_t s)
+__libnvme_public libnvme_host_t libnvme_subsystem_get_host(
+		libnvme_subsystem_t s)
 {
 	return s->h;
 }
 
-__public char *libnvme_subsystem_get_iopolicy(libnvme_subsystem_t s)
+__libnvme_public char *libnvme_subsystem_get_iopolicy(libnvme_subsystem_t s)
 {
 	__cleanup_free char *iopolicy = NULL;
 
@@ -480,23 +487,23 @@ __public char *libnvme_subsystem_get_iopolicy(libnvme_subsystem_t s)
 	return s->iopolicy;
 }
 
-__public libnvme_ns_t libnvme_subsystem_first_ns(libnvme_subsystem_t s)
+__libnvme_public libnvme_ns_t libnvme_subsystem_first_ns(libnvme_subsystem_t s)
 {
 	return list_top(&s->namespaces, struct libnvme_ns, entry);
 }
 
-__public libnvme_ns_t libnvme_subsystem_next_ns(libnvme_subsystem_t s,
+__libnvme_public libnvme_ns_t libnvme_subsystem_next_ns(libnvme_subsystem_t s,
 		libnvme_ns_t n)
 {
 	return n ? list_next(&s->namespaces, n, entry) : NULL;
 }
 
-__public libnvme_path_t libnvme_namespace_first_path(libnvme_ns_t ns)
+__libnvme_public libnvme_path_t libnvme_namespace_first_path(libnvme_ns_t ns)
 {
 	return list_top(&ns->head->paths, struct libnvme_path, nentry);
 }
 
-__public libnvme_path_t libnvme_namespace_next_path(libnvme_ns_t ns,
+__libnvme_public libnvme_path_t libnvme_namespace_next_path(libnvme_ns_t ns,
 		libnvme_path_t p)
 {
 	return p ? list_next(&ns->head->paths, p, nentry) : NULL;
@@ -522,7 +529,7 @@ static void __nvme_free_ns(struct libnvme_ns *n)
 }
 
 /* Stub for SWIG */
-__public void libnvme_free_ns(struct libnvme_ns *n)
+__libnvme_public void libnvme_free_ns(struct libnvme_ns *n)
 {
 	if (!n)
 		return;
@@ -554,7 +561,7 @@ static void __nvme_free_subsystem(struct libnvme_subsystem *s)
 	free(s);
 }
 
-__public void libnvme_subsystem_release_fds(struct libnvme_subsystem *s)
+__libnvme_public void libnvme_subsystem_release_fds(struct libnvme_subsystem *s)
 {
 	struct libnvme_ctrl *c, *_c;
 	struct libnvme_ns *n, *_n;
@@ -569,7 +576,7 @@ __public void libnvme_subsystem_release_fds(struct libnvme_subsystem *s)
 /*
  * Stub for SWIG
  */
-__public void libnvme_free_subsystem(libnvme_subsystem_t s)
+__libnvme_public void libnvme_free_subsystem(libnvme_subsystem_t s)
 {
 	if (!s)
 		return;
@@ -620,7 +627,7 @@ struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,
 	return nvme_alloc_subsystem(h, name, subsysnqn);
 }
 
-__public int libnvme_get_subsystem(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_get_subsystem(struct libnvme_global_ctx *ctx,
 		struct libnvme_host *h, const char *name,
 		const char *subsysnqn, struct libnvme_subsystem **subsys)
 {
@@ -649,7 +656,7 @@ void __libnvme_free_host(struct libnvme_host *h)
 	free(h);
 }
 
-__public void libnvme_host_release_fds(struct libnvme_host *h)
+__libnvme_public void libnvme_host_release_fds(struct libnvme_host *h)
 {
 	struct libnvme_subsystem *s, *_s;
 
@@ -658,7 +665,7 @@ __public void libnvme_host_release_fds(struct libnvme_host *h)
 }
 
 /* Stub for SWIG */
-__public void libnvme_free_host(struct libnvme_host *h)
+__libnvme_public void libnvme_free_host(struct libnvme_host *h)
 {
 	if (!h)
 		return;
@@ -833,17 +840,17 @@ static int libnvme_scan_subsystem(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public libnvme_ctrl_t libnvme_path_get_ctrl(libnvme_path_t p)
+__libnvme_public libnvme_ctrl_t libnvme_path_get_ctrl(libnvme_path_t p)
 {
 	return p->c;
 }
 
-__public libnvme_ns_t libnvme_path_get_ns(libnvme_path_t p)
+__libnvme_public libnvme_ns_t libnvme_path_get_ns(libnvme_path_t p)
 {
 	return p->n;
 }
 
-__public int libnvme_path_get_queue_depth(libnvme_path_t p)
+__libnvme_public int libnvme_path_get_queue_depth(libnvme_path_t p)
 {
 	__cleanup_free char *queue_depth = NULL;
 
@@ -855,7 +862,7 @@ __public int libnvme_path_get_queue_depth(libnvme_path_t p)
 	return p->queue_depth;
 }
 
-__public char *libnvme_path_get_ana_state(libnvme_path_t p)
+__libnvme_public char *libnvme_path_get_ana_state(libnvme_path_t p)
 {
 	__cleanup_free char *ana_state = NULL;
 
@@ -870,7 +877,7 @@ __public char *libnvme_path_get_ana_state(libnvme_path_t p)
 	return p->ana_state;
 }
 
-__public char *libnvme_path_get_numa_nodes(libnvme_path_t p)
+__libnvme_public char *libnvme_path_get_numa_nodes(libnvme_path_t p)
 {
 	__cleanup_free char *numa_nodes = NULL;
 
@@ -885,7 +892,8 @@ __public char *libnvme_path_get_numa_nodes(libnvme_path_t p)
 	return p->numa_nodes;
 }
 
-__public long libnvme_path_get_multipath_failover_count(libnvme_path_t p)
+__libnvme_public long libnvme_path_get_multipath_failover_count(
+		libnvme_path_t p)
 {
 	__cleanup_free char *failover_count = NULL;
 
@@ -896,7 +904,7 @@ __public long libnvme_path_get_multipath_failover_count(libnvme_path_t p)
 	return p->multipath_failover_count;
 }
 
-__public long libnvme_path_get_command_retry_count(libnvme_path_t p)
+__libnvme_public long libnvme_path_get_command_retry_count(libnvme_path_t p)
 {
 	__cleanup_free char *retry_count = NULL;
 
@@ -907,7 +915,7 @@ __public long libnvme_path_get_command_retry_count(libnvme_path_t p)
 	return p->command_retry_count;
 }
 
-__public long libnvme_path_get_command_error_count(libnvme_path_t p)
+__libnvme_public long libnvme_path_get_command_error_count(libnvme_path_t p)
 {
 	__cleanup_free char *error_count = NULL;
 
@@ -926,7 +934,7 @@ static libnvme_stat_t libnvme_path_get_stat(libnvme_path_t p, unsigned int idx)
 	return &p->stat[idx];
 }
 
-__public void libnvme_path_reset_stat(libnvme_path_t p)
+__libnvme_public void libnvme_path_reset_stat(libnvme_path_t p)
 {
 	libnvme_stat_t stat = &p->stat[0];
 
@@ -941,7 +949,7 @@ static libnvme_stat_t libnvme_ns_get_stat(libnvme_ns_t n, unsigned int idx)
 	return &n->stat[idx];
 }
 
-__public void libnvme_ns_reset_stat(libnvme_ns_t n)
+__libnvme_public void libnvme_ns_reset_stat(libnvme_ns_t n)
 {
 	libnvme_stat_t stat = &n->stat[0];
 
@@ -1004,7 +1012,7 @@ static int libnvme_update_stat(const char *sysfs_stat_path, libnvme_stat_t stat)
 	return 0;
 }
 
-__public int libnvme_path_update_stat(libnvme_path_t p, bool diffstat)
+__libnvme_public int libnvme_path_update_stat(libnvme_path_t p, bool diffstat)
 {
 	__cleanup_free char *sysfs_stat_path = NULL;
 	libnvme_stat_t stat;
@@ -1022,7 +1030,7 @@ __public int libnvme_path_update_stat(libnvme_path_t p, bool diffstat)
 	return libnvme_update_stat(sysfs_stat_path, stat);
 }
 
-__public int libnvme_ns_update_stat(libnvme_ns_t n, bool diffstat)
+__libnvme_public int libnvme_ns_update_stat(libnvme_ns_t n, bool diffstat)
 {
 	__cleanup_free char *sysfs_stat_path = NULL;
 	libnvme_stat_t stat;
@@ -1045,7 +1053,7 @@ static int libnvme_stat_get_inflights(libnvme_stat_t stat)
 	return stat->inflights;
 }
 
-__public unsigned int libnvme_path_get_inflights(libnvme_path_t p)
+__libnvme_public unsigned int libnvme_path_get_inflights(libnvme_path_t p)
 {
 	libnvme_stat_t curr;
 
@@ -1056,7 +1064,7 @@ __public unsigned int libnvme_path_get_inflights(libnvme_path_t p)
 	return libnvme_stat_get_inflights(curr);
 }
 
-__public unsigned int libnvme_ns_get_inflights(libnvme_ns_t n)
+__libnvme_public unsigned int libnvme_ns_get_inflights(libnvme_ns_t n)
 {
 	libnvme_stat_t curr;
 
@@ -1081,7 +1089,7 @@ static int libnvme_stat_get_io_ticks(libnvme_stat_t curr, libnvme_stat_t prev,
 	return delta;
 }
 
-__public unsigned int libnvme_path_get_io_ticks(libnvme_path_t p)
+__libnvme_public unsigned int libnvme_path_get_io_ticks(libnvme_path_t p)
 {
 	libnvme_stat_t curr, prev;
 
@@ -1094,7 +1102,7 @@ __public unsigned int libnvme_path_get_io_ticks(libnvme_path_t p)
 	return libnvme_stat_get_io_ticks(curr, prev, p->diffstat);
 }
 
-__public unsigned int libnvme_ns_get_io_ticks(libnvme_ns_t n)
+__libnvme_public unsigned int libnvme_ns_get_io_ticks(libnvme_ns_t n)
 {
 	libnvme_stat_t curr, prev;
 
@@ -1135,12 +1143,12 @@ static unsigned int __libnvme_path_get_ticks(libnvme_path_t p,
 	return libnvme_stat_get_ticks(curr, prev, grp, p->diffstat);
 }
 
-__public unsigned int libnvme_path_get_read_ticks(libnvme_path_t p)
+__libnvme_public unsigned int libnvme_path_get_read_ticks(libnvme_path_t p)
 {
 	return __libnvme_path_get_ticks(p, READ);
 }
 
-__public unsigned int libnvme_path_get_write_ticks(libnvme_path_t p)
+__libnvme_public unsigned int libnvme_path_get_write_ticks(libnvme_path_t p)
 {
 	return __libnvme_path_get_ticks(p, WRITE);
 }
@@ -1159,12 +1167,12 @@ static unsigned int __libnvme_ns_get_ticks(libnvme_ns_t n,
 	return libnvme_stat_get_ticks(curr, prev, grp, n->diffstat);
 }
 
-__public unsigned int libnvme_ns_get_read_ticks(libnvme_ns_t n)
+__libnvme_public unsigned int libnvme_ns_get_read_ticks(libnvme_ns_t n)
 {
 	return __libnvme_ns_get_ticks(n, READ);
 }
 
-__public unsigned int libnvme_ns_get_write_ticks(libnvme_ns_t n)
+__libnvme_public unsigned int libnvme_ns_get_write_ticks(libnvme_ns_t n)
 {
 	return __libnvme_ns_get_ticks(n, WRITE);
 }
@@ -1180,7 +1188,7 @@ static double libnvme_stat_get_interval(libnvme_stat_t curr,
 	return delta;
 }
 
-__public double libnvme_path_get_stat_interval(libnvme_path_t p)
+__libnvme_public double libnvme_path_get_stat_interval(libnvme_path_t p)
 {
 	libnvme_stat_t curr, prev;
 
@@ -1193,7 +1201,7 @@ __public double libnvme_path_get_stat_interval(libnvme_path_t p)
 	return libnvme_stat_get_interval(curr, prev);
 }
 
-__public double libnvme_ns_get_stat_interval(libnvme_ns_t n)
+__libnvme_public double libnvme_ns_get_stat_interval(libnvme_ns_t n)
 {
 	libnvme_stat_t curr, prev;
 
@@ -1234,12 +1242,12 @@ static unsigned long __libnvme_path_get_ios(libnvme_path_t p,
 	return libnvme_stat_get_ios(curr, prev, grp, p->diffstat);
 }
 
-__public unsigned long libnvme_path_get_read_ios(libnvme_path_t p)
+__libnvme_public unsigned long libnvme_path_get_read_ios(libnvme_path_t p)
 {
 	return __libnvme_path_get_ios(p, READ);
 }
 
-__public unsigned long libnvme_path_get_write_ios(libnvme_path_t p)
+__libnvme_public unsigned long libnvme_path_get_write_ios(libnvme_path_t p)
 {
 	return __libnvme_path_get_ios(p, WRITE);
 }
@@ -1258,12 +1266,12 @@ static unsigned long __libnvme_ns_get_ios(libnvme_ns_t n,
 	return libnvme_stat_get_ios(curr, prev, grp, n->diffstat);
 }
 
-__public unsigned long libnvme_ns_get_read_ios(libnvme_ns_t n)
+__libnvme_public unsigned long libnvme_ns_get_read_ios(libnvme_ns_t n)
 {
 	return __libnvme_ns_get_ios(n, READ);
 }
 
-__public unsigned long libnvme_ns_get_write_ios(libnvme_ns_t n)
+__libnvme_public unsigned long libnvme_ns_get_write_ios(libnvme_ns_t n)
 {
 	return __libnvme_ns_get_ios(n, WRITE);
 }
@@ -1296,12 +1304,14 @@ static unsigned long long __libnvme_path_get_sectors(libnvme_path_t p,
 	return libnvme_stat_get_sectors(curr, prev, grp, p->diffstat);
 }
 
-__public unsigned long long libnvme_path_get_read_sectors(libnvme_path_t p)
+__libnvme_public unsigned long long libnvme_path_get_read_sectors(
+		libnvme_path_t p)
 {
 	return __libnvme_path_get_sectors(p, READ);
 }
 
-__public unsigned long long libnvme_path_get_write_sectors(libnvme_path_t p)
+__libnvme_public unsigned long long libnvme_path_get_write_sectors(
+		libnvme_path_t p)
 {
 	return __libnvme_path_get_sectors(p, WRITE);
 }
@@ -1320,12 +1330,12 @@ static unsigned long long __libnvme_ns_get_sectors(libnvme_ns_t n,
 	return libnvme_stat_get_sectors(curr, prev, grp, n->diffstat);
 }
 
-__public unsigned long long libnvme_ns_get_read_sectors(libnvme_ns_t n)
+__libnvme_public unsigned long long libnvme_ns_get_read_sectors(libnvme_ns_t n)
 {
 	return __libnvme_ns_get_sectors(n, READ);
 }
 
-__public unsigned long long libnvme_ns_get_write_sectors(libnvme_ns_t n)
+__libnvme_public unsigned long long libnvme_ns_get_write_sectors(libnvme_ns_t n)
 {
 	return __libnvme_ns_get_sectors(n, WRITE);
 }
@@ -1392,7 +1402,7 @@ static int libnvme_ctrl_scan_path(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public struct libnvme_transport_handle *libnvme_ctrl_get_transport_handle(
+__libnvme_public struct libnvme_transport_handle *libnvme_ctrl_get_transport_handle(
 		libnvme_ctrl_t c)
 {
 	if (!c->hdl) {
@@ -1407,7 +1417,7 @@ __public struct libnvme_transport_handle *libnvme_ctrl_get_transport_handle(
 	return c->hdl;
 }
 
-__public void libnvme_ctrl_release_transport_handle(libnvme_ctrl_t c)
+__libnvme_public void libnvme_ctrl_release_transport_handle(libnvme_ctrl_t c)
 {
 	if (!c->hdl)
 		return;
@@ -1416,14 +1426,15 @@ __public void libnvme_ctrl_release_transport_handle(libnvme_ctrl_t c)
 	c->hdl = NULL;
 }
 
-__public libnvme_subsystem_t libnvme_ctrl_get_subsystem(libnvme_ctrl_t c)
+__libnvme_public libnvme_subsystem_t libnvme_ctrl_get_subsystem(
+		libnvme_ctrl_t c)
 {
 	return c->s;
 }
 
 
-__public char *libnvme_ctrl_get_src_addr(libnvme_ctrl_t c, char *src_addr,
-		size_t src_addr_len)
+__libnvme_public char *libnvme_ctrl_get_src_addr(
+		libnvme_ctrl_t c, char *src_addr, size_t src_addr_len)
 {
 	size_t l;
 	char *p;
@@ -1449,7 +1460,7 @@ __public char *libnvme_ctrl_get_src_addr(libnvme_ctrl_t c, char *src_addr,
 	return src_addr;
 }
 
-__public const char *libnvme_ctrl_get_state(libnvme_ctrl_t c)
+__libnvme_public const char *libnvme_ctrl_get_state(libnvme_ctrl_t c)
 {
 	char *state = c->state;
 
@@ -1458,7 +1469,7 @@ __public const char *libnvme_ctrl_get_state(libnvme_ctrl_t c)
 	return c->state;
 }
 
-__public long libnvme_ctrl_get_command_error_count(libnvme_ctrl_t c)
+__libnvme_public long libnvme_ctrl_get_command_error_count(libnvme_ctrl_t c)
 {
 	__cleanup_free char *error_count = NULL;
 
@@ -1469,7 +1480,7 @@ __public long libnvme_ctrl_get_command_error_count(libnvme_ctrl_t c)
 	return c->command_error_count;
 }
 
-__public long libnvme_ctrl_get_reset_count(libnvme_ctrl_t c)
+__libnvme_public long libnvme_ctrl_get_reset_count(libnvme_ctrl_t c)
 {
 	__cleanup_free char *reset_count = NULL;
 
@@ -1480,7 +1491,7 @@ __public long libnvme_ctrl_get_reset_count(libnvme_ctrl_t c)
 	return c->reset_count;
 }
 
-__public long libnvme_ctrl_get_reconnect_count(libnvme_ctrl_t c)
+__libnvme_public long libnvme_ctrl_get_reconnect_count(libnvme_ctrl_t c)
 {
 	__cleanup_free char *reconnect_count = NULL;
 
@@ -1491,7 +1502,8 @@ __public long libnvme_ctrl_get_reconnect_count(libnvme_ctrl_t c)
 	return c->reconnect_count;
 }
 
-__public int libnvme_ctrl_identify(libnvme_ctrl_t c, struct nvme_id_ctrl *id)
+__libnvme_public int libnvme_ctrl_identify(
+		libnvme_ctrl_t c, struct nvme_id_ctrl *id)
 {
 	struct libnvme_transport_handle *hdl =
 		libnvme_ctrl_get_transport_handle(c);
@@ -1501,22 +1513,23 @@ __public int libnvme_ctrl_identify(libnvme_ctrl_t c, struct nvme_id_ctrl *id)
 	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
-__public libnvme_ns_t libnvme_ctrl_first_ns(libnvme_ctrl_t c)
+__libnvme_public libnvme_ns_t libnvme_ctrl_first_ns(libnvme_ctrl_t c)
 {
 	return list_top(&c->namespaces, struct libnvme_ns, entry);
 }
 
-__public libnvme_ns_t libnvme_ctrl_next_ns(libnvme_ctrl_t c, libnvme_ns_t n)
+__libnvme_public libnvme_ns_t libnvme_ctrl_next_ns(
+		libnvme_ctrl_t c, libnvme_ns_t n)
 {
 	return n ? list_next(&c->namespaces, n, entry) : NULL;
 }
 
-__public libnvme_path_t libnvme_ctrl_first_path(libnvme_ctrl_t c)
+__libnvme_public libnvme_path_t libnvme_ctrl_first_path(libnvme_ctrl_t c)
 {
 	return list_top(&c->paths, struct libnvme_path, entry);
 }
 
-__public libnvme_path_t libnvme_ctrl_next_path(libnvme_ctrl_t c,
+__libnvme_public libnvme_path_t libnvme_ctrl_next_path(libnvme_ctrl_t c,
 		libnvme_path_t p)
 {
 	return p ? list_next(&c->paths, p, entry) : NULL;
@@ -1548,7 +1561,7 @@ void nvme_deconfigure_ctrl(libnvme_ctrl_t c)
 	FREE_CTRL_ATTR(c->phy_slot);
 }
 
-__public void libnvme_unlink_ctrl(libnvme_ctrl_t c)
+__libnvme_public void libnvme_unlink_ctrl(libnvme_ctrl_t c)
 {
 	list_del_init(&c->entry);
 	c->s = NULL;
@@ -1578,7 +1591,7 @@ static void __libnvme_free_ctrl(libnvme_ctrl_t c)
 	free(c);
 }
 
-__public void libnvme_free_ctrl(libnvme_ctrl_t c)
+__libnvme_public void libnvme_free_ctrl(libnvme_ctrl_t c)
 {
 	if (!c)
 		return;
@@ -2002,7 +2015,7 @@ bool _libnvme_ctrl_match_config(struct libnvme_ctrl *c,
 	return ctrl_match(c, &candidate);
 }
 
-__public bool libnvme_ctrl_match_config(struct libnvme_ctrl *c,
+__libnvme_public bool libnvme_ctrl_match_config(struct libnvme_ctrl *c,
 		const char *transport, const char *traddr, const char *trsvcid,
 		const char *subsysnqn, const char *host_traddr,
 		const char *host_iface)
@@ -2320,7 +2333,8 @@ static int libnvme_reconfigure_ctrl(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_init_ctrl(libnvme_host_t h, libnvme_ctrl_t c, int instance)
+__libnvme_public int libnvme_init_ctrl(
+		libnvme_host_t h, libnvme_ctrl_t c, int instance)
 {
 	__cleanup_free char *subsys_name = NULL, *name = NULL, *path = NULL;
 	libnvme_subsystem_t s;
@@ -2467,8 +2481,9 @@ skip_address:
 	return 0;
 }
 
-__public int libnvme_scan_ctrl(struct libnvme_global_ctx *ctx, const char *name,
-		   libnvme_ctrl_t *cp)
+__libnvme_public int libnvme_scan_ctrl(
+		struct libnvme_global_ctx *ctx, const char *name,
+		libnvme_ctrl_t *cp)
 {
 	__cleanup_free char *subsysnqn = NULL, *subsysname = NULL;
 	__cleanup_free char *hostnqn = NULL, *hostid = NULL;
@@ -2534,7 +2549,7 @@ __public int libnvme_scan_ctrl(struct libnvme_global_ctx *ctx, const char *name,
 	return 0;
 }
 
-__public void libnvme_rescan_ctrl(struct libnvme_ctrl *c)
+__libnvme_public void libnvme_rescan_ctrl(struct libnvme_ctrl *c)
 {
 	struct libnvme_global_ctx *ctx = c->s && c->s->h ? c->s->h->ctx : NULL;
 	if (!c->s)
@@ -2588,12 +2603,12 @@ void libnvme_ns_release_transport_handle(libnvme_ns_t n)
 	n->hdl = NULL;
 }
 
-__public libnvme_subsystem_t libnvme_ns_get_subsystem(libnvme_ns_t n)
+__libnvme_public libnvme_subsystem_t libnvme_ns_get_subsystem(libnvme_ns_t n)
 {
 	return n->s;
 }
 
-__public libnvme_ctrl_t libnvme_ns_get_ctrl(libnvme_ns_t n)
+__libnvme_public libnvme_ctrl_t libnvme_ns_get_ctrl(libnvme_ns_t n)
 {
 	return n->c;
 }
@@ -2603,28 +2618,28 @@ const char *libnvme_ns_head_get_sysfs_dir(libnvme_ns_head_t head)
 	return head->sysfs_dir;
 }
 
-__public const char *libnvme_ns_get_model(libnvme_ns_t n)
+__libnvme_public const char *libnvme_ns_get_model(libnvme_ns_t n)
 {
 	return n->c ? n->c->model : n->s->model;
 }
 
-__public const char *libnvme_ns_get_serial(libnvme_ns_t n)
+__libnvme_public const char *libnvme_ns_get_serial(libnvme_ns_t n)
 {
 	return n->c ? n->c->serial : n->s->serial;
 }
 
-__public const char *libnvme_ns_get_firmware(libnvme_ns_t n)
+__libnvme_public const char *libnvme_ns_get_firmware(libnvme_ns_t n)
 {
 	return n->c ? n->c->firmware : n->s->firmware;
 }
 
-__public void libnvme_ns_copy_uuid(libnvme_ns_t n,
+__libnvme_public void libnvme_ns_copy_uuid(libnvme_ns_t n,
 		unsigned char out[NVME_UUID_LEN])
 {
 	memcpy(out, n->uuid, NVME_UUID_LEN);
 }
 
-__public long libnvme_ns_get_command_retry_count(libnvme_ns_t n)
+__libnvme_public long libnvme_ns_get_command_retry_count(libnvme_ns_t n)
 {
 	__cleanup_free char *retry_count = NULL;
 
@@ -2635,7 +2650,7 @@ __public long libnvme_ns_get_command_retry_count(libnvme_ns_t n)
 	return n->command_retry_count;
 }
 
-__public long libnvme_ns_get_command_error_count(libnvme_ns_t n)
+__libnvme_public long libnvme_ns_get_command_error_count(libnvme_ns_t n)
 {
 	__cleanup_free char *error_count = NULL;
 
@@ -2646,7 +2661,8 @@ __public long libnvme_ns_get_command_error_count(libnvme_ns_t n)
 	return n->command_error_count;
 }
 
-__public long libnvme_ns_get_requeue_no_usable_path_count(libnvme_ns_t n)
+__libnvme_public long libnvme_ns_get_requeue_no_usable_path_count(
+		libnvme_ns_t n)
 {
 	__cleanup_free char *requeue_count = NULL;
 
@@ -2657,7 +2673,8 @@ __public long libnvme_ns_get_requeue_no_usable_path_count(libnvme_ns_t n)
 	return n->requeue_no_usable_path_count;
 }
 
-__public long libnvme_ns_get_fail_no_available_path_count(libnvme_ns_t n)
+__libnvme_public long libnvme_ns_get_fail_no_available_path_count(
+		libnvme_ns_t n)
 {
 	__cleanup_free char *fail_count = NULL;
 
@@ -2668,7 +2685,7 @@ __public long libnvme_ns_get_fail_no_available_path_count(libnvme_ns_t n)
 	return n->fail_no_available_path_count;
 }
 
-__public int libnvme_ns_identify(libnvme_ns_t n, struct nvme_id_ns *ns)
+__libnvme_public int libnvme_ns_identify(libnvme_ns_t n, struct nvme_id_ns *ns)
 {
 	struct libnvme_transport_handle *hdl;
 	struct libnvme_passthru_cmd cmd;
@@ -2696,7 +2713,8 @@ int libnvme_ns_identify_descs(libnvme_ns_t n, struct nvme_ns_id_desc *descs)
 	return libnvme_exec_admin_passthru(hdl, &cmd);
 }
 
-__public int libnvme_ns_verify(libnvme_ns_t n, off_t offset, size_t count)
+__libnvme_public int libnvme_ns_verify(
+		libnvme_ns_t n, off_t offset, size_t count)
 {
 	struct libnvme_transport_handle *hdl;
 	struct libnvme_passthru_cmd cmd;
@@ -2717,8 +2735,8 @@ __public int libnvme_ns_verify(libnvme_ns_t n, off_t offset, size_t count)
 	return libnvme_submit_io_passthru(hdl, &cmd);
 }
 
-__public int libnvme_ns_write_uncorrectable(libnvme_ns_t n, off_t offset,
-		size_t count)
+__libnvme_public int libnvme_ns_write_uncorrectable(
+		libnvme_ns_t n, off_t offset, size_t count)
 {
 	struct libnvme_transport_handle *hdl;
 	struct libnvme_passthru_cmd cmd;
@@ -2739,7 +2757,8 @@ __public int libnvme_ns_write_uncorrectable(libnvme_ns_t n, off_t offset,
 	return libnvme_submit_io_passthru(hdl, &cmd);
 }
 
-__public int libnvme_ns_write_zeros(libnvme_ns_t n, off_t offset, size_t count)
+__libnvme_public int libnvme_ns_write_zeros(
+		libnvme_ns_t n, off_t offset, size_t count)
 {
 	struct libnvme_transport_handle *hdl;
 	struct libnvme_passthru_cmd cmd;
@@ -2760,7 +2779,7 @@ __public int libnvme_ns_write_zeros(libnvme_ns_t n, off_t offset, size_t count)
 	return libnvme_submit_io_passthru(hdl, &cmd);
 }
 
-__public int libnvme_ns_write(libnvme_ns_t n, void *buf, off_t offset,
+__libnvme_public int libnvme_ns_write(libnvme_ns_t n, void *buf, off_t offset,
 		size_t count)
 {
 	struct libnvme_transport_handle *hdl;
@@ -2782,7 +2801,7 @@ __public int libnvme_ns_write(libnvme_ns_t n, void *buf, off_t offset,
 	return libnvme_submit_io_passthru(hdl, &cmd);
 }
 
-__public int libnvme_ns_read(libnvme_ns_t n, void *buf, off_t offset,
+__libnvme_public int libnvme_ns_read(libnvme_ns_t n, void *buf, off_t offset,
 		size_t count)
 {
 	struct libnvme_transport_handle *hdl;
@@ -2804,7 +2823,7 @@ __public int libnvme_ns_read(libnvme_ns_t n, void *buf, off_t offset,
 	return libnvme_submit_io_passthru(hdl, &cmd);
 }
 
-__public int libnvme_ns_compare(libnvme_ns_t n, void *buf, off_t offset,
+__libnvme_public int libnvme_ns_compare(libnvme_ns_t n, void *buf, off_t offset,
 		size_t count)
 {
 	struct libnvme_transport_handle *hdl;
@@ -2826,7 +2845,7 @@ __public int libnvme_ns_compare(libnvme_ns_t n, void *buf, off_t offset,
 	return libnvme_submit_io_passthru(hdl, &cmd);
 }
 
-__public int libnvme_ns_flush(libnvme_ns_t n)
+__libnvme_public int libnvme_ns_flush(libnvme_ns_t n)
 {
 	struct libnvme_transport_handle *hdl;
 	struct libnvme_passthru_cmd cmd;
@@ -3139,7 +3158,7 @@ static int __libnvme_scan_namespace(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public int libnvme_scan_namespace(struct libnvme_global_ctx *ctx,
+__libnvme_public int libnvme_scan_namespace(struct libnvme_global_ctx *ctx,
 		const char *name, libnvme_ns_t *ns)
 {
 	return __libnvme_scan_namespace(ctx, libnvme_ns_sysfs_dir(), name, ns);
@@ -3265,7 +3284,7 @@ static int libnvme_subsystem_scan_namespace(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__public struct libnvme_ns *libnvme_subsystem_lookup_namespace(
+__libnvme_public struct libnvme_ns *libnvme_subsystem_lookup_namespace(
 		struct libnvme_subsystem *s, __u32 nsid)
 {
 	struct libnvme_ns *n;

--- a/libnvme/src/nvme/uring.c
+++ b/libnvme/src/nvme/uring.c
@@ -103,7 +103,8 @@ static int nvme_submit_uring_cmd(struct io_uring *ring, int fd,
 	return 0;
 }
 
-__public int libnvme_wait_admin_passthru(struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_wait_admin_passthru(
+		struct libnvme_transport_handle *hdl)
 {
 	struct io_uring_cqe *cqe;
 	struct io_uring *ring;
@@ -148,8 +149,8 @@ int libnvme_submit_admin_passthru_async(struct libnvme_transport_handle *hdl,
 	return 0;
 }
 
-__public int libnvme_wait_io_passthru(
-		__unused struct libnvme_transport_handle *hdl)
+__libnvme_public int libnvme_wait_io_passthru(
+		__libnvme_unused struct libnvme_transport_handle *hdl)
 {
 	return 0;
 }

--- a/libnvme/src/nvme/util-fabrics.c
+++ b/libnvme/src/nvme/util-fabrics.c
@@ -15,7 +15,8 @@
 
 #include "compiler-attributes.h"
 
-__public struct nvmf_ext_attr *libnvmf_exat_ptr_next(struct nvmf_ext_attr *p)
+__libnvme_public struct nvmf_ext_attr *libnvmf_exat_ptr_next(
+		struct nvmf_ext_attr *p)
 {
 	__u16 size = libnvmf_exat_size(le16_to_cpu(p->exatlen));
 

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -181,7 +181,7 @@ static inline __u8 nvme_fabrics_status_to_errno(__u16 status)
 	return EIO;
 }
 
-__public __u8 libnvme_status_to_errno(int status, bool fabrics)
+__libnvme_public __u8 libnvme_status_to_errno(int status, bool fabrics)
 {
 	__u16 sc;
 
@@ -380,7 +380,7 @@ static const char *arg_str(const char * const *strings,
 	return "unrecognized";
 }
 
-__public const char *libnvme_status_to_string(int status, bool fabrics)
+__libnvme_public const char *libnvme_status_to_string(int status, bool fabrics)
 {
 	const char *s = "Unknown status";
 	__u16 sc, sct;
@@ -444,14 +444,14 @@ static const char * const libnvme_status[] = {
 	[ENVME_CONNECT_NOKEY] = "pre-shared TLS key is missing"
 };
 
-__public const char *libnvme_errno_to_string(int status)
+__libnvme_public const char *libnvme_errno_to_string(int status)
 {
 	const char *s = ARGSTR(libnvme_status, status);
 
 	return s;
 }
 
-__public const char *libnvme_strerror(int errnum)
+__libnvme_public const char *libnvme_strerror(int errnum)
 {
 	if (errnum >= ENVME_CONNECT_RESOLVE)
 		return libnvme_errno_to_string(errnum);
@@ -716,7 +716,7 @@ size_t get_entity_version(char *buffer, size_t bufsz)
 	return num_bytes;
 }
 
-__public const char *libnvme_get_version(enum libnvme_version type)
+__libnvme_public const char *libnvme_get_version(enum libnvme_version type)
 {
 	switch(type) {
 	case LIBNVME_VERSION_PROJECT:
@@ -728,7 +728,8 @@ __public const char *libnvme_get_version(enum libnvme_version type)
 	}
 }
 
-__public int libnvme_uuid_to_string(unsigned char uuid[NVME_UUID_LEN], char *str)
+__libnvme_public int libnvme_uuid_to_string(
+		unsigned char uuid[NVME_UUID_LEN], char *str)
 {
 	int n;
 	n = snprintf(str, NVME_UUID_LEN_STRING,
@@ -740,7 +741,8 @@ __public int libnvme_uuid_to_string(unsigned char uuid[NVME_UUID_LEN], char *str
 	return n != NVME_UUID_LEN_STRING - 1 ? -EINVAL : 0;
 }
 
-__public int libnvme_uuid_from_string(const char *str, unsigned char uuid[NVME_UUID_LEN])
+__libnvme_public int libnvme_uuid_from_string(
+		const char *str, unsigned char uuid[NVME_UUID_LEN])
 {
 	int n;
 
@@ -754,7 +756,7 @@ __public int libnvme_uuid_from_string(const char *str, unsigned char uuid[NVME_U
 
 }
 
-__public int libnvme_random_uuid(unsigned char uuid[NVME_UUID_LEN])
+__libnvme_public int libnvme_random_uuid(unsigned char uuid[NVME_UUID_LEN])
 {
 	__cleanup_fd int f = -1;
 	ssize_t n;
@@ -779,7 +781,7 @@ __public int libnvme_random_uuid(unsigned char uuid[NVME_UUID_LEN])
 	return 0;
 }
 
-__public int libnvme_find_uuid(struct nvme_id_uuid_list *uuid_list,
+__libnvme_public int libnvme_find_uuid(struct nvme_id_uuid_list *uuid_list,
 		const unsigned char uuid[NVME_UUID_LEN])
 {
 	const unsigned char uuid_end[NVME_UUID_LEN] = {0};

--- a/libnvme/tools/check-public-headers.py
+++ b/libnvme/tools/check-public-headers.py
@@ -9,7 +9,7 @@
 # Verify that every symbol exported in a version script has a prototype
 # declared in one of the installed header files.
 #
-# A __public function that appears in a .ld version script but not in any
+# A __libnvme_public function that appears in a .ld version script but not in any
 # installed header is technically callable by external code, but callers have
 # no declaration to include — they would need to write their own prototype or
 # use dlsym(), which defeats the purpose of a stable public API.

--- a/libnvme/tools/check-public-symbols.py
+++ b/libnvme/tools/check-public-symbols.py
@@ -6,17 +6,17 @@
 #
 # Authors: Martin Belanger <Martin.Belanger@dell.com>
 #
-# Verify that __public annotations and version-script entries are
+# Verify that __libnvme_public annotations and version-script entries are
 # kept in sync:
 #
-#   1. Every function definition annotated with __public in a .c
+#   1. Every function definition annotated with __libnvme_public in a .c
 #      file must appear in one of the three version scripts (libnvme.ld,
 #      libnvmf.ld, accessors.ld).  A function that is annotated but not
 #      listed is visible to the compiler but silently hidden by the linker
 #      version script's "local: *;" catch-all — the developer's intent to
 #      export it would be silently ignored.
 #
-#   2. Every symbol listed in a version script must have a __public
+#   2. Every symbol listed in a version script must have a __libnvme_public
 #      annotation on its definition.  Without the annotation the symbol is
 #      hidden at compile time (due to -fvisibility=hidden) and the build
 #      will either fail to link or produce a .so that is missing the symbol.
@@ -55,12 +55,12 @@ for ld_path in LD_FILES:
             ld_syms[m.group(1)] = ld_path
 
 # ---------------------------------------------------------------------------
-# Collect function names annotated with __public in .c files
+# Collect function names annotated with __libnvme_public in .c files
 # ---------------------------------------------------------------------------
-# Match: __public <return-type> [*] function_name(
+# Match: __libnvme_public <return-type> [*] function_name(
 # The .*\b is greedy so it skips over the return type and any __attribute__
 # qualifiers, leaving the last identifier before '(' as the function name.
-PUB_RE = re.compile(r'^__public\b.*\b([a-z_]\w+)\s*\(', re.MULTILINE)
+PUB_RE = re.compile(r'^__libnvme_public\b.*\b([a-z_]\w+)\s*\(', re.MULTILINE)
 
 pub_syms = {}  # symbol -> Path of the .c file that defines it
 
@@ -74,23 +74,23 @@ for c_path in sorted(SRC_DIR.glob('*.c')):
 # ---------------------------------------------------------------------------
 errors = 0
 
-# Check 1: __public in .c but missing from all .ld files
+# Check 1: __libnvme_public in .c but missing from all .ld files
 for sym, c_path in sorted(pub_syms.items()):
     if sym not in ld_syms:
-        print(f'ERROR: {sym}() is annotated __public in '
+        print(f'ERROR: {sym}() is annotated __libnvme_public in '
               f'{c_path.name} but is not listed in any version script')
         errors += 1
 
-# Check 2: listed in a .ld file but no __public definition found
+# Check 2: listed in a .ld file but no __libnvme_public definition found
 for sym, ld_path in sorted(ld_syms.items()):
     if sym not in pub_syms:
         print(f'ERROR: {sym}() is listed in {ld_path.name} but has no '
-              f'__public definition in {SRC_DIR.name}/*.c')
+              f'__libnvme_public definition in {SRC_DIR.name}/*.c')
         errors += 1
 
 if errors:
     print(f'\n{errors} error(s) found.')
     sys.exit(1)
 
-print(f'OK: {len(pub_syms)} __public symbols all present in version '
+print(f'OK: {len(pub_syms)} __libnvme_public symbols all present in version '
       f'scripts; {len(ld_syms)} version-script entries all annotated.')

--- a/libnvme/tools/generator/generate-accessors.py
+++ b/libnvme/tools/generator/generate-accessors.py
@@ -1172,7 +1172,7 @@ def generate_hdr(f, prefix, struct_name, members):
 # Source (*.c) code emitters
 # ---------------------------------------------------------------------------
 
-PUB = '__public '
+PUB = '__libnvme_public '
 
 
 def emit_src_setter_dynstr(f, prefix, sname, mname):


### PR DESCRIPTION
## libnvme: add `__libnvme_` prefix to all compiler attributes

### Problem

The macros defined in `compiler-attributes.h` — `__public`, `__weak`, and `__unused` — use short, generic names that sit in the C implementation-reserved namespace (`__` prefix). This caused a real build failure: musl libc uses `__unused` as a struct field name in `bits/stat.h`:

```c
long __unused[3];
```

When `compiler-attributes.h` is included before a musl system header, the preprocessor rewrites that field declaration to:

```c
long __attribute__((__unused__))[3];
```

which is a syntax error.

### Fix

Rename all three macros with a project-specific prefix:

| Old name | New name |
|---|---|
| `__public` | `__libnvme_public` |
| `__weak` | `__libnvme_weak` |
| `__unused` | `__libnvme_unused` |

The `__libnvme_` prefix is specific enough that no system header will ever use it as an identifier, while keeping the double-underscore convention already used throughout the codebase.

### Scope

- All source files under `libnvme/src/nvme/` updated
- Accessor generator (`generate-accessors.py`) updated; `accessors.c` and `accessors-fabrics.c` regenerated
- `check-public-symbols.py` and `check-public-headers.py` updated

### checkpatch

The longer prefix pushes some function signatures over the 80-column limit. Long signatures are wrapped so arguments begin on the continuation line. Three signatures remain marginally over 80 columns — `__libnvme_public` plus the return type and function name alone fills the line before any arguments appear. Separating the attribute from the function name is not valid, so these three warnings are unavoidable.
