### PR TITLE
libnvme: NVMe-oF controller ownership registry

### DIFF
--- a/Documentation/nvme-disconnect-all.txt
+++ b/Documentation/nvme-disconnect-all.txt
@@ -9,30 +9,67 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'disconnect-all'
+			[--transport=<STR> | -r <STR>]
+			[--owner=<NAME> | -O <NAME>]
+			[--force | -f]
 
 DESCRIPTION
 -----------
-Disconnects and removes all existing NVMe over Fabrics controllers.
+Disconnects and removes NVMe over Fabrics controllers.  The default
+behavior is ownership-aware: only controllers with no entry in the
+ownership registry are disconnected.  Controllers registered to an
+orchestrator (e.g. nvme-stas, nbft) are left untouched.
+
+Use --owner to target a specific orchestrator's controllers, or --force
+to disconnect all controllers regardless of ownership.  --force and
+--owner are mutually exclusive.  When --force is used interactively a
+confirmation prompt is shown.
 
 See the documentation for the nvme-disconnect(1) command for further
 background.
 
 OPTIONS
 -------
+-r <STR>::
+--transport=<STR>::
+	Limit disconnection to controllers using the specified transport
+	(e.g. tcp, rdma, fc).
+
+-O <NAME>::
+--owner=<NAME>::
+	Disconnect only controllers owned by NAME in the registry.
+
+-f::
+--force::
+	Disconnect all controllers regardless of ownership.  Requires
+	interactive confirmation when stdin is a terminal.
 
 include::global-options.txt[]
 
 EXAMPLES
 --------
-* Disconnect all existing nvme controllers:
+* Disconnect all unowned controllers (safe default):
 +
 ------------
 # nvme disconnect-all
+------------
++
+* Disconnect all controllers owned by nvme-stas:
++
+------------
+# nvme disconnect-all --owner stas
+------------
++
+* Disconnect all controllers regardless of ownership:
++
+------------
+# nvme disconnect-all --force
 ------------
 
 SEE ALSO
 --------
 nvme-disconnect(1)
+nvme-registry-list(1)
 
 NVME
 ----

--- a/Documentation/nvme-registry-delete.txt
+++ b/Documentation/nvme-registry-delete.txt
@@ -1,0 +1,49 @@
+nvme-registry-delete(1)
+=======================
+
+NAME
+----
+nvme-registry-delete - Remove a controller's ownership registry entry
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'registry-delete'
+			--device=<DEV> | -d <DEV>
+
+DESCRIPTION
+-----------
+Remove the ownership registry entry for an NVMe-oF controller.  The
+registry entry is stored at /run/nvme/registry/<device>.json.
+
+Under normal operation registry entries are removed automatically: a
+udev rule fires on the kernel REMOVE event and deletes the entry.  This
+command is provided for manual cleanup or for orchestrators that want to
+explicitly release ownership before disconnecting.
+
+OPTIONS
+-------
+-d <DEV>::
+--device=<DEV>::
+	NVMe device name (e.g. nvme3).
+
+include::global-options.txt[]
+
+EXAMPLES
+--------
+* Remove the registry entry for nvme3:
++
+------------
+# nvme registry-delete --device nvme3
+------------
+
+SEE ALSO
+--------
+nvme-registry-list(1)
+nvme-registry-retrieve(1)
+nvme-registry-update(1)
+nvme-disconnect-all(1)
+
+NVME
+----
+Part of the nvme-user suite

--- a/Documentation/nvme-registry-list.txt
+++ b/Documentation/nvme-registry-list.txt
@@ -1,0 +1,49 @@
+nvme-registry-list(1)
+=====================
+
+NAME
+----
+nvme-registry-list - List NVMe-oF controller ownership registry entries
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'registry-list'
+
+DESCRIPTION
+-----------
+List all live entries in the NVMe-oF controller ownership registry.  The
+registry records which orchestrator (e.g. nvme-stas, nbft) owns each
+connected NVMe-oF controller.  It is stored under /run/nvme/registry/ as
+one JSON file per live controller.
+
+One line is printed per live registered controller.  Controllers with no
+registry entry (unowned) and PCIe/apple-nvme controllers (which are never
+registered) are not shown.
+
+OPTIONS
+-------
+
+include::global-options.txt[]
+
+EXAMPLES
+--------
+* List all owned controllers:
++
+------------
+# nvme registry-list
+DEVICE           OWNER
+nvme1            stas
+nvme3            nbft
+------------
+
+SEE ALSO
+--------
+nvme-registry-retrieve(1)
+nvme-registry-update(1)
+nvme-registry-delete(1)
+nvme-disconnect-all(1)
+
+NVME
+----
+Part of the nvme-user suite

--- a/Documentation/nvme-registry-retrieve.txt
+++ b/Documentation/nvme-registry-retrieve.txt
@@ -1,0 +1,59 @@
+nvme-registry-retrieve(1)
+=========================
+
+NAME
+----
+nvme-registry-retrieve - Retrieve a field from a controller's registry entry
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'registry-retrieve'
+			[--device=<DEV> | -d <DEV>]
+			[--key=<KEY> | -k <KEY>]
+
+DESCRIPTION
+-----------
+Read a single field from the ownership registry entry for an NVMe-oF
+controller.  The registry is stored under /run/nvme/registry/ as one JSON
+file per live controller (e.g. nvme3.json).
+
+If --key is omitted the 'owner' field is retrieved.
+
+OPTIONS
+-------
+-d <DEV>::
+--device=<DEV>::
+	NVMe device name (e.g. nvme3).
+
+-k <KEY>::
+--key=<KEY>::
+	Registry field name to retrieve.  Defaults to 'owner'.
+
+include::global-options.txt[]
+
+EXAMPLES
+--------
+* Retrieve the owner of nvme3 (default key):
++
+------------
+# nvme registry-retrieve --device nvme3
+stas
+------------
++
+* Retrieve a specific field by key:
++
+------------
+# nvme registry-retrieve --device nvme3 --key device
+nvme3
+------------
+
+SEE ALSO
+--------
+nvme-registry-list(1)
+nvme-registry-update(1)
+nvme-registry-delete(1)
+
+NVME
+----
+Part of the nvme-user suite

--- a/Documentation/nvme-registry-update.txt
+++ b/Documentation/nvme-registry-update.txt
@@ -1,0 +1,59 @@
+nvme-registry-update(1)
+=======================
+
+NAME
+----
+nvme-registry-update - Update a field in a controller's registry entry
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'registry-update'
+			--device=<DEV> | -d <DEV>
+			--key=<KEY> | -k <KEY>
+			--value=<VAL> | -V <VAL>
+
+DESCRIPTION
+-----------
+Write a key/value pair to the ownership registry entry for an NVMe-oF
+controller.  If the entry does not exist it is created.  The write is
+atomic: a temporary file is created, synced, and renamed over the
+destination.
+
+This command is the primary mechanism for an orchestrator to claim or
+steal ownership of an existing connection.  All orchestrators are
+assumed to be cooperative; there is no OS-level enforcement of ownership.
+
+OPTIONS
+-------
+-d <DEV>::
+--device=<DEV>::
+	NVMe device name (e.g. nvme3).
+
+-k <KEY>::
+--key=<KEY>::
+	Registry field name to update (e.g. owner).
+
+-V <VAL>::
+--value=<VAL>::
+	New value for the field.
+
+include::global-options.txt[]
+
+EXAMPLES
+--------
+* Claim ownership of nvme3:
++
+------------
+# nvme registry-update --device nvme3 --key owner --value stas
+------------
+
+SEE ALSO
+--------
+nvme-registry-list(1)
+nvme-registry-retrieve(1)
+nvme-registry-delete(1)
+
+NVME
+----
+Part of the nvme-user suite

