### PR TITLE
build: switch to gcovr

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,4 +33,5 @@ jobs:
         with:
           root_dir: ${{ github.workspace }}
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -63,8 +63,9 @@ jobs:
             cd nvme-cli
             git checkout ${{ github.sha }}
             scripts/build.sh -b release -c gcc -p
-            sudo meson install -C .build-ci
-            sudo ldconfig /usr/local/lib64
+
+            # IMPORTANT: do NOT install for coverage run
+            export PATH="$PWD/.build-ci:$PATH"
 
             cd -
             git clone https://github.com/linux-blktests/blktests.git blktests
@@ -73,7 +74,7 @@ jobs:
             make
             mkdir -p results
             nvme --version | tee -a results/nvme-cli.version
-            sudo nvme --version | tee -a results/nvme-cli.version
+            sudo env PATH="$PWD/.build-ci:$PATH" nvme --version | tee -a results/nvme-cli.version
 
             # Run blktests nvme and md group
             cat > config << EF
@@ -82,15 +83,16 @@ jobs:
             EXCLUDE=(nvme/010 nvme/012 nvme/034 nvme/035)
             EF
             set +e
-            sudo ./check nvme md/001
+            sudo env PATH="$PWD/.build-ci:$PATH" ./check nvme md/001
             blktests_status=$?
             set -e
 
-            cd -
+            cd nvme-cli
+            gcovr -r . --object-directory .build-ci --xml-pretty -o coverage.xml
             CODECOV_VERSION="v0.8.0"
             curl -Os "https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov"
             chmod +x codecov
-            (cd nvme-cli && ../codecov -t "${{ secrets.CODECOV_TOKEN }}") || true
+            (cd nvme-cli && ../codecov -t "${{ secrets.CODECOV_TOKEN }}" -f coverage.xml) || true
             exit "${blktests_status}"
       - name: Run nvme-cli tests in VM
         if: success() || steps.blktests.conclusion == 'failure'
@@ -129,7 +131,7 @@ jobs:
             CODECOV_VERSION="v0.8.0"
             curl -Os "https://uploader.codecov.io/${CODECOV_VERSION}/linux/codecov"
             chmod +x codecov
-            ./codecov -t "$CODECOV_TOKEN" || true
+            ./codecov -t "$CODECOV_TOKEN" -f coverage.xml || true
             EOF
 
             sudo chmod +x test.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -453,6 +453,6 @@ fi
 fn_exists "build_${BUILDTOOL}_${CONFIG}" && "build_${BUILDTOOL}_${CONFIG}" || build_"${BUILDTOOL}"
 fn_exists "test_${BUILDTOOL}_${CONFIG}" && "test_${BUILDTOOL}_${CONFIG}" || test_"${BUILDTOOL}"
 if [[ "${use_coverage}" -eq 1 ]]; then
-    ninja -C "${BUILDDIR}" coverage --verbose
+    gcovr -r . "${BUILDDIR}" --xml-pretty -o coverage.xml
 fi
 fn_exists "install_${BUILDTOOL}_${CONFIG}" && "install_${BUILDTOOL}_${CONFIG}" || true;


### PR DESCRIPTION
lcov seems to be fragile with newer gcc version. The recommended way is to use gcovr instead of lcov.