### PR TITLE
fabrics: avoid segfault at sanitize_discovery_log_entry()

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1490,6 +1490,9 @@ out_free_log:
 static void sanitize_discovery_log_entry(struct libnvme_global_ctx *ctx,
 		struct nvmf_disc_log_entry *e)
 {
+	if (!e)
+		return;
+
 	strchomp(e->trsvcid, sizeof(e->trsvcid));
 	strchomp(e->traddr, sizeof(e->traddr));
 


### PR DESCRIPTION
Avoid a potential segfault at sanitize_discovery_log_entry() while dereferencing the nvmf_disc_log_entry pointer.