### PR TITLE
mem-win: Disable Windows min/max macros in favor of project solutions

### DIFF
--- a/common.h
+++ b/common.h
@@ -15,12 +15,8 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
-#ifndef min
 #define min(x, y) ((x) > (y) ? (y) : (x))
-#endif
-#ifndef max
 #define max(x, y) ((x) > (y) ? (x) : (y))
-#endif
 
 #ifdef __packed
 #else /* __packed */

--- a/libnvme/src/nvme/mem-win.c
+++ b/libnvme/src/nvme/mem-win.c
@@ -12,6 +12,8 @@
 #include <memoryapi.h>
 #include <sysinfoapi.h>
 
+#include <ccan/minmax/minmax.h>
+
 #include "compiler-attributes.h"
 #include "mem.h"
 #include "private.h"

--- a/meson.build
+++ b/meson.build
@@ -484,6 +484,15 @@ if libtype == 'static'
     requires = ''
 endif
 
+if host_system == 'windows'
+    add_project_arguments(
+        [
+            '-DNOMINMAX',   # don't include Windows min/max definitions
+        ],
+        language : 'c',
+    )
+endif
+
 substs = configuration_data()
 substs.set('VERSION', meson.project_version())
 substs.set('NVMECLI_LICENSE', meson.project_license()[0])


### PR DESCRIPTION
Disables definitions of min/max macros coming from Windows includes. Favors local solutions for min/max definitions isntead.
- Removes #ifndef guards around min/max in common.h that were added due to Windows default min/max definitions.
- Updates mem-win.c to use ccan/minmax definitions.