### PR TITLE
libnvme: zero-init ns in __nvme_transport_handle_open_direct()

### DIFF
--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -149,7 +149,7 @@ static int __nvme_transport_handle_open_direct(
 	struct libnvme_passthru_cmd dummy = { 0 };
 	__cleanup_free char *path = NULL;
 	char *name;
-	int ret, id, ns;
+	int ret, id, ns = 0;
 	bool c = true;
 
 	name = libnvme_basename(devname);


### PR DESCRIPTION
Minimal fix for an uninitialized-variable info leak in the ioctl_probing path.

When opening `/dev/nvmeX` (controller char dev), the local `ns` variable is left uninitialized after the "nvme%dn%d" sscanf
returns 1, then copied into `dummy.nsid` and submitted as a real admin SQE. A few bytes of caller-stack memory end up in
device-visible memory (typically the high half of a user-space pointer on x86_64, `0x00007fXX...`).  

This is the smallest possible fix — just initialize `ns = 0` so the leaked bytes become zeros. The dummy probe is still sent and still rejected by the controller as before.

**Alternative**: see #3349 for a more invasive fix that also removes the dummy submission entirely 
(probe via NULL argp +ENOTTY/EFAULT distinction). 