### PR TITLE
support fixed width table column

### DIFF
--- a/nvme-print-stdout-top.c
+++ b/nvme-print-stdout-top.c
@@ -408,11 +408,11 @@ static int stdout_top_print_path_health(FILE *stream, libnvme_subsystem_t s)
 	libnvme_path_t p;
 	struct table *t;
 	struct table_column columns[] = {
-		{"NSPath", LEFT},
-		{"ANAState", LEFT},
-		{"Retries", LEFT},
-		{"Failovers", LEFT},
-		{"Errors", LEFT}
+		{"NSPath",    LEFT, AUTO_WIDTH},
+		{"ANAState",  LEFT, AUTO_WIDTH},
+		{"Retries",   LEFT, AUTO_WIDTH},
+		{"Failovers", LEFT, AUTO_WIDTH},
+		{"Errors",    LEFT, AUTO_WIDTH}
 	};
 
 	t = table_create();
@@ -477,22 +477,22 @@ static int stdout_top_print_ctrl_summary(FILE *stream,
 	struct table *t;
 	bool is_fabric = false;
 	struct table_column columns[] = {
-		{"Ctrl", LEFT},
-		{"Paths", LEFT},
-		{"Node", LEFT},
-		{"Trtype", LEFT},
-		{"Address", LEFT},
-		{"State", LEFT},
-		{"Resets", LEFT},
-		{"Reconnects", LEFT},
-		{"Errors", LEFT},
-		{"r_IOPS", LEFT},
-		{"w_IOPS", LEFT},
-		{"r_clat", LEFT},
-		{"w_clat", LEFT},
-		{"r_bw", LEFT},
-		{"w_bw", LEFT},
-		{"Util%", LEFT},
+		{"Ctrl",       LEFT, AUTO_WIDTH},
+		{"Paths",      LEFT, AUTO_WIDTH},
+		{"Node",       LEFT, AUTO_WIDTH},
+		{"Trtype",     LEFT, AUTO_WIDTH},
+		{"Address",    LEFT, AUTO_WIDTH},
+		{"State",      LEFT, AUTO_WIDTH},
+		{"Resets",     LEFT, AUTO_WIDTH},
+		{"Reconnects", LEFT, AUTO_WIDTH},
+		{"Errors",     LEFT, AUTO_WIDTH},
+		{"r_IOPS",     LEFT, 9},
+		{"w_IOPS",     LEFT, 9},
+		{"r_clat",     LEFT, 8},
+		{"w_clat",     LEFT, 8},
+		{"r_bw",       LEFT, 13},
+		{"w_bw",       LEFT, 13},
+		{"Util%",      LEFT, 6},
 	};
 
 	t = table_create();
@@ -613,19 +613,19 @@ static int stdout_top_print_ns_stat(FILE *stream, libnvme_subsystem_t s)
 	char r_clat_str[16], w_clat_str[16];
 	struct table *t;
 	struct table_column columns[] = {
-		{"Namespace", LEFT},
-		{"NSID", LEFT},
-		{"Ctrl", LEFT},
-		{"Retries", LEFT},
-		{"Errors", LEFT},
-		{"r_IOPS", LEFT},
-		{"w_IOPS", LEFT},
-		{"r_clat", LEFT},
-		{"w_clat", LEFT},
-		{"r_bw", LEFT},
-		{"w_bw", LEFT},
-		{"Inflights", LEFT},
-		{"Util%", LEFT},
+		{"Namespace", LEFT, AUTO_WIDTH},
+		{"NSID",      LEFT, AUTO_WIDTH},
+		{"Ctrl",      LEFT, AUTO_WIDTH},
+		{"Retries",   LEFT, AUTO_WIDTH},
+		{"Errors",    LEFT, AUTO_WIDTH},
+		{"r_IOPS",    LEFT, 9},
+		{"w_IOPS",    LEFT, 9},
+		{"r_clat",    LEFT, 8},
+		{"w_clat",    LEFT, 8},
+		{"r_bw",      LEFT, 13},
+		{"w_bw",      LEFT, 13},
+		{"Inflights", LEFT, AUTO_WIDTH},
+		{"Util%",     LEFT, 6},
 	};
 
 	t = table_create();
@@ -716,19 +716,19 @@ static int stdout_top_print_nshead_stat(FILE *stream, libnvme_subsystem_t s)
 	char r_bw_str[16], w_bw_str[16];
 	struct table *t;
 	struct table_column columns[] = {
-			{"NSHead", LEFT},
-			{"NSID", LEFT},
-			{"Paths", LEFT},
-			{"Requeue-IO", LEFT},
-			{"Fail-IO", LEFT},
-			{"r_IOPS", LEFT},
-			{"w_IOPS", LEFT},
-			{"r_clat", LEFT},
-			{"w_clat", LEFT},
-			{"r_bw", LEFT},
-			{"w_bw", LEFT},
-			{"Inflights", LEFT},
-			{"Util%", LEFT},
+			{"NSHead",     LEFT, AUTO_WIDTH},
+			{"NSID",       LEFT, AUTO_WIDTH},
+			{"Paths",      LEFT, AUTO_WIDTH},
+			{"Requeue-IO", LEFT, AUTO_WIDTH},
+			{"Fail-IO",    LEFT, AUTO_WIDTH},
+			{"r_IOPS",     LEFT, 9},
+			{"w_IOPS",     LEFT, 9},
+			{"r_clat",     LEFT, 8},
+			{"w_clat",     LEFT, 8},
+			{"r_bw",       LEFT, 13},
+			{"w_bw",       LEFT, 13},
+			{"Inflights",  LEFT, AUTO_WIDTH},
+			{"Util%",      LEFT, 6},
 	};
 
 	t = table_create();
@@ -738,7 +738,7 @@ static int stdout_top_print_nshead_stat(FILE *stream, libnvme_subsystem_t s)
 	}
 
 	if (table_add_columns(t, columns, ARRAY_SIZE(columns)) < 0) {
-		nvme_show_error("Failed to add columns to shead stat table\n");
+		nvme_show_error("Failed to add columns to nshead stat table\n");
 		ret = 1;
 		goto free_tbl;
 	}
