### PR TITLE
libnvme: fix memleak in libnvme_subsystem_set_ns_path

### DIFF
--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -2776,7 +2776,7 @@ static void libnvme_subsystem_set_ns_path(libnvme_subsystem_t s, libnvme_ns_t n)
 	struct libnvme_ns_head *head = n->head;
 
 	if (libnvme_ns_head_get_sysfs_dir(head)) {
-		struct dirents paths = {};
+		__cleanup_dirents struct dirents paths = {};
 		int i;
 
 		/*


### PR DESCRIPTION
While building the NVMe topology on multipath systems, libnvme constructs the namespace path list by scanning the  /sys/block/<nshead-dev>/multipath directory to discover all paths associated with a namespace head node.

The scandir() helper allocates an array of struct dirent entries using malloc(), and it is the caller's responsibility to free the allocated array once it is no longer needed.

libnvme_subsystem_set_ns_path() invokes scandir() to discover namespace paths and populate head->paths, but it never frees the allocated dirent array, resulting in a memory leak.

Fix this by annotating the struct dirents instance with __cleanup_dirents, ensuring that the allocated dirent array is automatically freed when leaving scope.