### PR TITLE
CI: add no-fabrics build workflow with unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,26 @@ jobs:
         run: |
           scripts/build.sh minimal_static
 
+  build-nofabrics:
+    name: no-fabrics build with unit tests
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/linux-nvme/debian:latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Mark repo as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: build
+        run: |
+          scripts/build.sh nofabrics
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        name: upload logs
+        if: failure()
+        with:
+          name: no-fabrics log files
+          path: |
+            .build-ci/meson-logs/*.txt
+
   build-alpine:
     name: musl libc build on Alpine
     runs-on: ubuntu-latest

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,6 +36,7 @@ usage() {
     echo "  rst_docs            build rst documentation only"
     echo "  static              build a static binary"
     echo "  minimal_static      build a static binary without fabrics support"
+    echo "  nofabrics           build without fabrics support, run unit tests"
     echo "  libnvme             build only libnvme"
     echo "  tests               build for nightly build"
     echo ""
@@ -234,6 +235,20 @@ config_meson_minimal_static() {
         -Djson-c=disabled                       \
         -Dtests=false                           \
         -Dexamples=false                        \
+        "${BUILDDIR}"
+}
+
+config_meson_nofabrics() {
+    CC="${CC}" "${MESON}" setup                 \
+        --werror                                \
+        --buildtype="${BUILDTYPE}"              \
+        -Dfabrics=disabled                      \
+        -Dmi=disabled                           \
+        -Dpython=disabled                       \
+        -Djson-c=disabled                       \
+        -Dlibkmod=disabled                      \
+        -Dopenssl=disabled                      \
+        -Dkeyutils=disabled                     \
         "${BUILDDIR}"
 }
 


### PR DESCRIPTION
Add a CI workflow that configures and builds nvme-cli with all optional dependencies disabled (fabrics, mi, python, json-c, libkmod, openssl, keyutils) and runs the unit test suite against that build.

The existing build-musl-minimal-static job also builds without fabrics but explicitly disables tests (-Dtests=false), leaving the no-fabrics code path unvalidated by CI. This workflow closes that gap.