### PR TITLE
util: Fix buffer overflow in process_field_size_default

### DIFF
--- a/util/utils.c
+++ b/util/utils.c
@@ -10,6 +10,7 @@
 #include "utils.h"
 #include "types.h"
 #include "json.h"
+#include "cleanup.h"
 
 int hex_to_int(char c)
 {
@@ -156,100 +157,118 @@ void print_formatted_var_size_str(const char *msg, const __u8 *pdata, size_t dat
 	free(description_str);
 }
 
-void process_field_size_16(int offset, char *sfield, __u8 *buf, char *datastr)
+char *process_field_size_16(int offset, char *sfield, __u8 *buf)
 {
 	__u64 lval_lo, lval_hi;
+	char *datastr = NULL;
 
 	if (strstr(sfield, "GUID")) {
-		sprintf(datastr, "0x%"PRIx64"%"PRIx64"",
-			le64_to_cpu(*(__u64 *)(&buf[offset + 8])),
-			le64_to_cpu(*(__u64 *)(&buf[offset])));
+		if (asprintf(&datastr, "0x%"PRIx64"%"PRIx64"",
+			     le64_to_cpu(*(__u64 *)(&buf[offset + 8])),
+			     le64_to_cpu(*(__u64 *)(&buf[offset]))) < 0)
+			return NULL;
 	} else {
 		lval_lo = *((__u64 *)(&buf[offset]));
 		lval_hi = *((__u64 *)(&buf[offset + 8]));
 
-		if (lval_hi)
-			sprintf(datastr, "0x%"PRIx64"%016"PRIx64"",
-				le64_to_cpu(lval_hi), le64_to_cpu(lval_lo));
-		else
-			sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+		if (lval_hi) {
+			if (asprintf(&datastr, "0x%"PRIx64"%016"PRIx64"",
+				     le64_to_cpu(lval_hi), le64_to_cpu(lval_lo)) < 0)
+				return NULL;
+		} else {
+			if (asprintf(&datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo)) < 0)
+				return NULL;
+		}
 	}
+	return datastr;
 }
 
-void process_field_size_8(int offset, char *sfield, __u8 *buf, char *datastr)
+char *process_field_size_8(int offset, char *sfield, __u8 *buf)
 {
 	__u64 lval_lo;
+	char *datastr = NULL;
 
 	if (strstr(sfield, "Boot SSD Spec Version")) {
-		sprintf(datastr, "%x.%x.%x.%x",
-		le16_to_cpu(*((__u16 *)(&buf[300]))),
-		le16_to_cpu(*((__u16 *)(&buf[302]))),
-		le16_to_cpu(*((__u16 *)(&buf[304]))),
-		le16_to_cpu(*((__u16 *)(&buf[306]))));
+		if (asprintf(&datastr, "%x.%x.%x.%x",
+			     le16_to_cpu(*((__u16 *)(&buf[300]))),
+			     le16_to_cpu(*((__u16 *)(&buf[302]))),
+			     le16_to_cpu(*((__u16 *)(&buf[304]))),
+			     le16_to_cpu(*((__u16 *)(&buf[306])))) < 0)
+			return NULL;
 	} else if (strstr(sfield, "Firmware Revision")) {
 		char buffer[30] = {'\0'};
 
 		lval_lo = *((__u64 *)(&buf[offset]));
 
 		sprintf(buffer, "%"PRIx64, __builtin_bswap64(lval_lo));
-		sprintf(datastr, "%s", hex_to_ascii(buffer));
+		datastr = hex_to_ascii(buffer);
 	} else if (strstr(sfield, "Timestamp")) {
 		char ts_buf[128];
 
 		lval_lo = *((__u64 *)(&buf[offset]));
 
 		convert_ts(le64_to_cpu(lval_lo), ts_buf);
-		sprintf(datastr, "%s", ts_buf);
+		datastr = strdup(ts_buf);
 	} else {
 		lval_lo = *((__u64 *)(&buf[offset]));
 
-		sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+		if (asprintf(&datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo)) < 0)
+			return NULL;
 	}
+	return datastr;
 }
 
-void process_field_size_7(int offset, char *sfield, __u8 *buf, char *datastr)
+char *process_field_size_7(int offset, char *sfield, __u8 *buf)
 {
 	__u8 lval[8] = { 0 };
 	__u64 lval_lo;
+	char *datastr = NULL;
 
 	/* 7 bytes will be in little-endian format, with last byte as MSB */
 	memcpy(&lval[0], &buf[offset], 7);
 	memcpy((void *)&lval_lo, lval, 8);
-	sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+	if (asprintf(&datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo)) < 0)
+		return NULL;
+	return datastr;
 }
 