@@ -820,20 +820,20 @@ static int stdout_top_print_path_perf(FILE *stream, libnvme_subsystem_t s)
 	struct table *t;
 	const char *iopolicy = libnvme_subsystem_get_iopolicy(s);
 	struct table_column columns[] = {
-		{"NSHead", LEFT},
-		{"NSID", LEFT},
-		{"NSPath", LEFT},
-		{"Nodes", LEFT},
-		{"Qdepth", LEFT},
-		{"Ctrl", LEFT},
-		{"r_IOPS", LEFT},
-		{"w_IOPS", LEFT},
-		{"r_clat", LEFT},
-		{"w_clat", LEFT},
-		{"r_bw", LEFT},
-		{"w_bw", LEFT},
-		{"Inflights", LEFT},
-		{"Util%", LEFT},
+		{"NSHead",    LEFT, AUTO_WIDTH},
+		{"NSID",      LEFT, AUTO_WIDTH},
+		{"NSPath",    LEFT, AUTO_WIDTH},
+		{"Nodes",     LEFT, AUTO_WIDTH},
+		{"Qdepth",    LEFT, AUTO_WIDTH},
+		{"Ctrl",      LEFT, AUTO_WIDTH},
+		{"r_IOPS",    LEFT, 9},
+		{"w_IOPS",    LEFT, 9},
+		{"r_clat",    LEFT, 8},
+		{"w_clat",    LEFT, 8},
+		{"r_bw",      LEFT, 13},
+		{"w_bw",      LEFT, 13},
+		{"Inflights", LEFT, AUTO_WIDTH},
+		{"Util%",     LEFT, 6},
 	};
 
 	t = table_create();