--- a/fabrics.c
+++ b/fabrics.c
@@ -614,6 +614,8 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	}
 	if (context)
 		libnvme_set_application(ctx, context);
+	if (nbft)
+		libnvmf_context_set_owner(ctx, "nbft");
 
 	if (!nvme_read_config_checked(ctx, config_file))
 		json_config = true;
@@ -904,8 +906,137 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 	return 0;
 }
 
+static void print_registry_entry(const char *device, const char *owner,
+				  void *user_data)
+{
+	printf("%-16s %s\n", device, owner ? owner : "-");
+}
+
+int fabrics_registry_list(const char *desc, int argc, char **argv)
+{
+	printf("%-16s OWNER\n", "DEVICE");
+	return libnvmf_registry_for_each(print_registry_entry, NULL);
+}
+
+int fabrics_registry_retrieve(const char *desc, int argc, char **argv)
+{
+	const char *device_help = "NVMe device name (e.g. nvme3)";
+	const char *key_help = "field name to retrieve (default: owner)";
+	__cleanup_free char *value = NULL;
+	int ret;
+
+	struct config {
+		char *device;
+		char *key;
+	};
+
+	struct config cfg = { .key = "owner" };
+
+	NVME_ARGS(opts,
+		OPT_STRING("device", 'd', "DEV", &cfg.device, device_help),
+		OPT_STRING("key", 'k', "KEY", &cfg.key, key_help));
+
+	ret = argconfig_parse(argc, argv, desc, opts);
+	if (ret)
+		return ret;
+
+	if (!cfg.device) {
+		fprintf(stderr, "--device required\n");
+		return -EINVAL;
+	}
+	if (!strncmp(cfg.device, "/dev/", 5))
+		cfg.device += 5;
+
+	ret = libnvmf_registry_retrieve(cfg.device, cfg.key, &value);
+	if (ret == -ENOENT) {
+		fprintf(stderr, "%s: not registered or '%s' not found\n",
+			cfg.device, cfg.key);
+		return ret;
+	}
+	if (ret) {
+		fprintf(stderr, "retrieve failed: %s\n",
+			libnvme_strerror(-ret));
+		return ret;
+	}
+	printf("%s\n", value);
+	return 0;
+}
+
+int fabrics_registry_update(const char *desc, int argc, char **argv)
+{
+	const char *device_help = "NVMe device name (e.g. nvme3)";
+	const char *key_help = "field name to update (e.g. owner)";
+	const char *value_help = "new field value";
+	int ret;
+
+	struct config {
+		char *device;
+		char *key;
+		char *value;
+	};
+
+	struct config cfg = { 0 };
+
+	NVME_ARGS(opts,
+		OPT_STRING("device", 'd', "DEV", &cfg.device, device_help),
+		OPT_STRING("key", 'k', "KEY", &cfg.key, key_help),
+		OPT_STRING("value", 'V', "VAL", &cfg.value, value_help));
+
+	ret = argconfig_parse(argc, argv, desc, opts);
+	if (ret)
+		return ret;
+
+	if (!cfg.device || !cfg.key || !cfg.value) {
+		fprintf(stderr,
+			"--device, --key, and --value are required\n");
+		return -EINVAL;
+	}
+	if (!strncmp(cfg.device, "/dev/", 5))
+		cfg.device += 5;
+
+	ret = libnvmf_registry_update(cfg.device, cfg.key, cfg.value);
+	if (ret)
+		fprintf(stderr, "update failed: %s\n",
+			libnvme_strerror(-ret));
+	return ret;
+}
+
+int fabrics_registry_delete(const char *desc, int argc, char **argv)
+{
+	const char *device_help = "NVMe device name (e.g. nvme3)";
+	int ret;
+
+	struct config {
+		char *device;
+	};
+
+	struct config cfg = { 0 };
+
+	NVME_ARGS(opts,
+		OPT_STRING("device", 'd', "DEV", &cfg.device, device_help));
+
+	ret = argconfig_parse(argc, argv, desc, opts);
+	if (ret)
+		return ret;
+
+	if (!cfg.device) {
+		fprintf(stderr, "--device required\n");
+		return -EINVAL;
+	}
+	if (!strncmp(cfg.device, "/dev/", 5))
+		cfg.device += 5;
+
+	ret = libnvmf_registry_delete(cfg.device);
+	if (ret)
+		fprintf(stderr, "%s: %s\n", cfg.device,
+			libnvme_strerror(-ret));
+	return ret;
+}
+
 int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 {
+	const char *owner_help = "disconnect controllers owned by NAME";
+	const char *force_help = "disconnect all regardless of ownership";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	libnvme_host_t h;
 	libnvme_subsystem_t s;
@@ -914,16 +1045,39 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 
 	struct config {
 		char *transport;
+		char *owner;
+		bool force;
 	};
 
 	struct config cfg = { 0 };
 
 	NVME_ARGS(opts,
-		OPT_STRING("transport", 'r', "STR", (char *)&cfg.transport, nvmf_tport));
+		OPT_STRING("transport", 'r', "STR",
+			   (char *)&cfg.transport, nvmf_tport),
+		OPT_STRING("owner", 'O', "NAME", &cfg.owner, owner_help),
+		OPT_FLAG("force", 'f', &cfg.force, force_help));
 
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	if (cfg.force && cfg.owner) {
+		fprintf(stderr, "--force and --owner are mutually exclusive\n");
+		return -EINVAL;
+	}
+
+	if (cfg.force && isatty(STDIN_FILENO)) {
+		char ans[8] = { 0 };
+
+		fprintf(stderr,
+			"WARNING: --force disconnects all NVMeoF controllers\n"
+			"regardless of ownership. Type 'yes' to confirm: ");
+		if (!fgets(ans, sizeof(ans), stdin) ||
+		    strncmp(ans, "yes", 3) != 0) {
+			fprintf(stderr, "Aborted.\n");
+			return -EINVAL;
+		}
+	}
 
 	log_level = map_log_level(nvme_args.verbose, false);
 
