### PR TITLE
nvme-print-json: split fabrics Address into fields

### DIFF
--- a/Documentation/nvme-list-subsys.txt
+++ b/Documentation/nvme-list-subsys.txt
@@ -48,12 +48,22 @@ root@host# nvme list-subsys -o json
         {
           "Name" : "nvme0",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1",
+          "AddressDetails" : {
+            "traddr" : "1.1.1.3",
+            "host_traddr" : "1.1.1.1",
+            "trsvcid" : "4420"
+          }
         },
         {
           "Name" : "nvme1",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2",
+          "AddressDetails" : {
+            "traddr" : "1.1.1.3",
+            "host_traddr" : "1.1.1.2",
+            "trsvcid" : "4420"
+          }
         }
       ]
     },
@@ -66,12 +76,22 @@ root@host# nvme list-subsys -o json
         {
           "Name" : "nvme2",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.2",
+          "AddressDetails" : {
+            "traddr" : "1.1.1.3",
+            "host_traddr" : "1.1.1.2",
+            "trsvcid" : "4420"
+          }
         },
         {
           "Name" : "nvme3",
           "Transport" : "rdma",
-          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1"
+          "Address" : "traddr=1.1.1.3,trsvcid=4420,host_traddr=1.1.1.1",
+          "AddressDetails" : {
+            "traddr" : "1.1.1.3",
+            "host_traddr" : "1.1.1.1",
+            "trsvcid" : "4420"
+          }
         }
       ]
     }

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -110,6 +110,45 @@ static void obj_add_prix64(struct json_object *o, const char *k, uint64_t v)
 	obj_add_str(o, k, str);
 }
 
+static void obj_add_ctrl_address_details(struct json_object *o, const char *k,
+					 libnvme_ctrl_t c)
+{
+	struct json_object *address_details = json_create_object();
+	const char *value;
+	bool has_value = false;
+
+	value = libnvme_ctrl_get_traddr(c);
+	if (value) {
+		obj_add_str(address_details, "traddr", value);
+		has_value = true;
+	}
+
+	value = libnvme_ctrl_get_host_traddr(c);
+	if (value) {
+		obj_add_str(address_details, "host_traddr", value);
+		has_value = true;
+	}
+
+	value = libnvme_ctrl_get_host_iface(c);
+	if (value) {
+		obj_add_str(address_details, "host_iface", value);
+		has_value = true;
+	}
+
+	value = libnvme_ctrl_get_trsvcid(c);
+	if (value) {
+		obj_add_str(address_details, "trsvcid", value);
+		has_value = true;
+	}
+
+	if (!has_value) {
+		json_free_object(address_details);
+		return;
+	}
+
+	obj_add_obj(o, k, address_details);
+}
+
 static void obj_add_int_secs(struct json_object *o, const char *k, int v)
 {
 	char str[STR_LEN];
@@ -2702,6 +2741,7 @@ static unsigned int json_print_nvme_subsystem_multipath(libnvme_subsystem_t s, j
 		obj_add_str(path_attrs, "Name", libnvme_ctrl_get_name(c));
 		obj_add_str(path_attrs, "Transport", libnvme_ctrl_get_transport(c));
 		obj_add_str(path_attrs, "Address", libnvme_ctrl_get_traddr(c));
+		obj_add_ctrl_address_details(path_attrs, "AddressDetails", c);
 		obj_add_str(path_attrs, "State", libnvme_ctrl_get_state(c));
 		obj_add_str(path_attrs, "ANAState", libnvme_path_get_ana_state(p));
 		array_add_obj(paths, path_attrs);
@@ -2723,6 +2763,7 @@ static void json_print_nvme_subsystem_ctrls(libnvme_subsystem_t s,
 		obj_add_str(path_attrs, "Name", libnvme_ctrl_get_name(c));
 		obj_add_str(path_attrs, "Transport", libnvme_ctrl_get_transport(c));
 		obj_add_str(path_attrs, "Address", libnvme_ctrl_get_traddr(c));
+		obj_add_ctrl_address_details(path_attrs, "AddressDetails", c);
 		obj_add_str(path_attrs, "State", libnvme_ctrl_get_state(c));
 		array_add_obj(paths, path_attrs);
 	}
@@ -4679,6 +4720,7 @@ static void json_print_detail_list_multipath(libnvme_subsystem_t s,
 			obj_add_str(jpath, "Firmware", libnvme_ctrl_get_firmware(c));
 			obj_add_str(jpath, "Transport", libnvme_ctrl_get_transport(c));
 			obj_add_str(jpath, "Address", libnvme_ctrl_get_traddr(c));
+			obj_add_ctrl_address_details(jpath, "AddressDetails", c);
 			obj_add_str(jpath, "Slot", libnvme_ctrl_get_phy_slot(c));
 
 			array_add_obj(jpaths, jpath);
@@ -4707,6 +4749,7 @@ static void json_print_detail_list(libnvme_subsystem_t s, struct json_object *js
 		obj_add_str(jctrl, "Firmware", libnvme_ctrl_get_firmware(c));
 		obj_add_str(jctrl, "Transport", libnvme_ctrl_get_transport(c));
 		obj_add_str(jctrl, "Address", libnvme_ctrl_get_traddr(c));
+		obj_add_ctrl_address_details(jctrl, "AddressDetails", c);
 		obj_add_str(jctrl, "Slot", libnvme_ctrl_get_phy_slot(c));
 
 		libnvme_ctrl_for_each_ns(c, n) {
@@ -4815,6 +4858,7 @@ static void json_detail_list(struct libnvme_global_ctx *ctx)
 				obj_add_str(jctrl, "Firmware", libnvme_ctrl_get_firmware(c));
 				obj_add_str(jctrl, "Transport", libnvme_ctrl_get_transport(c));
 				obj_add_str(jctrl, "Address", libnvme_ctrl_get_traddr(c));
+				obj_add_ctrl_address_details(jctrl, "AddressDetails", c);
 				obj_add_str(jctrl, "Slot", libnvme_ctrl_get_phy_slot(c));
 
 				libnvme_ctrl_for_each_ns(c, n) {
@@ -4995,6 +5039,7 @@ static unsigned int json_subsystem_topology_multipath(libnvme_subsystem_t s,
 			obj_add_str(ctrl_attrs, "Name", libnvme_ctrl_get_name(c));
 			obj_add_str(ctrl_attrs, "Transport", libnvme_ctrl_get_transport(c));
 			obj_add_str(ctrl_attrs, "Address", libnvme_ctrl_get_traddr(c));
+			obj_add_ctrl_address_details(ctrl_attrs, "AddressDetails", c);
 			obj_add_str(ctrl_attrs, "State", libnvme_ctrl_get_state(c));
 			array_add_obj(ctrls, ctrl_attrs);
 			obj_add_array(path_attrs, "Controller", ctrls);
@@ -5033,6 +5078,7 @@ static void json_print_nvme_subsystem_topology(libnvme_subsystem_t s,
 						     libnvme_ctrl_get_transport(c));
 			obj_add_str(ctrl_attrs, "Address",
 						     libnvme_ctrl_get_traddr(c));
+			obj_add_ctrl_address_details(ctrl_attrs, "AddressDetails", c);
 			obj_add_str(ctrl_attrs, "State",
 						     libnvme_ctrl_get_state(c));
 


### PR DESCRIPTION
The Address string combines several fields into a string, which forces the user to parse the string. Add AddressDetails which splits out fields into separate key/value pairs.

Fixes: #https://github.com/linux-nvme/nvme-cli/issues/3256