-void process_field_size_6(int offset, char *sfield, __u8 *buf, char *datastr)
+char *process_field_size_6(int offset, char *sfield, __u8 *buf)
 {
 	__u32 ival;
 	__u16 sval;
 	__u64 lval_lo;
+	char *datastr = NULL;
 
 	if (strstr(sfield, "DSSD Spec Version")) {
-		sprintf(datastr, "%x.%x.%x.%x", buf[103],
-			le16_to_cpu(*((__u16 *)(&buf[101]))),
-			le16_to_cpu(*((__u16 *)(&buf[99]))), buf[98]);
+		if (asprintf(&datastr, "%x.%x.%x.%x", buf[103],
+			     le16_to_cpu(*((__u16 *)(&buf[101]))),
+			     le16_to_cpu(*((__u16 *)(&buf[99]))), buf[98]) < 0)
+			return NULL;
 	} else {
 		ival = *((__u32 *)(&buf[offset]));
 		sval = *((__u16 *)(&buf[offset + 4]));
 		lval_lo = (((__u64)sval << 32) | ival);
 
-		sprintf(datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo));
+		if (asprintf(&datastr, "0x%"PRIx64"", le64_to_cpu(lval_lo)) < 0)
+			return NULL;
 	}
+	return datastr;
 }
 