@@ -952,17 +1106,38 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 	libnvme_for_each_host(ctx, h) {
 		libnvme_for_each_subsystem(h, s) {
 			libnvme_subsystem_for_each_ctrl(s, c) {
+				const char *tr = libnvme_ctrl_get_transport(c);
+				const char *name;
+				char *reg_owner = NULL;
+				bool do_disconnect = false;
+
 				if (cfg.transport &&
-				    strcmp(cfg.transport,
-					   libnvme_ctrl_get_transport(c)))
+				    strcmp(cfg.transport, tr))
 					continue;
-				else if (!strcmp(libnvme_ctrl_get_transport(c),
-						 "pcie"))
+				if (!strcmp(tr, "pcie"))
 					continue;
-				if (libnvmf_disconnect_ctrl(c))
+
+				name = libnvme_ctrl_get_name(c);
+
+				if (cfg.force) {
+					do_disconnect = true;
+				} else {
+					libnvmf_registry_retrieve(name,
+						"owner", &reg_owner);
+					if (cfg.owner)
+						do_disconnect = reg_owner &&
+							!strcmp(reg_owner,
+								cfg.owner);
+					else
+						do_disconnect = !reg_owner;
+					free(reg_owner);
+				}
+
+				if (do_disconnect &&
+				    libnvmf_disconnect_ctrl(c))
 					fprintf(stderr,
 						"failed to disconnect %s\n",
-						libnvme_ctrl_get_name(c));
+						name);
 			}
 		}
 	}

--- a/fabrics.h
+++ b/fabrics.h
@@ -6,6 +6,10 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect);
 int fabrics_connect(const char *desc, int argc, char **argv);
 int fabrics_disconnect(const char *desc, int argc, char **argv);
 int fabrics_disconnect_all(const char *desc, int argc, char **argv);
+int fabrics_registry_list(const char *desc, int argc, char **argv);
+int fabrics_registry_retrieve(const char *desc, int argc, char **argv);
+int fabrics_registry_update(const char *desc, int argc, char **argv);
+int fabrics_registry_delete(const char *desc, int argc, char **argv);
 int fabrics_config(const char *desc, int argc, char **argv);
 int fabrics_dim(const char *desc, int argc, char **argv);
 

--- a/libnvme/libnvme/nvme.i
+++ b/libnvme/libnvme/nvme.i
@@ -66,6 +66,11 @@ static inline PyObject *Py_NewRef(PyObject *obj)
 %module(docstring=MODULE_DOCSTRING) nvme
 %feature("autodoc", "1");
 
+%pythonbegin %{
+import json
+import os
+%}
+
 %include "exception.i"
 
 %allowexception;
@@ -271,6 +276,28 @@ PyObject *read_hostid()
 	PyObject *obj = val ? PyUnicode_FromString(val) : Py_NewRef(Py_None);
 	free(val);
 	return obj;
+}
+
+void registry_update(const char *device, const char *key, const char *value)
+{
+	if (strncmp(device, "nvme", 4)) {
+		PyErr_Format(PyExc_ValueError,
+			     "invalid device '%s': must start with 'nvme'",
+			     device);
+		return;
+	}
+	libnvmf_registry_update(device, key, value);
+}
+
+void registry_delete(const char *device)
+{
+	if (strncmp(device, "nvme", 4)) {
+		PyErr_Format(PyExc_ValueError,
+			     "invalid device '%s': must start with 'nvme'",
+			     device);
+		return;
+	}
+	libnvmf_registry_delete(device);
 }
 
 /*============================================================================*/
@@ -552,6 +579,58 @@ from libnvme._exceptions import (
 	DiscoverError,
 	NotConnectedError,
 )
+
+def registry_retrieve(device):
+    """Retrieve a controller's registry entry as a dict.
+
+    Args:
+        device: Device name (e.g. 'nvme3').  Must start with 'nvme'.
+
+    Returns:
+        dict with the registry entry contents (e.g. {'device': 'nvme3',
+        'owner': 'stas'}), or None if the device is not registered.
+
+    Raises:
+        ValueError: If device does not start with 'nvme'.
+    """
+    if not device.startswith('nvme'):
+        raise ValueError(f"invalid device '{device}': must start with 'nvme'")
+    path = os.path.join('/run/nvme/registry', device + '.json')
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+def registry_entries():
+    """Yield each live registry entry as a dict.
+
+    Scans /run/nvme/registry/ and yields one dict per entry whose
+    corresponding /dev/nvmeX device node exists.  Stale entries
+    (controller removed by the kernel) are silently skipped.
+
+    Each dict contains at minimum 'device' and 'owner' keys, plus
+    any other fields stored in the registry JSON file.
+
+    Yields:
+        dict: Registry entry, e.g. {'device': 'nvme3', 'owner': 'stas'}.
+    """
+    registry_dir = '/run/nvme/registry'
+    try:
+        filenames = os.listdir(registry_dir)
+    except FileNotFoundError:
+        return
+    for filename in sorted(filenames):
+        if not filename.endswith('.json'):
+            continue
+        device = filename[:-5]
+        if not os.path.exists('/dev/' + device):
+            continue
+        try:
+            with open(os.path.join(registry_dir, filename)) as f:
+                yield json.load(f)
+        except (OSError, ValueError):
+            continue
 %}
 
 /*############################################################################*/
@@ -811,6 +890,16 @@ from libnvme._exceptions import (
 	$action
 	if (PyErr_Occurred()) SWIG_fail;
 }
