### PR TITLE
Small changes for cross-platform compatibility

### DIFF
--- a/libnvme/tools/check-public-symbols.py
+++ b/libnvme/tools/check-public-symbols.py
@@ -50,7 +50,7 @@ ld_syms = {}   # symbol -> Path of the .ld file that declares it
 for ld_path in LD_FILES:
     if not ld_path.exists():
         continue
-    for line in ld_path.read_text().splitlines():
+    for line in ld_path.read_text(encoding='utf-8').splitlines():
         m = re.match(r'^\s+([a-z]\w+);', line)
         if m:
             ld_syms[m.group(1)] = ld_path
@@ -66,7 +66,7 @@ PUB_RE = re.compile(r'^__libnvme_public\b.*\b([a-z_]\w+)\s*\(', re.MULTILINE)
 pub_syms = {}  # symbol -> Path of the .c file that defines it
 
 for c_path in sorted(SRC_DIR.glob('*.c')):
-    for m in PUB_RE.finditer(c_path.read_text()):
+    for m in PUB_RE.finditer(c_path.read_text(encoding='utf-8')):
         sym = m.group(1)
         pub_syms[sym] = c_path
 

--- a/plugins/ibm/ibm-nvme.c
+++ b/plugins/ibm/ibm-nvme.c
@@ -375,7 +375,7 @@ static int get_ibm_vpd_log(int argc, char **argv, struct command *cmd, struct pl
 	if (err < 0)
 		return err;
 
-	bzero(&vpd_log, sizeof(vpd_log));
+	memset(&vpd_log, 0, sizeof(vpd_log));
 	err = nvme_get_log_simple(hdl, 0xf1, &vpd_log, sizeof(vpd_log));
 
 	if (!err) {

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1278,7 +1278,7 @@ static int read_header(struct libnvme_passthru_cmd *cmd, __u8 *buf,
 	cmd->cdw10 = 0x400;
 	cmd->cdw12 = dw12;
 	cmd->data_len = 0x1000;
-	cmd->addr = (unsigned long)(void *)buf;
+	cmd->addr = (uintptr_t)(void *)buf;
 	return read_entire_cmd(cmd, 0x400, 0x400, -1, hdl, buf);
 }
 
@@ -1421,7 +1421,7 @@ static int get_internal_log(int argc, char **argv, struct command *acmd,
 	/* for 1.1 Fultondales will use old nlog, but current assert/event */
 	if ((intel->ver.major < 1 && intel->ver.minor < 1) ||
 	    (intel->ver.major <= 1 && intel->ver.minor <= 1 && cfg.log == 0)) {
-		cmd.addr = (unsigned long)(void *)buf;
+		cmd.addr = (uintptr_t)(void *)buf;
 		err = get_internal_log_old(buf, output, hdl, &cmd);
 		goto out;
 	}

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -242,7 +242,7 @@ static int ilog_dump_assert_logs(struct libnvme_transport_handle *hdl, struct il
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
 		.nsid = NVME_NSID_ALL,
-		.addr = (unsigned long)(void *)head_buf,
+		.addr = (__u64)(void *)head_buf,
 		.cdw12 = ASSERTLOG,
 		.cdw13 = 0,
 	};
@@ -265,7 +265,7 @@ static int ilog_dump_assert_logs(struct libnvme_transport_handle *hdl, struct il
 		close(output);
 		return err;
 	}
-	cmd.addr = (unsigned long)(void *)buf;
+	cmd.addr = (__u64)(void *)buf;
 
 	if (ilog->cfg->verbose) {
 		printf("Assert Log, cores: %d log size: %d header size: %d\n", ad->header.numcores,
@@ -299,7 +299,7 @@ static int ilog_dump_event_logs(struct libnvme_transport_handle *hdl, struct ilo
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
 		.nsid = NVME_NSID_ALL,
-		.addr = (unsigned long)(void *)head_buf,
+		.addr = (__u64)(void *)head_buf,
 		.cdw12 = EVENTLOG,
 		.cdw13 = 0,
 	};
@@ -322,7 +322,7 @@ static int ilog_dump_event_logs(struct libnvme_transport_handle *hdl, struct ilo
 		close(output);
 		return err;
 	}
-	cmd.addr = (unsigned long)(void *)buf;
+	cmd.addr = (__u64)(void *)buf;
 
 	if (ilog->cfg->verbose)
 		printf("Event Log, cores: %d log size: %d\n", core_num, ehdr->header.log_size * 4);
@@ -374,7 +374,7 @@ static int ilog_dump_nlogs(struct libnvme_transport_handle *hdl, struct ilog *il
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
 		.nsid = NVME_NSID_ALL,
-		.addr = (unsigned long)(void *)buf
+		.addr = (__u64)(void *)buf
 	};
 
 	struct dump_select {


### PR DESCRIPTION
- Updates check-public-symbols to work across platforms.
- Changes use of non-standard bzero to memset.
- Changes unsigned long casts that need to be 64-bits to use fixed width __u64 type.