### PR TITLE
ioctl: defer ioctl version probing until first use

### DIFF
--- a/libnvme/src/nvme/ioctl.c
+++ b/libnvme/src/nvme/ioctl.c
@@ -196,16 +196,60 @@ __libnvme_public int libnvme_submit_io_passthru(
 		struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd)
 {
+	int err;
+
 	if (!hdl)
 		return -ENODEV;
 
 	if (!cmd->timeout_ms && hdl->timeout)
 		cmd->timeout_ms = hdl->timeout;
 
-	if (hdl->ioctl_io64)
+	if (hdl->ioctl_io_state == IOCTL_STATE_IOCTL64)
 		return libnvme_submit_passthru64(hdl,
 			LIBNVME_IOCTL_IO64_CMD, cmd);
+
+	if (hdl->ioctl_io_state == IOCTL_STATE_IOCTL32 ||
+			!hdl->ctx->ioctl_probing)
+		goto do_ioctl32;
+
+	err = libnvme_submit_passthru64(hdl, LIBNVME_IOCTL_IO64_CMD, cmd);
+	if (err >= 0 || err != -ENOTTY) {
+		hdl->ioctl_io_state = IOCTL_STATE_IOCTL64;
+		return err;
+	}
+
+	hdl->ioctl_io_state = IOCTL_STATE_IOCTL32;
+
+do_ioctl32:
 	return libnvme_submit_passthru32(hdl, LIBNVME_IOCTL_IO_CMD, cmd);
+}
+
+static int submit_admin_passthru(struct libnvme_transport_handle *hdl,
+		struct libnvme_passthru_cmd *cmd)
+{
+	int err;
+
+	if (hdl->ioctl_admin_state == IOCTL_STATE_IOCTL64)
+		return libnvme_submit_passthru64(hdl,
+				LIBNVME_IOCTL_ADMIN64_CMD, cmd);
+
+	if (hdl->ioctl_admin_state == IOCTL_STATE_IOCTL32 ||
+			!hdl->ctx->ioctl_probing)
+		goto do_ioctl32;
+
+	err = libnvme_submit_passthru64(hdl, LIBNVME_IOCTL_ADMIN64_CMD, cmd);
+	if (err >= 0 || err != -ENOTTY) {
+		hdl->ioctl_admin_state = IOCTL_STATE_IOCTL64;
+		return err;
+	}
+
+	hdl->ioctl_admin_state = IOCTL_STATE_IOCTL32;
+
+do_ioctl32:
+	if (cmd->opcode == nvme_admin_fabrics)
+		return -ENOTSUP;
+
+	return libnvme_submit_passthru32(hdl, LIBNVME_IOCTL_ADMIN_CMD, cmd);
 }
 
 __libnvme_public int libnvme_submit_admin_passthru(
@@ -223,13 +267,7 @@ __libnvme_public int libnvme_submit_admin_passthru(
 
 	switch (hdl->type) {
 	case LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT:
-		if (hdl->ioctl_admin64)
-			return libnvme_submit_passthru64(hdl,
-				LIBNVME_IOCTL_ADMIN64_CMD, cmd);
-		if (cmd->opcode == nvme_admin_fabrics)
-			return -ENOTSUP;
-		return libnvme_submit_passthru32(hdl,
-				LIBNVME_IOCTL_ADMIN_CMD, cmd);
+		return submit_admin_passthru(hdl, cmd);
 	case LIBNVME_TRANSPORT_HANDLE_TYPE_MI:
 		return libnvme_mi_admin_admin_passthru(hdl, cmd);
 	default:

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -152,7 +152,6 @@ __libnvme_public void libnvme_transport_handle_set_timeout(
 static int __nvme_transport_handle_open_direct(
 		struct libnvme_transport_handle *hdl, const char *devname)
 {
-	struct libnvme_passthru_cmd dummy = { 0 };
 	__cleanup_free char *path = NULL;
 	char *name;
 	int ret, id, ns;
@@ -190,18 +189,6 @@ static int __nvme_transport_handle_open_direct(
 		}
 	} else if (!S_ISBLK(hdl->stat.st_mode)) {
 		return -EINVAL;
-	}
-
-	if (hdl->ctx->ioctl_probing) {
-		/* avoid kernel logging 'cmd does not match nsid' */
-		dummy.nsid = ns;
-		ret = ioctl(hdl->fd, LIBNVME_IOCTL_ADMIN64_CMD, &dummy);
-		if (ret > 0) {
-			hdl->ioctl_admin64 = true;
-			ret = ioctl(hdl->fd, LIBNVME_IOCTL_IO64_CMD, &dummy);
-			if (ret != -1 || errno != ENOTTY)
-				hdl->ioctl_io64 = true;
-		}
 	}
 
 	return 0;
@@ -253,7 +240,7 @@ __libnvme_public int libnvme_open(
 		hdl->fd = 0xFD;
 
 		if (!strcmp(name, "NVME_TEST_FD64"))
-			hdl->ioctl_admin64 = true;
+			hdl->ioctl_admin_state = IOCTL_STATE_IOCTL64;
 
 		*hdlp = hdl;
 		return 0;

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -143,6 +143,12 @@ enum libnvme_transport_handle_type {
 	LIBNVME_TRANSPORT_HANDLE_TYPE_MI,
 };
 
+enum ioctl_state {
+	IOCTL_STATE_UNKNOWN = 0,
+	IOCTL_STATE_IOCTL32 = 1,
+	IOCTL_STATE_IOCTL64 = 2,
+};
+
 struct libnvme_transport_handle {
 	struct libnvme_global_ctx *ctx;
 	enum libnvme_transport_handle_type type;
@@ -162,8 +168,8 @@ struct libnvme_transport_handle {
 	/* direct */
 	int fd;
 	struct stat stat;
-	bool ioctl_admin64;
-	bool ioctl_io64;
+	enum ioctl_state ioctl_admin_state;
+	enum ioctl_state ioctl_io_state;
 	bool uring_enabled;
 
 #ifdef CONFIG_MI


### PR DESCRIPTION
The eager ioctl probing with a dummy command causes the kernel to emit log messages. In addition, probing is performed for every handle, which becomes unnecessarily expensive when iterating over large setups with many fabrics controllers.

Defer ioctl version probing until the first actual command submission. Prefer the 64-bit ioctl opportunistically and fall back to the 32-bit variant only when the kernel returns -ENOTTY.

When --no-ioctl-probing is specified, skip probing entirely and use the 32-bit ioctl directly.

Fixes: https://github.com/linux-nvme/nvme-cli/pull/3349 https://github.com/linux-nvme/nvme-cli/pull/3348 https://github.com/linux-nvme/nvme-cli/pull/3312