+%exception registry_update {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+void registry_update(const char *device, const char *key, const char *value);
+%exception registry_delete {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+void registry_delete(const char *device);
 
 #include "tree.h"
 #include "fabrics.h"
@@ -846,7 +935,7 @@ struct libnvme_ns *libnvme_ctrl_first_ns(struct libnvme_ctrl *c);
 struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_ns *n);
 
 %extend libnvme_global_ctx {
-	%feature("autodoc", "__init__(self, config_file=None)\n"
+	%feature("autodoc", "__init__(self, owner=None, config_file=None)\n"
 		"\n"
 		"Create the root context for the libnvme device tree.\n"
 		"\n"
@@ -854,13 +943,22 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 		"Supports use as a context manager (``with GlobalCtx() as ctx:``).\n"
 		"\n"
 		"Args:\n"
+		"    owner:       Registry owner name for this orchestrator process\n"
+		"                 (e.g. 'stas', 'nbft').  When set, libnvme\n"
+		"                 automatically registers this process as the owner\n"
+		"                 of every controller connected through this context.\n"
+		"                 Pass None (default) to connect without registering.\n"
 		"    config_file: Path to a JSON config file, or None for defaults.") libnvme_global_ctx;
-	libnvme_global_ctx(const char *config_file = NULL) {
+	libnvme_global_ctx(const char *owner = NULL,
+			   const char *config_file = NULL) {
 		struct libnvme_global_ctx *ctx;
 
 		ctx = libnvme_create_global_ctx(stdout, LIBNVME_DEFAULT_LOGLEVEL);
 		if (!ctx)
 			return NULL;
+
+		if (owner)
+			libnvmf_context_set_owner(ctx, owner);
 
 		libnvme_scan_topology(ctx, NULL, NULL);
 		libnvme_read_config(ctx, config_file);
@@ -903,6 +1001,15 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 	void dump_config() {
 		libnvme_dump_config($self, STDERR_FILENO);
 	}
+	const char *_get_owner() {
+		return $self->owner;
+	}
+	%pythoncode %{
+	@property
+	def owner(self):
+	    """Registry owner name for this process, or None if not set."""
+	    return self._get_owner()
+	%}
 }
 
 

--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -41,6 +41,7 @@ if want_libnvme
         subdir('examples')
     endif
 
+    subdir('sysfiles')
     subdir('doc')
 else
     # Fallback to using a pre-installed libnvme (if available)

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -35,7 +35,12 @@ LIBNVMF_3 {
 		libnvmf_prtype_str;
 		libnvmf_qptype_str;
 		libnvmf_read_nbft;
+		libnvmf_context_set_owner;
 		libnvmf_register_ctrl;
+		libnvmf_registry_delete;
+		libnvmf_registry_for_each;
+		libnvmf_registry_retrieve;
+		libnvmf_registry_update;
 		libnvmf_sectype_str;
 		libnvmf_subtype_str;
 		libnvmf_treq_str;

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -71,6 +71,7 @@ if want_fabrics
         'nvme/fabrics.h',
         'nvme/nvme-types-nbft.h',
         'nvme/nbft.h',
+        'nvme/registry.h',
     ]
 else
     sources += [
@@ -100,7 +101,10 @@ else
 endif
 
 if json_c_dep.found() and want_fabrics
-    sources += 'nvme/json.c'
+    sources += [
+        'nvme/json.c',
+        'nvme/registry.c',
+    ]
 else
     sources += 'nvme/no-json.c'
 endif
@@ -139,7 +143,7 @@ if want_fabrics
         '-Wl,--version-script=@0@'.format(nvmf_accessors_ld),
     ]
     libconf.set('FABRICS_INCLUDE',
-                '#include <nvme/fabrics.h>\n#include <nvme/nbft.h>\n#include <nvme/accessors-fabrics.h>')
+                '#include <nvme/fabrics.h>\n#include <nvme/nbft.h>\n#include <nvme/accessors-fabrics.h>\n#include <nvme/registry.h>')
 else
     libconf.set('FABRICS_INCLUDE', '')
 endif

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -376,6 +376,15 @@ __libnvme_public int libnvmf_context_set_reconnect_policy(
 	return 0;
 }
 
+__libnvme_public void libnvmf_context_set_owner(struct libnvme_global_ctx *ctx,
+					    const char *owner)
+{
+	if (!ctx)
+		return;
+	free(ctx->owner);
+	ctx->owner = owner ? strdup(owner) : NULL;
+}
+
 /*
  * Derived from Linux's supported options (the opt_tokens table)
  * when the mechanism to report supported options was added (f18ee3d988157).

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -984,6 +984,7 @@ static int __nvmf_add_ctrl(struct libnvme_global_ctx *ctx, const char *argstr)
 {
 	__cleanup_fd int fd = -1;
 	int ret, len = strlen(argstr);
+	int instance;
 	char buf[0x1000], *options, *p;
 
 	fd = open(nvmf_dev, O_RDWR);
@@ -1035,8 +1036,11 @@ static int __nvmf_add_ctrl(struct libnvme_global_ctx *ctx, const char *argstr)
 	while ((p = strsep(&options, ",\n")) != NULL) {
 		if (!*p)
 			continue;
-		if (sscanf(p, "instance=%d", &ret) == 1)
-			return ret;
+		if (sscanf(p, "instance=%d", &instance) == 1) {
+			if (ctx->owner)
+				libnvmf_registry_create(instance, ctx->owner);
+			return instance;
+		}
 	}
 
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to parse ctrl info for \"%s\"\n", argstr);

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -419,6 +419,22 @@ int libnvmf_context_set_reconnect_policy(struct libnvmf_context *fctx,
 		int ctrl_loss_tmo, int reconnect_delay, int fast_io_fail_tmo);
 
 /**
+ * libnvmf_context_set_owner() - Set the registry owner name for this process
+ * @ctx:	Global context object
+ * @owner:	Owner name string (e.g. "stas", "nbft", "discoverd")
+ *
+ * Sets the owner name stored in @ctx.  When non-NULL, libnvme automatically
+ * calls libnvmf_registry_create() after every successful fabrics connect,
+ * registering the new controller under this owner name.  Call once at
+ * orchestrator startup before any connect operations.
+ *
+ * Passing NULL clears the owner; subsequent connects will not write registry
+ * entries.
+ */
+void libnvmf_context_set_owner(struct libnvme_global_ctx *ctx, const char *owner);
+
+
+/**
  * libnvmf_discovery() - Perform fabrics discovery
  * @ctx: Global context
  * @fctx: Fabrics context

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -86,6 +86,7 @@ __libnvme_public void libnvme_free_global_ctx(struct libnvme_global_ctx *ctx)
 	freeifaddrs(ctx->ifaddrs_cache); /* NULL-safe */
 	ctx->ifaddrs_cache = NULL;
 	free(ctx->options);
+	free(ctx->owner);
 #endif
 
 	libnvme_for_each_host_safe(ctx, h, _h)

--- a/libnvme/src/nvme/no-json.c
+++ b/libnvme/src/nvme/no-json.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 
 #include <libnvme.h>
+#include "compiler-attributes.h"
 
 int json_read_config(struct libnvme_global_ctx *ctx, const char *config_file)
 {
@@ -24,3 +25,35 @@ int json_dump_tree(struct libnvme_global_ctx *ctx)
 {
 	return -ENOTSUP;
 }
+
+#ifdef CONFIG_FABRICS
+int libnvmf_registry_create(int instance, const char *owner)
+{
+	return 0;
+}
+
+__libnvme_public int libnvmf_registry_retrieve(const char *device,
+					       const char *key, char **value)
+{
+	return -ENOTSUP;
+}
+
+__libnvme_public int libnvmf_registry_update(const char *device,
+					     const char *key, const char *value)
+{
+	return -ENOTSUP;
+}
+
+__libnvme_public int libnvmf_registry_delete(const char *device)
+{
+	return -ENOTSUP;
+}
+
+__libnvme_public int libnvmf_registry_for_each(
+		void (*cback)(const char *device, const char *owner,
+			      void *user_data),
+		void *user_data)
+{
+	return 0;
+}
+#endif

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -214,3 +214,17 @@ size_t libnvmf_get_entity_name(char *buffer, size_t bufsz);
  * Return: Number of characters copied to @buffer.
  */
 size_t libnvmf_get_entity_version(char *buffer, size_t bufsz);
+
+/**
+ * libnvmf_registry_create - Write a registry entry for a newly connected
+ *	controller.
+ * @instance: Kernel device instance number (e.g. 3 for nvme3)
+ * @owner:    Owner name string (e.g. "stas", "nbft", "discoverd")
+ *
+ * Internal; called from __nvmf_add_ctrl() once the kernel returns instance=N.
+ * Always overwrites any pre-existing entry: a recycled instance number means
+ * the old controller is gone.
+ *
+ * Return: 0 on success, negative errno otherwise.
+ */
+int libnvmf_registry_create(int instance, const char *owner);

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -435,6 +435,7 @@ struct libnvme_global_ctx { // !generate-python:alias=GlobalCtx
 #ifdef CONFIG_FABRICS
 	struct libnvme_fabric_options *options;
 	struct ifaddrs *ifaddrs_cache; /* init with libnvmf_getifaddrs() */
+	char *owner; /* registry owner name; NULL means unowned */
 #endif
 
 	enum libnvme_io_uring_state uring_state;

--- a/libnvme/src/nvme/registry.c
+++ b/libnvme/src/nvme/registry.c
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <json.h>
+
+#include "cleanup.h"
+#include "compiler-attributes.h"
+#include "private.h"
+#include "registry.h"
+
+static DEFINE_CLEANUP_FUNC(cleanup_json_object, struct json_object *,
+			    json_object_put)
+#define __cleanup_json	__cleanup(cleanup_json_object)
+
+/*
+ * __libnvme_weak allows test binaries to override this function with a strong
+ * definition that returns a temporary directory, redirecting all registry I/O
+ * away from /run/nvme/registry without any runtime conditionals in production
+ * code.
+ */
+__libnvme_weak const char *registry_dir(void)
+{
+	return "/run/nvme/registry";
+}
+
+static int ensure_registry_dir(void)
+{
+	__cleanup_free char *dir_copy = NULL;
+
+	if (mkdir(registry_dir(), 0755) == 0 || errno == EEXIST)
+		return 0;
+	if (errno != ENOENT)
+		return -errno;
+
+	/* Parent directory is missing; create it then retry. */
+	dir_copy = strdup(registry_dir());
+	if (!dir_copy)
+		return -ENOMEM;
+	if (mkdir(dirname(dir_copy), 0755) < 0 && errno != EEXIST)
+		return -errno;
+	if (mkdir(registry_dir(), 0755) < 0 && errno != EEXIST)
+		return -errno;
+	return 0;
+}
+
+static int write_json_atomic(struct json_object *root, const char *path)
+{
+	__cleanup_free char *tmp_path = NULL;
+	int fd, dir_fd, ret;
+
+	if (asprintf(&tmp_path, "%s.XXXXXX", path) < 0)
+		return -ENOMEM;
+
+	fd = mkstemp(tmp_path);
+	if (fd < 0)
+		return -errno;
+
+	fchmod(fd, 0644);
+
+	ret = json_object_to_fd(fd, root,
+				JSON_C_TO_STRING_PRETTY |
+				JSON_C_TO_STRING_NOSLASHESCAPE);
+	if (ret < 0) {
+		close(fd);
+		unlink(tmp_path);
+		return -EIO;
+	}
+
+	if (write(fd, "\n", 1) < 0) {
+		ret = -errno;
+		close(fd);
+		unlink(tmp_path);
+		return ret;
+	}
+
+	if (fsync(fd) < 0) {
+		ret = -errno;
+		close(fd);
+		unlink(tmp_path);
+		return ret;
+	}
+	close(fd);
+
+	if (rename(tmp_path, path) < 0) {
+		ret = -errno;
+		unlink(tmp_path);
+		return ret;
+	}
+
+	dir_fd = open(registry_dir(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if (dir_fd >= 0) {
+		fsync(dir_fd);
+		close(dir_fd);
+	}
+
+	return 0;
+}
+
+/*
+ * libnvmf_registry_create - Write a new registry entry for a freshly
+ * connected controller.  Internal; called from the connect path in fabrics.c
+ * once the kernel returns instance=N.  Always overwrites any pre-existing
+ * entry: instance recycling means an old nvmeN.json is stale by definition.
+ */
+int libnvmf_registry_create(int instance, const char *owner)
+{
+	int ret;
+	char device[32];
+	__cleanup_free char *path = NULL;
+	__cleanup_json struct json_object *root = NULL;
+
+	snprintf(device, sizeof(device), "nvme%d", instance);
+
+	ret = ensure_registry_dir();
+	if (ret)
+		return ret;
+
+	if (asprintf(&path, "%s/%s.json", registry_dir(), device) < 0)
+		return -ENOMEM;
+
+	root = json_object_new_object();
+	if (!root)
+		return -ENOMEM;
+
+	json_object_object_add(root, "device",
+			       json_object_new_string(device));
+	json_object_object_add(root, "owner",
+			       json_object_new_string(owner));
+
+	return write_json_atomic(root, path);
+}
+
+__libnvme_public int libnvmf_registry_retrieve(const char *device,
+					       const char *key, char **value)
+{
+	__cleanup_free char *path = NULL;
+	__cleanup_json struct json_object *root = NULL;
+	struct json_object *val_obj;
+	const char *str;
+
+	if (asprintf(&path, "%s/%s.json", registry_dir(), device) < 0)
+		return -ENOMEM;
+
+	root = json_object_from_file(path);
+	if (!root)
+		return -ENOENT;
+
+	if (!json_object_object_get_ex(root, key, &val_obj))
+		return -ENOENT;
+
+	str = json_object_get_string(val_obj);
+	if (!str)
+		return -ENOENT;
+
+	*value = strdup(str);
+	return *value ? 0 : -ENOMEM;
+}
+
+__libnvme_public int libnvmf_registry_update(const char *device,
+					     const char *key, const char *value)
+{
+	__cleanup_free char *path = NULL;
+	__cleanup_json struct json_object *root = NULL;
+	int ret;
+
+	ret = ensure_registry_dir();
+	if (ret)
+		return ret;
+
+	if (asprintf(&path, "%s/%s.json", registry_dir(), device) < 0)
+		return -ENOMEM;
+
+	root = json_object_from_file(path);
+	if (!root) {
+		root = json_object_new_object();
+		if (!root)
+			return -ENOMEM;
+		json_object_object_add(root, "device",
+				       json_object_new_string(device));
+	}
+
+	json_object_object_add(root, key, json_object_new_string(value));
+
+	return write_json_atomic(root, path);
+}
+
+__libnvme_public int libnvmf_registry_delete(const char *device)
+{
+	__cleanup_free char *path = NULL;
+
+	if (asprintf(&path, "%s/%s.json", registry_dir(), device) < 0)
+		return -ENOMEM;
+
+	if (unlink(path) < 0)
+		return -errno;
+
+	return 0;
+}
+
+__libnvme_public int libnvmf_registry_for_each(
+		void (*cback)(const char *device, const char *owner,
+			      void *user_data),
+		void *user_data)
+{
+	char dev_path[64];
+	char device[32];
+	struct dirent *de;
+	DIR *d;
+
+	d = opendir(registry_dir());
+	if (!d) {
+		if (errno == ENOENT)
+			return 0;
+		return -errno;
+	}
+
+	while ((de = readdir(d)) != NULL) {
+		char *owner = NULL;
+		size_t stem_len;
+		char *dot;
+
+		if (de->d_name[0] == '.')
+			continue;
+		dot = strrchr(de->d_name, '.');
+		if (!dot || strcmp(dot, ".json") != 0)
+			continue;
+		stem_len = dot - de->d_name;
+		if (stem_len >= sizeof(device))
+			continue;
+		memcpy(device, de->d_name, stem_len);
+		device[stem_len] = '\0';
+
+		snprintf(dev_path, sizeof(dev_path), "/dev/%s", device);
+		if (access(dev_path, F_OK) != 0)
+			continue;
+
+		libnvmf_registry_retrieve(device, "owner", &owner);
+		cback(device, owner, user_data);
+		free(owner);
+	}
+	closedir(d);
+	return 0;
+}

--- a/libnvme/src/nvme/registry.h
+++ b/libnvme/src/nvme/registry.h
@@ -1,0 +1,85 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+/**
+ * DOC: registry.h
+ *
+ * NVMe controller ownership registry.
+ *
+ * The registry records which orchestrator owns each connected NVMe-oF
+ * controller.  It is stored under /run/nvme/registry/ as one JSON file per
+ * live controller (e.g. nvme3.json).  Registry support is only available when
+ * fabrics support is enabled (-Dfabrics=enabled).
+ *
+ * The registry is a cooperative coordination mechanism.  All participants are
+ * assumed to be cooperative; there is no OS-level enforcement.  Its primary
+ * purpose is to prevent accidental disconnection of controllers managed by one
+ * orchestrator by another.
+ */
+
+/**
+ * libnvmf_registry_retrieve() - Read a field from a controller's registry entry
+ * @device:	Kernel device name (e.g. "nvme3")
+ * @key:	Field name to retrieve (e.g. "owner")
+ * @value:	On success, set to a newly allocated string with the field value.
+ *		The caller must free this string.
+ *
+ * Return: 0 on success, -ENOENT if the controller is not registered, the
+ * requested key is absent, or the entry cannot be parsed (parse failures are
+ * not distinguished from missing entries), -ENOMEM on allocation failure.
+ */
+int libnvmf_registry_retrieve(const char *device, const char *key,
+			       char **value);
+
+/**
+ * libnvmf_registry_update() - Update a field in a controller's registry entry
+ * @device:	Kernel device name (e.g. "nvme3")
+ * @key:	Field name to update (e.g. "owner")
+ * @value:	New field value (e.g. "stas")
+ *
+ * Writes the key/value pair to the controller's registry entry using an atomic
+ * tmp-file rename.  Creates the entry if it does not exist.  Used by
+ * orchestrators to claim or steal ownership of an existing connection.
+ *
+ * Return: 0 on success, -ENOMEM on allocation failure, -EIO if the entry
+ * cannot be serialized to JSON, negative errno from underlying system calls
+ * otherwise.
+ */
+int libnvmf_registry_update(const char *device, const char *key,
+			     const char *value);
+
+/**
+ * libnvmf_registry_delete() - Remove a controller's registry entry
+ * @device:	Kernel device name (e.g. "nvme3")
+ *
+ * Removes the registry entry for @device.  Called by the owning orchestrator
+ * on intentional disconnect.  The udev REMOVE rule handles the common case of
+ * kernel-driven removal directly via rm -f and does not call this function.
+ *
+ * Return: 0 on success, -ENOENT if no entry exists, -ENOMEM on allocation
+ * failure, negative errno from underlying system calls otherwise.
+ */
+int libnvmf_registry_delete(const char *device);
+
+/**
+ * libnvmf_registry_for_each() - Iterate over live controller registry entries
+ * @cback:	Callback invoked for each live entry
+ * @user_data:	User data passed to @cback
+ *
+ * Scans the registry directory and invokes @cback for each entry whose
+ * corresponding /dev/nvmeN device node exists.  Stale entries left behind
+ * after a controller is removed are silently skipped.
+ *
+ * Return: 0 on success, negative errno if the registry directory cannot be
+ * opened.  Returns 0 when the directory does not exist (nothing registered).
+ */
+int libnvmf_registry_for_each(
+		void (*cback)(const char *device, const char *owner,
+			      void *user_data),
+		void *user_data);

--- a/libnvme/sysfiles/meson.build
+++ b/libnvme/sysfiles/meson.build
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+if want_fabrics
+    install_data(
+        'udev/rules.d/70-nvmf-registry.rules',
+        install_dir: udevrulesdir,
+    )
+endif

--- a/libnvme/sysfiles/udev/rules.d/70-nvmf-registry.rules
+++ b/libnvme/sysfiles/udev/rules.d/70-nvmf-registry.rules
@@ -1,0 +1,5 @@
+# Remove the ownership registry entry when an NVMe-oF controller is removed by
+# the kernel.  The -f flag makes this a no-op for unowned controllers and
+# PCIe/apple-nvme devices that never have registry entries.
+ACTION=="remove", SUBSYSTEM=="nvme", \
+    RUN+="/bin/rm -f /run/nvme/registry/%k.json"

--- a/libnvme/test/meson.build
+++ b/libnvme/test/meson.build
@@ -140,6 +140,20 @@ tree = executable(
 
 test('libnvme - tree', tree)
 
+if want_fabrics and json_c_dep.found()
+    registry = executable(
+        'test-registry',
+        ['registry.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_test_dep,
+        ],
+    )
+
+    test('libnvme - registry', registry)
+endif
+
 if want_fabrics
     uriparser = executable(
         'test-uriparser',

--- a/libnvme/test/registry.c
+++ b/libnvme/test/registry.c
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/**
+ * This file is part of libnvme.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ *
+ * Unit tests for the NVMe controller ownership registry (registry.c).
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <nvme/registry.h>
+
+/* Internal — not exported in registry.h; declared here for testing. */
+int libnvmf_registry_create(int instance, const char *owner);
+
+/*
+ * Strong override of the __libnvme_weak registry_dir() in registry.c.
+ * Redirects all registry I/O to a per-run temp directory instead of
+ * /run/nvme/registry, so tests run unprivileged and don't touch the system.
+ */
+static char registry_tmpdir[256];
+
+const char *registry_dir(void)
+{
+	return registry_tmpdir;
+}
+
+/**
+ * test_create - libnvmf_registry_create() must write a JSON file containing
+ * the "device" and "owner" fields and return 0.
+ */
+static bool test_create(void)
+{
+	bool pass = true;
+	char *value;
+	int ret;
+
+	printf("\ntest_create:\n");
+
+	ret = libnvmf_registry_create(3, "stas");
+	if (ret) {
+		printf(" - create returned %d, expected 0 [FAIL]\n", ret);
+		return false;
+	}
+	printf(" - create returned 0 [PASS]\n");
+
+	ret = libnvmf_registry_retrieve("nvme3", "device", &value);
+	if (ret) {
+		printf(" - retrieve 'device' returned %d [FAIL]\n", ret);
+		pass = false;
+	} else if (strcmp(value, "nvme3") != 0) {
+		printf(" - 'device' is '%s', expected 'nvme3' [FAIL]\n", value);
+		free(value);
+		pass = false;
+	} else {
+		printf(" - 'device' field is correct [PASS]\n");
+		free(value);
+	}
+
+	ret = libnvmf_registry_retrieve("nvme3", "owner", &value);
+	if (ret) {
+		printf(" - retrieve 'owner' returned %d [FAIL]\n", ret);
+		pass = false;
+	} else if (strcmp(value, "stas") != 0) {
+		printf(" - 'owner' is '%s', expected 'stas' [FAIL]\n", value);
+		free(value);
+		pass = false;
+	} else {
+		printf(" - 'owner' field is correct [PASS]\n");
+		free(value);
+	}
+
+	libnvmf_registry_delete("nvme3");
+	return pass;
+}
+
+/**
+ * test_create_overwrite - Re-creating an entry for the same device must replace
+ * the old entry, not merge with it.  Instance recycling makes old entries stale.
+ */
+static bool test_create_overwrite(void)
+{
+	bool pass = true;
+	char *value;
+	int ret;
+
+	printf("\ntest_create_overwrite:\n");
+
+	ret = libnvmf_registry_create(5, "old-owner");
+	if (ret) {
+		printf(" - first create returned %d [FAIL]\n", ret);
+		return false;
+	}
+
+	ret = libnvmf_registry_create(5, "new-owner");
+	if (ret) {
+		printf(" - second create returned %d [FAIL]\n", ret);
+		libnvmf_registry_delete("nvme5");
+		return false;
+	}
+	printf(" - second create returned 0 [PASS]\n");
+
+	ret = libnvmf_registry_retrieve("nvme5", "owner", &value);
+	if (ret) {
+		printf(" - retrieve 'owner' returned %d [FAIL]\n", ret);
+		pass = false;
+	} else if (strcmp(value, "new-owner") != 0) {
+		printf(" - 'owner' is '%s', expected 'new-owner' [FAIL]\n",
+		       value);
+		free(value);
+		pass = false;
+	} else {
+		printf(" - old entry replaced by new owner [PASS]\n");
+		free(value);
+	}
+
+	libnvmf_registry_delete("nvme5");
+	return pass;
+}
+
+/**
+ * test_retrieve - libnvmf_registry_retrieve() must return -ENOENT for a
+ * device that has no registry entry, and -ENOENT for a missing key.
+ */
+static bool test_retrieve(void)
+{
+	bool pass = true;
+	char *value;
+	int ret;
+
+	printf("\ntest_retrieve:\n");
+
+	/* Missing device */
+	ret = libnvmf_registry_retrieve("nvme99", "owner", &value);
+	if (ret != -ENOENT) {
+		printf(" - retrieve missing device returned %d, expected -ENOENT [FAIL]\n",
+		       ret);
+		pass = false;
+	} else {
+		printf(" - retrieve missing device returns -ENOENT [PASS]\n");
+	}
+
+	/* Known device, missing key */
+	ret = libnvmf_registry_create(4, "nbft");
+	if (ret) {
+		printf(" - create returned %d [FAIL]\n", ret);
+		return false;
+	}
+
+	ret = libnvmf_registry_retrieve("nvme4", "no-such-key", &value);
+	if (ret != -ENOENT) {
+		printf(" - retrieve missing key returned %d, expected -ENOENT [FAIL]\n",
+		       ret);
+		pass = false;
+	} else {
+		printf(" - retrieve missing key returns -ENOENT [PASS]\n");
+	}
+
+	libnvmf_registry_delete("nvme4");
+	return pass;
+}
+
+/**
+ * test_update - libnvmf_registry_update() must create a new entry when none
+ * exists, update an existing field, and preserve unrelated fields.
+ */
+static bool test_update(void)
+{
+	bool pass = true;
+	char *value;
+	int ret;
+
+	printf("\ntest_update:\n");
+
+	/* Create via update when no entry exists */
+	ret = libnvmf_registry_update("nvme6", "owner", "discoverd");
+	if (ret) {
+		printf(" - update on missing entry returned %d [FAIL]\n", ret);
+		return false;
+	}
+	printf(" - update on missing entry returned 0 [PASS]\n");
+
+	ret = libnvmf_registry_retrieve("nvme6", "owner", &value);
+	if (ret) {
+		printf(" - retrieve after update returned %d [FAIL]\n", ret);
+		pass = false;
+	} else if (strcmp(value, "discoverd") != 0) {
+		printf(" - 'owner' is '%s', expected 'discoverd' [FAIL]\n",
+		       value);
+		free(value);
+		pass = false;
+	} else {
+		printf(" - 'owner' field written correctly [PASS]\n");
+		free(value);
+	}
+
+	/* Update overwrites an existing field */
+	ret = libnvmf_registry_update("nvme6", "owner", "stas");
+	if (ret) {
+		printf(" - overwrite update returned %d [FAIL]\n", ret);
+		pass = false;
+	}
+
+	ret = libnvmf_registry_retrieve("nvme6", "owner", &value);
+	if (ret) {
+		printf(" - retrieve after overwrite returned %d [FAIL]\n", ret);
+		pass = false;
+	} else if (strcmp(value, "stas") != 0) {
+		printf(" - 'owner' is '%s', expected 'stas' [FAIL]\n", value);
+		free(value);
+		pass = false;
+	} else {
+		printf(" - overwrite field is correct [PASS]\n");
+		free(value);
+	}
+
+	/* Adding a second key preserves the first */
+	ret = libnvmf_registry_update("nvme6", "extra", "extra-value");
+	if (ret) {
+		printf(" - add extra key returned %d [FAIL]\n", ret);
+		pass = false;
+	}
+
+	ret = libnvmf_registry_retrieve("nvme6", "owner", &value);
+	if (ret) {
+		printf(" - retrieve 'owner' after adding extra key returned %d [FAIL]\n",
+		       ret);
+		pass = false;
+	} else {
+		printf(" - 'owner' preserved after adding extra key [PASS]\n");
+		free(value);
+	}
+
+	libnvmf_registry_delete("nvme6");
+	return pass;
+}
+
+/**
+ * test_delete - libnvmf_registry_delete() must remove the entry and return
+ * -ENOENT when called again on the same device.
+ */
+static bool test_delete(void)
+{
+	bool pass = true;
+	int ret;
+
+	printf("\ntest_delete:\n");
+
+	ret = libnvmf_registry_create(7, "stas");
+	if (ret) {
+		printf(" - create returned %d [FAIL]\n", ret);
+		return false;
+	}
+
+	ret = libnvmf_registry_delete("nvme7");
+	if (ret) {
+		printf(" - delete returned %d, expected 0 [FAIL]\n", ret);
+		pass = false;
+	} else {
+		printf(" - delete returned 0 [PASS]\n");
+	}
+
+	ret = libnvmf_registry_delete("nvme7");
+	if (ret != -ENOENT) {
+		printf(" - second delete returned %d, expected -ENOENT [FAIL]\n",
+		       ret);
+		pass = false;
+	} else {
+		printf(" - second delete returns -ENOENT [PASS]\n");
+	}
+
+	return pass;
+}
+
+int main(int argc, char *argv[])
+{
+	char tmpl[] = "/tmp/nvme-registry-test-XXXXXX";
+	bool pass = true;
+	char *dir;
+
+	dir = mkdtemp(tmpl);
+	if (!dir) {
+		perror("mkdtemp");
+		return EXIT_FAILURE;
+	}
+
+	/* Point the weak registry_dir() override at our temp directory. */
+	snprintf(registry_tmpdir, sizeof(registry_tmpdir), "%s", dir);
+
+	pass &= test_create();
+	pass &= test_create_overwrite();
+	pass &= test_retrieve();
+	pass &= test_update();
+	pass &= test_delete();
+
+	/* Best-effort cleanup; rmdir fails if any test leaked a file. */
+	rmdir(registry_tmpdir);
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -110,6 +110,10 @@ COMMAND_LIST(
 	ENTRY("connect", "Connect to NVMeoF subsystem", connect_cmd)
 	ENTRY("disconnect", "Disconnect from NVMeoF subsystem", disconnect_cmd)
 	ENTRY("disconnect-all", "Disconnect from all connected NVMeoF subsystems", disconnect_all_cmd)
+	ENTRY("registry-list", "List NVMeoF controller ownership registry entries", registry_list_cmd)
+	ENTRY("registry-retrieve", "Retrieve a field from a controller's registry entry", registry_retrieve_cmd)
+	ENTRY("registry-update", "Update a field in a controller's registry entry", registry_update_cmd)
+	ENTRY("registry-delete", "Delete a controller's registry entry", registry_delete_cmd)
 	ENTRY("config", "Configuration of NVMeoF subsystems", config_cmd)
 	ENTRY("dim", "Send Discovery Information Management command to a Discovery Controller", dim_cmd)
 #endif

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5854,16 +5854,38 @@ static bool stdout_detailed_ctrl(const char *name, void *arg)
 	c = htable_ctrl_get(&res->ht_c, name);
 	assert(c);
 
-	printf("%-16s %-6s %-20s %-40s %-8s %-6s %-14s %-6s %-12s ",
-	       libnvme_ctrl_get_name(c),
-	       libnvme_ctrl_get_cntlid(c),
-	       libnvme_ctrl_get_serial(c),
-	       libnvme_ctrl_get_model(c),
-	       libnvme_ctrl_get_firmware(c),
-	       libnvme_ctrl_get_transport(c),
-	       libnvme_ctrl_get_traddr(c),
-	       libnvme_ctrl_get_phy_slot(c),
-	       libnvme_subsystem_get_name(libnvme_ctrl_get_subsystem(c)));
+	{
+		const char *tr = libnvme_ctrl_get_transport(c);
+		const char *owner_str = "-";
+#ifdef CONFIG_FABRICS
+		char *reg_owner = NULL;
+
+		if (!strcmp(tr, "pcie") || !strcmp(tr, "apple-nvme")) {
+			owner_str = "kernel";
+		} else {
+			libnvmf_registry_retrieve(libnvme_ctrl_get_name(c),
+						  "owner", &reg_owner);
+			if (reg_owner)
+				owner_str = reg_owner;
+		}
+#else
+		owner_str = "kernel";
+#endif
+		printf("%-16s %-12s %-6s %-20s %-40s %-8s %-6s %-14s %-6s %-12s ",
+		       libnvme_ctrl_get_name(c),
+		       owner_str,
+		       libnvme_ctrl_get_cntlid(c),
+		       libnvme_ctrl_get_serial(c),
+		       libnvme_ctrl_get_model(c),
+		       libnvme_ctrl_get_firmware(c),
+		       tr,
+		       libnvme_ctrl_get_traddr(c),
+		       libnvme_ctrl_get_phy_slot(c),
+		       libnvme_subsystem_get_name(libnvme_ctrl_get_subsystem(c)));
+#ifdef CONFIG_FABRICS
+		free(reg_owner);
+#endif
+	}
 
 	strset_init(&namespaces);
 
@@ -5935,11 +5957,11 @@ static void stdout_detailed_list(struct libnvme_global_ctx *ctx)
 	strset_iterate(&res.subsystems, stdout_detailed_subsys, &res);
 	printf("\n");
 
-	printf("%-16s %-6s %-20s %-40s %-8s %-6s %-14s %-6s %-12s %-16s\n", "Device",
-		"Cntlid", "SN", "MN", "FR", "TxPort", "Address", "Slot", "Subsystem",
-		"Namespaces");
-	printf("%-.16s %-.6s %-.20s %-.40s %-.8s %-.6s %-.14s %-.6s %-.12s %-.16s\n",
-			dash, dash, dash, dash, dash, dash, dash, dash, dash, dash);
+	printf("%-16s %-12s %-6s %-20s %-40s %-8s %-6s %-14s %-6s %-12s %-16s\n",
+		"Device", "Orchestrator", "Cntlid", "SN", "MN", "FR", "TxPort",
+		"Address", "Slot", "Subsystem", "Namespaces");
+	printf("%-.16s %-.12s %-.6s %-.20s %-.40s %-.8s %-.6s %-.14s %-.6s %-.12s %-.16s\n",
+		dash, dash, dash, dash, dash, dash, dash, dash, dash, dash, dash);
 	strset_iterate(&res.ctrls, stdout_detailed_ctrl, &res);
 	printf("\n");
 

--- a/nvme.c
+++ b/nvme.c
@@ -10469,6 +10469,38 @@ static int disconnect_cmd(int argc, char **argv, struct command *acmd, struct pl
 	return fabrics_disconnect(desc, argc, argv);
 }
 
+static int registry_list_cmd(int argc, char **argv, struct command *acmd,
+	struct plugin *plugin)
+{
+	const char *desc = "List NVMeoF controller ownership registry entries";
+
+	return fabrics_registry_list(desc, argc, argv);
+}
+
+static int registry_retrieve_cmd(int argc, char **argv, struct command *acmd,
+	struct plugin *plugin)
+{
+	const char *desc = "Retrieve a field from a controller registry entry";
+
+	return fabrics_registry_retrieve(desc, argc, argv);
+}
+
+static int registry_update_cmd(int argc, char **argv, struct command *acmd,
+	struct plugin *plugin)
+{
+	const char *desc = "Update a field in a controller's registry entry";
+
+	return fabrics_registry_update(desc, argc, argv);
+}
+
+static int registry_delete_cmd(int argc, char **argv, struct command *acmd,
+	struct plugin *plugin)
+{
+	const char *desc = "Delete a controller's registry entry";
+
+	return fabrics_registry_delete(desc, argc, argv);
+}
+
 int disconnect_all_cmd(int argc, char **argv, struct command *acmd,
 	struct plugin *plugin)
 {


### PR DESCRIPTION
This PR addresses: https://github.com/linux-nvme/nvme-cli/issues/2913

Multiple independent orchestrators (nvme-stas, NBFT, nvme-discoverd, manual nvme-cli) can establish NVMe-oF controller connections on the same host with no coordination. `nvme disconnect-all` is indiscriminate and dangerous in such environments.

This series introduces a cooperative userspace ownership registry so orchestrators can declare and respect ownership boundaries. Full design rationale and decisions are documented in: [nvme-registry-plan.md](https://github.com/user-attachments/files/28163658/nvme-registry-plan.md).

## What's new

- **libnvme**: registry API (`libnvmf_registry_retrieve/update/delete/for_each`), automatic registration on connect when `libnvmf_context_set_owner()` is set, Python bindings, unit tests
- **udev rule**: `70-nvmf-registry.rules` removes stale entries on controller removal
- **nvme disconnect-all**: ownership-aware by default; new `--owner` and `--force` options
- **nvme connect-all --nbft**: automatically registers controllers as owned by `"nbft"`
- **nvme registry-list/retrieve/update/delete**: new subcommands for manual registry management
- **nvme list -v**: new Orchestrator column

## Commits

1. `libnvme: add NVMe controller ownership registry` (78c9055)
2. `libnvmf: register controller ownership on successful connect` (6892470)
3. `nvme: add registry CLI commands and ownership-aware disconnect-all` (1c4dbdf)
4. `libnvme: expose registry API and owner in Python bindings` (43818fb)
5. `nvme: show orchestrator ownership in verbose list output` (dc0823e)
6. `libnvme: install udev rule to clean up registry on controller removal` (fa9e34b)
7. `nvme: add man pages for registry commands and update disconnect-all` (e5f500c)
