### PR TITLE
completions: fix ocp plugin command list and description

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -234,15 +234,15 @@ _nvme () {
 				_arguments '*:: :->subcmds'
 				_describe -t commands "nvme ocp eol-plp-failure-mode options" _eol_plp_failure_mode
 				;;
-			(clear-pcie-correctable-error-counters)
-				local _clear_pcie_correctable_error_counters
-				_clear_pcie_correctable_error_counters=(
+			(clear-pcie-correctable-errors)
+				local _clear_pcie_correctable_errors
+				_clear_pcie_correctable_errors=(
 				/dev/nvme':supply a device to use (required)'
 				--no-uuid':Skip UUID index search'
 				-n':alias for --no-uuid'
 				)
 				_arguments '*:: :->subcmds'
-				_describe -t commands "nvme ocp clear-pcie-correctable-error-counters options" _clear_pcie_correctable_error_counters
+				_describe -t commands "nvme ocp clear-pcie-correctable-errors options" _clear_pcie_correctable_errors
 				;;
 			(fw-activate-history)
 				local _fw_activate_history
@@ -2862,26 +2862,38 @@ _nvme () {
 		(ocp)
 			local _ocp
 			_ocp=(
-			smart-add-log':Retrieve extended SMART Information'
-			latency-monitor-log':Get Latency Monitor Log Page'
-			set-latency-monitor-feature':Set Latency Monitor feature'
-			internal-log':Retrieve and save internal device telemetry log'
-			clear-fw-activate-history':Clear firmware update history log"'
-			eol-plp-failure-mode':Define EOL or PLP circuitry failure mode'
-			clear-pcie-correctable-error-counters':Clear PCIe correctable error counters'
-			vs-fw-activate-history':Get firmware activation history log'
-			device-capability-log':Get Device capability log'
-			set-dssd-power-state-feature':Set DSSD Power State'
-			get-dssd-power-state-feature':Get DSSD Power State'
-			telemetry-string-log':Retrieve Telemetry string Log Page'
-			set-telemetry-profile':Set Telemetry Profile'
-			tcg-configuration-log':tcg configuration log'
-			get-error-injection':get error injection'
-			set-error-injection':set error injection'
-			hardware-component-log':retrieve hardware component log'
+			smart-add-log':Retrieve Extended SMART Information'
+			latency-monitor-log':Retrieve Latency Monitor Log Page'
+			set-latency-monitor-feature':Set Latency Monitor Feature'
+			internal-log':Retrieve and Save Internal Device Telemetry Log'
+			clear-fw-activate-history':Clear Firmware Update History'
+			eol-plp-failure-mode':Define EOL or PLP Circuitry Failure Mode'
+			clear-pcie-correctable-errors':Clear PCIe Correctable Error Counters'
+			fw-activate-history':Retrieve Firmware Activation History Log Page'
+			unsupported-reqs-log':Retrieve Unsupported Requirements Log Page'
+			error-recovery-log':Retrieve Error Recovery Log Page'
+			device-capability-log':Retrieve Device Capabilities Log Page'
+			set-dssd-power-state-feature':Set DSSD Power State Feature'
+			get-dssd-power-state-feature':Get DSSD Power State Feature'
+			set-plp-health-check-interval':Set PLP Health Check Interval'
+			get-plp-health-check-interval':Get PLP Health Check Interval'
+			telemetry-string-log':Retrieve Telemetry String Log Page'
+			set-telemetry-profile':Set Telemetry Profile Feature'
+			set-dssd-async-event-config':Set DSSD Asynchronous Event Configuration'
+			get-dssd-async-event-config':Get DSSD Asynchronous Event Configuration'
+			tcg-configuration-log':Retrieve TCG Configuration Log Page'
+			get-error-injection':Get Error Injection Feature'
+			set-error-injection':Set Error Injection Feature'
+			get-enable-ieee1667-silo':Get Enable IEEE1667 Silo Feature'
+			set-enable-ieee1667-silo':Set Enable IEEE1667 Silo Feature'
+			hardware-component-log':Retrieve Hardware Component Log Page'
 			get-latency-monitor':Get Latency Monitor Feature'
-			get-clear-pcie-correctable-errors':retrieve clear pcie correctable errors'
-			get-telemetry-profile':retrieve Get Telemetry Profile Feature'
+			get-clear-pcie-correctable-errors':Get Clear PCIe Correctable Error Counters Feature'
+			get-telemetry-profile':Get Telemetry Profile Feature'
+			persistent-event-log':Retrieve Persistent Event Log with OCP Events'
+			get-idle-wakeup-time':Get Idle Wake Up Time Configuration'
+			version':Shows the program version'
+			help':Display this help'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme ocp options" _ocp

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -1745,14 +1745,19 @@ _nvme_subcmds () {
 		[ocp]="smart-add-log latency-monitor-log \
 			set-latency-monitor-feature internal-log \
 			clear-fw-activate-history eol-plp-failure-mode \
-			clear-pcie-correctable-error-counters \
-			vs-fw-activate-history device-capability-log \
+			clear-pcie-correctable-errors \
+			fw-activate-history device-capability-log \
 			set-dssd-power-state-feature get-dssd-power-state-feature \
 			telemetry-string-log set-telemetry-profile \
 			set-dssd-async-event-config get-dssd-async-event-config \
 			get-error-injection set-error-injection \
 			hardware-component-log get-latency-monitor \
-			get-clear-pcie-correctable-errors get-telemetry-profile"
+			get-clear-pcie-correctable-errors get-telemetry-profile \
+			error-recovery-log unsupported-reqs-log \
+			tcg-configuration-log set-plp-health-check-interval \
+			get-plp-health-check-interval get-enable-ieee1667-silo \
+			set-enable-ieee1667-silo persistent-event-log \
+			get-idle-wakeup-time version help"
 		[mangoboost]="id-ctrl"
 	)
 

--- a/plugins/ocp/ocp-clear-features.c
+++ b/plugins/ocp/ocp-clear-features.c
@@ -61,7 +61,7 @@ static int ocp_clear_feature(int argc, char **argv, const char *desc, const __u8
 int get_ocp_error_counters(int argc, char **argv, struct command *acmd,
 			   struct plugin *plugin)
 {
-	const char *desc = "Define Issue Get Feature cmd (FID: 0xC3) Clear PCIe Corr Err Counters";
+	const char *desc = "Issue Get Feature command (FID: 0xC3) Clear PCIe Correctable Error Counters";
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 	const char *no_uuid = "Do not try to automatically detect UUID index";

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -403,7 +403,7 @@ int ocp_set_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 static int ocp_get_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 					   struct plugin *plugin)
 {
-	const char *desc = "Define Issue Get Feature command (FID: 0xC5) Latency Monitor";
+	const char *desc = "Issue Get Feature command (FID: 0xC5) Latency Monitor";
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 
@@ -1984,7 +1984,7 @@ static int ocp_set_telemetry_profile_feature(int argc, char **argv, struct comma
 static int ocp_get_telemetry_profile_feature(int argc, char **argv, struct command *acmd,
 					      struct plugin *plugin)
 {
-	const char *desc = "Define Issue Get Feature command (FID: 0xC8) Telemetry Profile";
+	const char *desc = "Issue Get Feature command (FID: 0xC8) Telemetry Profile";
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const char *nsid = "Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive";
 
@@ -2212,7 +2212,7 @@ static int set_plp_health_check_interval(int argc, char **argv, struct command *
 					 struct plugin *plugin)
 {
 
-	const char *desc = "Define Issue Set Feature command (FID : 0xC6) PLP Health Check Interval";
+	const char *desc = "Issue Set Feature command (FID: 0xC6) PLP Health Check Interval";
 	const char *plp_health_interval = "[31:16]:PLP Health Check Interval";
 	const char *sv = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
@@ -2271,7 +2271,7 @@ static int get_plp_health_check_interval(int argc, char **argv, struct command *
 					 struct plugin *plugin)
 {
 
-	const char *desc = "Define Issue Get Feature command (FID : 0xC6) PLP Health Check Interval";
+	const char *desc = "Issue Get Feature command (FID: 0xC6) PLP Health Check Interval";
 	const __u32 nsid = 0;
 	const __u8 fid = 0xc6;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
@@ -2319,7 +2319,7 @@ static int set_dssd_async_event_config(int argc, char **argv, struct command *ac
 				       struct plugin *plugin)
 {
 
-	const char *desc = "Issue Set Feature command (FID : 0xC9) DSSD Async Event Config";
+	const char *desc = "Issue Set Feature command (FID: 0xC9) DSSD Async Event Config";
 	const char *epn = "[0]:Enable Panic Notices";
 	const char *sv = "Specifies that the controller shall save the attribute";
 	const __u32 nsid = 0;
@@ -2373,7 +2373,7 @@ static int get_dssd_async_event_config(int argc, char **argv, struct command *ac
 				       struct plugin *plugin)
 {
 
-	const char *desc = "Issue Get Feature command (FID : 0xC9) DSSD Async Event Config";
+	const char *desc = "Issue Get Feature command (FID: 0xC9) DSSD Async Event Config";
 	const char *sel = "[0-3]: current/default/saved/supported";
 	const __u32 nsid = 0;
 	const __u8 fid = OCP_FID_DAEC;
@@ -2679,7 +2679,7 @@ static int error_injection_get(struct libnvme_transport_handle *hdl, const __u8 
 
 static int get_error_injection(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
-	const char *desc = "Return set of error injection";
+	const char *desc = "Get Error Injection Feature";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	int err;
@@ -2841,7 +2841,7 @@ static int enable_ieee1667_silo_get(struct libnvme_transport_handle *hdl, const 
 static int get_enable_ieee1667_silo(int argc, char **argv, struct command *acmd,
 				    struct plugin *plugin)
 {
-	const char *desc = "return set of enable IEEE1667 silo";
+	const char *desc = "Get Enable IEEE1667 Silo Feature";
 	int err;
 	struct config {
 		__u8 sel;
@@ -3057,7 +3057,7 @@ static int ocp_get_idle_wakeup_time_config_feature(int argc, char **argv,
 						    struct command *acmd,
 						    struct plugin *plugin)
 {
-	const char *desc = "Define Issue Get Feature cmd (FID: 0xCA) IWUT";
+	const char *desc = "Issue Get Feature command (FID: 0xCA) IWUT";
 	const char *sel = "[0-3]: current/default/saved/supported/";
 	const char *nsid = "Byte[04-07]: NSID Valid/Invalid/Inactive";
 

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -16,42 +16,41 @@
 
 PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),
 	COMMAND_LIST(
-		ENTRY("smart-add-log", "Retrieve extended SMART Information", smart_add_log)
-		ENTRY("latency-monitor-log", "Get Latency Monitor Log Page", ocp_latency_monitor_log)
-		ENTRY("set-latency-monitor-feature", "Set Latency Monitor feature", ocp_set_latency_monitor_feature)
-		ENTRY("internal-log", "Retrieve and save internal device telemetry log", ocp_telemetry_log)
-		ENTRY("clear-fw-activate-history", "Clear firmware update history log", clear_fw_update_history)
-		ENTRY("eol-plp-failure-mode", "Define EOL or PLP circuitry failure mode.", eol_plp_failure_mode)
-		ENTRY("clear-pcie-correctable-errors", "Clear PCIe correctable error counters", clear_pcie_correctable_error_counters)
-		ENTRY("fw-activate-history", "Get firmware activation history log", fw_activation_history_log)
-		ENTRY("unsupported-reqs-log", "Get Unsupported Requirements Log Page", ocp_unsupported_requirements_log)
+		ENTRY("smart-add-log", "Retrieve Extended SMART Information", smart_add_log)
+		ENTRY("latency-monitor-log", "Retrieve Latency Monitor Log Page", ocp_latency_monitor_log)
+		ENTRY("set-latency-monitor-feature", "Set Latency Monitor Feature", ocp_set_latency_monitor_feature)
+		ENTRY("internal-log", "Retrieve and Save Internal Device Telemetry Log", ocp_telemetry_log)
+		ENTRY("clear-fw-activate-history", "Clear Firmware Update History", clear_fw_update_history)
+		ENTRY("eol-plp-failure-mode", "Define EOL or PLP Circuitry Failure Mode", eol_plp_failure_mode)
+		ENTRY("clear-pcie-correctable-errors", "Clear PCIe Correctable Error Counters", clear_pcie_correctable_error_counters)
+		ENTRY("fw-activate-history", "Retrieve Firmware Activation History Log Page", fw_activation_history_log)
+		ENTRY("unsupported-reqs-log", "Retrieve Unsupported Requirements Log Page", ocp_unsupported_requirements_log)
 		ENTRY("error-recovery-log", "Retrieve Error Recovery Log Page", ocp_error_recovery_log)
-		ENTRY("device-capability-log", "Get Device capabilities Requirements Log Page", ocp_device_capabilities_log)
-		ENTRY("set-dssd-power-state-feature", "Set DSSD Power State feature", set_dssd_power_state_feature)
-		ENTRY("get-dssd-power-state-feature", "Get DSSD Power State feature", get_dssd_power_state_feature)
+		ENTRY("device-capability-log", "Retrieve Device Capabilities Log Page", ocp_device_capabilities_log)
+		ENTRY("set-dssd-power-state-feature", "Set DSSD Power State Feature", set_dssd_power_state_feature)
+		ENTRY("get-dssd-power-state-feature", "Get DSSD Power State Feature", get_dssd_power_state_feature)
 		ENTRY("set-plp-health-check-interval", "Set PLP Health Check Interval", set_plp_health_check_interval)
 		ENTRY("get-plp-health-check-interval", "Get PLP Health Check Interval", get_plp_health_check_interval)
-		ENTRY("telemetry-string-log", "Retrieve Telemetry string Log Page", ocp_telemetry_str_log_format)
+		ENTRY("telemetry-string-log", "Retrieve Telemetry String Log Page", ocp_telemetry_str_log_format)
 		ENTRY("set-telemetry-profile", "Set Telemetry Profile Feature", ocp_set_telemetry_profile_feature)
-		ENTRY("set-dssd-async-event-config", "Set DSSD Async Event Config", set_dssd_async_event_config)
-		ENTRY("get-dssd-async-event-config", "Get DSSD Async Event Config", get_dssd_async_event_config)
+		ENTRY("set-dssd-async-event-config", "Set DSSD Asynchronous Event Configuration", set_dssd_async_event_config)
+		ENTRY("get-dssd-async-event-config", "Get DSSD Asynchronous Event Configuration", get_dssd_async_event_config)
 		ENTRY("tcg-configuration-log", "Retrieve TCG Configuration Log Page", ocp_tcg_configuration_log)
-		ENTRY("get-error-injection", "Return set of error injection", get_error_injection)
-		ENTRY("set-error-injection", "Inject error conditions", set_error_injection)
-		ENTRY("get-enable-ieee1667-silo", "return set of enable IEEE1667 silo",
-		      get_enable_ieee1667_silo)
-		ENTRY("set-enable-ieee1667-silo", "enable IEEE1667 silo", set_enable_ieee1667_silo)
-		ENTRY("hardware-component-log", "retrieve hardware component log", hwcomp_log)
+		ENTRY("get-error-injection", "Get Error Injection Feature", get_error_injection)
+		ENTRY("set-error-injection", "Set Error Injection Feature", set_error_injection)
+		ENTRY("get-enable-ieee1667-silo", "Get Enable IEEE1667 Silo Feature", get_enable_ieee1667_silo)
+		ENTRY("set-enable-ieee1667-silo", "Set Enable IEEE1667 Silo Feature", set_enable_ieee1667_silo)
+		ENTRY("hardware-component-log", "Retrieve Hardware Component Log Page", hwcomp_log)
 		ENTRY("get-latency-monitor", "Get Latency Monitor Feature",
 		      ocp_get_latency_monitor_feature)
 		ENTRY("get-clear-pcie-correctable-errors",
-		      "Get Clear PCIe Correctable Error Counters feature",
+		      "Get Clear PCIe Correctable Error Counters Feature",
 		      get_clear_pcie_correctable_error_counters)
 		ENTRY("get-telemetry-profile", "Get Telemetry Profile Feature",
 		      ocp_get_telemetry_profile_feature)
-		ENTRY("persistent-event-log", "Retrieve Persistent Event Log with OCP events",
+		ENTRY("persistent-event-log", "Retrieve Persistent Event Log with OCP Events",
 		      ocp_get_persistent_event_log)
-		ENTRY("get-idle-wakeup-time", "Get Idle Wake Up Time Config",
+		ENTRY("get-idle-wakeup-time", "Get Idle Wake Up Time Configuration",
 		      ocp_get_idle_wakeup_time_config_feature)
 	)
 );

--- a/plugins/ocp/ocp-nvme.h
+++ b/plugins/ocp/ocp-nvme.h
@@ -44,7 +44,8 @@ PLUGIN(NAME("ocp", "OCP cloud SSD extensions", OCP_PLUGIN_VERSION),
 		ENTRY("hardware-component-log", "retrieve hardware component log", hwcomp_log)
 		ENTRY("get-latency-monitor", "Get Latency Monitor Feature",
 		      ocp_get_latency_monitor_feature)
-		ENTRY("get-clear-pcie-correctable-errors", "Clear PCIe correctable error counters",
+		ENTRY("get-clear-pcie-correctable-errors",
+		      "Get Clear PCIe Correctable Error Counters feature",
 		      get_clear_pcie_correctable_error_counters)
 		ENTRY("get-telemetry-profile", "Get Telemetry Profile Feature",
 		      ocp_get_telemetry_profile_feature)


### PR DESCRIPTION
Fix bash completion for the ocp plugin:
- Correct "clear-pcie-correctable-error-counters" to "clear-pcie-correctable-errors"
- Correct "vs-fw-activate-history" to "fw-activate-history"
- Add missing commands: error-recovery-log, unsupported-reqs-log, tcg-configuration-log, set-plp-health-check-interval, get-plp-health-check-interval, get-enable-ieee1667-silo, set-enable-ieee1667-silo, persistent-event-log, get-idle-wakeup-time
- Add "version" and "help" commands

Also fix the misleading description for get-clear-pcie-correctable-errors in ocp-nvme.h to clarify it retrieves the feature value rather than clearing the counters.