### PR TITLE
Minor cleanup for Windows support

### DIFF
--- a/libnvme/src/nvme/endian.h
+++ b/libnvme/src/nvme/endian.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32)
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 	#define htobe16(x) (x)
 	#define htobe32(x) (x)

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -1890,7 +1890,7 @@ void nvme_json_pel_vendor_specific_event(void *pevent_log_info, __u32 offset,
 {
 	__u32 progress = 0;
 	__u16 vsedl;
-	uint i;
+	__u32 i;
 	struct nvme_vs_event_desc *vs_desc;
 	struct json_object *vs_events = json_create_array();
 


### PR DESCRIPTION
- Replaces single use of uint with __u32 for better consistency and compatibility. 
- Cleans up Windows check in endian.h.