### PR TITLE
nvme-models: suppress missing sysfs entry messages

### DIFF
--- a/nvme-models.c
+++ b/nvme-models.c
@@ -245,8 +245,10 @@ static int read_sys_node(char *where, char *save, size_t savesz)
 	int fd, ret = 0, len;
 	fd = open(where, O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "Failed to open %s with errno %s\n",
-			where, libnvme_strerror(errno));
+		if (errno != ENOENT) {
+			fprintf(stderr, "Failed to open %s with errno %s\n",
+				where, libnvme_strerror(errno));
+		}
 		return 1;
 	}
 	/* -1 so we can safely use strstr below */


### PR DESCRIPTION
blktests nvme/033 with tr=loop fails because read_sys_node() reports missing sysfs entries as errors.

Some setups legitimately do not provide these attributes, so treat missing sysfs entries as optional and suppress the error messages.

Fixes: #3358 