-void process_field_size_default(int offset, char *sfield, __u8 *buf, int size, char *datastr)
+char *process_field_size_default(int offset, char *sfield, __u8 *buf, int size)
 {
-	__u8  cval;
-	char description_str[256] = "0x";
-	char temp_buffer[3] = { 0 };
+	/* "0x" prefix + 2 hex chars per byte + null terminator */
+	char *datastr = malloc(size * 2 + 3);
 
-	for (unsigned char i = 0; i < (unsigned char)size; i++) {
-		cval = (buf[offset + i]);
+	if (!datastr)
+		return NULL;
 
-		sprintf(temp_buffer, "%02X", cval);
-		strcat(description_str, temp_buffer);
-	}
-	sprintf(datastr, "%s", description_str);
+	datastr[0] = '0';
+	datastr[1] = 'x';
+	for (int i = 0; i < size; i++)
+		sprintf(&datastr[2 + i * 2], "%02X", buf[offset + i]);
+
+	return datastr;
 }
 
 void generic_structure_parser(__u8 *buf, struct request_data *req_data, int field_count,
@@ -258,7 +277,7 @@ void generic_structure_parser(__u8 *buf, struct request_data *req_data, int fiel
 	int offset = 0;
 
 	for (int field = 0; field < field_count; field++) {
-		char datastr[1024] = { 0 };
+		__cleanup_free char *datastr = NULL;
 		char *sfield = req_data[field].field;
 		int size = !spec ? req_data[field].size : req_data[field].size2;
 
@@ -267,43 +286,52 @@ void generic_structure_parser(__u8 *buf, struct request_data *req_data, int fiel
 
 		switch (size) {
 		case FIELD_SIZE_16:
-			process_field_size_16(offset, sfield, buf, datastr);
+			datastr = process_field_size_16(offset, sfield, buf);
 			break;
 		case FIELD_SIZE_8:
-			process_field_size_8(offset, sfield, buf, datastr);
+			datastr = process_field_size_8(offset, sfield, buf);
 			break;
 		case FIELD_SIZE_7:
-			process_field_size_7(offset, sfield, buf, datastr);
+			datastr = process_field_size_7(offset, sfield, buf);
 			break;
 		case FIELD_SIZE_6:
-			process_field_size_6(offset, sfield, buf, datastr);
+			datastr = process_field_size_6(offset, sfield, buf);
 			break;
 		case FIELD_SIZE_4:
-			sprintf(datastr, "0x%x", le32_to_cpu(*((__u32 *)(&buf[offset]))));
+			if (asprintf(&datastr, "0x%x",
+				     le32_to_cpu(*((__u32 *)(&buf[offset])))) < 0)
+				datastr = NULL;
 			break;
 		case FIELD_SIZE_3:
-			sprintf(datastr, "0x%02X%02X%02X",
-				buf[offset + 0], buf[offset + 1], buf[offset + 2]);
+			if (asprintf(&datastr, "0x%02X%02X%02X",
+				     buf[offset + 0], buf[offset + 1],
+				     buf[offset + 2]) < 0)
+				datastr = NULL;
 			break;
 		case FIELD_SIZE_2:
-			sprintf(datastr, "0x%04x", le16_to_cpu(*((__u16 *)(&buf[offset]))));
+			if (asprintf(&datastr, "0x%04x",
+				     le16_to_cpu(*((__u16 *)(&buf[offset])))) < 0)
+				datastr = NULL;
 			break;
 		case FIELD_SIZE_1:
-			sprintf(datastr, "0x%02x", buf[offset]);
+			if (asprintf(&datastr, "0x%02x", buf[offset]) < 0)
+				datastr = NULL;
 			break;
 		default:
-			process_field_size_default(offset, sfield, buf, size, datastr);
+			datastr = process_field_size_default(offset, sfield, buf, size);
 			break;
 		}
 		offset += size;
 		/* do not print reserved values */
 		if (strstr(sfield, "Reserved"))
 			continue;
-		if (stats)
-			json_object_add_value_string(stats, sfield, datastr);
-		else if (fp)
-			fprintf(fp, "%-40s : %-4s\n", sfield, datastr);
-		else
-			printf("%-40s : %-4s\n", sfield, datastr);
+		if (datastr) {
+			if (stats)
+				json_object_add_value_string(stats, sfield, datastr);
+			else if (fp)
+				fprintf(fp, "%-40s : %-4s\n", sfield, datastr);
+			else
+				printf("%-40s : %-4s\n", sfield, datastr);
+		}
 	}
 }

--- a/util/utils.h
+++ b/util/utils.h
@@ -89,62 +89,57 @@ void generic_structure_parser(__u8 *buf, struct request_data *req_data, int fiel
 void print_formatted_var_size_str(const char *msg, const __u8 *pdata, size_t data_size, FILE *fp);
 
 /**
- * @brief prints raw data to the buffer
+ * @brief formats a 16-byte field as a hex string
  *
- * @param offset, intput offset of the param
- * @param sfield, intput field
+ * @param offset, input offset of the param
+ * @param sfield, input field name
  * @param buf, input raw data
- * @param datastr, output data buffer
  *
- * @return 0 success
+ * @return allocated string (caller must free), or NULL on error
  */
-void process_field_size_16(int offset, char *sfield, __u8 *buf, char *datastr);
+char *process_field_size_16(int offset, char *sfield, __u8 *buf);
 
 /**
- * @brief prints raw data to the buffer
+ * @brief formats an 8-byte field as a hex string
  *
- * @param offset, intput offset of the param
- * @param sfield, intput field
+ * @param offset, input offset of the param
+ * @param sfield, input field name
  * @param buf, input raw data
- * @param datastr, output data buffer
  *
- * @return 0 success
+ * @return allocated string (caller must free), or NULL on error
  */
-void process_field_size_8(int offset, char *sfield, __u8 *buf, char *datastr);
+char *process_field_size_8(int offset, char *sfield, __u8 *buf);
 
 /**
- * @brief prints raw data to the buffer
+ * @brief formats a 7-byte field as a hex string
  *
- * @param offset, intput offset of the param
- * @param sfield, intput field
+ * @param offset, input offset of the param
+ * @param sfield, input field name
  * @param buf, input raw data
- * @param datastr, output data buffer
  *
- * @return 0 success
+ * @return allocated string (caller must free), or NULL on error
  */
-void process_field_size_7(int offset, char *sfield, __u8 *buf, char *datastr);
+char *process_field_size_7(int offset, char *sfield, __u8 *buf);
 
 /**
- * @brief prints raw data to the buffer
+ * @brief formats a 6-byte field as a hex string
  *
- * @param offset, intput offset of the param
- * @param sfield, intput field
+ * @param offset, input offset of the param
+ * @param sfield, input field name
  * @param buf, input raw data
- * @param datastr, output data buffer
  *
- * @return 0 success
+ * @return allocated string (caller must free), or NULL on error
  */
-void process_field_size_6(int offset, char *sfield, __u8 *buf, char *datastr);
+char *process_field_size_6(int offset, char *sfield, __u8 *buf);
 
 /**
- * @brief prints raw data to the buffer
+ * @brief formats a variable-size field as a hex string
  *
- * @param offset, intput offset of the param
- * @param sfield, intput field
+ * @param offset, input offset of the param
+ * @param sfield, input field name
  * @param buf, input raw data
  * @param size, input data size
- * @param datastr, output data buffer
  *
- * @return 0 success
+ * @return allocated string (caller must free), or NULL on error
  */
-void process_field_size_default(int offset, char *sfield, __u8 *buf, int size, char *datastr);
+char *process_field_size_default(int offset, char *sfield, __u8 *buf, int size);


### PR DESCRIPTION
The process_field_size_default function used a fixed 256-byte buffer for formatting hex output, which overflowed when processing fields larger than 127 bytes (such as Reserved fields up to 302 bytes in Micron SMART logs). This caused segmentation faults.

Additionally, the loop counter was an unsigned char, limiting processing to 255 bytes maximum.

Fix by:
- Converting all process_field_size_* functions to return dynamically allocated strings instead of writing to caller-provided buffers
- Using asprintf() for consistent dynamic allocation
- Using __cleanup_free in the caller for automatic memory management
- Also fixes a pre-existing memory leak where hex_to_ascii() return value was never freed

Fixes #2954