### PR TITLE
nvme-types-base: rename nvme_cmd_get_log_telemetry_host_lsp

### DIFF
--- a/libnvme/src/nvme/nvme-types-base.h
+++ b/libnvme/src/nvme/nvme-types-base.h
@@ -4010,11 +4010,11 @@ struct nvme_self_test_log {
 } __attribute__((packed));
 
 /**
- * enum nvme_cmd_get_log_telemetry_host_lsp - Telemetry Host-Initiated log specific field
+ * enum nvme_log_telemetry_host_lsp - Telemetry Host-Initiated log specific field
  * @NVME_LOG_TELEM_HOST_LSP_RETAIN:	Get Telemetry Data Blocks
  * @NVME_LOG_TELEM_HOST_LSP_CREATE:	Create Telemetry Data Blocks
  */
-enum nvme_cmd_get_log_telemetry_host_lsp {
+enum nvme_log_telemetry_host_lsp {
 	NVME_LOG_TELEM_HOST_LSP_RETAIN			= 0,
 	NVME_LOG_TELEM_HOST_LSP_CREATE			= 1,
 };


### PR DESCRIPTION
Rename to nvme_log_telemetry_host_lsp to drop the get.