### PR TITLE
build: generate coverage report for nightly tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: build
         run: |
-          scripts/build.sh coverage
+          scripts/build.sh -p
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         env:
           CODECOV_WORKING_DIR: ${{ github.workspace }}

--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -62,7 +62,7 @@ jobs:
             git clone https://github.com/${{ github.repository }} nvme-cli
             cd nvme-cli
             git checkout ${{ github.sha }}
-            scripts/build.sh -b release -c gcc
+            scripts/build.sh -b release -c gcc -p
             sudo meson install -C .build-ci
             sudo ldconfig /usr/local/lib64
 
@@ -81,7 +81,17 @@ jobs:
             NVMET_TRTYPES="loop rdma tcp"
             EXCLUDE=(nvme/010 nvme/012 nvme/034 nvme/035)
             EF
+            set +e
             sudo ./check nvme md/001
+            blktests_status=$?
+            set -e
+
+            cd -
+            CODECOV_VERSION="v0.8.0"
+            curl -Os "https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov"
+            chmod +x codecov
+            (cd nvme-cli && ../codecov -t "${{ secrets.CODECOV_TOKEN }}") || true
+            exit "${blktests_status}"
       - name: Run nvme-cli tests in VM
         if: success() || steps.blktests.conclusion == 'failure'
         uses: ./.github/actions/kubevirt-action
@@ -90,6 +100,7 @@ jobs:
           kernel_version: linus-master
           vm_artifact_upload_dir: nvme-cli/tests/nvmetests/
           run_cmds: |
+            export CODECOV_TOKEN="${{ secrets.CODECOV_TOKEN }}"
             #Preventing bash variable expension for the outer cat by using
             #single quotes around EOF
             cat > test.sh << 'EOF'
@@ -113,7 +124,12 @@ jobs:
             EOJ
             cat tests/config.json
 
-            scripts/build.sh -b release -c gcc tests
+            scripts/build.sh -b release -c gcc -p tests
+
+            CODECOV_VERSION="v0.8.0"
+            curl -Os "https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov"
+            chmod +x codecov
+            ./codecov -t "$CODECOV_TOKEN" || true
             EOF
 
             sudo chmod +x test.sh
@@ -130,6 +146,7 @@ jobs:
             sudo podman run --privileged \
             -v /dev:/dev \
             -e BDEV0 \
+            -e CODECOV_TOKEN \
             -v "${PWD}/test.sh":"/test.sh" \
             -v "${PWD}/nvme-cli":"/nvme-cli":z \
             ghcr.io/linux-nvme/debian:latest /test.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,6 +19,7 @@ usage() {
     echo " -b [release]|debug   build type"
     echo " -c [gcc]|clang       compiler to use"
     echo " -m [meson]|muon      use meson or muon"
+    echo " -p                   enable coverage report"
     echo " -t [arm]|ppc64le|s390x  cross compile target"
     echo " -x                   run test with valgrind"
     echo ""
@@ -28,7 +29,6 @@ usage() {
     echo "  fallback            download all dependencies"
     echo "                      and build them as shared libraries"
     echo "  cross               use cross toolchain to build"
-    echo "  coverage            build coverage report"
     echo "  distro              build libnvme and nvme-cli separately"
     echo "  docs                build all documentation"
     echo "  man_docs            build man documentation only"
@@ -49,9 +49,10 @@ BUILDTYPE=release
 CROSS_TARGET=arm
 CC=${CC:-"gcc"}
 
+use_coverage=0
 use_valgrind=0
 
-while getopts "b:c:m:t:x" o; do
+while getopts "b:c:m:pt:x" o; do
     case "${o}" in
         b)
             BUILDTYPE="${OPTARG}"
@@ -61,6 +62,9 @@ while getopts "b:c:m:t:x" o; do
             ;;
         m)
             BUILDTOOL="${OPTARG}"
+            ;;
+        p)
+            use_coverage=1
             ;;
         t)
             CROSS_TARGET="${OPTARG}"
@@ -140,16 +144,6 @@ config_meson_cross() {
         --cross-file=.github/cross/ubuntu-cross-${CROSS_TARGET}.txt \
         -Dpython=disabled               \
         -Dopenssl=disabled              \
-        "${BUILDDIR}"
-}
-
-config_meson_coverage() {
-    CC="${CC}" "${MESON}" setup                 \
-        --werror                                \
-        --buildtype="${BUILDTYPE}"              \
-        --wrap-mode=nofallback                  \
-        -Dlibdbus=enabled                       \
-        -Db_coverage=true                       \
         "${BUILDDIR}"
 }
 
@@ -319,12 +313,6 @@ test_meson_rst_docs() {
 	true
 }
 
-test_meson_coverage() {
-    "${MESON}" test                             \
-        -C "${BUILDDIR}"
-    ninja -C "${BUILDDIR}" coverage --verbose
-}
-
 install_meson_docs() {
     "${MESON}" install                          \
         -C "${BUILDDIR}"
@@ -434,6 +422,11 @@ test_meson_distro() {
     test_meson
 }
 
+if [[ "${use_coverage}" -eq 1 && "${BUILDTOOL}" != "meson" ]]; then
+     echo "error: coverage reporting (-p) is only supported with the meson build tool" >&2
+     exit 1
+fi
+
 if [[ "${BUILDTOOL}" == "muon" ]]; then
     SAMU="$(which samu 2> /dev/null)" || true
     if [[ -z "${SAMU}" ]]; then
@@ -454,6 +447,12 @@ echo "muon: ${MUON}"
 rm -rf "${BUILDDIR}"
 
 config_"${BUILDTOOL}"_"${CONFIG}"
+if [[ "${use_coverage}" -eq 1 ]]; then
+    "${MESON}" setup --reconfigure "${BUILDDIR}" -Db_coverage=true
+fi
 fn_exists "build_${BUILDTOOL}_${CONFIG}" && "build_${BUILDTOOL}_${CONFIG}" || build_"${BUILDTOOL}"
 fn_exists "test_${BUILDTOOL}_${CONFIG}" && "test_${BUILDTOOL}_${CONFIG}" || test_"${BUILDTOOL}"
+if [[ "${use_coverage}" -eq 1 ]]; then
+    ninja -C "${BUILDDIR}" coverage --verbose
+fi
 fn_exists "install_${BUILDTOOL}_${CONFIG}" && "install_${BUILDTOOL}_${CONFIG}" || true;


### PR DESCRIPTION
Extend the coverage report for the nightly tests. This covers the fabrics features and the passthru code paths in nvme-cli during the end-to-end tests.

Fixes: #3241