### PR TITLE
sed: clarifying SUM sed policy reporting

### DIFF
--- a/plugins/sed/sedopal_cmd.c
+++ b/plugins/sed/sedopal_cmd.c
@@ -791,8 +791,8 @@ void sedopal_print_sum(void *data)
 		(sumd->flags & SUM_FEATURE_ANY) ? "yes" : "no");
 	printf("\tAll Locking Objects in SUM?     : %s\n",
 		(sumd->flags & SUM_FEATURE_ALL) ? "yes" : "no");
-	printf("\tUser Authority of Objects       : %s\n",
-		(sumd->flags & SUM_FEATURE_POLICY) ? "yes" : "no");
+	printf("\tUser Controls Locking Range     : %s\n",
+		(sumd->flags & SUM_FEATURE_POLICY) ? "no" : "yes");
 }
 
 /*


### PR DESCRIPTION
The SUM policy bit indicates if the linked SUM user is in control of the the range (and common name) of its SUM locking range.  A policy of 0 indicates the SUM user is in control.  A policy of 1 indicates that any admin is in control. The value is set to 1 by default when SUM is disabled. An admin will set the policy when SUM is enabled. See section 4.2.1.4 of TCG Storage Opal SSC Feature Set: Single User Mode v1.00.