### PR TITLE
build: remove default prefix option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,7 +23,6 @@ project(
     default_options: [
         'c_std=gnu99',
         'buildtype=debugoptimized',
-        'prefix=/usr/local',
         'warning_level=1',
         'sysconfdir=etc',
         'wrap_mode=nofallback',


### PR DESCRIPTION
Hard coding the default prefix causes issues on windows. meson's docs says "prefix defaults to C:/ on Windows, and /usr/local otherwise. You should always override this value.", see https://mesonbuild.com/Builtin-options.html. There is no value, only downside on Windows, to setting the value here. If the user want a different value it should be overridden via the command line. During development we should not have to set the prefix, it should just default to a sane value.

Windows with default prefix removed
  Paths
    prefixdir       : C:/msys64/ucrt64
    sysconfdir      : C:/msys64/ucrt64/etc
    sbindir         : C:/msys64/ucrt64/sbin
Windows with default prefix set to "prefix=/usr/local". Or, Linux with and without "prefix=/usr/local"
  Paths
    prefixdir       : /usr/local
    sysconfdir      : /usr/local/etc
    sbindir         : /usr/local/sbin