### PR TITLE
fdp: Remove unused linux/fs.h include

### DIFF
--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -6,7 +6,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <inttypes.h>
-#include <linux/fs.h>
 #include <sys/stat.h>
 
 #include <libnvme.h>


### PR DESCRIPTION
Remove include of linux/fs.h from fdp.c.
Nothing in fdp.c relies on linux/fs.h, and removing it allows compilation on Windows.