@@ -1262,18 +1262,18 @@ static int stdout_top_draw_subsys_screen(struct dashboard_ctx *db_ctx,
 	char r_clat_str[16], w_clat_str[16];
 	struct table *t;
 	struct table_column columns[] = {
-		{"Subsystem", LEFT},
-		{"Namespaces", LEFT},
-		{"Paths", LEFT},
-		{"Ctrls", LEFT},
-		{"IOPolicy", LEFT},
-		{"r_IOPS", LEFT},
-		{"w_IOPS", LEFT},
-		{"r_clat", LEFT},
-		{"w_clat", LEFT},
-		{"r_bw", LEFT},
-		{"w_bw", LEFT},
-		{"Util%", LEFT},
+		{"Subsystem",  LEFT, AUTO_WIDTH},
+		{"Namespaces", LEFT, AUTO_WIDTH},
+		{"Paths",      LEFT, AUTO_WIDTH},
+		{"Ctrls",      LEFT, AUTO_WIDTH},
+		{"IOPolicy",   LEFT, AUTO_WIDTH},
+		{"r_IOPS",     LEFT, 9},
+		{"w_IOPS",     LEFT, 9},
+		{"r_clat",     LEFT, 8},
+		{"w_clat",     LEFT, 8},
+		{"r_bw",       LEFT, 13},
+		{"w_bw",       LEFT, 13},
+		{"Util%",      LEFT, 6},
 	};
 
 	fprintf(stream, "---- nvme-top - Refresh: %d Second ----\n",

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5995,16 +5995,16 @@ static void stdout_tabular_subsystem_topology_multipath(libnvme_subsystem_t s)
 	struct table *t;
 	const char *iopolicy = libnvme_subsystem_get_iopolicy(s);
 	struct table_column columns[] = {
-		{"NSHead", LEFT, 0},
-		{"NSID", LEFT, 0},
-		{"NSPath", LEFT, 0},
-		{"ANAState", LEFT, 0},
-		{"Nodes", LEFT, 0},
-		{"Qdepth", LEFT, 0},
-		{"Controller", LEFT, 0},
-		{"TrType", LEFT, 0},
-		{"Address", LEFT, 0},
-		{"State", LEFT, 0},
+		{"NSHead",     LEFT, AUTO_WIDTH},
+		{"NSID",       LEFT, AUTO_WIDTH},
+		{"NSPath",     LEFT, AUTO_WIDTH},
+		{"ANAState",   LEFT, AUTO_WIDTH},
+		{"Nodes",      LEFT, AUTO_WIDTH},
+		{"Qdepth",     LEFT, AUTO_WIDTH},
+		{"Controller", LEFT, AUTO_WIDTH},
+		{"TrType",     LEFT, AUTO_WIDTH},
+		{"Address",    LEFT, AUTO_WIDTH},
+		{"State",      LEFT, AUTO_WIDTH},
 	};
 
 	t = table_create();
@@ -6227,12 +6227,12 @@ static void stdout_tabular_subsystem_topology(libnvme_subsystem_t s)
 	int ret, num_ns;
 	struct table *t;
 	struct table_column columns[] = {
-		{"Namespace", LEFT, 0},
-		{"NSID", LEFT, 0},
-		{"Controller", LEFT, 0},
-		{"Trtype", LEFT, 0},
-		{"Address", LEFT, 0},
-		{"State", LEFT, 0},
+		{"Namespace",  LEFT, AUTO_WIDTH},
+		{"NSID",       LEFT, AUTO_WIDTH},
+		{"Controller", LEFT, AUTO_WIDTH},
+		{"Trtype",     LEFT, AUTO_WIDTH},
+		{"Address",    LEFT, AUTO_WIDTH},
+		{"State",      LEFT, AUTO_WIDTH},
 	};
 
 	t = table_create();

--- a/util/table.c
+++ b/util/table.c
@@ -256,6 +256,9 @@ void table_add_row(struct table *t, int row_id)
 
 	/* Adjust the column width based on the row value. */
 	for (col = 0; col < t->num_columns; col++) {
+		if (!t->columns[col].auto_adjust)
+			continue;
+
 		max_width = t->columns[col].width;
 		width = table_get_value_width(&row->val[col]);
 		if (width > max_width)
@@ -299,7 +302,17 @@ static int table_add_column(struct table *t, struct table_column *c)
 	if (!t->columns[col].name)
 		return -ENOMEM;
 	t->columns[col].align = c->align;
-	t->columns[col].width = strlen(c->name);
+
+	if (c->width == AUTO_WIDTH) {
+		t->columns[col].width = strlen(c->name);
+		t->columns[col].auto_adjust = true;
+	} else {
+		if (c->width < strlen(c->name))
+			return -EINVAL;
+
+		t->columns[col].width = c->width;
+		t->columns[col].auto_adjust = false;
+	}
 
 	return 0;
 }
@@ -335,7 +348,7 @@ free_col:
 
 int table_add_columns(struct table *t, struct table_column *c, int num_columns)
 {
-	int col;
+	int ret = 0, col;
 
 	t->columns = calloc(num_columns, sizeof(struct table_column));
 	if (!t->columns)
@@ -343,24 +356,36 @@ int table_add_columns(struct table *t, struct table_column *c, int num_columns)
 
 	for (col = 0; col < num_columns; col++) {
 		t->columns[col].name = strdup(c[col].name);
-		if (!t->columns[col].name)
+		if (!t->columns[col].name) {
+			ret = -ENOMEM;
 			goto free_col;
+		}
 
 		t->columns[col].align = c[col].align;
-		if (c[col].width > strlen(t->columns[col].name))
-			t->columns[col].width = c[col].width;
-		else
+
+		if (c[col].width == AUTO_WIDTH) {
 			t->columns[col].width = strlen(t->columns[col].name);
+			t->columns[col].auto_adjust = true;
+		} else {
+			if (c[col].width < strlen(t->columns[col].name)) {
+				ret = -EINVAL;
+				goto free_col;
+			}
+			t->columns[col].width = c[col].width;
+			t->columns[col].auto_adjust = false;
+		}
 	}
 	t->num_columns = num_columns;
 
-	return 0;
+	return ret;
 free_col:
-	while (--col >= 0)
+	while (col >= 0) {
 		free(t->columns[col].name);
+		col--;
+	}
 	free(t->columns);
 	t->columns = NULL;
-	return -ENOMEM;
+	return ret;
 }
 
 void table_free(struct table *t)

--- a/util/table.c
+++ b/util/table.c
@@ -293,13 +293,13 @@ static int table_add_column(struct table *t, struct table_column *c)
 	if (!new_columns)
 		return -ENOMEM;
 
+	t->num_columns++;
 	t->columns = new_columns;
 	t->columns[col].name = strdup(c->name);
 	if (!t->columns[col].name)
 		return -ENOMEM;
 	t->columns[col].align = c->align;
 	t->columns[col].width = strlen(c->name);
-	t->num_columns++;
 
 	return 0;
 }
@@ -309,7 +309,7 @@ int table_add_columns_filter(struct table *t, struct table_column *c,
 			bool (*filter)(const char *name, void *arg),
 			void *arg)
 {
-	int col;
+	int ret = 0, col;
 
 	if (!filter)
 		return table_add_columns(t, c, num_columns);
@@ -318,12 +318,19 @@ int table_add_columns_filter(struct table *t, struct table_column *c,
 		if (!filter(c[col].name, arg))
 			continue;	/* skip this column */
 
-		if (table_add_column(t, &c[col]))
-			goto out;
+		ret = table_add_column(t, &c[col]);
+		if (ret < 0)
+			goto free_col;
 	}
-	return 0;
-out:
-	return -ENOMEM;
+
+	return ret;
+
+free_col:
+	while (t->num_columns > 0)
+		free(t->columns[--t->num_columns].name);
+	free(t->columns);
+	t->columns = NULL;
+	return ret;
 }
 
 int table_add_columns(struct table *t, struct table_column *c, int num_columns)

--- a/util/table.h
+++ b/util/table.h
@@ -4,6 +4,9 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <limits.h>
+
+#define AUTO_WIDTH	INT_MAX
 
 enum fmt_type {
 	FMT_STRING,
@@ -40,9 +43,21 @@ struct table_row {
 };
 
 struct table_column {
-	char *name;
-	enum alignment align;
-	int width;		/* auto populated */
+	char *name;		/* column name */
+	enum alignment align;	/* column value alignment */
+
+	/*
+	 * The table supports both fixed and auto column width. Auto width could
+	 * be specified by setting @width to AUTO_WIDTH. Fixed width must be at-
+	 * least strlen(@name) or more.
+	 */
+	int width;
+	/*
+	 * Controls whether to auto adjust column width or not.
+	 * NOTE: This field is internally used by table APIs and it should not
+	 * be used by the users of table APIs.
+	 */
+	bool auto_adjust;
 };
 
 struct table {


### PR DESCRIPTION
Currently table API only support automatic resize of the table columns. This series adds support for fixed width columns. This would then allow us to use auto size columns for one shot nvme-cli commands and use fixed width columns for real-time dashboard display such as nvme-top.

This pacthset adds three commits:
The first commit extends the table API to support fixed width column. With this change now auto size table columns requires the column width to be inited using AUTO_WIDTH (a special macro defined as INT_MAX) and fixed width columns shall be inited using constant width integer value. 
The second commit then update the show topology tabular output  (which is one shot nvme-cli command) using AUTO_WIDTH for the column.
The third patch updates the nvme-top tables using fixed width columns.

----------------------------------------------------------------------------------------------------------- 

Force pushed PR with the following change:
Split the first patch into two patches and created the new commit to fix a potential memlelak in table API

The following patch is splitted into two patches: 
util/table: extend table APIs to support fixed width column

first patch: util/table: fix memory leak in table_add_columns_filter()
second patch: util/table: extend table APIs to support fixed width column

The remaining patches remain as is.