### PR TITLE
tree: remove fabrics-only code from tree.c

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -196,7 +196,7 @@ static void save_discovery_log(char *raw, struct nvmf_discovery_log *log)
 static int setup_common_context(struct libnvmf_context *fctx,
 		struct nvmf_args *fa);
 
-struct cb_fabrics_data {
+struct hook_fabrics_data {
 	struct nvmf_args *fa;
 	nvme_print_flags_t flags;
 	bool quiet;
@@ -205,7 +205,7 @@ struct cb_fabrics_data {
 	FILE *f;
 };
 
-static bool cb_decide_retry(struct libnvmf_context *fctx, int err,
+static bool hook_decide_retry(struct libnvmf_context *fctx, int err,
 		void *user_data)
 {
 	if (err == -EAGAIN || (err == -EINTR && !nvme_sigint_received)) {
@@ -216,21 +216,21 @@ static bool cb_decide_retry(struct libnvmf_context *fctx, int err,
 	return false;
 }
 
-static void cb_connected(struct libnvmf_context *fctx,
+static void hook_connected(struct libnvmf_context *fctx,
 		struct libnvme_ctrl *c, void *user_data)
 {
-	struct cb_fabrics_data *cfd = user_data;
+	struct hook_fabrics_data *hfd = user_data;
 
-	if (cfd->quiet)
+	if (hfd->quiet)
 		return;
 
-	if (cfd->flags == NORMAL) {
+	if (hfd->flags == NORMAL) {
 		printf("connecting to device: %s\n", libnvme_ctrl_get_name(c));
 		return;
 	}
 
 #ifdef CONFIG_JSONC
-	if (cfd->flags == JSON) {
+	if (hfd->flags == JSON) {
 		struct json_object *root;
 
 		root = json_create_object();
@@ -245,7 +245,7 @@ static void cb_connected(struct libnvmf_context *fctx,
 #endif
 }
 
-static void cb_already_connected(struct libnvmf_context *fctx,
+static void hook_already_connected(struct libnvmf_context *fctx,
 		struct libnvme_host *host, const char *subsysnqn,
 		const char *transport, const char *traddr,
 		const char *trsvcid, void *user_data)
@@ -258,43 +258,43 @@ static void cb_already_connected(struct libnvmf_context *fctx,
 		transport, traddr, trsvcid);
 }
 
-static void cb_discovery_log(struct libnvmf_context *fctx,
+static void hook_discovery_log(struct libnvmf_context *fctx,
 		bool connect, struct nvmf_discovery_log *log,
 		uint64_t numrec, void *user_data)
 {
-	struct cb_fabrics_data *cfd = user_data;
+	struct hook_fabrics_data *hfd = user_data;
 
-	if (cfd->raw)
-		save_discovery_log(cfd->raw, log);
+	if (hfd->raw)
+		save_discovery_log(hfd->raw, log);
 	else if (!connect)
-		nvme_show_discovery_log(log, numrec, cfd->flags);
+		nvme_show_discovery_log(log, numrec, hfd->flags);
 }
 
-static int cb_parser_init(struct libnvmf_context *dctx, void *user_data)
+static int hook_parser_init(struct libnvmf_context *dctx, void *user_data)
 {
-	struct cb_fabrics_data *cfd = user_data;
+	struct hook_fabrics_data *hfd = user_data;
 
-	cfd->f = fopen(PATH_NVMF_DISC, "r");
-	if (cfd->f == NULL) {
+	hfd->f = fopen(PATH_NVMF_DISC, "r");
+	if (hfd->f == NULL) {
 		fprintf(stderr, "No params given and no %s\n", PATH_NVMF_DISC);
 		return -ENOENT;
 	}
 
-	cfd->argv = calloc(MAX_DISC_ARGS, sizeof(char *));
-	if (!cfd->argv)
+	hfd->argv = calloc(MAX_DISC_ARGS, sizeof(char *));
+	if (!hfd->argv)
 		return -1;
 
-	cfd->argv[0] = "discover";
+	hfd->argv[0] = "discover";
 
 	return 0;
 }
 
-static void cb_parser_cleanup(struct libnvmf_context *fctx, void *user_data)
+static void hook_parser_cleanup(struct libnvmf_context *fctx, void *user_data)
 {
-	struct cb_fabrics_data *cfd = user_data;
+	struct hook_fabrics_data *hfd = user_data;
 
-	free(cfd->argv);
-	fclose(cfd->f);
+	free(hfd->argv);
+	fclose(hfd->f);
 }
 
 static int set_fabrics_options(struct libnvmf_context *fctx,
@@ -327,9 +327,9 @@ static int set_fabrics_options(struct libnvmf_context *fctx,
 	return 0;
 }
 
-static int cb_parser_next_line(struct libnvmf_context *fctx, void *user_data)
+static int hook_parser_next_line(struct libnvmf_context *fctx, void *user_data)
 {
-	struct cb_fabrics_data *cfd = user_data;
+	struct hook_fabrics_data *hfd = user_data;
 	struct nvmf_args fa;
 	char *ptr, *p, line[4096];
 	int argc, ret = 0;
@@ -339,9 +339,9 @@ static int cb_parser_next_line(struct libnvmf_context *fctx, void *user_data)
 		  OPT_FLAG("persistent",   'p', &persistent, "persistent discovery connection"),
 		  OPT_FLAG("force",          0, &force,      "Force persistent discovery controller creation"));
 
-	memcpy(&fa, cfd->fa, sizeof(fa));
+	memcpy(&fa, hfd->fa, sizeof(fa));
 next:
-	if (fgets(line, sizeof(line), cfd->f) == NULL)
+	if (fgets(line, sizeof(line), hfd->f) == NULL)
 		return -EOF;
 
 	if (line[0] == '#' || line[0] == '\n')
@@ -350,11 +350,11 @@ next:
 	argc = 1;
 	p = line;
 	while ((ptr = strsep(&p, " =\n")) != NULL)
-		cfd->argv[argc++] = ptr;
-	cfd->argv[argc] = NULL;
+		hfd->argv[argc++] = ptr;
+	hfd->argv[argc] = NULL;
 
 	fa.subsysnqn = NVME_DISC_SUBSYS_NAME;
-	ret = argconfig_parse(argc, cfd->argv, "config", opts);
+	ret = argconfig_parse(argc, hfd->argv, "config", opts);
 	if (ret)
 		goto next;
 	if (!fa.transport && !fa.traddr)
@@ -408,8 +408,8 @@ static int create_common_context(struct libnvme_global_ctx *ctx,
 	struct libnvmf_context *fctx;
 	int err;
 
-	err = libnvmf_context_create(ctx, cb_decide_retry, cb_connected,
-		cb_already_connected, user_data, &fctx);
+	err = libnvmf_context_create(ctx, hook_decide_retry, hook_connected,
+		hook_already_connected, user_data, &fctx);
 	if (err)
 		return err;
 
@@ -458,8 +458,8 @@ static int create_discovery_context(struct libnvme_global_ctx *ctx,
 	if (err)
 		return err;
 
-	err = libnvmf_context_set_discovery_cbs(fctx, cb_discovery_log,
-		cb_parser_init, cb_parser_cleanup, cb_parser_next_line);
+	err = libnvmf_context_set_discovery_hooks(fctx, hook_discovery_log,
+		hook_parser_init, hook_parser_cleanup, hook_parser_next_line);
 	if (err)
 		goto err;
 
@@ -645,7 +645,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 			device += 5;
 	}
 
-	struct cb_fabrics_data dld = {
+	struct hook_fabrics_data dld = {
 		.fa = &fa,
 		.flags = flags,
 		.raw = raw,
@@ -760,12 +760,12 @@ do_connect:
 		return ret;
 	}
 
-	struct cb_fabrics_data cfd = {
+	struct hook_fabrics_data hfd = {
 		.flags = flags,
 		.quiet = dump_config,
 		.raw = raw,
 	};
-	ret = create_common_context(ctx, persistent, &fa, &cfd, &fctx);
+	ret = create_common_context(ctx, persistent, &fa, &hfd, &fctx);
 	if (ret)
 		return ret;
 

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -15,7 +15,7 @@ LIBNVMF_3 {
 		libnvmf_context_set_connection;
 		libnvmf_context_set_crypto;
 		libnvmf_context_set_device;
-		libnvmf_context_set_discovery_cbs;
+		libnvmf_context_set_discovery_hooks;
 		libnvmf_context_set_discovery_defaults;
 		libnvmf_context_set_fabrics_config;
 		libnvmf_context_set_hostnqn;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -222,11 +222,11 @@ __libnvme_public int libnvmf_context_create(struct libnvme_global_ctx *ctx,
 
 	libnvmf_default_config(&fctx->cfg);
 
-	fctx->decide_retry = decide_retry;
-	fctx->connected = connected;
-	fctx->already_connected = already_connected;
+	fctx->hooks.decide_retry = decide_retry;
+	fctx->hooks.connected = connected;
+	fctx->hooks.already_connected = already_connected;
 
-	fctx->user_data = user_data;
+	fctx->hooks.user_data = user_data;
 
 	*fctxp = fctx;
 	return 0;
@@ -254,10 +254,10 @@ __libnvme_public int libnvmf_context_set_discovery_hooks(
 		int (*parser_next_line)(struct libnvmf_context *fctx,
 			void *user_data))
 {
-	fctx->discovery_log = discovery_log;
-	fctx->parser_init = parser_init;
-	fctx->parser_cleanup = parser_cleanup;
-	fctx->parser_next_line = parser_next_line;
+	fctx->hooks.discovery_log = discovery_log;
+	fctx->hooks.parser_init = parser_init;
+	fctx->hooks.parser_cleanup = parser_cleanup;
+	fctx->hooks.parser_next_line = parser_next_line;
 
 	return 0;
 }
@@ -2077,9 +2077,9 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 	}
 
 	numrec = le64_to_cpu(log->numrec);
-	if (fctx->discovery_log)
-		fctx->discovery_log(fctx, connect, log, numrec,
-			fctx->user_data);
+	if (fctx->hooks.discovery_log)
+		fctx->hooks.discovery_log(fctx, connect, log, numrec,
+			fctx->hooks.user_data);
 
 	if (!connect)
 		return 0;
@@ -2159,9 +2159,9 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 		} else if (err == -ENVME_CONNECT_ALREADY) {
 			struct nvmf_disc_log_entry *e = &log->entries[i];
 
-			nfctx.already_connected(&nfctx, h, e->subnqn,
+			nfctx.hooks.already_connected(&nfctx, h, e->subnqn,
 				libnvmf_trtype_str(e->trtype), e->traddr,
-				e->trsvcid, nfctx.user_data);
+				e->trsvcid, nfctx.hooks.user_data);
 		}
 	}
 
@@ -2204,7 +2204,7 @@ retry:
 	err = libnvmf_add_ctrl(h, c);
 	if (!err)
 		return 0;
-	if (fctx->decide_retry(fctx, err, fctx->user_data))
+	if (fctx->hooks.decide_retry(fctx, err, fctx->hooks.user_data))
 		goto retry;
 
 	return err;
@@ -2503,12 +2503,12 @@ __libnvme_public int libnvmf_discovery_config_file(
 	if (err)
 		return err;
 
-	err = fctx->parser_init(fctx, fctx->user_data);
+	err = fctx->hooks.parser_init(fctx, fctx->hooks.user_data);
 	if (err)
 		return err;
 
 	do {
-		err = fctx->parser_next_line(fctx, fctx->user_data);
+		err = fctx->hooks.parser_next_line(fctx, fctx->hooks.user_data);
 		if (err)
 			break;
 
@@ -2533,7 +2533,7 @@ __libnvme_public int libnvmf_discovery_config_file(
 		libnvme_free_ctrl(c);
 	} while (!err);
 
-	fctx->parser_cleanup(fctx, fctx->user_data);
+	fctx->hooks.parser_cleanup(fctx, fctx->hooks.user_data);
 
 	if (err != -EOF)
 		return err;
@@ -2730,8 +2730,8 @@ static int nbft_connect(struct libnvme_global_ctx *ctx,
 		return ret;
 	}
 
-	if (fctx->connected)
-		fctx->connected(fctx, c, fctx->user_data);
+	if (fctx->hooks.connected)
+		fctx->hooks.connected(fctx, c, fctx->hooks.user_data);
 
 	return 0;
 }
@@ -3159,9 +3159,11 @@ __libnvme_public int libnvmf_connect(
 
 	c = lookup_ctrl(h, fctx);
 	if (c && libnvme_ctrl_get_name(c) && !fctx->cfg.duplicate_connect) {
-		fctx->already_connected(fctx, h, libnvme_ctrl_get_subsysnqn(c),
-			libnvme_ctrl_get_transport(c), libnvme_ctrl_get_traddr(c),
-			libnvme_ctrl_get_trsvcid(c), fctx->user_data);
+		fctx->hooks.already_connected(fctx, h,
+			libnvme_ctrl_get_subsysnqn(c),
+			libnvme_ctrl_get_transport(c),
+			libnvme_ctrl_get_traddr(c),
+			libnvme_ctrl_get_trsvcid(c), fctx->hooks.user_data);
 		return -EALREADY;
 	}
 
@@ -3196,7 +3198,7 @@ __libnvme_public int libnvmf_connect(
 		return err;
 	}
 
-	fctx->connected(fctx, c, fctx->user_data);
+	fctx->hooks.connected(fctx, c, fctx->hooks.user_data);
 
 	return 0;
 }

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3169,6 +3169,7 @@ __libnvme_public int libnvmf_connect(
 
 	nvme_parse_tls_args(fctx->keyring, fctx->tls_key,
 		fctx->tls_key_identity, &fctx->ctrl_params.cfg, c);
+	update_config(c, &fctx->ctrl_params.cfg);
 
 	/*
 	 * We are connecting to a discovery controller, so let's treat

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -220,7 +220,7 @@ __libnvme_public int libnvmf_context_create(struct libnvme_global_ctx *ctx,
 
 	fctx->ctx = ctx;
 
-	libnvmf_default_config(&fctx->cfg);
+	libnvmf_default_config(&fctx->ctrl_params.cfg);
 
 	fctx->hooks.decide_retry = decide_retry;
 	fctx->hooks.connected = connected;
@@ -276,25 +276,7 @@ __libnvme_public int libnvmf_context_set_fabrics_config(
 		struct libnvmf_context *fctx,
 		struct libnvme_fabrics_config *cfg)
 {
-	fctx->cfg.queue_size = cfg->queue_size;
-	fctx->cfg.nr_io_queues = cfg->nr_io_queues;
-	fctx->cfg.reconnect_delay = cfg->reconnect_delay;
-	fctx->cfg.ctrl_loss_tmo = cfg->ctrl_loss_tmo;
-	fctx->cfg.fast_io_fail_tmo = cfg->fast_io_fail_tmo;
-	fctx->cfg.keep_alive_tmo = cfg->keep_alive_tmo;
-	fctx->cfg.nr_write_queues = cfg->nr_write_queues;
-	fctx->cfg.nr_poll_queues = cfg->nr_poll_queues;
-	fctx->cfg.tos = cfg->tos;
-	fctx->cfg.keyring_id = cfg->keyring_id;
-	fctx->cfg.tls_key_id = cfg->tls_key_id;
-	fctx->cfg.tls_configured_key_id = cfg->tls_configured_key_id;
-	fctx->cfg.duplicate_connect = cfg->duplicate_connect;
-	fctx->cfg.disable_sqflow = cfg->disable_sqflow;
-	fctx->cfg.hdr_digest = cfg->hdr_digest;
-	fctx->cfg.data_digest = cfg->data_digest;
-	fctx->cfg.tls = cfg->tls;
-	fctx->cfg.concat = cfg->concat;
-
+	libnvme_fabrics_config_copy(&fctx->ctrl_params.cfg, cfg);
 	return 0;
 }
 
@@ -303,12 +285,12 @@ __libnvme_public int libnvmf_context_set_connection(
 		const char *transport, const char *traddr, const char *trsvcid,
 		const char *host_traddr, const char *host_iface)
 {
-	fctx->subsysnqn = subsysnqn;
-	fctx->transport = transport;
-	fctx->traddr = traddr;
-	fctx->trsvcid = trsvcid;
-	fctx->host_traddr = host_traddr;
-	fctx->host_iface = host_iface;
+	fctx->ctrl_params.subsysnqn = subsysnqn;
+	fctx->ctrl_params.transport = transport;
+	fctx->ctrl_params.traddr = traddr;
+	fctx->ctrl_params.trsvcid = trsvcid;
+	fctx->ctrl_params.host_traddr = host_traddr;
+	fctx->ctrl_params.host_iface = host_iface;
 
 	return 0;
 }
@@ -396,7 +378,7 @@ __libnvme_public int libnvmf_context_set_device(
 __libnvme_public struct libnvme_fabrics_config *libnvmf_context_get_fabrics_config(
 		struct libnvmf_context *fctx)
 {
-	return &fctx->cfg;
+	return &fctx->ctrl_params.cfg;
 }
 
 __libnvme_public struct libnvme_fabrics_config *libnvmf_ctrl_get_fabrics_config(
@@ -1072,20 +1054,16 @@ static int __nvmf_add_ctrl(struct libnvme_global_ctx *ctx, const char *argstr)
 
 static const char *lookup_context(struct libnvme_global_ctx *ctx, libnvme_ctrl_t c)
 {
-
+	struct libnvmf_context fctx = {};
 	libnvme_host_t h;
 	libnvme_subsystem_t s;
 
+	fctx.ctrl_params.transport = libnvme_ctrl_get_transport(c);
+	fctx.ctrl_params.traddr = libnvme_ctrl_get_traddr(c);
+	fctx.ctrl_params.trsvcid = libnvme_ctrl_get_trsvcid(c);
+
 	libnvme_for_each_host(ctx, h) {
 		libnvme_for_each_subsystem(h, s) {
-			struct libnvmf_context fctx = {
-				.transport = libnvme_ctrl_get_transport(c),
-				.traddr = libnvme_ctrl_get_traddr(c),
-				.host_traddr = NULL,
-				.host_iface = NULL,
-				.trsvcid = libnvme_ctrl_get_trsvcid(c),
-				.subsysnqn = NULL,
-			};
 			if (libnvmf_ctrl_find(s, &fctx))
 				return libnvme_subsystem_get_application(s);
 		}
@@ -1097,7 +1075,7 @@ static const char *lookup_context(struct libnvme_global_ctx *ctx, libnvme_ctrl_t
 __libnvme_public int libnvmf_create_ctrl(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, libnvme_ctrl_t *cp)
 {
-	return libnvme_create_ctrl(ctx, fctx, cp);
+	return libnvme_create_ctrl(ctx, &fctx->ctrl_params, cp);
 }
 
 __libnvme_public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
@@ -1116,12 +1094,13 @@ __libnvme_public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
 	if (s) {
 		libnvme_ctrl_t fc;
 		struct libnvmf_context fctx = {
-			.transport = libnvme_ctrl_get_transport(c),
-			.traddr = libnvme_ctrl_get_traddr(c),
-			.host_traddr = libnvme_ctrl_get_host_traddr(c),
-			.host_iface = libnvme_ctrl_get_trsvcid(c),
-			.trsvcid = libnvme_ctrl_get_trsvcid(c),
-			.subsysnqn = NULL,
+			.ctrl_params = {
+				.transport = libnvme_ctrl_get_transport(c),
+				.traddr = libnvme_ctrl_get_traddr(c),
+				.host_traddr = libnvme_ctrl_get_host_traddr(c),
+				.host_iface = libnvme_ctrl_get_trsvcid(c),
+				.trsvcid = libnvme_ctrl_get_trsvcid(c),
+			},
 		};
 
 		fc = libnvmf_ctrl_find(s, &fctx);
@@ -1275,8 +1254,8 @@ static int nvmf_connect_disc_entry(libnvme_host_t h,
 		switch (e->adrfam) {
 		case NVMF_ADDR_FAMILY_IP4:
 		case NVMF_ADDR_FAMILY_IP6:
-			fctx->traddr = e->traddr;
-			fctx->trsvcid = e->trsvcid;
+			fctx->ctrl_params.traddr = e->traddr;
+			fctx->ctrl_params.trsvcid = e->trsvcid;
 			break;
 		default:
 			libnvme_msg(h->ctx, LIBNVME_LOG_ERR,
@@ -1288,7 +1267,7 @@ static int nvmf_connect_disc_entry(libnvme_host_t h,
         case NVMF_TRTYPE_FC:
 		switch (e->adrfam) {
 		case NVMF_ADDR_FAMILY_FC:
-			fctx->traddr = e->traddr;
+			fctx->ctrl_params.traddr = e->traddr;
 			break;
 		default:
 			libnvme_msg(h->ctx, LIBNVME_LOG_ERR,
@@ -1298,7 +1277,7 @@ static int nvmf_connect_disc_entry(libnvme_host_t h,
 		}
 		break;
 	case NVMF_TRTYPE_LOOP:
-		fctx->traddr = strlen(e->traddr) ? e->traddr : NULL;
+		fctx->ctrl_params.traddr = strlen(e->traddr) ? e->traddr : NULL;
 		break;
 	default:
 		libnvme_msg(h->ctx, LIBNVME_LOG_ERR, "skipping unsupported transport %d\n",
@@ -1306,18 +1285,19 @@ static int nvmf_connect_disc_entry(libnvme_host_t h,
 		return -EINVAL;
 	}
 
-	fctx->transport = libnvmf_trtype_str(e->trtype);
-	fctx->subsysnqn = e->subnqn;
+	fctx->ctrl_params.transport = libnvmf_trtype_str(e->trtype);
+	fctx->ctrl_params.subsysnqn = e->subnqn;
 
-	libnvme_msg(h->ctx, LIBNVME_LOG_DEBUG, "lookup ctrl "
-		 "(transport: %s, traddr: %s, trsvcid %s)\n",
-		 fctx->transport, fctx->traddr, fctx->trsvcid);
+	libnvme_msg(h->ctx, LIBNVME_LOG_DEBUG,
+		 "lookup ctrl (transport: %s, traddr: %s, trsvcid %s)\n",
+		 fctx->ctrl_params.transport, fctx->ctrl_params.traddr,
+		 fctx->ctrl_params.trsvcid);
 
-	ret = libnvme_create_ctrl(h->ctx, fctx, &c);
+	ret = libnvme_create_ctrl(h->ctx, &fctx->ctrl_params, &c);
 	if (ret) {
 		libnvme_msg(h->ctx, LIBNVME_LOG_DEBUG, "skipping discovery entry, "
 			 "failed to allocate %s controller with traddr %s\n",
-			 fctx->transport, fctx->traddr);
+			 fctx->ctrl_params.transport, fctx->ctrl_params.traddr);
 		return ret;
 	}
 
@@ -2003,9 +1983,10 @@ static int setup_connection(struct libnvmf_context *fctx, struct libnvme_host *h
 	if (fctx->hostkey)
 		libnvme_host_set_dhchap_host_key(h, fctx->hostkey);
 
-	if (!fctx->trsvcid)
-		fctx->trsvcid = libnvmf_get_default_trsvcid(fctx->transport,
-			discovery);
+	if (!fctx->ctrl_params.trsvcid)
+		fctx->ctrl_params.trsvcid =
+			libnvmf_get_default_trsvcid(fctx->ctrl_params.transport,
+				discovery);
 
 	return 0;
 }
@@ -2013,14 +1994,16 @@ static int setup_connection(struct libnvmf_context *fctx, struct libnvme_host *h
 
 static int set_discovery_kato(struct libnvmf_context *fctx)
 {
-	int tmo = fctx->cfg.keep_alive_tmo;
+	int tmo = fctx->ctrl_params.cfg.keep_alive_tmo;
 
 	/* Set kato to NVMF_DEF_DISC_TMO for persistent controllers */
-	if (fctx->persistent && !fctx->cfg.keep_alive_tmo)
-		fctx->cfg.keep_alive_tmo = fctx->default_keep_alive_timeout;
+	if (fctx->persistent && !fctx->ctrl_params.cfg.keep_alive_tmo)
+		fctx->ctrl_params.cfg.keep_alive_tmo =
+			fctx->default_keep_alive_timeout;
 	/* Set kato to zero for non-persistent controllers */
-	else if (!fctx->persistent && (fctx->cfg.keep_alive_tmo > 0))
-		fctx->cfg.keep_alive_tmo = 0;
+	else if (!fctx->persistent &&
+		 (fctx->ctrl_params.cfg.keep_alive_tmo > 0))
+		fctx->ctrl_params.cfg.keep_alive_tmo = 0;
 
 	return tmo;
 }
@@ -2090,16 +2073,16 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 		bool discover = false;
 		bool disconnect;
 		libnvme_ctrl_t child = { 0 };
-		int tmo = fctx->cfg.keep_alive_tmo;
+		int tmo = fctx->ctrl_params.cfg.keep_alive_tmo;
 		struct libnvmf_context nfctx = *fctx;
 
 		sanitize_discovery_log_entry(c->ctx, e);
 
-		nfctx.subsysnqn = e->subnqn;
-		nfctx.transport = libnvmf_trtype_str(e->trtype);
-		nfctx.traddr = e->traddr;
-		nfctx.trsvcid = e->trsvcid;
-		nfctx.cfg = fctx->cfg;
+		nfctx.ctrl_params.subsysnqn = e->subnqn;
+		nfctx.ctrl_params.transport = libnvmf_trtype_str(e->trtype);
+		nfctx.ctrl_params.traddr = e->traddr;
+		nfctx.ctrl_params.trsvcid = e->trsvcid;
+		nfctx.ctrl_params.cfg = fctx->ctrl_params.cfg;
 
 		/* Already connected ? */
 		cl = lookup_ctrl(h, &nfctx);
@@ -2108,7 +2091,7 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 
 		/* Skip connect if the transport types don't match */
 		if (strcmp(libnvme_ctrl_get_transport(c),
-			   nfctx.transport))
+			   nfctx.ctrl_params.transport))
 			continue;
 
 		if (e->subtype == NVME_NQN_DISC ||
@@ -2146,7 +2129,7 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 
 		err = nvmf_connect_disc_entry(h, e, &nfctx, &discover, &child);
 
-		nfctx.cfg.keep_alive_tmo = tmo;
+		nfctx.ctrl_params.cfg.keep_alive_tmo = tmo;
 
 		if (!child) {
 			if (discover)
@@ -2217,13 +2200,14 @@ static int __create_discovery_ctrl(struct libnvme_global_ctx *ctx,
 	libnvme_ctrl_t c;
 	int tmo, ret;
 
-	ret = libnvme_create_ctrl(ctx, fctx, &c);
+	ret = libnvme_create_ctrl(ctx, &fctx->ctrl_params, &c);
 	if (ret)
 		return ret;
 
 	libnvme_ctrl_set_discovery_ctrl(c, true);
 	libnvme_ctrl_set_unique_discovery_ctrl(c,
-		     strcmp(fctx->subsysnqn, NVME_DISC_SUBSYS_NAME));
+		strcmp(fctx->ctrl_params.subsysnqn,
+		       NVME_DISC_SUBSYS_NAME));
 	tmo = set_discovery_kato(fctx);
 
 	if (libnvme_ctrl_get_unique_discovery_ctrl(c) && fctx->hostkey) {
@@ -2233,7 +2217,7 @@ static int __create_discovery_ctrl(struct libnvme_global_ctx *ctx,
 	}
 
 	ret = libnvme_add_ctrl(fctx, h, c);
-	fctx->cfg.keep_alive_tmo = tmo;
+	fctx->ctrl_params.cfg.keep_alive_tmo = tmo;
 	if (ret) {
 		libnvme_free_ctrl(c);
 		return ret;
@@ -2295,7 +2279,7 @@ static int nvmf_create_discovery_ctrl(struct libnvme_global_ctx *ctx,
 	libnvmf_disconnect_ctrl(c);
 	libnvme_free_ctrl(c);
 
-	fctx->subsysnqn = id->subnqn;
+	fctx->ctrl_params.subsysnqn = id->subnqn;
 	ret = __create_discovery_ctrl(ctx, fctx, h, &c);
 	if (ret)
 		return ret;
@@ -2312,23 +2296,23 @@ int _discovery_config_json(struct libnvme_global_ctx *ctx,
 	libnvme_ctrl_t cn;
 	int ret = 0;
 
-	nfctx.transport = libnvme_ctrl_get_transport(c);
-	nfctx.traddr = libnvme_ctrl_get_traddr(c);
-	nfctx.host_traddr = libnvme_ctrl_get_host_traddr(c);
-	nfctx.host_iface = libnvme_ctrl_get_host_iface(c);
+	nfctx.ctrl_params.transport = libnvme_ctrl_get_transport(c);
+	nfctx.ctrl_params.traddr = libnvme_ctrl_get_traddr(c);
+	nfctx.ctrl_params.host_traddr = libnvme_ctrl_get_host_traddr(c);
+	nfctx.ctrl_params.host_iface = libnvme_ctrl_get_host_iface(c);
 
-	if (!nfctx.transport && !nfctx.traddr)
+	if (!nfctx.ctrl_params.transport && !nfctx.ctrl_params.traddr)
 		return 0;
 
 	/* ignore none fabric transports */
-	if (strcmp(nfctx.transport, "tcp") &&
-	    strcmp(nfctx.transport, "rdma") &&
-	    strcmp(nfctx.transport, "fc"))
+	if (strcmp(nfctx.ctrl_params.transport, "tcp") &&
+	    strcmp(nfctx.ctrl_params.transport, "rdma") &&
+	    strcmp(nfctx.ctrl_params.transport, "fc"))
 		return 0;
 
 	/* ignore if no host_traddr for fc */
-	if (!strcmp(nfctx.transport, "fc")) {
-		if (!nfctx.host_traddr) {
+	if (!strcmp(nfctx.ctrl_params.transport, "fc")) {
+		if (!nfctx.ctrl_params.host_traddr) {
 			libnvme_msg(ctx, LIBNVME_LOG_ERR,
 				 "host_traddr required for fc\n");
 			return 0;
@@ -2336,24 +2320,26 @@ int _discovery_config_json(struct libnvme_global_ctx *ctx,
 	}
 
 	/* ignore if host_iface set for any transport other than tcp */
-	if (!strcmp(nfctx.transport, "rdma") ||
-	    !strcmp(nfctx.transport, "fc")) {
-		if (nfctx.host_iface) {
+	if (!strcmp(nfctx.ctrl_params.transport, "rdma") ||
+	    !strcmp(nfctx.ctrl_params.transport, "fc")) {
+		if (nfctx.ctrl_params.host_iface) {
 			libnvme_msg(ctx, LIBNVME_LOG_ERR,
 				 "host_iface not permitted for rdma or fc\n");
 			return 0;
 		}
 	}
 
-	nfctx.trsvcid = libnvme_ctrl_get_trsvcid(c);
-	if (!nfctx.trsvcid || !strcmp(nfctx.trsvcid, ""))
-		nfctx.trsvcid =
-			libnvmf_get_default_trsvcid(nfctx.transport, true);
+	nfctx.ctrl_params.trsvcid = libnvme_ctrl_get_trsvcid(c);
+	if (!nfctx.ctrl_params.trsvcid ||
+	    !strcmp(nfctx.ctrl_params.trsvcid, ""))
+		nfctx.ctrl_params.trsvcid =
+			libnvmf_get_default_trsvcid(
+				nfctx.ctrl_params.transport, true);
 
 	if (force)
-		nfctx.subsysnqn = libnvme_ctrl_get_subsysnqn(c);
+		nfctx.ctrl_params.subsysnqn = libnvme_ctrl_get_subsysnqn(c);
 	else
-		nfctx.subsysnqn = NVME_DISC_SUBSYS_NAME;
+		nfctx.ctrl_params.subsysnqn = NVME_DISC_SUBSYS_NAME;
 
 	if (libnvme_ctrl_get_persistent(c))
 		nfctx.persistent = true;
@@ -2565,10 +2551,10 @@ __libnvme_public int libnvmf_config_modify(struct libnvme_global_ctx *ctx,
 	if (fctx->hostkey)
 		libnvme_host_set_dhchap_host_key(h, fctx->hostkey);
 
-	s = libnvme_lookup_subsystem(h, NULL, fctx->subsysnqn);
+	s = libnvme_lookup_subsystem(h, NULL, fctx->ctrl_params.subsysnqn);
 	if (!s) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to lookup subsystem '%s'\n",
-			fctx->subsysnqn);
+			fctx->ctrl_params.subsysnqn);
 		return -ENODEV;
 	}
 
@@ -2581,9 +2567,9 @@ __libnvme_public int libnvmf_config_modify(struct libnvme_global_ctx *ctx,
 		libnvme_ctrl_set_dhchap_ctrl_key(c, fctx->ctrlkey);
 
 	nvme_parse_tls_args(fctx->keyring, fctx->tls_key,
-			    fctx->tls_key_identity, &fctx->cfg, c);
+			    fctx->tls_key_identity, &fctx->ctrl_params.cfg, c);
 
-	update_config(c, &fctx->cfg);
+	update_config(c, &fctx->ctrl_params.cfg);
 
 	return 0;
 }
@@ -2695,7 +2681,7 @@ static int nbft_connect(struct libnvme_global_ctx *ctx,
 	if (c && libnvme_ctrl_get_name(c))
 		return 0;
 
-	ret = libnvme_create_ctrl(ctx, fctx, &c);
+	ret = libnvme_create_ctrl(ctx, &fctx->ctrl_params, &c);
 	if (ret)
 		return ret;
 
@@ -2761,14 +2747,14 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 		struct nvmf_disc_log_entry *e = &log->entries[i];
 		struct libnvmf_context nfctx = *fctx;
 		libnvme_ctrl_t cl;
-		int tmo = fctx->cfg.keep_alive_tmo;
+		int tmo = fctx->ctrl_params.cfg.keep_alive_tmo;
 
 		sanitize_discovery_log_entry(c->ctx, e);
 
-		nfctx.subsysnqn = e->subnqn;
-		nfctx.transport = libnvmf_trtype_str(e->trtype);
-		nfctx.traddr = e->traddr;
-		nfctx.trsvcid = e->trsvcid;
+		nfctx.ctrl_params.subsysnqn = e->subnqn;
+		nfctx.ctrl_params.transport = libnvmf_trtype_str(e->trtype);
+		nfctx.ctrl_params.traddr = e->traddr;
+		nfctx.ctrl_params.trsvcid = e->trsvcid;
 
 		if (e->subtype == NVME_NQN_CURR)
 			continue;
@@ -2780,7 +2766,7 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 
 		/* Skip connect if the transport types don't match */
 		if (strcmp(libnvme_ctrl_get_transport(c),
-			   nfctx.transport))
+			   nfctx.ctrl_params.transport))
 			continue;
 
 		if (e->subtype == NVME_NQN_DISC) {
@@ -2802,11 +2788,12 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 			 * firmware had. Retry without host_traddr.
 			 */
 			if (ret == -ENVME_CONNECT_ADDRNOTAVAIL &&
-			    !strcmp(nfctx.transport, "tcp") &&
+			    !strcmp(nfctx.ctrl_params.transport, "tcp") &&
 			    strlen(dd->hfi->tcp_info.dhcp_server_ipaddr) > 0) {
-				const char *htradr = nfctx.host_traddr;
+				const char *htradr =
+					nfctx.ctrl_params.host_traddr;
 
-				nfctx.host_traddr = NULL;
+				nfctx.ctrl_params.host_traddr = NULL;
 				ret = nbft_connect(ctx, &nfctx, h, e, NULL);
 
 				if (ret == 0)
@@ -2824,7 +2811,7 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 				break;
 		}
 
-		fctx->cfg.keep_alive_tmo = tmo;
+		fctx->ctrl_params.cfg.keep_alive_tmo = tmo;
 	}
 
 	libnvme_free(log);
@@ -2906,17 +2893,17 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 					continue;
 				}
 
-				nfctx.host_traddr = NULL;
-				if (!fctx->host_traddr &&
+				nfctx.ctrl_params.host_traddr = NULL;
+				if (!fctx->ctrl_params.host_traddr &&
 				    !strncmp((*ss)->transport, "tcp", 3))
-					nfctx.host_traddr =
+					nfctx.ctrl_params.host_traddr =
 						hfi->tcp_info.ipaddr;
 
-				nfctx.subsysnqn = (*ss)->subsys_nqn;
-				nfctx.transport = (*ss)->transport;
-				nfctx.traddr = (*ss)->traddr;
-				nfctx.trsvcid = (*ss)->trsvcid;
-				nfctx.host_iface = NULL;
+				nfctx.ctrl_params.subsysnqn = (*ss)->subsys_nqn;
+				nfctx.ctrl_params.transport = (*ss)->transport;
+				nfctx.ctrl_params.traddr = (*ss)->traddr;
+				nfctx.ctrl_params.trsvcid = (*ss)->trsvcid;
+				nfctx.ctrl_params.host_iface = NULL;
 
 				rr = nbft_connect(ctx, &nfctx, h, NULL, *ss);
 
@@ -2926,9 +2913,10 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 				 * firmware had. Retry without host_traddr.
 				 */
 				if (rr == -ENVME_CONNECT_ADDRNOTAVAIL &&
-				    !strcmp(nfctx.transport, "tcp") &&
+				    !strcmp(nfctx.ctrl_params.transport,
+					    "tcp") &&
 				    strlen(hfi->tcp_info.dhcp_server_ipaddr) > 0) {
-					nfctx.host_traddr = NULL;
+					nfctx.ctrl_params.host_traddr = NULL;
 
 					rr = nbft_connect(ctx, &nfctx, h, NULL,
 						*ss);
@@ -2986,7 +2974,7 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 				continue;
 
 			host_traddr = NULL;
-			if (!fctx->host_traddr &&
+			if (!fctx->ctrl_params.host_traddr &&
 			    !strncmp(uri->protocol, "tcp", 3))
 				host_traddr = hfi->tcp_info.ipaddr;
 			if (uri->port > 0) {
@@ -2999,12 +2987,12 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 					strdup(libnvmf_get_default_trsvcid(
 						uri->protocol, true));
 
-			nfctx.subsysnqn = NVME_DISC_SUBSYS_NAME;
-			nfctx.transport =  uri->protocol;
-			nfctx.traddr = uri->host;
-			nfctx.trsvcid = trsvcid;
-			nfctx.host_traddr = host_traddr;
-			nfctx.host_iface = NULL;
+			nfctx.ctrl_params.subsysnqn = NVME_DISC_SUBSYS_NAME;
+			nfctx.ctrl_params.transport =  uri->protocol;
+			nfctx.ctrl_params.traddr = uri->host;
+			nfctx.ctrl_params.trsvcid = trsvcid;
+			nfctx.ctrl_params.host_traddr = host_traddr;
+			nfctx.ctrl_params.host_iface = NULL;
 
 			/* Lookup existing discovery controller */
 			c = lookup_ctrl(h, &nfctx);
@@ -3015,9 +3003,10 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 				ret = nvmf_create_discovery_ctrl(ctx, &nfctx,
 					h, &c);
 				if (ret == -ENVME_CONNECT_ADDRNOTAVAIL &&
-				    !strcmp(nfctx.transport, "tcp") &&
+				    !strcmp(nfctx.ctrl_params.transport,
+					    "tcp") &&
 				    strlen(hfi->tcp_info.dhcp_server_ipaddr) > 0) {
-					nfctx.traddr = NULL;
+					nfctx.ctrl_params.traddr = NULL;
 					ret = nvmf_create_discovery_ctrl(ctx,
 						&nfctx, h, &c);
 				}
@@ -3098,11 +3087,11 @@ __libnvme_public int libnvmf_discovery(
 				 * for the udev rules). This ensures that host-traddr/
 				 * host-iface are consistent with the discovery controller (c).
 				 */
-				if (!fctx->host_traddr)
-					fctx->host_traddr = (char *)
+				if (!fctx->ctrl_params.host_traddr)
+					fctx->ctrl_params.host_traddr = (char *)
 						libnvme_ctrl_get_host_traddr(c);
-				if (!fctx->host_iface)
-					fctx->host_iface = (char *)
+				if (!fctx->ctrl_params.host_iface)
+					fctx->ctrl_params.host_iface = (char *)
 						libnvme_ctrl_get_host_iface(c);
 			}
 		} else {
@@ -3158,7 +3147,8 @@ __libnvme_public int libnvmf_connect(
 		return err;
 
 	c = lookup_ctrl(h, fctx);
-	if (c && libnvme_ctrl_get_name(c) && !fctx->cfg.duplicate_connect) {
+	if (c && libnvme_ctrl_get_name(c) &&
+	    !fctx->ctrl_params.cfg.duplicate_connect) {
 		fctx->hooks.already_connected(fctx, h,
 			libnvme_ctrl_get_subsysnqn(c),
 			libnvme_ctrl_get_transport(c),
@@ -3167,7 +3157,7 @@ __libnvme_public int libnvmf_connect(
 		return -EALREADY;
 	}
 
-	err = libnvme_create_ctrl(ctx, fctx, &c);
+	err = libnvme_create_ctrl(ctx, &fctx->ctrl_params, &c);
 	if (err)
 		return err;
 
@@ -3178,13 +3168,13 @@ __libnvme_public int libnvmf_connect(
 	}
 
 	nvme_parse_tls_args(fctx->keyring, fctx->tls_key,
-		fctx->tls_key_identity, &fctx->cfg, c);
+		fctx->tls_key_identity, &fctx->ctrl_params.cfg, c);
 
 	/*
 	 * We are connecting to a discovery controller, so let's treat
 	 * this as a persistent connection and specify a KATO.
 	 */
-	if (!strcmp(fctx->subsysnqn, NVME_DISC_SUBSYS_NAME)) {
+	if (!strcmp(fctx->ctrl_params.subsysnqn, NVME_DISC_SUBSYS_NAME)) {
 		fctx->persistent = true;
 
 		set_discovery_kato(fctx);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -241,7 +241,7 @@ __libnvme_public void libnvmf_context_free(struct libnvmf_context *fctx)
 	free(fctx);
 }
 
-__libnvme_public int libnvmf_context_set_discovery_cbs(
+__libnvme_public int libnvmf_context_set_discovery_hooks(
 		struct libnvmf_context *fctx,
 		void (*discovery_log)(struct libnvmf_context *fctx,
 			bool connect,

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2082,7 +2082,6 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 		nfctx.ctrl_params.transport = libnvmf_trtype_str(e->trtype);
 		nfctx.ctrl_params.traddr = e->traddr;
 		nfctx.ctrl_params.trsvcid = e->trsvcid;
-		nfctx.ctrl_params.cfg = fctx->ctrl_params.cfg;
 
 		/* Already connected ? */
 		cl = lookup_ctrl(h, &nfctx);
@@ -2558,7 +2557,7 @@ __libnvme_public int libnvmf_config_modify(struct libnvme_global_ctx *ctx,
 		return -ENODEV;
 	}
 
-	c = libnvme_lookup_ctrl(s, fctx, NULL);
+	c = libnvme_lookup_ctrl(s, &fctx->ctrl_params, NULL);
 	if (!c) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to lookup controller\n");
 		return -ENODEV;

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -252,10 +252,10 @@ const char *libnvmf_get_default_trsvcid(const char *transport,
 /**
  * libnvmf_context_create() - Create a new fabrics context for discovery/connect
  * @ctx: Global context
- * @decide_retry: Callback to decide if a retry should be attempted
- * @connected: Callback invoked when a connection is established
- * @already_connected: Callback invoked if already connected
- * @user_data: User data passed to callbacks
+ * @decide_retry: Hook to decide if a retry should be attempted
+ * @connected: Hook invoked when a connection is established
+ * @already_connected: Hook invoked if already connected
+ * @user_data: User data passed to hooks
  * @fctxp: Pointer to store the created context
  *
  * Allocates and initializes a new fabrics context for discovery/connect
@@ -286,18 +286,18 @@ int libnvmf_context_create(struct libnvme_global_ctx *ctx,
 void libnvmf_context_free(struct libnvmf_context *fctx);
 
 /**
- * libnvmf_context_set_discovery_cbs() - Set discovery callbacks for context
+ * libnvmf_context_set_discovery_hooks() - Set discovery hooks for context
  * @fctx: Fabrics context
- * @discovery_log: Callback for discovery log events
- * @parser_init: Callback to initialize parser
- * @parser_cleanup: Callback to cleanup parser
- * @parser_next_line: Callback to parse next line
+ * @discovery_log: Hook for discovery log events
+ * @parser_init: Hook to initialize parser
+ * @parser_cleanup: Hook to cleanup parser
+ * @parser_next_line: Hook to parse next line
  *
- * Sets the callbacks used during discovery operations for the given context.
+ * Sets the hooks used during discovery operations for the given context.
  *
  * Return: 0 on success, or a negative error code on failure.
  */
-int libnvmf_context_set_discovery_cbs(struct libnvmf_context *fctx,
+int libnvmf_context_set_discovery_hooks(struct libnvmf_context *fctx,
 		void (*discovery_log)(struct libnvmf_context *fctx,
 			bool connect, struct nvmf_discovery_log *log,
 			uint64_t numrec, void *user_data),

--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -89,19 +89,19 @@ static void json_parse_port(libnvme_subsystem_t s, struct json_object *port_obj)
 	attr_obj = json_object_object_get(port_obj, "transport");
 	if (!attr_obj)
 		return;
-	fctx.transport = json_object_get_string(attr_obj);
+	fctx.ctrl_params.transport = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "traddr");
 	if (attr_obj)
-		fctx.traddr = json_object_get_string(attr_obj);
+		fctx.ctrl_params.traddr = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "host_traddr");
 	if (attr_obj)
-		fctx.host_traddr = json_object_get_string(attr_obj);
+		fctx.ctrl_params.host_traddr = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "host_iface");
 	if (attr_obj)
-		fctx.host_iface = json_object_get_string(attr_obj);
+		fctx.ctrl_params.host_iface = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "trsvcid");
 	if (attr_obj)
-		fctx.trsvcid = json_object_get_string(attr_obj);
+		fctx.ctrl_params.trsvcid = json_object_get_string(attr_obj);
 	c = libnvme_lookup_ctrl(s, &fctx, NULL);
 	if (!c)
 		return;

--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -16,7 +16,6 @@
 
 #include "cleanup.h"
 #include "private.h"
-#include "private-fabrics.h"
 
 #define JSON_UPDATE_INT_OPTION(c, k, a, o)				\
 	if (!strcmp(# a, k ) && !c->a) c->a = json_object_get_int(o);
@@ -84,25 +83,25 @@ static void json_parse_port(libnvme_subsystem_t s, struct json_object *port_obj)
 {
 	libnvme_ctrl_t c;
 	struct json_object *attr_obj;
-	struct libnvmf_context fctx = {};
+	struct libnvme_ctrl_params params = {};
 
 	attr_obj = json_object_object_get(port_obj, "transport");
 	if (!attr_obj)
 		return;
-	fctx.ctrl_params.transport = json_object_get_string(attr_obj);
+	params.transport = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "traddr");
 	if (attr_obj)
-		fctx.ctrl_params.traddr = json_object_get_string(attr_obj);
+		params.traddr = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "host_traddr");
 	if (attr_obj)
-		fctx.ctrl_params.host_traddr = json_object_get_string(attr_obj);
+		params.host_traddr = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "host_iface");
 	if (attr_obj)
-		fctx.ctrl_params.host_iface = json_object_get_string(attr_obj);
+		params.host_iface = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(port_obj, "trsvcid");
 	if (attr_obj)
-		fctx.ctrl_params.trsvcid = json_object_get_string(attr_obj);
-	c = libnvme_lookup_ctrl(s, &fctx, NULL);
+		params.trsvcid = json_object_get_string(attr_obj);
+	c = libnvme_lookup_ctrl(s, &params, NULL);
 	if (!c)
 		return;
 	json_update_attributes(c, port_obj);

--- a/libnvme/src/nvme/no-fabrics.c
+++ b/libnvme/src/nvme/no-fabrics.c
@@ -20,7 +20,7 @@ void libnvmf_default_config(struct libnvme_fabrics_config *cfg)
 
 ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
 		struct candidate_args *candidate,
-		const struct libnvmf_context *fctx)
+		const struct libnvme_ctrl_params *params)
 {
 	return NULL;
 }

--- a/libnvme/src/nvme/no-fabrics.c
+++ b/libnvme/src/nvme/no-fabrics.c
@@ -6,7 +6,7 @@
  * Authors: Daniel Wagner <dwagner@suse.de>
  */
 
-#include "private-fabrics.h"
+#include "private.h"
 
 bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
 		const char *transport, const char *traddr)
@@ -18,14 +18,27 @@ void libnvmf_default_config(struct libnvme_fabrics_config *cfg)
 {
 }
 
-ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
-		struct candidate_args *candidate,
-		const struct libnvme_ctrl_params *params)
-{
-	return NULL;
-}
-
 void libnvmf_read_sysfs_fabrics_attrs(struct libnvme_global_ctx *ctx,
 		libnvme_ctrl_t c)
 {
+}
+
+libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
+		const struct libnvme_ctrl_params *params, libnvme_ctrl_t p)
+{
+#ifndef _WIN32
+	struct libnvme_ctrl *c;
+
+	c = p ? libnvme_subsystem_next_ctrl(s, p) :
+		libnvme_subsystem_first_ctrl(s);
+	for (; c; c = libnvme_subsystem_next_ctrl(s, c)) {
+		if (!streq0(c->transport, params->transport))
+			continue;
+		if (params->traddr && c->traddr &&
+		    !streqcase0(c->traddr, params->traddr))
+			continue;
+		return c;
+	}
+#endif
+	return NULL;
 }

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -19,7 +19,7 @@
 struct libnvmf_context {
 	struct libnvme_global_ctx *ctx;
 
-	/* common callbacks */
+	/* common hooks */
 	bool (*decide_retry)(struct libnvmf_context *fctx, int err,
 			void *user_data);
 	void (*connected)(struct libnvmf_context *fctx, struct libnvme_ctrl *c,
@@ -29,7 +29,7 @@ struct libnvmf_context {
 			const char *transport, const char *traddr,
 			const char *trsvcid, void *user_data);
 
-	/* discovery callbacks */
+	/* discovery hooks */
 	void (*discovery_log)(struct libnvmf_context *fctx,
 			bool connect,
 			struct nvmf_discovery_log *log,

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -46,6 +46,9 @@ struct libnvmf_context {
 	struct libnvme_global_ctx *ctx;
 	struct libnvmf_hooks hooks;
 
+	/* NVMe controller parameters */
+	struct libnvme_ctrl_params ctrl_params;
+
 	/* discovery defaults */
 	int default_max_discovery_retries;
 	int default_keep_alive_timeout;
@@ -53,15 +56,6 @@ struct libnvmf_context {
 	/* common fabrics configuration */
 	const char *device;
 	bool persistent;
-	struct libnvme_fabrics_config cfg;
-
-	/* connection configuration */
-	const char *subsysnqn;
-	const char *transport;
-	const char *traddr;
-	const char *trsvcid;
-	const char *host_traddr;
-	const char *host_iface;
 
 	/* host configuration */
 	const char *hostnqn;

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -187,20 +187,18 @@ bool libnvme_tree_ctrl_match(struct libnvme_ctrl *c,
 		struct candidate_args *candidate);
 ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
 		struct candidate_args *candidate,
-		const struct libnvmf_context *fctx);
+		const struct libnvme_ctrl_params *params);
 
 bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
 		const char *transport, const char *traddr);
 
 void libnvmf_default_config(struct libnvme_fabrics_config *cfg);
 
-void libnvmf_read_sysfs_fabrics_attrs(struct libnvme_global_ctx *ctx,
-		libnvme_ctrl_t c);
-
 ctrl_match_t libnvme_candidate_init(struct libnvme_global_ctx *ctx,
-		struct candidate_args *candidate, struct libnvmf_context *fctx);
+		struct candidate_args *candidate,
+		const struct libnvme_ctrl_params *params);
 libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
-		struct libnvmf_context *fctx, libnvme_ctrl_t p);
+		const struct libnvme_ctrl_params *params, libnvme_ctrl_t p);
 
 bool libnvmf_ctrl_match_config(struct libnvme_ctrl *c,
 		struct libnvmf_context *fctx);

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -183,23 +183,6 @@ struct candidate_args {
 typedef bool (*ctrl_match_t)(struct libnvme_ctrl *c,
 		struct candidate_args *candidate);
 
-bool libnvme_tree_ctrl_match(struct libnvme_ctrl *c,
-		struct candidate_args *candidate);
-ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
-		struct candidate_args *candidate,
-		const struct libnvme_ctrl_params *params);
-
-bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
-		const char *transport, const char *traddr);
-
-void libnvmf_default_config(struct libnvme_fabrics_config *cfg);
-
-ctrl_match_t libnvme_candidate_init(struct libnvme_global_ctx *ctx,
-		struct candidate_args *candidate,
-		const struct libnvme_ctrl_params *params);
-libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
-		const struct libnvme_ctrl_params *params, libnvme_ctrl_t p);
-
 bool libnvmf_ctrl_match_config(struct libnvme_ctrl *c,
 		struct libnvmf_context *fctx);
 struct libnvme_ctrl *libnvmf_ctrl_find(struct libnvme_subsystem *s,

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -16,9 +16,7 @@
 
 #include "nvme/private.h"
 
-struct libnvmf_context {
-	struct libnvme_global_ctx *ctx;
-
+struct libnvmf_hooks {
 	/* common hooks */
 	bool (*decide_retry)(struct libnvmf_context *fctx, int err,
 			void *user_data);
@@ -40,6 +38,13 @@ struct libnvmf_context {
 			void *user_data);
 	int (*parser_next_line)(struct libnvmf_context *fctx,
 			void *user_data);
+
+	void *user_data;
+};
+
+struct libnvmf_context {
+	struct libnvme_global_ctx *ctx;
+	struct libnvmf_hooks hooks;
 
 	/* discovery defaults */
 	int default_max_discovery_retries;
@@ -68,8 +73,6 @@ struct libnvmf_context {
 	const char *keyring;
 	char *tls_key;
 	const char *tls_key_identity;
-
-	void *user_data;
 };
 
 

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -463,8 +463,6 @@ struct libnvme_transport_handle *__libnvme_open(struct libnvme_global_ctx *ctx,
 struct libnvme_transport_handle *__libnvme_create_transport_handle(
 		struct libnvme_global_ctx *ctx);
 
-struct libnvmf_context;
-
 int libnvme_create_ctrl(struct libnvme_global_ctx *ctx,
 		const struct libnvme_ctrl_params *params,
 		struct libnvme_ctrl **cp);
@@ -474,8 +472,11 @@ struct libnvme_host *libnvme_lookup_host(struct libnvme_global_ctx *ctx,
 		const char *hostnqn, const char *hostid);
 struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,
 		const char *name, const char *subsysnqn);
-struct libnvme_ctrl * libnvme_lookup_ctrl(struct libnvme_subsystem * s,
-		struct libnvmf_context *fctx, struct libnvme_ctrl *p);
+struct libnvme_ctrl *libnvme_lookup_ctrl(struct libnvme_subsystem *s,
+		const struct libnvme_ctrl_params *params,
+		struct libnvme_ctrl *p);
+void libnvmf_read_sysfs_fabrics_attrs(struct libnvme_global_ctx *ctx,
+		libnvme_ctrl_t c);
 
 void __libnvme_free_host(struct libnvme_host * h);
 

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -131,6 +131,29 @@ struct libnvme_fabrics_config { // !generate-accessors !generate-dict-table
 	bool concat;
 };
 
+/**
+ * struct libnvme_ctrl_params - Parameters for creating a controller instance
+ * @transport:		Transport type: loop, fc, rdma, tcp, pcie, apple-nvme
+ * @traddr:		Transport address (destination address)
+ * @host_traddr:	Host transport address (source address)
+ * @host_iface:		Host interface for connection (tcp only)
+ * @trsvcid:		Transport service ID
+ * @subsysnqn:		Subsystem NQN
+ * @cfg:		Fabrics tuning parameters
+ */
+struct libnvme_ctrl_params {
+	const char *transport;
+	const char *traddr;
+	const char *host_traddr;
+	const char *host_iface;
+	const char *trsvcid;
+	const char *subsysnqn;
+	struct libnvme_fabrics_config cfg;
+};
+
+void libnvme_fabrics_config_copy(struct libnvme_fabrics_config *dst,
+		const struct libnvme_fabrics_config *src);
+
 struct libnvme_log {
 	int fd;
 	int level;
@@ -443,7 +466,7 @@ struct libnvme_transport_handle *__libnvme_create_transport_handle(
 struct libnvmf_context;
 
 int libnvme_create_ctrl(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx,
+		const struct libnvme_ctrl_params *params,
 		struct libnvme_ctrl **cp);
 void nvme_deconfigure_ctrl(struct libnvme_ctrl *c);
 

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -475,6 +475,11 @@ struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,
 struct libnvme_ctrl *libnvme_lookup_ctrl(struct libnvme_subsystem *s,
 		const struct libnvme_ctrl_params *params,
 		struct libnvme_ctrl *p);
+bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
+		const char *transport, const char *traddr);
+void libnvmf_default_config(struct libnvme_fabrics_config *cfg);
+libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
+		const struct libnvme_ctrl_params *params, libnvme_ctrl_t p);
 void libnvmf_read_sysfs_fabrics_attrs(struct libnvme_global_ctx *ctx,
 		libnvme_ctrl_t c);
 

--- a/libnvme/src/nvme/tree-fabrics.c
+++ b/libnvme/src/nvme/tree-fabrics.c
@@ -248,13 +248,13 @@ ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
 		struct candidate_args *candidate,
 		const struct libnvmf_context *fctx)
 {
-	if (streq0(fctx->transport, "tcp")) {
+	if (streq0(fctx->ctrl_params.transport, "tcp")) {
 		candidate->iface_list = libnvmf_getifaddrs(ctx);
 		candidate->addreq = libnvme_ipaddrs_eq;
 		return _tcp_match_ctrl;
 	}
 
-	if (streq0(fctx->transport, "rdma")) {
+	if (streq0(fctx->ctrl_params.transport, "rdma")) {
 		candidate->addreq = libnvme_ipaddrs_eq;
 		return libnvme_tree_ctrl_match;
 	}

--- a/libnvme/src/nvme/tree-fabrics.c
+++ b/libnvme/src/nvme/tree-fabrics.c
@@ -246,15 +246,15 @@ static bool _tcp_match_ctrl(struct libnvme_ctrl *c,
 
 ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
 		struct candidate_args *candidate,
-		const struct libnvmf_context *fctx)
+		const struct libnvme_ctrl_params *params)
 {
-	if (streq0(fctx->ctrl_params.transport, "tcp")) {
+	if (streq0(params->transport, "tcp")) {
 		candidate->iface_list = libnvmf_getifaddrs(ctx);
 		candidate->addreq = libnvme_ipaddrs_eq;
 		return _tcp_match_ctrl;
 	}
 
-	if (streq0(fctx->ctrl_params.transport, "rdma")) {
+	if (streq0(params->transport, "rdma")) {
 		candidate->addreq = libnvme_ipaddrs_eq;
 		return libnvme_tree_ctrl_match;
 	}
@@ -353,7 +353,8 @@ bool libnvmf_ctrl_match_config(struct libnvme_ctrl *c,
 	struct candidate_args candidate = {};
 	ctrl_match_t ctrl_match;
 
-	ctrl_match = libnvme_candidate_init(c->ctx, &candidate, fctx);
+	ctrl_match = libnvme_candidate_init(c->ctx, &candidate,
+					    &fctx->ctrl_params);
 
 	return ctrl_match(c, &candidate);
 }
@@ -361,5 +362,5 @@ bool libnvmf_ctrl_match_config(struct libnvme_ctrl *c,
 libnvme_ctrl_t libnvmf_ctrl_find(libnvme_subsystem_t s,
 		struct libnvmf_context *fctx)
 {
-	return libnvme_ctrl_find(s, fctx, NULL/*p*/);
+	return libnvme_ctrl_find(s, &fctx->ctrl_params, NULL/*p*/);
 }

--- a/libnvme/src/nvme/tree-fabrics.c
+++ b/libnvme/src/nvme/tree-fabrics.c
@@ -244,7 +244,49 @@ static bool _tcp_match_ctrl(struct libnvme_ctrl *c,
 	return true;
 }
 
-ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
+/**
+ * _libnvmf_tree_ctrl_match() - Generic ctrl matcher for non-TCP transports
+ * @c:		An existing controller instance
+ * @candidate:	Candidate ctrl we're trying to match with @c.
+ *
+ * We want to determine if an existing controller can be re-used
+ * for the candidate controller we're trying to instantiate. This function
+ * is the generic matcher used for all non-TCP transports.
+ *
+ * Return: true if a match is found, false otherwise.
+ */
+static bool _libnvmf_tree_ctrl_match(struct libnvme_ctrl *c,
+		struct candidate_args *candidate)
+{
+	if (!streq0(c->transport, candidate->transport))
+		return false;
+
+	if (candidate->traddr && c->traddr &&
+	    !candidate->addreq(c->traddr, candidate->traddr))
+		return false;
+
+	if (candidate->host_traddr && c->host_traddr &&
+	    !candidate->addreq(c->host_traddr, candidate->host_traddr))
+		return false;
+
+	if (candidate->host_iface && c->host_iface &&
+	    !streq0(c->host_iface, candidate->host_iface))
+		return false;
+
+	if (candidate->trsvcid && c->trsvcid &&
+	    !streq0(c->trsvcid, candidate->trsvcid))
+		return false;
+
+	if (candidate->well_known_nqn && !libnvme_ctrl_get_discovery_ctrl(c))
+		return false;
+
+	if (candidate->subsysnqn && !streq0(c->subsysnqn, candidate->subsysnqn))
+		return false;
+
+	return true;
+}
+
+static ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
 		struct candidate_args *candidate,
 		const struct libnvme_ctrl_params *params)
 {
@@ -256,7 +298,7 @@ ctrl_match_t libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
 
 	if (streq0(params->transport, "rdma")) {
 		candidate->addreq = libnvme_ipaddrs_eq;
-		return libnvme_tree_ctrl_match;
+		return _libnvmf_tree_ctrl_match;
 	}
 
 	return NULL;
@@ -347,14 +389,84 @@ void libnvmf_read_sysfs_fabrics_attrs(struct libnvme_global_ctx *ctx,
 	libnvmf_read_sysfs_tls_mode(ctx, c);
 }
 
+/**
+ * _libnvmf_candidate_init() - Init candidate and get the matching function
+ * @ctx:	Global context
+ * @candidate:	Candidate struct to initialize
+ * @params:	Controller parameters to match against
+ *
+ * Return: The matching function to use when comparing an existing
+ * controller to the candidate controller.
+ */
+static ctrl_match_t _libnvmf_candidate_init(struct libnvme_global_ctx *ctx,
+		struct candidate_args *candidate,
+		const struct libnvme_ctrl_params *params)
+{
+	ctrl_match_t m;
+
+	memset(candidate, 0, sizeof(*candidate));
+
+	candidate->traddr = params->traddr;
+	candidate->trsvcid = params->trsvcid;
+	candidate->transport = params->transport;
+	candidate->subsysnqn = params->subsysnqn;
+	candidate->host_iface =
+		streqcase0(params->host_iface, "none") ?
+		NULL : params->host_iface;
+	candidate->host_traddr =
+		streqcase0(params->host_traddr, "none") ?
+		NULL : params->host_traddr;
+
+	if (streq0(params->subsysnqn, NVME_DISC_SUBSYS_NAME)) {
+		/* Since TP8013, the NQN of discovery controllers can be the
+		 * well-known NQN (i.e. nqn.2014-08.org.nvmexpress.discovery) or
+		 * a unique NQN. A DC created using the well-known NQN may later
+		 * display a unique NQN when looked up in the sysfs. Therefore,
+		 * ignore (i.e. set to NULL) the well-known NQN when looking for
+		 * a match.
+		 */
+		candidate->subsysnqn = NULL;
+		candidate->well_known_nqn = true;
+	}
+
+	m = libnvmf_candidate_init(ctx, candidate, params);
+	if (m)
+		return m;
+
+	/* All other transport types */
+	candidate->addreq = streqcase0;
+	return _libnvmf_tree_ctrl_match;
+}
+
+libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
+		const struct libnvme_ctrl_params *params, libnvme_ctrl_t p)
+{
+	struct candidate_args candidate = {};
+	struct libnvme_ctrl *c, *matching_c = NULL;
+	ctrl_match_t ctrl_match;
+
+	ctrl_match = _libnvmf_candidate_init(s->h->ctx, &candidate, params);
+
+	c = p ? libnvme_subsystem_next_ctrl(s, p) :
+		libnvme_subsystem_first_ctrl(s);
+	for (; c != NULL; c = libnvme_subsystem_next_ctrl(s, c)) {
+		if (ctrl_match(c, &candidate)) {
+			matching_c = c;
+			break;
+		}
+	}
+
+	return matching_c;
+}
+
 bool libnvmf_ctrl_match_config(struct libnvme_ctrl *c,
 		struct libnvmf_context *fctx)
 {
 	struct candidate_args candidate = {};
 	ctrl_match_t ctrl_match;
 
-	ctrl_match = libnvme_candidate_init(c->ctx, &candidate,
-					    &fctx->ctrl_params);
+	ctrl_match = _libnvmf_candidate_init(c->ctx, &candidate,
+					     &fctx->ctrl_params);
 
 	return ctrl_match(c, &candidate);
 }

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1635,13 +1635,7 @@ bool libnvme_tree_ctrl_match(struct libnvme_ctrl *c,
  * libnvme_candidate_init() - Init candidate and get the matching function
  *
  * @candidate:		Candidate struct to initialize
- * @transport:		Transport name
- * @traddr:		Transport address
- * @trsvcid:		Transport service identifier
- * @subsysnqn:		Subsystem NQN
- * @host_traddr:	Host transport address
- * @host_iface:		Host interface name
- * @host_iface:		Host interface name
+ * @params:		Controller parameters to match against
  *
  * The function _candidate_free() must be called to release resources once
  * the candidate object is not longer required.
@@ -1650,24 +1644,25 @@ bool libnvme_tree_ctrl_match(struct libnvme_ctrl *c,
  * controller to the candidate controller.
  */
 ctrl_match_t libnvme_candidate_init(struct libnvme_global_ctx *ctx,
-		struct candidate_args *candidate, struct libnvmf_context *fctx)
+		struct candidate_args *candidate,
+		const struct libnvme_ctrl_params *params)
 {
 	ctrl_match_t m;
 
 	memset(candidate, 0, sizeof(*candidate));
 
-	candidate->traddr = fctx->ctrl_params.traddr;
-	candidate->trsvcid = fctx->ctrl_params.trsvcid;
-	candidate->transport = fctx->ctrl_params.transport;
-	candidate->subsysnqn = fctx->ctrl_params.subsysnqn;
+	candidate->traddr = params->traddr;
+	candidate->trsvcid = params->trsvcid;
+	candidate->transport = params->transport;
+	candidate->subsysnqn = params->subsysnqn;
 	candidate->host_iface =
-		streqcase0(fctx->ctrl_params.host_iface, "none") ?
-		NULL : fctx->ctrl_params.host_iface;
+		streqcase0(params->host_iface, "none") ?
+		NULL : params->host_iface;
 	candidate->host_traddr =
-		streqcase0(fctx->ctrl_params.host_traddr, "none") ?
-		NULL : fctx->ctrl_params.host_traddr;
+		streqcase0(params->host_traddr, "none") ?
+		NULL : params->host_traddr;
 
-	if (streq0(fctx->ctrl_params.subsysnqn, NVME_DISC_SUBSYS_NAME)) {
+	if (streq0(params->subsysnqn, NVME_DISC_SUBSYS_NAME)) {
 		/* Since TP8013, the NQN of discovery controllers can be the
 		 * well-known NQN (i.e. nqn.2014-08.org.nvmexpress.discovery) or
 		 * a unique NQN. A DC created using the well-known NQN may later
@@ -1679,7 +1674,7 @@ ctrl_match_t libnvme_candidate_init(struct libnvme_global_ctx *ctx,
 		candidate->well_known_nqn = true;
 	}
 
-	m = libnvmf_candidate_init(ctx, candidate, fctx);
+	m = libnvmf_candidate_init(ctx, candidate, params);
 	if (m)
 		return m;
 
@@ -1689,14 +1684,14 @@ ctrl_match_t libnvme_candidate_init(struct libnvme_global_ctx *ctx,
 }
 
 libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
-		struct libnvmf_context *fctx, libnvme_ctrl_t p)
+		const struct libnvme_ctrl_params *params, libnvme_ctrl_t p)
 {
 	struct candidate_args candidate = {};
 	struct libnvme_ctrl *c, *matching_c = NULL;
 	ctrl_match_t ctrl_match;
 
 	/* Init candidate and get the matching function to use */
-	ctrl_match = libnvme_candidate_init(s->h->ctx, &candidate, fctx);
+	ctrl_match = libnvme_candidate_init(s->h->ctx, &candidate, params);
 
 	c = p ? libnvme_subsystem_next_ctrl(s, p) : libnvme_subsystem_first_ctrl(s);
 	for (; c != NULL; c = libnvme_subsystem_next_ctrl(s, c)) {
@@ -1710,32 +1705,32 @@ libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
 }
 
 libnvme_ctrl_t libnvme_lookup_ctrl(libnvme_subsystem_t s,
-			     struct libnvmf_context *fctx,
+			     const struct libnvme_ctrl_params *in,
 			     libnvme_ctrl_t p)
 {
 	struct libnvme_global_ctx *ctx;
+	struct libnvme_ctrl_params search;
 	struct libnvme_ctrl *c;
-	const char *subsysnqn = fctx->ctrl_params.subsysnqn;
-	struct libnvme_ctrl_params params;
 	int ret;
 
-	if (!s || !fctx->ctrl_params.transport)
+	if (!s || !in->transport)
 		return NULL;
 
-	/* Clear out subsysnqn; might be different for discovery subsystems */
-	fctx->ctrl_params.subsysnqn = NULL;
-	c = libnvme_ctrl_find(s, fctx, p);
-	if (c) {
-		fctx->ctrl_params.subsysnqn = subsysnqn;
+	/*
+	 * Clear subsysnqn for the initial search; discovery subsystems
+	 * may report a different NQN than the one used to connect.
+	 */
+	search = *in;
+	libnvme_fabrics_config_copy(&search.cfg, &in->cfg);
+	search.subsysnqn = NULL;
+	c = libnvme_ctrl_find(s, &search, p);
+	if (c)
 		return c;
-	}
 
 	ctx = s->h ? s->h->ctx : NULL;
-	params = fctx->ctrl_params;
-	params.subsysnqn = s->subsysnqn;
-	libnvmf_default_config(&params.cfg);
-	ret = libnvme_create_ctrl(ctx, &params, &c);
-	fctx->ctrl_params.subsysnqn = subsysnqn;
+	search.subsysnqn = s->subsysnqn;
+	libnvmf_default_config(&search.cfg);
+	ret = libnvme_create_ctrl(ctx, &search, &c);
 	if (ret)
 		return NULL;
 
@@ -1969,7 +1964,8 @@ __libnvme_public int libnvme_init_ctrl(
 	return ret;
 }
 
-int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,
+static int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx,
+		libnvme_subsystem_t s,
 		const char *path, const char *name, libnvme_ctrl_t *cp)
 {
 	__cleanup_free char *addr = NULL, *address = NULL, *transport = NULL;
@@ -2034,16 +2030,14 @@ int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,
 skip_address:
 	p = NULL;
 	do {
-		struct libnvmf_context fctx = {
-			.ctrl_params = {
-				.transport = transport,
-				.traddr = traddr,
-				.host_traddr = host_traddr,
-				.host_iface = host_iface,
-				.trsvcid = trsvcid,
-			},
+		struct libnvme_ctrl_params params = {
+			.transport = transport,
+			.traddr = traddr,
+			.host_traddr = host_traddr,
+			.host_iface = host_iface,
+			.trsvcid = trsvcid,
 		};
-		c = libnvme_lookup_ctrl(s, &fctx, p);
+		c = libnvme_lookup_ctrl(s, &params, p);
 		if (c) {
 			if (!c->name)
 				break;

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -28,7 +28,6 @@
 #include "cleanup.h"
 #include "cleanup-linux.h"
 #include "private.h"
-#include "private-fabrics.h"
 #include "util.h"
 #include "compiler-attributes.h"
 
@@ -1587,121 +1586,6 @@ int libnvme_create_ctrl(struct libnvme_global_ctx *ctx,
 
 	*cp = c;
 	return 0;
-}
-
-/**
- * libnvme_tree_ctrl_match() - Generic controller matcher for non-TCP transports
- * @c:	An existing controller instance
- * @candidate:	Candidate ctrl we're trying to match with @c.
- *
- * We want to determine if an existing controller can be re-used
- * for the candidate controller we're trying to instantiate. This function
- * is the generic matcher used for all non-TCP transports.
- *
- * Return: true if a match is found, false otherwise.
- */
-bool libnvme_tree_ctrl_match(struct libnvme_ctrl *c,
-		struct candidate_args *candidate)
-{
-	if (!streq0(c->transport, candidate->transport))
-		return false;
-
-	if (candidate->traddr && c->traddr &&
-	    !candidate->addreq(c->traddr, candidate->traddr))
-		return false;
-
-	if (candidate->host_traddr && c->host_traddr &&
-	    !candidate->addreq(c->host_traddr, candidate->host_traddr))
-		return false;
-
-	if (candidate->host_iface && c->host_iface &&
-	    !streq0(c->host_iface, candidate->host_iface))
-		return false;
-
-	if (candidate->trsvcid && c->trsvcid &&
-	    !streq0(c->trsvcid, candidate->trsvcid))
-		return false;
-
-	if (candidate->well_known_nqn && !libnvme_ctrl_get_discovery_ctrl(c))
-		return false;
-
-	if (candidate->subsysnqn && !streq0(c->subsysnqn, candidate->subsysnqn))
-		return false;
-
-	return true;
-}
-
-/**
- * libnvme_candidate_init() - Init candidate and get the matching function
- *
- * @candidate:		Candidate struct to initialize
- * @params:		Controller parameters to match against
- *
- * The function _candidate_free() must be called to release resources once
- * the candidate object is not longer required.
- *
- * Return: The matching function to use when comparing an existing
- * controller to the candidate controller.
- */
-ctrl_match_t libnvme_candidate_init(struct libnvme_global_ctx *ctx,
-		struct candidate_args *candidate,
-		const struct libnvme_ctrl_params *params)
-{
-	ctrl_match_t m;
-
-	memset(candidate, 0, sizeof(*candidate));
-
-	candidate->traddr = params->traddr;
-	candidate->trsvcid = params->trsvcid;
-	candidate->transport = params->transport;
-	candidate->subsysnqn = params->subsysnqn;
-	candidate->host_iface =
-		streqcase0(params->host_iface, "none") ?
-		NULL : params->host_iface;
-	candidate->host_traddr =
-		streqcase0(params->host_traddr, "none") ?
-		NULL : params->host_traddr;
-
-	if (streq0(params->subsysnqn, NVME_DISC_SUBSYS_NAME)) {
-		/* Since TP8013, the NQN of discovery controllers can be the
-		 * well-known NQN (i.e. nqn.2014-08.org.nvmexpress.discovery) or
-		 * a unique NQN. A DC created using the well-known NQN may later
-		 * display a unique NQN when looked up in the sysfs. Therefore,
-		 * ignore (i.e. set to NULL) the well-known NQN when looking for
-		 * a match.
-		 */
-		candidate->subsysnqn = NULL;
-		candidate->well_known_nqn = true;
-	}
-
-	m = libnvmf_candidate_init(ctx, candidate, params);
-	if (m)
-		return m;
-
-	/* All other transport types */
-	candidate->addreq = streqcase0;
-	return libnvme_tree_ctrl_match;
-}
-
-libnvme_ctrl_t libnvme_ctrl_find(libnvme_subsystem_t s,
-		const struct libnvme_ctrl_params *params, libnvme_ctrl_t p)
-{
-	struct candidate_args candidate = {};
-	struct libnvme_ctrl *c, *matching_c = NULL;
-	ctrl_match_t ctrl_match;
-
-	/* Init candidate and get the matching function to use */
-	ctrl_match = libnvme_candidate_init(s->h->ctx, &candidate, params);
-
-	c = p ? libnvme_subsystem_next_ctrl(s, p) : libnvme_subsystem_first_ctrl(s);
-	for (; c != NULL; c = libnvme_subsystem_next_ctrl(s, c)) {
-		if (ctrl_match(c, &candidate)) {
-			matching_c = c;
-			break;
-		}
-	}
-
-	return matching_c;
 }
 
 libnvme_ctrl_t libnvme_lookup_ctrl(libnvme_subsystem_t s,

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1539,22 +1539,22 @@ __libnvme_public void libnvme_free_ctrl(libnvme_ctrl_t c)
 }
 
 int libnvme_create_ctrl(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, libnvme_ctrl_t *cp)
+		const struct libnvme_ctrl_params *params, libnvme_ctrl_t *cp)
 {
 	struct libnvme_ctrl *c;
 
-	if (!fctx->transport) {
+	if (!params->transport) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "No transport specified\n");
 		return -EINVAL;
 	}
-	if (strncmp(fctx->transport, "loop", 4) &&
-	    strncmp(fctx->transport, "pcie", 4) &&
-	    strncmp(fctx->transport, "apple-nvme", 10) && !fctx->traddr) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR, "No transport address for '%s'\n",
-			 fctx->transport);
-	       return -EINVAL;
+	if (strncmp(params->transport, "loop", 4) &&
+	    strncmp(params->transport, "pcie", 4) &&
+	    strncmp(params->transport, "apple-nvme", 10) && !params->traddr) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR,
+			"No transport address for '%s'\n", params->transport);
+		return -EINVAL;
 	}
-	if (!fctx->subsysnqn) {
+	if (!params->subsysnqn) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "No subsystem NQN specified\n");
 		return -EINVAL;
 	}
@@ -1564,25 +1564,26 @@ int libnvme_create_ctrl(struct libnvme_global_ctx *ctx,
 
 	c->ctx = ctx;
 	c->hdl = NULL;
-	c->cfg = fctx->cfg;
+	libnvme_fabrics_config_copy(&c->cfg, &params->cfg);
 	list_head_init(&c->namespaces);
 	list_head_init(&c->paths);
 	list_node_init(&c->entry);
-	c->transport = strdup(fctx->transport);
-	c->subsysnqn = strdup(fctx->subsysnqn);
-	if (fctx->traddr)
-		c->traddr = strdup(fctx->traddr);
-	if (fctx->host_traddr) {
-		if (traddr_is_hostname(ctx, fctx->transport, fctx->host_traddr))
-			hostname2traddr(ctx, fctx->host_traddr,
+	c->transport = strdup(params->transport);
+	c->subsysnqn = strdup(params->subsysnqn);
+	if (params->traddr)
+		c->traddr = strdup(params->traddr);
+	if (params->host_traddr) {
+		if (traddr_is_hostname(ctx, params->transport,
+				params->host_traddr))
+			hostname2traddr(ctx, params->host_traddr,
 					&c->host_traddr);
 		if (!c->host_traddr)
-			c->host_traddr = strdup(fctx->host_traddr);
+			c->host_traddr = strdup(params->host_traddr);
 	}
-	if (fctx->host_iface)
-		c->host_iface = strdup(fctx->host_iface);
-	if (fctx->trsvcid)
-		c->trsvcid = strdup(fctx->trsvcid);
+	if (params->host_iface)
+		c->host_iface = strdup(params->host_iface);
+	if (params->trsvcid)
+		c->trsvcid = strdup(params->trsvcid);
 
 	*cp = c;
 	return 0;
@@ -1655,16 +1656,18 @@ ctrl_match_t libnvme_candidate_init(struct libnvme_global_ctx *ctx,
 
 	memset(candidate, 0, sizeof(*candidate));
 
-	candidate->traddr = fctx->traddr;
-	candidate->trsvcid = fctx->trsvcid;
-	candidate->transport = fctx->transport;
-	candidate->subsysnqn = fctx->subsysnqn;
-	candidate->host_iface = streqcase0(fctx->host_iface, "none") ?
-		NULL : fctx->host_iface;
-	candidate->host_traddr = streqcase0(fctx->host_traddr, "none") ?
-		NULL : fctx->host_traddr;
+	candidate->traddr = fctx->ctrl_params.traddr;
+	candidate->trsvcid = fctx->ctrl_params.trsvcid;
+	candidate->transport = fctx->ctrl_params.transport;
+	candidate->subsysnqn = fctx->ctrl_params.subsysnqn;
+	candidate->host_iface =
+		streqcase0(fctx->ctrl_params.host_iface, "none") ?
+		NULL : fctx->ctrl_params.host_iface;
+	candidate->host_traddr =
+		streqcase0(fctx->ctrl_params.host_traddr, "none") ?
+		NULL : fctx->ctrl_params.host_traddr;
 
-	if (streq0(fctx->subsysnqn, NVME_DISC_SUBSYS_NAME)) {
+	if (streq0(fctx->ctrl_params.subsysnqn, NVME_DISC_SUBSYS_NAME)) {
 		/* Since TP8013, the NQN of discovery controllers can be the
 		 * well-known NQN (i.e. nqn.2014-08.org.nvmexpress.discovery) or
 		 * a unique NQN. A DC created using the well-known NQN may later
@@ -1712,27 +1715,27 @@ libnvme_ctrl_t libnvme_lookup_ctrl(libnvme_subsystem_t s,
 {
 	struct libnvme_global_ctx *ctx;
 	struct libnvme_ctrl *c;
-	const char *subsysnqn = fctx->subsysnqn;
+	const char *subsysnqn = fctx->ctrl_params.subsysnqn;
+	struct libnvme_ctrl_params params;
 	int ret;
 
-	if (!s || !fctx->transport)
+	if (!s || !fctx->ctrl_params.transport)
 		return NULL;
 
 	/* Clear out subsysnqn; might be different for discovery subsystems */
-	fctx->subsysnqn = NULL;
+	fctx->ctrl_params.subsysnqn = NULL;
 	c = libnvme_ctrl_find(s, fctx, p);
 	if (c) {
-		fctx->subsysnqn = subsysnqn;
+		fctx->ctrl_params.subsysnqn = subsysnqn;
 		return c;
 	}
 
 	ctx = s->h ? s->h->ctx : NULL;
-	/* Set the NQN to the subsystem the controller should be created in */
-	fctx->subsysnqn = s->subsysnqn;
-	libnvmf_default_config(&fctx->cfg);
-	ret = libnvme_create_ctrl(ctx, fctx, &c);
-	/* And restore NQN to avoid issues with repetitive calls */
-	fctx->subsysnqn = subsysnqn;
+	params = fctx->ctrl_params;
+	params.subsysnqn = s->subsysnqn;
+	libnvmf_default_config(&params.cfg);
+	ret = libnvme_create_ctrl(ctx, &params, &c);
+	fctx->ctrl_params.subsysnqn = subsysnqn;
 	if (ret)
 		return NULL;
 
@@ -2032,11 +2035,13 @@ skip_address:
 	p = NULL;
 	do {
 		struct libnvmf_context fctx = {
-			.transport = transport,
-			.traddr = traddr,
-			.host_traddr = host_traddr,
-			.host_iface = host_iface,
-			.trsvcid = trsvcid,
+			.ctrl_params = {
+				.transport = transport,
+				.traddr = traddr,
+				.host_traddr = host_traddr,
+				.host_iface = host_iface,
+				.trsvcid = trsvcid,
+			},
 		};
 		c = libnvme_lookup_ctrl(s, &fctx, p);
 		if (c) {

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -975,3 +975,15 @@ char *libnvme_basename(const char *path)
 	char *p = (char *) strrchr(path, '/');
 	return p ? p + 1 : (char *) path;
 }
+
+/*
+ * libnvme_fabrics_config currently contains only scalar fields, so a
+ * shallow copy is correct. This function exists as a single point of
+ * change: if a string or pointer field is ever added, update only this
+ * function to perform a deep copy rather than patching every call site.
+ */
+void libnvme_fabrics_config_copy(struct libnvme_fabrics_config *dst,
+		const struct libnvme_fabrics_config *src)
+{
+	*dst = *src;
+}

--- a/libnvme/test/tree-fabrics.c
+++ b/libnvme/test/tree-fabrics.c
@@ -143,7 +143,7 @@ static struct libnvme_global_ctx *create_tree(void)
 		assert(!libnvme_get_subsystem(ctx, h, d->subsysname,
 			d->f.ctrl_params.subsysnqn, &d->s));
 		assert(d->s);
-		d->c = libnvme_lookup_ctrl(d->s, &d->f, NULL);
+		d->c = libnvme_lookup_ctrl(d->s, &d->f.ctrl_params, NULL);
 		assert(d->c);
 		d->ctrl_id = i;
 
@@ -180,7 +180,7 @@ static bool tcp_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 
 	f.ctrl_params.host_traddr = NULL;
 	f.ctrl_params.host_iface = NULL;
-	c = libnvme_lookup_ctrl(s, &f, NULL);
+	c = libnvme_lookup_ctrl(s, &f.ctrl_params, NULL);
 	printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid, "", "");
 	show_ctrl(c);
 	pass &= match_ctrl(d, c);
@@ -189,7 +189,7 @@ static bool tcp_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 	if (d->f.ctrl_params.host_traddr) {
 		f = d->f;
 		f.ctrl_params.host_iface = NULL;
-		c = libnvme_lookup_ctrl(s, &f, NULL);
+		c = libnvme_lookup_ctrl(s, &f.ctrl_params, NULL);
 		printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid,
 		       f.ctrl_params.host_traddr, "");
 		show_ctrl(c);
@@ -200,7 +200,7 @@ static bool tcp_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 	if (d->f.ctrl_params.host_iface) {
 		f = d->f;
 		f.ctrl_params.host_traddr = NULL;
-		c = libnvme_lookup_ctrl(s, &f, NULL);
+		c = libnvme_lookup_ctrl(s, &f.ctrl_params, NULL);
 		printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid,
 		       "", f.ctrl_params.host_iface);
 		show_ctrl(c);
@@ -210,7 +210,7 @@ static bool tcp_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 
 	if (d->f.ctrl_params.host_iface && d->f.ctrl_params.traddr) {
 		f = d->f;
-		c = libnvme_lookup_ctrl(s, &f, NULL);
+		c = libnvme_lookup_ctrl(s, &f.ctrl_params, NULL);
 		printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid,
 		       f.ctrl_params.host_traddr, f.ctrl_params.host_iface);
 		show_ctrl(c);
@@ -229,7 +229,7 @@ static bool default_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 
 	f.ctrl_params.host_iface = NULL;
 	f.ctrl_params.trsvcid = NULL;
-	c = libnvme_lookup_ctrl(s, &f, NULL);
+	c = libnvme_lookup_ctrl(s, &f.ctrl_params, NULL);
 	printf("%10s %12s %10s -> ", "", "", "");
 	show_ctrl(c);
 	pass &= match_ctrl(d, c);
@@ -311,7 +311,7 @@ static bool test_src_addr(void)
 			      DEFAULT_SUBSYSNQN, &s);
 	assert(s);
 
-	c = libnvme_lookup_ctrl(s, &fctx, NULL);
+	c = libnvme_lookup_ctrl(s, &fctx.ctrl_params, NULL);
 	assert(c);
 
 	c->address = NULL;
@@ -488,7 +488,8 @@ static bool ctrl_match(const char *tag,
 		&s));
 	assert(s);
 
-	reference_ctrl = libnvme_lookup_ctrl(s, &reference->f, NULL);
+	reference_ctrl = libnvme_lookup_ctrl(s,
+				&reference->f.ctrl_params, NULL);
 	assert(reference_ctrl);
 	reference_ctrl->name = "nvme1";  /* fake the device name */
 	if (reference->address)
@@ -497,7 +498,8 @@ static bool ctrl_match(const char *tag,
 	/* libnvmf_ctrl_find() MUST BE RUN BEFORE libnvme_lookup_ctrl() */
 	found_ctrl = libnvmf_ctrl_find(s, &candidate->f);
 
-	candidate_ctrl = libnvme_lookup_ctrl(s, &candidate->f, NULL);
+	candidate_ctrl = libnvme_lookup_ctrl(s,
+				&candidate->f.ctrl_params, NULL);
 
 	if (should_match) {
 		if (candidate_ctrl != reference_ctrl) {
@@ -1301,7 +1303,8 @@ static bool ctrl_config_match(const char *tag,
 		&s));
 	assert(s);
 
-	reference_ctrl = libnvme_lookup_ctrl(s, &reference->f, NULL);
+	reference_ctrl = libnvme_lookup_ctrl(s,
+				&reference->f.ctrl_params, NULL);
 	assert(reference_ctrl);
 	reference_ctrl->name = "nvme1";  /* fake the device name */
 	if (reference->address)
@@ -1511,7 +1514,7 @@ static bool test_well_known_nqn(void)
 	/* Subsystem 1: discovery subsystem with a discovery ctrl */
 	assert(!libnvme_get_subsystem(ctx, h, "disc",
 		NVME_DISC_SUBSYS_NAME, &s_disc));
-	disc_ctrl = libnvme_lookup_ctrl(s_disc, &fctx, NULL);
+	disc_ctrl = libnvme_lookup_ctrl(s_disc, &fctx.ctrl_params, NULL);
 	assert(disc_ctrl);
 	disc_ctrl->name = "nvme1";
 	libnvme_ctrl_set_discovery_ctrl(disc_ctrl, true);
@@ -1527,7 +1530,7 @@ static bool test_well_known_nqn(void)
 	/* Subsystem 2: regular subsystem; discovery_ctrl defaults to false */
 	assert(!libnvme_get_subsystem(ctx, h, "regular",
 		DEFAULT_SUBSYSNQN, &s_regular));
-	regular_ctrl = libnvme_lookup_ctrl(s_regular, &fctx, NULL);
+	regular_ctrl = libnvme_lookup_ctrl(s_regular, &fctx.ctrl_params, NULL);
 	assert(regular_ctrl);
 	regular_ctrl->name = "nvme2";
 
@@ -1736,9 +1739,9 @@ static bool test_lookup_ctrl_pagination(void)
 	assert(s);
 
 	/* Build list: [ctrl_a, ctrl_b] */
-	ctrl_a = libnvme_lookup_ctrl(s, &fctx_a, NULL);
+	ctrl_a = libnvme_lookup_ctrl(s, &fctx_a.ctrl_params, NULL);
 	assert(ctrl_a);
-	ctrl_b = libnvme_lookup_ctrl(s, &fctx_b, NULL);
+	ctrl_b = libnvme_lookup_ctrl(s, &fctx_b.ctrl_params, NULL);
 	assert(ctrl_b);
 
 	/* p=NULL: search starts from head, finds ctrl_a */
@@ -1753,7 +1756,7 @@ static bool test_lookup_ctrl_pagination(void)
 	/* p=ctrl_b: search starts after ctrl_b; ctrl_a is before ctrl_b so
 	 * it is skipped. No match found → a new ctrl is created.
 	 */
-	ctrl_new = libnvme_lookup_ctrl(s, &fctx_a, ctrl_b);
+	ctrl_new = libnvme_lookup_ctrl(s, &fctx_a.ctrl_params, ctrl_b);
 	if (ctrl_new && ctrl_new != ctrl_a) {
 		printf(" - lookup_ctrl(p=ctrl_b) skips ctrl_a, creates new ctrl [PASS]\n");
 	} else {
@@ -1765,7 +1768,7 @@ static bool test_lookup_ctrl_pagination(void)
 	 * p=ctrl_a: search starts after ctrl_a → checks ctrl_b (no match),
 	 * then ctrl_new (match) → returns ctrl_new without creating.
 	 */
-	ctrl_found_again = libnvme_lookup_ctrl(s, &fctx_a, ctrl_a);
+	ctrl_found_again = libnvme_lookup_ctrl(s, &fctx_a.ctrl_params, ctrl_a);
 	if (ctrl_found_again == ctrl_new) {
 		printf(" - lookup_ctrl(p=ctrl_a) finds ctrl_new [PASS]\n");
 	} else {

--- a/libnvme/test/tree-fabrics.c
+++ b/libnvme/test/tree-fabrics.c
@@ -36,9 +36,10 @@ struct test_data {
 
 #define DEFAULTS(t, a, h, i, s) \
 	.f = { .hostnqn = DEFAULT_HOSTNQN, \
-		.subsysnqn = DEFAULT_SUBSYSNQN,			     \
-		.transport = (t), .traddr = (a), .host_traddr = (h), \
-		.host_iface = (i), .trsvcid = (s), },		     \
+		.ctrl_params = { .subsysnqn = DEFAULT_SUBSYSNQN,	     \
+			.transport = (t), .traddr = (a),	     \
+			.host_traddr = (h), .host_iface = (i),	     \
+			.trsvcid = (s), }, },			     \
 	.subsysname = DEFAULT_SUBSYSNAME
 
 struct test_data test_data[] = {
@@ -97,26 +98,27 @@ static bool match_ctrl(struct test_data *d, libnvme_ctrl_t c)
 	if (d->c != c)
 		pass = false;
 
-	if (strcmp(d->f.transport, libnvme_ctrl_get_transport(d->c)))
+	if (strcmp(d->f.ctrl_params.transport,
+		   libnvme_ctrl_get_transport(d->c)))
 		pass = false;
 
-	if (strcmp(d->f.traddr, libnvme_ctrl_get_traddr(d->c)))
+	if (strcmp(d->f.ctrl_params.traddr, libnvme_ctrl_get_traddr(d->c)))
 		pass = false;
 
 
 	host_traddr = libnvme_ctrl_get_host_traddr(c);
-	if (d->f.host_traddr &&
-	    (!host_traddr || strcmp(d->f.host_traddr, host_traddr)))
+	if (d->f.ctrl_params.host_traddr &&
+	    (!host_traddr || strcmp(d->f.ctrl_params.host_traddr, host_traddr)))
 		pass = false;
 
 	host_iface = libnvme_ctrl_get_host_iface(c);
-	if (d->f.host_iface &&
-	    (!host_iface || strcmp(d->f.host_iface, host_iface)))
+	if (d->f.ctrl_params.host_iface &&
+	    (!host_iface || strcmp(d->f.ctrl_params.host_iface, host_iface)))
 		pass = false;
 
 	trsvid = libnvme_ctrl_get_trsvcid(c);
-	if (d->f.trsvcid &&
-	    (!trsvid || strcmp(d->f.trsvcid, trsvid)))
+	if (d->f.ctrl_params.trsvcid &&
+	    (!trsvid || strcmp(d->f.ctrl_params.trsvcid, trsvid)))
 		pass = false;
 
 	printf("[%s]", pass ? "PASS" : "FAILED");
@@ -139,7 +141,7 @@ static struct libnvme_global_ctx *create_tree(void)
 		struct test_data *d = &test_data[i];
 
 		assert(!libnvme_get_subsystem(ctx, h, d->subsysname,
-			d->f.subsysnqn, &d->s));
+			d->f.ctrl_params.subsysnqn, &d->s));
 		assert(d->s);
 		d->c = libnvme_lookup_ctrl(d->s, &d->f, NULL);
 		assert(d->c);
@@ -176,39 +178,41 @@ static bool tcp_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 	bool pass = true;
 	struct libnvmf_context f = d->f;
 
-	f.host_traddr = NULL;
-	f.host_iface = NULL;
+	f.ctrl_params.host_traddr = NULL;
+	f.ctrl_params.host_iface = NULL;
 	c = libnvme_lookup_ctrl(s, &f, NULL);
-	printf("%10s %12s %10s -> ", f.trsvcid, "", "");
+	printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid, "", "");
 	show_ctrl(c);
 	pass &= match_ctrl(d, c);
 	printf("\n");
 
-	if (d->f.host_traddr) {
+	if (d->f.ctrl_params.host_traddr) {
 		f = d->f;
-		f.host_iface = NULL;
+		f.ctrl_params.host_iface = NULL;
 		c = libnvme_lookup_ctrl(s, &f, NULL);
-		printf("%10s %12s %10s -> ", f.trsvcid, f.host_traddr, "");
+		printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid,
+		       f.ctrl_params.host_traddr, "");
 		show_ctrl(c);
 		pass &= match_ctrl(d, c);
 		printf("\n");
 	}
 
-	if (d->f.host_iface) {
+	if (d->f.ctrl_params.host_iface) {
 		f = d->f;
-		f.host_traddr = NULL;
+		f.ctrl_params.host_traddr = NULL;
 		c = libnvme_lookup_ctrl(s, &f, NULL);
-		printf("%10s %12s %10s -> ", f.trsvcid, "", f.host_iface);
+		printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid,
+		       "", f.ctrl_params.host_iface);
 		show_ctrl(c);
 		pass &= match_ctrl(d, c);
 		printf("\n");
 	}
 
-	if (d->f.host_iface && d->f.traddr) {
+	if (d->f.ctrl_params.host_iface && d->f.ctrl_params.traddr) {
 		f = d->f;
 		c = libnvme_lookup_ctrl(s, &f, NULL);
-		printf("%10s %12s %10s -> ", f.trsvcid,
-		       f.host_traddr, f.host_iface);
+		printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid,
+		       f.ctrl_params.host_traddr, f.ctrl_params.host_iface);
 		show_ctrl(c);
 		pass &= match_ctrl(d, c);
 		printf("\n");
@@ -223,8 +227,8 @@ static bool default_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 	bool pass = true;
 	struct libnvmf_context f = d->f;
 
-	f.host_iface = NULL;
-	f.trsvcid = NULL;
+	f.ctrl_params.host_iface = NULL;
+	f.ctrl_params.trsvcid = NULL;
 	c = libnvme_lookup_ctrl(s, &f, NULL);
 	printf("%10s %12s %10s -> ", "", "", "");
 	show_ctrl(c);
@@ -252,7 +256,7 @@ static bool ctrl_lookups(struct libnvme_global_ctx *ctx)
 		show_ctrl(d->c);
 		printf("\n");
 
-		if (!strcmp("tcp", d->f.transport))
+		if (!strcmp("tcp", d->f.ctrl_params.transport))
 			pass &= tcp_ctrl_lookup(s, d);
 		else
 			pass &= default_ctrl_lookup(s, d);
@@ -283,11 +287,11 @@ static bool test_src_addr(void)
 {
 	struct libnvme_global_ctx *ctx;
 	struct libnvmf_context fctx = {
-		.transport = "tcp",
-		.traddr = "192.168.56.1",
-		.host_traddr = NULL,
-		.host_iface = NULL,
-		.trsvcid = "8009",
+		.ctrl_params = {
+			.transport = "tcp",
+			.traddr = "192.168.56.1",
+			.trsvcid = "8009",
+		},
 	};
 	bool pass = true;
 	libnvme_host_t h;
@@ -447,13 +451,13 @@ static void set_ctrl_args(struct ctrl_args *args,
 			  const char *address,
 			  const char *subsysnqn)
 {
-	args->f.transport   = transport;
-	args->f.traddr      = traddr;
-	args->f.trsvcid     = trsvcid;
-	args->f.host_traddr = host_traddr;
-	args->f.host_iface  = host_iface;
+	args->f.ctrl_params.transport   = transport;
+	args->f.ctrl_params.traddr      = traddr;
+	args->f.ctrl_params.trsvcid     = trsvcid;
+	args->f.ctrl_params.host_traddr = host_traddr;
+	args->f.ctrl_params.host_iface  = host_iface;
 	args->address     = address;
-	args->f.subsysnqn   = subsysnqn;
+	args->f.ctrl_params.subsysnqn   = subsysnqn;
 }
 
 static bool ctrl_match(const char *tag,
@@ -470,6 +474,9 @@ static bool ctrl_match(const char *tag,
 	libnvme_ctrl_t found_ctrl;
 	libnvme_subsystem_t s;
 
+	const struct libnvme_ctrl_params *cp = &candidate->f.ctrl_params;
+	const struct libnvme_ctrl_params *rp = &reference->f.ctrl_params;
+
 	ctx = libnvme_create_global_ctx(stdout, LIBNVME_LOG_INFO);
 	assert(ctx);
 
@@ -477,8 +484,7 @@ static bool ctrl_match(const char *tag,
 	assert(h);
 
 	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
-		 reference->f.subsysnqn ?
-			reference->f.subsysnqn : DEFAULT_SUBSYSNQN,
+		 rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN,
 		&s));
 	assert(s);
 
@@ -497,48 +503,44 @@ static bool ctrl_match(const char *tag,
 		if (candidate_ctrl != reference_ctrl) {
 			printf("%s-%d-%d: Candidate (%s, %s, %s, %s, %s, %s) failed to match (%s, %s, %s, %s, %s, %s, %s)\n",
 			       tag, reference_id, candidate_id,
-			       candidate->f.transport, candidate->f.traddr,
-			       candidate->f.trsvcid, candidate->f.subsysnqn,
-			       candidate->f.host_traddr,
-			       candidate->f.host_iface,
-			       reference->f.transport, reference->f.traddr,
-			       reference->f.trsvcid, reference->f.subsysnqn,
-			       reference->f.host_traddr,
-			       reference->f.host_iface, reference->address);
+			       cp->transport, cp->traddr,
+			       cp->trsvcid, cp->subsysnqn,
+			       cp->host_traddr, cp->host_iface,
+			       rp->transport, rp->traddr,
+			       rp->trsvcid, rp->subsysnqn,
+			       rp->host_traddr, rp->host_iface,
+			       reference->address);
 			return false;
 		}
 
 		if (!found_ctrl) {
 			printf("%s-%d-%d: Candidate (%s, %s, %s, %s, %s, %s) failed to find controller\n",
 			       tag, reference_id, candidate_id,
-			       candidate->f.transport, candidate->f.traddr,
-			       candidate->f.trsvcid, candidate->f.subsysnqn,
-			       candidate->f.host_traddr,
-			       candidate->f.host_iface);
+			       cp->transport, cp->traddr,
+			       cp->trsvcid, cp->subsysnqn,
+			       cp->host_traddr, cp->host_iface);
 			return false;
 		}
 	} else {
 		if (candidate_ctrl == reference_ctrl) {
 			printf("%s-%d-%d: Candidate (%s, %s, %s, %s, %s, %s) should not match (%s, %s, %s, %s, %s, %s, %s)\n",
 			       tag, reference_id, candidate_id,
-			       candidate->f.transport, candidate->f.traddr,
-			       candidate->f.trsvcid, candidate->f.subsysnqn,
-			       candidate->f.host_traddr,
-			       candidate->f.host_iface,
-			       reference->f.transport, reference->f.traddr,
-			       reference->f.trsvcid, reference->f.subsysnqn,
-			       reference->f.host_traddr,
-			       reference->f.host_iface, reference->address);
+			       cp->transport, cp->traddr,
+			       cp->trsvcid, cp->subsysnqn,
+			       cp->host_traddr, cp->host_iface,
+			       rp->transport, rp->traddr,
+			       rp->trsvcid, rp->subsysnqn,
+			       rp->host_traddr, rp->host_iface,
+			       reference->address);
 			return false;
 		}
 
 		if (found_ctrl) {
 			printf("%s-%d-%d: Candidate (%s, %s, %s, %s, %s, %s) should not have found controller. found_ctrl=%p reference=%p\n",
 			       tag, reference_id, candidate_id,
-			       candidate->f.transport, candidate->f.traddr,
-			       candidate->f.trsvcid, candidate->f.subsysnqn,
-			       candidate->f.host_traddr,
-			       candidate->f.host_iface,
+			       cp->transport, cp->traddr,
+			       cp->trsvcid, cp->subsysnqn,
+			       cp->host_traddr, cp->host_iface,
 			       found_ctrl, reference_ctrl);
 			return false;
 		}
@@ -1280,6 +1282,8 @@ static bool ctrl_config_match(const char *tag,
 			      struct ctrl_args *candidate,
 			      bool should_match)
 {
+	const struct libnvme_ctrl_params *cp = &candidate->f.ctrl_params;
+	const struct libnvme_ctrl_params *rp = &reference->f.ctrl_params;
 	struct libnvme_global_ctx *ctx;
 	bool match;
 	libnvme_host_t h;
@@ -1293,8 +1297,7 @@ static bool ctrl_config_match(const char *tag,
 	assert(h);
 
 	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
-		reference->f.subsysnqn ?
-			reference->f.subsysnqn : DEFAULT_SUBSYSNQN,
+		 rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN,
 		&s));
 	assert(s);
 
@@ -1310,20 +1313,18 @@ static bool ctrl_config_match(const char *tag,
 		if (!match) {
 			printf("%s-%d-%d: Failed to match config for Candidate (%s, %s, %s, %s, %s, %s)\n",
 			       tag, reference_id, candidate_id,
-			       candidate->f.transport, candidate->f.traddr,
-			       candidate->f.trsvcid, candidate->f.subsysnqn,
-			       candidate->f.host_traddr,
-			       candidate->f.host_iface);
+			       cp->transport, cp->traddr,
+			       cp->trsvcid, cp->subsysnqn,
+			       cp->host_traddr, cp->host_iface);
 			return false;
 		}
 	} else {
 		if (match) {
 			printf("%s-%d-%d: Config should not have matched for Candidate (%s, %s, %s, %s, %s, %s)\n",
 			       tag, reference_id, candidate_id,
-			       candidate->f.transport, candidate->f.traddr,
-			       candidate->f.trsvcid, candidate->f.subsysnqn,
-			       candidate->f.host_traddr,
-			       candidate->f.host_iface);
+			       cp->transport, cp->traddr,
+			       cp->trsvcid, cp->subsysnqn,
+			       cp->host_traddr, cp->host_iface);
 			return false;
 		}
 	}
@@ -1484,15 +1485,19 @@ static bool test_well_known_nqn(void)
 	libnvme_ctrl_t disc_ctrl, regular_ctrl, found;
 	bool pass = true;
 	struct libnvmf_context fctx = {
-		.transport = "tcp",
-		.traddr = "1.2.3.4",
-		.trsvcid = "8009",
+		.ctrl_params = {
+			.transport = "tcp",
+			.traddr = "1.2.3.4",
+			.trsvcid = "8009",
+		},
 	};
 	struct libnvmf_context fctx_wknqn = {
-		.transport = "tcp",
-		.traddr = "1.2.3.4",
-		.trsvcid = "8009",
-		.subsysnqn = NVME_DISC_SUBSYS_NAME,
+		.ctrl_params = {
+			.transport = "tcp",
+			.traddr = "1.2.3.4",
+			.trsvcid = "8009",
+			.subsysnqn = NVME_DISC_SUBSYS_NAME,
+		},
 	};
 
 	printf("\ntest_well_known_nqn:\n");
@@ -1705,14 +1710,18 @@ static bool test_lookup_ctrl_pagination(void)
 	libnvme_ctrl_t ctrl_a, ctrl_b, found, ctrl_new, ctrl_found_again;
 	bool pass = true;
 	struct libnvmf_context fctx_a = {
-		.transport = "rdma",
-		.traddr = "192.168.1.1",
-		.trsvcid = "4420",
+		.ctrl_params = {
+			.transport = "rdma",
+			.traddr = "192.168.1.1",
+			.trsvcid = "4420",
+		},
 	};
 	struct libnvmf_context fctx_b = {
-		.transport = "rdma",
-		.traddr = "192.168.1.2",
-		.trsvcid = "4420",
+		.ctrl_params = {
+			.transport = "rdma",
+			.traddr = "192.168.1.2",
+			.trsvcid = "4420",
+		},
 	};
 
 	printf("\ntest_lookup_ctrl_pagination:\n");


### PR DESCRIPTION
# Summary

The ultimate goal of this series is to completely remove fabrics-only code from `tree.c` so that PCIe-only builds carry zero NVMe-oF overhead. The previous series (already merged) created `tree-fabrics.c` and moved the TCP matching functions and sysfs readers there. This series goes further by decoupling the controller allocation and lookup machinery from `libnvmf_context`, then moving the ctrl-find cluster itself into `tree-fabrics.c`, leaving `tree.c` with no `#include "private-fabrics.h"` dependency.

## fabrics: rename callbacks to hooks (327e17cc2)

Renames `libnvmf_callbacks` → `libnvmf_hooks` and the corresponding `libnvmf_context_set_*_cbs()` accessors to `libnvmf_context_set_*_hooks()`. The term "hooks" is more accurate — these are injection points for application behaviour, not observer callbacks. Preparatory rename before the structural changes that follow.

## fabrics: group hooks and user_data into struct libnvmf_hooks (7efbed4b7)

Embeds all hook function pointers and `user_data` into a nested `struct libnvmf_hooks hooks` inside `libnvmf_context`. This makes the relationship between the hooks and their shared `user_data` explicit in the type system. Call sites change from `fctx->hook_name(...)` to `fctx->hooks.hook_name(...)`.

## tree/fabrics: introduce libnvme\_ctrl\_params and embed in libnvmf\_context (01d61a178)

Introduces `struct libnvme_ctrl_params` to group the connection-target fields (`transport`, `traddr`, `trsvcid`, `subsysnqn`, `host_traddr`, `host_iface`, and the embedded `struct libnvme_fabrics_config`). The struct is embedded as `ctrl_params` in `libnvmf_context`, replacing the individual fields that were scattered across the context. Also introduces `libnvme_fabrics_config_copy()` as a safe alternative to raw struct assignment for `struct libnvme_fabrics_config`, guarding against future additions of owned pointer members.

## fabrics: fix libnvmf\_connect() not propagating resolved TLS key IDs (3a1667ef1)

Pre-existing bug uncovered during refactoring: `nvme_parse_tls_args()` resolves symbolic TLS key identifiers into numeric IDs and writes them into `fctx->ctrl_params.cfg`, but this happens *after* `libnvme_create_ctrl()` has already copied `cfg` to `c->cfg`, so the resolved IDs never reached the controller. The fix mirrors the pattern already present in `libnvmf_config_modify()`: call `update_config(c, &fctx->ctrl_params.cfg)` after `nvme_parse_tls_args()`.

## tree: decouple ctrl-find/alloc from libnvmf\_context (d3ed1ed98)

The ctrl-find/alloc cluster (`libnvme_candidate_init`, `libnvme_ctrl_find`, `libnvme_lookup_ctrl`, `libnvme_ctrl_alloc`) only ever accessed `fctx->ctrl_params.*`, so passing the full `libnvmf_context` was unnecessary coupling. All four functions are changed to accept `const struct libnvme_ctrl_params *` instead. `libnvme_ctrl_alloc` becomes static. `json.c` is simplified to use `struct libnvme_ctrl_params` directly and drops its `private-fabrics.h` include.

## tree: move ctrl-find cluster to tree-fabrics.c (8648654)

Moves the ctrl-find/match functions from `tree.c` into `tree-fabrics.c`: `_libnvmf_tree_ctrl_match` and `_libnvmf_candidate_init` become static; `libnvme_ctrl_find` is non-static because `tree.c::libnvme_lookup_ctrl` still calls it, so a simplified no-fabrics stub (transport + traddr matching) is added to `no-fabrics.c`. The declarations of `traddr_is_hostname`, `libnvmf_default_config`, and `libnvme_ctrl_find` are promoted from `private-fabrics.h` to `private.h`. The `#include "private-fabrics.h"` is removed from `tree.c`.
