### PR TITLE
libnvme-mi: use callbacks for mi submit logging

### DIFF
--- a/libnvme/src/libnvme-mi.ld
+++ b/libnvme/src/libnvme-mi.ld
@@ -14,6 +14,8 @@ LIBNVME_MI_3 {
 		libnvme_mi_ctrl_id;
 		libnvme_mi_endpoint_desc;
 		libnvme_mi_ep_get_timeout;
+		libnvme_mi_ep_set_submit_entry;
+		libnvme_mi_ep_set_submit_exit;
 		libnvme_mi_ep_set_timeout;
 		libnvme_mi_first_endpoint;
 		libnvme_mi_init_transport_handle;
@@ -31,8 +33,6 @@ LIBNVME_MI_3 {
 		libnvme_mi_scan_mctp;
 		libnvme_mi_set_csi;
 		libnvme_mi_status_to_string;
-		libnvme_mi_submit_entry;
-		libnvme_mi_submit_exit;
 	local:
 		*;
 };

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -186,6 +186,7 @@ LIBNVME_3 {
 		libnvme_subsystem_next_ns;
 		libnvme_subsystem_release_fds;
 		libnvme_transport_handle_get_fd;
+		libnvme_transport_handle_get_mi_ep;
 		libnvme_transport_handle_get_name;
 		libnvme_transport_handle_is_ctrl;
 		libnvme_transport_handle_is_direct;

--- a/libnvme/src/nvme/lib-types.h
+++ b/libnvme/src/nvme/lib-types.h
@@ -12,6 +12,7 @@
 
 struct libnvme_global_ctx;
 struct libnvme_transport_handle;
+struct libnvme_mi_ep;
 
 /**
  * struct libnvme_passthru_cmd - nvme passthrough command structure

--- a/libnvme/src/nvme/lib.h
+++ b/libnvme/src/nvme/lib.h
@@ -100,6 +100,19 @@ void libnvme_close(struct libnvme_transport_handle *hdl);
 libnvme_fd_t libnvme_transport_handle_get_fd(struct libnvme_transport_handle *hdl);
 
 /**
+ * libnvme_transport_handle_get_mi_ep() - get the MI endpoint from a
+ * transport handle
+ * @hdl: transport handle
+ *
+ * Retrieve the MI endpoint associated with this transport handle. Only valid
+ * for MI-type transport handles (check with libnvme_transport_handle_is_mi
+ * first).
+ *
+ * Return: the MI endpoint, or NULL if the handle is not an MI handle.
+ */
+struct libnvme_mi_ep *libnvme_transport_handle_get_mi_ep(struct libnvme_transport_handle *hdl);
+
+/**
  * libnvme_transport_handle_get_name - Return name of the device
  * transport handle
  * @hdl:	Transport handle

--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -293,6 +293,9 @@ struct libnvme_mi_ep *libnvme_mi_init_ep(struct libnvme_global_ctx *ctx)
 	ep->mprt_max = 0;
 	list_head_init(&ep->controllers);
 
+	ep->mi_submit_entry = __libnvme_mi_submit_entry;
+	ep->mi_submit_exit = __libnvme_mi_submit_exit;
+
 	list_add(&ctx->endpoints, &ep->root_entry);
 
 	return ep;
@@ -322,6 +325,28 @@ __libnvme_public unsigned int libnvme_mi_ep_get_timeout(libnvme_mi_ep_t ep)
 	return ep->timeout;
 }
 
+__libnvme_public void libnvme_mi_ep_set_submit_entry(libnvme_mi_ep_t ep,
+		void *(*mi_submit_entry)(struct libnvme_mi_ep *ep,
+				__u8 type, const struct nvme_mi_msg_hdr *hdr,
+				size_t hdr_len, const void *data,
+				size_t data_len))
+{
+	ep->mi_submit_entry = mi_submit_entry;
+	if (!ep->mi_submit_entry)
+		ep->mi_submit_entry = __libnvme_mi_submit_entry;
+}
+
+__libnvme_public void libnvme_mi_ep_set_submit_exit(libnvme_mi_ep_t ep,
+		void (*mi_submit_exit)(struct libnvme_mi_ep *ep,
+				__u8 type, const struct nvme_mi_msg_hdr *hdr,
+				size_t hdr_len, const void *data,
+				size_t data_len, void *user_data))
+{
+	ep->mi_submit_exit = mi_submit_exit;
+	if (!ep->mi_submit_exit)
+		ep->mi_submit_exit = __libnvme_mi_submit_exit;
+}
+
 static bool libnvme_mi_ep_has_quirk(libnvme_mi_ep_t ep, unsigned long quirk)
 {
 	return ep->quirks & quirk;
@@ -349,6 +374,15 @@ __libnvme_public struct libnvme_transport_handle *libnvme_mi_init_transport_hand
 __libnvme_public __u16 libnvme_mi_ctrl_id(struct libnvme_transport_handle *hdl)
 {
 	return hdl->id;
+}
+
+__libnvme_public struct libnvme_mi_ep *libnvme_transport_handle_get_mi_ep(
+		struct libnvme_transport_handle *hdl)
+{
+	if (!hdl || !libnvme_transport_handle_is_mi(hdl))
+		return NULL;
+
+	return hdl->ep;
 }
 
 __libnvme_public int libnvme_mi_scan_ep(libnvme_mi_ep_t ep, bool force_rescan)
@@ -424,19 +458,19 @@ static int libnvme_mi_verify_resp_mic(struct libnvme_mi_resp *resp)
 	return resp->mic != ~crc;
 }
 
-__libnvme_public __libnvme_weak void *libnvme_mi_submit_entry(
-		__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
-		const void *data, size_t data_len)
+void *__libnvme_mi_submit_entry(struct libnvme_mi_ep *ep,
+		__u8 type, const struct nvme_mi_msg_hdr *hdr,
+		size_t hdr_len, const void *data, size_t data_len)
 {
 	return NULL;
 }
 
-__libnvme_public __libnvme_weak void libnvme_mi_submit_exit(
-		__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
-		const void *data, size_t data_len, void *user_data)
+void __libnvme_mi_submit_exit(struct libnvme_mi_ep *ep,
+		__u8 type, const struct nvme_mi_msg_hdr *hdr,
+		size_t hdr_len, const void *data, size_t data_len,
+		void *user_data)
 {
 }
-
 
 int libnvme_mi_async_read(libnvme_mi_ep_t ep, struct libnvme_mi_resp *resp)
 {
@@ -496,13 +530,10 @@ int libnvme_mi_async_read(libnvme_mi_ep_t ep, struct libnvme_mi_resp *resp)
 
 
 int libnvme_mi_submit(libnvme_mi_ep_t ep, struct libnvme_mi_req *req,
-		   struct libnvme_mi_resp *resp)
+		struct libnvme_mi_resp *resp)
 {
 	int rc;
 	void *user_data;
-
-	user_data = libnvme_mi_submit_entry(req->hdr->type, req->hdr, req->hdr_len, req->data,
-					 req->data_len);
 
 	if (req->hdr_len < sizeof(struct nvme_mi_msg_hdr))
 		return -EINVAL;
@@ -515,6 +546,9 @@ int libnvme_mi_submit(libnvme_mi_ep_t ep, struct libnvme_mi_req *req,
 
 	if (resp->hdr_len & 0x3)
 		return -EINVAL;
+
+	user_data = ep->mi_submit_entry(ep, req->hdr->type, req->hdr,
+		req->hdr_len, req->data, req->data_len);
 
 	libnvme_mi_ep_probe(ep);
 
@@ -569,8 +603,8 @@ int libnvme_mi_submit(libnvme_mi_ep_t ep, struct libnvme_mi_req *req,
 		return -EIO;
 	}
 
-	libnvme_mi_submit_exit(resp->hdr->type, resp->hdr, resp->hdr_len, resp->data, resp->data_len,
-			    user_data);
+	ep->mi_submit_exit(ep, resp->hdr->type, resp->hdr, resp->hdr_len,
+		resp->data, resp->data_len, user_data);
 
 	return 0;
 }

--- a/libnvme/src/nvme/mi.h
+++ b/libnvme/src/nvme/mi.h
@@ -372,6 +372,49 @@ __u16 libnvme_mi_ctrl_id(struct libnvme_transport_handle *hdl);
  */
 char *libnvme_mi_endpoint_desc(libnvme_mi_ep_t ep);
 
+/**
+ * libnvme_mi_ep_set_submit_entry() - Install MI submit-entry callback
+ * @ep: endpoint to configure
+ * @mi_submit_entry: After input validation the callback is invoked before an MI
+ *		command is submitted. The function receives the endpoint,
+ *		message type, header, and data about to be sent, and may return
+ *		an opaque pointer representing per-command context. This pointer
+ *		is later passed unmodified to the mi_submit_exit callback.
+ *		Implementations typically use this hook for logging, tracing, or
+ *		allocating per-command state.
+ *
+ * Installs a callback invoked at the moment an MI command enters the submission
+ * path. This applies to all MI operations through this endpoint (both endpoint-
+ * level MI commands and controller admin commands). Passing NULL removes any
+ * previously installed callback.
+ */
+void libnvme_mi_ep_set_submit_entry(
+	libnvme_mi_ep_t ep,
+	void *(*mi_submit_entry)(struct libnvme_mi_ep *ep, __u8 type,
+				 const struct nvme_mi_msg_hdr *hdr,
+				 size_t hdr_len, const void *data,
+				 size_t data_len));
+
+/**
+ * libnvme_mi_ep_set_submit_exit() - Install MI submit-exit callback
+ * @ep: endpoint to configure
+ * @mi_submit_exit: Callback invoked after an MI command completes callback
+ *		(i.e., after a response has been received and passed basic
+ *		validation). The function receives the endpoint, message type,
+ *		header, data, and the @user_data pointer returned earlier by the
+ *		mi_submit_entry callback. Implementations typically use this
+ *		hook for logging, tracing, or freeing per-command state.
+ *
+ * Installs a callback invoked when an MI command completes. This applies to all
+ * MI operations through this endpoint. Passing NULL removes any previously
+ * installed callback.
+ */
+void libnvme_mi_ep_set_submit_exit(libnvme_mi_ep_t ep,
+		void (*mi_submit_exit)(struct libnvme_mi_ep *ep,
+				__u8 type, const struct nvme_mi_msg_hdr *hdr,
+				size_t hdr_len, const void *data,
+				size_t data_len, void *user_data));
+
 /* MI Command API: libnvme_mi_mi_ prefix */
 
 /**

--- a/libnvme/src/nvme/private-mi.h
+++ b/libnvme/src/nvme/private-mi.h
@@ -68,6 +68,14 @@ struct libnvme_mi_ep {
 	bool last_resp_time_valid;
 
 	struct libnvme_mi_aem_ctx *aem_ctx;
+
+	void *(*mi_submit_entry)(struct libnvme_mi_ep *ep,
+			__u8 type, const struct nvme_mi_msg_hdr *hdr,
+			size_t hdr_len, const void *data, size_t data_len);
+	void  (*mi_submit_exit)(struct libnvme_mi_ep *ep,
+			__u8 type, const struct nvme_mi_msg_hdr *hdr,
+			size_t hdr_len, const void *data, size_t data_len,
+			void *user_data);
 };
 
 struct libnvme_mi_transport {

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -458,6 +458,18 @@ void __libnvme_submit_exit(struct libnvme_transport_handle *hdl,
 bool __libnvme_decide_retry(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd, int err);
 
+#ifdef CONFIG_MI
+struct nvme_mi_msg_hdr;
+
+void *__libnvme_mi_submit_entry(struct libnvme_mi_ep *ep,
+		__u8 type, const struct nvme_mi_msg_hdr *hdr,
+		size_t hdr_len, const void *data, size_t data_len);
+void __libnvme_mi_submit_exit(struct libnvme_mi_ep *ep,
+		__u8 type, const struct nvme_mi_msg_hdr *hdr,
+		size_t hdr_len, const void *data, size_t data_len,
+		void *user_data);
+#endif
+
 struct libnvme_transport_handle *__libnvme_open(struct libnvme_global_ctx *ctx,
 		const char *name);
 struct libnvme_transport_handle *__libnvme_create_transport_handle(

--- a/logging.c
+++ b/logging.c
@@ -169,7 +169,8 @@ static void nvme_show_req(__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t h
 	}
 }
 
-void *libnvme_mi_submit_entry(__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
+void *nvme_mi_submit_entry(struct libnvme_mi_ep *ep, __u8 type,
+			   const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
 			   const void *data, size_t data_len)
 {
 	memset(&sb, 0, sizeof(sb));
@@ -212,7 +213,8 @@ static void nvme_show_resp(__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t 
 	}
 }
 
-void libnvme_mi_submit_exit(__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
+void nvme_mi_submit_exit(struct libnvme_mi_ep *ep, __u8 type,
+			 const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
 			 const void *data, size_t data_len, void *user_data)
 {
 	struct submit_data *sb = user_data;

--- a/logging.h
+++ b/logging.h
@@ -21,6 +21,8 @@ extern int log_level;
 
 struct libnvme_transport_handle;
 struct libnvme_passthru_cmd;
+struct libnvme_mi_ep;
+struct nvme_mi_msg_hdr;
 
 void *nvme_submit_entry(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd);
@@ -28,6 +30,13 @@ void nvme_submit_exit(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd, int err, void *user_data);
 bool nvme_decide_retry(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd, int err);
+
+void *nvme_mi_submit_entry(struct libnvme_mi_ep *ep, __u8 type,
+		const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
+		const void *data, size_t data_len);
+void nvme_mi_submit_exit(struct libnvme_mi_ep *ep, __u8 type,
+		const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,
+		const void *data, size_t data_len, void *user_data);
 
 bool is_printable_at_level(int level);
 int map_log_level(int verbose, bool quiet);

--- a/nvme.c
+++ b/nvme.c
@@ -358,6 +358,17 @@ static void setup_transport_handle(struct libnvme_global_ctx *ctx,
 	libnvme_transport_handle_set_submit_entry(hdl, nvme_submit_entry);
 	libnvme_transport_handle_set_submit_exit(hdl, nvme_submit_exit);
 	libnvme_transport_handle_set_decide_retry(hdl, nvme_decide_retry);
+
+#ifdef CONFIG_MI
+	if (libnvme_transport_handle_is_mi(hdl)) {
+		libnvme_mi_ep_t ep = libnvme_transport_handle_get_mi_ep(hdl);
+		if (ep) {
+			libnvme_mi_ep_set_submit_entry(ep, nvme_mi_submit_entry);
+			libnvme_mi_ep_set_submit_exit(ep, nvme_mi_submit_exit);
+		}
+	}
+#endif
+
 	libnvme_set_dry_run(ctx, nvme_args.dry_run);
 	if (nvme_args.timeout != NVME_DEFAULT_IOCTL_TIMEOUT)
 		libnvme_transport_handle_set_timeout(hdl, nvme_args.timeout);


### PR DESCRIPTION
Switch over from the weak symbol approach to explicit callbacks for logging. This makes the MI APIs consistent with the NVME API which also replaced the weak symbol approach with the explicit callbacks.

Fixes: #3305