### PR TITLE
nvme: do not print status message on default

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -176,7 +176,7 @@ static void save_discovery_log(char *raw, struct nvmf_discovery_log *log)
 
 	fd = open(raw, O_CREAT | O_RDWR | O_TRUNC, 0600);
 	if (fd < 0) {
-		fprintf(stderr, "failed to open %s: %s\n", raw, libnvme_strerror(errno));
+		nvme_show_error("failed to open %s: %s", raw, libnvme_strerror(errno));
 		return;
 	}
 
@@ -184,10 +184,10 @@ static void save_discovery_log(char *raw, struct nvmf_discovery_log *log)
 
 	ret = write(fd, log, len);
 	if (ret < 0)
-		fprintf(stderr, "failed to write to %s: %s\n",
+		nvme_show_error("failed to write to %s: %s",
 			raw, libnvme_strerror(errno));
 	else
-		printf("Discovery log is saved to %s\n", raw);
+		nvme_show_verbose_info("Discovery log is saved to %s", raw);
 
 	close(fd);
 }
@@ -224,7 +224,7 @@ static void hook_connected(struct libnvmf_context *fctx,
 		return;
 
 	if (hfd->flags == NORMAL) {
-		printf("connecting to device: %s\n", libnvme_ctrl_get_name(c));
+		nvme_show_verbose_info("connecting to device: %s", libnvme_ctrl_get_name(c));
 		return;
 	}
 
@@ -252,7 +252,7 @@ static void hook_already_connected(struct libnvmf_context *fctx,
 	if (quiet)
 		return;
 
-	fprintf(stderr,	"already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s\n",
+	nvme_show_error("already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
 		libnvme_host_get_hostnqn(host), subsysnqn,
 		transport, traddr, trsvcid);
 }
@@ -275,7 +275,7 @@ static int hook_parser_init(struct libnvmf_context *dctx, void *user_data)
 
 	hfd->f = fopen(PATH_NVMF_DISC, "r");
 	if (hfd->f == NULL) {
-		fprintf(stderr, "No params given and no %s\n", PATH_NVMF_DISC);
+		nvme_show_error("No params given and no %s", PATH_NVMF_DISC);
 		return -ENOENT;
 	}
 
@@ -540,7 +540,7 @@ unref:
 	kmod_unref(ctx);
 
 	if (err)
-		fprintf(stderr, "Couldn't load the nvme-fabrics module\n");
+		nvme_show_error("Couldn't load the nvme-fabrics module");
 #endif
 }
 
@@ -595,7 +595,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx) {
-		fprintf(stderr, "Failed to create topology root: %s\n",
+		nvme_show_error("Failed to create topology root: %s",
 			libnvme_strerror(errno));
 		return -ENOMEM;
 	}
@@ -609,7 +609,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	if (owner || nbft) {
 		ret = libnvme_set_owner(ctx, owner ? owner : "nbft");
 		if (ret) {
-			fprintf(stderr, "failed to set owner: %s\n",
+			nvme_show_error("failed to set owner: %s",
 				libnvme_strerror(-ret));
 			return ret;
 		}
@@ -623,7 +623,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
+		nvme_show_error("Failed to scan topology: %s",
 			libnvme_strerror(-ret));
 		return ret;
 	}
@@ -707,20 +707,20 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 		goto do_connect;
 
 	if (!fa.subsysnqn) {
-		fprintf(stderr,
+		nvme_show_error(
 			"required argument [--nqn | -n] not specified\n");
 		return -EINVAL;
 	}
 
 	if (!fa.transport) {
-		fprintf(stderr,
+		nvme_show_error(
 			"required argument [--transport | -t] not specified\n");
 		return -EINVAL;
 	}
 
 	if (strcmp(fa.transport, "loop")) {
 		if (!fa.traddr) {
-			fprintf(stderr,
+			nvme_show_error(
 				"required argument [--traddr | -a] not specified for transport %s\n",
 				fa.transport);
 			return -EINVAL;
@@ -732,7 +732,7 @@ do_connect:
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx) {
-		fprintf(stderr, "Failed to create topology root: %s\n",
+		nvme_show_error("Failed to create topology root: %s",
 			libnvme_strerror(errno));
 		return -ENOMEM;
 	}
@@ -741,7 +741,7 @@ do_connect:
 	if (owner) {
 		ret = libnvme_set_owner(ctx, owner);
 		if (ret) {
-			fprintf(stderr, "failed to set owner: %s\n",
+			nvme_show_error("failed to set owner: %s",
 				libnvme_strerror(-ret));
 			return ret;
 		}
@@ -753,7 +753,7 @@ do_connect:
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
+		nvme_show_error("Failed to scan topology: %s",
 			libnvme_strerror(-ret));
 		return ret;
 	}
@@ -784,7 +784,7 @@ do_connect:
 					      fa.host_traddr, fa.host_iface,
 					      fa.hostnqn, fa.hostid);
 		if (tid && libnvmf_exclusion_match(ctx, tid))
-			fprintf(stderr,
+			nvme_show_error(
 				"Note: %s is on the exclusion list; connecting anyway\n",
 				fa.subsysnqn ? fa.subsysnqn : "this controller");
 		libnvmf_tid_free(tid);
@@ -792,7 +792,7 @@ do_connect:
 
 	ret = libnvmf_connect(ctx, fctx);
 	if (ret) {
-		fprintf(stderr, "failed to connect: %s\n",
+		nvme_show_error("failed to connect: %s",
 			libnvme_strerror(-ret));
 		return ret;
 	}
@@ -844,7 +844,7 @@ static void nvmf_disconnect_nqn(struct libnvme_global_ctx *ctx, char *nqn)
 			}
 		}
 	}
-	printf("NQN:%s disconnected %d controller(s)\n", nqn, i);
+	nvme_show_verbose_result("NQN:%s disconnected %d controller(s)", nqn, i);
 }
 
 int fabrics_disconnect(const char *desc, int argc, char **argv)
@@ -874,12 +874,12 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 		return ret;
 
 	if (cfg.nqn && cfg.device) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Both device name [--device | -d] and NQN [--nqn | -n] are specified\n");
 		return -EINVAL;
 	}
 	if (!cfg.nqn && !cfg.device) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Neither device name [--device | -d] nor NQN [--nqn | -n] provided\n");
 		return -EINVAL;
 	}
@@ -888,7 +888,7 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx) {
-		fprintf(stderr, "Failed to create topology root: %s\n",
+		nvme_show_error("Failed to create topology root: %s",
 			libnvme_strerror(errno));
 		return -ENOMEM;
 	}
@@ -905,7 +905,7 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 		if (ret == -ENOENT)
 			return 0;
 
-		fprintf(stderr, "Failed to scan topology: %s\n",
+		nvme_show_error("Failed to scan topology: %s",
 			libnvme_strerror(-ret));
 		return ret;
 	}
@@ -921,7 +921,7 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 			ret = libnvmf_exclusion_add_subsysnqn(ctx, NULL,
 							      cfg.nqn);
 			if (ret)
-				fprintf(stderr,
+				nvme_show_error(
 					"Warning: failed to write exclusion entry: %s\n",
 					libnvme_strerror(-ret));
 		}
@@ -937,7 +937,7 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 				p += 5;
 			c = lookup_nvme_ctrl(ctx, p);
 			if (!c) {
-				fprintf(stderr,
+				nvme_show_error(
 					"Did not find device %s\n", p);
 				return -ENODEV;
 			}
@@ -950,13 +950,13 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 				ret = libnvmf_exclusion_add_ctrl(ctx, NULL,
 								 c);
 				if (ret)
-					fprintf(stderr,
+					nvme_show_error(
 						"Warning: failed to write exclusion entry: %s\n",
 						libnvme_strerror(-ret));
 			}
 			ret = libnvmf_disconnect_ctrl(c);
 			if (ret)
-				fprintf(stderr,
+				nvme_show_error(
 					"Failed to disconnect %s: %s\n",
 					p, libnvme_strerror(-ret));
 		}
@@ -1013,7 +1013,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 		return ret;
 
 	if (cfg.force && cfg.owner) {
-		fprintf(stderr, "--force and --owner are mutually exclusive\n");
+		nvme_show_error("--force and --owner are mutually exclusive");
 		return -EINVAL;
 	}
 
@@ -1021,21 +1021,21 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 		char ans[8] = { 0 };
 
 		if (cfg.force)
-			fprintf(stderr,
+			nvme_show_error(
 				"WARNING: --force disconnects all NVMeoF controllers\n"
 				"regardless of ownership. Type 'yes' to confirm: ");
 		else
-			fprintf(stderr,
+			nvme_show_error(
 				"WARNING: --owner disconnects all NVMeoF controllers\n"
 				"owned by '%s'. Type 'yes' to confirm: ",
 				cfg.owner);
 		if (!fgets(ans, sizeof(ans), stdin)) {
-			fprintf(stderr, "Aborted.\n");
+			nvme_show_error("Aborted.");
 			return -EINVAL;
 		}
 		ans[strcspn(ans, "\n")] = '\0';
 		if (strcmp(ans, "yes") != 0) {
-			fprintf(stderr, "Aborted.\n");
+			nvme_show_error("Aborted.");
 			return -EINVAL;
 		}
 	}
@@ -1044,7 +1044,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx) {
-		fprintf(stderr, "Failed to create topology root: %s\n",
+		nvme_show_error("Failed to create topology root: %s",
 			libnvme_strerror(errno));
 		return -ENOMEM;
 	}
@@ -1061,7 +1061,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 		if (ret == -ENOENT)
 			return 0;
 
-		fprintf(stderr, "Failed to scan topology: %s\n",
+		nvme_show_error("Failed to scan topology: %s",
 			libnvme_strerror(-ret));
 		return ret;
 	}
@@ -1073,7 +1073,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 							  cfg.owner, cfg.force))
 					continue;
 				if (libnvmf_disconnect_ctrl(c))
-					fprintf(stderr,
+					nvme_show_error(
 						"failed to disconnect %s\n",
 						libnvme_ctrl_get_name(c));
 			}
@@ -1111,7 +1111,7 @@ int fabrics_config(const char *desc, int argc, char **argv)
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx) {
-		fprintf(stderr, "Failed to create topology root: %s\n",
+		nvme_show_error("Failed to create topology root: %s",
 			libnvme_strerror(errno));
 		return -ENOMEM;
 	}
@@ -1123,7 +1123,7 @@ int fabrics_config(const char *desc, int argc, char **argv)
 		libnvme_skip_namespaces(ctx);
 		ret = libnvme_scan_topology(ctx, NULL, NULL);
 		if (ret < 0) {
-			fprintf(stderr, "Failed to scan topology: %s\n",
+			nvme_show_error("Failed to scan topology: %s",
 				libnvme_strerror(-ret));
 			return -ret;
 		}
@@ -1133,13 +1133,13 @@ int fabrics_config(const char *desc, int argc, char **argv)
 		__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 
 		if (!fa.subsysnqn) {
-			fprintf(stderr,
+			nvme_show_error(
 				"required argument [--nqn | -n] needed with --modify\n");
 			return -EINVAL;
 		}
 
 		if (!fa.transport) {
-			fprintf(stderr,
+			nvme_show_error(
 				"required argument [--transport | -t] needed with --modify\n");
 			return -EINVAL;
 		}
@@ -1150,7 +1150,7 @@ int fabrics_config(const char *desc, int argc, char **argv)
 
 		ret = libnvmf_config_modify(ctx, fctx);
 		if (ret) {
-			fprintf(stderr, "failed to update config\n");
+			nvme_show_error("failed to update config");
 			return ret;
 		}
 	}
@@ -1182,12 +1182,12 @@ static int dim_operation(libnvme_ctrl_t c, enum nvmf_dim_tas tas, const char *na
 	t = (tas > NVMF_DIM_TAS_DEREGISTER || !task[tas]) ? "reserved" : task[tas];
 	status = libnvmf_register_ctrl(c, tas, &result);
 	if (status == NVME_SC_SUCCESS) {
-		printf("%s DIM %s command success\n", name, t);
+		nvme_show_verbose_result("%s DIM %s command success", name, t);
 	} else if (status < NVME_SC_SUCCESS) {
-		fprintf(stderr, "%s DIM %s command error. Status:0x%04x - %s\n",
+		nvme_show_error("%s DIM %s command error. Status:0x%04x - %s",
 			name, t, status, libnvme_status_to_string(status, false));
 	} else {
-		fprintf(stderr, "%s DIM %s command error. Result:0x%04x, Status:0x%04x - %s\n",
+		nvme_show_error("%s DIM %s command error. Result:0x%04x, Status:0x%04x - %s",
 			name, t, result, status, libnvme_status_to_string(status, false));
 	}
 
@@ -1218,13 +1218,13 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 		return ret;
 
 	if (!cfg.nqn && !cfg.device) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Neither device name [--device | -d] nor NQN [--nqn | -n] provided\n");
 		return -EINVAL;
 	}
 
 	if (!cfg.tas) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Task [--task | -t] must be specified\n");
 		return -EINVAL;
 	}
@@ -1235,7 +1235,7 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 	} else if (strstarts("deregister", cfg.tas)) {
 		tas = NVMF_DIM_TAS_DEREGISTER;
 	} else {
-		fprintf(stderr, "Invalid --task: %s\n", cfg.tas);
+		nvme_show_error("Invalid --task: %s", cfg.tas);
 		return -EINVAL;
 	}
 
@@ -1243,7 +1243,7 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx) {
-		fprintf(stderr, "Failed to create topology root: %s\n",
+		nvme_show_error("Failed to create topology root: %s",
 			libnvme_strerror(errno));
 		return -ENODEV;
 	}
@@ -1252,7 +1252,7 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret < 0) {
-		fprintf(stderr, "Failed to scan topology: %s\n",
+		nvme_show_error("Failed to scan topology: %s",
 			libnvme_strerror(-ret));
 		return ret;
 	}
@@ -1284,7 +1284,7 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 				p += 5;
 			ret = libnvme_scan_ctrl(ctx, p, &c);
 			if (ret) {
-				fprintf(stderr,
+				nvme_show_error(
 					"Did not find device %s: %s\n",
 					p, libnvme_strerror(ret));
 				return ret;

--- a/logging.c
+++ b/logging.c
@@ -104,7 +104,7 @@ static void nvme_log_retry(int errnum)
 	if (log_level < LIBNVME_LOG_DEBUG)
 		return;
 
-	printf("passthru command returned '%s'\n", libnvme_strerror(errnum));
+	print_debug("passthru command returned '%s'\n", libnvme_strerror(errnum));
 }
 
 void *nvme_submit_entry(struct libnvme_transport_handle *hdl,
@@ -209,8 +209,8 @@ void *nvme_mi_submit_entry(struct libnvme_mi_ep *ep, __u8 type,
 static void nvme_show_resp_admin(const struct nvme_mi_admin_resp_hdr *hdr, size_t hdr_len,
 				 const void *data, size_t data_len)
 {
-	printf("result       : %08x\n", le32_to_cpu(hdr->cdw0));
-	printf("err          : %d\n", hdr->status);
+	nvme_show_key_value("result       ", "%08x", le32_to_cpu(hdr->cdw0));
+	nvme_show_key_value("err          ", "%d", hdr->status);
 }
 
 static void nvme_show_resp(__u8 type, const struct nvme_mi_msg_hdr *hdr, size_t hdr_len,

--- a/nvme-models.c
+++ b/nvme-models.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include "nvme-models.h"
 #include "nvme.h"
+#include "nvme-print.h"
 
 static char *_fmt1 = "/sys/class/nvme/nvme%d/device/subsystem_vendor";
 static char *_fmt2 = "/sys/class/nvme/nvme%d/device/subsystem_device";
@@ -246,7 +247,7 @@ static int read_sys_node(char *where, char *save, size_t savesz)
 	fd = open(where, O_RDONLY);
 	if (fd < 0) {
 		if (errno != ENOENT) {
-			fprintf(stderr, "Failed to open %s with errno %s\n",
+			nvme_show_error("Failed to open %s with errno %s",
 				where, libnvme_strerror(errno));
 		}
 		return 1;
@@ -295,7 +296,7 @@ static FILE *open_pci_ids(void)
 			return fp;
 	}
 
-	fprintf(stderr, "Could not find pci.ids file\n");
+	nvme_show_error("Could not find pci.ids file");
 	return NULL;
 }
 
@@ -350,7 +351,7 @@ static char *__nvme_product_name(int id)
 
 	result = malloc(LINE_BUF_SIZE);
 	if (!result) {
-		fprintf(stderr, "malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("malloc: %s", libnvme_strerror(errno));
 		free_all();
 		return NULL;
 	}

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -5503,13 +5503,30 @@ void json_show_init(void)
 		json_r = json_create_object();
 }
 
+bool json_empty(struct json_object *obj)
+{
+	if (!obj)
+		return true;
+
+	switch (json_object_get_type(obj)) {
+	case json_type_object:
+		return json_object_object_length(obj) == 0;
+	case json_type_array:
+		return json_object_array_length(obj) == 0;
+	default:
+		return false; /* scalars always have something to print */
+	}
+}
+
 void json_show_finish(void)
 {
 	if (--json_init)
 		return;
 
-	if (json_r)
+	if (!json_empty(json_r))
 		json_output_object(json_r);
+	else
+		json_free_object(json_r);
 
 	json_r = NULL;
 }

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1743,6 +1743,20 @@ void nvme_show_message(bool error, const char *msg, ...)
 	va_end(ap);
 }
 
+void nvme_show_verbose_message(const char *msg, ...)
+{
+	va_list ap;
+
+	if (!nvme_args.verbose)
+		return;
+
+	va_start(ap, msg);
+
+	nvme_show_message(true, msg, ap);
+
+	va_end(ap);
+}
+
 void nvme_show_perror(const char *msg, ...)
 {
 	struct print_ops *ops = nvme_print_ops(NORMAL);
@@ -1771,6 +1785,19 @@ void nvme_show_key_value(const char *key, const char *val, ...)
 
 	if (ops && ops->show_key_value)
 		ops->show_key_value(key, val, ap);
+
+	va_end(ap);
+}
+void nvme_show_verbose_key_value(const char *key, const char *val, ...)
+{
+	va_list ap;
+
+	if (!nvme_args.verbose)
+		return;
+
+	va_start(ap, val);
+
+	nvme_show_key_value(key, val, ap);
 
 	va_end(ap);
 }

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -17,6 +17,8 @@ typedef struct nvme_effects_log_node {
 
 #define nvme_show_error(msg, ...) nvme_show_message(true, msg, ##__VA_ARGS__)
 #define nvme_show_result(msg, ...) nvme_show_message(false, msg, ##__VA_ARGS__)
+#define nvme_show_verbose_result(msg, ...) nvme_show_verbose_message(msg, ##__VA_ARGS__)
+#define nvme_show_verbose_info(msg, ...) nvme_show_verbose_message(msg, ##__VA_ARGS__)
 
 #define POWER_OF_TWO(exponent) (1 << (exponent))
 
@@ -373,11 +375,13 @@ const char *nvme_ipmsr_srs_to_string(__u8 srs);
 void nvme_dev_full_path(libnvme_ns_t n, char *path, size_t len);
 void nvme_generic_full_path(libnvme_ns_t n, char *path, size_t len);
 void nvme_show_message(bool error, const char *msg, ...);
+void nvme_show_verbose_message(const char *msg, ...);
 void nvme_show_perror(const char *msg, ...);
 void nvme_show_error_status(int status, const char *msg, ...);
 void nvme_show_init(void);
 void nvme_show_finish(void);
 void nvme_show_key_value(const char *key, const char *value, ...);
+void nvme_show_verbose_key_value(const char *key, const char *value, ...);
 bool nvme_is_fabrics_reg(int offset);
 bool nvme_is_fabrics_optional_reg(int offset);
 bool nvme_registers_cmbloc_support(__u32 cmbsz);

--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -48,7 +48,7 @@ static int read_file(const char *file, unsigned char **data, unsigned int *len)
 	if (file == NULL) return err;
 
 	if ((fd = nvme_open_rawdata(file, O_RDONLY)) < 0) {
-		fprintf(stderr, "Failed to open %s: %s\n", file, libnvme_strerror(errno));
+		nvme_show_error("Failed to open %s: %s", file, libnvme_strerror(errno));
 		return fd;
 	}
 
@@ -61,7 +61,7 @@ static int read_file(const char *file, unsigned char **data, unsigned int *len)
 	size = sb.st_size;
 	buf = libnvme_alloc(size);
 	if (!buf) {
-		fprintf(stderr, "No memory for reading file :%s\n", file);
+		nvme_show_error("No memory for reading file :%s", file);
 		err = -ENOMEM;
 		goto out;
 	}
@@ -69,7 +69,7 @@ static int read_file(const char *file, unsigned char **data, unsigned int *len)
 	err = read(fd, buf, size);
 	if (err < 0) {
 		err = -errno;
-		fprintf(stderr, "Failed to read data from file"
+		nvme_show_error("Failed to read data from file"
 				" %s with %s\n", file, libnvme_strerror(errno));
 		libnvme_free(buf);
 		goto out;
@@ -96,11 +96,11 @@ static void write_file(unsigned char *data, size_t len, const char *dir,
 
 	if ((fp = fopen(temp_folder, "ab+")) != NULL) {
 		if (fwrite(data, 1, len,  fp) != len) {
-			fprintf(stderr, "Failed to write %s data to %s\n",
+			nvme_show_error("Failed to write %s data to %s",
 				 msg ? msg : "", temp_folder);
 		}
 	} else  {
-		fprintf(stderr, "Failed to open %s file to write %s\n",
+		nvme_show_error("Failed to open %s file to write %s",
 			temp_folder, msg ? msg : "");
 	}
 }
@@ -215,7 +215,7 @@ rpmb_request_init(unsigned int   req_size,
 	struct rpmb_data_frame_t *req = NULL;
 
 	if ((req = (struct rpmb_data_frame_t *)calloc(req_size, 1)) == NULL) {
-		fprintf(stderr, "Memory allocation failed for request 0x%04x\n",
+		nvme_show_error("Memory allocation failed for request 0x%04x",
 			type);
 		return req;
 	}
@@ -251,19 +251,19 @@ static int check_rpmb_response(struct rpmb_data_frame_t *req,
 	/* check error status before comparing nonce and mac */
 	if (rsp->result != 0)  {
 		if (rsp->type != ((req->type << 8) & 0xFF00)) {
-			fprintf(stderr, "%s ! non-matching response 0x%04x for"
+			nvme_show_error("%s ! non-matching response 0x%04x for"
 				" 0x%04x\n", msg, rsp->type, req->type);
 		} else if ((rsp->result & 0x80) == 0x80) {
-			fprintf(stderr, "%s ! Expired write-counter !\n", msg);
+			nvme_show_error("%s ! Expired write-counter !", msg);
 		} else if (rsp->result) {
-			fprintf(stderr, "%s ! %s\n", msg,
+			nvme_show_error("%s ! %s", msg,
 				rpmb_result_string[rsp->result & 0x7F]);
 		} else if (memcmp(req->nonce, rsp->nonce, 16)) {
-			fprintf(stderr, "%s ! non-matching nonce\n", msg);
+			nvme_show_error("%s ! non-matching nonce", msg);
 		} else if (memcmp(req->mac, rsp->mac, 32)) {
-			fprintf(stderr, "%s ! non-matching MAC\n", msg);
+			nvme_show_error("%s ! non-matching MAC", msg);
 		} else if ((req->write_counter + 1) != rsp->write_counter) {
-			fprintf(stderr, "%s ! out-of-sync write-counters\n", msg);
+			nvme_show_error("%s ! out-of-sync write-counters", msg);
 		}
 	}
 	
@@ -289,7 +289,7 @@ rpmb_read_request(struct libnvme_transport_handle *hdl,
 
 	error = send_rpmb_req(hdl, req->target, req_size, req);
 	if (error != 0) {
-		fprintf(stderr, "%s failed with error = 0x%x\n",
+		nvme_show_error("%s failed with error = 0x%x",
 			msg, error);
 		goto error_out;
 	}
@@ -297,14 +297,14 @@ rpmb_read_request(struct libnvme_transport_handle *hdl,
 	/* read the result back */
 	rsp = (struct rpmb_data_frame_t *)calloc(rsp_size, 1);
 	if (rsp == NULL) {
-		fprintf(stderr, "memory alloc failed for %s\n", msg);
+		nvme_show_error("memory alloc failed for %s", msg);
 		goto error_out;
 	}
 
 	/* Read result of previous request */
 	error = recv_rpmb_rsp(hdl, req->target, rsp_size, rsp);
 	if (error) {
-		fprintf(stderr, "error 0x%x receiving response for %s\n",
+		nvme_show_error("error 0x%x receiving response for %s",
 			error, msg);
 		goto error_out;
 	}
@@ -373,7 +373,7 @@ static unsigned int rpmb_read_config_block(struct libnvme_transport_handle *hdl,
 	/* copy configuration data to be sent back to caller */
 	cfg = (struct rpmb_config_block_t *)calloc(cfg_size, 1);
 	if (cfg == NULL) {
-		fprintf(stderr, "failed to allocate RPMB config buffer\n");
+		nvme_show_error("failed to allocate RPMB config buffer");
 		goto out;
 	}
 
@@ -405,7 +405,7 @@ static int rpmb_auth_data_read(struct libnvme_transport_handle *hdl,
 	int error = -1;
 
 	if (bufp == NULL) {
-		fprintf(stderr, "Failed to allocated memory for read-data req\n");
+		nvme_show_error("Failed to allocated memory for read-data req");
 		goto out;
 	}
 	
@@ -417,7 +417,7 @@ static int rpmb_auth_data_read(struct libnvme_transport_handle *hdl,
 			break;
 		if ((rsp = rpmb_read_request(hdl, req, req_size, rsp_size)) == NULL)
 		{
-			fprintf(stderr, "read_request failed\n");
+			nvme_show_error("read_request failed");
 			free(req);
 			break;
 		}
@@ -456,14 +456,14 @@ static int rpmb_program_auth_key(struct libnvme_transport_handle *hdl,
 	req = rpmb_request_init(req_size, RPMB_REQ_AUTH_KEY_PROGRAM, target,
 				0, 0, 0, key_buf, (223 - key_size), key_size);
 	if (req == NULL) {
-		fprintf(stderr, "failed to allocate request buffer memory\n");
+		nvme_show_error("failed to allocate request buffer memory");
 		goto out;
 	}
 
 	/* send the request and get response */
 	err = send_rpmb_req(hdl, req->target, req_size, req);
 	if (err) {
-		fprintf(stderr, "RPMB request 0x%04x for 0x%x, err: %d\n", req->type, req->target,
+		nvme_show_error("RPMB request 0x%04x for 0x%x, err: %d", req->type, req->target,
 			err);
 		goto out;
 	}
@@ -471,7 +471,7 @@ static int rpmb_program_auth_key(struct libnvme_transport_handle *hdl,
 	/* send the request to get the result and then request to get the response */
 	rsp = (struct rpmb_data_frame_t *)calloc(rsp_size, 1);
 	if (!rsp) {
-		fprintf(stderr, "failed to allocate response buffer memory\n");
+		nvme_show_error("failed to allocate response buffer memory");
 		err = -ENOMEM;
 		goto out;
 	}
@@ -480,7 +480,7 @@ static int rpmb_program_auth_key(struct libnvme_transport_handle *hdl,
 	rsp->type = RPMB_REQ_READ_RESULT;
 	err = send_rpmb_req(hdl, req->target, rsp_size, rsp);
 	if (err || rsp->result) {
-		fprintf(stderr, "Program auth key read result 0x%x, error = 0x%x\n", rsp->result,
+		nvme_show_error("Program auth key read result 0x%x, error = 0x%x", rsp->result,
 			err);
 		goto out;
 	}
@@ -489,7 +489,7 @@ static int rpmb_program_auth_key(struct libnvme_transport_handle *hdl,
 	memset(rsp, 0, rsp_size);
 	err = recv_rpmb_rsp(hdl, req->target, rsp_size, rsp);
 	if (err != 0)
-		fprintf(stderr, "Program Key recv error = 0x%x\n", err);
+		nvme_show_error("Program Key recv error = 0x%x", err);
 	else
 		err = check_rpmb_response(req, rsp, "Failed to Program Key");
 out:
@@ -523,7 +523,7 @@ static int auth_data_write_chunk(struct libnvme_transport_handle *hdl,
 	/* get current write counter and copy to the request  */
 	error = rpmb_read_write_counter(hdl, tgt, &write_cntr);
 	if (error != 0) {
-	   fprintf(stderr, "Failed to read write counter for write-data\n");
+	   nvme_show_error("Failed to read write counter for write-data");
 	    goto out;
 	}
 	
@@ -531,7 +531,7 @@ static int auth_data_write_chunk(struct libnvme_transport_handle *hdl,
 				addr, (msg_size / 512), msg_buf,
 				offsetof(struct rpmb_data_frame_t, data), msg_size);
 	if (req == NULL) {
-		fprintf(stderr, "Memory alloc failed for write-data command\n");
+		nvme_show_error("Memory alloc failed for write-data command");
 		goto out;
 	}
 
@@ -541,7 +541,7 @@ static int auth_data_write_chunk(struct libnvme_transport_handle *hdl,
 	mac = create_hmac_sha256(((unsigned char *)req + 223), req_size - 223,
 				 keybuf, keysize);
 	if (mac == NULL) {
-		fprintf(stderr, "failed to compute HMAC-SHA256\n");
+		nvme_show_error("failed to compute HMAC-SHA256");
 		error = -1;
 		goto out;
 	}
@@ -551,7 +551,7 @@ static int auth_data_write_chunk(struct libnvme_transport_handle *hdl,
 	/* send the request and get response */
 	error = send_rpmb_req(hdl, tgt, req_size, req);
 	if (error != 0) {
-	    fprintf(stderr, "RPMB request 0x%04x for 0x%x, error: %d\n",
+	    nvme_show_error("RPMB request 0x%04x for 0x%x, error: %d",
 		    req->type, tgt, error);
 	    goto out;
 	}
@@ -562,7 +562,7 @@ static int auth_data_write_chunk(struct libnvme_transport_handle *hdl,
 	rsp->type = RPMB_REQ_READ_RESULT;
 	error = send_rpmb_req(hdl, tgt, rsp_size, rsp);
 	if (error != 0 || rsp->result != 0) {
-		fprintf(stderr, "Write-data read result 0x%x, error = 0x%x\n",
+		nvme_show_error("Write-data read result 0x%x, error = 0x%x",
 			rsp->result, error);
 		goto out;
 	}
@@ -571,7 +571,7 @@ static int auth_data_write_chunk(struct libnvme_transport_handle *hdl,
 	memset(rsp, 0, rsp_size);
 	error = recv_rpmb_rsp(hdl, tgt, rsp_size, rsp);
 	if (error != 0)
-		fprintf(stderr, "Auth data write recv error = 0x%x\n", error);
+		nvme_show_error("Auth data write recv error = 0x%x", error);
 	else 
     		error = check_rpmb_response(req, rsp, "Failed to write-data");
 out:
@@ -632,14 +632,14 @@ static int rpmb_write_config_block(struct libnvme_transport_handle *hdl,
 				cfg_buf, offsetof(struct rpmb_data_frame_t, data),
 				cfg_size);
 	if (req == NULL) {
-		fprintf(stderr, "failed to allocate rpmb request buffer\n");
+		nvme_show_error("failed to allocate rpmb request buffer");
 		goto out; 
 	}
 
 	/* read config block write_counter from controller */
 	write_cntr = rpmb_read_config_block(hdl, &cfg_buf_read);
 	if (cfg_buf_read == NULL) {
-	    	fprintf(stderr, "failed to read config block write counter\n");
+	    	nvme_show_error("failed to read config block write counter");
 		error = -EIO;
 	    	goto out;
 	}
@@ -649,7 +649,7 @@ static int rpmb_write_config_block(struct libnvme_transport_handle *hdl,
 	mac = create_hmac_sha256(((unsigned char *)req + 223), req_size - 223,
 				 keybuf, keysize);
 	if (mac == NULL) {
-		fprintf(stderr, "failed to compute hmac-sha256 hash\n");
+		nvme_show_error("failed to compute hmac-sha256 hash");
 		error = -EINVAL;
 	    	goto out;
 	}
@@ -658,7 +658,7 @@ static int rpmb_write_config_block(struct libnvme_transport_handle *hdl,
 	
 	error = send_rpmb_req(hdl, 0, req_size, req);
 	if (error != 0) {
-		fprintf(stderr, "Write-config RPMB request, error = 0x%x\n",
+		nvme_show_error("Write-config RPMB request, error = 0x%x",
 			error);
 		goto out;
 	}
@@ -666,7 +666,7 @@ static int rpmb_write_config_block(struct libnvme_transport_handle *hdl,
 	/* get response */
 	rsp = (struct rpmb_data_frame_t *)calloc(rsp_size, 1);
 	if (rsp == NULL) {
-		fprintf(stderr, "failed to allocate response buffer memory\n");
+		nvme_show_error("failed to allocate response buffer memory");
 		error = -ENOMEM;
 		goto out;
 	}
@@ -678,7 +678,7 @@ static int rpmb_write_config_block(struct libnvme_transport_handle *hdl,
 	/* get the response and validate */
 	error = recv_rpmb_rsp(hdl, req->target, rsp_size, rsp);
 	if (error != 0) {
-		fprintf(stderr,"Failed getting write-config response\
+		nvme_show_error("Failed getting write-config response\
 			error = 0x%x\n", error);
 		goto out;
 	}
@@ -777,7 +777,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 	
 	regs.rpmbs = le32_to_cpu(ctrl.rpmbs);
 	if (regs.num_targets == 0) {
-		fprintf(stderr, "No RPMB targets are supported by the drive\n");
+		nvme_show_error("No RPMB targets are supported by the drive");
 		return -1;
 	}
 	
@@ -800,7 +800,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 	else if (strcmp(cfg.cmd, "read-config") == 0)
 		cfg.opt = RPMB_REQ_AUTH_DCB_READ;
 	else {
-		fprintf(stderr, "Invalid option %s for rpmb command\n", cfg.cmd);
+		nvme_show_error("Invalid option %s for rpmb command", cfg.cmd);
 		return -1;
 	}
 	
@@ -811,12 +811,12 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 	{
 		key_buf = read_rpmb_key(cfg.key, cfg.keyfile, &key_size);
 		if (key_buf == NULL) {
-			fprintf(stderr, "Failed to read key\n");
+			nvme_show_error("Failed to read key");
 			return -1;
 		}
 	
 		if (key_size > 223 || key_size <= 0) {
-			fprintf(stderr, "Invalid key size %d, valid input 1 to 223\n",
+			nvme_show_error("Invalid key size %d, valid input 1 to 223",
 			key_size);
 			return -1;
 		}
@@ -830,7 +830,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 			} else {
 				err = read_file(cfg.msgfile, &msg_buf, &msg_size);
 				if (err || msg_size <= 0) {
-					fprintf(stderr, "Failed to read file %s\n",
+					nvme_show_error("Failed to read file %s",
 						cfg.msgfile);
 					return -1;
 				}
@@ -842,13 +842,13 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 		case RPMB_REQ_READ_WRITE_CNTR:
 			err = rpmb_read_write_counter(hdl, cfg.target, &write_cntr);
 			if (err == 0)
-				printf("Write Counter is: %u\n", write_cntr);
+				nvme_show_result("Write Counter is: %u", write_cntr);
 			break;
 	
 		case RPMB_REQ_AUTH_DCB_READ:
 			write_cntr = rpmb_read_config_block(hdl, &msg_buf);
 			if (msg_buf == NULL) {
-				fprintf(stderr, "failed read config blk\n");
+				nvme_show_error("failed read config blk");
 				return -1;
 			}
 
@@ -856,14 +856,14 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 			if (cfg.msgfile == 0) {
 				struct rpmb_config_block_t *cfg =
 						(struct rpmb_config_block_t *)msg_buf;
-				printf("Boot Partition Protection is %s\n",
-					((cfg->bp_enable & 0x1)  ? "Enabled" : "Disabled"));
-				printf("Boot Partition 1 is %s\n",
-					((cfg->bp_lock & 0x2) ? "Locked" : "Unlocked"));
-				printf("Boot Partition 0 is %s\n",
-					((cfg->bp_lock & 0x1) ? "Locked" : "Unlocked"));
+				nvme_show_result("Boot Partition Protection is %s",
+					                 ((cfg->bp_enable & 0x1)  ? "Enabled" : "Disabled"));
+				nvme_show_result("Boot Partition 1 is %s",
+					                 ((cfg->bp_lock & 0x2) ? "Locked" : "Unlocked"));
+				nvme_show_result("Boot Partition 0 is %s",
+					                 ((cfg->bp_lock & 0x1) ? "Locked" : "Unlocked"));
 			} else {
-				printf("Saving received config data to %s file\n", cfg.msgfile);
+				nvme_show_result("Saving received config data to %s file", cfg.msgfile);
 				write_file(msg_buf, sizeof(struct rpmb_config_block_t), NULL,
 					   cfg.msgfile, NULL);
 			}
@@ -874,7 +874,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 			/* check if requested data is beyond what target supports */
 			msg_size = cfg.blocks * 512;
 			if (invalid_xfer_size(cfg.blocks, regs.total_size)) {
-				fprintf(stderr, "invalid transfer size %d \n",
+				nvme_show_error("invalid transfer size %d ",
 					msg_size);
 				break;
 			}
@@ -883,8 +883,8 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 						  cfg.blocks,
 						  (regs.access_size + 1));
 			if (err > 0 && msg_buf != NULL) {
-				printf("Writing %d bytes to file %s\n",
-					err * 512, cfg.msgfile);
+				nvme_show_result("Writing %d bytes to file %s",
+					                 err * 512, cfg.msgfile);
 				write_file(msg_buf, err * 512, NULL,
 					   cfg.msgfile, NULL);
 			}
@@ -893,7 +893,7 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 		case RPMB_REQ_AUTH_DATA_WRITE:
 			if (invalid_xfer_size(cfg.blocks, regs.total_size) || 
 			    (cfg.blocks * 512) > msg_size) {
-				fprintf(stderr, "invalid transfer size %d\n", 
+				nvme_show_error("invalid transfer size %d",
 					cfg.blocks * 512);
 				break;
 			} else if ((cfg.blocks * 512) < msg_size) {
@@ -906,8 +906,8 @@ int rpmb_cmd_option(int argc, char **argv, struct command *acmd, struct plugin *
 						   key_buf, key_size);
 
 			/* print whatever extent of data written to target */
-			printf("Written %d sectors out of %d @target(%d):0x%x\n",
-				err/512, msg_size/512, cfg.target, cfg.address);
+			nvme_show_result("Written %d sectors out of %d @target(%d):0x%x",
+				                 err/512, msg_size/512, cfg.target, cfg.address);
 			break;
 
 		case RPMB_REQ_AUTH_DCB_WRITE:

--- a/nvme.c
+++ b/nvme.c
@@ -508,6 +508,16 @@ int validate_output_format(const char *format, nvme_print_flags_t *flags)
 	return 0;
 }
 
+bool nvme_is_output_format_normal(void)
+{
+	nvme_print_flags_t flags;
+
+	if (validate_output_format(nvme_args.output_format, &flags))
+		return false;
+
+	return flags == NORMAL;
+}
+
 bool nvme_is_output_format_json(void)
 {
 	nvme_print_flags_t flags;
@@ -795,7 +805,7 @@ static int __get_telemetry_log_ctrl(struct libnvme_transport_handle *hdl,
 		*size = NVME_LOG_TELEM_BLOCK_SIZE;
 		*buf = log;
 
-		printf("Warning: Telemetry Controller-Initiated Data Not Available.\n");
+		nvme_show_error("Warning: Telemetry Controller-Initiated Data Not Available.");
 		return 0;
 	}
 
@@ -1623,14 +1633,14 @@ static int get_persistent_event_log(int argc, char **argv,
 	}
 
 	if (cfg.action == NVME_PEVENT_LOG_RELEASE_CTX) {
-		printf("Releasing Persistent Event Log Context\n");
+		nvme_show_error("Releasing Persistent Event Log Context");
 		return 0;
 	}
 
 	if (!cfg.log_len && cfg.action != NVME_PEVENT_LOG_EST_CTX_AND_READ) {
 		cfg.log_len = le64_to_cpu(pevent->tll);
 	} else if (!cfg.log_len && cfg.action == NVME_PEVENT_LOG_EST_CTX_AND_READ) {
-		printf("Establishing Persistent Event Log Context\n");
+		nvme_show_error("Establishing Persistent Event Log Context");
 		return 0;
 	}
 
@@ -1666,8 +1676,7 @@ static int get_persistent_event_log(int argc, char **argv,
 
 	pevent_collected = pevent_log_info;
 	if (pevent_collected->gen_number != pevent->gen_number) {
-		printf("Collected Persistent Event Log may be invalid,\n"
-		       "Re-read the log is required\n");
+		nvme_show_error("Collected Persistent Event Log may be invalid, Re-read the log is required");
 		return -EINVAL;
 	}
 
@@ -1946,7 +1955,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *acmd, struct
 	if (err != bpsz)
 		fprintf(stderr, "Failed to flush all data to file!\n");
 	else
-		printf("Data flushed into file %s\n", cfg.file_name);
+		nvme_show_result("Data flushed into file %s", cfg.file_name);
 
 	return 0;
 }
@@ -2216,8 +2225,8 @@ static int io_mgmt_send(int argc, char **argv, struct command *acmd, struct plug
 		return err;
 	}
 
-	printf("io-mgmt-send: Success, mos:%u mo:%u nsid:%d\n", cfg.mos, cfg.mo,
-	       cfg.nsid);
+	nvme_show_verbose_result("io-mgmt-send: Success, mos:%u mo:%u nsid:%d",
+				 cfg.mos, cfg.mo, cfg.nsid);
 
 	return err;
 }
@@ -2279,8 +2288,8 @@ static int io_mgmt_recv(int argc, char **argv, struct command *acmd, struct plug
 		return err;
 	}
 
-	printf("io-mgmt-recv: Success, mos:%u mo:%u nsid:%d\n", cfg.mos, cfg.mo,
-	       cfg.nsid);
+	nvme_show_verbose_result("io-mgmt-recv: Success, mos:%u mo:%u nsid:%d",
+				 cfg.mos, cfg.mo, cfg.nsid);
 
 	if (cfg.file) {
 		dfd = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -2477,7 +2486,7 @@ static int get_log(int argc, char **argv, struct command *acmd, struct plugin *p
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	cmd.cdw10 |= NVME_FIELD_ENCODE(cfg.lsp,
 			NVME_LOG_CDW10_LSP_SHIFT,
@@ -2501,9 +2510,9 @@ static int get_log(int argc, char **argv, struct command *acmd, struct plugin *p
 	}
 
 	if (!cfg.raw_binary) {
-		printf("Device:%s log-id:%d namespace-id:%#x\n",
-		       libnvme_transport_handle_get_name(hdl), cfg.log_id,
-		       cfg.namespace_id);
+		nvme_show_result("Device:%s log-id:%d namespace-id:%#x",
+		                 libnvme_transport_handle_get_name(hdl), cfg.log_id,
+		                 cfg.namespace_id);
 		d(log, cfg.log_len, 16, 1);
 		if (nvme_args.verbose)
 			nvme_show_log(libnvme_transport_handle_get_name(hdl),
@@ -2923,8 +2932,8 @@ static void ns_mgmt_show_status(struct libnvme_transport_handle *hdl, int err, c
 	nvme_show_init();
 
 	if (!err) {
-		nvme_show_key_value(cmd, "success");
-		nvme_show_key_value("nsid", "%d", nsid);
+		nvme_show_verbose_key_value(cmd, "success");
+		nvme_show_verbose_key_value("nsid", "%d", nsid);
 	} else {
 		nvme_show_status(err);
 		if (!is_ns_mgmt_support(hdl))
@@ -2987,7 +2996,7 @@ static int delete_ns(int argc, char **argv, struct command *acmd, struct plugin 
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	ns_mgmt_show_status(hdl, err, acmd->name, cfg.namespace_id);
@@ -3081,7 +3090,7 @@ static int nvme_attach_ns(int argc, char **argv, int attach, const char *desc, s
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	ns_mgmt_show_status(hdl, err, acmd->name, cfg.nsid);
@@ -3448,7 +3457,7 @@ parse_lba:
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	nsid = cmd.result;
@@ -4328,7 +4337,7 @@ static int id_iocs(int argc, char **argv, struct command *acmd, struct plugin *p
 		return err;
 	}
 
-	printf("NVMe Identify I/O Command Set:\n");
+	nvme_show_result("NVMe Identify I/O Command Set:");
 	nvme_show_id_iocs(iocs, flags);
 
 	return err;
@@ -4380,8 +4389,8 @@ static int id_domain(int argc, char **argv, struct command *acmd, struct plugin 
 		return err;
 	}
 
-	printf("NVMe Identify command for Domain List is successful:\n");
-	printf("NVMe Identify Domain List:\n");
+	nvme_show_verbose_result("NVMe Identify command for Domain List is successful:");
+	nvme_show_verbose_result("NVMe Identify Domain List:");
 	nvme_show_id_domain_list(id_domain, flags);
 
 	return err;
@@ -4415,7 +4424,7 @@ static int get_ns_id(int argc, char **argv, struct command *acmd, struct plugin 
 		return -errno;
 	}
 
-	printf("%s: namespace-id:%d\n", libnvme_transport_handle_get_name(hdl), nsid);
+	nvme_show_result("%s: namespace-id:%d", libnvme_transport_handle_get_name(hdl), nsid);
 
 	return 0;
 }
@@ -4474,8 +4483,9 @@ static int virtual_mgmt(int argc, char **argv, struct command *acmd, struct plug
 		return err;
 	}
 
-	printf("success, Number of Controller Resources Modified (NRM):%"
-	       PRIu64 "\n", (uint64_t)cmd.result);
+	nvme_show_verbose_result(
+		"success, Number of Controller Resources Modified (NRM):%" PRIu64,
+		(uint64_t)cmd.result);
 
 	return err;
 }
@@ -4600,7 +4610,7 @@ static int nvme_sleep(unsigned int seconds)
 	sleep(seconds);
 
 	if (nvme_sigint_received) {
-		printf("\nInterrupted device self-test operation by SIGINT\n");
+		nvme_show_error("Interrupted device self-test operation by SIGINT");
 		return -SIGINT;
 	}
 
@@ -4631,17 +4641,20 @@ static int wait_self_test(struct libnvme_transport_handle *hdl)
 
 	wthr = le16_to_cpu(ctrl->edstt) * 60 / 100 + 60;
 
-	printf("Waiting for self test completion...\n");
+	nvme_show_result("Waiting for self test completion...");
 	while (true) {
-		printf("\r[%.*s%c%.*s] %3d%%", p / 2, dash, spin[i % 4], 49 - p / 2, space, p);
-		fflush(stdout);
+		if (nvme_is_output_format_normal()) {
+			print_info("\r[%.*s%c%.*s] %3d%%", p / 2, dash, spin[i % 4], 49 - p / 2, space, p);
+			fflush(stdout);
+		}
 		err = nvme_sleep(1);
 		if (err)
 			return err;
 
 		err = nvme_get_log_device_self_test(hdl, log);
 		if (err) {
-			printf("\n");
+			if (nvme_is_output_format_normal())
+				print_info("\n");
 			nvme_show_err(err, "self test log\n");
 			return err;
 		}
@@ -4652,12 +4665,14 @@ static int wait_self_test(struct libnvme_transport_handle *hdl)
 		}
 
 		if (log->completion == 0 && p > 0) {
-			printf("\r[%.*s] %3d%%\n", 50, dash, 100);
+			if (nvme_is_output_format_normal())
+				print_info("\r[%.*s] %3d%%\n", 50, dash, 100);
 			break;
 		}
 
 		if (log->completion < p) {
-			printf("\n");
+			if (nvme_is_output_format_normal())
+				print_info("\n");
 			nvme_show_error("progress broken");
 			return -EIO;
 		} else if (log->completion != p) {
@@ -4682,7 +4697,7 @@ static void abort_self_test(struct libnvme_transport_handle *hdl, bool ish,
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -4690,7 +4705,7 @@ static void abort_self_test(struct libnvme_transport_handle *hdl, bool ish,
 		return;
 	}
 
-	printf("Aborting device self-test operation\n");
+	nvme_show_result("Aborting device self-test operation");
 }
 
 static int device_self_test(int argc, char **argv, struct command *acmd, struct plugin *plugin)
@@ -4754,17 +4769,18 @@ static int device_self_test(int argc, char **argv, struct command *acmd, struct 
 
 		err = nvme_get_log_device_self_test(hdl, log);
 		if (err) {
-			printf("\n");
+			if (nvme_is_output_format_normal())
+				print_info("\n");
 			nvme_show_err(err, "self test log\n");
 		}
 
 		if (log->completion == 0) {
-			printf("no self test running\n");
+			nvme_show_result("no self test running");
 		} else {
 			if (cfg.wait)
 				err = wait_self_test(hdl);
 			else
-				printf("progress %d%%\n", log->completion);
+				nvme_show_result("progress %d%%", log->completion);
 		}
 
 		goto check_abort;
@@ -4775,7 +4791,7 @@ static int device_self_test(int argc, char **argv, struct command *acmd, struct 
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -4784,13 +4800,13 @@ static int device_self_test(int argc, char **argv, struct command *acmd, struct 
 	}
 
 	if (cfg.stc == NVME_ST_CODE_ABORT)
-		printf("Aborting device self-test operation\n");
+		nvme_show_result("Aborting device self-test operation");
 	else if (cfg.stc == NVME_ST_CODE_EXTENDED)
-		printf("Extended Device self-test started\n");
+		nvme_show_result("Extended Device self-test started");
 	else if (cfg.stc == NVME_ST_CODE_SHORT)
-		printf("Short Device self-test started\n");
+		nvme_show_result("Short Device self-test started");
 	else if (cfg.stc == NVME_ST_CODE_HOST_INIT)
-		printf("Host-Initiated Refresh started\n");
+		nvme_show_result("Host-Initiated Refresh started");
 
 	if (cfg.wait && cfg.stc != NVME_ST_CODE_ABORT)
 		err = wait_self_test(hdl);
@@ -5081,8 +5097,8 @@ static int fw_download_single(struct libnvme_transport_handle *hdl, void *fw_buf
 	int err, try;
 
 	if (progress) {
-		printf("Firmware download: transferring 0x%08x/0x%08x bytes: %03d%%\r",
-		       offset, fw_len, (int)(100 * offset / fw_len));
+		print_info("Firmware download: transferring 0x%08x/0x%08x bytes: %03d%%\r",
+		           offset, fw_len, (int)(100 * offset / fw_len));
 	}
 
 	if (libnvme_transport_handle_is_mi(hdl))
@@ -5127,7 +5143,7 @@ static int fw_download_single(struct libnvme_transport_handle *hdl, void *fw_buf
 		 * \n), and flush before we write to stderr.
 		 */
 		if (progress) {
-			printf("\n");
+			print_info("\n");
 			fflush(stdout);
 		}
 
@@ -5270,7 +5286,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 	}
 
 	if (cfg.ish && !libnvme_transport_handle_is_mi(hdl)) {
-		printf("ISH is supported only for NVMe-MI\n");
+		nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 
 	for (pos = 0; pos < fw_size; pos += cfg.xfer) {
@@ -5286,8 +5302,8 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 	if (!err) {
 		/* end the progress output */
 		if (cfg.progress)
-			printf("\n");
-		printf("Firmware download success\n");
+			print_info("\n");
+		nvme_show_verbose_result("Firmware download success");
 	}
 
 	return err;
@@ -5331,16 +5347,16 @@ static void fw_commit_print_mud(bool mud_supported, __u64 result)
 	if (!mud_supported)
 		return;
 
-	printf("Multiple Update Detected (MUD) Value: %#" PRIx64 "\n",
-		(uint64_t)result);
+	nvme_show_result("Multiple Update Detected (MUD) Value: %#" PRIx64,
+		                 (uint64_t)result);
 
 	if (result & 0x1)
-		printf("Detected an overlapping firmware/boot partition image update command\n"
-		       "sequence due to processing a command from an Admin SQ on a controller\n");
+		nvme_show_result("Detected an overlapping firmware/boot partition image update command "
+		                 "sequence due to processing a command from an Admin SQ on a controller");
 
 	if (result >> 1 & 0x1)
-		printf("Detected an overlapping firmware/boot partition image update command\n"
-		       "sequence due to processing a command from a Management Endpoint\n");
+		nvme_show_result("Detected an overlapping firmware/boot partition image update command "
+		                 "sequence due to processing a command from a Management Endpoint");
 }
 
 static void fw_commit_err(int err, __u8 action, __u8 slot, __u8 bpid)
@@ -5353,12 +5369,12 @@ static void fw_commit_err(int err, __u8 action, __u8 slot, __u8 bpid)
 		case NVME_SC_FW_NEEDS_CONV_RESET:
 		case NVME_SC_FW_NEEDS_SUBSYS_RESET:
 		case NVME_SC_FW_NEEDS_RESET:
-			printf("Success activating firmware action:%d slot:%d",
-			       action, slot);
+			print_info("Success activating firmware action:%d slot:%d",
+			           action, slot);
 			if (action == 6 || action == 7)
-				printf(" bpid:%d", bpid);
-			printf(", but firmware requires %s reset\n",
-			       nvme_fw_status_reset_type(val));
+				print_info(" bpid:%d", bpid);
+			print_info(", but firmware requires %s reset\n",
+			           nvme_fw_status_reset_type(val));
 			return;
 		default:
 			break;
@@ -5464,7 +5480,7 @@ static int fw_commit(int argc, char **argv, struct command *acmd, struct plugin 
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -5472,11 +5488,12 @@ static int fw_commit(int argc, char **argv, struct command *acmd, struct plugin 
 		return err;
 	}
 
-	printf("Success committing firmware action:%d slot:%d",
-	       cfg.action, cfg.slot);
 	if (cfg.action == 6 || cfg.action == 7)
-		printf(" bpid:%d", cfg.bpid);
-	printf("\n");
+		nvme_show_verbose_result("Success committing firmware action:%d slot:%d bpid:%d",
+					 cfg.action, cfg.slot, cfg.bpid);
+	else
+		nvme_show_verbose_result("Success committing firmware action:%d slot:%d",
+					 cfg.action, cfg.slot);
 	fw_commit_print_mud(mud_supported, cmd.result);
 
 	return err;
@@ -5507,8 +5524,10 @@ static int subsystem_reset(int argc, char **argv, struct command *acmd, struct p
 			nvme_show_error("Subsystem-reset: NVM Subsystem Reset not supported.");
 		else
 			nvme_show_error("Subsystem-reset: %s", libnvme_strerror(-err));
-	} else if (nvme_args.verbose)
-		printf("resetting subsystem through %s\n", libnvme_transport_handle_get_name(hdl));
+	} else {
+		nvme_show_verbose_info("resetting subsystem through %s",
+				       libnvme_transport_handle_get_name(hdl));
+	}
 
 	return err;
 }
@@ -5535,8 +5554,9 @@ static int reset(int argc, char **argv, struct command *acmd, struct plugin *plu
 	err = libnvme_reset_ctrl(hdl);
 	if (err < 0)
 		nvme_show_error("Reset: %s", libnvme_strerror(-err));
-	else if (nvme_args.verbose)
-		printf("resetting controller %s\n", libnvme_transport_handle_get_name(hdl));
+	else
+		nvme_show_verbose_info("resetting controller %s",
+				       libnvme_transport_handle_get_name(hdl));
 
 	return err;
 }
@@ -5570,8 +5590,9 @@ static int ns_rescan(int argc, char **argv, struct command *acmd, struct plugin 
 	err = libnvme_rescan_ns(hdl);
 	if (err < 0)
 		nvme_show_error("Namespace Rescan: %s\n", libnvme_strerror(-err));
-	else if (nvme_args.verbose)
-		printf("rescanning namespaces through %s\n", libnvme_transport_handle_get_name(hdl));
+	else
+		nvme_show_verbose_info("rescanning namespaces through %s",
+				       libnvme_transport_handle_get_name(hdl));
 
 	return err;
 }
@@ -5622,19 +5643,22 @@ static int wait_sanitize(struct libnvme_transport_handle *hdl)
 	if (wthr != 0xffffffff && NVME_GET(log->scdw10, SANITIZE_CDW10_EMVS))
 		wthr += le32_to_cpu(log->etpvds);
 
-	printf("Waiting for sanitize completion...\n");
+	nvme_show_result("Waiting for sanitize completion...");
 	while (true) {
-		printf("\r[%.*s%c%.*s] %3d%%", p * 100 / 0xffff / 2, dash,
-		       spin[i % 4], 49 - p * 100 / 0xffff / 2, space,
-		       p * 100 / 0xffff);
-		fflush(stdout);
+		if (nvme_is_output_format_normal()) {
+			print_info("\r[%.*s%c%.*s] %3d%%", p * 100 / 0xffff / 2, dash,
+			           spin[i % 4], 49 - p * 100 / 0xffff / 2, space,
+			           p * 100 / 0xffff);
+			fflush(stdout);
+		}
 		err = nvme_sleep(1);
 		if (err)
 			return err;
 
 		err = nvme_get_log_sanitize(hdl, false, log);
 		if (err) {
-			printf("\n");
+			if (nvme_is_output_format_normal())
+				print_info("\n");
 			nvme_show_err(err, "sanitize status log");
 			return err;
 		}
@@ -5647,12 +5671,14 @@ static int wait_sanitize(struct libnvme_transport_handle *hdl)
 		}
 
 		if (le16_to_cpu(log->sprog) == 0xffff) {
-			printf("\r[%.*s] %3d%%\n", 50, dash, 100);
+			if (nvme_is_output_format_normal())
+				print_info("\r[%.*s] %3d%%\n", 50, dash, 100);
 			break;
 		}
 
 		if (le16_to_cpu(log->sprog) < p) {
-			printf("\n");
+			if (nvme_is_output_format_normal())
+				print_info("\n");
 			nvme_show_error("progress broken");
 			return -EIO;
 		} else if (le16_to_cpu(log->sprog) != p) {
@@ -5858,7 +5884,7 @@ static int sanitize_cmd(int argc, char **argv, struct command *acmd, struct plug
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 
 	do {
@@ -5959,7 +5985,7 @@ static int sanitize_ns_cmd(int argc, char **argv, struct command *acmd,
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -6431,8 +6457,8 @@ static int nvme_set_single_property(struct libnvme_transport_handle *hdl, int of
 		return err;
 	}
 
-	printf("set-property: %#02x (%s), value: %#"PRIx64"\n", offset,
-	       nvme_register_to_string(offset), value);
+	nvme_show_result("set-property: %#02x (%s), value: %#"PRIx64, offset,
+	                 nvme_register_to_string(offset), value);
 
 	return err;
 }
@@ -6440,8 +6466,8 @@ static int nvme_set_single_property(struct libnvme_transport_handle *hdl, int of
 static int set_register_property(struct libnvme_transport_handle *hdl, int offset, uint64_t value)
 {
 	if (!nvme_is_fabrics_reg(offset)) {
-		printf("register: %#04x (%s) not fabrics\n", offset,
-		       nvme_register_to_string(offset));
+		nvme_show_error("register: %#04x (%s) not fabrics", offset,
+		                nvme_register_to_string(offset));
 		return -EINVAL;
 	}
 
@@ -6458,8 +6484,8 @@ static int nvme_set_register(struct libnvme_transport_handle *hdl, void *bar, in
 	else
 		mmio_write32(bar + offset, value);
 
-	printf("set-register: %#02x (%s), value: %#"PRIx64"\n", offset,
-	       nvme_register_to_string(offset), value);
+	nvme_show_result("set-register: %#02x (%s), value: %#"PRIx64, offset,
+	                 nvme_register_to_string(offset), value);
 
 	return 0;
 }
@@ -7030,7 +7056,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -7038,7 +7064,7 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		return err;
 	}
 
-	printf("Success formatting namespace:%x\n", cfg.namespace_id);
+	nvme_show_verbose_result("Success formatting namespace:%x", cfg.namespace_id);
 	if (libnvme_transport_handle_is_direct(hdl) && cfg.lbaf != prev_lbaf) {
 		if (libnvme_transport_handle_is_ctrl(hdl)) {
 			if (libnvme_rescan_ns(hdl) < 0) {
@@ -7209,10 +7235,10 @@ static int set_feature(int argc, char **argv, struct command *acmd, struct plugi
 		return err;
 	}
 
-	printf("set-feature:%#0*x (%s), value:%#0*" PRIx64
-	       ", cdw12:%#0*x, save:%#x\n", cfg.fid ? 4 : 2, cfg.fid,
-	       nvme_feature_to_string(cfg.fid), cfg.value ? 10 : 8,
-	       (uint64_t)cfg.value, cfg.cdw12 ? 10 : 8, cfg.cdw12, cfg.sv);
+	nvme_show_result("set-feature:%#0*x (%s), value:%#0*" PRIx64
+	                 ", cdw12:%#0*x, save:%#x", cfg.fid ? 4 : 2, cfg.fid,
+	                 nvme_feature_to_string(cfg.fid), cfg.value ? 10 : 8,
+	                 (uint64_t)cfg.value, cfg.cdw12 ? 10 : 8, cfg.cdw12, cfg.sv);
 	if (cfg.fid == NVME_FEAT_FID_LBA_STS_INTERVAL)
 		nvme_show_lba_status_info(result);
 	if (buf) {
@@ -7328,7 +7354,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -7336,7 +7362,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 		return err;
 	}
 
-	printf("NVME Security Send Command Success\n");
+	nvme_show_verbose_result("NVME Security Send Command Success");
 
 	return err;
 }
@@ -7458,9 +7484,9 @@ static int dir_send(int argc, char **argv, struct command *acmd, struct plugin *
 		return err;
 	}
 
-	printf(
+	nvme_show_result(
 	    "%s: type %#x, operation %#x, spec_val %#x, nsid %#x, result %#"
-	    PRIx64 "\n", __func__, cfg.dtype, cfg.doper, cfg.dspec,
+	    PRIx64, __func__, cfg.dtype, cfg.doper, cfg.dspec,
 	    cfg.namespace_id, (uint64_t)cmd.result);
 
 	if (buf) {
@@ -7531,7 +7557,7 @@ static int write_uncor(int argc, char **argv, struct command *acmd, struct plugi
 		return err;
 	}
 
-	printf("NVME Write Uncorrectable Success\n");
+	nvme_show_verbose_result("NVME Write Uncorrectable Success");
 
 	return err;
 }
@@ -7886,16 +7912,16 @@ static int write_zeroes(int argc, char **argv,
 		return err;
 	}
 
-	printf("NVME Write Zeroes Success\n");
+	nvme_show_verbose_result("NVME Write Zeroes Success");
 
 	if (!cfg.nsz || !nvme_args.verbose)
 		return err;
 
 	if (cmd.result & 0x1)
-		printf(
-		    "All logical blocks in the entire namespace cleared to zero\n");
+		nvme_show_result(
+		    "All logical blocks in the entire namespace cleared to zero");
 	else
-		printf("%d logical blocks cleared to zero\n", cfg.block_count);
+		nvme_show_result("%d logical blocks cleared to zero", cfg.block_count);
 
 	return err;
 }
@@ -8010,7 +8036,7 @@ static int dsm(int argc, char **argv, struct command *acmd, struct plugin *plugi
 		return err;
 	}
 
-	printf("NVMe DSM: success\n");
+	nvme_show_verbose_result("NVMe DSM: success");
 
 	return err;
 }
@@ -8228,7 +8254,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 		return err;
 	}
 
-	nvme_show_key_value("NVMe Copy", "success");
+	nvme_show_verbose_result("NVMe Copy: success");
 
 	return err;
 }
@@ -8278,7 +8304,7 @@ static int flush_cmd(int argc, char **argv, struct command *acmd, struct plugin 
 		return err;
 	}
 
-	printf("NVMe Flush: success\n");
+	nvme_show_verbose_result("NVMe Flush: success");
 
 	return err;
 }
@@ -8356,7 +8382,7 @@ static int resv_acquire(int argc, char **argv, struct command *acmd, struct plug
 		return err;
 	}
 
-	printf("NVME Reservation Acquire success\n");
+	nvme_show_verbose_result("NVME Reservation Acquire success");
 
 	return err;
 }
@@ -8438,7 +8464,7 @@ static int resv_register(int argc, char **argv, struct command *acmd, struct plu
 		return err;
 	}
 
-	printf("NVME Reservation  success\n");
+	nvme_show_verbose_result("NVME Reservation success");
 
 	return err;
 }
@@ -8515,7 +8541,7 @@ static int resv_release(int argc, char **argv, struct command *acmd, struct plug
 		return err;
 	}
 
-	printf("NVME Reservation Release success\n");
+	nvme_show_verbose_result("NVME Reservation Release success");
 
 	return err;
 }
@@ -8879,22 +8905,22 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	}
 
 	if (cfg.show || nvme_args.dry_run) {
-		printf("opcode       : %02x\n", opcode);
-		printf("nsid         : %02x\n", cfg.nsid);
-		printf("flags        : %02x\n", 0);
-		printf("control      : %04x\n", control);
-		printf("nblocks      : %04x\n", nblocks);
-		printf("metadata     : %"PRIx64"\n", (uint64_t)(uintptr_t)mbuffer);
-		printf("addr         : %"PRIx64"\n", (uint64_t)(uintptr_t)buffer);
-		printf("slba         : %"PRIx64"\n", (uint64_t)cfg.start_block);
-		printf("dsmgmt       : %08x\n", dsmgmt);
-		printf("reftag       : %"PRIx64"\n", (uint64_t)cfg.ilbrt);
-		printf("apptag       : %04x\n", cfg.lbat);
-		printf("appmask      : %04x\n", cfg.lbatm);
-		printf("storagetagcheck : %04x\n", cfg.stc);
-		printf("storagetag      : %"PRIx64"\n", (uint64_t)cfg.lbst);
-		printf("pif             : %02x\n", pif);
-		printf("sts             : %02x\n", sts);
+		nvme_show_result("opcode       : %02x", opcode);
+		nvme_show_result("nsid         : %02x", cfg.nsid);
+		nvme_show_result("flags        : %02x", 0);
+		nvme_show_result("control      : %04x", control);
+		nvme_show_result("nblocks      : %04x", nblocks);
+		nvme_show_result("metadata     : %"PRIx64, (uint64_t)(uintptr_t)mbuffer);
+		nvme_show_result("addr         : %"PRIx64, (uint64_t)(uintptr_t)buffer);
+		nvme_show_result("slba         : %"PRIx64, (uint64_t)cfg.start_block);
+		nvme_show_result("dsmgmt       : %08x", dsmgmt);
+		nvme_show_result("reftag       : %"PRIx64, (uint64_t)cfg.ilbrt);
+		nvme_show_result("apptag       : %04x", cfg.lbat);
+		nvme_show_result("appmask      : %04x", cfg.lbatm);
+		nvme_show_result("storagetagcheck : %04x", cfg.stc);
+		nvme_show_result("storagetag      : %"PRIx64, (uint64_t)cfg.lbst);
+		nvme_show_result("pif             : %02x", pif);
+		nvme_show_result("sts             : %02x", sts);
 	}
 	if (nvme_args.dry_run)
 		return 0;
@@ -8923,7 +8949,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	err = libnvme_exec_io_passthru(hdl, &cmd);
 	gettimeofday(&end_time, NULL);
 	if (cfg.latency)
-		printf(" latency: %s: %llu us\n", command, elapsed_utime(start_time, end_time));
+		nvme_show_result(" latency: %s: %llu us", command, elapsed_utime(start_time, end_time));
 	if (err) {
 		nvme_show_err(err, "submit-io");
 		return err;
@@ -8941,7 +8967,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 		    libnvme_strerror(errno));
 		err = -EINVAL;
 	} else {
-		fprintf(stderr, "%s: Success\n", command);
+		nvme_show_verbose_result("%s: Success", command);
 	}
 
 	return err;
@@ -9067,7 +9093,7 @@ static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		return err;
 	}
 
-	printf("NVME Verify Success\n");
+	nvme_show_verbose_result("NVME Verify Success");
 
 	return err;
 }
@@ -9142,7 +9168,7 @@ static int sec_recv(int argc, char **argv, struct command *acmd, struct plugin *
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 
 	nvme_init_security_receive(&cmd, cfg.namespace_id, cfg.nssf, cfg.spsp,
@@ -9153,7 +9179,7 @@ static int sec_recv(int argc, char **argv, struct command *acmd, struct plugin *
 		return err;
 	}
 
-	printf("NVME Security Receive Command Success\n");
+	nvme_show_verbose_result("NVME Security Receive Command Success");
 	if (!cfg.raw_binary)
 		d(sec_buf, cfg.size, 16, 1);
 	else if (cfg.size)
@@ -9235,7 +9261,7 @@ static int get_lba_status(int argc, char **argv, struct command *acmd,
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -9312,7 +9338,7 @@ static int capacity_mgmt(int argc, char **argv, struct command *acmd, struct plu
 		if (libnvme_transport_handle_is_mi(hdl))
 			nvme_init_mi_cmd_flags(&cmd, ish);
 		else
-			printf("ISH is supported only for NVMe-MI\n");
+			nvme_show_error("ISH is supported only for NVMe-MI");
 	}
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
@@ -9320,15 +9346,14 @@ static int capacity_mgmt(int argc, char **argv, struct command *acmd, struct plu
 		return err;
 	}
 
-	printf("Capacity Management Command is Success\n");
+	nvme_show_verbose_result("Capacity Management Command is Success");
 
 	if (cfg.operation == 1)
-		printf("Created Element Identifier for Endurance Group is: %"
-		       PRIu64 "\n", (uint64_t)cmd.result);
+		nvme_show_result("Created Element Identifier for Endurance Group is: %"
+		                 PRIu64, (uint64_t)cmd.result);
 	else if (cfg.operation == 3)
-		printf(
-		    "Created Element Identifier for NVM Set is: %" PRIu64 "\n",
-		    (uint64_t)cmd.result);
+		nvme_show_result("Created Element Identifier for NVM Set is: %"
+		                 PRIu64, (uint64_t)cmd.result);
 
 	return err;
 }
@@ -9526,7 +9551,7 @@ static int lockdown_cmd(int argc, char **argv, struct command *acmd, struct plug
 		return err;
 	}
 
-	printf("Lockdown Command is Successful\n");
+	nvme_show_verbose_result("Lockdown Command is Successful");
 
 	return err;
 }
@@ -9746,23 +9771,23 @@ static int passthru(int argc, char **argv, bool admin,
 	}
 
 	if (cfg.show_command || nvme_args.dry_run) {
-		printf("opcode       : %02x\n", cfg.opcode);
-		printf("flags        : %02x\n", cfg.flags);
-		printf("rsvd1        : %04x\n", cfg.rsvd);
-		printf("nsid         : %08x\n", cfg.namespace_id);
-		printf("cdw2         : %08x\n", cfg.cdw2);
-		printf("cdw3         : %08x\n", cfg.cdw3);
-		printf("data_len     : %08x\n", cfg.data_len);
-		printf("metadata_len : %08x\n", cfg.metadata_len);
-		printf("addr         : %"PRIx64"\n", (uint64_t)(uintptr_t)data);
-		printf("metadata     : %"PRIx64"\n", (uint64_t)(uintptr_t)mdata);
-		printf("cdw10        : %08x\n", cfg.cdw10);
-		printf("cdw11        : %08x\n", cfg.cdw11);
-		printf("cdw12        : %08x\n", cfg.cdw12);
-		printf("cdw13        : %08x\n", cfg.cdw13);
-		printf("cdw14        : %08x\n", cfg.cdw14);
-		printf("cdw15        : %08x\n", cfg.cdw15);
-		printf("timeout_ms   : %08x\n", nvme_args.timeout);
+		nvme_show_result("opcode       : %02x", cfg.opcode);
+		nvme_show_result("flags        : %02x", cfg.flags);
+		nvme_show_result("rsvd1        : %04x", cfg.rsvd);
+		nvme_show_result("nsid         : %08x", cfg.namespace_id);
+		nvme_show_result("cdw2         : %08x", cfg.cdw2);
+		nvme_show_result("cdw3         : %08x", cfg.cdw3);
+		nvme_show_result("data_len     : %08x", cfg.data_len);
+		nvme_show_result("metadata_len : %08x", cfg.metadata_len);
+		nvme_show_result("addr         : %"PRIx64, (uint64_t)(uintptr_t)data);
+		nvme_show_result("metadata     : %"PRIx64, (uint64_t)(uintptr_t)mdata);
+		nvme_show_result("cdw10        : %08x", cfg.cdw10);
+		nvme_show_result("cdw11        : %08x", cfg.cdw11);
+		nvme_show_result("cdw12        : %08x", cfg.cdw12);
+		nvme_show_result("cdw13        : %08x", cfg.cdw13);
+		nvme_show_result("cdw14        : %08x", cfg.cdw14);
+		nvme_show_result("cdw15        : %08x", cfg.cdw15);
+		nvme_show_result("timeout_ms   : %08x", nvme_args.timeout);
 	}
 	if (nvme_args.dry_run)
 		return 0;
@@ -9795,19 +9820,19 @@ static int passthru(int argc, char **argv, bool admin,
 	gettimeofday(&end_time, NULL);
 	cmd_name = nvme_cmd_to_string(admin, cfg.opcode);
 	if (cfg.latency)
-		printf("%s Command %s latency: %llu us\n", admin ? "Admin" : "IO",
-		       strcmp(cmd_name, "Unknown") ? cmd_name : "Vendor Specific",
-		       elapsed_utime(start_time, end_time));
+		nvme_show_result("%s Command %s latency: %llu us", admin ? "Admin" : "IO",
+		                 strcmp(cmd_name, "Unknown") ? cmd_name : "Vendor Specific",
+		                 elapsed_utime(start_time, end_time));
 
 	if (err) {
 		nvme_show_err(err, __func__);
 		return err;
 	}
 
-	fprintf(stderr, "%s Command %s is Success and result: 0x%" PRIx64 "\n",
-		admin ? "Admin" : "IO",
-		strcmp(cmd_name, "Unknown") ?
-		cmd_name : "Vendor Specific", (uint64_t)cmd.result);
+	nvme_show_verbose_result("%s Command %s is Success and result: 0x%" PRIx64,
+				 admin ? "Admin" : "IO",
+				 strcmp(cmd_name, "Unknown") ?
+				 cmd_name : "Vendor Specific", (uint64_t)cmd.result);
 	if (cfg.read)
 		passthru_print_read_output(cfg, data, dfd, mdata, mfd, err);
 
@@ -9841,7 +9866,7 @@ static int gen_hostnqn_cmd(int argc, char **argv, struct command *acmd, struct p
 				acmd->name);
 		return -ENOTSUP;
 	}
-	printf("%s\n", hostnqn);
+	nvme_show_result("%s", hostnqn);
 	free(hostnqn);
 	return 0;
 }
@@ -9859,7 +9884,7 @@ static int show_hostnqn_cmd(int argc, char **argv, struct command *acmd, struct 
 		return -ENOENT;
 	}
 
-	fprintf(stdout, "%s\n", hostnqn);
+	nvme_show_result("%s", hostnqn);
 	free(hostnqn);
 
 	return 0;
@@ -9978,7 +10003,7 @@ static int gen_dhchap_key(int argc, char **argv, struct command *acmd, struct pl
 	memset(encoded_key, 0, sizeof(encoded_key));
 	base64_encode(key, cfg.key_len, encoded_key);
 
-	printf("DHHC-1:%02x:%s:\n", cfg.hmac, encoded_key);
+	nvme_show_result("DHHC-1:%02x:%s:", cfg.hmac, encoded_key);
 	return 0;
 }
 
@@ -10067,7 +10092,7 @@ static int check_dhchap_key(int argc, char **argv, struct command *acmd, struct 
 		nvme_show_error("CRC mismatch (key %08x, crc %08x)", key_crc, crc);
 		return -EINVAL;
 	}
-	printf("Key is valid (HMAC %d, length %d, CRC %08x)\n", hmac, decoded_len, crc);
+	nvme_show_result("Key is valid (HMAC %d, length %d, CRC %08x)", hmac, decoded_len, crc);
 	return 0;
 }
 
@@ -10247,7 +10272,7 @@ static int gen_tls_key(int argc, char **argv, struct command *acmd, struct plugi
 		nvme_show_error("Failed to export key, %s", libnvme_strerror(-err));
 		return err;
 	}
-	printf("%s\n", encoded_key);
+	nvme_show_result("%s", encoded_key);
 
 	if (cfg.insert) {
 		if (cfg.compat)
@@ -10265,7 +10290,7 @@ static int gen_tls_key(int argc, char **argv, struct command *acmd, struct plugi
 			return err;
 		}
 
-		printf("Inserted TLS key %08x\n", (unsigned int)tls_key);
+		nvme_show_result("Inserted TLS key %08x", (unsigned int)tls_key);
 
 		if (cfg.keyfile) {
 			err = append_keyfile(ctx, cfg.keyring,
@@ -10390,7 +10415,7 @@ static int check_tls_key(int argc, char **argv, struct command *acmd, struct plu
 			nvme_show_error("Failed to insert key, error %d");
 			return err;
 		}
-		printf("Inserted TLS key %08x\n", (unsigned int)tls_key);
+		nvme_show_result("Inserted TLS key %08x", (unsigned int)tls_key);
 
 		if (cfg.keyfile) {
 			err = append_keyfile(ctx, cfg.keyring,
@@ -10416,7 +10441,7 @@ static int check_tls_key(int argc, char **argv, struct command *acmd, struct plu
 					err);
 			return err;
 		}
-		printf("%s\n", tls_id);
+		nvme_show_result("%s", tls_id);
 	}
 	return 0;
 }
@@ -10582,8 +10607,7 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 			return err;
 		}
 
-		if (nvme_args.verbose)
-			printf("exporting to %s\n", cfg.keyfile);
+		nvme_show_verbose_info("exporting to %s", cfg.keyfile);
 
 		return 0;
 	} else if (cfg.import) {
@@ -10594,8 +10618,7 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 			return err;
 		}
 
-		if (nvme_args.verbose)
-			printf("importing from %s\n", cfg.keyfile);
+		nvme_show_verbose_info("importing from %s", cfg.keyfile);
 	} else {
 		err = libnvmf_revoke_tls_key(ctx, cfg.keyring, cfg.keytype,
 			cfg.revoke);
@@ -10605,8 +10628,7 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 			return err;
 		}
 
-		if (nvme_args.verbose)
-			printf("revoking key\n");
+		nvme_show_verbose_info("revoking key");
 	}
 
 	if (old_umask != 0 && fd) {
@@ -10861,12 +10883,13 @@ static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc
 	}
 
 	result = cmd.result;
-	printf(
-	    "%s Command is Success and result: 0x%08x (status: 0x%02x, response: 0x%06x)\n",
-	    nvme_cmd_to_string(true, admin_opcode), result, result & 0xff,
-	    result >> 8);
+	nvme_show_verbose_result(
+		"%s Command is Success and result: 0x%08x (status: 0x%02x, response: 0x%06x)",
+		nvme_cmd_to_string(true, admin_opcode), result,
+		result & 0xff, result >> 8);
 	if (result & 0xff)
-		printf("status: %s\n", libnvme_mi_status_to_string(result & 0xff));
+		nvme_show_verbose_result("status: %s",
+					 libnvme_mi_status_to_string(result & 0xff));
 	if (!send && strlen(cfg.input_file)) {
 		if (write(fd, (void *)data, cfg.data_len) < 0)
 			perror("failed to write data buffer");

--- a/plugins/amzn/amzn-nvme.c
+++ b/plugins/amzn/amzn-nvme.c
@@ -592,7 +592,7 @@ static int get_stats(int argc, char **argv, struct command *acmd,
 		return rc;
 
 	if (nvme_identify_ctrl(hdl, &ctrl)) {
-		fprintf(stderr, "Failed to get identify controller\n");
+		nvme_show_error("Failed to get identify controller");
 		rc = -errno;
 		goto done;
 	}
@@ -618,14 +618,14 @@ static int get_stats(int argc, char **argv, struct command *acmd,
 			  &log, len);
 	rc = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 	if (rc != 0) {
-		fprintf(stderr, "[ERROR] %s: Failed to get log page, rc = %d\n",
+		nvme_show_error("[ERROR] %s: Failed to get log page, rc = %d",
 			__func__, rc);
 		goto done;
 	}
 
 	if (log.base.magic != AMZN_NVME_EBS_STATS_MAGIC &&
 		log.base.magic != AMZN_NVME_LOCAL_STORAGE_STATS_MAGIC) {
-		fprintf(stderr, "[ERROR] %s: Not an EC2 device\n", __func__);
+		nvme_show_error("[ERROR] %s: Not an EC2 device", __func__);
 		rc = -ENOTSUP;
 		goto done;
 	}

--- a/plugins/exclusion/exclusion-nvme.c
+++ b/plugins/exclusion/exclusion-nvme.c
@@ -20,6 +20,7 @@
 
 #include "common.h"
 #include "nvme.h"
+#include "nvme-print.h"
 #include "util/cleanup.h"
 
 #define CREATE_CMD
@@ -33,7 +34,7 @@
 static int require_root(void)
 {
 	if (geteuid() != 0) {
-		fprintf(stderr, "this command requires root privileges (try sudo)\n");
+		nvme_show_error("this command requires root privileges (try sudo)");
 		return -EPERM;
 	}
 	return 0;
@@ -65,9 +66,9 @@ static int excl_create(int argc, char **argv, struct command *acmd,
 	ctx = libnvme_create_global_ctx();
 	ret = libnvmf_exclusion_create(ctx, cfg.name);
 	if (ret == -EEXIST)
-		fprintf(stderr, "exclusion list '%s' already exists\n", cfg.name);
+		nvme_show_error("exclusion list '%s' already exists", cfg.name);
 	else if (ret)
-		fprintf(stderr, "create failed: %s\n", libnvme_strerror(-ret));
+		nvme_show_error("create failed: %s", libnvme_strerror(-ret));
 	return ret;
 }
 
@@ -97,9 +98,9 @@ static int excl_delete(int argc, char **argv, struct command *acmd,
 	ctx = libnvme_create_global_ctx();
 	ret = libnvmf_exclusion_delete(ctx, cfg.name);
 	if (ret == -ENOENT)
-		fprintf(stderr, "exclusion list '%s' not found\n", cfg.name);
+		nvme_show_error("exclusion list '%s' not found", cfg.name);
 	else if (ret)
-		fprintf(stderr, "delete failed: %s\n", libnvme_strerror(-ret));
+		nvme_show_error("delete failed: %s", libnvme_strerror(-ret));
 	return ret;
 }
 
@@ -137,15 +138,15 @@ static int excl_list(int argc, char **argv, struct command *acmd,
 	if (!cfg.name) {
 		ret = libnvmf_exclusion_list_for_each(ctx, print_list_name, NULL);
 		if (ret)
-			fprintf(stderr, "list failed: %s\n", libnvme_strerror(-ret));
+			nvme_show_error("list failed: %s", libnvme_strerror(-ret));
 		return ret;
 	}
 
 	ret = libnvmf_exclusion_entry_for_each(ctx, cfg.name, print_entry, NULL);
 	if (ret == -ENOENT)
-		fprintf(stderr, "exclusion list '%s' not found\n", cfg.name);
+		nvme_show_error("exclusion list '%s' not found", cfg.name);
 	else if (ret)
-		fprintf(stderr, "list failed: %s\n", libnvme_strerror(-ret));
+		nvme_show_error("list failed: %s", libnvme_strerror(-ret));
 	return ret;
 }
 
@@ -173,7 +174,7 @@ static int excl_add(int argc, char **argv, struct command *acmd,
 		return ret;
 
 	if (!cfg.entry) {
-		fprintf(stderr, "--entry required\n");
+		nvme_show_error("--entry required");
 		return -EINVAL;
 	}
 
@@ -183,15 +184,15 @@ static int excl_add(int argc, char **argv, struct command *acmd,
 
 	ctx = libnvme_create_global_ctx();
 	if (!libnvmf_exclusion_entry_valid(ctx, cfg.entry)) {
-		fprintf(stderr, "invalid entry: %s\n", cfg.entry);
+		nvme_show_error("invalid entry: %s", cfg.entry);
 		return -EINVAL;
 	}
 
 	ret = libnvmf_exclusion_add(ctx, cfg.name, cfg.entry);
 	if (ret == -EINVAL)
-		fprintf(stderr, "invalid list name: %s\n", cfg.name);
+		nvme_show_error("invalid list name: %s", cfg.name);
 	else if (ret)
-		fprintf(stderr, "add failed: %s\n", libnvme_strerror(-ret));
+		nvme_show_error("add failed: %s", libnvme_strerror(-ret));
 	return ret;
 }
 
@@ -253,9 +254,9 @@ static int excl_remove(int argc, char **argv, struct command *acmd,
 	ret = libnvmf_exclusion_entry_for_each(ctx, cfg.name, collect_entry, &ec);
 	if (ret) {
 		if (ret == -ENOENT)
-			fprintf(stderr, "exclusion list '%s' not found\n", cfg.name);
+			nvme_show_error("exclusion list '%s' not found", cfg.name);
 		else
-			fprintf(stderr, "list failed: %s\n", libnvme_strerror(-ret));
+			nvme_show_error("list failed: %s", libnvme_strerror(-ret));
 		return ret;
 	}
 
@@ -284,7 +285,7 @@ static int excl_remove(int argc, char **argv, struct command *acmd,
 
 	ret = libnvmf_exclusion_remove(ctx, cfg.name, ec.entries[choice - 1]);
 	if (ret)
-		fprintf(stderr, "remove failed: %s\n", libnvme_strerror(-ret));
+		nvme_show_error("remove failed: %s", libnvme_strerror(-ret));
 
 out:
 	for (i = 0; i < ec.count; i++)
@@ -354,7 +355,7 @@ static int validate_conf_file(struct libnvme_global_ctx *ctx, const char *path)
 			char *end = strchr(s, ']');
 
 			if (!end) {
-				fprintf(stderr,
+				nvme_show_error(
 					"line %u: malformed section header\n",
 					lineno);
 				errors++;
@@ -387,7 +388,7 @@ static int validate_conf_file(struct libnvme_global_ctx *ctx, const char *path)
 			continue;
 
 		if (!in_excl) {
-			fprintf(stderr,
+			nvme_show_error(
 				"line %u: entry outside the [exclusions] section\n",
 				lineno);
 			errors++;
@@ -404,7 +405,7 @@ static int validate_conf_file(struct libnvme_global_ctx *ctx, const char *path)
 
 		/* Pure check — no filesystem side effects. */
 		if (!libnvmf_exclusion_entry_valid(ctx, val)) {
-			fprintf(stderr, "line %u: invalid entry: %s\n",
+			nvme_show_error("line %u: invalid entry: %s",
 				lineno, val);
 			errors++;
 		}
@@ -513,7 +514,7 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 	 */
 	ret = libnvmf_exclusion_read(ctx, cfg.name, &text, &version);
 	if (ret) {
-		fprintf(stderr, "cannot read '%s': %s\n",
+		nvme_show_error("cannot read '%s': %s",
 			cfg.name, libnvme_strerror(-ret));
 		return ret;
 	}
@@ -532,7 +533,7 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 	fd = mkstemp(tmp_path);
 	if (fd < 0) {
 		ret = -errno;
-		fprintf(stderr, "cannot create temp file: %s\n",
+		nvme_show_error("cannot create temp file: %s",
 			libnvme_strerror(-ret));
 		return ret;
 	}
@@ -552,7 +553,7 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 re_edit:
 	ret = run_editor(tmp_path);
 	if (ret) {
-		fprintf(stderr, "editor failed\n");
+		nvme_show_error("editor failed");
 		unlink(tmp_path);
 		return ret;
 	}
@@ -561,13 +562,13 @@ re_edit:
 	if (ret) {
 		char ans[8];
 
-		fprintf(stderr, "File has errors. Re-edit? [y/N] ");
+		nvme_show_error("File has errors. Re-edit? [y/N] ");
 		fflush(stderr);
 		if (fgets(ans, sizeof(ans), stdin) &&
 		    (ans[0] == 'y' || ans[0] == 'Y'))
 			goto re_edit;
 
-		fprintf(stderr,
+		nvme_show_error(
 			"Discarding changes -- your edits are kept at %s\n",
 			tmp_path);
 		return -EINVAL;
@@ -578,7 +579,7 @@ re_edit:
 
 		if (!edited) {
 			ret = errno ? -errno : -EIO;
-			fprintf(stderr, "cannot read back temp file: %s\n",
+			nvme_show_error("cannot read back temp file: %s",
 				libnvme_strerror(-ret));
 			unlink(tmp_path);
 			return ret;
@@ -587,13 +588,13 @@ re_edit:
 	}
 
 	if (ret == -ESTALE) {
-		fprintf(stderr,
+		nvme_show_error(
 			"the list changed on disk since you opened it; your "
 			"edits were NOT saved -- kept at %s\n", tmp_path);
 		return ret;
 	}
 	if (ret) {
-		fprintf(stderr, "cannot save: %s -- your edits are kept at %s\n",
+		nvme_show_error("cannot save: %s -- your edits are kept at %s",
 			libnvme_strerror(-ret), tmp_path);
 		return ret;
 	}

--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -64,7 +64,7 @@ static int fdp_configs(int argc, char **argv, struct command *acmd,
 		flags |= VERBOSE;
 
 	if (!cfg.egid) {
-		fprintf(stderr, "endurance group identifier required\n");
+		nvme_show_error("endurance group identifier required");
 		return -EINVAL;
 	}
 
@@ -194,7 +194,7 @@ static int fdp_stats(int argc, char **argv, struct command *acmd, struct plugin 
 		flags = BINARY;
 
 	if (!cfg.egid) {
-		fprintf(stderr, "endurance group identifier required\n");
+		nvme_show_error("endurance group identifier required");
 		return -EINVAL;
 	}
 
@@ -253,7 +253,7 @@ static int fdp_events(int argc, char **argv, struct command *acmd, struct plugin
 		flags = BINARY;
 
 	if (!cfg.egid) {
-		fprintf(stderr, "endurance group identifier required\n");
+		nvme_show_error("endurance group identifier required");
 		return -EINVAL;
 	}
 
@@ -380,7 +380,7 @@ static int fdp_update(int argc, char **argv, struct command *acmd, struct plugin
 		perror("could not parse pids");
 		return -EINVAL;
 	} else if (npids == 0) {
-		fprintf(stderr, "no placement identifiers set\n");
+		nvme_show_error("no placement identifiers set");
 		return -EINVAL;
 	}
 
@@ -402,7 +402,7 @@ static int fdp_update(int argc, char **argv, struct command *acmd, struct plugin
 		return err;
 	}
 
-	printf("update: Success\n");
+	nvme_show_verbose_result("update: Success");
 
 	return 0;
 }
@@ -452,10 +452,10 @@ static int fdp_set_events(int argc, char **argv, struct command *acmd, struct pl
 		perror("could not parse event types");
 		return -EINVAL;
 	} else if (nev == 0) {
-		fprintf(stderr, "no event types set\n");
+		nvme_show_error("no event types set");
 		return -EINVAL;
 	} else if (nev > 255) {
-		fprintf(stderr, "too many event types (max 255)\n");
+		nvme_show_error("too many event types (max 255)");
 		return -EINVAL;
 	}
 
@@ -463,7 +463,7 @@ static int fdp_set_events(int argc, char **argv, struct command *acmd, struct pl
 		err = libnvme_get_nsid(hdl, &cfg.nsid);
 		if (err < 0) {
 			if (errno != ENOTTY) {
-				fprintf(stderr, "get-namespace-id: %s\n", libnvme_strerror(errno));
+				nvme_show_error("get-namespace-id: %s", libnvme_strerror(errno));
 				return err;
 			}
 
@@ -482,7 +482,7 @@ static int fdp_set_events(int argc, char **argv, struct command *acmd, struct pl
 		return err;;
 	}
 
-	printf("set-events: Success\n");
+	nvme_show_verbose_result("set-events: Success");
 
 	return 0;
 }

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -32,6 +32,7 @@
 #include "common.h"
 #include "nvme-cmds.h"
 #include "nvme.h"
+#include "nvme-print.h"
 #include "plugin.h"
 
 #include "util/suffix.h"
@@ -339,7 +340,7 @@ static int huawei_list(int argc, char **argv, struct command *acmd,
 
 	list_items = calloc(n, sizeof(*list_items));
 	if (!list_items) {
-		fprintf(stderr, "can not allocate controller list payload\n");
+		nvme_show_error("can not allocate controller list payload");
 		ret = ENOMEM;
 		goto out_free_devices;
 	}
@@ -350,7 +351,7 @@ static int huawei_list(int argc, char **argv, struct command *acmd,
 		snprintf(path, sizeof(path), "/dev/%s", devices[i]->d_name);
 		ret = libnvme_open(ctx, path, &hdl);
 		if (ret) {
-			fprintf(stderr, "Cannot open device %s: %s\n",
+			nvme_show_error("Cannot open device %s: %s",
 				path, libnvme_strerror(-ret));
 			continue;
 		}

--- a/plugins/ibm/ibm-nvme.c
+++ b/plugins/ibm/ibm-nvme.c
@@ -256,7 +256,7 @@ static int get_ibm_addi_smart_log(int argc, char **argv, struct command *cmd, st
 	} else if (err > 0)
 		nvme_show_status(err);
 	else
-		nvme_show_error("ibm additional smart log: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ibm additional smart log: %s", libnvme_strerror(errno));
 
 	return err;
 }
@@ -387,7 +387,7 @@ static int get_ibm_vpd_log(int argc, char **argv, struct command *cmd, struct pl
 	} else if (err > 0)
 		nvme_show_status(err);
 	else
-		nvme_show_error("ibm vpd log: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ibm vpd log: %s", libnvme_strerror(errno));
 
 	return err;
 }
@@ -575,7 +575,7 @@ static int get_ibm_persistent_event_log(int argc, char **argv,
 	err = nvme_get_log_persistent_event(hdl, NVME_PEVENT_LOG_EST_CTX_AND_READ,
 			&pevent_log, sizeof(pevent_log));
 	if (err) {
-		fprintf(stderr, "Setting persistent event log read ctx failed (ignored)!\n");
+		nvme_show_error("Setting persistent event log read ctx failed (ignored)!");
 		return err;
 	}
 

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -256,6 +256,7 @@ show_intel_smart_log_jsn(struct nvme_additional_smart_log *smart,
 	json_object_add_value_object(root, "Device stats", dev_stats);
 
 	json_print_object(root, NULL);
+	printf("\n");
 	json_free_object(root);
 }
 
@@ -787,6 +788,7 @@ static void json_lat_stats_3_0(struct intel_lat_stats *stats, int write)
 	json_lat_stats_linear(stats, bucket_list, 388, 391, 4, 32, true);
 
 	json_print_object(root, NULL);
+	printf("\n");
 	json_free_object(root);
 }
 
@@ -814,6 +816,7 @@ static void json_lat_stats_4_0(struct intel_lat_stats *stats, int write)
 			end ? POSINF : NOINF, stats->data[i]);
 	}
 	json_print_object(root, NULL);
+	printf("\n");
 	json_free_object(root);
 }
 
@@ -891,6 +894,7 @@ static void json_lat_stats_v1000_0(struct optane_lat_stats *stats, int write)
 	json_object_add_value_uint(subroot, "value in us", stats->data[8]);
 
 	json_print_object(root, NULL);
+	printf("\n");
 	json_free_object(root);
 
 }

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1091,7 +1091,7 @@ static int get_lat_stats_log(int argc, char **argv, struct command *acmd, struct
 				0, thresholds, sizeof(thresholds),
 				&result);
 		if (err) {
-			fprintf(stderr, "Querying thresholds failed. ");
+			nvme_show_error("Querying thresholds failed. ");
 			nvme_show_status(err);
 			return err;
 		}
@@ -1240,7 +1240,7 @@ static int read_entire_cmd(struct libnvme_passthru_cmd *cmd, int total_size,
 	while (total_size > 0) {
 		err = libnvme_exec_admin_passthru(hdl, cmd);
 		if (err) {
-			fprintf(stderr,
+			nvme_show_error(
 				"failed on cmd.data_len %u cmd.cdw13 %u cmd.cdw12 %x cmd.cdw10 %u err %x remaining size %d\n",
 				cmd->data_len, cmd->cdw13, cmd->cdw12,
 				cmd->cdw10, err, total_size);
@@ -1521,7 +1521,7 @@ out:
 		perror("intel log");
 		err = EIO;
 	} else
-		printf("Successfully wrote log to %s\n", cfg.file);
+		nvme_show_verbose_result("Successfully wrote log to %s", cfg.file);
 	close(output);
 out_free:
 	free(intel);
@@ -1603,9 +1603,9 @@ static int enable_lat_stats_tracking(int argc, char **argv,
 			nvme_show_status(err);
 		} else if (err < 0) {
 			perror("Enable latency tracking");
-			fprintf(stderr, "Command failed while parsing.\n");
+			nvme_show_error("Command failed while parsing.");
 		} else {
-			printf("Successfully set enable bit for FID (0x%X) to %i.\n",
+			nvme_show_verbose_result("Successfully set enable bit for FID (0x%X) to %i.",
 				fid, option);
 		}
 		break;
@@ -1659,7 +1659,7 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 	err = nvme_get_log_simple(hdl, 0xc2,
 				  media_version, sizeof(media_version));
 	if (err) {
-		fprintf(stderr, "Querying media version failed. ");
+		nvme_show_error("Querying media version failed. ");
 		nvme_show_status(err);
 		goto close_dev;
 	}
@@ -1671,7 +1671,7 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 						      thresholds,
 						      sizeof(thresholds));
 		if (num == -1) {
-			fprintf(stderr, "ERROR: Bucket list is malformed\n");
+			nvme_show_error("ERROR: Bucket list is malformed");
 			goto close_dev;
 
 		}
@@ -1683,10 +1683,10 @@ static int set_lat_stats_thresholds(int argc, char **argv,
 			nvme_show_status(err);
 		} else if (err < 0) {
 			perror("Enable latency tracking");
-			fprintf(stderr, "Command failed while parsing.\n");
+			nvme_show_error("Command failed while parsing.");
 		}
 	} else {
-		fprintf(stderr, "Unsupported command\n");
+		nvme_show_error("Unsupported command");
 	}
 
 close_dev:

--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -115,7 +115,7 @@ static int lm_create_cdq(int argc, char **argv, struct command *acmd, struct plu
 	else if (err)
 		nvme_show_status(err);
 	else
-		printf("Create CDQ Successful: CDQID=0x%04x\n",
+		nvme_show_verbose_result("Create CDQ Successful: CDQID=0x%04x",
 			NVME_GET((__u32)cmd.result, LM_CREATE_CDQ_CDQID));
 
 	return err;
@@ -153,7 +153,7 @@ static int lm_delete_cdq(int argc, char **argv, struct command *acmd, struct plu
 	else if (err > 0)
 		nvme_show_status(err);
 	else
-		printf("Delete CDQ Successful: CDQID=0x%04x\n", cfg.cdqid);
+		nvme_show_verbose_result("Delete CDQ Successful: CDQID=0x%04x", cfg.cdqid);
 
 	return err;
 }
@@ -236,7 +236,7 @@ static int lm_track_send(int argc, char **argv, struct command *acmd, struct plu
 	else if (err)
 		nvme_show_status(err);
 	else
-		printf("Track Send (%s) Successful\n",
+		nvme_show_verbose_result("Track Send (%s) Successful",
 		       ARGSTR(lm_track_send_select_argstr, cfg.sel));
 
 	return err;
@@ -383,7 +383,7 @@ static int lm_migration_send(int argc, char **argv, struct command *acmd, struct
 	else if (err > 0)
 		nvme_show_status(err);
 	else
-		printf("Migration Send (%s) Successful\n",
+		nvme_show_verbose_result("Migration Send (%s) Successful",
 		       ARGSTR(lm_migration_send_select_argstr, cfg.sel));
 
 
@@ -558,7 +558,7 @@ static int lm_set_cdq(int argc, char **argv, struct command *acmd, struct plugin
 	else if (err)
 		nvme_show_status(err);
 	else
-		printf("Success. Head Pointer: %d\n", cfg.hp);
+		nvme_show_verbose_result("Success. Head Pointer: %d", cfg.hp);
 
 	return err;
 }

--- a/plugins/lm/lm-print-json.c
+++ b/plugins/lm/lm-print-json.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "nvme-print.h"
 #include "lm-print.h"
 #include "common.h"
 
@@ -7,7 +8,7 @@ static void json_controller_state_data(struct nvme_lm_controller_state_data *dat
 				      __u32 offset)
 {
 	if (offset) {
-		fprintf(stderr, "cannot understand non-zero offset\n");
+		nvme_show_error("cannot understand non-zero offset");
 		return;
 	}
 

--- a/plugins/lm/lm-print-stdout.c
+++ b/plugins/lm/lm-print-stdout.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 
 #include "common.h"
+#include "nvme-print.h"
 #include "lm-print.h"
 #include "util/types.h"
 
@@ -12,7 +13,7 @@ static void stdout_controller_state_data(struct nvme_lm_controller_state_data *d
 					 __u32 offset)
 {
 	if (offset) {
-		fprintf(stderr, "cannot understand non-zero offset\n");
+		nvme_show_error("cannot understand non-zero offset");
 		return;
 	}
 
@@ -32,7 +33,7 @@ static void stdout_controller_state_data(struct nvme_lm_controller_state_data *d
 
 		len -= sizeof(struct nvme_lm_controller_state_data_header);
 	} else {
-		fprintf(stderr, "WARNING: Header truncated\n");
+		nvme_show_error("WARNING: Header truncated");
 		len = 0;
 	}
 
@@ -54,7 +55,7 @@ static void stdout_controller_state_data(struct nvme_lm_controller_state_data *d
 		len -= sizeof(struct nvme_lm_nvme_controller_state_data_header);
 
 		if (len < niosq * sizeof(struct nvme_lm_io_submission_queue_data)) {
-			fprintf(stderr, "WARNING: I/O Submission Queues truncated\n");
+			nvme_show_error("WARNING: I/O Submission Queues truncated");
 			niosq = len / sizeof(struct nvme_lm_io_submission_queue_data);
 		}
 
@@ -88,7 +89,7 @@ static void stdout_controller_state_data(struct nvme_lm_controller_state_data *d
 		len -= niosq * sizeof(struct nvme_lm_io_submission_queue_data);
 
 		if (len < niocq * sizeof(struct nvme_lm_io_completion_queue_data)) {
-			fprintf(stderr, "WARNING: I/O Completion Queues truncated\n");
+			nvme_show_error("WARNING: I/O Completion Queues truncated");
 			niocq = len / sizeof(struct nvme_lm_io_completion_queue_data);
 		}
 
@@ -123,7 +124,7 @@ static void stdout_controller_state_data(struct nvme_lm_controller_state_data *d
 			}
 		}
 	} else
-		fprintf(stderr, "WARNING: NVMe Controller State Data Structure truncated\n");
+		nvme_show_error("WARNING: NVMe Controller State Data Structure truncated");
 }
 
 static void stdout_show_controller_data_queue(struct nvme_lm_ctrl_data_queue_fid_data *data)

--- a/plugins/lm/lm-print.c
+++ b/plugins/lm/lm-print.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "nvme-print.h"
 #include "lm-print.h"
 
 #define lm_print(name, flags, ...) \
@@ -8,7 +9,7 @@
 		if (ops && ops->name) \
 			ops->name(__VA_ARGS__); \
 		else \
-			fprintf(stderr, "unhandled output format\n"); \
+			nvme_show_error("unhandled output format"); \
 	} while (false)
 
 static struct lm_print_ops *lm_print_ops(nvme_print_flags_t flags)

--- a/plugins/memblaze/memblaze-nvme.c
+++ b/plugins/memblaze/memblaze-nvme.c
@@ -781,7 +781,7 @@ static int mb_selective_download(int argc, char **argv, struct command *acmd, st
 		return err;
 
 	if (strlen(cfg.select) != 3) {
-		fprintf(stderr, "Invalid select flag\n");
+		nvme_show_error("Invalid select flag");
 		err = EINVAL;
 		goto out;
 	}
@@ -796,14 +796,14 @@ static int mb_selective_download(int argc, char **argv, struct command *acmd, st
 	} else if (!strncmp(cfg.select, "ALL", 3)) {
 		selectNo = 26;
 	} else {
-		fprintf(stderr, "Invalid select flag\n");
+		nvme_show_error("Invalid select flag");
 		err = EINVAL;
 		goto out;
 	}
 
 	fw_fd = open(cfg.fw, O_RDONLY);
 	if (fw_fd < 0) {
-		fprintf(stderr, "no firmware file provided\n");
+		nvme_show_error("no firmware file provided");
 		err = EINVAL;
 		goto out;
 	}
@@ -817,14 +817,14 @@ static int mb_selective_download(int argc, char **argv, struct command *acmd, st
 
 	fw_size = sb.st_size;
 	if (fw_size & 0x3) {
-		fprintf(stderr, "Invalid size:%d for f/w image\n", fw_size);
+		nvme_show_error("Invalid size:%d for f/w image", fw_size);
 		err = EINVAL;
 		goto out_close;
 	}
 
 	fw_buf = libnvme_alloc(fw_size);
 	if (!fw_buf) {
-		fprintf(stderr, "No memory for f/w size:%d\n", fw_size);
+		nvme_show_error("No memory for f/w size:%d", fw_size);
 		err = ENOMEM;
 		goto out_close;
 	}
@@ -860,7 +860,7 @@ static int mb_selective_download(int argc, char **argv, struct command *acmd, st
 
 	if (err == 0x10B || err == 0x20B) {
 		err = 0;
-		fprintf(stderr, "Update successful! Please power cycle for changes to take effect\n");
+		nvme_show_verbose_result("Update successful! Please power cycle for changes to take effect");
 	}
 
 out_close:
@@ -1106,9 +1106,9 @@ static int mb_set_lat_stats(int argc, char **argv, struct command *acmd, struct 
 			nvme_show_status(err);
 		} else if (err < 0) {
 			perror("Enable latency tracking");
-			fprintf(stderr, "Command failed while parsing.\n");
+			nvme_show_error("Command failed while parsing.");
 		} else {
-			printf("Successfully set enable bit for FID (0x%X) to %i.\n", 0xe2, option);
+			nvme_show_verbose_result("Successfully set enable bit for FID (0x%X) to %i.", 0xe2, option);
 		}
 		break;
 	default:
@@ -1529,10 +1529,10 @@ static void smart_log_add_print(struct smart_log_add *log, const char *devname)
 			sizeof(struct smart_log_add_v3) / sizeof(struct smart_log_add_item_10));
 
 	case 1:
-		fprintf(stderr, "Version %d: N/A\n", version);
+		nvme_show_error("Version %d: N/A", version);
 		break;
 	default:
-		fprintf(stderr, "Version %d: Not supported yet\n", version);
+		nvme_show_error("Version %d: Not supported yet", version);
 		break;
 	}
 }
@@ -1733,7 +1733,7 @@ static int mb_set_latency_feature(int argc, char **argv, struct command *acmd, s
 			((cfg.de_allocate_trim_threshold & 0xff) << 16),
 			0, 0, NULL, 0, &result);
 	if (!err)
-		printf("%s have done successfully. result = %#" PRIx64 ".\n",
+		nvme_show_verbose_result("%s have done successfully. result = %#" PRIx64 ".",
 			acmd->name, (uint64_t)result);
 	else if (err > 0)
 		nvme_show_status(err);
@@ -1765,7 +1765,7 @@ static int mb_get_latency_feature(int argc, char **argv, struct command *acmd, s
 			NVME_GET_FEATURES_SEL_CURRENT, &res);
 	if (!err) {
 		uint32_t result = res;
-		printf("%s have done successfully. result = %#" PRIx32 ".\n", acmd->name, result);
+		nvme_show_verbose_result("%s have done successfully. result = %#" PRIx32 ".", acmd->name, result);
 
 		printf("latency statistics enable status = %d\n", (result & (0x01 << 0)) >> 0);
 		printf("high latency enable status = %d\n", (result & (0x01 << 1)) >> 1);
@@ -1875,14 +1875,14 @@ static void latency_stats_print(struct latency_stats *log, const char *devname)
 			latency_stats_v2_0_print(log, sizeof(struct latency_stats));
 			break;
 		default:
-			fprintf(stderr, "Major Version %u, Minor Version %u: Not supported yet\n",
+			nvme_show_error("Major Version %u, Minor Version %u: Not supported yet",
 				major_version, minor_version);
 			break;
 		}
 		break;
 
 	default:
-		fprintf(stderr, "Major Version %u: Not supported yet\n", major_version);
+		nvme_show_error("Major Version %u: Not supported yet", major_version);
 		break;
 	}
 }
@@ -1986,7 +1986,7 @@ static void high_latency_log_print(struct high_latency_log *log, const char *dev
 		break;
 
 	default:
-		fprintf(stderr, "Version %u: Not supported yet\n", version);
+		nvme_show_error("Version %u: Not supported yet", version);
 		break;
 	}
 }
@@ -2227,7 +2227,7 @@ static void performance_stats_print(struct performance_stats *log, const char *d
 		performance_stats_v2_print(log, duration);
 		break;
 	default:
-		fprintf(stderr, "Version %u: Not supported yet\n", version);
+		nvme_show_error("Version %u: Not supported yet", version);
 		break;
 	}
 }
@@ -2264,7 +2264,7 @@ static int mb_get_performance_stats(int argc, char **argv, struct command *acmd,
 
 	// Check parameters
 	if (cfg.duration < 1 || cfg.duration > 24) {
-		fprintf(stderr, "duration must be between 1 and 24.\n");
+		nvme_show_error("duration must be between 1 and 24.");
 		exit(1);
 	}
 

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -391,10 +391,10 @@ static int ZipAndRemoveDir(char *strDirName, char *strFileName)
 	if (nRet || (stat(strFileName, &sb) == -1)) {
 		err = -EINVAL;
 		if (is_tgz)
-			fprintf(stderr, "Failed to create log data package, "
+			nvme_show_error("Failed to create log data package, "
 				"check if tar and gzip commands are installed!\n");
 		else
-			fprintf(stderr, "Failed to create log data package, "
+			nvme_show_error("Failed to create log data package, "
 				"check if zip command is installed!\n");
 	}
 
@@ -719,7 +719,7 @@ static int micron_selective_download(int argc, char **argv,
 		return err;
 
 	if (strlen(cfg.select) != 3) {
-		fprintf(stderr, "Invalid select flag\n");
+		nvme_show_error("Invalid select flag");
 		return -EINVAL;
 	}
 
@@ -733,13 +733,13 @@ static int micron_selective_download(int argc, char **argv,
 	} else if (!strncmp(cfg.select, "ALL", 3)) {
 		selectNo = 26;
 	} else {
-		fprintf(stderr, "Invalid select flag\n");
+		nvme_show_error("Invalid select flag");
 		return -EINVAL;
 	}
 
 	fw_fd = open(cfg.fw, O_RDONLY);
 	if (fw_fd < 0) {
-		fprintf(stderr, "no firmware file provided\n");
+		nvme_show_error("no firmware file provided");
 		return -EINVAL;
 	}
 
@@ -752,14 +752,14 @@ static int micron_selective_download(int argc, char **argv,
 
 	fw_size = sb.st_size;
 	if (fw_size & 0x3) {
-		fprintf(stderr, "Invalid size:%d for f/w image\n", fw_size);
+		nvme_show_error("Invalid size:%d for f/w image", fw_size);
 		err = EINVAL;
 		goto out;
 	}
 
 	fw_buf = libnvme_alloc(fw_size);
 	if (!fw_buf) {
-		fprintf(stderr, "No memory for f/w size:%d\n", fw_size);
+		nvme_show_error("No memory for f/w size:%d", fw_size);
 		err = ENOMEM;
 		goto out;
 	}
@@ -795,7 +795,7 @@ static int micron_selective_download(int argc, char **argv,
 
 	if (err == 0x10B || err == 0x20B) {
 		err = 0;
-		fprintf(stderr,
+		nvme_show_error(
 			"Update successful! Power cycle for changes to take effect\n");
 	}
 
@@ -852,9 +852,9 @@ static int micron_smbus_option(int argc, char **argv,
 		err = nvme_set_features_simple(hdl, 1, fid, opt.save, cdw11,
 				&result);
 		if (!err)
-			printf("successfully enabled SMBus on drive\n");
+			nvme_show_verbose_result("successfully enabled SMBus on drive");
 		else
-			printf("Failed to enabled SMBus on drive\n");
+			nvme_show_error("Failed to enabled SMBus on drive");
 	} else if (!strcmp(opt.option, "status")) {
 		err = nvme_get_features(hdl, 1, fid, opt.value, 0, 0, NULL, 0, &result);
 		if (!err)
@@ -862,15 +862,15 @@ static int micron_smbus_option(int argc, char **argv,
 				   (result & 1) ? "enabled" : "disabled",
 				   (result & 2) ? "hottest component" : "composite");
 		else
-			printf("Failed to retrieve SMBus status on the drive\n");
+			nvme_show_error("Failed to retrieve SMBus status on the drive");
 	} else if (!strcmp(opt.option, "disable")) {
 		cdw11 = opt.value << 1 | 0;
 		err = nvme_set_features_simple(hdl, 1, fid, opt.save, cdw11,
 				&result);
 		if (!err)
-			printf("Successfully disabled SMBus on drive\n");
+			nvme_show_verbose_result("Successfully disabled SMBus on drive");
 		else
-			printf("Failed to disable SMBus on drive\n");
+			nvme_show_error("Failed to disable SMBus on drive");
 	} else {
 		printf("Invalid option %s, valid values are enable, disable or status\n",
 			   opt.option);
@@ -2204,7 +2204,7 @@ static void GetGenericLogs(struct libnvme_transport_handle *hdl, const char *dir
 	err = nvme_get_log_persistent_event(hdl, NVME_PEVENT_LOG_EST_CTX_AND_READ,
 						&pevent_log, sizeof(pevent_log));
 	if (err) {
-		fprintf(stderr, "Setting persistent event log read ctx failed (ignored)!\n");
+		nvme_show_error("Setting persistent event log read ctx failed (ignored)!");
 		return;
 	}
 
@@ -2258,7 +2258,7 @@ static int micron_telemetry_log(struct libnvme_transport_handle *hdl, __u8 type,
 	else
 		err = nvme_get_log_telemetry_host(hdl, 0, buffer, bs);
 	if (err) {
-		fprintf(stderr, "Failed to get telemetry log header for 0x%X\n", type);
+		nvme_show_error("Failed to get telemetry log header for 0x%X", type);
 		libnvme_free(buffer);
 		return err;
 	}
@@ -2273,7 +2273,7 @@ static int micron_telemetry_log(struct libnvme_transport_handle *hdl, __u8 type,
 	data_area[0] = data_area[4] > data_area[0] ? data_area[4] : data_area[0];
 
 	if (!data_area[da]) {
-		fprintf(stderr, "Requested telemetry data for 0x%X is empty\n", type);
+		nvme_show_error("Requested telemetry data for 0x%X is empty", type);
 		libnvme_free(buffer);
 		buffer = NULL;
 		return -1;
@@ -2370,7 +2370,7 @@ static int GetFeatureSettings(struct libnvme_transport_handle *hdl, const char *
 			if (bufp)
 				WriteData(bufp, len, dir, fmap[i].file, msg);
 		} else {
-			fprintf(stderr, "Feature 0x%x data not retrieved, error %d (ignored)!\n",
+			nvme_show_error("Feature 0x%x data not retrieved, error %d (ignored)!",
 					fmap[i].id, err);
 			errcnt++;
 		}
@@ -2418,12 +2418,12 @@ static int micron_drive_info(int argc, char **argv, struct command *acmd,
 		return err;
 
 	if (model == UNKNOWN_MODEL) {
-		fprintf(stderr, "ERROR : Unsupported drive for vs-drive-info cmd");
+		nvme_show_error("ERROR : Unsupported drive for vs-drive-info cmd");
 		return -1;
 	}
 
 	if (strcmp(cfg.fmt, "normal") && strcmp(cfg.fmt, "json")) {
-		fprintf(stderr, "Invalid output format\n");
+		nvme_show_error("Invalid output format");
 		return -1;
 	}
 
@@ -2437,13 +2437,13 @@ static int micron_drive_info(int argc, char **argv, struct command *acmd,
 		admin_cmd.cdw12 = 3;
 		err = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (err) {
-			fprintf(stderr, "ERROR : drive-info opcode failed with 0x%x\n", err);
+			nvme_show_error("ERROR : drive-info opcode failed with 0x%x", err);
 			return -1;
 		}
 	} else {
 		err = nvme_identify_ctrl(hdl, &ctrl);
 		if (err) {
-			fprintf(stderr, "ERROR : identify_ctrl() failed with 0x%x\n", err);
+			nvme_show_error("ERROR : identify_ctrl() failed with 0x%x", err);
 			return -1;
 		}
 		dinfo.hw_ver_major = ctrl.vs[820];
@@ -2752,7 +2752,7 @@ static int micron_fw_activation_history(int argc, char **argv, struct command *a
 	err = -EINVAL;
 	if ((eModel != M51CX) && (eModel != M51BY) && (eModel != M51CY)
 				&& (eModel != M6003) && (eModel != M6004)) {
-		fprintf(stderr, "Unsupported drive model for vs-fw-activate-history command\n");
+		nvme_show_error("Unsupported drive model for vs-fw-activate-history command");
 		goto out;
 	}
 
@@ -2768,13 +2768,13 @@ static int micron_fw_activation_history(int argc, char **argv, struct command *a
 
 	/* check version and log page */
 	if (table->log_page != 0xC2 || (table->version != 2 && table->version != 1)) {
-		fprintf(stderr, "Unsupported fw activation history page: %x, version: %x\n",
+		nvme_show_error("Unsupported fw activation history page: %x, version: %x",
 				table->log_page, table->version);
 		goto out;
 	}
 
 	if (!table->num_entries) {
-		fprintf(stderr, "No entries were found in fw activation history log\n");
+		nvme_show_error("No entries were found in fw activation history log");
 		goto out;
 	}
 
@@ -2922,10 +2922,10 @@ static int micron_latency_stats_track(int argc, char **argv, struct command *acm
 	err = nvme_set_features(hdl, 0, MICRON_FID_LATENCY_MONITOR, 1, enable,
 			command_mask, timing_mask, 0, 0, NULL, 0, &result);
 	if (!err) {
-		printf("Successfully %sd latency monitoring for %s commands with %dms threshold\n",
+		nvme_show_verbose_result("Successfully %sd latency monitoring for %s commands with %dms threshold",
 				opt.option, opt.command, !opt.threshold ? 800 : opt.threshold * 10);
 	} else {
-		printf("Failed to %s latency monitoring for %s commands with %dms threshold\n",
+		nvme_show_error("Failed to %s latency monitoring for %s commands with %dms threshold",
 				opt.option, opt.command, !opt.threshold ? 800 : opt.threshold * 10);
 	}
 
@@ -3234,16 +3234,16 @@ static int micron_telemetry_cntrl_option(int argc, char **argv,
 		err = nvme_set_features(hdl, 1, fid, (opt.select & 0x1), 1, 0, 0, 0, 0,
 				NULL, 0, &result);
 		if (!err)
-			printf("successfully set controller telemetry option\n");
+			nvme_show_verbose_result("successfully set controller telemetry option");
 		else
-			printf("Failed to set controller telemetry option\n");
+			nvme_show_error("Failed to set controller telemetry option");
 	} else if (!strcmp(opt.option, "disable")) {
 		err = nvme_set_features(hdl, 1, fid, (opt.select & 0x1), 0, 0, 0, 0, 0,
 				NULL, 0, &result);
 		if (!err)
-			printf("successfully disabled controller telemetry option\n");
+			nvme_show_verbose_result("successfully disabled controller telemetry option");
 		else
-			printf("Failed to disable controller telemetry option\n");
+			nvme_show_error("Failed to disable controller telemetry option");
 	} else if (!strcmp(opt.option, "status")) {
 		err = nvme_get_features(hdl, 1, fid, opt.select & 0x3, 0, 0, NULL, 0,
 				&result);
@@ -3313,13 +3313,13 @@ static int get_common_log(struct libnvme_transport_handle *hdl, uint8_t id, uint
 
 	ret = nvme_get_log_simple(hdl, id, &hdr, sizeof(hdr));
 	if (ret) {
-		fprintf(stderr, "pull hdr failed for  %u with error: 0x%x\n", id, ret);
+		nvme_show_error("pull hdr failed for  %u with error: 0x%x", id, ret);
 		return ret;
 	}
 
 	if (hdr.id != id || !hdr.log_size || !hdr.max_size ||
 		hdr.write_pointer < sizeof(hdr)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"invalid log data for LOG: 0x%X, id: 0x%X, size: %u, max: %u, wp: %u, flags: %u, np: %u\n"
 			, id, hdr.id, hdr.log_size, hdr.max_size, hdr.write_pointer, hdr.flags,
 			hdr.next_pointer);
@@ -3333,7 +3333,7 @@ static int get_common_log(struct libnvme_transport_handle *hdl, uint8_t id, uint
 	if (hdr.log_size == sizeof(hdr)) {
 		buffer = (uint8_t *)libnvme_alloc(sizeof(hdr));
 		if (!buffer) {
-			fprintf(stderr, "malloc of %zu bytes failed for log: 0x%X\n",
+			nvme_show_error("malloc of %zu bytes failed for log: 0x%X",
 				sizeof(hdr), id);
 			return -ENOMEM;
 		}
@@ -3341,7 +3341,7 @@ static int get_common_log(struct libnvme_transport_handle *hdl, uint8_t id, uint
 	} else if (hdr.log_size < hdr.max_size) {
 		buffer = (uint8_t *)libnvme_alloc(sizeof(hdr) + hdr.log_size);
 		if (!buffer) {
-			fprintf(stderr, "malloc of %zu bytes failed for log: 0x%X\n",
+			nvme_show_error("malloc of %zu bytes failed for log: 0x%X",
 				hdr.log_size + sizeof(hdr), id);
 			return -ENOMEM;
 		}
@@ -3359,7 +3359,7 @@ static int get_common_log(struct libnvme_transport_handle *hdl, uint8_t id, uint
 		 */
 		buffer = (uint8_t *)libnvme_alloc(hdr.max_size + sizeof(hdr));
 		if (!buffer) {
-			fprintf(stderr, "malloc of %zu bytes failed for log: 0x%X\n",
+			nvme_show_error("malloc of %zu bytes failed for log: 0x%X",
 				hdr.max_size + sizeof(hdr), id);
 			return -ENOMEM;
 		}
@@ -3373,7 +3373,7 @@ static int get_common_log(struct libnvme_transport_handle *hdl, uint8_t id, uint
 						   buffer + sizeof(hdr));
 			if (ret) {
 				libnvme_free(buffer);
-				fprintf(stderr, "failed to get log: 0x%X\n", id);
+				nvme_show_error("failed to get log: 0x%X", id);
 				return ret;
 			}
 			log_size += first;
@@ -3382,7 +3382,7 @@ static int get_common_log(struct libnvme_transport_handle *hdl, uint8_t id, uint
 			ret = nvme_get_log_lpo(hdl, id, sizeof(hdr), chunk, second,
 						   buffer + sizeof(hdr) + first);
 			if (ret) {
-				fprintf(stderr, "failed to get log: 0x%X\n", id);
+				nvme_show_error("failed to get log: 0x%X", id);
 				libnvme_free(buffer);
 				return ret;
 			}
@@ -3647,7 +3647,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 	}
 
 	if (!is_safe_path(cfg.package)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Invalid package path: contains unsafe characters\n");
 		goto out;
 	}
@@ -3693,7 +3693,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 			strOSDirName, sizeof(strOSDirName),
 			strCtrlDirName, sizeof(strCtrlDirName));
 	if (err) {
-		fprintf(stderr, "Failed to create debug data directories\n");
+		nvme_show_error("Failed to create debug data directories");
 		goto out;
 	}
 
@@ -4051,13 +4051,13 @@ static int micron_device_waf(int argc, char **argv, struct command *acmd,
 
 	err = nvme_get_log_smart(hdl, NVME_NSID_ALL, &smart_log);
 	if (err != 0) {
-		fprintf(stderr, "nvme_smart_log() failed, err = %d\n", err);
+		nvme_show_error("nvme_smart_log() failed, err = %d", err);
 		goto out;
 	}
 
 	err = nvme_get_log_simple(hdl, 0xC0, logC0, C0_log_size);
 	if (err != 0) {
-		fprintf(stderr, "Failed to get extended smart log, err = %d\n", err);
+		nvme_show_error("Failed to get extended smart log, err = %d", err);
 		goto out;
 	}
 
@@ -4334,14 +4334,14 @@ static int micron_health_info(int argc, char **argv, struct command *acmd,
 		return err;
 
 	if (eModel == UNKNOWN_MODEL)
-		fprintf(stderr, "WARNING: Unknown drive model\n");
+		nvme_show_error("WARNING: Unknown drive model");
 
 	if (!strcmp(cfg.fmt, "json"))
 		is_json = true;
 
 	err = nvme_get_log_smart(hdl, NVME_NSID_ALL, &smart_log);
 	if (err) {
-		fprintf(stderr, "Failed to get SMART log: %s\n",
+		nvme_show_error("Failed to get SMART log: %s",
 			libnvme_strerror(err));
 		return err;
 	}
@@ -4420,19 +4420,19 @@ static int micron_id_ctrl(int argc, char **argv, struct command *acmd,
 		return err;
 
 	if (eModel == UNKNOWN_MODEL) {
-		fprintf(stderr,
+		nvme_show_error(
 			"WARNING: Drive not recognized as Micron, proceeding anyway\n");
 	}
 
 	err = validate_output_format(nvme_args.output_format, &flags);
 	if (err < 0) {
-		fprintf(stderr, "Invalid output format\n");
+		nvme_show_error("Invalid output format");
 		return err;
 	}
 
 	err = nvme_identify_ctrl(hdl, &ctrl);
 	if (err) {
-		fprintf(stderr, "identify controller failed: %s\n",
+		nvme_show_error("identify controller failed: %s",
 			libnvme_strerror(err));
 		return err;
 	}

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -15,6 +15,7 @@
 #include <libnvme.h>
 
 #include "common.h"
+#include "nvme-print.h"
 #include "micron-utils.h"
 #include "util/cleanup.h"
 
@@ -55,7 +56,7 @@ int micron_get_pci_ids(
 			ctrl_sysfs_dir);
 		ReadSysFile(id_path, did);
 	} else {
-		fprintf(stderr, "Unable to find sysfs dir for %s\n",
+		nvme_show_error("Unable to find sysfs dir for %s",
 			libnvme_transport_handle_get_name(hdl));
 		return -EINVAL;
 	}
@@ -305,7 +306,7 @@ void micron_write_os_config_to_file(const char *file_name)
 					break;
 				pos += n;
 			}
-			fprintf(stderr, "Failed to run \"%s\": %s\n",
+			nvme_show_error("Failed to run \"%s\": %s",
 				cmdline, strerror(-ret));
 		}
 	}

--- a/plugins/micron/micron-utils-win.c
+++ b/plugins/micron/micron-utils-win.c
@@ -133,7 +133,7 @@ void micron_write_os_config_to_file(const char *file_name)
 
 	fp = fopen(file_name, "w+");
 	if (!fp) {
-		fprintf(stderr, "Failed to create %s\n", file_name);
+		nvme_show_error("Failed to create %s", file_name);
 		return;
 	}
 

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -29,6 +29,7 @@
 #include "common.h"
 #include "nvme-cmds.h"
 #include "nvme.h"
+#include "nvme-print.h"
 #include "util/suffix.h"
 
 #define CREATE_CMD
@@ -179,7 +180,7 @@ static void ontap_get_subsysname(char *subnqn, char *subsysname,
 		memcpy(subsysname, subname, len);
 		subsysname[len] = '\0';
 	} else
-		fprintf(stderr, "Unable to fetch ONTAP subsystem name\n");
+		nvme_show_error("Unable to fetch ONTAP subsystem name");
 }
 
 static void ontap_labels_to_str(char *dst, char *src, int count)
@@ -221,7 +222,7 @@ static void netapp_get_ontap_labels(char *vsname, char *nspath,
 		ontap_labels_to_str(vsname, vserver_name, label_len);
 	} else {
 		/* not the expected vserver tlv */
-		fprintf(stderr, "Unable to fetch ONTAP vserver name\n");
+		nvme_show_error("Unable to fetch ONTAP vserver name");
 		return;
 	}
 
@@ -235,7 +236,7 @@ static void netapp_get_ontap_labels(char *vsname, char *nspath,
 		ontap_labels_to_str(vol_name, volume_name, label_len);
 	} else {
 		/* not the expected volume tlv */
-		fprintf(stderr, "Unable to fetch ONTAP volume name\n");
+		nvme_show_error("Unable to fetch ONTAP volume name");
 		return;
 	}
 
@@ -249,7 +250,7 @@ static void netapp_get_ontap_labels(char *vsname, char *nspath,
 		ontap_labels_to_str(ns_name, namespace_name, label_len);
 	} else {
 		/* not the expected namespace tlv */
-		fprintf(stderr, "Unable to fetch ONTAP namespace name\n");
+		nvme_show_error("Unable to fetch ONTAP namespace name");
 		return;
 	}
 
@@ -748,7 +749,7 @@ static int nvme_get_ontap_c2_log(struct libnvme_transport_handle *hdl, __u32 nsi
 
 	err = libnvme_exec_admin_passthru(hdl, &get_log);
 	if (err) {
-		fprintf(stderr, "ioctl error %0x\n", err);
+		nvme_show_error("ioctl error %0x", err);
 		return 1;
 	}
 
@@ -763,7 +764,7 @@ static int netapp_smdevices_get_info(struct libnvme_transport_handle *hdl,
 
 	err = nvme_identify_ctrl(hdl, &item->ctrl);
 	if (err) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Identify Controller failed to %s (%s)\n", dev,
 			err < 0 ? libnvme_strerror(-err) :
 			libnvme_status_to_string(err, false));
@@ -779,7 +780,7 @@ static int netapp_smdevices_get_info(struct libnvme_transport_handle *hdl,
 
 	err = nvme_identify_ns(hdl, item->nsid, &item->ns);
 	if (err) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Unable to identify namespace for %s (%s)\n",
 			dev, err < 0 ? libnvme_strerror(-err) :
 			libnvme_status_to_string(err, false));
@@ -799,7 +800,7 @@ static int netapp_ontapdevices_get_info(struct libnvme_transport_handle *hdl,
 
 	err = nvme_identify_ctrl(hdl, &item->ctrl);
 	if (err) {
-		fprintf(stderr, "Identify Controller failed to %s (%s)\n",
+		nvme_show_error("Identify Controller failed to %s (%s)",
 			dev, err < 0 ? libnvme_strerror(-err) :
 			libnvme_status_to_string(err, false));
 		return 0;
@@ -813,7 +814,7 @@ static int netapp_ontapdevices_get_info(struct libnvme_transport_handle *hdl,
 
 	err = nvme_identify_ns(hdl, item->nsid, &item->ns);
 	if (err) {
-		fprintf(stderr, "Unable to identify namespace for %s (%s)\n",
+		nvme_show_error("Unable to identify namespace for %s (%s)",
 			dev, err < 0 ? libnvme_strerror(-err) :
 			libnvme_status_to_string(err, false));
 		return 0;
@@ -821,7 +822,7 @@ static int netapp_ontapdevices_get_info(struct libnvme_transport_handle *hdl,
 
 	nsdescs = libnvme_alloc(0x1000);
 	if (!nsdescs) {
-		fprintf(stderr, "Cannot allocate controller list payload\n");
+		nvme_show_error("Cannot allocate controller list payload");
 		return 0;
 	}
 
@@ -829,7 +830,7 @@ static int netapp_ontapdevices_get_info(struct libnvme_transport_handle *hdl,
 
 	err = nvme_identify_ns_descs_list(hdl, item->nsid, nsdescs);
 	if (err) {
-		fprintf(stderr, "Unable to identify namespace descriptor for %s (%s)\n",
+		nvme_show_error("Unable to identify namespace descriptor for %s (%s)",
 			dev, err < 0 ? libnvme_strerror(-err) :
 			libnvme_status_to_string(err, false));
 		libnvme_free(nsdescs);
@@ -841,7 +842,7 @@ static int netapp_ontapdevices_get_info(struct libnvme_transport_handle *hdl,
 
 	err = nvme_get_ontap_c2_log(hdl, item->nsid, item->log_data, ONTAP_C2_LOG_SIZE);
 	if (err) {
-		fprintf(stderr, "Unable to get log page data for %s (%s)\n",
+		nvme_show_error("Unable to get log page data for %s (%s)",
 			dev, err < 0 ? libnvme_strerror(-err) :
 			libnvme_status_to_string(err, false));
 		return 0;
@@ -915,14 +916,14 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 
 	fmt = netapp_output_format(nvme_args.output_format);
 	if (fmt != NNORMAL && fmt != NCOLUMN && fmt != NJSON) {
-		fprintf(stderr, "Unrecognized output format: %s\n",
+		nvme_show_error("Unrecognized output format: %s",
 			nvme_args.output_format);
 		return -EINVAL;
 	}
 
 	num = scandir(dev_path, &devices, netapp_nvme_filter, alphasort);
 	if (num <= 0) {
-		fprintf(stderr, "No smdevices detected\n");
+		nvme_show_error("No smdevices detected");
 		return num;
 	}
 
@@ -935,20 +936,20 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 		char path[512];
 
 		if (sscanf(devname, "nvme%dn%d", &subsys_num, &nsid) != 2) {
-			fprintf(stderr, "Invalid device name %s\n", devname);
+			nvme_show_error("Invalid device name %s", devname);
 			return -EINVAL;
 		}
 
 		sprintf(path, "/dev/%s", devname);
 		if (stat(path, &st) != 0) {
-			fprintf(stderr, "%s does not exist\n", path);
+			nvme_show_error("%s does not exist", path);
 			return -EINVAL;
 		}
 	}
 
 	smdevices = calloc(num, sizeof(*smdevices));
 	if (!smdevices) {
-		fprintf(stderr, "Unable to allocate memory for devices\n");
+		nvme_show_error("Unable to allocate memory for devices");
 		return -ENOMEM;
 	}
 
@@ -957,7 +958,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 			devices[i]->d_name);
 		ret = libnvme_open(ctx, path, &hdl);
 		if (ret) {
-			fprintf(stderr, "Unable to open %s: %s\n", path,
+			nvme_show_error("Unable to open %s: %s", path,
 				libnvme_strerror(-ret));
 			continue;
 		}
@@ -980,7 +981,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 			netapp_smdevices_print_json(smdevices,
 					num_smdevices, devname);
 	} else
-		fprintf(stderr, "No smdevices detected\n");
+		nvme_show_error("No smdevices detected");
 
 	for (i = 0; i < num; i++)
 		free(devices[i]);
@@ -1015,7 +1016,7 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 
 	fmt = netapp_output_format(nvme_args.output_format);
 	if (fmt != NNORMAL && fmt != NCOLUMN && fmt != NJSON) {
-		fprintf(stderr, "Unrecognized output format: %s\n",
+		nvme_show_error("Unrecognized output format: %s",
 			nvme_args.output_format);
 		return -EINVAL;
 	}
@@ -1029,26 +1030,26 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 		char path[512];
 
 		if (sscanf(devname, "nvme%dn%d", &subsys_num, &nsid) != 2) {
-			fprintf(stderr, "Invalid device name %s\n", devname);
+			nvme_show_error("Invalid device name %s", devname);
 			return -EINVAL;
 		}
 
 		sprintf(path, "/dev/%s", devname);
 		if (stat(path, &st) != 0) {
-			fprintf(stderr, "%s does not exist\n", path);
+			nvme_show_error("%s does not exist", path);
 			return -EINVAL;
 		}
 	}
 
 	num = scandir(dev_path, &devices, netapp_nvme_filter, alphasort);
 	if (num <= 0) {
-		fprintf(stderr, "No ontapdevices detected\n");
+		nvme_show_error("No ontapdevices detected");
 		return num;
 	}
 
 	ontapdevices = calloc(num, sizeof(*ontapdevices));
 	if (!ontapdevices) {
-		fprintf(stderr, "Unable to allocate memory for devices\n");
+		nvme_show_error("Unable to allocate memory for devices");
 		return -ENOMEM;
 	}
 
@@ -1057,7 +1058,7 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 				devices[i]->d_name);
 		ret = libnvme_open(ctx, path, &hdl);
 		if (ret) {
-			fprintf(stderr, "Unable to open %s: %s\n", path,
+			nvme_show_error("Unable to open %s: %s", path,
 					libnvme_strerror(-ret));
 			continue;
 		}
@@ -1081,7 +1082,7 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 			netapp_ontapdevices_print_json(ontapdevices,
 					num_ontapdevices, devname);
 	} else
-		fprintf(stderr, "No ontapdevices detected\n");
+		nvme_show_error("No ontapdevices detected");
 
 	for (i = 0; i < num; i++)
 		free(devices[i]);

--- a/plugins/ocp/ocp-clear-features.c
+++ b/plugins/ocp/ocp-clear-features.c
@@ -40,7 +40,7 @@ static int ocp_clear_feature(int argc, char **argv, const char *desc, const __u8
 		/* OCP 2.0 requires UUID index support */
 		err = ocp_get_uuid_index(hdl, &uuid_index);
 		if (err || !uuid_index) {
-			fprintf(stderr, "ERROR: No OCP UUID index found\n");
+			nvme_show_error("ERROR: No OCP UUID index found");
 			return err;
 		}
 	}
@@ -49,11 +49,11 @@ static int ocp_clear_feature(int argc, char **argv, const char *desc, const __u8
 			&result);
 
 	if (err == 0)
-		printf("Success : %s\n", desc);
+		nvme_show_verbose_result("Success : %s", desc);
 	else if (err > 0)
 		nvme_show_status(err);
 	else
-		printf("Fail : %s\n", desc);
+		nvme_show_error("Fail : %s", desc);
 
 	return err;
 }

--- a/plugins/ocp/ocp-fw-activation-history.c
+++ b/plugins/ocp/ocp-fw-activation-history.c
@@ -59,7 +59,7 @@ int ocp_fw_activation_history_log(int argc, char **argv, struct command *acmd,
 				  sizeof(ocp_fw_activation_history_guid));
 
 	if (!err && guid_cmp_res) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Error: Unexpected data. Log page guid does not match with expected.\n");
 		err = -EINVAL;
 	}
@@ -70,7 +70,7 @@ int ocp_fw_activation_history_log(int argc, char **argv, struct command *acmd,
 		err = validate_output_format(nvme_args.output_format,
 			&print_flag);
 		if (err < 0) {
-			fprintf(stderr, "Error: Invalid output format.\n");
+			nvme_show_error("Error: Invalid output format.");
 			return err;
 		}
 

--- a/plugins/ocp/ocp-hardware-component-log.c
+++ b/plugins/ocp/ocp-hardware-component-log.c
@@ -24,7 +24,7 @@
 #define print_info_error(...) \
 	do { \
 		if (log_level >= LIBNVME_LOG_INFO) \
-			fprintf(stderr, __VA_ARGS__); \
+			nvme_show_error( __VA_ARGS__); \
 	} while (false)
 
 #ifdef HWCOMP_DUMMY
@@ -217,7 +217,7 @@ static int get_hwcomp_log_data(struct libnvme_transport_handle *hdl, struct hwco
 
 	log->desc = calloc(1, len);
 	if (!log->desc) {
-		fprintf(stderr, "error: ocp: calloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("error: ocp: calloc: %s", libnvme_strerror(errno));
 		return -errno;
 	}
 
@@ -250,7 +250,7 @@ static int get_hwcomp_log(struct libnvme_transport_handle *hdl, __u32 id, bool l
 
 	ret = validate_output_format(nvme_args.output_format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "error: ocp: invalid output format\n");
+		nvme_show_error("error: ocp: invalid output format");
 		return ret;
 	}
 
@@ -307,7 +307,7 @@ int ocp_hwcomp_log(int argc, char **argv, struct command *acmd, struct plugin *p
 
 	ret = get_hwcomp_log(hdl, cfg.id, cfg.list);
 	if (ret)
-		fprintf(stderr, "error: ocp: failed to get hwcomp log: %02X, ret: %d\n",
+		nvme_show_error("error: ocp: failed to get hwcomp log: %02X, ret: %d",
 			OCP_LID_HWCOMP, ret);
 
 	return ret;

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -208,13 +208,13 @@ static int get_c3_log_page(struct libnvme_transport_handle *hdl, char *format)
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR : OCP : invalid output format\n");
+		nvme_show_error("ERROR : OCP : invalid output format");
 		return ret;
 	}
 
 	data = malloc(sizeof(__u8) * C3_LATENCY_MON_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * C3_LATENCY_MON_LOG_BUF_LEN);
@@ -222,7 +222,7 @@ static int get_c3_log_page(struct libnvme_transport_handle *hdl, char *format)
 	ret = ocp_get_log_simple(hdl, OCP_LID_LMLOG, C3_LATENCY_MON_LOG_BUF_LEN, data);
 
 	if (strcmp(format, "json"))
-		fprintf(stderr, "NVMe Status:%s(%x)\n", libnvme_status_to_string(ret, false), ret);
+		nvme_show_error("NVMe Status:%s(%x)", libnvme_status_to_string(ret, false), ret);
 
 	if (!ret) {
 		log_data = (struct ssd_latency_monitor_log *)data;
@@ -235,15 +235,15 @@ static int get_c3_log_page(struct libnvme_transport_handle *hdl, char *format)
 			if (lat_mon_guid[i] != log_data->log_page_guid[i]) {
 				int j;
 
-				fprintf(stderr, "ERROR : OCP : Unknown GUID in C3 Log Page data\n");
-				fprintf(stderr, "ERROR : OCP : Expected GUID: 0x");
+				nvme_show_error("ERROR : OCP : Unknown GUID in C3 Log Page data");
+				nvme_show_error("ERROR : OCP : Expected GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", lat_mon_guid[j]);
+					nvme_show_error("%02x", lat_mon_guid[j]);
 
-				fprintf(stderr, "\nERROR : OCP : Actual GUID: 0x");
+				nvme_show_error("\nERROR : OCP : Actual GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%02x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -251,7 +251,7 @@ static int get_c3_log_page(struct libnvme_transport_handle *hdl, char *format)
 		}
 		ocp_c3_log(hdl, log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR : OCP : Unable to read C3 data from buffer\n");
+		nvme_show_error("ERROR : OCP : Unable to read C3 data from buffer");
 	}
 
 out:
@@ -276,7 +276,7 @@ static int ocp_latency_monitor_log(int argc, char **argv,
 
 	ret = get_c3_log_page(hdl, nvme_args.output_format);
 	if (ret)
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR : OCP : Failure reading the C3 Log Page, ret = %d\n",
 			ret);
 
@@ -389,7 +389,7 @@ int ocp_set_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 		printf("discard debug log: 0x%x\n", buf.discard_debug_log);
 		printf("latency monitor feature enable: 0x%x\n", buf.latency_monitor_feature_enable);
 	} else if (err > 0) {
-		fprintf(stderr, "NVMe Status:%s(%x)\n", libnvme_status_to_string(err, false), err);
+		nvme_show_error("NVMe Status:%s(%x)", libnvme_status_to_string(err, false), err);
 	}
 
 	return err;
@@ -531,7 +531,7 @@ static int eol_plp_failure_mode_set(struct libnvme_transport_handle *hdl, const 
 		nvme_show_status(err);
 	} else if (err < 0) {
 		nvme_show_perror("Define EOL/PLP failure mode");
-		fprintf(stderr, "Command failed while parsing.\n");
+		nvme_show_error("Command failed while parsing.");
 	} else {
 		nvme_show_result("Successfully set mode (feature: %#0*x): %#0*x (%s: %s).",
 				 fid ? 4 : 2, fid, mode ? 10 : 8, mode,
@@ -1180,7 +1180,7 @@ static int get_telemetry_log_page_data(struct libnvme_transport_handle *hdl,
 	hdr = malloc(bs);
 	telemetry_log = malloc(bs);
 	if (!hdr || !telemetry_log) {
-		fprintf(stderr, "Failed to allocate %zu bytes for log: %s\n",
+		nvme_show_error("Failed to allocate %zu bytes for log: %s",
 			bs, libnvme_strerror(errno));
 		err = -ENOMEM;
 		goto exit_status;
@@ -1189,7 +1189,7 @@ static int get_telemetry_log_page_data(struct libnvme_transport_handle *hdl,
 
 	fd = nvme_open_rawdata(output_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (fd < 0) {
-		fprintf(stderr, "Failed to open output file %s: %s!\n",
+		nvme_show_error("Failed to open output file %s: %s!",
 				output_file, libnvme_strerror(errno));
 		err = fd;
 		goto exit_status;
@@ -1201,16 +1201,16 @@ static int get_telemetry_log_page_data(struct libnvme_transport_handle *hdl,
 			NVME_LOG_CDW10_LSP_MASK);
 	err = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 	if (err < 0)
-		nvme_show_error("Failed to fetch the log from drive.\n");
+		nvme_show_error("Failed to fetch the log from drive.");
 	else if (err > 0) {
 		nvme_show_status(err);
-		nvme_show_error("Failed to fetch telemetry-header. Error:%d.\n", err);
+		nvme_show_error("Failed to fetch telemetry-header. Error:%d.", err);
 		goto close_fd;
 	}
 
 	err = write(fd, (void *)hdr, bs);
 	if (err != bs) {
-		nvme_show_error("Failed to write data to file.\n");
+		nvme_show_error("Failed to write data to file.");
 		goto close_fd;
 	}
 
@@ -1238,17 +1238,17 @@ static int get_telemetry_log_page_data(struct libnvme_transport_handle *hdl,
 		nvme_init_get_log_lpo(&cmd, offset);
 		err = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 		if (err < 0) {
-			nvme_show_error("Failed to fetch the log from drive.\n");
+			nvme_show_error("Failed to fetch the log from drive.");
 			break;
 		} else if (err > 0) {
-			nvme_show_error("Failed to fetch telemetry-log.\n");
+			nvme_show_error("Failed to fetch telemetry-log.");
 			nvme_show_status(err);
 			break;
 		}
 
 		err = write(fd, (void *)telemetry_log, bs);
 		if (err != bs) {
-			nvme_show_error("Failed to write data to file.\n");
+			nvme_show_error("Failed to write data to file.");
 			break;
 		}
 		err = 0;
@@ -1279,7 +1279,7 @@ static int get_c9_log_page_data(struct libnvme_transport_handle *hdl,
 
 	header_data = (__u8 *)malloc(sizeof(__u8) * C9_TELEMETRY_STR_LOG_LEN);
 	if (!header_data) {
-		fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(header_data, 0, sizeof(__u8) * C9_TELEMETRY_STR_LOG_LEN);
@@ -1321,21 +1321,21 @@ static int get_c9_log_page_data(struct libnvme_transport_handle *hdl,
 
 		pC9_string_buffer = (__u8 *)malloc(sizeof(__u8) * total_log_page_sz);
 		if (!pC9_string_buffer) {
-			fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 			return -1;
 		}
 		memset(pC9_string_buffer, 0, sizeof(__u8) * total_log_page_sz);
 
 		ret = ocp_get_log_simple(hdl, OCP_LID_TELSLG, total_log_page_sz, pC9_string_buffer);
 	} else {
-		fprintf(stderr, "ERROR : OCP : Unable to read C9 data, ret: %d.\n", ret);
+		nvme_show_error("ERROR : OCP : Unable to read C9 data, ret: %d.", ret);
 		return ret;
 	}
 
 	if (save_bin) {
 		fd = nvme_open_rawdata(output_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (fd < 0) {
-			fprintf(stderr, "Failed to open output file %s: %s!\n", output_file,
+			nvme_show_error("Failed to open output file %s: %s!", output_file,
 				libnvme_strerror(errno));
 			ret = fd;
 			goto free;
@@ -1343,7 +1343,7 @@ static int get_c9_log_page_data(struct libnvme_transport_handle *hdl,
 
 		ret = write(fd, (void *)pC9_string_buffer, total_log_page_sz);
 		if (ret != total_log_page_sz)
-			fprintf(stderr, "Failed to flush all data to file! ret: %d\n", ret);
+			nvme_show_error("Failed to flush all data to file! ret: %d", ret);
 		else
 			/* all data written, set ret = SUCCESS */
 			ret = 0;
@@ -1369,18 +1369,18 @@ int parse_ocp_telemetry_log(struct ocp_telemetry_parse_options *options)
 				read_binary_file(NULL, (const char *)options->telemetry_log,
 						 &telemetry_buffer_size, 1);
 			if (ptelemetry_buffer == NULL) {
-				nvme_show_error("Failed to read telemetry-log.\n");
+				nvme_show_error("Failed to read telemetry-log.");
 				return -1;
 			}
 		}
 	} else {
-		nvme_show_error("telemetry-log is empty.\n");
+		nvme_show_error("telemetry-log is empty.");
 		return -1;
 	}
 
 	log_id = ptelemetry_buffer[0];
 	if ((log_id != NVME_LOG_LID_TELEMETRY_HOST) && (log_id != NVME_LOG_LID_TELEMETRY_CTRL)) {
-		nvme_show_error("Invalid LogPageId [0x%02X]\n", log_id);
+		nvme_show_error("Invalid LogPageId [0x%02X]", log_id);
 		return -1;
 	}
 
@@ -1390,18 +1390,18 @@ int parse_ocp_telemetry_log(struct ocp_telemetry_parse_options *options)
 			pstring_buffer = read_binary_file(NULL, (const char *)options->string_log,
 							  &string_buffer_size, 1);
 			if (pstring_buffer == NULL) {
-				nvme_show_error("Failed to read string-log.\n");
+				nvme_show_error("Failed to read string-log.");
 				return -1;
 			}
 		}
 	} else {
-		nvme_show_error("string-log is empty.\n");
+		nvme_show_error("string-log is empty.");
 		return -1;
 	}
 
 	status = validate_output_format(options->output_format, &fmt);
 	if (status < 0) {
-		nvme_show_error("Invalid output format\n");
+		nvme_show_error("Invalid output format");
 		return status;
 	}
 
@@ -1508,13 +1508,13 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *acmd, struct
 
 		if (tele_area == 4) {
 			if (!(ctrl.lpa & 0x40)) {
-				nvme_show_error("Telemetry data area 4 not supported by device.\n");
+				nvme_show_error("Telemetry data area 4 not supported by device.");
 				goto out;
 			}
 
 			err = libnvme_set_etdas(hdl, &host_behavior_changed);
 			if (err) {
-				fprintf(stderr, "%s: Failed to set ETDAS bit\n", __func__);
+				nvme_show_error("%s: Failed to set ETDAS bit", __func__);
 				return err;
 			}
 		}
@@ -1526,7 +1526,7 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *acmd, struct
 				tele_area,
 				(const char *)file_path_telemetry);
 		if (err) {
-			nvme_show_error("Failed to fetch telemetry-log from the drive.\n");
+			nvme_show_error("Failed to fetch telemetry-log from the drive.");
 			goto out;
 		}
 		nvme_show_result("telemetry.bin generated. Proceeding with next steps.\n");
@@ -1537,7 +1537,7 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *acmd, struct
 			err = libnvme_clear_etdas(hdl, &host_behavior_changed);
 			if (err) {
 				/* Continue on if this fails, it's not a fatal condition */
-				nvme_show_error("Failed to clear ETDAS bit.\n");
+				nvme_show_error("Failed to clear ETDAS bit.");
 			}
 		}
 	}
@@ -1549,7 +1549,7 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *acmd, struct
 		sprintf(file_path_string, "%s-%s", opt.output_file, string_suffix);
 		err = get_c9_log_page_data(hdl, 0, 1, (const char *)file_path_string);
 		if (err) {
-			nvme_show_error("Failed to fetch string-log from the drive.\n");
+			nvme_show_error("Failed to fetch string-log from the drive.");
 			goto out;
 		}
 		nvme_show_result("string.bin generated. Proceeding with next steps.\n");
@@ -1588,7 +1588,7 @@ static int ocp_telemetry_log(int argc, char **argv, struct command *acmd, struct
 
 		err = get_telemetry_dump(hdl, opt.output_file, sn, tele_type, tele_area, true);
 		if (err)
-			fprintf(stderr, "NVMe Status: %s(%x)\n", libnvme_status_to_string(err, false),
+			nvme_show_error("NVMe Status: %s(%x)", libnvme_status_to_string(err, false),
 				err);
 		break;
 	}
@@ -1629,13 +1629,13 @@ static int get_c5_log_page(struct libnvme_transport_handle *hdl, char *format)
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR : OCP : invalid output format\n");
+		nvme_show_error("ERROR : OCP : invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * C5_UNSUPPORTED_REQS_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * C5_UNSUPPORTED_REQS_LEN);
@@ -1650,14 +1650,14 @@ static int get_c5_log_page(struct libnvme_transport_handle *hdl, char *format)
 		 */
 		for (i = 0; i < 16; i++) {
 			if (unsupported_req_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR : OCP : Unknown GUID in C5 Log Page data\n");
-				fprintf(stderr, "ERROR : OCP : Expected GUID: 0x");
+				nvme_show_error("ERROR : OCP : Unknown GUID in C5 Log Page data");
+				nvme_show_error("ERROR : OCP : Expected GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", unsupported_req_guid[j]);
-				fprintf(stderr, "\nERROR : OCP : Actual GUID: 0x");
+					nvme_show_error("%02x", unsupported_req_guid[j]);
+				nvme_show_error("\nERROR : OCP : Actual GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%02x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -1665,7 +1665,7 @@ static int get_c5_log_page(struct libnvme_transport_handle *hdl, char *format)
 		}
 		ocp_c5_log(hdl, log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR : OCP : Unable to read C3 data from buffer\n");
+		nvme_show_error("ERROR : OCP : Unable to read C3 data from buffer");
 	}
 
 out:
@@ -1697,7 +1697,7 @@ static int ocp_unsupported_requirements_log(int argc, char **argv, struct comman
 
 	ret = get_c5_log_page(hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR : OCP : Failure reading the C5 Log Page, ret = %d\n", ret);
+		nvme_show_error("ERROR : OCP : Failure reading the C5 Log Page, ret = %d", ret);
 
 	return ret;
 }
@@ -1730,13 +1730,13 @@ static int get_c1_log_page(struct libnvme_transport_handle *hdl, char *format)
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR : OCP : invalid output format\n");
+		nvme_show_error("ERROR : OCP : invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * C1_ERROR_RECOVERY_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * C1_ERROR_RECOVERY_LOG_BUF_LEN);
@@ -1752,14 +1752,14 @@ static int get_c1_log_page(struct libnvme_transport_handle *hdl, char *format)
 		 */
 		for (i = 0; i < 16; i++) {
 			if (error_recovery_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR : OCP : Unknown GUID in C1 Log Page data\n");
-				fprintf(stderr, "ERROR : OCP : Expected GUID: 0x");
+				nvme_show_error("ERROR : OCP : Unknown GUID in C1 Log Page data");
+				nvme_show_error("ERROR : OCP : Expected GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", error_recovery_guid[j]);
-				fprintf(stderr, "\nERROR : OCP : Actual GUID: 0x");
+					nvme_show_error("%02x", error_recovery_guid[j]);
+				nvme_show_error("\nERROR : OCP : Actual GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%02x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -1767,7 +1767,7 @@ static int get_c1_log_page(struct libnvme_transport_handle *hdl, char *format)
 		}
 		ocp_c1_log(log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR : OCP : Unable to read C1 data from buffer\n");
+		nvme_show_error("ERROR : OCP : Unable to read C1 data from buffer");
 	}
 
 out:
@@ -1798,7 +1798,7 @@ static int ocp_error_recovery_log(int argc, char **argv, struct command *acmd, s
 
 	ret = get_c1_log_page(hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR : OCP : Failure reading the C1h Log Page, ret = %d\n", ret);
+		nvme_show_error("ERROR : OCP : Failure reading the C1h Log Page, ret = %d", ret);
 
 	return ret;
 }
@@ -1830,13 +1830,13 @@ static int get_c4_log_page(struct libnvme_transport_handle *hdl, char *format)
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR : OCP : invalid output format\n");
+		nvme_show_error("ERROR : OCP : invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * C4_DEV_CAP_REQ_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * C4_DEV_CAP_REQ_LEN);
@@ -1852,14 +1852,14 @@ static int get_c4_log_page(struct libnvme_transport_handle *hdl, char *format)
 		 */
 		for (i = 0; i < 16; i++) {
 			if (dev_cap_req_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR : OCP : Unknown GUID in C4 Log Page data\n");
-				fprintf(stderr, "ERROR : OCP : Expected GUID: 0x");
+				nvme_show_error("ERROR : OCP : Unknown GUID in C4 Log Page data");
+				nvme_show_error("ERROR : OCP : Expected GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", dev_cap_req_guid[j]);
-				fprintf(stderr, "\nERROR : OCP : Actual GUID: 0x");
+					nvme_show_error("%02x", dev_cap_req_guid[j]);
+				nvme_show_error("\nERROR : OCP : Actual GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%02x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -1867,7 +1867,7 @@ static int get_c4_log_page(struct libnvme_transport_handle *hdl, char *format)
 		}
 		ocp_c4_log(log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR : OCP : Unable to read C4 data from buffer\n");
+		nvme_show_error("ERROR : OCP : Unable to read C4 data from buffer");
 	}
 
 out:
@@ -1898,7 +1898,7 @@ static int ocp_device_capabilities_log(int argc, char **argv, struct command *ac
 
 	ret = get_c4_log_page(hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR : OCP : Failure reading the C4h Log Page, ret = %d\n", ret);
+		nvme_show_error("ERROR : OCP : Failure reading the C4h Log Page, ret = %d", ret);
 
 	return ret;
 }
@@ -1928,9 +1928,9 @@ static int ocp_set_telemetry_profile(struct libnvme_transport_handle *hdl, __u8 
 		nvme_show_status(err);
 	} else if (err < 0) {
 		nvme_show_perror("Set Telemetry Profile");
-		fprintf(stderr, "Command failed while parsing.\n");
+		nvme_show_error("Command failed while parsing.");
 	} else {
-		printf("Successfully Set Telemetry Profile (feature: 0xC8) to below values\n");
+		nvme_show_verbose_result("Successfully Set Telemetry Profile (feature: 0xC8) to below values");
 		printf("Telemetry Profile Select: 0x%x\n", tps);
 	}
 
@@ -2065,9 +2065,9 @@ set_dssd_power_state(struct libnvme_transport_handle *hdl,
 		nvme_show_status(err);
 	} else if (err < 0) {
 		nvme_show_perror("Define DSSD Power State");
-		fprintf(stderr, "Command failed while parsing.\n");
+		nvme_show_error("Command failed while parsing.");
 	} else {
-		printf("Successfully set DSSD Power State (feature: 0xC7) to below values\n");
+		nvme_show_verbose_result("Successfully set DSSD Power State (feature: 0xC7) to below values");
 		printf("DSSD Power State: 0x%x\n", power_state);
 		printf("Save bit Value: 0x%x\n", sv);
 	}
@@ -2142,7 +2142,7 @@ static int get_dssd_power_state(struct libnvme_transport_handle *hdl, const __u3
 		if (sel == NVME_GET_FEATURES_SEL_SUPPORTED)
 			nvme_show_select_result(fid, result);
 	} else {
-		nvme_show_error("Could not get feature: 0xC7 with sel: %d\n", sel);
+		nvme_show_error("Could not get feature: 0xC7 with sel: %d", sel);
 	}
 
 	return err;
@@ -2251,9 +2251,9 @@ static int set_plp_health_check_interval(int argc, char **argv, struct command *
 		nvme_show_status(err);
 	} else if (err < 0) {
 		nvme_show_perror("Define PLP Health Check Interval");
-		fprintf(stderr, "Command failed while parsing.\n");
+		nvme_show_error("Command failed while parsing.");
 	} else {
-		printf("Successfully set the PLP Health Check Interval");
+		nvme_show_verbose_result("Successfully set the PLP Health Check Interval");
 		printf("PLP Health Check Interval: 0x%x\n", cfg.plp_health_interval);
 		printf("Save bit Value: 0x%x\n", cfg.sv);
 	}
@@ -2353,9 +2353,9 @@ static int set_dssd_async_event_config(int argc, char **argv, struct command *ac
 		nvme_show_status(err);
 	} else if (err < 0) {
 		nvme_show_perror("Set DSSD Asynchronous Event Configuration\n");
-		fprintf(stderr, "Command failed while parsing.\n");
+		nvme_show_error("Command failed while parsing.");
 	} else {
-		printf("Successfully set the DSSD Asynchronous Event Configuration\n");
+		nvme_show_verbose_result("Successfully set the DSSD Asynchronous Event Configuration");
 		printf("Enable Panic Notices bit Value: 0x%x\n", cfg.epn);
 		printf("Save bit Value: 0x%x\n", cfg.sv);
 	}
@@ -2398,7 +2398,7 @@ static int get_dssd_async_event_config(int argc, char **argv, struct command *ac
 		if (cfg.sel == NVME_GET_FEATURES_SEL_SUPPORTED)
 			nvme_show_select_result(fid, result);
 	} else {
-		nvme_show_error("Could not get feature: 0xC9\n");
+		nvme_show_error("Could not get feature: 0xC9");
 	}
 
 	return err;
@@ -2423,7 +2423,7 @@ static int get_c9_log_page(struct libnvme_transport_handle *hdl,
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR : OCP : invalid output format\n");
+		nvme_show_error("ERROR : OCP : invalid output format");
 		return ret;
 	}
 
@@ -2432,7 +2432,7 @@ static int get_c9_log_page(struct libnvme_transport_handle *hdl,
 	if ((!ret) && (fmt != BINARY))
 		ocp_c9_log(log_data, pC9_string_buffer, total_log_page_sz, fmt);
 	else if (ret)
-		fprintf(stderr, "ERROR : OCP : Unable to read C9 data from buffer\n");
+		nvme_show_error("ERROR : OCP : Unable to read C9 data from buffer");
 
 	free(header_data);
 	return ret;
@@ -2475,7 +2475,7 @@ static int ocp_telemetry_str_log_format(int argc, char **argv, struct command *a
 
 	ret = get_c9_log_page(hdl, cfg.output_format, file_path);
 	if (ret)
-		fprintf(stderr, "ERROR : OCP : Failure reading the C9 Log Page, ret = %d\n", ret);
+		nvme_show_error("ERROR : OCP : Failure reading the C9 Log Page, ret = %d", ret);
 
 	return ret;
 }
@@ -2511,13 +2511,13 @@ static int get_c7_log_page(struct libnvme_transport_handle *hdl, char *format)
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR : OCP : invalid output format\n");
+		nvme_show_error("ERROR : OCP : invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * C7_TCG_CONFIGURATION_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * C7_TCG_CONFIGURATION_LEN);
@@ -2532,14 +2532,14 @@ static int get_c7_log_page(struct libnvme_transport_handle *hdl, char *format)
 		 */
 		for (i = 0; i < 16; i++) {
 			if (tcg_configuration_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR : OCP : Unknown GUID in C7 Log Page data\n");
-				fprintf(stderr, "ERROR : OCP : Expected GUID: 0x");
+				nvme_show_error("ERROR : OCP : Unknown GUID in C7 Log Page data");
+				nvme_show_error("ERROR : OCP : Expected GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", tcg_configuration_guid[j]);
-				fprintf(stderr, "\nERROR : OCP : Actual GUID: 0x");
+					nvme_show_error("%02x", tcg_configuration_guid[j]);
+				nvme_show_error("\nERROR : OCP : Actual GUID: 0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%02x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%02x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -2547,7 +2547,7 @@ static int get_c7_log_page(struct libnvme_transport_handle *hdl, char *format)
 		}
 		ocp_c7_log(hdl, log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR : OCP : Unable to read C7 data from buffer\n");
+		nvme_show_error("ERROR : OCP : Unable to read C7 data from buffer");
 	}
 
 out:
@@ -2579,7 +2579,7 @@ static int ocp_tcg_configuration_log(int argc, char **argv, struct command *acmd
 
 	ret = get_c7_log_page(hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR : OCP : Failure reading the C7 Log Page, ret = %d\n", ret);
+		nvme_show_error("ERROR : OCP : Failure reading the C7 Log Page, ret = %d", ret);
 
 	return ret;
 }
@@ -2884,7 +2884,7 @@ static int enable_ieee1667_silo_set(struct libnvme_transport_handle *hdl,
 		nvme_show_status(err);
 	} else if (err < 0) {
 		nvme_show_perror(enable_ieee1667_silo);
-		fprintf(stderr, "Command failed while parsing.\n");
+		nvme_show_error("Command failed while parsing.");
 	} else {
 		nvme_show_result("Successfully set enable (feature: 0x%02x): %d (%s: %s).", fid,
 				 enable, save ? "Save" : "Not save",

--- a/plugins/ocp/ocp-print.c
+++ b/plugins/ocp/ocp-print.c
@@ -9,7 +9,7 @@
 		if (ops && ops->name) \
 			ops->name(__VA_ARGS__); \
 		else \
-			fprintf(stderr, "unhandled output format\n"); \
+			nvme_show_error("unhandled output format"); \
 	} while (false)
 
 static struct ocp_print_ops *ocp_print_ops(nvme_print_flags_t flags)

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -38,13 +38,13 @@ static int get_c0_log_page(struct libnvme_transport_handle *hdl, char *format,
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR : OCP : invalid output format\n");
+		nvme_show_error("ERROR : OCP : invalid output format");
 		return ret;
 	}
 
 	data = malloc(sizeof(__u8) * C0_SMART_CLOUD_ATTR_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR : OCP : malloc : %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * C0_SMART_CLOUD_ATTR_LEN);
@@ -59,7 +59,7 @@ static int get_c0_log_page(struct libnvme_transport_handle *hdl, char *format,
 	ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 
 	if (strcmp(format, "json"))
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
+		nvme_show_error("NVMe Status:%s(%x)",
 			libnvme_status_to_string(ret, false), ret);
 
 	if (ret == 0) {
@@ -69,15 +69,15 @@ static int get_c0_log_page(struct libnvme_transport_handle *hdl, char *format,
 			if (scao_guid[i] != data->log_page_guid[i]) {
 				int j;
 
-				fprintf(stderr, "ERROR : OCP : Unknown GUID in C0 Log Page data\n");
-				fprintf(stderr, "ERROR : OCP : Expected GUID:  0x");
+				nvme_show_error("ERROR : OCP : Unknown GUID in C0 Log Page data");
+				nvme_show_error("ERROR : OCP : Expected GUID:  0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", scao_guid[j]);
+					nvme_show_error("%x", scao_guid[j]);
 
-				fprintf(stderr, "\nERROR : OCP : Actual GUID:    0x");
+				nvme_show_error("\nERROR : OCP : Actual GUID:    0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -87,7 +87,7 @@ static int get_c0_log_page(struct libnvme_transport_handle *hdl, char *format,
 		/* print the data */
 		ocp_smart_extended_log(data, format_version, fmt);
 	} else {
-		fprintf(stderr, "ERROR : OCP : Unable to read C0 data from buffer\n");
+		nvme_show_error("ERROR : OCP : Unable to read C0 data from buffer");
 	}
 
 out:
@@ -112,7 +112,7 @@ int ocp_smart_add_log(int argc, char **argv, struct command *acmd,
 	ret = get_c0_log_page(hdl, nvme_args.output_format,
 			      nvme_args.output_format_ver);
 	if (ret)
-		fprintf(stderr, "ERROR : OCP : Failure reading the C0 Log Page, ret = %d\n",
+		nvme_show_error("ERROR : OCP : Failure reading the C0 Log Page, ret = %d",
 			ret);
 	return ret;
 }

--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1097,7 +1097,7 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 		parse_ocp_telemetry_string_log(event_fifo_number, 0, 0, EVENT_STRING, description);
 
 	if (status != 0) {
-		nvme_show_error("Failed to get C9 String. status: %d\n", status);
+		nvme_show_error("Failed to get C9 String. status: %d", status);
 		return -1;
 	}
 
@@ -1245,12 +1245,12 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 			}
 
 			if (ret) {
-				fprintf(stderr,
+				nvme_show_error(
 					"ERROR : OCP : Invalid NVMe Event FIFO entry\n");
-				fprintf(stderr,
+				nvme_show_error(
 					"FIFO: %d, offset: 0x%x\n",
 					fifo_num, offset_to_move);
-				fprintf(stderr,
+				nvme_show_error(
 					"Type: 0x%x, ID: 0x%x, Size: 0x%x\n",
 					pevent_descriptor->debug_event_class_type,
 					pevent_descriptor->event_id,
@@ -1392,7 +1392,7 @@ int parse_event_fifos(struct json_object *root, struct nvme_ocp_telemetry_offset
 						      pstring_buffer, poffsets, fifo_size, fp);
 
 			if (status != 0) {
-				nvme_show_error("Failed to parse Event FIFO. status:%d\n", status);
+				nvme_show_error("Failed to parse Event FIFO. status:%d", status);
 				return -1;
 			}
 		}
@@ -1726,7 +1726,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 
 			status = parse_statistics(NULL, &offsets, fp);
 			if (status != 0) {
-				nvme_show_error("status: %d\n", status);
+				nvme_show_error("status: %d", status);
 				return -1;
 			}
 
@@ -1746,7 +1746,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 				status = parse_statistics(NULL, &offsets, fp);
 
 				if (status != 0) {
-					nvme_show_error("status: %d\n", status);
+					nvme_show_error("status: %d", status);
 					return -1;
 				}
 
@@ -1761,7 +1761,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			fprintf(fp, STR_LINE);
 			fclose(fp);
 		} else {
-			nvme_show_error("Failed to open %s file.\n", file_path);
+			nvme_show_error("Failed to open %s file.", file_path);
 			return -1;
 		}
 	} else {
@@ -1831,7 +1831,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 		printf(STR_LINE);
 		status = parse_statistics(NULL, &offsets, NULL);
 		if (status != 0) {
-			nvme_show_error("status: %d\n", status);
+			nvme_show_error("status: %d", status);
 			return -1;
 		}
 
@@ -1850,7 +1850,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			printf(STR_LINE);
 			status = parse_statistics(NULL, &offsets, NULL);
 			if (status != 0) {
-				nvme_show_error("status: %d\n", status);
+				nvme_show_error("status: %d", status);
 				return -1;
 			}
 
@@ -1936,7 +1936,7 @@ int print_ocp_telemetry_json(struct ocp_telemetry_parse_options *options)
 	//Data Area 1 Statistics
 	status = parse_statistics(root, &offsets, NULL);
 	if (status != 0) {
-		nvme_show_error("status: %d\n", status);
+		nvme_show_error("status: %d", status);
 		return -1;
 	}
 
@@ -1951,7 +1951,7 @@ int print_ocp_telemetry_json(struct ocp_telemetry_parse_options *options)
 		//Data Area 2 Statistics
 		status = parse_statistics(root, &offsets, NULL);
 		if (status != 0) {
-			nvme_show_error("status: %d\n", status);
+			nvme_show_error("status: %d", status);
 			return -1;
 		}
 
@@ -1970,7 +1970,7 @@ int print_ocp_telemetry_json(struct ocp_telemetry_parse_options *options)
 			fputs(json_string, fp);
 			fclose(fp);
 		} else {
-			nvme_show_error("Failed to open %s file.\n", file_path);
+			nvme_show_error("Failed to open %s file.", file_path);
 			return -1;
 		}
 	} else {

--- a/plugins/registry/registry-nvme.c
+++ b/plugins/registry/registry-nvme.c
@@ -16,6 +16,7 @@
 
 #include "common.h"
 #include "nvme.h"
+#include "nvme-print.h"
 #include "util/cleanup.h"
 
 #define CREATE_CMD
@@ -58,7 +59,7 @@ static bool confirm_owner_change(void)
 	if (!isatty(STDIN_FILENO))
 		return true;
 
-	fprintf(stderr,
+	nvme_show_error(
 		"Changing or removing the owner may prevent NVMe orchestrators from\n"
 		"protecting this controller against accidental removal. Continue? [y/N]: ");
 
@@ -124,11 +125,11 @@ static int registry_retrieve(int argc, char **argv, struct command *acmd,
 
 	device = get_device(argc, argv);
 	if (!device) {
-		fprintf(stderr, "device required\n");
+		nvme_show_error("device required");
 		return -EINVAL;
 	}
 	if (!cfg.attr) {
-		fprintf(stderr, "--attr required\n");
+		nvme_show_error("--attr required");
 		return -EINVAL;
 	}
 
@@ -139,12 +140,12 @@ static int registry_retrieve(int argc, char **argv, struct command *acmd,
 
 	ret = libnvmf_registry_retrieve(ctx, device, cfg.attr, &value);
 	if (ret == -ENOENT) {
-		fprintf(stderr, "%s: not registered or '%s' not found\n",
+		nvme_show_error("%s: not registered or '%s' not found",
 			device, cfg.attr);
 		return ret;
 	}
 	if (ret) {
-		fprintf(stderr, "retrieve failed: %s\n", libnvme_strerror(-ret));
+		nvme_show_error("retrieve failed: %s", libnvme_strerror(-ret));
 		return ret;
 	}
 	printf("%s\n", value);
@@ -178,16 +179,16 @@ static int registry_update(int argc, char **argv, struct command *acmd,
 
 	device = get_device(argc, argv);
 	if (!device) {
-		fprintf(stderr, "device required\n");
+		nvme_show_error("device required");
 		return -EINVAL;
 	}
 	if (!cfg.attr || !cfg.value) {
-		fprintf(stderr, "--attr and --value are required\n");
+		nvme_show_error("--attr and --value are required");
 		return -EINVAL;
 	}
 
 	if (!strcmp(cfg.attr, "owner") && !confirm_owner_change()) {
-		fprintf(stderr, "Aborted.\n");
+		nvme_show_error("Aborted.");
 		return 0;
 	}
 
@@ -198,7 +199,7 @@ static int registry_update(int argc, char **argv, struct command *acmd,
 
 	ret = libnvmf_registry_update(ctx, device, cfg.attr, cfg.value);
 	if (ret)
-		fprintf(stderr, "update failed: %s\n", libnvme_strerror(-ret));
+		nvme_show_error("update failed: %s", libnvme_strerror(-ret));
 	return ret;
 }
 
@@ -226,7 +227,7 @@ static int registry_delete(int argc, char **argv, struct command *acmd,
 
 	device = get_device(argc, argv);
 	if (!device) {
-		fprintf(stderr, "device required\n");
+		nvme_show_error("device required");
 		return -EINVAL;
 	}
 
@@ -237,7 +238,7 @@ static int registry_delete(int argc, char **argv, struct command *acmd,
 	 */
 	if ((!cfg.attr || !strcmp(cfg.attr, "owner")) &&
 	    !confirm_owner_change()) {
-		fprintf(stderr, "Aborted.\n");
+		nvme_show_error("Aborted.");
 		return 0;
 	}
 
@@ -251,6 +252,6 @@ static int registry_delete(int argc, char **argv, struct command *acmd,
 	else
 		ret = libnvmf_registry_delete(ctx, device);
 	if (ret)
-		fprintf(stderr, "%s: %s\n", device, libnvme_strerror(-ret));
+		nvme_show_error("%s: %s", device, libnvme_strerror(-ret));
 	return ret;
 }

--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -53,12 +53,12 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	err = nvme_identify_ctrl(hdl, &ctrl);
 	if (err) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", err);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", err);
 		return err;
 	}
 
 	if (!(ctrl.lpa & 0x8)) {
-		fprintf(stderr, "Telemetry log pages not supported by device\n");
+		nvme_show_error("Telemetry log pages not supported by device");
 		return -EINVAL;
 	}
 
@@ -69,14 +69,14 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 
 	if (data_area == 4) {
 		if (!(ctrl.lpa & 0x40)) {
-			fprintf(stderr, "%s: Telemetry data area 4 not supported by device\n",
+			nvme_show_error("%s: Telemetry data area 4 not supported by device",
 				__func__);
 			return -EINVAL;
 		}
 
 		err = libnvme_set_etdas(hdl, &host_behavior_changed);
 		if (err) {
-			fprintf(stderr, "%s: Failed to set ETDAS bit\n", __func__);
+			nvme_show_error("%s: Failed to set ETDAS bit", __func__);
 			return err;
 		}
 	}
@@ -93,23 +93,23 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 		host_gen = 0;
 		ctrl_init = 1;
 	} else if (type == SNDK_TELEMETRY_TYPE_BOTH) {
-		fprintf(stderr,
+		nvme_show_error(
 			"%s: BOTH type should be handled by sndk_do_cap_both_telemetry_log\n",
 			__func__);
 		return -EINVAL;
 	} else {
-		fprintf(stderr, "%s: Invalid type parameter; type = %d\n", __func__, type);
+		nvme_show_error("%s: Invalid type parameter; type = %d", __func__, type);
 		return -EINVAL;
 	}
 
 	if (!file) {
-		fprintf(stderr, "%s: Please provide an output file!\n", __func__);
+		nvme_show_error("%s: Please provide an output file!", __func__);
 		return -EINVAL;
 	}
 
 	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
-		fprintf(stderr, "%s: Failed to open output file %s: %s!\n",
+		nvme_show_error("%s: Failed to open output file %s: %s!",
 				__func__, file, libnvme_strerror(errno));
 		return output;
 	}
@@ -129,7 +129,7 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 		goto close_output;
 	} else if (err > 0) {
 		nvme_show_status(err);
-		fprintf(stderr, "%s: Failed to acquire telemetry header!\n", __func__);
+		nvme_show_error("%s: Failed to acquire telemetry header!", __func__);
 		goto close_output;
 	}
 
@@ -152,7 +152,7 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 			data_ptr += data_written;
 		} else {
 			/* Unexpected overwrite */
-			fprintf(stderr, "Failure: Unexpected telemetry log overwrite\n" \
+			nvme_show_error("Failure: Unexpected telemetry log overwrite" \
 				"- data_remaining = 0x%x, data_written = 0x%x\n",
 				data_remaining, data_written);
 			break;
@@ -160,7 +160,7 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 	}
 
 	if (fsync(output) < 0) {
-		fprintf(stderr, "ERROR: %s: fsync: %s\n", __func__, libnvme_strerror(errno));
+		nvme_show_error("ERROR: %s: fsync: %s", __func__, libnvme_strerror(errno));
 		err = -1;
 	}
 
@@ -168,7 +168,7 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 		host_behavior_changed = false;
 		err = libnvme_clear_etdas(hdl, &host_behavior_changed);
 		if (err) {
-			fprintf(stderr, "%s: Failed to clear ETDAS bit\n", __func__);
+			nvme_show_error("%s: Failed to clear ETDAS bit", __func__);
 			return err;
 		}
 	}
@@ -192,7 +192,7 @@ static int sndk_do_cap_both_telemetry_log(struct libnvme_global_ctx *ctx,
 
 	base_name = strdup(tar_file);
 	if (!base_name) {
-		fprintf(stderr, "%s: Memory allocation failed\n", __func__);
+		nvme_show_error("%s: Memory allocation failed", __func__);
 		return -ENOMEM;
 	}
 	
@@ -207,40 +207,40 @@ static int sndk_do_cap_both_telemetry_log(struct libnvme_global_ctx *ctx,
 	snprintf(controller_file, PATH_MAX, "%s_controller_telemetry.bin",
 		 base_name);
 	
-	fprintf(stderr, "%s: Capturing HOST telemetry to %s\n", __func__,
+	nvme_show_error("%s: Capturing HOST telemetry to %s", __func__,
 		host_file);
 	ret = sndk_do_cap_telemetry_log(ctx, hdl, host_file, bs,
 					SNDK_TELEMETRY_TYPE_HOST, data_area);
 	if (ret) {
-		fprintf(stderr, "%s: Failed to capture HOST telemetry: %d\n",
+		nvme_show_error("%s: Failed to capture HOST telemetry: %d",
 			__func__, ret);
 		goto cleanup;
 	}
 	
-	fprintf(stderr, "%s: Capturing CONTROLLER telemetry to %s\n", __func__,
+	nvme_show_error("%s: Capturing CONTROLLER telemetry to %s", __func__,
 		controller_file);
 	ret = sndk_do_cap_telemetry_log(ctx, hdl, controller_file, bs,
 					SNDK_TELEMETRY_TYPE_CONTROLLER,
 					data_area);
 	if (ret) {
-		fprintf(stderr,
+		nvme_show_error(
 			"%s: Failed to capture CONTROLLER telemetry: %d\n",
 			__func__, ret);
 		goto cleanup_host;
 	}
 	
 	/* Create tar file containing both telemetry files */
-	fprintf(stderr, "%s: Creating tar file %s\n", __func__, tar_file);
+	nvme_show_error("%s: Creating tar file %s", __func__, tar_file);
 	snprintf(tar_cmd, sizeof(tar_cmd), "tar -cf \"%s\" \"%s\" \"%s\"",
 		 tar_file, host_file, controller_file);
 	
 	ret = system(tar_cmd);
 	if (ret) {
-		fprintf(stderr, "%s: Failed to create tar file: %s\n",
+		nvme_show_error("%s: Failed to create tar file: %s",
 			__func__, tar_file);
 		ret = -1;
 	} else {
-		fprintf(stderr, "%s: Successfully created tar file: %s\n",
+		nvme_show_verbose_result("%s: Successfully created tar file: %s",
 			__func__, tar_file);
 		ret = 0;
 	}
@@ -269,7 +269,7 @@ static __u32 sndk_dump_udui_data(struct libnvme_transport_handle *hdl,
 	admin_cmd.cdw12 = offset;
 	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
-		fprintf(stderr, "ERROR: SNDK: reading DUI data failed\n");
+		nvme_show_error("ERROR: SNDK: reading DUI data failed");
 		nvme_show_status(ret);
 	}
 
@@ -290,7 +290,7 @@ static int sndk_do_cap_udui(struct libnvme_transport_handle *hdl, char *file,
 
 	log = (struct nvme_telemetry_log *)malloc(udui_log_hdr_size);
 	if (!log) {
-		fprintf(stderr,
+		nvme_show_error(
 			"%s: ERROR: log header malloc failed : status %s, size 0x%x\n",
 			__func__, libnvme_strerror(errno), udui_log_hdr_size);
 		return -1;
@@ -300,7 +300,7 @@ static int sndk_do_cap_udui(struct libnvme_transport_handle *hdl, char *file,
 	/* get the udui telemetry and log headers */
 	ret = sndk_dump_udui_data(hdl, udui_log_hdr_size, 0, (__u8 *)log);
 	if (ret) {
-		fprintf(stderr, "%s: ERROR: SNDK: Get UDUI header failed\n", __func__);
+		nvme_show_error("%s: ERROR: SNDK: Get UDUI header failed", __func__);
 		nvme_show_status(ret);
 		goto out;
 	}
@@ -311,7 +311,7 @@ static int sndk_do_cap_udui(struct libnvme_transport_handle *hdl, char *file,
 
 	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
-		fprintf(stderr, "%s: Failed to open output file %s: %s!\n", __func__, file,
+		nvme_show_error("%s: Failed to open output file %s: %s!", __func__, file,
 			libnvme_strerror(errno));
 		goto out;
 	}
@@ -322,7 +322,7 @@ static int sndk_do_cap_udui(struct libnvme_transport_handle *hdl, char *file,
 		ret = sndk_dump_udui_data(hdl, chunk_size, offset,
 					  ((__u8 *)log));
 		if (ret) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: Get UDUI failed, offset = 0x%"PRIx64", size = %u\n",
 				__func__, (uint64_t)offset, chunk_size);
 			break;
@@ -331,7 +331,7 @@ static int sndk_do_cap_udui(struct libnvme_transport_handle *hdl, char *file,
 		/* write the dump data into the file */
 		written = write(output, (void *)log, chunk_size);
 		if (written != chunk_size) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: SNDK: Failed to flush DUI data to file!\n" \
 				"- written = %zd, offset = 0x%"PRIx64", chunk_size = %u\n",
 				__func__, written, (uint64_t)offset, chunk_size);
@@ -345,7 +345,7 @@ static int sndk_do_cap_udui(struct libnvme_transport_handle *hdl, char *file,
 	close(output);
 	nvme_show_status(ret);
 	if (verbose)
-		fprintf(stderr,
+		nvme_show_error(
 			"INFO: SNDK: Capture Device Unit Info log length = 0x%"PRIx64"\n",
 			(uint64_t)total_size);
 
@@ -363,7 +363,7 @@ static int sndk_get_default_telemetry_da(struct libnvme_transport_handle *hdl,
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	err = nvme_identify_ctrl(hdl, &ctrl);
 	if (err) {
-		fprintf(stderr, "ERROR: SNDK: nvme_identify_ctrl() failed 0x%x\n", err);
+		nvme_show_error("ERROR: SNDK: nvme_identify_ctrl() failed 0x%x", err);
 		return err;
 	}
 
@@ -448,7 +448,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 	if (cfg.xfer_size) {
 		xfer_size = cfg.xfer_size;
 	} else {
-		fprintf(stderr, "ERROR: SNDK: Invalid length\n");
+		nvme_show_error("ERROR: SNDK: Invalid length");
 		goto out;
 	}
 
@@ -460,7 +460,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 		/* verify file name and path is valid before getting dump data */
 		verify_file = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (verify_file < 0) {
-			fprintf(stderr, "ERROR: SNDK: open: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: SNDK: open: %s", libnvme_strerror(errno));
 			goto out;
 		}
 		close(verify_file);
@@ -478,24 +478,24 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 
 		ret = sndk_get_serial_name(hdl, f, PATH_MAX-5, fileSuffix);
 		if (ret) {
-			fprintf(stderr, "ERROR: SNDK: failed to generate file name\n");
+			nvme_show_error("ERROR: SNDK: failed to generate file name");
 			goto out;
 		}
 	}
 
 	if (!cfg.file) {
 		if (strlen(f) > PATH_MAX - 5) {
-			fprintf(stderr, "ERROR: SNDK: file name overflow\n");
+			nvme_show_error("ERROR: SNDK: file name overflow");
 			ret = -1;
 			goto out;
 		}
 		strcat(f, ".bin");
 	}
-	fprintf(stderr, "%s: filename = %s\n", __func__, f);
+	nvme_show_error("%s: filename = %s", __func__, f);
 
 	if (cfg.data_area) {
 		if (cfg.data_area > 5 || cfg.data_area < 1) {
-			fprintf(stderr, "ERROR: SNDK: Data area must be 1-5\n");
+			nvme_show_error("ERROR: SNDK: Data area must be 1-5");
 			ret = -1;
 			goto out;
 		}
@@ -514,7 +514,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 		telemetry_type = SNDK_TELEMETRY_TYPE_BOTH;
 		telemetry_data_area = cfg.data_area;
 	} else {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: SNDK: Invalid type - Must be NONE, HOST, CONTROLLER, or BOTH\n");
 		ret = -1;
 		goto out;
@@ -527,7 +527,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 		/* If no data area specified, get the default value */
 		if (telemetry_data_area == 0) {
 			if (sndk_get_default_telemetry_da(hdl, &telemetry_data_area)) {
-				fprintf(stderr, "%s: Error determining default telemetry data area\n",
+				nvme_show_error("%s: Error determining default telemetry data area",
 						__func__);
 				return -EINVAL;
 			}
@@ -559,7 +559,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 
 	if (capabilities & SNDK_DRIVE_CAP_UDUI) {
 		if (cfg.data_area) {
-			fprintf(stderr,
+			nvme_show_error(
 				"ERROR: SNDK: Data area parameter is not supported when type is NONE\n");
 			ret = -1;
 			goto out;
@@ -676,10 +676,10 @@ static int sndk_drive_resize(int argc, char **argv,
 		ret = sndk_do_sn861_drive_resize(hdl, cfg.size, &result);
 
 		if (!ret) {
-			fprintf(stderr, "The drive-resize command was successful.  A system ");
-			fprintf(stderr, "shutdown is required to complete the operation.\n");
+			nvme_show_verbose_result("The drive-resize command was successful.  A system ");
+			nvme_show_error("shutdown is required to complete the operation.");
 		} else
-			fprintf(stderr, "ERROR: SNDK: %s failure, ret: %d, result: 0x%"PRIx64"\n",
+			nvme_show_error("ERROR: SNDK: %s failure, ret: %d, result: 0x%"PRIx64"\n",
 					__func__, ret, (uint64_t)result);
 	} else {
 		/* Fallback to WDC plugin command if otherwise not supported */
@@ -794,7 +794,7 @@ static void sndk_print_fw_act_history_log_normal(__u8 *data, int num_entries)
 				entryIdx = 0;
 		}
 	} else
-		fprintf(stderr, "ERROR: SNDK: %s: Unknown log page\n", __func__);
+		nvme_show_error("ERROR: SNDK: %s: Unknown log page", __func__);
 }
 
 static void sndk_print_fw_act_history_log_json(__u8 *data, int num_entries)
@@ -897,7 +897,7 @@ static void sndk_print_fw_act_history_log_json(__u8 *data, int num_entries)
 				entryIdx = 0;
 		}
 	} else
-		fprintf(stderr, "ERROR: SNDK: %s: Unknown log page\n", __func__);
+		nvme_show_error("ERROR: SNDK: %s: Unknown log page", __func__);
 
 	json_free_object(root);
 }
@@ -905,7 +905,7 @@ static void sndk_print_fw_act_history_log_json(__u8 *data, int num_entries)
 static int sndk_print_fw_act_history_log(__u8 *data, int num_entries, int fmt)
 {
 	if (!data) {
-		fprintf(stderr, "ERROR: SNDK: Invalid buffer in print_fw act_history_log\n");
+		nvme_show_error("ERROR: SNDK: Invalid buffer in print_fw act_history_log");
 		return -1;
 	}
 
@@ -935,13 +935,13 @@ static int sndk_get_fw_act_history_C2(struct libnvme_global_ctx *ctx, struct lib
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: SNDK: invalid output format\n");
+		nvme_show_error("ERROR: SNDK: invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * SNDK_FW_ACT_HISTORY_C2_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: SNDK: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: SNDK: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -972,15 +972,15 @@ static int sndk_get_fw_act_history_C2(struct libnvme_global_ctx *ctx, struct lib
 				ret = sndk_print_fw_act_history_log(data, num_entries,
 					fmt);
 			} else  {
-				fprintf(stderr, "INFO: SNDK: No entries found.\n");
+				nvme_show_error("INFO: SNDK: No entries found.");
 				ret = 0;
 			}
 		} else {
-			fprintf(stderr, "ERROR: SNDK: Invalid C2 log page GUID\n");
+			nvme_show_error("ERROR: SNDK: Invalid C2 log page GUID");
 			ret = -1;
 		}
 	} else {
-		fprintf(stderr, "ERROR: SNDK: Unable to read FW Activate History Log Page data\n");
+		nvme_show_error("ERROR: SNDK: Unable to read FW Activate History Log Page data");
 		ret = -1;
 	}
 
@@ -1022,8 +1022,8 @@ static int sndk_vs_fw_activate_history(int argc, char **argv,
 		ret = sndk_get_fw_act_history_C2(ctx, hdl, cfg.output_format);
 
 		if (ret) {
-			fprintf(stderr, "ERROR: SNDK: Failure reading the FW ");
-			fprintf(stderr, "Activate History, ret = %d\n", ret);
+			nvme_show_error("ERROR: SNDK: Failure reading the FW ");
+			nvme_show_error("Activate History, ret = %d", ret);
 		}
 	} else
 		/* Fall back to the wdc plugin command */
@@ -1070,8 +1070,8 @@ static int sndk_clear_fw_activate_history(int argc, char **argv,
 		ret = sndk_do_clear_fw_activate_history_fid(hdl);
 
 		if (ret) {
-			fprintf(stderr, "ERROR: SNDK: Failure clearing the FW ");
-			fprintf(stderr, "Activate History, ret = %d\n", ret);
+			nvme_show_error("ERROR: SNDK: Failure clearing the FW ");
+			nvme_show_error("Activate History, ret = %d", ret);
 		}
 	} else
 		/* Fall back to the wdc plugin command */

--- a/plugins/sandisk/sandisk-utils.c
+++ b/plugins/sandisk/sandisk-utils.c
@@ -60,7 +60,7 @@ int sndk_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transport_ha
 	} else {
 		ret = libnvme_scan_namespace(ctx, name, &n);
 		if (!ret) {
-			fprintf(stderr, "Unable to find %s\n", name);
+			nvme_show_error("Unable to find %s", name);
 			return ret;
 		}
 
@@ -73,7 +73,7 @@ int sndk_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transport_ha
 
 	fd = open(vid, O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "ERROR: SNDK: %s : Open vendor file failed\n", __func__);
+		nvme_show_error("ERROR: SNDK: %s : Open vendor file failed", __func__);
 		return -1;
 	}
 
@@ -81,7 +81,7 @@ int sndk_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transport_ha
 	close(fd);
 
 	if (ret < 0) {
-		fprintf(stderr, "%s: Read of pci vendor id failed\n", __func__);
+		nvme_show_error("%s: Read of pci vendor id failed", __func__);
 		return -1;
 	}
 	id[ret < 32 ? ret : 31] = '\0';
@@ -93,7 +93,7 @@ int sndk_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transport_ha
 
 	fd = open(did, O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "ERROR: SNDK: %s : Open device file failed\n", __func__);
+		nvme_show_error("ERROR: SNDK: %s : Open device file failed", __func__);
 		return -1;
 	}
 
@@ -101,7 +101,7 @@ int sndk_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transport_ha
 	close(fd);
 
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: SNDK: %s: Read of pci device id failed\n", __func__);
+		nvme_show_error("ERROR: SNDK: %s: Read of pci device id failed", __func__);
 		return -1;
 	}
 	id[ret < 32 ? ret : 31] = '\0';
@@ -120,7 +120,7 @@ int sndk_get_vendor_id(struct libnvme_transport_handle *hdl, uint32_t *vendor_id
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: SNDK: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: SNDK: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 
@@ -149,7 +149,7 @@ bool sndk_check_device(struct libnvme_global_ctx *ctx,
 	    read_vendor_id == SNDK_NVME_WDC_VID)
 		supported = true;
 	else
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: SNDK: unsupported Sandisk device, Vendor ID = 0x%x, Device ID = 0x%x\n",
 			read_vendor_id, read_device_id);
 
@@ -204,7 +204,7 @@ bool sndk_parse_dev_mng_log_entry(void *data,
 	log_length = le32_to_cpu(hdr_ptr->length);
 	/* Ensure log data is large enough for common header */
 	if (log_length < sizeof(struct sndk_c2_log_page_header)) {
-		fprintf(stderr,
+		nvme_show_error(
 		    "ERROR: %s: log smaller than header. log_len: 0x%x  HdrSize: %"PRIxPTR"\n",
 		    __func__, log_length, sizeof(struct sndk_c2_log_page_header));
 		return found;
@@ -216,7 +216,7 @@ bool sndk_parse_dev_mng_log_entry(void *data,
 	remaining_len = log_length - offset;
 
 	if (!log_entry) {
-		fprintf(stderr, "ERROR: SNDK - %s: No log entry pointer.\n", __func__);
+		nvme_show_error("ERROR: SNDK - %s: No log entry pointer.", __func__);
 		return found;
 	}
 	*log_entry = NULL;
@@ -232,22 +232,22 @@ bool sndk_parse_dev_mng_log_entry(void *data,
 		 * of the data, we must be at the end of the data
 		 */
 		if (!log_entry_size || log_entry_size > remaining_len) {
-			fprintf(stderr, "ERROR: SNDK: %s: Detected unaligned end of the data. ",
+			nvme_show_error("ERROR: SNDK: %s: Detected unaligned end of the data. ",
 				__func__);
-			fprintf(stderr, "Data Offset: 0x%x Entry Size: 0x%x, ",
+			nvme_show_error("Data Offset: 0x%x Entry Size: 0x%x, ",
 				offset, log_entry_size);
-			fprintf(stderr, "Remaining Log Length: 0x%x Entry Id: 0x%x\n",
+			nvme_show_error("Remaining Log Length: 0x%x Entry Id: 0x%x",
 				remaining_len, log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
 		} else if (!log_entry_id || log_entry_id > 200) {
 			/* Invalid entry - fail the search */
-			fprintf(stderr, "ERROR: SNDK: %s: Invalid entry found at offset: 0x%x ",
+			nvme_show_error("ERROR: SNDK: %s: Invalid entry found at offset: 0x%x ",
 				__func__, offset);
-			fprintf(stderr, "Entry Size: 0x%x, Remaining Log Length: 0x%x ",
+			nvme_show_error("Entry Size: 0x%x, Remaining Log Length: 0x%x ",
 				log_entry_size, remaining_len);
-			fprintf(stderr, "Entry Id: 0x%x\n", log_entry_id);
+			nvme_show_error("Entry Id: 0x%x", log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
@@ -352,13 +352,13 @@ bool sndk_get_dev_mgment_data(struct libnvme_global_ctx *ctx, struct libnvme_tra
 		if (uuid_index >= 0)
 			found = sndk_get_dev_mgmt_log_page_data(hdl, data, uuid_index);
 		else {
-			fprintf(stderr, "%s: UUID lists are supported but a matching ",
+			nvme_show_error("%s: UUID lists are supported but a matching ",
 				__func__);
-			fprintf(stderr, "uuid was not found\n");
+			nvme_show_error("uuid was not found");
 		}
 	} else {
 		/* UUID lists are not supported, Default to uuid-index 0  */
-		fprintf(stderr, "INFO: SNDK: %s:  UUID Lists not supported\n",
+		nvme_show_error("INFO: SNDK: %s:  UUID Lists not supported",
 				__func__);
 		uuid_index = 0;
 		found = sndk_get_dev_mgmt_log_page_data(hdl, data, uuid_index);
@@ -381,7 +381,7 @@ bool sndk_validate_dev_mng_log(void *data)
 	log_length = le32_to_cpu(hdr_ptr->length);
 	/* Ensure log data is large enough for common header */
 	if (log_length < sizeof(struct sndk_c2_log_page_header)) {
-		fprintf(stderr,
+		nvme_show_error(
 		    "ERROR: %s: log smaller than header. log_len: 0x%x  HdrSize: %"PRIxPTR"\n",
 		    __func__, log_length, sizeof(struct sndk_c2_log_page_header));
 		return valid_log;
@@ -402,22 +402,22 @@ bool sndk_validate_dev_mng_log(void *data)
 		 * of the data, we must be at the end of the data
 		 */
 		if (!log_entry_size || log_entry_size > remaining_len) {
-			fprintf(stderr, "ERROR: SNDK: %s: Detected unaligned end of the data. ",
+			nvme_show_error("ERROR: SNDK: %s: Detected unaligned end of the data. ",
 				__func__);
-			fprintf(stderr, "Data Offset: 0x%x Entry Size: 0x%x, ",
+			nvme_show_error("Data Offset: 0x%x Entry Size: 0x%x, ",
 				offset, log_entry_size);
-			fprintf(stderr, "Remaining Log Length: 0x%x Entry Id: 0x%x\n",
+			nvme_show_error("Remaining Log Length: 0x%x Entry Id: 0x%x",
 				remaining_len, log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
 		} else if (!log_entry_id || log_entry_id > 200) {
 			/* Invalid entry - fail the search */
-			fprintf(stderr, "ERROR: SNDK: %s: Invalid entry found at offset: 0x%x ",
+			nvme_show_error("ERROR: SNDK: %s: Invalid entry found at offset: 0x%x ",
 				__func__, offset);
-			fprintf(stderr, "Entry Size: 0x%x, Remaining Log Length: 0x%x ",
+			nvme_show_error("Entry Size: 0x%x, Remaining Log Length: 0x%x ",
 				log_entry_size, remaining_len);
-			fprintf(stderr, "Entry Id: 0x%x\n", log_entry_id);
+			nvme_show_error("Entry Id: 0x%x", log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
@@ -452,7 +452,7 @@ bool sndk_get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl,
 
 	data = (__u8 *)malloc(sizeof(__u8) * SNDK_DEV_MGMNT_LOG_PAGE_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: SNDK: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: SNDK: malloc: %s", libnvme_strerror(errno));
 		return false;
 	}
 
@@ -467,7 +467,7 @@ bool sndk_get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl,
 				       NVME_LOG_CDW14_UUID_MASK);
 	ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 	if (ret) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: SNDK: Unable to get 0x%x Log Page with uuid %d, ret = 0x%x\n",
 			SNDK_NVME_GET_DEV_MGMNT_LOG_PAGE_ID, uuid_ix, ret);
 		goto end;
@@ -481,7 +481,7 @@ bool sndk_get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl,
 		free(data);
 		data = calloc(length, sizeof(__u8));
 		if (!data) {
-			fprintf(stderr, "ERROR: SNDK: malloc: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: SNDK: malloc: %s", libnvme_strerror(errno));
 			goto end;
 		}
 
@@ -494,7 +494,7 @@ bool sndk_get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl,
 				NVME_LOG_CDW14_UUID_MASK);
 		ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 		if (ret) {
-			fprintf(stderr,
+			nvme_show_error(
 				"ERROR: SNDK: Unable to read 0x%x Log with uuid %d, ret = 0x%x\n",
 				SNDK_NVME_GET_DEV_MGMNT_LOG_PAGE_ID, uuid_ix, ret);
 			goto end;
@@ -506,13 +506,13 @@ bool sndk_get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl,
 		/* Ensure size of log data matches length in log header */
 		*log_data = calloc(length, sizeof(__u8));
 		if (!*log_data) {
-			fprintf(stderr, "ERROR: SNDK: calloc: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: SNDK: calloc: %s", libnvme_strerror(errno));
 			valid = false;
 			goto end;
 		}
 		memcpy((void *)*log_data, data, length);
 	} else {
-		fprintf(stderr, "ERROR: SNDK: C2 log page not found with uuid index %d\n",
+		nvme_show_error("ERROR: SNDK: C2 log page not found with uuid index %d",
 			uuid_ix);
 	}
 
@@ -743,7 +743,7 @@ __u64 sndk_get_enc_drive_capabilities(struct libnvme_global_ctx *ctx,
 			}
 		} else {
 			/* UUID Lists not supported, Use default uuid index - 0 */
-			fprintf(stderr, "INFO: SNDK: %s:  UUID Lists not supported\n",
+			nvme_show_error("INFO: SNDK: %s:  UUID Lists not supported",
 					__func__);
 			uuid_index = 0;
 		}
@@ -752,14 +752,14 @@ __u64 sndk_get_enc_drive_capabilities(struct libnvme_global_ctx *ctx,
 		if (run_wdc_nvme_check_supported_log_page(ctx, hdl,
 				SNDK_NVME_GET_DEV_MGMNT_LOG_PAGE_ID,
 				uuid_index) == false) {
-			fprintf(stderr, "ERROR: SNDK: 0xC2 Log Page not supported, ");
-			fprintf(stderr, "uuid_index: %d\n", uuid_index);
+			nvme_show_error("ERROR: SNDK: 0xC2 Log Page not supported, ");
+			nvme_show_error("uuid_index: %d", uuid_index);
 			ret = -1;
 			goto out;
 		}
 
 		if (!sndk_get_dev_mgment_data(ctx, hdl, &dev_mng_log)) {
-			fprintf(stderr, "ERROR: SNDK: 0xC2 Log Page not found\n");
+			nvme_show_error("ERROR: SNDK: 0xC2 Log Page not found");
 			ret = -1;
 			goto out;
 		}
@@ -768,20 +768,20 @@ __u64 sndk_get_enc_drive_capabilities(struct libnvme_global_ctx *ctx,
 		if (!sndk_nvme_parse_dev_status_log_entry(dev_mng_log,
 				SNDK_C2_CUSTOMER_ID_ID,
 				(void *)&cust_id))
-			fprintf(stderr, "ERROR: SNDK: Get Customer FW ID Failed\n");
+			nvme_show_error("ERROR: SNDK: Get Customer FW ID Failed");
 
 		/* Get the marketing name */
 		if (!sndk_nvme_parse_dev_status_log_str(dev_mng_log,
 				SNDK_C2_MARKETING_NAME_ID,
 				(char *)marketing_name,
 				&market_name_len))
-			fprintf(stderr, "ERROR: SNDK: Get Marketing Name Failed\n");
+			nvme_show_error("ERROR: SNDK: Get Marketing Name Failed");
 
 		/* Get the drive form factor */
 		if (!sndk_nvme_parse_dev_status_log_entry(dev_mng_log,
 				SNDK_C2_FORM_FACTOR,
 				(void *)&drive_form_factor))
-			fprintf(stderr, "ERROR: SNDK: Getting Form Factor Failed\n");
+			nvme_show_error("ERROR: SNDK: Getting Form Factor Failed");
 
 		/* verify the 0xC0 log page is supported */
 		if (run_wdc_nvme_check_supported_log_page(ctx, hdl,
@@ -863,7 +863,7 @@ int sndk_get_serial_name(struct libnvme_transport_handle *hdl, char *file,
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: SNDK: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: SNDK: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 	/* Remove trailing spaces from the name */
@@ -876,7 +876,7 @@ int sndk_get_serial_name(struct libnvme_transport_handle *hdl, char *file,
 
 	res_len = snprintf(file, len, "%s%.*s%s", orig, ctrl_sn_len, ctrl.sn, suffix);
 	if (len <= res_len) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: SNDK: cannot format SN due to unexpected length\n");
 		return -1;
 	}
@@ -934,13 +934,13 @@ int sndk_check_ctrl_telemetry_option_disabled(struct libnvme_transport_handle *h
 		NULL, 4, &result);
 	if (!err) {
 		if (result) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: Controller-initiated option telemetry disabled\n",
 				__func__);
 			return -EINVAL;
 		}
 	} else {
-		fprintf(stderr, "ERROR: SNDK: Get telemetry option feature failed.");
+		nvme_show_error("ERROR: SNDK: Get telemetry option feature failed.");
 		nvme_show_status(err);
 		return -EPERM;
 	}

--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -580,7 +580,7 @@ int sfx_nvme_get_log(struct libnvme_transport_handle *hdl, __u32 nsid, __u8 log_
 static int get_bb_table(struct libnvme_transport_handle *hdl, __u32 nsid, unsigned char *buf, __u64 size)
 {
 	if (libnvme_transport_handle_get_fd(hdl) < 0 || !buf || size != 256*4096*sizeof(unsigned char)) {
-		fprintf(stderr, "Invalid Param \r\n");
+		nvme_show_error("Invalid Param \r");
 		return -EINVAL;
 	}
 
@@ -667,7 +667,7 @@ static int sfx_get_bad_block(int argc, char **argv, struct command *acmd, struct
 
 	data_buf = malloc(buf_size);
 	if (!data_buf) {
-		fprintf(stderr, "malloc fail, errno %d\r\n", errno);
+		nvme_show_error("malloc fail, errno %d\r", errno);
 		return -1;
 	}
 
@@ -678,7 +678,7 @@ static int sfx_get_bad_block(int argc, char **argv, struct command *acmd, struct
 		nvme_show_status(err);
 	} else {
 		bd_table_show(data_buf, buf_size);
-		printf("ScaleFlux get bad block table: success\n");
+		nvme_show_verbose_result("ScaleFlux get bad block table: success");
 	}
 
 	free(data_buf);
@@ -753,18 +753,18 @@ static int change_sanity_check(struct libnvme_transport_handle *hdl, __u64 trg_i
 			    (SFX_PAGE_SHIFT - SECTOR_SHIFT);
 	if (trg_in_4k < provisioned_cap_4k ||
 	    trg_in_4k > ((__u64)provisioned_cap_4k * 4)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"WARNING: Only support 1.0~4.0 x provisioned capacity!\n");
 		if (trg_in_4k < provisioned_cap_4k)
-			fprintf(stderr,
+			nvme_show_error(
 				"WARNING: The target capacity is less than 1.0 x provisioned capacity!\n");
 		else
-			fprintf(stderr,
+			nvme_show_error(
 				"WARNING: The target capacity is larger than 4.0 x provisioned capacity!\n");
 		return -1;
 	}
 	if (trg_in_4k > ((__u64)provisioned_cap_4k*4)) {
-		fprintf(stderr, "WARNING: the target capacity is too large\n");
+		nvme_show_error("WARNING: the target capacity is too large");
 		return -1;
 	}
 
@@ -780,7 +780,7 @@ static int change_sanity_check(struct libnvme_transport_handle *hdl, __u64 trg_i
 		}
 		mem_need = (trg_in_4k - cur_in_4k) * 8;
 		if (s_info.freeram <= 10 || mem_need > s_info.freeram) {
-			fprintf(stderr,
+			nvme_show_error(
 			    "WARNING: Free memory is not enough! Please drop cache or extend more memory and retry\n"
 			    "WARNING: Memory needed is %"PRIu64", free memory is %"PRIu64"\n",
 			    (uint64_t)mem_need, (uint64_t)s_info.freeram);
@@ -803,16 +803,16 @@ static int sfx_confirm_change(const char *str)
 {
 	unsigned char confirm;
 
-	fprintf(stderr, "WARNING: %s.\n"
+	nvme_show_error("WARNING: %s."
 			"Use the force [--force] option to suppress this warning.\n", str);
 
-	fprintf(stderr, "Confirm Y/y, Others cancel:\n");
+	nvme_show_error("Confirm Y/y, Others cancel:");
 	confirm = (unsigned char)fgetc(stdin);
 	if (confirm != 'y' && confirm != 'Y') {
-		fprintf(stderr, "Canceled.\n");
+		nvme_show_error("Canceled.");
 		return 0;
 	}
-	fprintf(stderr, "Sending operation ...\n");
+	nvme_show_error("Sending operation ...");
 	return 1;
 }
 
@@ -872,7 +872,7 @@ static int change_cap(int argc, char **argv, struct command *acmd, struct plugin
 	} else if (err) {
 		nvme_show_status(err);
 	} else {
-		printf("ScaleFlux change-capacity: success\n");
+		nvme_show_verbose_result("ScaleFlux change-capacity: success");
 		ioctl(libnvme_transport_handle_get_fd(hdl), BLKRRPART);
 	}
 	return err;
@@ -888,7 +888,7 @@ static int sfx_verify_chr(struct libnvme_transport_handle *hdl)
 		return errno;
 	}
 	if (!S_ISCHR(nvme_stat.st_mode)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Error: requesting clean card on non-controller handle\n");
 		return -ENOTBLK;
 	}
@@ -906,7 +906,7 @@ static int sfx_clean_card(struct libnvme_transport_handle *hdl)
 	if (ret)
 		perror("Ioctl Fail.");
 	else
-		printf("ScaleFlux clean card success\n");
+		nvme_show_verbose_result("ScaleFlux clean card success");
 
 	return ret;
 }
@@ -962,7 +962,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *acmd, struct p
 		return err;
 
 	if (!cfg.feature_id) {
-		fprintf(stderr, "feature-id required param\n");
+		nvme_show_error("feature-id required param");
 			return -EINVAL;
 	}
 
@@ -996,7 +996,7 @@ static int sfx_set_feature(int argc, char **argv, struct command *acmd, struct p
 		}
 	} else if (cfg.feature_id == SFX_FEAT_UP_P_CAP) {
 		if (cfg.value <= 0) {
-			fprintf(stderr, "Invalid Param\n");
+			nvme_show_error("Invalid Param");
 					return -EINVAL;
 		}
 
@@ -1052,7 +1052,7 @@ static int sfx_get_feature(int argc, char **argv, struct command *acmd, struct p
 		return err;
 
 	if (!cfg.feature_id) {
-		fprintf(stderr, "feature-id required param\n");
+		nvme_show_error("feature-id required param");
 			return -EINVAL;
 	}
 
@@ -1130,7 +1130,7 @@ static int nvme_parse_evtlog(void *pevent_log_info, __u32 log_len, char *output)
 
 	fd = fopen(output, "w+");
 	if (!fd) {
-		fprintf(stderr, "Failed to open %s file to write\n", output);
+		nvme_show_error("Failed to open %s file to write", output);
 		err = ENOENT;
 		goto ret;
 	}
@@ -1179,7 +1179,7 @@ static int nvme_parse_evtlog(void *pevent_log_info, __u32 log_len, char *output)
 			str_pos = strlen(str_buffer);
 
 			if (fwrite(str_buffer, 1, str_pos, fd) != str_pos) {
-				fprintf(stderr, "Failed to write parse result to output file\n");
+				nvme_show_error("Failed to write parse result to output file");
 				goto close_fd;
 			}
 		}
@@ -1191,7 +1191,7 @@ static int nvme_parse_evtlog(void *pevent_log_info, __u32 log_len, char *output)
 			util_spinner("Parse", (float) (offset) / (float) (log_len));
 	}
 
-	printf("\nParse-evtlog: Success\n");
+	nvme_show_verbose_result("Parse-evtlog: Success");
 
 close_fd:
 	fclose(fd);
@@ -1241,7 +1241,7 @@ static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespac
 				       NVME_LOG_CDW10_LSP_MASK);
 	err = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 	if (err) {
-		fprintf(stderr, "Unable to get evtlog lsp=0x%x, ret = 0x%x\n",
+		nvme_show_error("Unable to get evtlog lsp=0x%x, ret = 0x%x",
 				lsp, err);
 		goto free_pevent;
 	}
@@ -1254,7 +1254,7 @@ static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespac
 				       NVME_LOG_CDW10_LSP_MASK);
 	err = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 	if (err) {
-		fprintf(stderr, "Unable to get evtlog lsp=0x%x, ret = 0x%x\n",
+		nvme_show_error("Unable to get evtlog lsp=0x%x, ret = 0x%x",
 			lsp, err);
 		goto free_pevent;
 	}
@@ -1271,7 +1271,7 @@ static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespac
 
 	fd = fopen(file, "wb+");
 	if (!fd) {
-		fprintf(stderr, "Failed to open %s file to write\n", file);
+		nvme_show_error("Failed to open %s file to write", file);
 		err = ENOENT;
 		goto free_pevent;
 	}
@@ -1296,14 +1296,14 @@ static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespac
 		nvme_init_get_log_lpo(&cmd, lpo);
 		err = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 		if (err) {
-			fprintf(stderr,
+			nvme_show_error(
 				"Unable to get evtlog offset=0x%x len 0x%x ret = 0x%x\n",
 				offset, len, err);
 			goto close_fd;
 		}
 
 		if (fwrite(log, 1, len, fd) != len) {
-			fprintf(stderr, "Failed to write evtlog to file\n");
+			nvme_show_error("Failed to write evtlog to file");
 			goto close_fd;
 		}
 
@@ -1312,13 +1312,13 @@ static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespac
 		util_spinner("Parse", (float) (offset) / (float) (log_len));
 	}
 
-	printf("\nDump-evtlog: Success\n");
+	nvme_show_verbose_result("Dump-evtlog: Success");
 
 	if (parse) {
 		libnvme_free_huge(&mh);
 		pevent_log_info = libnvme_alloc_huge(log_len, &mh);
 		if (!pevent_log_info) {
-			fprintf(stderr, "Failed to alloc enough memory 0x%x to parse evtlog\n", log_len);
+			nvme_show_error("Failed to alloc enough memory 0x%x to parse evtlog", log_len);
 			err = -ENOMEM;
 			goto close_fd;
 		}
@@ -1326,12 +1326,12 @@ static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespac
 		fclose(fd);
 		fd = fopen(file, "rb");
 		if (!fd) {
-			fprintf(stderr, "Failed to open %s file to read\n", file);
+			nvme_show_error("Failed to open %s file to read", file);
 			err = ENOENT;
 			goto free_pevent;
 		}
 		if (fread(pevent_log_info, 1, log_len, fd) != log_len) {
-			fprintf(stderr, "Failed to read evtlog to buffer\n");
+			nvme_show_error("Failed to read evtlog to buffer");
 			goto close_fd;
 		}
 
@@ -1386,12 +1386,12 @@ static int sfx_dump_evtlog(int argc, char **argv, struct command *acmd, struct p
 		return err;
 
 	if (!cfg.file) {
-		fprintf(stderr, "file required param\n");
+		nvme_show_error("file required param");
 		return -EINVAL;
 	}
 
 	if (cfg.parse && !cfg.output) {
-		fprintf(stderr, "output file required if evtlog need be parsed\n");
+		nvme_show_error("output file required if evtlog need be parsed");
 		return -EINVAL;
 	}
 
@@ -1443,7 +1443,7 @@ static int nvme_expand_cap(struct libnvme_transport_handle *hdl, __u32 namespace
 	}
 
 	if (strcmp(dev_name, devices[num-1]->d_name)) {
-		fprintf(stderr, "Expand namespace not the last one\n");
+		nvme_show_error("Expand namespace not the last one");
 		err = EINVAL;
 		goto free_devices;
 	}
@@ -1469,7 +1469,7 @@ static int nvme_expand_cap(struct libnvme_transport_handle *hdl, __u32 namespace
 
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
-		fprintf(stderr, "Create ns failed\n");
+		nvme_show_error("Create ns failed");
 		nvme_show_status(err);
 		goto free_devices;
 	}
@@ -1522,7 +1522,7 @@ static int sfx_expand_cap(int argc, char **argv, struct command *acmd, struct pl
 
 	if (cfg.namespace_id == NVME_NSID_ALL) {
 		if (libnvme_transport_handle_is_ctrl(hdl)) {
-			fprintf(stderr, "namespace_id or namespace device required\n");
+			nvme_show_error("namespace_id or namespace device required");
 			return -EINVAL;
 		} else {
 			cfg.namespace_id = atoi(&libnvme_transport_handle_get_name(hdl)[strlen(libnvme_transport_handle_get_name(hdl)) - 1]);
@@ -1530,12 +1530,12 @@ static int sfx_expand_cap(int argc, char **argv, struct command *acmd, struct pl
 	}
 
 	if (!cfg.namespace_size) {
-		fprintf(stderr, "namespace_size required param\n");
+		nvme_show_error("namespace_size required param");
 		return -EINVAL;
 	}
 
 	if (!cfg.namespace_cap) {
-		fprintf(stderr, "namespace_cap required param\n");
+		nvme_show_error("namespace_cap required param");
 		return -EINVAL;
 	}
 
@@ -1543,7 +1543,7 @@ static int sfx_expand_cap(int argc, char **argv, struct command *acmd, struct pl
 	if (err)
 		return err;
 
-	printf("%s: Success, create nsid:%d\n", acmd->name, cfg.namespace_id);
+	nvme_show_verbose_result("%s: Success, create nsid:%d", acmd->name, cfg.namespace_id);
 
 	return 0;
 }
@@ -1653,7 +1653,7 @@ static int sfx_status(int argc, char **argv, struct command *acmd, struct plugin
 	else if (strncmp("0x1dfd", pci_vid, 6) == 0)
 		strncpy(vendor, "DIGISTOR", 10);
 	else {
-		fprintf(stderr, "Please use on a ScaleFlux device\n");
+		nvme_show_error("Please use on a ScaleFlux device");
 		return -1;
 	}
 
@@ -1815,7 +1815,7 @@ static int sfx_status(int argc, char **argv, struct command *acmd, struct plugin
 	//Populate id-ctrl
 	err = nvme_identify_ctrl(hdl, &id_ctrl);
 	if (err) {
-		fprintf(stderr, "Unable to read nvme_identify_ctrl() error code:%x\n", err);
+		nvme_show_error("Unable to read nvme_identify_ctrl() error code:%x", err);
 		return err;
 	}
 	//Re-format specific fields so they can be safely treated as strings later

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1454,7 +1454,7 @@ static int clear_fw_activate_history(int argc, char **argv, struct command *acmd
 		err = nvme_set_features(hdl, 0, 0xC1, 0, 0x80000000, 0, 0, 0, 0, NULL,
 				0, &result);
 		if (err)
-			fprintf(stderr, "%s: couldn't clear PCIe correctable errors\n",
+			nvme_show_error("%s: couldn't clear PCIe correctable errors",
 				__func__);
 	}
 
@@ -1513,7 +1513,7 @@ static int vs_clr_pcie_correctable_errs(int argc, char **argv, struct command *a
 		err = nvme_set_features(hdl, 0, 0xC3, 0, 0x80000000, 0, 0, 0, 0, NULL,
 				0, &result);
 		if (err)
-			fprintf(stderr, "%s: couldn't clear PCIe correctable errors\n", __func__);
+			nvme_show_error("%s: couldn't clear PCIe correctable errors", __func__);
 	}
 
 	err = nvme_set_features_simple(hdl, 0, 0xE1, cfg.save, 0xCB, &result);
@@ -1604,7 +1604,7 @@ static int get_host_tele(int argc, char **argv, struct command *acmd, struct plu
 		log = malloc(bytesToGet);
 
 		if (!log) {
-			fprintf(stderr, "could not alloc buffer for log\n");
+			nvme_show_error("could not alloc buffer for log");
 
 			return -EINVAL;
 		}
@@ -1709,7 +1709,7 @@ static int get_ctrl_tele(int argc, char **argv, struct command *acmd, struct plu
 		log = malloc(bytesToGet);
 
 		if (!log) {
-			fprintf(stderr, "could not alloc buffer for log\n");
+			nvme_show_error("could not alloc buffer for log");
 			return -EINVAL;
 		}
 
@@ -1824,7 +1824,7 @@ static int vs_internal_log(int argc, char **argv, struct command *acmd, struct p
 		log = malloc(bytesToGet);
 
 		if (!log) {
-			fprintf(stderr, "could not alloc buffer for log\n");
+			nvme_show_error("could not alloc buffer for log");
 			err = EINVAL;
 			goto out;
 		}

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -143,6 +143,7 @@ static void json_log_pages_supp(log_page_map *logPageMap)
 		json_array_add_value_object(logPages, lbaf);
 	}
 	json_print_object(root, NULL);
+	printf("\n");
 	json_free_object(root);
 }
 
@@ -968,6 +969,7 @@ static int vs_smart_log(int argc, char **argv, struct command *acmd, struct plug
 				}
 			} else if (flags & JSON) {
 				json_print_object(root, NULL);
+				printf("\n");
 				json_free_object(root);
 			}
 		} else if (err > 0) {
@@ -987,6 +989,7 @@ static int vs_smart_log(int argc, char **argv, struct command *acmd, struct plug
 				json_array_add_value_object(lbafs, lbafs_ExtSmart);
 
 				json_print_object(root, NULL);
+				printf("\n");
 				json_free_object(root);
 			}
 		}
@@ -1363,6 +1366,7 @@ static void json_stx_vs_fw_activate_history(stx_fw_activ_history_log_page fwActi
 	}
 
 	json_print_object(root, NULL);
+	printf("\n");
 	json_free_object(root);
 }
 

--- a/plugins/sed/sed.c
+++ b/plugins/sed/sed.c
@@ -75,7 +75,7 @@ static int sed_opal_open_device(struct libnvme_global_ctx **ctx, struct libnvme_
 		return err;
 
 	if (!libnvme_transport_handle_is_ns(*hdl)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR : The NVMe namespace device (e.g. /dev/nvme0n1) "
 			"must be specified\n");
 		err = -EINVAL;
@@ -115,7 +115,7 @@ static int sed_opal_initialize(int argc, char **argv, struct command *acmd,
 
 	err = sedopal_cmd_initialize(libnvme_transport_handle_get_fd(hdl));
 	if ((err != 0) && (err != -EOPNOTSUPP))
-		fprintf(stderr, "initialize: SED error -  %s\n",
+		nvme_show_error("initialize: SED error -  %s",
 				sedopal_error_to_text(err));
 
 	return err;
@@ -135,7 +135,7 @@ static int sed_opal_revert(int argc, char **argv, struct command *acmd,
 
 	err = sedopal_cmd_revert(libnvme_transport_handle_get_fd(hdl));
 	if ((err != 0) && (err != -EOPNOTSUPP) && (err != EPERM))
-		fprintf(stderr, "revert: SED error -  %s\n",
+		nvme_show_error("revert: SED error -  %s",
 				sedopal_error_to_text(err));
 
 	return err;
@@ -155,7 +155,7 @@ static int sed_opal_lock(int argc, char **argv, struct command *acmd,
 
 	err = sedopal_cmd_lock(libnvme_transport_handle_get_fd(hdl));
 	if ((err != 0) && (err != -EOPNOTSUPP))
-		fprintf(stderr, "lock: SED error -  %s\n",
+		nvme_show_error("lock: SED error -  %s",
 				sedopal_error_to_text(err));
 
 	return err;
@@ -175,7 +175,7 @@ static int sed_opal_unlock(int argc, char **argv, struct command *acmd,
 
 	err = sedopal_cmd_unlock(libnvme_transport_handle_get_fd(hdl));
 	if ((err != 0) && (err != -EOPNOTSUPP))
-		fprintf(stderr, "unlock: SED error -  %s\n",
+		nvme_show_error("unlock: SED error -  %s",
 				sedopal_error_to_text(err));
 
 	return err;
@@ -195,7 +195,7 @@ static int sed_opal_password(int argc, char **argv, struct command *acmd,
 
 	err = sedopal_cmd_password(libnvme_transport_handle_get_fd(hdl));
 	if ((err != 0) && (err != EPERM))
-		fprintf(stderr, "password: SED error -  %s\n",
+		nvme_show_error("password: SED error -  %s",
 				sedopal_error_to_text(err));
 
 	return err;

--- a/plugins/sed/sedopal_cmd.c
+++ b/plugins/sed/sedopal_cmd.c
@@ -16,6 +16,7 @@
 
 #include "sedopal_spec.h"
 #include "sedopal_cmd.h"
+#include "nvme-print.h"
 
 /*
  * ask user for key rather than obtaining it from kernel keyring
@@ -131,12 +132,12 @@ char *sedopal_get_password(char *prompt)
 
 	len = strlen(pass);
 	if (len < SEDOPAL_MIN_PASSWORD_LEN) {
-		fprintf(stderr, "Error: password is not long enough\n");
+		nvme_show_error("Error: password is not long enough");
 		return NULL;
 	}
 
 	if (len > SEDOPAL_MAX_PASSWORD_LEN) {
-		fprintf(stderr, "Error: password is too long\n");
+		nvme_show_error("Error: password is too long");
 		return NULL;
 	}
 
@@ -190,7 +191,7 @@ int sedopal_set_key(struct opal_key *key)
 		if (sedopal_ask_new_key) {
 			pass = sedopal_get_password(SEDOPAL_REENTER_PW_PROMPT);
 			if (strncmp((char *)key->key, pass, key->key_len)) {
-				fprintf(stderr,
+				nvme_show_error(
 					"Error: passwords don't match\n");
 				return -EINVAL;
 			}
@@ -222,7 +223,7 @@ int sedopal_cmd_initialize(int fd)
 	locking_state = sedopal_locking_state(fd);
 
 	if (locking_state & OPAL_FEATURE_LOCKING_ENABLED) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Error: cannot initialize an initialized drive\n");
 		return -EOPNOTSUPP;
 	}
@@ -238,7 +239,7 @@ int sedopal_cmd_initialize(int fd)
 	 */
 	rc = ioctl(fd, IOC_OPAL_TAKE_OWNERSHIP, &key);
 	if (rc != 0) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Error: failed to take device ownership - %d\n", rc);
 		return rc;
 	}
@@ -252,7 +253,7 @@ int sedopal_cmd_initialize(int fd)
 
 	rc = ioctl(fd, IOC_OPAL_ACTIVATE_LSP, &lr_act);
 	if (rc != 0) {
-		fprintf(stderr, "Error: failed to activate LSP - %d\n", rc);
+		nvme_show_error("Error: failed to activate LSP - %d", rc);
 		return rc;
 	}
 
@@ -271,7 +272,7 @@ int sedopal_cmd_initialize(int fd)
 
 	rc = ioctl(fd, IOC_OPAL_LR_SETUP, &lr_setup);
 	if (rc != 0) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Error: failed to setup locking range - %d\n", rc);
 		return rc;
 	}
@@ -289,7 +290,7 @@ int sedopal_cmd_initialize(int fd)
 
 	rc = ioctl(fd, IOC_OPAL_SET_PW, &new_pw);
 	if (rc != 0)
-		fprintf(stderr, "Error: failed setting password - %d\n", rc);
+		nvme_show_error("Error: failed setting password - %d", rc);
 
 	return rc;
 }
@@ -326,7 +327,7 @@ int sedopal_cmd_unlock(int fd)
 	 */
 	if (rc == 0) {
 		if (ioctl(fd, BLKRRPART, 0) != 0)
-			fprintf(stderr,
+			nvme_show_error(
 				"Warning: failed re-reading partition\n");
 	}
 
@@ -345,7 +346,7 @@ int sedopal_lock_unlock(int fd, int lock_state)
 	locking_state = sedopal_locking_state(fd);
 
 	if (!(locking_state & OPAL_FEATURE_LOCKING_ENABLED)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Error: cannot lock/unlock an uninitialized drive\n");
 		return -EOPNOTSUPP;
 	}
@@ -360,7 +361,7 @@ int sedopal_lock_unlock(int fd, int lock_state)
 
 	rc = ioctl(fd, IOC_OPAL_LOCK_UNLOCK, &opal_lu);
 	if (rc != 0)
-		fprintf(stderr,
+		nvme_show_error(
 			"Error: failed locking or unlocking - %d\n", rc);
 	return rc;
 }
@@ -399,7 +400,7 @@ static int sedopal_revert_destructive(int fd)
 	int rc;
 
 	if (!sedopal_confirm_revert()) {
-		fprintf(stderr, "Aborting destructive revert\n");
+		nvme_show_error("Aborting destructive revert");
 		return -1;
 	}
 
@@ -425,7 +426,7 @@ static int sedopal_revert_psid(int fd)
 	int rc;
 
 	if (!sedopal_confirm_revert()) {
-		fprintf(stderr, "Aborting PSID revert\n");
+		nvme_show_error("Aborting PSID revert");
 		return -1;
 	}
 
@@ -434,15 +435,15 @@ static int sedopal_revert_psid(int fd)
 		rc = ioctl(fd, IOC_OPAL_PSID_REVERT_TPR, &key);
 		if (rc != 0) {
 			if (rc == EPERM)
-				fprintf(stderr, "Error: incorrect password\n");
+				nvme_show_error("Error: incorrect password");
 			else
-				fprintf(stderr, "PSID_REVERT_TPR rc %d\n", rc);
+				nvme_show_error("PSID_REVERT_TPR rc %d", rc);
 		}
 	}
 
 	return rc;
 #else
-	fprintf(stderr, "ERROR : PSID revert is not supported\n");
+	nvme_show_error("ERROR : PSID revert is not supported");
 	return -EOPNOTSUPP;
 #endif /* IOC_OPAL_PSID_REVERT_TPR */
 }
@@ -473,13 +474,13 @@ int sedopal_cmd_revert(int fd)
 		locking_state = sedopal_locking_state(fd);
 
 		if (!(locking_state & OPAL_FEATURE_LOCKING_ENABLED)) {
-			fprintf(stderr,
+			nvme_show_error(
 				"Error: can't revert an uninitialized drive\n");
 			return -EOPNOTSUPP;
 		}
 
 		if (locking_state & OPAL_FEATURE_LOCKED) {
-			fprintf(stderr,
+			nvme_show_error(
 				"Error: cannot revert drive while locked\n");
 			return -EOPNOTSUPP;
 		}
@@ -499,14 +500,14 @@ int sedopal_cmd_revert(int fd)
 			 */
 			rc = ioctl(fd, IOC_OPAL_REVERT_TPR, &revert_lsp.key);
 			if (rc != 0)
-				fprintf(stderr, "Error: revert TPR - %d\n", rc);
+				nvme_show_error("Error: revert TPR - %d", rc);
 		}
 
 		if (rc != 0) {
 			if (rc == EPERM)
-				fprintf(stderr, "Error: incorrect password\n");
+				nvme_show_error("Error: incorrect password");
 			else
-				fprintf(stderr, "Error: revert %s - %d\n",
+				nvme_show_error("Error: revert %s - %d",
 					revert, rc);
 		}
 #else
@@ -515,7 +516,7 @@ int sedopal_cmd_revert(int fd)
 	}
 
 	if ((rc != 0) && (rc != EPERM))
-		fprintf(stderr, "Error: failed reverting drive - %d\n", rc);
+		nvme_show_error("Error: failed reverting drive - %d", rc);
 
 	return rc;
 }
@@ -555,9 +556,9 @@ int sedopal_cmd_password(int fd)
 	rc = ioctl(fd, IOC_OPAL_SET_PW, &new_pw);
 	if (rc != 0) {
 		if (rc == EPERM)
-			fprintf(stderr, "Error: incorrect password\n");
+			nvme_show_error("Error: incorrect password");
 		else
-			fprintf(stderr, "Error: setting password - %d\n", rc);
+			nvme_show_error("Error: setting password - %d", rc);
 		return rc;
 	}
 
@@ -568,9 +569,9 @@ int sedopal_cmd_password(int fd)
 	rc = ioctl(fd, IOC_OPAL_SET_SID_PW, &new_pw);
 	if (rc != 0) {
 		if (rc == EPERM)
-			fprintf(stderr, "Error: incorrect password\n");
+			nvme_show_error("Error: incorrect password");
 		else
-			fprintf(stderr, "Error: setting SID pw - %d\n", rc);
+			nvme_show_error("Error: setting SID pw - %d", rc);
 	}
 #endif
 
@@ -586,7 +587,7 @@ void sedopal_print_locking_features(void *data)
 	uint8_t features;
 
 	if (!ld) {
-		fprintf(stderr, "Error retrieving details about locking features\n");
+		nvme_show_error("Error retrieving details about locking features");
 		return;
 	}
 
@@ -1046,7 +1047,7 @@ int sedopal_discover_device(int fd, struct level_0_discovery_features **feat,
 
 	rc = ioctl(fd, IOC_OPAL_DISCOVERY, &discover);
 	if (rc < 0) {
-		fprintf(stderr, "Error: ioctl IOC_OPAL_DISCOVERY failed\n");
+		nvme_show_error("Error: ioctl IOC_OPAL_DISCOVERY failed");
 		return rc;
 	}
 
@@ -1064,7 +1065,7 @@ int sedopal_discover_device(int fd, struct level_0_discovery_features **feat,
 	return 0
 		;
 #else /* IOC_OPAL_DISCOVERY */
-	fprintf(stderr, "ERROR : NVMe device discovery is not supported\n");
+	nvme_show_error("ERROR : NVMe device discovery is not supported");
 	return -EOPNOTSUPP;
 #endif
 }
@@ -1096,7 +1097,7 @@ int sedopal_cmd_discover(int fd)
 
 	rc = 0;
 	if (!(sfp.features & OPAL_SED_LOCKING_SUPPORT)) {
-		fprintf(stderr, "Error: device does not support SED Opal\n");
+		nvme_show_error("Error: device does not support SED Opal");
 		rc = -1;
 	} else
 		sedopal_print_locking_features(sfp.locking_desc);

--- a/plugins/shannon/shannon-nvme.c
+++ b/plugins/shannon/shannon-nvme.c
@@ -213,11 +213,11 @@ static int get_additional_feature(int argc, char **argv, struct command *acmd, s
 		return err;
 
 	if (cfg.sel > 7) {
-		fprintf(stderr, "invalid 'select' param:%d\n", cfg.sel);
+		nvme_show_error("invalid 'select' param:%d", cfg.sel);
 		return -EINVAL;
 	}
 	if (!cfg.feature_id) {
-		fprintf(stderr, "feature-id required param\n");
+		nvme_show_error("feature-id required param");
 		return -EINVAL;
 	}
 	if (cfg.data_len) {
@@ -291,14 +291,14 @@ static int set_additional_feature(int argc, char **argv, struct command *acmd, s
 		return err;
 
 	if (!cfg.feature_id) {
-		fprintf(stderr, "feature-id required param\n");
+		nvme_show_error("feature-id required param");
 		return -EINVAL;
 	}
 
 	if (cfg.data_len) {
 		buf = libnvme_alloc(cfg.data_len);
 		if (!buf) {
-			fprintf(stderr, "can not allocate feature payload\n");
+			nvme_show_error("can not allocate feature payload");
 			return -ENOMEM;
 		}
 		memset(buf, 0, cfg.data_len);
@@ -308,13 +308,13 @@ static int set_additional_feature(int argc, char **argv, struct command *acmd, s
 		if (strlen(cfg.file)) {
 			ffd = open(cfg.file, O_RDONLY);
 			if (ffd <= 0) {
-				fprintf(stderr, "no firmware file provided\n");
+				nvme_show_error("no firmware file provided");
 				return -EINVAL;
 			}
 		}
 		err = read(ffd, (void *)buf, cfg.data_len);
 		if (err < 0) {
-			fprintf(stderr, "failed to read data buffer from input file\n");
+			nvme_show_error("failed to read data buffer from input file");
 			return -EINVAL;
 		}
 	}

--- a/plugins/solidigm/solidigm-garbage-collection.c
+++ b/plugins/solidigm/solidigm-garbage-collection.c
@@ -83,7 +83,7 @@ int solidigm_get_garbage_collection_log(int argc, char **argv, struct command *a
 
 	err = validate_output_format(nvme_args.output_format, &flags);
 	if (err) {
-		fprintf(stderr, "Invalid output format '%s'\n",
+		nvme_show_error("Invalid output format '%s'",
 			nvme_args.output_format);
 		return -EINVAL;
 	}

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -286,7 +286,7 @@ static int ilog_dump_assert_logs(struct libnvme_transport_handle *hdl, struct il
 		}
 	}
 	close(output);
-	printf("Successfully wrote Assert to %s\n", file_path);
+	nvme_show_verbose_result("Successfully wrote Assert to %s", file_path);
 	return err;
 }
 
@@ -344,7 +344,7 @@ static int ilog_dump_event_logs(struct libnvme_transport_handle *hdl, struct ilo
 		}
 	}
 	close(output);
-	printf("Successfully wrote Events to %s\n", file_path);
+	nvme_show_verbose_result("Successfully wrote Events to %s", file_path);
 	return err;
 }
 
@@ -432,7 +432,7 @@ static int ilog_dump_nlogs(struct libnvme_transport_handle *hdl, struct ilog *il
 	} while (++log_select.selectCore < core_num);
 	if (is_open) {
 		close(output);
-		printf("Successfully wrote Nlog to %s\n", file_path);
+		nvme_show_verbose_result("Successfully wrote Nlog to %s", file_path);
 	}
 	return err;
 }
@@ -489,7 +489,7 @@ static int log_save(struct log *log, const char *parent_dir_name, const char *su
 		bytes_remaining -= bytes_written;
 		buffer += bytes_written;
 	}
-	printf("Successfully wrote %s to %s\n", log->desc, file_path);
+	nvme_show_verbose_result("Successfully wrote %s to %s", log->desc, file_path);
 	return 0;
 }
 
@@ -876,7 +876,7 @@ int solidigm_get_internal_log(int argc, char **argv, struct command *acmd,
 	else if (!strcmp(cfg.type, "EXTENDED"))
 		log_type = EXTENDED;
 	else {
-		fprintf(stderr, "Invalid log type: %s\n", cfg.type);
+		nvme_show_error("Invalid log type: %s", cfg.type);
 		return -EINVAL;
 	}
 

--- a/plugins/solidigm/solidigm-latency-tracking.c
+++ b/plugins/solidigm/solidigm-latency-tracking.c
@@ -286,7 +286,7 @@ static int latency_tracking_enable(struct latency_tracker *lt)
 		return 0;
 
 	if (lt->cfg.enable && lt->cfg.disable) {
-		fprintf(stderr, "Cannot enable and disable simultaneously.\n");
+		nvme_show_error("Cannot enable and disable simultaneously.");
 		return -EINVAL;
 	}
 
@@ -297,10 +297,10 @@ static int latency_tracking_enable(struct latency_tracker *lt)
 		nvme_show_status(err);
 	} else if (err < 0) {
 		perror("Enable latency tracking");
-		fprintf(stderr, "Command failed while parsing.\n");
+		nvme_show_error("Command failed while parsing.");
 	} else {
 		if (lt->print_flags == NORMAL) {
-			printf("Successfully set enable bit for UUID-idx:%d FID:0x%X, to %i.\n",
+			nvme_show_verbose_result("Successfully set enable bit for UUID-idx:%d FID:0x%X, to %i.",
 				lt->uuid_index, LATENCY_TRACKING_FID, lt->cfg.enable);
 		}
 	}
@@ -316,7 +316,7 @@ static int latency_tracker_get_log(struct latency_tracker *lt)
 	int err;
 
 	if (lt->cfg.read && lt->cfg.write) {
-		fprintf(stderr, "Cannot capture read and write logs simultaneously.\n");
+		nvme_show_error("Cannot capture read and write logs simultaneously.");
 		return -EINVAL;
 	}
 
@@ -376,18 +376,18 @@ int solidigm_get_latency_tracking_log(int argc, char **argv, struct command *acm
 
 	err = validate_output_format(nvme_args.output_format, &lt.print_flags);
 	if (err < 0) {
-		fprintf(stderr, "Invalid output format '%s'\n",
+		nvme_show_error("Invalid output format '%s'",
 			nvme_args.output_format);
 		return -EINVAL;
 	}
 
 	if (lt.cfg.type > 0xf) {
-		fprintf(stderr, "Invalid Log type value '%d'\n", lt.cfg.type);
+		nvme_show_error("Invalid Log type value '%d'", lt.cfg.type);
 		return -EINVAL;
 	}
 
 	if (lt.cfg.type && !(lt.cfg.read || lt.cfg.write)) {
-		fprintf(stderr, "Log type option valid only when retrieving statistics\n");
+		nvme_show_error("Log type option valid only when retrieving statistics");
 		return -EINVAL;
 	}
 
@@ -421,7 +421,7 @@ int solidigm_get_latency_tracking_log(int argc, char **argv, struct command *acm
 			       (uint64_t)enabled);
 		}
 	} else {
-		fprintf(stderr, "Could not read feature id 0xE2.\n");
+		nvme_show_error("Could not read feature id 0xE2.");
 	}
 	return err;
 }

--- a/plugins/solidigm/solidigm-log-page-dir.c
+++ b/plugins/solidigm/solidigm-log-page-dir.c
@@ -239,7 +239,7 @@ int solidigm_get_log_page_directory_log(int argc, char **argv, struct command *a
 
 		err = validate_output_format(nvme_args.output_format, &print_flag);
 		if (err) {
-			nvme_show_error("Error: Invalid output format specified: %s.\n",
+			nvme_show_error("Error: Invalid output format specified: %s.",
 					nvme_args.output_format);
 			return err;
 		}

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -277,7 +277,7 @@ int solidigm_get_additional_smart_log(int argc, char **argv, struct command *acm
 
 	err = validate_output_format(nvme_args.output_format, &flags);
 	if (err < 0) {
-		fprintf(stderr, "Invalid output format '%s'\n",
+		nvme_show_error("Invalid output format '%s'",
 			nvme_args.output_format);
 		return err;
 	}

--- a/plugins/solidigm/solidigm-temp-stats.c
+++ b/plugins/solidigm/solidigm-temp-stats.c
@@ -85,7 +85,7 @@ int sldgm_get_temp_stats_log(int argc, char **argv, struct command *acmd, struct
 			uint64_t *guid = (uint64_t *)&buffer[4080];
 
 			if (guid[1] == 0xC7BB98B7D0324863 && guid[0] == 0xBB2C23990E9C722F) {
-				fprintf(stderr,
+				nvme_show_error(
 					"Error: Log page has OCP unsupported Requirements GUID\n");
 				return -EBADMSG;
 			}

--- a/plugins/solidigm/solidigm-workload-tracker.c
+++ b/plugins/solidigm/solidigm-workload-tracker.c
@@ -312,7 +312,7 @@ static int wltracker_show_newer_entries(struct wltracker *wlt)
 	content_group = workloadEnable.contentGroup;
 
 	if (cnt == 0) {
-		nvme_show_error("Warning : No valid workload log data\n");
+		nvme_show_error("Warning : No valid workload log data");
 		return 0;
 	}
 

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -77,14 +77,14 @@ static int nvme_get_sct_status(struct libnvme_transport_handle *hdl, __u32 devic
 
 	err = nvme_sct_op(hdl, OP_SCT_STATUS, DW10_SCT_STATUS_COMMAND, DW11_SCT_STATUS_COMMAND, data, data_len);
 	if (err) {
-		fprintf(stderr, "%s: SCT status failed :%d\n", __func__, err);
+		nvme_show_error("%s: SCT status failed :%d", __func__, err);
 		return err;
 	}
 
 	status = data;
 	if (status[0] != 1U) {
 		/* Eek, wrong version in status header */
-		fprintf(stderr, "%s: unexpected value in SCT status[0]:(%x)\n", __func__, status[0]);
+		nvme_show_error("%s: unexpected value in SCT status[0]:(%x)", __func__, status[0]);
 		return -EINVAL;
 	}
 
@@ -102,7 +102,7 @@ static int nvme_get_sct_status(struct libnvme_transport_handle *hdl, __u32 devic
 		};
 
 		if (!supported) {
-			fprintf(stderr, "%s: command unsupported on this device: (0x%x)\n", __func__, status[1]);
+			nvme_show_error("%s: command unsupported on this device: (0x%x)", __func__, status[1]);
 			return -EINVAL;
 		}
 	}
@@ -217,7 +217,7 @@ static int nvme_get_internal_log(struct libnvme_transport_handle *hdl,
 
 	err = nvme_sct_command_transfer_log(hdl, current);
 	if (err) {
-		fprintf(stderr, "%s: SCT command transfer failed\n", __func__);
+		nvme_show_error("%s: SCT command transfer failed", __func__);
 		goto end;
 	}
 
@@ -230,7 +230,7 @@ static int nvme_get_internal_log(struct libnvme_transport_handle *hdl,
 	/* Read the header to get the last log page - offsets 8->11, 12->15, 16->19 */
 	err = nvme_sct_data_transfer(hdl, page_data, page_data_len, 0);
 	if (err) {
-		fprintf(stderr, "%s: SCT data transfer failed, page 0\n", __func__);
+		nvme_show_error("%s: SCT data transfer failed, page 0", __func__);
 		goto end;
 	}
 
@@ -255,13 +255,13 @@ static int nvme_get_internal_log(struct libnvme_transport_handle *hdl,
 		progress_runner(progress);
 		o_fd = nvme_open_rawdata(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (o_fd < 0) {
-			fprintf(stderr, "%s: couldn't output file %s\n", __func__, filename);
+			nvme_show_error("%s: couldn't output file %s", __func__, filename);
 			err = -EINVAL;
 			goto end;
 		}
 		err = d_raw_to_fd(page_data, page_data_len, o_fd);
 		if (err) {
-			fprintf(stderr, "%s: couldn't write all data to output file\n", __func__);
+			nvme_show_error("%s: couldn't write all data to output file", __func__);
 			goto end;
 		}
 	}
@@ -276,7 +276,7 @@ static int nvme_get_internal_log(struct libnvme_transport_handle *hdl,
 					     pages_chunk * page_data_len,
 					     i * page_sector_len);
 		if (err) {
-			fprintf(stderr, "%s: SCT data transfer command failed\n", __func__);
+			nvme_show_error("%s: SCT data transfer command failed", __func__);
 			goto end;
 		}
 
@@ -291,7 +291,7 @@ static int nvme_get_internal_log(struct libnvme_transport_handle *hdl,
 			progress_runner(progress);
 			err = d_raw_to_fd(page_data, pages_chunk * page_data_len, o_fd);
 			if (err) {
-				fprintf(stderr, "%s: couldn't write all data to output file\n",
+				nvme_show_error("%s: couldn't write all data to output file",
 					__func__);
 				goto end;
 			}
@@ -303,7 +303,7 @@ static int nvme_get_internal_log(struct libnvme_transport_handle *hdl,
 	fprintf(stdout, "\n");
 	err = nvme_get_sct_status(hdl, MASK_IGNORE);
 	if (err) {
-		fprintf(stderr, "%s: bad SCT status\n", __func__);
+		nvme_show_error("%s: bad SCT status", __func__);
 		goto end;
 	}
 end:
@@ -375,7 +375,7 @@ static int nvme_get_vendor_log(struct libnvme_transport_handle *hdl,
 	err = nvme_get_nsid_log(hdl, namespace_id, false, log_page,
 				log, log_len);
 	if (err) {
-		fprintf(stderr, "%s: couldn't get log 0x%x\n", __func__,
+		nvme_show_error("%s: couldn't get log 0x%x", __func__,
 			log_page);
 		return err;
 	}
@@ -383,13 +383,13 @@ static int nvme_get_vendor_log(struct libnvme_transport_handle *hdl,
 		int o_fd = nvme_open_rawdata(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 
 		if (o_fd < 0) {
-			fprintf(stderr, "%s: couldn't output file %s\n",
+			nvme_show_error("%s: couldn't output file %s",
 				__func__, filename);
 			return -EINVAL;
 		}
 		err = d_raw_to_fd(log, log_len, o_fd);
 		if (err) {
-			fprintf(stderr, "%s: couldn't write all data to output file %s\n",
+			nvme_show_error("%s: couldn't write all data to output file %s",
 				__func__, filename);
 			/* Attempt following close */
 		}
@@ -434,12 +434,12 @@ static int vendor_log(int argc, char **argv, struct command *acmd, struct plugin
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (err) {
-		fprintf(stderr, "%s: failed to parse arguments\n", __func__);
+		nvme_show_error("%s: failed to parse arguments", __func__);
 		return -EINVAL;
 	}
 
 	if ((cfg.log != 0xC0) && (cfg.log != 0xCA)) {
-		fprintf(stderr, "%s: invalid log page 0x%x - should be 0xC0 or 0xCA\n", __func__, cfg.log);
+		nvme_show_error("%s: invalid log page 0x%x - should be 0xC0 or 0xCA", __func__, cfg.log);
 		err = -EINVAL;
 		goto end;
 	}
@@ -447,7 +447,7 @@ static int vendor_log(int argc, char **argv, struct command *acmd, struct plugin
 	err = nvme_get_vendor_log(hdl, cfg.namespace_id, cfg.log,
 				  cfg.output_file);
 	if (err)
-		fprintf(stderr, "%s: couldn't get vendor log 0x%x\n", __func__, cfg.log);
+		nvme_show_error("%s: couldn't get vendor log 0x%x", __func__, cfg.log);
 end:
 	if (err > 0)
 		nvme_show_status(err);
@@ -480,7 +480,7 @@ static int internal_log(int argc, char **argv, struct command *acmd, struct plug
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (err) {
-		fprintf(stderr, "%s: failed to parse arguments\n", __func__);
+		nvme_show_error("%s: failed to parse arguments", __func__);
 		return -EINVAL;
 	}
 
@@ -492,7 +492,7 @@ static int internal_log(int argc, char **argv, struct command *acmd, struct plug
 	err = nvme_get_internal_log_file(hdl, cfg.output_file,
 					 !cfg.prev_log);
 	if (err < 0)
-		fprintf(stderr, "%s: couldn't get fw log\n", __func__);
+		nvme_show_error("%s: couldn't get fw log", __func__);
 	if (err > 0)
 		nvme_show_status(err);
 
@@ -517,7 +517,7 @@ static int clear_correctable_errors(int argc, char **argv, struct command *acmd,
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (err) {
-		fprintf(stderr, "%s: failed to parse arguments\n", __func__);
+		nvme_show_error("%s: failed to parse arguments", __func__);
 		return -EINVAL;
 	}
 
@@ -529,7 +529,7 @@ static int clear_correctable_errors(int argc, char **argv, struct command *acmd,
 	err = nvme_set_features(hdl, namespace_id, feature_id, save, value, cdw12,
 			0, 0, 0, NULL, 0, &result);
 	if (err)
-		fprintf(stderr, "%s: couldn't clear PCIe correctable errors\n",
+		nvme_show_error("%s: couldn't clear PCIe correctable errors",
 			__func__);
 end:
 	if (err > 0)

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -1493,7 +1493,7 @@ static int wdc_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transp
 	} else {
 		ret = libnvme_scan_namespace(ctx, name, &n);
 		if (ret) {
-			fprintf(stderr, "Unable to find %s\n", name);
+			nvme_show_error("Unable to find %s", name);
 			return ret;
 		}
 
@@ -1506,7 +1506,7 @@ static int wdc_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transp
 
 	fd = open(vid, O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "ERROR: WDC: %s : Open vendor file failed\n", __func__);
+		nvme_show_error("ERROR: WDC: %s : Open vendor file failed", __func__);
 		return -1;
 	}
 
@@ -1514,7 +1514,7 @@ static int wdc_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transp
 	close(fd);
 
 	if (ret < 0) {
-		fprintf(stderr, "%s: Read of pci vendor id failed\n", __func__);
+		nvme_show_error("%s: Read of pci vendor id failed", __func__);
 		return -1;
 	}
 	id[ret < 32 ? ret : 31] = '\0';
@@ -1526,7 +1526,7 @@ static int wdc_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transp
 
 	fd = open(did, O_RDONLY);
 	if (fd < 0) {
-		fprintf(stderr, "ERROR: WDC: %s : Open device file failed\n", __func__);
+		nvme_show_error("ERROR: WDC: %s : Open device file failed", __func__);
 		return -1;
 	}
 
@@ -1534,7 +1534,7 @@ static int wdc_get_pci_ids(struct libnvme_global_ctx *ctx, struct libnvme_transp
 	close(fd);
 
 	if (ret < 0) {
-		fprintf(stderr, "%s: Read of pci device id failed\n", __func__);
+		nvme_show_error("%s: Read of pci device id failed", __func__);
 		return -1;
 	}
 	id[ret < 32 ? ret : 31] = '\0';
@@ -1553,7 +1553,7 @@ static int wdc_get_vendor_id(struct libnvme_transport_handle *hdl, uint32_t *ven
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 
@@ -1627,7 +1627,7 @@ static int wdc_get_model_number(struct libnvme_transport_handle *hdl, char *mode
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 
@@ -1661,7 +1661,7 @@ static bool wdc_check_device(struct libnvme_global_ctx *ctx, struct libnvme_tran
 	    read_vendor_id == WDC_NVME_SNDK_VID)
 		supported = true;
 	else
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: unsupported WDC device, Vendor ID = 0x%x, Device ID = 0x%x\n",
 			read_vendor_id, read_device_id);
 
@@ -1683,7 +1683,7 @@ static bool wdc_enc_check_model(struct libnvme_transport_handle *hdl)
 	if (strstr(model, WDC_OPENFLEX_MI_DEVICE_MODEL))
 		supported = true;
 	else
-		fprintf(stderr, "ERROR: WDC: unsupported WDC enclosure, Model = %s\n", model);
+		nvme_show_error("ERROR: WDC: unsupported WDC enclosure, Model = %s", model);
 
 	return supported;
 }
@@ -1809,7 +1809,7 @@ static __u64 wdc_get_drive_capabilities(struct libnvme_global_ctx *ctx, struct l
 			cust_id = wdc_get_fw_cust_id(ctx, hdl);
 			/* Can still determine some capabilities in this case, but log an error */
 			if (cust_id == WDC_INVALID_CUSTOMER_ID)
-				fprintf(stderr,
+				nvme_show_error(
 					"%s: ERROR: WDC: invalid customer ID; device ID = %x\n",
 					__func__, read_device_id);
 
@@ -1892,7 +1892,7 @@ static __u64 wdc_get_drive_capabilities(struct libnvme_global_ctx *ctx, struct l
 			cust_id = wdc_get_fw_cust_id(ctx, hdl);
 			/* Can still determine some capabilities in this case, but log an error */
 			if (cust_id == WDC_INVALID_CUSTOMER_ID)
-				fprintf(stderr,
+				nvme_show_error(
 					"%s: ERROR: WDC: invalid customer ID; device ID = %x\n",
 					__func__, read_device_id);
 
@@ -2138,14 +2138,14 @@ static __u64 wdc_get_enc_drive_capabilities(struct libnvme_global_ctx *ctx,
 		if (wdc_nvme_check_supported_log_page(ctx, hdl,
 				WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_ID,
 				uuid_index) == false) {
-			fprintf(stderr, "ERROR: SNDK: 0xC2 Log Page not supported, index: %d\n",
+			nvme_show_error("ERROR: SNDK: 0xC2 Log Page not supported, index: %d",
 					uuid_index);
 			ret = -1;
 			goto out;
 		}
 
 		if (!get_dev_mgment_data(ctx, hdl, &dev_mng_log)) {
-			fprintf(stderr, "ERROR: SNDK: 0xC2 Log Page not found\n");
+			nvme_show_error("ERROR: SNDK: 0xC2 Log Page not found");
 			ret = -1;
 			goto out;
 		}
@@ -2154,13 +2154,13 @@ static __u64 wdc_get_enc_drive_capabilities(struct libnvme_global_ctx *ctx,
 		if (!wdc_nvme_parse_dev_status_log_entry(dev_mng_log,
 				&cust_id,
 				WDC_C2_CUSTOMER_ID_ID))
-			fprintf(stderr, "ERROR: SNDK: Get Customer FW ID Failed\n");
+			nvme_show_error("ERROR: SNDK: Get Customer FW ID Failed");
 
 		if (!wdc_nvme_parse_dev_status_log_str(dev_mng_log,
 				WDC_C2_MARKETING_NAME_ID,
 				(char *)marketing_name,
 				&market_name_len))
-			fprintf(stderr, "ERROR: SNDK: Get Marketing Name Failed\n");
+			nvme_show_error("ERROR: SNDK: Get Marketing Name Failed");
 
 		/* verify the 0xC3 log page is supported */
 		if (wdc_nvme_check_supported_log_page(ctx, hdl,
@@ -2225,7 +2225,7 @@ static int wdc_get_serial_name(struct libnvme_transport_handle *hdl, char *file,
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 	/* Remove trailing spaces from the name */
@@ -2238,7 +2238,7 @@ static int wdc_get_serial_name(struct libnvme_transport_handle *hdl, char *file,
 
 	res_len = snprintf(file, len, "%s%.*s%s", orig, ctrl_sn_len, ctrl.sn, suffix);
 	if (len <= res_len) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: cannot format serial number due to data of unexpected length\n");
 		return -1;
 	}
@@ -2253,20 +2253,20 @@ static int wdc_create_log_file(const char *file, const __u8 *drive_log_data,
 	int ret;
 
 	if (!drive_log_length) {
-		fprintf(stderr, "ERROR: WDC: invalid log file length\n");
+		nvme_show_error("ERROR: WDC: invalid log file length");
 		return -1;
 	}
 
 	fd = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (fd < 0) {
-		fprintf(stderr, "ERROR: WDC: open: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: open: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
 	while (drive_log_length > WRITE_SIZE) {
 		ret = write(fd, drive_log_data, WRITE_SIZE);
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC: write: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: WDC: write: %s", libnvme_strerror(errno));
 			close(fd);
 			return -1;
 		}
@@ -2276,13 +2276,13 @@ static int wdc_create_log_file(const char *file, const __u8 *drive_log_data,
 
 	ret = write(fd, drive_log_data, drive_log_length);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: write: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: write: %s", libnvme_strerror(errno));
 		close(fd);
 		return -1;
 	}
 
 	if (fsync(fd) < 0) {
-		fprintf(stderr, "ERROR: WDC: fsync: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: fsync: %s", libnvme_strerror(errno));
 		close(fd);
 		return -1;
 	}
@@ -2304,7 +2304,7 @@ bool wdc_validate_dev_mng_log(void *data)
 	log_length = le32_to_cpu(hdr_ptr->length);
 	/* Ensure log data is large enough for common header */
 	if (log_length < sizeof(struct wdc_c2_log_page_header)) {
-		fprintf(stderr,
+		nvme_show_error(
 		    "ERROR: %s: log smaller than header. log_len: 0x%x  HdrSize: %"PRIxPTR"\n",
 		    __func__, log_length, sizeof(struct wdc_c2_log_page_header));
 		return valid_log;
@@ -2325,22 +2325,22 @@ bool wdc_validate_dev_mng_log(void *data)
 		 * of the data, we must be at the end of the data
 		 */
 		if (!log_entry_size || log_entry_size > remaining_len) {
-			fprintf(stderr, "ERROR: WDC: %s: Detected unaligned end of the data. ",
+			nvme_show_error("ERROR: WDC: %s: Detected unaligned end of the data. ",
 				__func__);
-			fprintf(stderr, "Data Offset: 0x%x Entry Size: 0x%x, ",
+			nvme_show_error("Data Offset: 0x%x Entry Size: 0x%x, ",
 				offset, log_entry_size);
-			fprintf(stderr, "Remaining Log Length: 0x%x Entry Id: 0x%x\n",
+			nvme_show_error("Remaining Log Length: 0x%x Entry Id: 0x%x",
 				remaining_len, log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
 		} else if (!log_entry_id || log_entry_id > 200) {
 			/* Invalid entry - fail the search */
-			fprintf(stderr, "ERROR: WDC: %s: Invalid entry found at offset: 0x%x ",
+			nvme_show_error("ERROR: WDC: %s: Invalid entry found at offset: 0x%x ",
 				__func__, offset);
-			fprintf(stderr, "Entry Size: 0x%x, Remaining Log Length: 0x%x ",
+			nvme_show_error("Entry Size: 0x%x, Remaining Log Length: 0x%x ",
 				log_entry_size, remaining_len);
-			fprintf(stderr, "Entry Id: 0x%x\n", log_entry_id);
+			nvme_show_error("Entry Id: 0x%x", log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
@@ -2377,7 +2377,7 @@ bool wdc_parse_dev_mng_log_entry(void *data, __u32 entry_id,
 	log_length = le32_to_cpu(hdr_ptr->length);
 	/* Ensure log data is large enough for common header */
 	if (log_length < sizeof(struct wdc_c2_log_page_header)) {
-		fprintf(stderr,
+		nvme_show_error(
 		    "ERROR: %s: log smaller than header. log_len: 0x%x  HdrSize: %"PRIxPTR"\n",
 		    __func__, log_length, sizeof(struct wdc_c2_log_page_header));
 		return found;
@@ -2389,7 +2389,7 @@ bool wdc_parse_dev_mng_log_entry(void *data, __u32 entry_id,
 	remaining_len = log_length - offset;
 
 	if (!log_entry) {
-		fprintf(stderr, "ERROR: WDC - %s: No log entry pointer.\n", __func__);
+		nvme_show_error("ERROR: WDC - %s: No log entry pointer.", __func__);
 		return found;
 	}
 	*log_entry = NULL;
@@ -2405,22 +2405,22 @@ bool wdc_parse_dev_mng_log_entry(void *data, __u32 entry_id,
 		 * of the data, we must be at the end of the data
 		 */
 		if (!log_entry_size || log_entry_size > remaining_len) {
-			fprintf(stderr, "ERROR: WDC: %s: Detected unaligned end of the data. ",
+			nvme_show_error("ERROR: WDC: %s: Detected unaligned end of the data. ",
 				__func__);
-			fprintf(stderr, "Data Offset: 0x%x Entry Size: 0x%x, ",
+			nvme_show_error("Data Offset: 0x%x Entry Size: 0x%x, ",
 				offset, log_entry_size);
-			fprintf(stderr, "Remaining Log Length: 0x%x Entry Id: 0x%x\n",
+			nvme_show_error("Remaining Log Length: 0x%x Entry Id: 0x%x",
 				remaining_len, log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
 		} else if (!log_entry_id || log_entry_id > 200) {
 			/* Invalid entry - fail the search */
-			fprintf(stderr, "ERROR: WDC: %s: Invalid entry found at offset: 0x%x ",
+			nvme_show_error("ERROR: WDC: %s: Invalid entry found at offset: 0x%x ",
 				__func__, offset);
-			fprintf(stderr, "Entry Size: 0x%x, Remaining Log Length: 0x%x ",
+			nvme_show_error("Entry Size: 0x%x, Remaining Log Length: 0x%x ",
 				log_entry_size, remaining_len);
-			fprintf(stderr, "Entry Id: 0x%x\n", log_entry_id);
+			nvme_show_error("Entry Id: 0x%x", log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
@@ -2461,7 +2461,7 @@ bool wdc_get_dev_mng_log_entry(__u32 log_length, __u32 entry_id,
 	struct wdc_c2_log_subpage_header *p_next_log_entry = NULL;
 
 	if (!*p_p_found_log_entry) {
-		fprintf(stderr, "ERROR: WDC - %s: No ppLogEntry pointer.\n", __func__);
+		nvme_show_error("ERROR: WDC - %s: No ppLogEntry pointer.", __func__);
 		return false;
 	}
 
@@ -2469,7 +2469,7 @@ bool wdc_get_dev_mng_log_entry(__u32 log_length, __u32 entry_id,
 
 	/* Ensure log data is large enough for common header */
 	if (log_length < sizeof(struct wdc_c2_log_page_header)) {
-		fprintf(stderr,
+		nvme_show_error(
 		    "ERROR: WDC - %s: Buffer is not large enough for the common header. BufSize: 0x%x  HdrSize: %"PRIxPTR"\n",
 		    __func__, log_length, sizeof(struct wdc_c2_log_page_header));
 		return false;
@@ -2500,22 +2500,22 @@ bool wdc_get_dev_mng_log_entry(__u32 log_length, __u32 entry_id,
 		 * of the data, we must be at the end of the data
 		 */
 		if (!log_entry_size || log_entry_size > remaining_len) {
-			fprintf(stderr, "ERROR: WDC: %s: Detected unaligned end of the data. ",
+			nvme_show_error("ERROR: WDC: %s: Detected unaligned end of the data. ",
 				__func__);
-			fprintf(stderr, "Data Offset: 0x%x Entry Size: 0x%x, ",
+			nvme_show_error("Data Offset: 0x%x Entry Size: 0x%x, ",
 				offset, log_entry_size);
-			fprintf(stderr, "Remaining Log Length: 0x%x Entry Id: 0x%x\n",
+			nvme_show_error("Remaining Log Length: 0x%x Entry Id: 0x%x",
 				remaining_len, log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
 		} else if (!log_entry_id || log_entry_id > 200) {
 			/* Invalid entry - fail the search */
-			fprintf(stderr, "ERROR: WDC: %s: Invalid entry found at offset: 0x%x ",
+			nvme_show_error("ERROR: WDC: %s: Invalid entry found at offset: 0x%x ",
 				__func__, offset);
-			fprintf(stderr, "Entry Size: 0x%x, Remaining Log Length: 0x%x ",
+			nvme_show_error("Entry Size: 0x%x, Remaining Log Length: 0x%x ",
 				log_entry_size, remaining_len);
-			fprintf(stderr, "Entry Id: 0x%x\n", log_entry_id);
+			nvme_show_error("Entry Id: 0x%x", log_entry_id);
 
 			/* Force the loop to end */
 			remaining_len = 0;
@@ -2558,7 +2558,7 @@ static bool get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl, voi
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_C2_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return false;
 	}
 
@@ -2573,7 +2573,7 @@ static bool get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl, voi
 				       NVME_LOG_CDW14_UUID_MASK);
 	ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 	if (ret) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: Unable to get 0x%x Log Page with uuid %d, ret = 0x%x\n",
 			WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_ID, uuid_ix, ret);
 		goto end;
@@ -2587,7 +2587,7 @@ static bool get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl, voi
 		free(data);
 		data = calloc(length, sizeof(__u8));
 		if (!data) {
-			fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 			goto end;
 		}
 
@@ -2600,7 +2600,7 @@ static bool get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl, voi
 					       NVME_LOG_CDW14_UUID_MASK);
 		ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 		if (ret) {
-			fprintf(stderr,
+			nvme_show_error(
 				"ERROR: WDC: Unable to read 0x%x Log with uuid %d, ret = 0x%x\n",
 				WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_ID, uuid_ix, ret);
 			goto end;
@@ -2612,13 +2612,13 @@ static bool get_dev_mgmt_log_page_data(struct libnvme_transport_handle *hdl, voi
 		/* Ensure size of log data matches length in log header */
 		*log_data = calloc(length, sizeof(__u8));
 		if (!*log_data) {
-			fprintf(stderr, "ERROR: WDC: calloc: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: WDC: calloc: %s", libnvme_strerror(errno));
 			valid = false;
 			goto end;
 		}
 		memcpy((void *)*log_data, data, length);
 	} else {
-		fprintf(stderr, "ERROR: WDC: C2 log page not found with uuid index %d\n",
+		nvme_show_error("ERROR: WDC: C2 log page not found with uuid index %d",
 			uuid_ix);
 	}
 
@@ -2643,7 +2643,7 @@ static bool get_dev_mgmt_log_page_lid_data(struct libnvme_transport_handle *hdl,
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_C2_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return false;
 	}
 
@@ -2657,7 +2657,7 @@ static bool get_dev_mgmt_log_page_lid_data(struct libnvme_transport_handle *hdl,
 				       NVME_LOG_CDW14_UUID_MASK);
 	ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 	if (ret) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: Unable to get 0x%x Log Page length with uuid %d, ret = 0x%x\n",
 			lid, uuid_ix, ret);
 		goto end;
@@ -2671,7 +2671,7 @@ static bool get_dev_mgmt_log_page_lid_data(struct libnvme_transport_handle *hdl,
 		free(data);
 		data = calloc(length, sizeof(__u8));
 		if (!data) {
-			fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 			goto end;
 		}
 
@@ -2683,7 +2683,7 @@ static bool get_dev_mgmt_log_page_lid_data(struct libnvme_transport_handle *hdl,
 					       NVME_LOG_CDW14_UUID_MASK);
 		ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 		if (ret) {
-			fprintf(stderr,
+			nvme_show_error(
 				"ERROR: WDC: Unable to read 0x%x Log Page data with uuid %d, ret = 0x%x\n",
 				lid, uuid_ix, ret);
 			goto end;
@@ -2698,16 +2698,16 @@ static bool get_dev_mgmt_log_page_lid_data(struct libnvme_transport_handle *hdl,
 	if (found && sph) {
 		*cbs_data = calloc(le32_to_cpu(sph->length), sizeof(__u8));
 		if (!*cbs_data) {
-			fprintf(stderr, "ERROR: WDC: calloc: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: WDC: calloc: %s", libnvme_strerror(errno));
 			found = false;
 			goto end;
 		}
 		memcpy((void *)*cbs_data, (void *)&sph->data, le32_to_cpu(sph->length));
 	} else if(found && !sph) {
-		fprintf(stderr, "ERROR: WDC: C2 log id 0x%x not present in log page with uuid index %d\n",log_id, uuid_ix);
+		nvme_show_error("ERROR: WDC: C2 log id 0x%x not present in log page with uuid index %d",log_id, uuid_ix);
 		found = false;
 	} else {
-		fprintf(stderr, "ERROR: WDC: C2 log id 0x%x not found with uuid index %d\n",
+		nvme_show_error("ERROR: WDC: C2 log id 0x%x not found with uuid index %d",
 			log_id, uuid_ix);
 	}
 
@@ -2751,9 +2751,9 @@ static bool get_dev_mgment_data(struct libnvme_global_ctx *ctx, struct libnvme_t
 		if (uuid_index >= 0)
 			found = get_dev_mgmt_log_page_data(hdl, data, uuid_index);
 		else {
-			fprintf(stderr, "%s: UUID lists are supported but a matching ",
+			nvme_show_error("%s: UUID lists are supported but a matching ",
 				__func__);
-			fprintf(stderr, "uuid was not found\n");
+			nvme_show_error("uuid was not found");
 		}
 	} else if (needs_c2_log_page_check(device_id)) {
 		/* In certain devices that don't support UUID lists, there are multiple
@@ -2768,7 +2768,7 @@ static bool get_dev_mgment_data(struct libnvme_global_ctx *ctx, struct libnvme_t
 		if (!found) {
 			/* not found with uuid = 1 try with uuid = 0 */
 			uuid_index = 0;
-			fprintf(stderr, "Not found, requesting log page with uuid_index %d\n",
+			nvme_show_error("Not found, requesting log page with uuid_index %d",
 					uuid_index);
 
 			found = get_dev_mgmt_log_page_data(hdl, data, uuid_index);
@@ -2821,9 +2821,9 @@ static bool get_dev_mgment_cbs_data(struct libnvme_global_ctx *ctx, struct libnv
 			found = get_dev_mgmt_log_page_lid_data(hdl, cbs_data, lid,
 							       log_id, uuid_index);
 		else {
-			fprintf(stderr, "%s: UUID lists are supported but a matching ",
+			nvme_show_error("%s: UUID lists are supported but a matching ",
 			__func__);
-			fprintf(stderr, "uuid was not found\n");
+			nvme_show_error("uuid was not found");
 		}
 	} else if (needs_c2_log_page_check(device_id)) {
 		/* In certain devices that don't support UUID lists, there are multiple
@@ -2836,7 +2836,7 @@ static bool get_dev_mgment_cbs_data(struct libnvme_global_ctx *ctx, struct libnv
 		if (!found) {
 			/* not found with uuid = 1 try with uuid = 0 */
 			uuid_index = 0;
-			fprintf(stderr, "Not found, requesting log page with uuid_index %d\n",
+			nvme_show_error("Not found, requesting log page with uuid_index %d",
 					uuid_index);
 
 			found = get_dev_mgmt_log_page_lid_data(hdl, cbs_data, lid, log_id,
@@ -2911,9 +2911,9 @@ static bool wdc_nvme_check_supported_log_page(struct libnvme_global_ctx *ctx,
 
 #ifdef WDC_NVME_CLI_DEBUG
 				if (!found) {
-					fprintf(stderr, "ERROR: WDC: Log Page 0x%x not supported\n",
+					nvme_show_error("ERROR: WDC: Log Page 0x%x not supported",
 						log_id);
-					fprintf(stderr, "WDC: Supported Log Pages:\n");
+					nvme_show_error("WDC: Supported Log Pages:");
 					/* print the supported pages */
 					d((__u8 *)cbs_data->data, le32_to_cpu(cbs_data->length),
 						16, 1);
@@ -2921,10 +2921,10 @@ static bool wdc_nvme_check_supported_log_page(struct libnvme_global_ctx *ctx,
 #endif
 				free(cbs_data);
 			} else {
-				fprintf(stderr, "ERROR: WDC: cbs_data ptr = NULL\n");
+				nvme_show_error("ERROR: WDC: cbs_data ptr = NULL");
 			}
 		} else {
-			fprintf(stderr, "ERROR: WDC: 0xC2 Log Page entry ID 0x%x not found\n",
+			nvme_show_error("ERROR: WDC: 0xC2 Log Page entry ID 0x%x not found",
 				WDC_C2_LOG_PAGES_SUPPORTED_ID);
 		}
 	}
@@ -3024,7 +3024,7 @@ static __u32 wdc_dump_length(struct libnvme_transport_handle *link, __u32 opcode
 	if (ret) {
 		l->log_size = 0;
 		ret = -1;
-		fprintf(stderr, "ERROR: WDC: reading dump length failed\n");
+		nvme_show_error("ERROR: WDC: reading dump length failed");
 		nvme_show_status(ret);
 		return ret;
 	}
@@ -3050,7 +3050,7 @@ static __u32 wdc_dump_length_e6(struct libnvme_transport_handle *hdl, __u32 opco
 
 	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: reading dump length failed\n");
+		nvme_show_error("ERROR: WDC: reading dump length failed");
 		nvme_show_status(ret);
 	}
 
@@ -3077,7 +3077,7 @@ static __u32 wdc_dump_dui_data(struct libnvme_transport_handle *hdl, __u32 dataL
 
 	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: reading DUI data failed\n");
+		nvme_show_error("ERROR: WDC: reading DUI data failed");
 		nvme_show_status(ret);
 	}
 
@@ -3108,7 +3108,7 @@ static __u32 wdc_dump_dui_data_v2(struct libnvme_transport_handle *hdl, __u32 da
 
 	ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: reading DUI data V2 failed\n");
+		nvme_show_error("ERROR: WDC: reading DUI data V2 failed");
 		nvme_show_status(ret);
 	}
 
@@ -3127,7 +3127,7 @@ static int wdc_do_dump(struct libnvme_transport_handle *hdl, __u32 opcode, __u32
 
 	dump_data = (__u8 *)malloc(sizeof(__u8) * dump_length);
 	if (!dump_data) {
-		fprintf(stderr, "%s: ERROR: malloc: %s\n", __func__, libnvme_strerror(errno));
+		nvme_show_error("%s: ERROR: malloc: %s", __func__, libnvme_strerror(errno));
 		return -1;
 	}
 	memset(dump_data, 0, sizeof(__u8) * dump_length);
@@ -3147,7 +3147,7 @@ static int wdc_do_dump(struct libnvme_transport_handle *hdl, __u32 opcode, __u32
 		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (ret) {
 			nvme_show_status(ret);
-			fprintf(stderr, "%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx\n",
+			nvme_show_error("%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx",
 				__func__, i, admin_cmd.data_len, curr_data_offset, (unsigned long)admin_cmd.addr);
 			break;
 		}
@@ -3185,9 +3185,9 @@ static int wdc_do_dump_e6(struct libnvme_transport_handle *hdl, __u32 opcode, __
 	/* if data_len is not 4 byte aligned */
 	if (data_len & 0x00000003) {
 		/* Round down to the next 4 byte aligned value */
-		fprintf(stderr, "%s: INFO: data_len 0x%x not 4 byte aligned.\n",
+		nvme_show_error("%s: INFO: data_len 0x%x not 4 byte aligned.",
 				__func__, data_len);
-		fprintf(stderr, "%s: INFO: Round down to 0x%x.\n",
+		nvme_show_error("%s: INFO: Round down to 0x%x.",
 				__func__, (data_len &= 0xFFFFFFFC));
 		data_len &= 0xFFFFFFFC;
 	}
@@ -3195,7 +3195,7 @@ static int wdc_do_dump_e6(struct libnvme_transport_handle *hdl, __u32 opcode, __
 	dump_data = (__u8 *)malloc(sizeof(__u8) * data_len);
 
 	if (!dump_data) {
-		fprintf(stderr, "%s: ERROR: malloc: %s\n", __func__, libnvme_strerror(errno));
+		nvme_show_error("%s: ERROR: malloc: %s", __func__, libnvme_strerror(errno));
 		return -1;
 	}
 	memset(dump_data, 0, sizeof(__u8) * data_len);
@@ -3222,7 +3222,7 @@ static int wdc_do_dump_e6(struct libnvme_transport_handle *hdl, __u32 opcode, __
 		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (ret) {
 			nvme_show_status(ret);
-			fprintf(stderr, "%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx\n",
+			nvme_show_error("%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx",
 					__func__, i, admin_cmd.data_len, curr_data_offset, (unsigned long)admin_cmd.addr);
 			break;
 		}
@@ -3233,12 +3233,12 @@ static int wdc_do_dump_e6(struct libnvme_transport_handle *hdl, __u32 opcode, __
 	}
 
 	if (!ret) {
-		fprintf(stderr, "%s: INFO: ", __func__);
+		nvme_show_error("%s: INFO: ", __func__);
 		nvme_show_status(ret);
 	} else {
-		fprintf(stderr, "%s: FAILURE: ", __func__);
+		nvme_show_error("%s: FAILURE: ", __func__);
 		nvme_show_status(ret);
-		fprintf(stderr, "%s: Partial data may have been captured\n", __func__);
+		nvme_show_error("%s: Partial data may have been captured", __func__);
 		snprintf(file + strlen(file), PATH_MAX, "%s", "-PARTIAL");
 	}
 
@@ -3267,18 +3267,18 @@ static int wdc_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	err = nvme_identify_ctrl(hdl, &ctrl);
 	if (err) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", err);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", err);
 		return err;
 	}
 
 	if (!(ctrl.lpa & 0x8)) {
-		fprintf(stderr, "Telemetry Host-Initiated and Telemetry Controller-Initiated log pages not supported\n");
+		nvme_show_error("Telemetry Host-Initiated and Telemetry Controller-Initiated log pages not supported");
 		return -EINVAL;
 	}
 
 	err = libnvme_scan_topology(ctx, NULL, NULL);
 	if (err) {
-		fprintf(stderr, "Failed to scan nvme subsystems\n");
+		nvme_show_error("Failed to scan nvme subsystems");
 		return err;
 	}
 
@@ -3300,11 +3300,11 @@ static int wdc_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 					host_gen = 0;
 					ctrl_init = 1;
 				} else {
-					fprintf(stderr, "%s: Controller initiated option telemetry log page disabled\n", __func__);
+					nvme_show_error("%s: Controller initiated option telemetry log page disabled", __func__);
 					return -EINVAL;
 				}
 			} else {
-				fprintf(stderr, "ERROR: WDC: Get telemetry option feature failed.");
+				nvme_show_error("ERROR: WDC: Get telemetry option feature failed.");
 				nvme_show_status(err);
 				return -EPERM;
 			}
@@ -3313,18 +3313,18 @@ static int wdc_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 			ctrl_init = 1;
 		}
 	} else {
-		fprintf(stderr, "%s: Invalid type parameter; type = %d\n", __func__, type);
+		nvme_show_error("%s: Invalid type parameter; type = %d", __func__, type);
 		return -EINVAL;
 	}
 
 	if (!file) {
-		fprintf(stderr, "%s: Please provide an output file!\n", __func__);
+		nvme_show_error("%s: Please provide an output file!", __func__);
 		return -EINVAL;
 	}
 
 	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
-		fprintf(stderr, "%s: Failed to open output file %s: %s!\n",
+		nvme_show_error("%s: Failed to open output file %s: %s!",
 				__func__, file, libnvme_strerror(errno));
 		return output;
 	}
@@ -3344,7 +3344,7 @@ static int wdc_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 		goto close_output;
 	} else if (err > 0) {
 		nvme_show_status(err);
-		fprintf(stderr, "%s: Failed to acquire telemetry header!\n", __func__);
+		nvme_show_error("%s: Failed to acquire telemetry header!", __func__);
 		goto close_output;
 	}
 
@@ -3367,14 +3367,14 @@ static int wdc_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 			data_ptr += data_written;
 		} else {
 			/* Unexpected overwrite */
-			fprintf(stderr, "Failure: Unexpected telemetry log overwrite - data_remaining = 0x%x, data_written = 0x%x\n",
+			nvme_show_error("Failure: Unexpected telemetry log overwrite - data_remaining = 0x%x, data_written = 0x%x",
 					data_remaining, data_written);
 			break;
 		}
 	}
 
 	if (fsync(output) < 0) {
-		fprintf(stderr, "ERROR: %s: fsync: %s\n", __func__, libnvme_strerror(errno));
+		nvme_show_error("ERROR: %s: fsync: %s", __func__, libnvme_strerror(errno));
 		err = -1;
 	}
 
@@ -3394,7 +3394,7 @@ static int wdc_do_cap_diag(struct libnvme_global_ctx *ctx, struct libnvme_transp
 
 	log_hdr = (struct wdc_e6_log_hdr *)malloc(e6_log_hdr_size);
 	if (!log_hdr) {
-		fprintf(stderr, "%s: ERROR: malloc: %s\n", __func__, libnvme_strerror(errno));
+		nvme_show_error("%s: ERROR: malloc: %s", __func__, libnvme_strerror(errno));
 		ret = -1;
 		goto out;
 	}
@@ -3402,7 +3402,7 @@ static int wdc_do_cap_diag(struct libnvme_global_ctx *ctx, struct libnvme_transp
 
 	if (type == WDC_TELEMETRY_TYPE_NONE) {
 		if (data_area) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: Data area parameter is not supported when type is NONE\n",
 				__func__);
 			ret = -1;
@@ -3422,7 +3422,7 @@ static int wdc_do_cap_diag(struct libnvme_global_ctx *ctx, struct libnvme_transp
 				log_hdr->log_size[2] << 8 | log_hdr->log_size[3]);
 
 		if (!cap_diag_length) {
-			fprintf(stderr, "INFO: WDC: Capture Diagnostics log is empty\n");
+			nvme_show_error("INFO: WDC: Capture Diagnostics log is empty");
 		} else {
 			ret = wdc_do_dump_e6(hdl,
 					 WDC_NVME_CAP_DIAG_OPCODE,
@@ -3430,7 +3430,7 @@ static int wdc_do_cap_diag(struct libnvme_global_ctx *ctx, struct libnvme_transp
 							(WDC_NVME_CAP_DIAG_SUBCMD << WDC_NVME_SUBCMD_SHIFT) | WDC_NVME_CAP_DIAG_CMD,
 							file, xfer_size, (__u8 *)log_hdr);
 
-			fprintf(stderr, "INFO: WDC: Capture Diagnostics log, length = 0x%x\n", cap_diag_length);
+			nvme_show_error("INFO: WDC: Capture Diagnostics log, length = 0x%x", cap_diag_length);
 		}
 	} else if ((type == WDC_TELEMETRY_TYPE_HOST) ||
 			(type == WDC_TELEMETRY_TYPE_CONTROLLER)) {
@@ -3438,7 +3438,7 @@ static int wdc_do_cap_diag(struct libnvme_global_ctx *ctx, struct libnvme_transp
 		ret = wdc_do_cap_telemetry_log(ctx, hdl, file, xfer_size,
 					       type, data_area);
 	} else {
-		fprintf(stderr, "%s: ERROR: Invalid type : %d\n", __func__, type);
+		nvme_show_error("%s: ERROR: Invalid type : %d", __func__, type);
 	}
 
 out:
@@ -3462,15 +3462,15 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 	int ret = 0;
 
 	if (verbose) {
-		fprintf(stderr, "INFO: WDC: Capture V1 Device Unit Info log, data area = %d\n",
+		nvme_show_error("INFO: WDC: Capture V1 Device Unit Info log, data area = %d",
 			data_area);
-		fprintf(stderr, "INFO: WDC: DUI Header Version = 0x%x\n", log_hdr->hdr_version);
-		fprintf(stderr, "INFO: WDC: DUI section count = 0x%x\n", log_hdr->section_count);
-		fprintf(stderr, "INFO: WDC: DUI log size = 0x%x\n", log_hdr->log_size);
+		nvme_show_error("INFO: WDC: DUI Header Version = 0x%x", log_hdr->hdr_version);
+		nvme_show_error("INFO: WDC: DUI section count = 0x%x", log_hdr->section_count);
+		nvme_show_error("INFO: WDC: DUI log size = 0x%x", log_hdr->log_size);
 	}
 
 	if (!cap_dui_length) {
-		fprintf(stderr, "INFO: WDC: Capture V1 Device Unit Info log is empty\n");
+		nvme_show_error("INFO: WDC: Capture V1 Device Unit Info log is empty");
 		return 0;
 	}
 
@@ -3479,7 +3479,7 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 		for (j = 0; j < log_hdr->section_count; j++) {
 			log_size += log_hdr->log_section[j].section_size;
 			if (verbose)
-				fprintf(stderr,
+				nvme_show_error(
 					"%s: section size 0x%x, total size = 0x%x\n",
 					__func__,
 					(unsigned int)log_hdr->log_section[j].section_size,
@@ -3494,7 +3494,7 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 
 	dump_data = (__u8 *)malloc(sizeof(__u8) * xfer_size);
 	if (!dump_data) {
-		fprintf(stderr, "%s: ERROR: dump data V1 malloc failed : status %s, size = 0x%x\n",
+		nvme_show_error("%s: ERROR: dump data V1 malloc failed : status %s, size = 0x%x",
 			__func__, libnvme_strerror(errno), (unsigned int)xfer_size);
 		return -1;
 	}
@@ -3502,7 +3502,7 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 
 	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
-		fprintf(stderr, "%s: Failed to open output file %s: %s!\n", __func__, file,
+		nvme_show_error("%s: Failed to open output file %s: %s!", __func__, file,
 			libnvme_strerror(errno));
 		free(dump_data);
 		return output;
@@ -3511,7 +3511,7 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 	/* write the telemetry and log headers into the dump_file */
 	err = write(output, (void *)log_hdr, WDC_NVME_CAP_DUI_HEADER_SIZE);
 	if (err != WDC_NVME_CAP_DUI_HEADER_SIZE) {
-		fprintf(stderr, "%s: Failed to flush header data to file!\n", __func__);
+		nvme_show_error("%s: Failed to flush header data to file!", __func__);
 		goto free_mem;
 	}
 
@@ -3528,10 +3528,10 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 
 		ret = wdc_dump_dui_data(hdl, xfer_size, curr_data_offset, buffer_addr, last_xfer);
 		if (ret) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: WDC: Get chunk %d, size = 0x%"PRIx64", offset = 0x%x, addr = %p\n",
 				__func__, i, (uint64_t)log_size, curr_data_offset, buffer_addr);
-			fprintf(stderr, "%s: ERROR: WDC: ", __func__);
+			nvme_show_error("%s: ERROR: WDC: ", __func__);
 			nvme_show_status(ret);
 			break;
 		}
@@ -3539,7 +3539,7 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 		/* write the dump data into the file */
 		err = write(output, (void *)buffer_addr, xfer_size);
 		if (err != xfer_size) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: WDC: Failed to flush DUI data to file! chunk %d, err = 0x%x, xfer_size = 0x%x\n",
 				__func__, i, err, xfer_size);
 			ret = -1;
@@ -3577,19 +3577,19 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 	cap_dui_length_v3 = le64_to_cpu(log_hdr_v3->log_size);
 
 	if (verbose) {
-		fprintf(stderr,
+		nvme_show_error(
 			"INFO: WDC: Capture V2 or V3 Device Unit Info log, data area = %d\n",
 			data_area);
 
-		fprintf(stderr, "INFO: WDC: DUI Header Version = 0x%x\n",
+		nvme_show_error("INFO: WDC: DUI Header Version = 0x%x",
 			log_hdr_v3->hdr_version);
 		if ((log_hdr->hdr_version & 0xFF) == 0x03)
-			fprintf(stderr, "INFO: WDC: DUI Product ID = 0x%x/%c\n",
+			nvme_show_error("INFO: WDC: DUI Product ID = 0x%x/%c",
 				log_hdr_v3->product_id, log_hdr_v3->product_id);
 	}
 
 	if (!cap_dui_length_v3) {
-		fprintf(stderr, "INFO: WDC: Capture V2 or V3 Device Unit Info log is empty\n");
+		nvme_show_error("INFO: WDC: Capture V2 or V3 Device Unit Info log is empty");
 		return 0;
 	}
 
@@ -3600,14 +3600,14 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 					log_hdr_v3->log_section[j].data_area_id) {
 				log_size += log_hdr_v3->log_section[j].section_size;
 				if (verbose)
-					fprintf(stderr,
+					nvme_show_error(
 						"%s: Data area ID %d : section size 0x%x, total size = 0x%"PRIx64"\n",
 						__func__, log_hdr_v3->log_section[j].data_area_id,
 						(unsigned int)log_hdr_v3->log_section[j].section_size,
 						(uint64_t)log_size);
 			} else {
 				if (verbose)
-					fprintf(stderr, "%s: break, total size = 0x%"PRIx64"\n",
+					nvme_show_error("%s: break, total size = 0x%"PRIx64"\n",
 						__func__, (uint64_t)log_size);
 				break;
 			}
@@ -3619,7 +3619,7 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 	*total_size = log_size;
 
 	if (offset >= *total_size) {
-		fprintf(stderr,
+		nvme_show_error(
 			"%s: INFO: WDC: Offset 0x%"PRIx64" exceeds total size 0x%"PRIx64", no data retrieved\n",
 			__func__, (uint64_t)offset, (uint64_t)*total_size);
 		return -1;
@@ -3627,7 +3627,7 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 
 	dump_data = (__u8 *)malloc(sizeof(__u8) * xfer_size_long);
 	if (!dump_data) {
-		fprintf(stderr,
+		nvme_show_error(
 			"%s: ERROR: dump data v3 malloc failed : status %s, size = 0x%"PRIx64"\n",
 			__func__, libnvme_strerror(errno), (uint64_t)xfer_size_long);
 		return -1;
@@ -3636,7 +3636,7 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 
 	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
-		fprintf(stderr, "%s: Failed to open output file %s: %s!\n",
+		nvme_show_error("%s: Failed to open output file %s: %s!",
 				__func__, file, libnvme_strerror(errno));
 		free(dump_data);
 		return output;
@@ -3652,7 +3652,7 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 			log_size = min(*total_size, file_size);
 
 		if (verbose)
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: INFO: WDC: Offset 0x%"PRIx64", file size 0x%"PRIx64", total size 0x%"PRIx64", log size 0x%"PRIx64"\n",
 				__func__, (uint64_t)offset,
 				(uint64_t)file_size, (uint64_t)*total_size, (uint64_t)log_size);
@@ -3672,11 +3672,11 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 		ret = wdc_dump_dui_data_v2(hdl, (__u32)xfer_size_long, curr_data_offset, buffer_addr,
 					   last_xfer);
 		if (ret) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: WDC: Get chunk %d, size = 0x%"PRIx64", offset = 0x%"PRIx64", addr = %p\n",
 				__func__, i, (uint64_t)*total_size, (uint64_t)curr_data_offset,
 				buffer_addr);
-			fprintf(stderr, "%s: ERROR: WDC: ", __func__);
+			nvme_show_error("%s: ERROR: WDC: ", __func__);
 			nvme_show_status(ret);
 			break;
 		}
@@ -3684,7 +3684,7 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 		/* write the dump data into the file */
 		err = write(output, (void *)buffer_addr, xfer_size_long);
 		if (err != xfer_size_long) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: WDC: Failed to flush DUI data to file! chunk %d, err = 0x%x, xfer_size = 0x%"PRIx64"\n",
 				__func__, i, err, (uint64_t)xfer_size_long);
 			ret = -1;
@@ -3723,15 +3723,15 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 	cap_dui_length_v4 = le64_to_cpu(log_hdr_v4->log_size_sectors) * WDC_NVME_SN730_SECTOR_SIZE;
 
 	if (verbose) {
-		fprintf(stderr, "INFO: WDC: Capture V4 Device Unit Info log, data area = %d\n", data_area);
-		fprintf(stderr, "INFO: WDC: DUI Header Version = 0x%x\n", log_hdr_v4->hdr_version);
-		fprintf(stderr, "INFO: WDC: DUI Product ID = 0x%x/%c\n", log_hdr_v4->product_id, log_hdr_v4->product_id);
-		fprintf(stderr, "INFO: WDC: DUI log size sectors = 0x%x\n", log_hdr_v4->log_size_sectors);
-		fprintf(stderr, "INFO: WDC: DUI cap_dui_length = 0x%"PRIx64"\n", (uint64_t)cap_dui_length_v4);
+		nvme_show_error("INFO: WDC: Capture V4 Device Unit Info log, data area = %d", data_area);
+		nvme_show_error("INFO: WDC: DUI Header Version = 0x%x", log_hdr_v4->hdr_version);
+		nvme_show_error("INFO: WDC: DUI Product ID = 0x%x/%c", log_hdr_v4->product_id, log_hdr_v4->product_id);
+		nvme_show_error("INFO: WDC: DUI log size sectors = 0x%x", log_hdr_v4->log_size_sectors);
+		nvme_show_error("INFO: WDC: DUI cap_dui_length = 0x%"PRIx64"\n", (uint64_t)cap_dui_length_v4);
 	}
 
 	if (!cap_dui_length_v4) {
-		fprintf(stderr, "INFO: WDC: Capture V4 Device Unit Info log is empty\n");
+		nvme_show_error("INFO: WDC: Capture V4 Device Unit Info log is empty");
 		return 0;
 	}
 
@@ -3743,14 +3743,14 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 				section_size_bytes = ((__s64)log_hdr_v4->log_section[j].section_size_sectors * WDC_NVME_SN730_SECTOR_SIZE);
 				log_size += section_size_bytes;
 				if (verbose)
-					fprintf(stderr,
+					nvme_show_error(
 						"%s: Data area ID %d : section size 0x%x sectors, section size 0x%"PRIx64" bytes, total size = 0x%"PRIx64"\n",
 						__func__, log_hdr_v4->log_section[j].data_area_id,
 						log_hdr_v4->log_section[j].section_size_sectors,
 						(uint64_t)section_size_bytes, (uint64_t)log_size);
 			} else {
 				if (verbose)
-					fprintf(stderr, "%s: break, total size = 0x%"PRIx64"\n", __func__, (uint64_t)log_size);
+					nvme_show_error("%s: break, total size = 0x%"PRIx64"\n", __func__, (uint64_t)log_size);
 				break;
 			}
 		}
@@ -3761,7 +3761,7 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 	*total_size = log_size;
 
 	if (offset >= *total_size) {
-		fprintf(stderr,
+		nvme_show_error(
 			"%s: INFO: WDC: Offset 0x%"PRIx64" exceeds total size 0x%"PRIx64", no data retrieved\n",
 			__func__, (uint64_t)offset, (uint64_t)*total_size);
 		return -1;
@@ -3769,7 +3769,7 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 
 	dump_data = (__u8 *)malloc(sizeof(__u8) * xfer_size_long);
 	if (!dump_data) {
-		fprintf(stderr, "%s: ERROR: dump data V4 malloc failed : status %s, size = 0x%x\n",
+		nvme_show_error("%s: ERROR: dump data V4 malloc failed : status %s, size = 0x%x",
 			__func__, libnvme_strerror(errno), (unsigned int)xfer_size_long);
 		return -1;
 	}
@@ -3777,7 +3777,7 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 
 	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
-		fprintf(stderr, "%s: Failed to open output file %s: %s!\n", __func__, file,
+		nvme_show_error("%s: Failed to open output file %s: %s!", __func__, file,
 			libnvme_strerror(errno));
 		free(dump_data);
 		return output;
@@ -3793,7 +3793,7 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 			log_size = min(*total_size, file_size);
 
 		if (verbose)
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: INFO: WDC: Offset 0x%"PRIx64", file size 0x%"PRIx64", total size 0x%"PRIx64", log size 0x%"PRIx64"\n",
 				__func__, (uint64_t)offset, (uint64_t)file_size,
 				(uint64_t)*total_size, (uint64_t)log_size);
@@ -3812,11 +3812,11 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 
 		ret = wdc_dump_dui_data_v2(hdl, (__u32)xfer_size_long, curr_data_offset, buffer_addr, last_xfer);
 		if (ret) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: WDC: Get chunk %d, size = 0x%"PRIx64", offset = 0x%"PRIx64", addr = %p\n",
 				__func__, i, (uint64_t)log_size, (uint64_t)curr_data_offset,
 				buffer_addr);
-			fprintf(stderr, "%s: ERROR: WDC:", __func__);
+			nvme_show_error("%s: ERROR: WDC:", __func__);
 			nvme_show_status(ret);
 			break;
 		}
@@ -3824,7 +3824,7 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 		/* write the dump data into the file */
 		err = write(output, (void *)buffer_addr, xfer_size_long);
 		if (err != xfer_size_long) {
-			fprintf(stderr,
+			nvme_show_error(
 				"%s: ERROR: WDC: Failed to flush DUI data to file! chunk %d, err = 0x%x, xfer_size_long = 0x%"PRIx64"\n",
 				__func__, i, err, (uint64_t)xfer_size_long);
 			ret = -1;
@@ -3852,7 +3852,7 @@ static int wdc_do_cap_dui(struct libnvme_transport_handle *hdl, char *file, __u3
 
 	log_hdr = (struct wdc_dui_log_hdr *)malloc(dui_log_hdr_size);
 	if (!log_hdr) {
-		fprintf(stderr, "%s: ERROR: log header malloc failed : status %s, size 0x%x\n",
+		nvme_show_error("%s: ERROR: log header malloc failed : status %s, size 0x%x",
 				__func__, libnvme_strerror(errno), dui_log_hdr_size);
 		return -1;
 	}
@@ -3861,8 +3861,8 @@ static int wdc_do_cap_dui(struct libnvme_transport_handle *hdl, char *file, __u3
 	/* get the dui telemetry and log headers */
 	ret = wdc_dump_dui_data(hdl, WDC_NVME_CAP_DUI_HEADER_SIZE, 0x00,	(__u8 *)log_hdr, last_xfer);
 	if (ret) {
-		fprintf(stderr, "%s: ERROR: WDC: Get DUI headers failed\n", __func__);
-		fprintf(stderr, "%s: ERROR: WDC: ", __func__);
+		nvme_show_error("%s: ERROR: WDC: Get DUI headers failed", __func__);
+		nvme_show_error("%s: ERROR: WDC: ", __func__);
 		nvme_show_status(ret);
 		goto out;
 	}
@@ -3886,14 +3886,14 @@ static int wdc_do_cap_dui(struct libnvme_transport_handle *hdl, char *file, __u3
 		if (ret)
 			goto out;
 	} else {
-		fprintf(stderr, "INFO: WDC: Unsupported header version = 0x%x\n",
+		nvme_show_error("INFO: WDC: Unsupported header version = 0x%x",
 			log_hdr->hdr_version);
 		goto out;
 	}
 
 	nvme_show_status(ret);
 	if (verbose)
-		fprintf(stderr, "INFO: WDC: Capture Device Unit Info log, length = 0x%"PRIx64"\n",
+		nvme_show_error("INFO: WDC: Capture Device Unit Info log, length = 0x%"PRIx64"\n",
 			(uint64_t)total_size);
 
 out:
@@ -3942,12 +3942,12 @@ static int wdc_cap_diag(int argc, char **argv, struct command *acmd,
 		xfer_size = cfg.xfer_size;
 	ret = wdc_get_serial_name(hdl, f, PATH_MAX, "cap_diag");
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: failed to generate file name\n");
+		nvme_show_error("ERROR: WDC: failed to generate file name");
 		return ret;
 	}
 	if (!cfg.file) {
 		if (strlen(f) > PATH_MAX - 5) {
-			fprintf(stderr, "ERROR: WDC: file name overflow\n");
+			nvme_show_error("ERROR: WDC: file name overflow");
 			return -1;
 		}
 		strcat(f, ".bin");
@@ -3957,7 +3957,7 @@ static int wdc_cap_diag(int argc, char **argv, struct command *acmd,
 	if ((capabilities & WDC_DRIVE_CAP_CAP_DIAG) == WDC_DRIVE_CAP_CAP_DIAG)
 		ret = wdc_do_cap_diag(ctx, hdl, f, xfer_size, 0, 0);
 	else
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 	return ret;
 }
 
@@ -3969,7 +3969,7 @@ static int wdc_do_get_sn730_log_len(struct libnvme_transport_handle *hdl, uint32
 
 	output = (uint32_t *)malloc(sizeof(uint32_t));
 	if (!output) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(output, 0, sizeof(uint32_t));
@@ -3996,7 +3996,7 @@ static int wdc_do_get_sn730_log(struct libnvme_transport_handle *hdl, void *log_
 
 	output = (uint8_t *)calloc(SN730_LOG_CHUNK_SIZE, sizeof(uint8_t));
 	if (!output) {
-		fprintf(stderr, "ERROR: WDC: calloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: calloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(&admin_cmd, 0, sizeof(struct libnvme_passthru_cmd));
@@ -4022,7 +4022,7 @@ static int get_sn730_log_chunks(struct libnvme_transport_handle *hdl, uint8_t *l
 
 	chunk_buf = (uint8_t *)malloc(sizeof(uint8_t) * SN730_LOG_CHUNK_SIZE);
 	if (!chunk_buf) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		ret = -1;
 		goto out;
 	}
@@ -4065,7 +4065,7 @@ static int wdc_do_sn730_get_and_tar(struct libnvme_transport_handle *hdl, char *
 
 	tarInfo = (struct tarfile_metadata *)malloc(sizeof(struct tarfile_metadata));
 	if (!tarInfo) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		ret = -1;
 		goto free_buf;
 	}
@@ -4086,16 +4086,16 @@ static int wdc_do_sn730_get_and_tar(struct libnvme_transport_handle *hdl, char *
 		wdc_UtilsSnprintf((char *)tarInfo->bufferFolderPath, MAX_PATH_LEN, "%s%s%s",
 				(char *)tarInfo->currDir, WDC_DE_PATH_SEPARATOR, (char *)tarInfo->bufferFolderName);
 	} else {
-		fprintf(stderr, "ERROR: WDC: get current working directory failed\n");
+		nvme_show_error("ERROR: WDC: get current working directory failed");
 		goto free_buf;
 	}
 
 	ret = wdc_UtilsCreateDir((char *)tarInfo->bufferFolderPath);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: create directory failed, ret = %d, dir = %s\n", ret, tarInfo->bufferFolderPath);
+		nvme_show_error("ERROR: WDC: create directory failed, ret = %d, dir = %s", ret, tarInfo->bufferFolderPath);
 		goto free_buf;
 	} else {
-		fprintf(stderr, "Stored log files in directory: %s\n", tarInfo->bufferFolderPath);
+		nvme_show_error("Stored log files in directory: %s", tarInfo->bufferFolderPath);
 	}
 
 	ret = wdc_do_get_sn730_log_len(hdl, &full_log_len, SN730_GET_FULL_LOG_LENGTH);
@@ -4125,7 +4125,7 @@ static int wdc_do_sn730_get_and_tar(struct libnvme_transport_handle *hdl, char *
 	extended_log_buf = (uint8_t *) calloc(extended_log_len, sizeof(uint8_t));
 
 	if (!full_log_buf || !key_log_buf || !core_dump_log_buf || !extended_log_buf) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		ret = -1;
 		goto free_buf;
 	}
@@ -4183,7 +4183,7 @@ static int wdc_do_sn730_get_and_tar(struct libnvme_transport_handle *hdl, char *
 	ret = system(tarInfo->tarCmd);
 
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Tar of log data failed, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: Tar of log data failed, ret = %d", ret);
 
 free_buf:
 	free(tarInfo);
@@ -4210,7 +4210,7 @@ static int dump_internal_logs(struct libnvme_transport_handle *hdl, const char *
 	hdr = malloc(bs);
 	telemetry_log = malloc(bs);
 	if (!hdr || !telemetry_log) {
-		fprintf(stderr, "Failed to allocate %zu bytes for log: %s\n", bs, libnvme_strerror(errno));
+		nvme_show_error("Failed to allocate %zu bytes for log: %s", bs, libnvme_strerror(errno));
 		err = -ENOMEM;
 		goto free_mem;
 	}
@@ -4219,7 +4219,7 @@ static int dump_internal_logs(struct libnvme_transport_handle *hdl, const char *
 	sprintf(file_path, "%s/telemetry.bin", dir_name);
 	output = nvme_open_rawdata(file_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
-		fprintf(stderr, "Failed to open output file %s: %s!\n", file_path, libnvme_strerror(errno));
+		nvme_show_error("Failed to open output file %s: %s!", file_path, libnvme_strerror(errno));
 		err = output;
 		goto free_mem;
 	}
@@ -4234,13 +4234,13 @@ static int dump_internal_logs(struct libnvme_transport_handle *hdl, const char *
 		perror("get-telemetry-log");
 	else if (err > 0) {
 		nvme_show_status(err);
-		fprintf(stderr, "Failed to acquire telemetry header %d!\n", err);
+		nvme_show_error("Failed to acquire telemetry header %d!", err);
 		goto close_output;
 	}
 
 	err = write(output, (void *)hdr, bs);
 	if (err != bs) {
-		fprintf(stderr, "Failed to flush all data to file!\n");
+		nvme_show_error("Failed to flush all data to file!");
 		goto close_output;
 	}
 
@@ -4255,14 +4255,14 @@ static int dump_internal_logs(struct libnvme_transport_handle *hdl, const char *
 			perror("get-telemetry-log");
 			break;
 		} else if (err > 0) {
-			fprintf(stderr, "Failed to acquire full telemetry log!\n");
+			nvme_show_error("Failed to acquire full telemetry log!");
 			nvme_show_status(err);
 			break;
 		}
 
 		err = write(output, (void *)telemetry_log, bs);
 		if (err != bs) {
-			fprintf(stderr, "Failed to flush all data to file!\n");
+			nvme_show_error("Failed to flush all data to file!");
 			break;
 		}
 		err = 0;
@@ -4287,7 +4287,7 @@ static int wdc_get_default_telemetry_da(struct libnvme_transport_handle *hdl,
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	err = nvme_identify_ctrl(hdl, &ctrl);
 	if (err) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", err);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", err);
 		return err;
 	}
 
@@ -4373,7 +4373,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 	if (cfg.xfer_size) {
 		xfer_size = cfg.xfer_size;
 	} else {
-		fprintf(stderr, "ERROR: WDC: Invalid length\n");
+		nvme_show_error("ERROR: WDC: Invalid length");
 		goto out;
 	}
 
@@ -4386,7 +4386,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 			/* verify file name and path is valid before getting dump data */
 			verify_file = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 			if (verify_file < 0) {
-				fprintf(stderr, "ERROR: WDC: open: %s\n", libnvme_strerror(errno));
+				nvme_show_error("ERROR: WDC: open: %s", libnvme_strerror(errno));
 				goto out;
 			}
 			close(verify_file);
@@ -4403,24 +4403,24 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 
 			ret = wdc_get_serial_name(hdl, f, PATH_MAX, fileSuffix);
 			if (ret) {
-				fprintf(stderr, "ERROR: WDC: failed to generate file name\n");
+				nvme_show_error("ERROR: WDC: failed to generate file name");
 				goto out;
 			}
 		}
 
 		if (!cfg.file) {
 			if (strlen(f) > PATH_MAX - 5) {
-				fprintf(stderr, "ERROR: WDC: file name overflow\n");
+				nvme_show_error("ERROR: WDC: file name overflow");
 				ret = -1;
 				goto out;
 			}
 			strcat(f, ".bin");
 		}
-		fprintf(stderr, "%s: filename = %s\n", __func__, f);
+		nvme_show_error("%s: filename = %s", __func__, f);
 
 		if (cfg.data_area) {
 			if (cfg.data_area > 5 || cfg.data_area < 1) {
-				fprintf(stderr, "ERROR: WDC: Data area must be 1-5\n");
+				nvme_show_error("ERROR: WDC: Data area must be 1-5");
 				ret = -1;
 				goto out;
 			}
@@ -4436,7 +4436,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 			telemetry_type = WDC_TELEMETRY_TYPE_CONTROLLER;
 			telemetry_data_area = cfg.data_area;
 		} else {
-			fprintf(stderr,
+			nvme_show_error(
 				"ERROR: WDC: Invalid type - Must be NONE, HOST or CONTROLLER\n");
 			ret = -1;
 			goto out;
@@ -4456,27 +4456,27 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 
 			ret = wdc_get_serial_name(hdl, fb, PATH_MAX/2 - 7, fileSuffix);
 			if (ret) {
-				fprintf(stderr, "ERROR: WDC: failed to generate file name\n");
+				nvme_show_error("ERROR: WDC: failed to generate file name");
 				goto out;
 			}
 
 			if (strlen(fb) > PATH_MAX/2 - 7) {
-				fprintf(stderr, "ERROR: WDC: file name overflow\n");
+				nvme_show_error("ERROR: WDC: file name overflow");
 				ret = -1;
 				goto out;
 			}
 		}
-		fprintf(stderr, "%s: filename = %s.tar.gz\n", __func__, fb);
+		nvme_show_error("%s: filename = %s.tar.gz", __func__, fb);
 
 
 		memset(file_path, 0, sizeof(file_path));
 		if (snprintf(file_path, PATH_MAX/2 - 8, "%s.tar.gz", fb) >= PATH_MAX/2 - 8) {
-			fprintf(stderr, "File path is too long!\n");
+			nvme_show_error("File path is too long!");
 			ret = -1;
 			goto out;
 		}
 		if (access(file_path, F_OK) != -1) {
-			fprintf(stderr, "Output file already exists!\n");
+			nvme_show_error("Output file already exists!");
 			ret = -EEXIST;
 			goto out;
 		}
@@ -4487,7 +4487,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 		if (!wdc_is_sn861(device_id)) {
 			if (telemetry_type != WDC_TELEMETRY_TYPE_NONE &&
 			    wdc_get_default_telemetry_da(hdl, &telemetry_data_area)) {
-				fprintf(stderr, "%s: Error determining default telemetry data area\n",
+				nvme_show_error("%s: Error determining default telemetry data area",
 					__func__);
 				return -EINVAL;
 			}
@@ -4500,7 +4500,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 
 			ret = mkdir(fb, 0666);
 			if (ret) {
-				fprintf(stderr, "Failed to create directory!\n");
+				nvme_show_error("Failed to create directory!");
 				goto out;
 			}
 
@@ -4514,14 +4514,14 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 			if (snprintf(cmd_buf, PATH_MAX,
 				     "tar --remove-files -czf %s %s",
 				     file_path, fb) >= PATH_MAX) {
-				fprintf(stderr, "Command buffer is too long!\n");
+				nvme_show_error("Command buffer is too long!");
 				ret = -1;
 				goto out;
 			}
 
 			ret = system(cmd_buf);
 			if (ret)
-				fprintf(stderr, "Failed to create an archive file!\n");
+				nvme_show_error("Failed to create an archive file!");
 		}
 		goto out;
 	}
@@ -4529,7 +4529,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 		if ((telemetry_type == WDC_TELEMETRY_TYPE_HOST) ||
 			(telemetry_type == WDC_TELEMETRY_TYPE_CONTROLLER)) {
 			if (wdc_get_default_telemetry_da(hdl, &telemetry_data_area)) {
-				fprintf(stderr, "%s: Error determining default telemetry data area\n",
+				nvme_show_error("%s: Error determining default telemetry data area",
 					__func__);
 				return -EINVAL;
 			}
@@ -4555,7 +4555,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 		if ((telemetry_type == WDC_TELEMETRY_TYPE_HOST) ||
 			(telemetry_type == WDC_TELEMETRY_TYPE_CONTROLLER)) {
 			if (wdc_get_default_telemetry_da(hdl, &telemetry_data_area)) {
-				fprintf(stderr, "%s: Error determining default telemetry data area\n",
+				nvme_show_error("%s: Error determining default telemetry data area",
 					__func__);
 				return -EINVAL;
 			}
@@ -4572,7 +4572,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 	if ((capabilities & WDC_SN730B_CAP_VUC_LOG) == WDC_SN730B_CAP_VUC_LOG) {
 		ret = wdc_do_sn730_get_and_tar(hdl, f);
 	} else {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	}
 out:
@@ -4624,18 +4624,18 @@ static int wdc_do_crash_dump(struct libnvme_transport_handle *hdl, char *file, i
 
 	if (ret == -1) {
 		if (type == WDC_NVME_PFAIL_DUMP_TYPE)
-			fprintf(stderr, "INFO: WDC: Pfail dump get size failed\n");
+			nvme_show_error("INFO: WDC: Pfail dump get size failed");
 		else
-			fprintf(stderr, "INFO: WDC: Crash dump get size failed\n");
+			nvme_show_error("INFO: WDC: Crash dump get size failed");
 
 		return -1;
 	}
 
 	if (!crash_dump_length) {
 		if (type == WDC_NVME_PFAIL_DUMP_TYPE)
-			fprintf(stderr, "INFO: WDC: Pfail dump is empty\n");
+			nvme_show_error("INFO: WDC: Pfail dump is empty");
 		else
-			fprintf(stderr, "INFO: WDC: Crash dump is empty\n");
+			nvme_show_error("INFO: WDC: Crash dump is empty");
 	} else {
 		ret = wdc_do_dump(hdl,
 			opcode,
@@ -4667,7 +4667,7 @@ static int wdc_crash_dump(struct libnvme_transport_handle *hdl, const char *file
 
 	ret = wdc_get_serial_name(hdl, f, PATH_MAX, dump_type);
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: failed to generate file name\n");
+		nvme_show_error("ERROR: WDC: failed to generate file name");
 	else
 		ret = wdc_do_crash_dump(hdl, f, type);
 	return ret;
@@ -4690,7 +4690,7 @@ static int wdc_do_drive_log(struct libnvme_transport_handle *hdl, const char *fi
 
 	drive_log_data = (__u8 *)malloc(sizeof(__u8) * drive_log_length);
 	if (!drive_log_data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -4743,14 +4743,14 @@ static int wdc_drive_log(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_DRIVE_LOG)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	} else {
 		if (cfg.file)
 			strncpy(f, cfg.file, PATH_MAX - 1);
 		ret = wdc_get_serial_name(hdl, f, PATH_MAX, "drive_log");
 		if (ret)
-			fprintf(stderr, "ERROR: WDC: failed to generate file name\n");
+			nvme_show_error("ERROR: WDC: failed to generate file name");
 		else
 			ret = wdc_do_drive_log(hdl, f);
 	}
@@ -4789,12 +4789,12 @@ static int wdc_get_crash_dump(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_CRASH_DUMP)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	} else {
 		ret = wdc_crash_dump(hdl, cfg.file, WDC_NVME_CRASH_DUMP_TYPE);
 		if (ret)
-			fprintf(stderr, "ERROR: WDC: failed to read crash dump\n");
+			nvme_show_error("ERROR: WDC: failed to read crash dump");
 	}
 	return ret;
 }
@@ -4829,12 +4829,12 @@ static int wdc_get_pfail_dump(int argc, char **argv, struct command *acmd,
 
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if (!(capabilities & WDC_DRIVE_CAP_PFAIL_DUMP)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	} else {
 		ret = wdc_crash_dump(hdl, cfg.file, WDC_NVME_PFAIL_DUMP_TYPE);
 		if (ret)
-			fprintf(stderr, "ERROR: WDC: failed to read pfail crash dump\n");
+			nvme_show_error("ERROR: WDC: failed to read pfail crash dump");
 	}
 	return ret;
 }
@@ -4909,7 +4909,7 @@ static int wdc_purge(int argc, char **argv,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if (!(capabilities & WDC_DRIVE_CAP_PURGE)) {
 		ret = -1;
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 	} else {
 		err_str = "";
 		memset(&admin_cmd, 0, sizeof(admin_cmd));
@@ -4929,7 +4929,7 @@ static int wdc_purge(int argc, char **argv,
 			}
 		}
 
-		fprintf(stderr, "%s", err_str);
+		nvme_show_error("%s", err_str);
 		nvme_show_status(ret);
 	}
 	return ret;
@@ -4961,7 +4961,7 @@ static int wdc_purge_monitor(int argc, char **argv,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if (!(capabilities & WDC_DRIVE_CAP_PURGE)) {
 		ret = -1;
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 	} else {
 		memset(output, 0, sizeof(output));
 		memset(&admin_cmd, 0, sizeof(struct libnvme_passthru_cmd));
@@ -5105,7 +5105,7 @@ static void wdc_print_log_json(struct wdc_ssd_perf_stats *perf)
 static int wdc_print_log(struct wdc_ssd_perf_stats *perf, int fmt)
 {
 	if (!perf) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read perf stats\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read perf stats");
 		return -1;
 	}
 	switch (fmt) {
@@ -5132,7 +5132,7 @@ static int wdc_print_latency_monitor_log_normal(struct libnvme_transport_handle 
 	if (!err) {
 		printf("  Serial Number:  %-.*s\n", (int)sizeof(ctrl.sn), ctrl.sn);
 	} else {
-		fprintf(stderr, "ERROR: WDC: latency monitor read id ctrl failure, err = %d\n", err);
+		nvme_show_error("ERROR: WDC: latency monitor read id ctrl failure, err = %d", err);
 		return err;
 	}
 
@@ -6328,7 +6328,7 @@ static int nvme_get_print_ocp_cloud_smart_log(struct libnvme_transport_handle *h
 
 	log_ptr = malloc(sizeof(*log_ptr));
 	if (!log_ptr) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -6353,16 +6353,16 @@ static int nvme_get_print_ocp_cloud_smart_log(struct libnvme_transport_handle *h
 		/* Verify GUID matches */
 		for (i = 0; i < 16; i++) {
 			if (scao_guid[i] != log_ptr->log_page_guid[i]) {
-				fprintf(stderr, "ERROR: WDC: Unknown GUID in C0 Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unknown GUID in C0 Log Page data");
 				int j;
 
-				fprintf(stderr, "ERROR: WDC: Expected GUID:  0x");
+				nvme_show_error("ERROR: WDC: Expected GUID:  0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", scao_guid[j]);
-				fprintf(stderr, "\nERROR: WDC: Actual GUID:    0x");
+					nvme_show_error("%x", scao_guid[j]);
+				nvme_show_error("\nERROR: WDC: Actual GUID:    0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", log_ptr->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", log_ptr->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				break;
@@ -6373,7 +6373,7 @@ static int nvme_get_print_ocp_cloud_smart_log(struct libnvme_transport_handle *h
 			/* parse the data */
 			wdc_print_c0_cloud_attr_log(log_ptr, fmt, hdl);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read C0 Log Page data\n");
+		nvme_show_error("ERROR: WDC: Unable to read C0 Log Page data");
 		ret = -1;
 	}
 
@@ -6393,7 +6393,7 @@ static int nvme_get_print_c0_eol_log(struct libnvme_transport_handle *hdl,
 
 	log_ptr = (void *)malloc(sizeof(__u8) * length);
 	if (!log_ptr) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -6418,8 +6418,8 @@ static int nvme_get_print_c0_eol_log(struct libnvme_transport_handle *hdl,
 		/* parse the data */
 		wdc_print_c0_eol_log(log_ptr, fmt);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read C0 Log Page data ");
-		fprintf(stderr, "with uuid index %d\n", uuid_index);
+		nvme_show_error("ERROR: WDC: Unable to read C0 Log Page data ");
+		nvme_show_error("with uuid index %d", uuid_index);
 		ret = -1;
 	}
 
@@ -6435,7 +6435,7 @@ static int nvme_get_ext_smart_cloud_log(struct libnvme_transport_handle *hdl, __
 
 	log_ptr = (__u8 *)malloc(sizeof(__u8) * WDC_NVME_SMART_CLOUD_ATTR_LEN);
 	if (!log_ptr) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -6451,16 +6451,16 @@ static int nvme_get_ext_smart_cloud_log(struct libnvme_transport_handle *hdl, __
 		/* Verify GUID matches */
 		for (i = 0; i < WDC_C0_GUID_LENGTH; i++) {
 			if (ext_smart_guid[i] != *&log_ptr[SCAO_V1_LPG + i]) {
-				fprintf(stderr, "ERROR: WDC: Unknown GUID in C0 Log Page V1 data\n");
+				nvme_show_error("ERROR: WDC: Unknown GUID in C0 Log Page V1 data");
 				int j;
 
-				fprintf(stderr, "ERROR: WDC: Expected GUID:  0x");
+				nvme_show_error("ERROR: WDC: Expected GUID:  0x");
 				for (j = 0; j < WDC_C0_GUID_LENGTH; j++)
-					fprintf(stderr, "%x", ext_smart_guid[j]);
-				fprintf(stderr, "\nERROR: WDC: Actual GUID:    0x");
+					nvme_show_error("%x", ext_smart_guid[j]);
+				nvme_show_error("\nERROR: WDC: Actual GUID:    0x");
 				for (j = 0; j < WDC_C0_GUID_LENGTH; j++)
-					fprintf(stderr, "%x", *&log_ptr[SCAO_V1_LPG + j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", *&log_ptr[SCAO_V1_LPG + j]);
+				nvme_show_error("");
 
 				ret = -1;
 				break;
@@ -6482,7 +6482,7 @@ static int nvme_get_hw_rev_log(struct libnvme_transport_handle *hdl, __u8 **data
 
 	log_ptr = malloc(sizeof(*log_ptr));
 	if (!log_ptr) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -6498,16 +6498,16 @@ static int nvme_get_hw_rev_log(struct libnvme_transport_handle *hdl, __u8 **data
 		/* Verify GUID matches */
 		for (i = 0; i < WDC_NVME_C6_GUID_LENGTH; i++) {
 			if (hw_rev_log_guid[i] != log_ptr->hw_rev_guid[i]) {
-				fprintf(stderr, "ERROR: WDC: Unknown GUID in HW Revision Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unknown GUID in HW Revision Log Page data");
 				int j;
 
-				fprintf(stderr, "ERROR: WDC: Expected GUID:  0x");
+				nvme_show_error("ERROR: WDC: Expected GUID:  0x");
 				for (j = 0; j < WDC_NVME_C6_GUID_LENGTH; j++)
-					fprintf(stderr, "%x", hw_rev_log_guid[j]);
-				fprintf(stderr, "\nERROR: WDC: Actual GUID:    0x");
+					nvme_show_error("%x", hw_rev_log_guid[j]);
+				nvme_show_error("\nERROR: WDC: Actual GUID:    0x");
 				for (j = 0; j < WDC_NVME_C6_GUID_LENGTH; j++)
-					fprintf(stderr, "%x", log_ptr->hw_rev_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", log_ptr->hw_rev_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				break;
@@ -7139,7 +7139,7 @@ static void wdc_print_eol_c0_json(void *data)
 static int wdc_print_ext_smart_cloud_log(void *data, int fmt)
 {
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read 0xC0 V1 log\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read 0xC0 V1 log");
 		return -1;
 	}
 	switch (fmt) {
@@ -7160,7 +7160,7 @@ static int wdc_print_c0_cloud_attr_log(void *data,
 	struct ocp_cloud_smart_log *log = (struct ocp_cloud_smart_log *)data;
 
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read 0xC0 log\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read 0xC0 log");
 		return -1;
 	}
 
@@ -7181,7 +7181,7 @@ static int wdc_print_c0_cloud_attr_log(void *data,
 static int wdc_print_c0_eol_log(void *data, int fmt)
 {
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read 0xC0 log\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read 0xC0 log");
 		return -1;
 	}
 	switch (fmt) {
@@ -7214,7 +7214,7 @@ static int wdc_get_c0_log_page_sn_customer_id_0x100X(struct libnvme_transport_ha
 				namespace_id,
 				fmt);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unknown uuid index\n");
+		nvme_show_error("ERROR: WDC: Unknown uuid index");
 		ret = -1;
 	}
 
@@ -7229,7 +7229,7 @@ static int wdc_get_c0_log_page_sn(struct libnvme_global_ctx *ctx, struct libnvme
 
 	cust_id = wdc_get_fw_cust_id(ctx, hdl);
 	if (cust_id == WDC_INVALID_CUSTOMER_ID) {
-		fprintf(stderr, "%s: ERROR: WDC: invalid customer id\n", __func__);
+		nvme_show_error("%s: ERROR: WDC: invalid customer id", __func__);
 		return -1;
 	}
 
@@ -7259,7 +7259,7 @@ static int wdc_get_c0_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 		return -1;
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
@@ -7325,14 +7325,14 @@ static int wdc_get_c0_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 			/* parse the data */
 			wdc_print_ext_smart_cloud_log(data, fmt);
 		} else {
-			fprintf(stderr, "ERROR: WDC: Unable to read C0 Log Page V1 data\n");
+			nvme_show_error("ERROR: WDC: Unable to read C0 Log Page V1 data");
 			ret = -1;
 		}
 
 		free(data);
 		break;
 	default:
-		fprintf(stderr, "ERROR: WDC: Unknown device id - 0x%x\n", device_id);
+		nvme_show_error("ERROR: WDC: Unknown device id - 0x%x", device_id);
 		ret = -1;
 		break;
 
@@ -7346,7 +7346,7 @@ static int wdc_print_latency_monitor_log(struct libnvme_transport_handle *hdl,
 					 int fmt)
 {
 	if (!log_data) {
-		fprintf(stderr, "ERROR: WDC: Invalid C3 log data buffer\n");
+		nvme_show_error("ERROR: WDC: Invalid C3 log data buffer");
 		return -1;
 	}
 	switch (fmt) {
@@ -7363,7 +7363,7 @@ static int wdc_print_latency_monitor_log(struct libnvme_transport_handle *hdl,
 static int wdc_print_error_rec_log(struct wdc_ocp_c1_error_recovery_log *log_data, int fmt)
 {
 	if (!log_data) {
-		fprintf(stderr, "ERROR: WDC: Invalid C1 log data buffer\n");
+		nvme_show_error("ERROR: WDC: Invalid C1 log data buffer");
 		return -1;
 	}
 	switch (fmt) {
@@ -7380,7 +7380,7 @@ static int wdc_print_error_rec_log(struct wdc_ocp_c1_error_recovery_log *log_dat
 static int wdc_print_dev_cap_log(struct wdc_ocp_C4_dev_cap_log *log_data, int fmt)
 {
 	if (!log_data) {
-		fprintf(stderr, "ERROR: WDC: Invalid C4 log data buffer\n");
+		nvme_show_error("ERROR: WDC: Invalid C4 log data buffer");
 		return -1;
 	}
 	switch (fmt) {
@@ -7397,7 +7397,7 @@ static int wdc_print_dev_cap_log(struct wdc_ocp_C4_dev_cap_log *log_data, int fm
 static int wdc_print_unsupported_reqs_log(struct wdc_ocp_C5_unsupported_reqs *log_data, int fmt)
 {
 	if (!log_data) {
-		fprintf(stderr, "ERROR: WDC: Invalid C5 log data buffer\n");
+		nvme_show_error("ERROR: WDC: Invalid C5 log data buffer");
 		return -1;
 	}
 	switch (fmt) {
@@ -7414,7 +7414,7 @@ static int wdc_print_unsupported_reqs_log(struct wdc_ocp_C5_unsupported_reqs *lo
 static int wdc_print_fb_ca_log(struct wdc_ssd_ca_perf_stats *perf, int fmt)
 {
 	if (!perf) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read perf stats\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read perf stats");
 		return -1;
 	}
 	switch (fmt) {
@@ -7431,7 +7431,7 @@ static int wdc_print_fb_ca_log(struct wdc_ssd_ca_perf_stats *perf, int fmt)
 static int wdc_print_bd_ca_log(struct libnvme_transport_handle *hdl, void *bd_data, int fmt)
 {
 	if (!bd_data) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read data\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read data");
 		return -1;
 	}
 	switch (fmt) {
@@ -7442,7 +7442,7 @@ static int wdc_print_bd_ca_log(struct libnvme_transport_handle *hdl, void *bd_da
 		wdc_print_bd_ca_log_json(bd_data);
 		break;
 	default:
-		fprintf(stderr, "ERROR: WDC: Unknown format - %d\n", fmt);
+		nvme_show_error("ERROR: WDC: Unknown format - %d", fmt);
 		return -1;
 	}
 	return 0;
@@ -7451,7 +7451,7 @@ static int wdc_print_bd_ca_log(struct libnvme_transport_handle *hdl, void *bd_da
 static int wdc_print_d0_log(struct wdc_ssd_d0_smart_log *perf, int fmt)
 {
 	if (!perf) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read perf stats\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read perf stats");
 		return -1;
 	}
 	switch (fmt) {
@@ -7470,7 +7470,7 @@ static int wdc_print_fw_act_history_log(__u8 *data, int num_entries, int fmt,
 					__u32 device_id)
 {
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: Invalid buffer to read fw activate history entries\n");
+		nvme_show_error("ERROR: WDC: Invalid buffer to read fw activate history entries");
 		return -1;
 	}
 
@@ -7500,21 +7500,21 @@ static int wdc_get_ca_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 		return -1;
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	/* verify the 0xCA log page is supported */
 	if (wdc_nvme_check_supported_log_page(ctx, hdl,
 			WDC_NVME_GET_DEVICE_INFO_LOG_OPCODE, 0) == false) {
-		fprintf(stderr, "ERROR: WDC: 0xCA Log Page not supported\n");
+		nvme_show_error("ERROR: WDC: 0xCA Log Page not supported");
 		return -1;
 	}
 
 	/* get the FW customer id */
 	cust_id = wdc_get_fw_cust_id(ctx, hdl);
 	if (cust_id == WDC_INVALID_CUSTOMER_ID) {
-		fprintf(stderr, "%s: ERROR: WDC: invalid customer id\n", __func__);
+		nvme_show_error("%s: ERROR: WDC: invalid customer id", __func__);
 		return -1;
 	}
 
@@ -7525,7 +7525,7 @@ static int wdc_get_ca_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 		if (cust_id == WDC_CUSTOMER_ID_0x1005) {
 			data = (__u8 *)malloc(sizeof(__u8) * WDC_FB_CA_LOG_BUF_LEN);
 			if (!data) {
-				fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+				nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 				return -1;
 			}
 
@@ -7542,12 +7542,12 @@ static int wdc_get_ca_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 				perf = (struct wdc_ssd_ca_perf_stats *)(data);
 				ret = wdc_print_fb_ca_log(perf, fmt);
 			} else {
-				fprintf(stderr, "ERROR: WDC: Unable to read CA Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unable to read CA Log Page data");
 				ret = -1;
 			}
 		} else {
 
-			fprintf(stderr, "ERROR: WDC: Unsupported Customer id, id = 0x%x\n", cust_id);
+			nvme_show_error("ERROR: WDC: Unsupported Customer id, id = 0x%x", cust_id);
 			return -1;
 		}
 		break;
@@ -7561,7 +7561,7 @@ static int wdc_get_ca_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 		if (cust_id == WDC_CUSTOMER_ID_0x1005) {
 			data = (__u8 *)malloc(sizeof(__u8) * WDC_FB_CA_LOG_BUF_LEN);
 			if (!data) {
-				fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+				nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 				return -1;
 			}
 
@@ -7578,14 +7578,14 @@ static int wdc_get_ca_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 				perf = (struct wdc_ssd_ca_perf_stats *)(data);
 				ret = wdc_print_fb_ca_log(perf, fmt);
 			} else {
-				fprintf(stderr, "ERROR: WDC: Unable to read CA Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unable to read CA Log Page data");
 				ret = -1;
 			}
 		} else if ((cust_id == WDC_CUSTOMER_ID_GN) || (cust_id == WDC_CUSTOMER_ID_GD) ||
 				(cust_id == WDC_CUSTOMER_ID_BD)) {
 			data = (__u8 *)malloc(sizeof(__u8) * WDC_BD_CA_LOG_BUF_LEN);
 			if (!data) {
-				fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+				nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 				return -1;
 			}
 
@@ -7600,16 +7600,16 @@ static int wdc_get_ca_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 				/* parse the data */
 				ret = wdc_print_bd_ca_log(hdl, data, fmt);
 			} else {
-				fprintf(stderr, "ERROR: WDC: Unable to read CA Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unable to read CA Log Page data");
 				ret = -1;
 			}
 		} else {
-			fprintf(stderr, "ERROR: WDC: Unsupported Customer id, id = 0x%x\n", cust_id);
+			nvme_show_error("ERROR: WDC: Unsupported Customer id, id = 0x%x", cust_id);
 			return -1;
 		}
 		break;
 	default:
-		fprintf(stderr, "ERROR: WDC: Log page 0xCA not supported for this device\n");
+		nvme_show_error("ERROR: WDC: Log page 0xCA not supported for this device");
 		return -1;
 	}
 
@@ -7637,18 +7637,18 @@ static int wdc_get_c1_log_page(struct libnvme_global_ctx *ctx,
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	if (interval < 1 || interval > 15) {
-		fprintf(stderr, "ERROR: WDC: interval out of range [1-15]\n");
+		nvme_show_error("ERROR: WDC: interval out of range [1-15]");
 		return -1;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_ADD_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * WDC_ADD_LOG_BUF_LEN);
@@ -7672,7 +7672,7 @@ static int wdc_get_c1_log_page(struct libnvme_global_ctx *ctx,
 			skip_cnt = le16_to_cpu(sph->subpage_length) + 4;
 		}
 		if (ret)
-			fprintf(stderr, "ERROR: WDC: Unable to read data from buffer\n");
+			nvme_show_error("ERROR: WDC: Unable to read data from buffer");
 	}
 	free(data);
 	return ret;
@@ -7691,13 +7691,13 @@ static int wdc_get_c3_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_LATENCY_MON_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * WDC_LATENCY_MON_LOG_BUF_LEN);
@@ -7706,14 +7706,14 @@ static int wdc_get_c3_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 				  data, WDC_LATENCY_MON_LOG_BUF_LEN);
 
 	if (strcmp(format, "json"))
-		fprintf(stderr, "NVMe Status:%s(%x)\n", libnvme_status_to_string(ret, false), ret);
+		nvme_show_error("NVMe Status:%s(%x)", libnvme_status_to_string(ret, false), ret);
 
 	if (!ret) {
 		log_data = (struct wdc_ssd_latency_monitor_log *)data;
 
 		/* check log page version */
 		if (log_data->log_page_version != WDC_LATENCY_MON_VERSION) {
-			fprintf(stderr, "ERROR: WDC: invalid latency monitor version\n");
+			nvme_show_error("ERROR: WDC: invalid latency monitor version");
 			ret = -1;
 			goto out;
 		}
@@ -7722,16 +7722,16 @@ static int wdc_get_c3_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 		/* Verify GUID matches */
 		for (i = 0; i < 16; i++) {
 			if (wdc_lat_mon_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR: WDC: Unknown GUID in C3 Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unknown GUID in C3 Log Page data");
 				int j;
 
-				fprintf(stderr, "ERROR: WDC: Expected GUID:  0x");
+				nvme_show_error("ERROR: WDC: Expected GUID:  0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", wdc_lat_mon_guid[j]);
-				fprintf(stderr, "\nERROR: WDC: Actual GUID:    0x");
+					nvme_show_error("%x", wdc_lat_mon_guid[j]);
+				nvme_show_error("\nERROR: WDC: Actual GUID:    0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -7741,7 +7741,7 @@ static int wdc_get_c3_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 		/* parse the data */
 		wdc_print_latency_monitor_log(hdl, log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read C3 data from buffer\n");
+		nvme_show_error("ERROR: WDC: Unable to read C3 data from buffer");
 	}
 
 out:
@@ -7763,13 +7763,13 @@ static int wdc_get_ocp_c1_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_ERROR_REC_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * WDC_ERROR_REC_LOG_BUF_LEN);
@@ -7778,7 +7778,7 @@ static int wdc_get_ocp_c1_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 				  data, WDC_ERROR_REC_LOG_BUF_LEN);
 
 	if (strcmp(format, "json"))
-		fprintf(stderr, "NVMe Status:%s(%x)\n", libnvme_status_to_string(ret, false), ret);
+		nvme_show_error("NVMe Status:%s(%x)", libnvme_status_to_string(ret, false), ret);
 
 	if (!ret) {
 		log_data = (struct wdc_ocp_c1_error_recovery_log *)data;
@@ -7786,7 +7786,7 @@ static int wdc_get_ocp_c1_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 		/* check log page version */
 		if ((log_data->log_page_version < 1) ||
 			(log_data->log_page_version > 3)) {
-			fprintf(stderr, "ERROR: WDC: invalid error recovery log version - %d\n",
+			nvme_show_error("ERROR: WDC: invalid error recovery log version - %d",
 				log_data->log_page_version);
 			ret = -1;
 			goto out;
@@ -7795,16 +7795,16 @@ static int wdc_get_ocp_c1_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 		/* Verify GUID matches */
 		for (i = 0; i < WDC_OCP_C1_GUID_LENGTH; i++) {
 			if (wdc_ocp_c1_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR: WDC: Unknown GUID in C1 Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unknown GUID in C1 Log Page data");
 				int j;
 
-				fprintf(stderr, "ERROR: WDC: Expected GUID:  0x");
+				nvme_show_error("ERROR: WDC: Expected GUID:  0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", wdc_ocp_c1_guid[j]);
-				fprintf(stderr, "\nERROR: WDC: Actual GUID:    0x");
+					nvme_show_error("%x", wdc_ocp_c1_guid[j]);
+				nvme_show_error("\nERROR: WDC: Actual GUID:    0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -7814,7 +7814,7 @@ static int wdc_get_ocp_c1_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 		/* parse the data */
 		wdc_print_error_rec_log(log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read error recovery (C1) data from buffer\n");
+		nvme_show_error("ERROR: WDC: Unable to read error recovery (C1) data from buffer");
 	}
 
 out:
@@ -7835,13 +7835,13 @@ static int wdc_get_ocp_c4_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_DEV_CAP_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * WDC_DEV_CAP_LOG_BUF_LEN);
@@ -7850,14 +7850,14 @@ static int wdc_get_ocp_c4_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 				  data, WDC_DEV_CAP_LOG_BUF_LEN);
 
 	if (strcmp(format, "json"))
-		fprintf(stderr, "NVMe Status:%s(%x)\n", libnvme_status_to_string(ret, false), ret);
+		nvme_show_error("NVMe Status:%s(%x)", libnvme_status_to_string(ret, false), ret);
 
 	if (!ret) {
 		log_data = (struct wdc_ocp_C4_dev_cap_log *)data;
 
 		/* check log page version */
 		if (log_data->log_page_version != WDC_DEV_CAP_LOG_VERSION) {
-			fprintf(stderr, "ERROR: WDC: invalid device capabilities log version - %d\n", log_data->log_page_version);
+			nvme_show_error("ERROR: WDC: invalid device capabilities log version - %d", log_data->log_page_version);
 			ret = -1;
 			goto out;
 		}
@@ -7865,16 +7865,16 @@ static int wdc_get_ocp_c4_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 		/* Verify GUID matches */
 		for (i = 0; i < WDC_OCP_C4_GUID_LENGTH; i++) {
 			if (wdc_ocp_c4_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR: WDC: Unknown GUID in C4 Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unknown GUID in C4 Log Page data");
 				int j;
 
-				fprintf(stderr, "ERROR: WDC: Expected GUID:  0x");
+				nvme_show_error("ERROR: WDC: Expected GUID:  0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", wdc_ocp_c4_guid[j]);
-				fprintf(stderr, "\nERROR: WDC: Actual GUID:    0x");
+					nvme_show_error("%x", wdc_ocp_c4_guid[j]);
+				nvme_show_error("\nERROR: WDC: Actual GUID:    0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -7884,7 +7884,7 @@ static int wdc_get_ocp_c4_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 		/* parse the data */
 		wdc_print_dev_cap_log(log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read device capabilities (C4) data from buffer\n");
+		nvme_show_error("ERROR: WDC: Unable to read device capabilities (C4) data from buffer");
 	}
 
 out:
@@ -7905,13 +7905,13 @@ static int wdc_get_ocp_c5_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_UNSUPPORTED_REQS_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * WDC_UNSUPPORTED_REQS_LOG_BUF_LEN);
@@ -7920,15 +7920,15 @@ static int wdc_get_ocp_c5_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 				  data, WDC_UNSUPPORTED_REQS_LOG_BUF_LEN);
 
 	if (strcmp(format, "json"))
-		fprintf(stderr, "NVMe Status:%s(%x)\n", libnvme_status_to_string(ret, false), ret);
+		nvme_show_error("NVMe Status:%s(%x)", libnvme_status_to_string(ret, false), ret);
 
 	if (!ret) {
 		log_data = (struct wdc_ocp_C5_unsupported_reqs *)data;
 
 		/* check log page version */
 		if (log_data->log_page_version != WDC_UNSUPPORTED_REQS_LOG_VERSION) {
-			fprintf(stderr, "ERROR: WDC: invalid 0xC5 log page version\n");
-			fprintf(stderr, "ERROR: WDC: log page version: %d\n",
+			nvme_show_error("ERROR: WDC: invalid 0xC5 log page version");
+			nvme_show_error("ERROR: WDC: log page version: %d",
 				log_data->log_page_version);
 			ret = -1;
 			goto out;
@@ -7937,16 +7937,16 @@ static int wdc_get_ocp_c5_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 		/* Verify GUID matches */
 		for (i = 0; i < WDC_OCP_C5_GUID_LENGTH; i++) {
 			if (wdc_ocp_c5_guid[i] != log_data->log_page_guid[i]) {
-				fprintf(stderr, "ERROR: WDC: Unknown GUID in C5 Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unknown GUID in C5 Log Page data");
 				int j;
 
-				fprintf(stderr, "ERROR: WDC: Expected GUID:  0x");
+				nvme_show_error("ERROR: WDC: Expected GUID:  0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", wdc_ocp_c5_guid[j]);
-				fprintf(stderr, "\nERROR: WDC: Actual GUID:    0x");
+					nvme_show_error("%x", wdc_ocp_c5_guid[j]);
+				nvme_show_error("\nERROR: WDC: Actual GUID:    0x");
 				for (j = 0; j < 16; j++)
-					fprintf(stderr, "%x", log_data->log_page_guid[j]);
-				fprintf(stderr, "\n");
+					nvme_show_error("%x", log_data->log_page_guid[j]);
+				nvme_show_error("");
 
 				ret = -1;
 				goto out;
@@ -7956,7 +7956,7 @@ static int wdc_get_ocp_c5_log_page(struct libnvme_global_ctx *ctx, struct libnvm
 		/* parse the data */
 		wdc_print_unsupported_reqs_log(log_data, fmt);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read unsupported requirements (C5) data from buffer\n");
+		nvme_show_error("ERROR: WDC: Unable to read unsupported requirements (C5) data from buffer");
 	}
 
 out:
@@ -7976,20 +7976,20 @@ static int wdc_get_d0_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	/* verify the 0xD0 log page is supported */
 	if (wdc_nvme_check_supported_log_page(ctx, hdl,
 			WDC_NVME_GET_VU_SMART_LOG_OPCODE, 0) == false) {
-		fprintf(stderr, "ERROR: WDC: 0xD0 Log Page not supported\n");
+		nvme_show_error("ERROR: WDC: 0xD0 Log Page not supported");
 		return -1;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_NVME_VU_SMART_LOG_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 	memset(data, 0, sizeof(__u8) * WDC_NVME_VU_SMART_LOG_LEN);
@@ -8005,7 +8005,7 @@ static int wdc_get_d0_log_page(struct libnvme_global_ctx *ctx, struct libnvme_tr
 		perf = (struct wdc_ssd_d0_smart_log *)(data);
 		ret = wdc_print_d0_log(perf, fmt);
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read D0 Log Page data\n");
+		nvme_show_error("ERROR: WDC: Unable to read D0 Log Page data");
 		ret = -1;
 	}
 
@@ -8340,7 +8340,7 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 	} else if (cfg.log_page_version == 1) {
 		uuid_index = 1;
 	} else {
-		fprintf(stderr, "ERROR: WDC: unsupported log page version for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported log page version for this command");
 		ret = -1;
 		goto out;
 	}
@@ -8348,7 +8348,7 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 	num = argconfig_parse_comma_sep_array(cfg.log_page_mask, log_page_list, 16);
 
 	if (num == -1) {
-		fprintf(stderr, "ERROR: WDC: log page list is malformed\n");
+		nvme_show_error("ERROR: WDC: log page list is malformed");
 		ret = -1;
 		goto out;
 	}
@@ -8369,13 +8369,13 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 	}
 
 	if (!page_mask)
-		fprintf(stderr, "ERROR: WDC: Unknown log page mask - %s\n", cfg.log_page_mask);
+		nvme_show_error("ERROR: WDC: Unknown log page mask - %s", cfg.log_page_mask);
 
 	ret = wdc_get_pci_ids(ctx, hdl, &device_id, &read_vendor_id);
 
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if (!(capabilities & WDC_DRIVE_CAP_SMART_LOG_MASK)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -8388,14 +8388,14 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 				nvme_args.output_format,
 				uuid_index, cfg.namespace_id);
 			if (ret)
-				fprintf(stderr,
+				nvme_show_error(
 					"ERROR: WDC: Failure reading the C0 Log Page, ret = %d\n",
 					ret);
 		} else {
 			ret = validate_output_format(nvme_args.output_format,
 				&fmt);
 			if (ret < 0) {
-				fprintf(stderr, "Invalid output format: %s\n",
+				nvme_show_error("Invalid output format: %s",
 					nvme_args.output_format);
 				goto out;
 			}
@@ -8412,7 +8412,7 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 		/* Get the CA Log Page */
 		ret = wdc_get_ca_log_page(ctx, hdl, nvme_args.output_format);
 		if (ret)
-			fprintf(stderr, "ERROR: WDC: Failure reading the CA Log Page, ret = %d\n", ret);
+			nvme_show_error("ERROR: WDC: Failure reading the CA Log Page, ret = %d", ret);
 	}
 	if (((capabilities & WDC_DRIVE_CAP_C1_LOG_PAGE) == WDC_DRIVE_CAP_C1_LOG_PAGE) &&
 	    (page_mask & WDC_C1_PAGE_MASK)) {
@@ -8420,14 +8420,14 @@ static int wdc_vs_smart_add_log(int argc, char **argv, struct command *acmd,
 		ret = wdc_get_c1_log_page(ctx, hdl, nvme_args.output_format,
 					  cfg.interval);
 		if (ret)
-			fprintf(stderr, "ERROR: WDC: Failure reading the C1 Log Page, ret = %d\n", ret);
+			nvme_show_error("ERROR: WDC: Failure reading the C1 Log Page, ret = %d", ret);
 	}
 	if (((capabilities & WDC_DRIVE_CAP_D0_LOG_PAGE) == WDC_DRIVE_CAP_D0_LOG_PAGE) &&
 	    (page_mask & WDC_D0_PAGE_MASK)) {
 		/* Get the D0 Log Page */
 		ret = wdc_get_d0_log_page(ctx, hdl, nvme_args.output_format);
 		if (ret)
-			fprintf(stderr, "ERROR: WDC: Failure reading the D0 Log Page, ret = %d\n", ret);
+			nvme_show_error("ERROR: WDC: Failure reading the D0 Log Page, ret = %d", ret);
 	}
 
 out:
@@ -8469,7 +8469,7 @@ static int wdc_cu_smart_log(int argc, char **argv, struct command *acmd,
 
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if (!(capabilities & WDC_DRIVE_CAP_SMART_LOG_MASK)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -8481,14 +8481,14 @@ static int wdc_cu_smart_log(int argc, char **argv, struct command *acmd,
 		ret = validate_output_format(nvme_args.output_format, &fmt);
 
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC: invalid output format\n");
+			nvme_show_error("ERROR: WDC: invalid output format");
 			return ret;
 		}
 
 		/* verify the 0xCA log page is supported */
 		if (wdc_nvme_check_supported_log_page(ctx, hdl,
 				WDC_NVME_GET_DEVICE_INFO_LOG_OPCODE, 0) == false) {
-			fprintf(stderr, "ERROR: WDC: 0xCA Log Page not supported\n");
+			nvme_show_error("ERROR: WDC: 0xCA Log Page not supported");
 			return -1;
 		}
 
@@ -8499,7 +8499,7 @@ static int wdc_cu_smart_log(int argc, char **argv, struct command *acmd,
 		case WDC_NVME_SN861_DEV_ID_1:
 			data = (__u8 *)malloc(WDC_BD_CA_LOG_BUF_LEN);
 			if (!data) {
-				fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+				nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 				ret = -1;
 				break;
 			}
@@ -8523,18 +8523,18 @@ static int wdc_cu_smart_log(int argc, char **argv, struct command *acmd,
 				/* parse the data */
 				ret = wdc_print_bd_ca_log(hdl, data, fmt);
 			} else {
-				fprintf(stderr, "ERROR: WDC: Unable to read CA Log Page data\n");
+				nvme_show_error("ERROR: WDC: Unable to read CA Log Page data");
 				ret = -1;
 			}
 
 			free(data);
 			break;
 		default:
-			fprintf(stderr, "ERROR: WDC: Command not supported on this device\n");
+			nvme_show_error("ERROR: WDC: Command not supported on this device");
 			ret = -1;
 		}
 	} else {
-		fprintf(stderr, "ERROR: WDC: CA log page supported on this device\n");
+		nvme_show_error("ERROR: WDC: CA log page supported on this device");
 		ret = -1;
 	}
 
@@ -8578,7 +8578,7 @@ static int wdc_vs_cloud_log(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_CLOUD_LOG_PAGE)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -8593,13 +8593,13 @@ static int wdc_vs_cloud_log(int argc, char **argv, struct command *acmd,
 	if (!ret) {
 		ret = validate_output_format(cfg.output_format, &fmt);
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC %s: invalid output format\n", __func__);
+			nvme_show_error("ERROR: WDC %s: invalid output format", __func__);
 		} else {
 			/* parse the data */
 			wdc_print_ext_smart_cloud_log(data, fmt);
 		}
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read C0 Log Page V1 data\n");
+		nvme_show_error("ERROR: WDC: Unable to read C0 Log Page V1 data");
 		ret = -1;
 	}
 
@@ -8645,7 +8645,7 @@ static int wdc_vs_hw_rev_log(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_HW_REV_LOG_PAGE)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -8658,12 +8658,12 @@ static int wdc_vs_hw_rev_log(int argc, char **argv, struct command *acmd,
 	if (!ret) {
 		ret = validate_output_format(cfg.output_format, &fmt);
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC %s: invalid output format\n", __func__);
+			nvme_show_error("ERROR: WDC %s: invalid output format", __func__);
 			goto free_buf;
 		}
 
 		if (!data) {
-			fprintf(stderr, "ERROR: WDC: Invalid buffer to read Hardware Revision log\n");
+			nvme_show_error("ERROR: WDC: Invalid buffer to read Hardware Revision log");
 			ret = -1;
 			goto out;
 		}
@@ -8678,7 +8678,7 @@ static int wdc_vs_hw_rev_log(int argc, char **argv, struct command *acmd,
 			break;
 		}
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read Hardware Revision Log Page data\n");
+		nvme_show_error("ERROR: WDC: Unable to read Hardware Revision Log Page data");
 		ret = -1;
 	}
 
@@ -8733,7 +8733,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_DEVICE_WAF)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -8747,7 +8747,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *acmd,
 		ret = -1;
 		goto out;
 	} else {
-		fprintf(stderr, "smart log: %s\n", libnvme_strerror(errno));
+		nvme_show_error("smart log: %s", libnvme_strerror(errno));
 		ret = -1;
 		goto out;
 	}
@@ -8764,7 +8764,7 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *acmd,
 
 		free(data);
 	} else {
-		fprintf(stderr, "ERROR: WDC %s: get smart cloud log failure\n", __func__);
+		nvme_show_error("ERROR: WDC %s: get smart cloud log failure", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -8774,12 +8774,12 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *acmd,
 
 	ret = validate_output_format(cfg.output_format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC %s: invalid output format\n", __func__);
+		nvme_show_error("ERROR: WDC %s: invalid output format", __func__);
 		goto out;
 	}
 
 	if (!data_units_written) {
-		fprintf(stderr, "ERROR: WDC %s: 0 data units written\n", __func__);
+		nvme_show_error("ERROR: WDC %s: 0 data units written", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -8836,14 +8836,14 @@ static int wdc_get_latency_monitor_log(int argc, char **argv, struct command *ac
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_C3_LOG_PAGE)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
 
 	ret = wdc_get_c3_log_page(ctx, hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Failure reading the Latency Monitor (C3) Log Page, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: Failure reading the Latency Monitor (C3) Log Page, ret = %d", ret);
 
 out:
 	return ret;
@@ -8879,14 +8879,14 @@ static int wdc_get_error_recovery_log(int argc, char **argv, struct command *acm
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_OCP_C1_LOG_PAGE)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
 
 	ret = wdc_get_ocp_c1_log_page(ctx, hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Failure reading the Error Recovery (C1) Log Page, ret = 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: Failure reading the Error Recovery (C1) Log Page, ret = 0x%x", ret);
 
 out:
 	return ret;
@@ -8922,14 +8922,14 @@ static int wdc_get_dev_capabilities_log(int argc, char **argv, struct command *a
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_OCP_C4_LOG_PAGE)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
 
 	ret = wdc_get_ocp_c4_log_page(ctx, hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Failure reading the Device Capabilities (C4) Log Page, ret = 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: Failure reading the Device Capabilities (C4) Log Page, ret = 0x%x", ret);
 
 out:
 	return ret;
@@ -8965,14 +8965,14 @@ static int wdc_get_unsupported_reqs_log(int argc, char **argv, struct command *a
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_OCP_C5_LOG_PAGE)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
 
 	ret = wdc_get_ocp_c5_log_page(ctx, hdl, cfg.output_format);
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Failure reading the Unsupported Requirements (C5) Log Page, ret = 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: Failure reading the Unsupported Requirements (C5) Log Page, ret = 0x%x", ret);
 
 out:
 	return ret;
@@ -9040,7 +9040,7 @@ static int wdc_clear_pcie_correctable_errors(int argc, char **argv, struct comma
 
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if (!(capabilities & WDC_DRIVE_CAP_CLEAR_PCIE_MASK)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -9087,7 +9087,7 @@ static int wdc_drive_status(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if ((capabilities & WDC_DRIVE_CAP_DRIVE_STATUS) != WDC_DRIVE_CAP_DRIVE_STATUS) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -9115,14 +9115,14 @@ static int wdc_drive_status(int argc, char **argv, struct command *acmd,
 	if (wdc_nvme_check_supported_log_page(ctx, hdl,
 			WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_ID,
 			uuid_index) == false) {
-		fprintf(stderr, "ERROR: WDC: 0xC2 Log Page not supported, uuid_index: %d\n",
+		nvme_show_error("ERROR: WDC: 0xC2 Log Page not supported, uuid_index: %d",
 				uuid_index);
 		ret = -1;
 		goto out;
 	}
 
 	if (!get_dev_mgment_data(ctx, hdl, &dev_mng_log)) {
-		fprintf(stderr, "ERROR: WDC: 0xC2 Log Page not found\n");
+		nvme_show_error("ERROR: WDC: 0xC2 Log Page not found");
 		ret = -1;
 		goto out;
 	}
@@ -9130,34 +9130,34 @@ static int wdc_drive_status(int argc, char **argv, struct command *acmd,
 	/* Get the assert dump present status */
 	if (!wdc_nvme_parse_dev_status_log_entry(dev_mng_log, &assert_status,
 			WDC_C2_ASSERT_DUMP_PRESENT_ID))
-		fprintf(stderr, "ERROR: WDC: Get Assert Status Failed\n");
+		nvme_show_error("ERROR: WDC: Get Assert Status Failed");
 
 	/* Get the thermal throttling status */
 	if (!wdc_nvme_parse_dev_status_log_entry(dev_mng_log, &thermal_status,
 			WDC_C2_THERMAL_THROTTLE_STATUS_ID))
-		fprintf(stderr, "ERROR: WDC: Get Thermal Throttling Status Failed\n");
+		nvme_show_error("ERROR: WDC: Get Thermal Throttling Status Failed");
 
 	/* Get EOL status */
 	if (!wdc_nvme_parse_dev_status_log_entry(dev_mng_log, &eol_status,
 			WDC_C2_USER_EOL_STATUS_ID)) {
-		fprintf(stderr, "ERROR: WDC: Get User EOL Status Failed\n");
+		nvme_show_error("ERROR: WDC: Get User EOL Status Failed");
 		eol_status = cpu_to_le32(-1);
 	}
 
 	/* Get Customer EOL state */
 	if (!wdc_nvme_parse_dev_status_log_entry(dev_mng_log, &user_eol_state,
 			WDC_C2_USER_EOL_STATE_ID))
-		fprintf(stderr, "ERROR: WDC: Get User EOL State Failed\n");
+		nvme_show_error("ERROR: WDC: Get User EOL State Failed");
 
 	/* Get System EOL state*/
 	if (!wdc_nvme_parse_dev_status_log_entry(dev_mng_log, &system_eol_state,
 			WDC_C2_SYSTEM_EOL_STATE_ID))
-		fprintf(stderr, "ERROR: WDC: Get System EOL State Failed\n");
+		nvme_show_error("ERROR: WDC: Get System EOL State Failed");
 
 	/* Get format corrupt reason*/
 	if (!wdc_nvme_parse_dev_status_log_entry(dev_mng_log, &format_corrupt_reason,
 			WDC_C2_FORMAT_CORRUPT_REASON_ID))
-		fprintf(stderr, "ERROR: WDC: Get Format Corrupt Reason Failed\n");
+		nvme_show_error("ERROR: WDC: Get Format Corrupt Reason Failed");
 
 	printf("  Drive Status :-\n");
 	if ((int)le32_to_cpu(eol_status) >= 0)
@@ -9231,13 +9231,13 @@ static int wdc_clear_assert_dump(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if ((capabilities & WDC_DRIVE_CAP_CLEAR_ASSERT) != WDC_DRIVE_CAP_CLEAR_ASSERT) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
 	if (!wdc_nvme_get_dev_status_log_data(ctx, hdl, &assert_status,
 			WDC_C2_ASSERT_DUMP_PRESENT_ID)) {
-		fprintf(stderr, "ERROR: WDC: Get Assert Status Failed\n");
+		nvme_show_error("ERROR: WDC: Get Assert Status Failed");
 		ret = -1;
 		goto out;
 	}
@@ -9252,7 +9252,7 @@ static int wdc_clear_assert_dump(int argc, char **argv, struct command *acmd,
 		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		nvme_show_status(ret);
 	} else
-		fprintf(stderr, "INFO: WDC: No Assert Dump Present\n");
+		nvme_show_error("INFO: WDC: No Assert Dump Present");
 
 out:
 	return ret;
@@ -9271,21 +9271,21 @@ static int wdc_get_fw_act_history(struct libnvme_global_ctx *ctx, struct libnvme
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
 	/* verify the FW Activate History log page is supported */
 	if (!wdc_nvme_check_supported_log_page(ctx, hdl,
 			WDC_NVME_GET_FW_ACT_HISTORY_LOG_ID, 0)) {
-		fprintf(stderr, "ERROR: WDC: %d Log Page not supported\n",
+		nvme_show_error("ERROR: WDC: %d Log Page not supported",
 			WDC_NVME_GET_FW_ACT_HISTORY_LOG_ID);
 		return -1;
 	}
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_FW_ACT_HISTORY_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -9307,16 +9307,16 @@ static int wdc_get_fw_act_history(struct libnvme_global_ctx *ctx, struct libnvme
 			ret = wdc_print_fw_act_history_log(data, fw_act_history_hdr->num_entries,
 							   fmt, 0, 0, 0);
 		} else if (!fw_act_history_hdr->num_entries) {
-			fprintf(stderr, "INFO: WDC: No FW Activate History entries found.\n");
+			nvme_show_error("INFO: WDC: No FW Activate History entries found.");
 			ret = 0;
 		} else {
-			fprintf(stderr,
+			nvme_show_error(
 				"ERROR: WDC: Invalid number entries found in FW Activate History Log Page - %d\n",
 				fw_act_history_hdr->num_entries);
 			ret = -1;
 		}
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read FW Activate History Log Page data\n");
+		nvme_show_error("ERROR: WDC: Unable to read FW Activate History Log Page data");
 		ret = -1;
 	}
 
@@ -9331,7 +9331,7 @@ static __u32 wdc_get_fw_cust_id(struct libnvme_global_ctx *ctx, struct libnvme_t
 	__u32 *cust_id_ptr = NULL;
 
 	if (!get_dev_mgment_cbs_data(ctx, hdl, WDC_C2_CUSTOMER_ID_ID, (void *)&cust_id_ptr))
-		fprintf(stderr, "%s: ERROR: WDC: 0xC2 Log Page entry ID 0x%x not found\n",
+		nvme_show_error("%s: ERROR: WDC: 0xC2 Log Page entry ID 0x%x not found",
 			__func__, WDC_C2_CUSTOMER_ID_ID);
 	else
 		cust_id = *cust_id_ptr;
@@ -9357,7 +9357,7 @@ static int wdc_get_fw_act_history_C2(struct libnvme_global_ctx *ctx, struct libn
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		return ret;
 	}
 
@@ -9365,7 +9365,7 @@ static int wdc_get_fw_act_history_C2(struct libnvme_global_ctx *ctx, struct libn
 
 	data = (__u8 *)malloc(sizeof(__u8) * WDC_FW_ACT_HISTORY_C2_LOG_BUF_LEN);
 	if (!data) {
-		fprintf(stderr, "ERROR: WDC: malloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: malloc: %s", libnvme_strerror(errno));
 		return -1;
 	}
 
@@ -9395,7 +9395,7 @@ static int wdc_get_fw_act_history_C2(struct libnvme_global_ctx *ctx, struct libn
 				if (!wdc_is_sn861(device_id)) {
 					cust_id = wdc_get_fw_cust_id(ctx, hdl);
 					if (cust_id == WDC_INVALID_CUSTOMER_ID) {
-						fprintf(stderr,
+						nvme_show_error(
 							"%s: ERROR: WDC: invalid customer id\n",
 							__func__);
 						ret = -1;
@@ -9407,15 +9407,15 @@ static int wdc_get_fw_act_history_C2(struct libnvme_global_ctx *ctx, struct libn
 				ret = wdc_print_fw_act_history_log(data, num_entries,
 					fmt, cust_id, vendor_id, device_id);
 			} else  {
-				fprintf(stderr, "INFO: WDC: No entries found.\n");
+				nvme_show_error("INFO: WDC: No entries found.");
 				ret = 0;
 			}
 		} else {
-			fprintf(stderr, "ERROR: WDC: Invalid C2 log page GUID\n");
+			nvme_show_error("ERROR: WDC: Invalid C2 log page GUID");
 			ret = -1;
 		}
 	} else {
-		fprintf(stderr, "ERROR: WDC: Unable to read FW Activate History Log Page data\n");
+		nvme_show_error("ERROR: WDC: Unable to read FW Activate History Log Page data");
 		ret = -1;
 	}
 
@@ -9454,7 +9454,7 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *acm
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_FW_ACTIVATE_HISTORY_MASK)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -9464,7 +9464,7 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *acm
 		/* get the FW customer id */
 		cust_fw_id = wdc_get_fw_cust_id(ctx, hdl);
 		if (cust_fw_id == WDC_INVALID_CUSTOMER_ID) {
-			fprintf(stderr, "%s: ERROR: WDC: invalid customer id\n", __func__);
+			nvme_show_error("%s: ERROR: WDC: invalid customer id", __func__);
 			ret = -1;
 			goto out;
 		}
@@ -9481,7 +9481,7 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *acm
 	}
 
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Failure reading the FW Activate History, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: Failure reading the FW Activate History, ret = %d", ret);
 out:
 	return ret;
 }
@@ -9537,7 +9537,7 @@ static int wdc_clear_fw_activate_history(int argc, char **argv, struct command *
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_CLEAR_FW_ACT_HISTORY_MASK)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -9593,7 +9593,7 @@ static int wdc_vs_telemetry_controller_option(int argc, char **argv, struct comm
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if ((capabilities & WDC_DRVIE_CAP_DISABLE_CTLR_TELE_LOG) != WDC_DRVIE_CAP_DISABLE_CTLR_TELE_LOG) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -9601,7 +9601,7 @@ static int wdc_vs_telemetry_controller_option(int argc, char **argv, struct comm
 	/* allow only one option at a time */
 	if ((cfg.disable + cfg.enable + cfg.status) > 1) {
 
-		fprintf(stderr, "ERROR: WDC: Invalid option\n");
+		nvme_show_error("ERROR: WDC: Invalid option");
 		ret = -1;
 		goto out;
 	}
@@ -9624,15 +9624,15 @@ static int wdc_vs_telemetry_controller_option(int argc, char **argv, struct comm
 				&result);
 			if (!ret) {
 				if (result)
-					fprintf(stderr, "Controller Option Telemetry Log Page State: Disabled\n");
+					nvme_show_error("Controller Option Telemetry Log Page State: Disabled");
 				else
-					fprintf(stderr, "Controller Option Telemetry Log Page State: Enabled\n");
+					nvme_show_error("Controller Option Telemetry Log Page State: Enabled");
 			} else {
 				nvme_show_status(ret);
 			}
 		} else {
-			fprintf(stderr, "ERROR: WDC: unsupported option for this command\n");
-			fprintf(stderr, "Please provide an option, -d, -e or -s\n");
+			nvme_show_error("ERROR: WDC: unsupported option for this command");
+			nvme_show_error("Please provide an option, -d, -e or -s");
 			ret = -1;
 			goto out;
 		}
@@ -9655,7 +9655,7 @@ static int wdc_get_serial_and_fw_rev(struct libnvme_transport_handle *hdl, char 
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 	/* Remove trailing spaces from the name */
@@ -9679,7 +9679,7 @@ static int wdc_get_max_transfer_len(struct libnvme_transport_handle *hdl, __u32 
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 
@@ -9710,7 +9710,7 @@ static int wdc_de_VU_read_size(struct libnvme_transport_handle *hdl, __u32 fileI
 	if (!ret && logSize)
 		*logSize = cmd.result;
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr, "ERROR: WDC: VUReadSize() failed, ");
+		nvme_show_error("ERROR: WDC: VUReadSize() failed, ");
 		nvme_show_status(ret);
 	}
 
@@ -9745,7 +9745,7 @@ static int wdc_de_VU_read_buffer(struct libnvme_transport_handle *hdl, __u32 fil
 	ret = libnvme_exec_admin_passthru(hdl, &cmd);
 
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr, "ERROR: WDC: VUReadBuffer() failed, ");
+		nvme_show_error("ERROR: WDC: VUReadBuffer() failed, ");
 		nvme_show_status(ret);
 	}
 
@@ -9770,7 +9770,7 @@ static int wdc_get_log_dir_max_entries(struct libnvme_transport_handle *hdl, __u
 	/* 1.Get log directory first four bytes */
 	ret = wdc_de_VU_read_size(hdl, 0, 5, (__u32 *)&headerPayloadSize);
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: %s: Failed to get headerPayloadSize from file directory 0x%x\n",
 			__func__, ret);
 		return ret;
@@ -9783,7 +9783,7 @@ static int wdc_get_log_dir_max_entries(struct libnvme_transport_handle *hdl, __u
 	/* 2.Read to get file offsets */
 	ret = wdc_de_VU_read_buffer(hdl, 0, 5, 0, fileIdOffsetsBuffer, &fileIdOffsetsBufferSize);
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: %s: Failed to get fileIdOffsets from file directory 0x%x\n",
 			__func__, ret);
 		goto end;
@@ -9838,7 +9838,7 @@ static int wdc_fetch_log_directory(struct libnvme_transport_handle *hdl, struct 
 
 	ret = wdc_de_VU_read_size(hdl, 0, 5, &fileDirectorySize);
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: %s: Failed to get filesystem directory size, ret = %d\n",
 			__func__, ret);
 		goto end;
@@ -9847,7 +9847,7 @@ static int wdc_fetch_log_directory(struct libnvme_transport_handle *hdl, struct 
 	fileDirectory = (__u8 *)calloc(1, fileDirectorySize);
 	ret = wdc_de_VU_read_buffer(hdl, 0, 5, 0, fileDirectory, &fileDirectorySize);
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr, "ERROR: WDC: %s: Failed to get filesystem directory, ret = %d\n",
+		nvme_show_error("ERROR: WDC: %s: Failed to get filesystem directory, ret = %d",
 			__func__, ret);
 		goto end;
 	}
@@ -9926,7 +9926,7 @@ static int wdc_fetch_log_file_from_device(struct libnvme_transport_handle *hdl, 
 			ret = wdc_de_VU_read_buffer(hdl, fileId, spiDestn,
 					(__u32)((offsetIdx * chunckSize) / sizeof(__u32)), dataBuffer + (offsetIdx * chunckSize), &buffSize);
 			if (ret != WDC_STATUS_SUCCESS) {
-				fprintf(stderr, "ERROR: WDC: %s: wdc_de_VU_read_buffer failed with ret = %d, fileId = 0x%x, fileSize = 0x%lx\n",
+				nvme_show_error("ERROR: WDC: %s: wdc_de_VU_read_buffer failed with ret = %d, fileId = 0x%x, fileSize = 0x%lx",
 						__func__, ret, fileId, (unsigned long)fileSize);
 				break;
 			}
@@ -9937,7 +9937,7 @@ static int wdc_fetch_log_file_from_device(struct libnvme_transport_handle *hdl, 
 					    (__u32)((offsetIdx * chunckSize) / sizeof(__u32)),
 					    dataBuffer, &buffSize);
 		if (ret != WDC_STATUS_SUCCESS) {
-			fprintf(stderr, "ERROR: WDC: %s: wdc_de_VU_read_buffer failed with ret = %d, fileId = 0x%x, fileSize = 0x%lx\n",
+			nvme_show_error("ERROR: WDC: %s: wdc_de_VU_read_buffer failed with ret = %d, fileId = 0x%x, fileSize = 0x%lx",
 					__func__, ret, fileId, (unsigned long)fileSize);
 		}
 	}
@@ -9973,7 +9973,7 @@ static int wdc_de_get_dump_trace(struct libnvme_transport_handle *hdl, const cha
 		/* Get dumptrace size */
 		ret = wdc_de_VU_read_size(hdl, 0, WDC_DE_DUMPTRACE_DESTINATION, &dumptraceSize);
 		if (ret != WDC_STATUS_SUCCESS) {
-			fprintf(stderr, "ERROR: WDC: %s: wdc_de_VU_read_size failed with ret = %d\n",
+			nvme_show_error("ERROR: WDC: %s: wdc_de_VU_read_size failed with ret = %d",
 					__func__, ret);
 			break;
 		}
@@ -9981,7 +9981,7 @@ static int wdc_de_get_dump_trace(struct libnvme_transport_handle *hdl, const cha
 		/* Make sure the size requested is greater than dword */
 		if (dumptraceSize < 4) {
 			ret = WDC_STATUS_FAILURE;
-			fprintf(stderr, "ERROR: WDC: %s: wdc_de_VU_read_size failed, read size is less than 4 bytes, dumptraceSize = 0x%x\n",
+			nvme_show_error("ERROR: WDC: %s: wdc_de_VU_read_size failed, read size is less than 4 bytes, dumptraceSize = 0x%x",
 					__func__, dumptraceSize);
 			break;
 		}
@@ -10002,7 +10002,7 @@ static int wdc_de_get_dump_trace(struct libnvme_transport_handle *hdl, const cha
 		lastPktReadBufferLen = (dumptraceSize % maxTransferLen) ? (dumptraceSize % maxTransferLen) : chunkSize;
 
 		if (!readBuffer) {
-			fprintf(stderr, "ERROR: WDC: %s: readBuffer calloc failed\n", __func__);
+			nvme_show_error("ERROR: WDC: %s: readBuffer calloc failed", __func__);
 			ret = WDC_STATUS_INSUFFICIENT_MEMORY;
 			break;
 		}
@@ -10017,7 +10017,7 @@ static int wdc_de_get_dump_trace(struct libnvme_transport_handle *hdl, const cha
 			ret = wdc_de_VU_read_buffer(hdl, 0, WDC_DE_DUMPTRACE_DESTINATION, 0,
 						    readBuffer + offset, &readBufferLen);
 			if (ret != WDC_STATUS_SUCCESS) {
-				fprintf(stderr,
+				nvme_show_error(
 					"ERROR: WDC: %s: wdc_de_VU_read_buffer failed, ret = %d on offset 0x%x\n",
 					__func__, ret, offset);
 				break;
@@ -10028,10 +10028,10 @@ static int wdc_de_get_dump_trace(struct libnvme_transport_handle *hdl, const cha
 	if (ret == WDC_STATUS_SUCCESS) {
 		ret = wdc_WriteToFile(binFileName, (char *)readBuffer, dumptraceSize);
 		if (ret != WDC_STATUS_SUCCESS)
-			fprintf(stderr, "ERROR: WDC: %s: wdc_WriteToFile failed, ret = %d\n",
+			nvme_show_error("ERROR: WDC: %s: wdc_WriteToFile failed, ret = %d",
 				__func__, ret);
 	} else {
-		fprintf(stderr, "ERROR: WDC: %s: Read Buffer Loop failed, ret = %d\n", __func__,
+		nvme_show_error("ERROR: WDC: %s: Read Buffer Loop failed, ret = %d", __func__,
 			ret);
 	}
 
@@ -10050,14 +10050,14 @@ int wdc_fetch_vu_file_directory(struct libnvme_transport_handle *hdl,
 	char fileName[MAX_PATH_LEN];
 
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr, "WDC: wdc_fetch_log_directory failed, ret = %d\n", ret);
+		nvme_show_error("WDC: wdc_fetch_log_directory failed, ret = %d", ret);
 		return ret;
 	}
 
 	/* Get Debug Data Files */
 	for (listIdx = 0; listIdx < deEssentialsList.numOfValidLogEntries; listIdx++) {
 		if (!deEssentialsList.logEntry[listIdx].metaData.fileSize) {
-			fprintf(stderr, "ERROR: WDC: File Size for %s is 0\n",
+			nvme_show_error("ERROR: WDC: File Size for %s is 0",
 				deEssentialsList.logEntry[listIdx].metaData.fileName);
 			ret = WDC_STATUS_FILE_SIZE_ZERO;
 		} else {
@@ -10081,7 +10081,7 @@ int wdc_fetch_vu_file_directory(struct libnvme_transport_handle *hdl,
 					wdc_WriteToFile(fileName, dataBuffer, (__u32)deEssentialsList.logEntry[listIdx].metaData.fileSize);
 				}
 			} else {
-				fprintf(stderr, "ERROR: WDC: wdc_fetch_log_file_from_device: %s failed, ret = %d\n",
+				nvme_show_error("ERROR: WDC: wdc_fetch_log_file_from_device: %s failed, ret = %d",
 						deEssentialsList.logEntry[listIdx].metaData.fileName, ret);
 			}
 			free(dataBuffer);
@@ -10099,7 +10099,7 @@ int wdc_read_debug_directory(struct libnvme_transport_handle *hdl, __s8 *bufferF
 	struct WDC_DE_VU_LOG_DIRECTORY deEssentialsList;
 
 	if (ret != WDC_STATUS_SUCCESS) {
-		fprintf(stderr, "WDC: wdc_get_log_dir_max_entries failed, ret = %d\n", ret);
+		nvme_show_error("WDC: wdc_get_log_dir_max_entries failed, ret = %d", ret);
 		return ret;
 	}
 
@@ -10157,11 +10157,11 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 	memset(&timeInfo, 0, sizeof(timeInfo));
 
 	if (wdc_get_serial_and_fw_rev(hdl, (char *)idSerialNo, (char *)idFwRev)) {
-		fprintf(stderr, "ERROR: WDC: get serial # and fw revision failed\n");
+		nvme_show_error("ERROR: WDC: get serial # and fw revision failed");
 		return -1;
 	}
 
-	fprintf(stderr, "Get Drive Essentials Data for device serial #: %s and fw revision: %s\n",
+	nvme_show_error("Get Drive Essentials Data for device serial #: %s and fw revision: %s",
 		idSerialNo, idFwRev);
 
 	/* Create Drive Essentials directory */
@@ -10192,24 +10192,24 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 			wdc_UtilsSnprintf((char *)bufferFolderPath, MAX_PATH_LEN, "%s%s%s",
 					(char *)currDir, WDC_DE_PATH_SEPARATOR, (char *)bufferFolderName);
 		} else {
-			fprintf(stderr, "ERROR: WDC: get current working directory failed\n");
+			nvme_show_error("ERROR: WDC: get current working directory failed");
 			return -1;
 		}
 	}
 
 	ret = wdc_UtilsCreateDir((char *)bufferFolderPath);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: create directory failed, ret = %d, dir = %s\n", ret, bufferFolderPath);
+		nvme_show_error("ERROR: WDC: create directory failed, ret = %d, dir = %s", ret, bufferFolderPath);
 		return -1;
 	}
 
-	fprintf(stderr, "Store Drive Essentials bin files in directory: %s\n", bufferFolderPath);
+	nvme_show_error("Store Drive Essentials bin files in directory: %s", bufferFolderPath);
 
 	/* Get Identify Controller Data */
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed, ret = %d", ret);
 		return -1;
 	}
 
@@ -10221,7 +10221,7 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 	memset(&ns, 0, sizeof(struct nvme_id_ns));
 	ret = nvme_identify_ns(hdl, 1, &ns);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ns() failed, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ns() failed, ret = %d", ret);
 	} else {
 		wdc_UtilsSnprintf(fileName, MAX_PATH_LEN, "%s%s%s_%s_%s.bin", (char *)bufferFolderPath, WDC_DE_PATH_SEPARATOR,
 				"IdentifyNamespace", (char *)serialNo, (char *)timeString);
@@ -10236,7 +10236,7 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 
 	ret = nvme_get_log_error(hdl, NVME_NSID_ALL, elogNumEntries, elogBuffer);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_error_log() failed, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_error_log() failed, ret = %d", ret);
 	} else {
 		wdc_UtilsSnprintf(fileName, MAX_PATH_LEN, "%s%s%s_%s_%s.bin", (char *)bufferFolderPath, WDC_DE_PATH_SEPARATOR,
 				"ErrorLog", (char *)serialNo, (char *)timeString);
@@ -10250,7 +10250,7 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 	memset(&smart_log, 0, sizeof(struct nvme_smart_log));
 	ret = nvme_get_log_smart(hdl, NVME_NSID_ALL, &smart_log);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_smart_log() failed, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_smart_log() failed, ret = %d", ret);
 	} else {
 		wdc_UtilsSnprintf(fileName, MAX_PATH_LEN, "%s%s%s_%s_%s.bin", (char *)bufferFolderPath, WDC_DE_PATH_SEPARATOR,
 				"SmartLog", (char *)serialNo, (char *)timeString);
@@ -10261,7 +10261,7 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 	memset(&fw_log, 0, sizeof(struct nvme_firmware_slot));
 	ret = nvme_get_log_fw_slot(hdl, false, &fw_log);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_fw_log() failed, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_fw_log() failed, ret = %d", ret);
 	} else {
 		wdc_UtilsSnprintf(fileName, MAX_PATH_LEN, "%s%s%s_%s_%s.bin", (char *)bufferFolderPath, WDC_DE_PATH_SEPARATOR,
 				"FwSLotLog", (char *)serialNo, (char *)timeString);
@@ -10282,7 +10282,7 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 					  deVULogPagesList[vuLogIdx].logPageId,
 					  dataBuffer, dataBufferSize);
 		if (ret) {
-			fprintf(stderr, "ERROR: WDC: libnvme_get_log() for log page 0x%x failed, ret = %d\n",
+			nvme_show_error("ERROR: WDC: libnvme_get_log() for log page 0x%x failed, ret = %d",
 					deVULogPagesList[vuLogIdx].logPageId, ret);
 		} else {
 			wdc_UtilsDeleteCharFromString((char *)deVULogPagesList[vuLogIdx].logPageIdStr, 4, ' ');
@@ -10308,7 +10308,7 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 			NVME_GET_FEATURES_SEL_CURRENT, 0, 0, &featureIdBuff,
 			sizeof(featureIdBuff), &result);
 		if (ret) {
-			fprintf(stderr, "ERROR: WDC: nvme_get_feature id 0x%x failed, ret = %d\n",
+			nvme_show_error("ERROR: WDC: nvme_get_feature id 0x%x failed, ret = %d",
 					deFeatureIdList[listIdx].featureId, ret);
 		} else {
 			wdc_UtilsSnprintf(fileName, MAX_PATH_LEN, "%s%s%s0x%x_%s_%s_%s.bin", (char *)bufferFolderPath, WDC_DE_PATH_SEPARATOR,
@@ -10324,7 +10324,7 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 	wdc_UtilsSnprintf(fileName, MAX_PATH_LEN, "%s%s%s_%s_%s.bin", (char *)bufferFolderPath, WDC_DE_PATH_SEPARATOR, "dumptrace", serialNo, timeString);
 	ret = wdc_de_get_dump_trace(hdl, (char *)bufferFolderPath, 0, fileName);
 	if (ret != WDC_STATUS_SUCCESS)
-		fprintf(stderr, "ERROR: WDC: wdc_de_get_dump_trace failed, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: wdc_de_get_dump_trace failed, ret = %d", ret);
 
 	/* Tar the Drive Essentials directory */
 	wdc_UtilsSnprintf(tarFileName, sizeof(tarFileName), "%s%s", (char *)bufferFolderPath, WDC_DE_TAR_FILE_EXTN);
@@ -10340,10 +10340,10 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 	ret = system(tarCmd);
 
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Tar of Drive Essentials data failed, ret = %d\n",
+		nvme_show_error("ERROR: WDC: Tar of Drive Essentials data failed, ret = %d",
 			ret);
 
-	fprintf(stderr, "Get of Drive Essentials data successful\n");
+	nvme_show_verbose_result("Get of Drive Essentials data successful");
 	return 0;
 }
 
@@ -10383,7 +10383,7 @@ static int wdc_drive_essentials(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if ((capabilities & WDC_DRIVE_CAP_DRIVE_ESSENTIALS) != WDC_DRIVE_CAP_DRIVE_ESSENTIALS) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -10481,7 +10481,7 @@ static int wdc_drive_resize(int argc, char **argv,
 	if ((capabilities & WDC_DRIVE_CAP_RESIZE) == WDC_DRIVE_CAP_RESIZE) {
 		ret = wdc_do_drive_resize(hdl, cfg.size);
 	} else {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	}
 
@@ -10523,7 +10523,7 @@ static int wdc_namespace_resize(int argc, char **argv,
 
 	if ((cfg.op_option != 0x1) && (cfg.op_option != 0x2) && (cfg.op_option != 0x3) &&
 	    (cfg.op_option != 0xF)) {
-		fprintf(stderr, "ERROR: WDC: unsupported OP option parameter\n");
+		nvme_show_error("ERROR: WDC: unsupported OP option parameter");
 		return -1;
 	}
 
@@ -10540,7 +10540,7 @@ static int wdc_namespace_resize(int argc, char **argv,
 		if (ret)
 			printf("ERROR: WDC: Namespace Resize of namespace id 0x%x, op option 0x%x failed\n", cfg.namespace_id, cfg.op_option);
 	} else {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	}
 
@@ -10588,7 +10588,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 
 	if (cfg.log_id != NVME_LOG_LID_TELEMETRY_HOST &&
 	    cfg.log_id != NVME_LOG_LID_TELEMETRY_CTRL) {
-		fprintf(stderr, "ERROR: WDC: Invalid Log ID. It must be 7 (Host) or 8 (Controller)\n");
+		nvme_show_error("ERROR: WDC: Invalid Log ID. It must be 7 (Host) or 8 (Controller)");
 		return -1;
 	}
 
@@ -10598,7 +10598,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 		/* verify the passed in file name and path is valid before getting the dump data */
 		verify_file = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (verify_file < 0) {
-			fprintf(stderr, "ERROR: WDC: open: %s\n", libnvme_strerror(errno));
+			nvme_show_error("ERROR: WDC: open: %s", libnvme_strerror(errno));
 			return -1;
 		}
 		close(verify_file);
@@ -10615,23 +10615,23 @@ static int wdc_reason_identifier(int argc, char **argv,
 			snprintf(fileSuffix, PATH_MAX, "_error_reason_identifier_host_%s", (char *)timeStamp);
 
 		if (wdc_get_serial_name(hdl, f, PATH_MAX, fileSuffix) == -1) {
-			fprintf(stderr, "ERROR: WDC: failed to generate file name\n");
+			nvme_show_error("ERROR: WDC: failed to generate file name");
 			return -1;
 		}
 		if (strlen(f) > PATH_MAX - 5) {
-			fprintf(stderr, "ERROR: WDC: file name overflow\n");
+			nvme_show_error("ERROR: WDC: file name overflow");
 			return -1;
 		}
 		strcat(f, ".bin");
 	}
 
-	fprintf(stderr, "%s: filename = %s\n", __func__, f);
+	nvme_show_error("%s: filename = %s", __func__, f);
 
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if ((capabilities & WDC_DRIVE_CAP_REASON_ID) == WDC_DRIVE_CAP_REASON_ID) {
 		ret = wdc_do_get_reason_id(hdl, f, cfg.log_id);
 	} else {
-		fprintf(stderr, "ERROR: WDC:unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC:unsupported device for this command");
 		ret = -1;
 	}
 
@@ -10841,7 +10841,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 
 	ret = validate_output_format(cfg.output_format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "%s: ERROR: WDC: invalid output format\n", __func__);
+		nvme_show_error("%s: ERROR: WDC: invalid output format", __func__);
 		return ret;
 	}
 
@@ -10852,7 +10852,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_LOG_PAGE_DIR)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	} else {
 		memset(&uuid_list, 0, sizeof(struct nvme_id_uuid_list));
@@ -10860,9 +10860,9 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 			uuid_supported = true;
 
 		if (uuid_supported)
-			fprintf(stderr, "WDC: UUID lists supported\n");
+			nvme_show_error("WDC: UUID lists supported");
 		else
-			fprintf(stderr, "WDC: UUID lists NOT supported\n");
+			nvme_show_error("WDC: UUID lists NOT supported");
 
 
 		ret = wdc_get_pci_ids(ctx, hdl, &device_id, &read_vendor_id);
@@ -10891,7 +10891,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 
 			/* verify the 0xC2 Device Manageability log page is supported */
 			if (!wdc_nvme_check_supported_log_page(ctx, hdl, log_id, uuid_index)) {
-				fprintf(stderr, "%s: ERROR: WDC: 0x%x Log Page not supported\n",
+				nvme_show_error("%s: ERROR: WDC: 0x%x Log Page not supported",
 					__func__, log_id);
 				ret = -1;
 				goto out;
@@ -10900,14 +10900,14 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 			if (!get_dev_mgment_cbs_data(ctx, hdl,
 						    WDC_C2_LOG_PAGES_SUPPORTED_ID,
 						    (void *)&cbs_data)) {
-				fprintf(stderr,
+				nvme_show_error(
 					"%s: ERROR: WDC: 0xC2 Log Page entry ID 0x%x not found\n",
 					__func__, WDC_C2_LOG_PAGES_SUPPORTED_ID);
 				ret = -1;
 				goto out;
 			}
 			if (!cbs_data) {
-				fprintf(stderr, "%s: ERROR: WDC: NULL_data ptr\n", __func__);
+				nvme_show_error("%s: ERROR: WDC: NULL_data ptr", __func__);
 				ret = -1;
 				goto out;
 			}
@@ -10933,7 +10933,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 				printf("\n");
 				json_free_object(root);
 			} else {
-				fprintf(stderr,
+				nvme_show_error(
 					"%s: ERROR: WDC: Invalid format, format = %s\n",
 					__func__, cfg.output_format);
 			}
@@ -10945,7 +10945,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 
 			data = libnvme_alloc(512);
 			if (!data) {
-				fprintf(stderr,
+				nvme_show_error(
 					"can not allocate log page directory payload\n");
 				return -ENOMEM;
 			}
@@ -10972,7 +10972,7 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 					__show_log_page_directory(dir);
 				}
 			} else {
-				fprintf(stderr, "NVMe Status:%s(%x)\n",
+				nvme_show_error("NVMe Status:%s(%x)",
 					libnvme_status_to_string(ret, false), ret);
 			}
 		}
@@ -10996,7 +10996,7 @@ static int wdc_get_drive_reason_id(struct libnvme_transport_handle *hdl, char *d
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", ret);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", ret);
 		return -1;
 	}
 	/* Remove trailing spaces from the sn and mn */
@@ -11012,7 +11012,7 @@ static int wdc_get_drive_reason_id(struct libnvme_transport_handle *hdl, char *d
 
 	res_len = snprintf(drive_reason_id, len, "%s_%s_%s", ctrl.sn, ctrl.mn, reason_id_str);
 	if (len <= res_len) {
-		fprintf(stderr,
+		nvme_show_error(
 			"ERROR: WDC: cannot format serial number due to data of unexpected length\n");
 		return -1;
 	}
@@ -11029,14 +11029,14 @@ static int wdc_save_reason_id(struct libnvme_transport_handle *hdl, __u8 *rsn_id
 	struct stat st = {0};
 
 	if (wdc_get_drive_reason_id(hdl, drive_reason_id, PATH_MAX) == -1) {
-		fprintf(stderr, "%s: ERROR: failed to get drive reason id\n", __func__);
+		nvme_show_error("%s: ERROR: failed to get drive reason id", __func__);
 		return -1;
 	}
 
 	/* make the nvmecli dir in /usr/local if it doesn't already exist */
 	if (stat(reason_id_path, &st) == -1) {
 		if (mkdir(reason_id_path, 0700) < 0) {
-			fprintf(stderr, "%s: ERROR: failed to mkdir %s: %s\n",
+			nvme_show_error("%s: ERROR: failed to mkdir %s: %s",
 				__func__, reason_id_path, libnvme_strerror(errno));
 			return -1;
 		}
@@ -11046,7 +11046,7 @@ static int wdc_save_reason_id(struct libnvme_transport_handle *hdl, __u8 *rsn_id
 		    drive_reason_id, ".bin") < 0)
 		return -ENOMEM;
 
-	fprintf(stderr, "%s: reason id file = %s\n", __func__, reason_id_file);
+	nvme_show_error("%s: reason id file = %s", __func__, reason_id_file);
 
 	/* save off the error reason identifier to a file in /usr/local/nvmecli */
 	ret = wdc_create_log_file(reason_id_file, rsn_ident, WDC_REASON_ID_ENTRY_LEN);
@@ -11063,7 +11063,7 @@ static int wdc_clear_reason_id(struct libnvme_transport_handle *hdl)
 	char drive_reason_id[PATH_MAX] = {0};
 
 	if (wdc_get_drive_reason_id(hdl, drive_reason_id, PATH_MAX) == -1) {
-		fprintf(stderr, "%s: ERROR: failed to get drive reason id\n", __func__);
+		nvme_show_error("%s: ERROR: failed to get drive reason id", __func__);
 		return -1;
 	}
 
@@ -11101,7 +11101,7 @@ static int wdc_dump_telemetry_hdr(struct libnvme_transport_handle *hdl, int log_
 		perror("get-telemetry-log");
 	} else if (ret > 0) {
 		nvme_show_status(ret);
-		fprintf(stderr, "%s: ERROR: Failed to acquire telemetry header, ret = %d!\n", __func__, ret);
+		nvme_show_error("%s: ERROR: Failed to acquire telemetry header, ret = %d!", __func__, ret);
 	}
 
 	return ret;
@@ -11116,7 +11116,7 @@ static int wdc_do_get_reason_id(struct libnvme_transport_handle *hdl, const char
 
 	log_hdr = (struct nvme_telemetry_log *)malloc(log_hdr_size);
 	if (!log_hdr) {
-		fprintf(stderr, "%s: ERROR: malloc failed, size : 0x%x, status: %s\n", __func__, log_hdr_size, libnvme_strerror(errno));
+		nvme_show_error("%s: ERROR: malloc failed, size : 0x%x, status: %s", __func__, log_hdr_size, libnvme_strerror(errno));
 		ret = -1;
 		goto out;
 	}
@@ -11124,7 +11124,7 @@ static int wdc_do_get_reason_id(struct libnvme_transport_handle *hdl, const char
 
 	ret = wdc_dump_telemetry_hdr(hdl, log_id, log_hdr);
 	if (ret) {
-		fprintf(stderr, "%s: ERROR: get telemetry header failed, ret  : %d\n", __func__, ret);
+		nvme_show_error("%s: ERROR: get telemetry header failed, ret  : %d", __func__, ret);
 		ret = -1;
 		goto out;
 	}
@@ -11267,7 +11267,7 @@ static void wdc_print_nand_stats_normal(__u16 version, void *data)
 		break;
 
 	default:
-		fprintf(stderr, "WDC: Nand Stats ERROR: Invalid version\n");
+		nvme_show_error("WDC: Nand Stats ERROR: Invalid version");
 		break;
 
 	}
@@ -11495,12 +11495,12 @@ static int wdc_do_vs_nand_stats_sn810_2(struct libnvme_transport_handle *hdl, ch
 					   NVME_NSID_ALL);
 
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: %s : Failed to retrieve NAND stats\n", __func__);
+		nvme_show_error("ERROR: WDC: %s : Failed to retrieve NAND stats", __func__);
 		goto out;
 	} else {
 		ret = validate_output_format(format, &fmt);
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC: %s : invalid output format\n", __func__);
+			nvme_show_error("ERROR: WDC: %s : invalid output format", __func__);
 			goto out;
 		}
 
@@ -11531,7 +11531,7 @@ static int wdc_do_vs_nand_stats(struct libnvme_transport_handle *hdl, char *form
 
 	output = (uint8_t *)calloc(WDC_NVME_NAND_STATS_SIZE, sizeof(uint8_t));
 	if (!output) {
-		fprintf(stderr, "ERROR: WDC: calloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: calloc: %s", libnvme_strerror(errno));
 		ret = -1;
 		goto out;
 	}
@@ -11539,12 +11539,12 @@ static int wdc_do_vs_nand_stats(struct libnvme_transport_handle *hdl, char *form
 	ret = nvme_get_log_simple(hdl, WDC_NVME_NAND_STATS_LOG_ID,
 				  (void *)output, WDC_NVME_NAND_STATS_SIZE);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC: %s : Failed to retrieve NAND stats\n", __func__);
+		nvme_show_error("ERROR: WDC: %s : Failed to retrieve NAND stats", __func__);
 		goto out;
 	} else {
 		ret = validate_output_format(format, &fmt);
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC: invalid output format\n");
+			nvme_show_error("ERROR: WDC: invalid output format");
 			goto out;
 		}
 
@@ -11599,12 +11599,12 @@ static int wdc_vs_nand_stats(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_NAND_STATS)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	} else {
 		ret = wdc_get_pci_ids(ctx, hdl, &read_device_id, &read_vendor_id);
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC: %s: failure to get pci ids, ret = %d\n", __func__, ret);
+			nvme_show_error("ERROR: WDC: %s: failure to get pci ids, ret = %d", __func__, ret);
 			return -1;
 		}
 
@@ -11620,7 +11620,7 @@ static int wdc_vs_nand_stats(int argc, char **argv, struct command *acmd,
 	}
 
 	if (ret)
-		fprintf(stderr, "ERROR: WDC: Failure reading NAND statistics, ret = %d\n", ret);
+		nvme_show_error("ERROR: WDC: Failure reading NAND statistics, ret = %d", ret);
 
 	return ret;
 }
@@ -11675,13 +11675,13 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *acmd,
 
 	ret = validate_output_format(cfg.output_format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		goto out;
 	}
 
 	pcieStatsPtr = libnvme_alloc_huge(pcie_stats_size, &mh);
 	if (!pcieStatsPtr) {
-		fprintf(stderr, "ERROR: WDC: PCIE Stats alloc: %s\n", libnvme_strerror(errno));
+		nvme_show_error("ERROR: WDC: PCIE Stats alloc: %s", libnvme_strerror(errno));
 		ret = -1;
 		goto out;
 	}
@@ -11691,12 +11691,12 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_PCIE_STATS)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 	} else {
 		ret = wdc_do_vs_pcie_stats(hdl, pcieStatsPtr);
 		if (ret) {
-			fprintf(stderr, "ERROR: WDC: Failure reading PCIE statistics, ret = 0x%x\n", ret);
+			nvme_show_error("ERROR: WDC: Failure reading PCIE statistics, ret = 0x%x", ret);
 		} else {
 			/* parse the data */
 			switch (fmt) {
@@ -11758,14 +11758,14 @@ static int wdc_vs_drive_info(int argc, char **argv,
 
 	ret = validate_output_format(cfg.output_format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC %s invalid output format\n", __func__);
+		nvme_show_error("ERROR: WDC %s invalid output format", __func__);
 		return ret;
 	}
 
 	/* get the id ctrl data used to fill in drive info below */
 	ret = nvme_identify_ctrl(hdl, &ctrl);
 	if (ret) {
-		fprintf(stderr, "ERROR: WDC %s: Identify Controller failed\n", __func__);
+		nvme_show_error("ERROR: WDC %s: Identify Controller failed", __func__);
 		return ret;
 	}
 
@@ -11778,7 +11778,7 @@ static int wdc_vs_drive_info(int argc, char **argv,
 	if ((capabilities & WDC_DRIVE_CAP_INFO) == WDC_DRIVE_CAP_INFO) {
 		ret = wdc_get_pci_ids(ctx, hdl, &read_device_id, &read_vendor_id);
 		if (ret < 0) {
-			fprintf(stderr, "ERROR: WDC: %s: failure to get pci ids, ret = %d\n", __func__, ret);
+			nvme_show_error("ERROR: WDC: %s: failure to get pci ids, ret = %d", __func__, ret);
 			goto out;
 		}
 
@@ -11860,14 +11860,14 @@ static int wdc_vs_drive_info(int argc, char **argv,
 				free(data);
 				data = NULL;
 			} else {
-				fprintf(stderr, "ERROR: WDC: %s: failure to get hw revision log\n", __func__);
+				nvme_show_error("ERROR: WDC: %s: failure to get hw revision log", __func__);
 				ret = -1;
 				goto out;
 			}
 
 			/* Get the Smart C0 log page */
 			if (!(capabilities & WDC_DRIVE_CAP_CLOUD_LOG_PAGE)) {
-				fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+				nvme_show_error("ERROR: WDC: unsupported device for this command");
 				ret = -1;
 				goto out;
 			}
@@ -11889,7 +11889,7 @@ static int wdc_vs_drive_info(int argc, char **argv,
 				tcg_dev_ownership = le32_to_cpu(ext_smart_log_ptr->ext_smart_tcgos);
 				free(data);
 			} else {
-				fprintf(stderr, "ERROR: WDC: %s: failure to get extended smart cloud log\n", __func__);
+				nvme_show_error("ERROR: WDC: %s: failure to get extended smart cloud log", __func__);
 				ret = -1;
 				goto out;
 			}
@@ -11964,12 +11964,12 @@ static int wdc_vs_drive_info(int argc, char **argv,
 			}
 			break;
 		default:
-			fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+			nvme_show_error("ERROR: WDC: unsupported device for this command");
 			ret = -1;
 			break;
 		}
 	} else {
-		fprintf(stderr, "ERROR: WDC: capability not supported by this device\n");
+		nvme_show_error("ERROR: WDC: capability not supported by this device");
 		ret = -1;
 	}
 
@@ -12012,7 +12012,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 
 	ret = validate_output_format(cfg.output_format, &fmt);
 	if (ret < 0) {
-		fprintf(stderr, "ERROR: WDC: invalid output format\n");
+		nvme_show_error("ERROR: WDC: invalid output format");
 		goto out;
 	}
 
@@ -12020,7 +12020,7 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 	wdc_check_device(ctx, hdl);
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 	if ((capabilities & WDC_DRIVE_CAP_TEMP_STATS) != WDC_DRIVE_CAP_TEMP_STATS) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		ret = -1;
 		goto out;
 	}
@@ -12224,7 +12224,7 @@ static int wdc_cloud_ssd_plugin_version(int argc, char **argv, struct command *a
 		/* print command and supported status */
 		printf("WDC Cloud SSD Plugin Version: 1.0\n");
 	} else {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 	}
 
 	return 0;
@@ -12278,13 +12278,13 @@ static int wdc_cloud_boot_SSD_version(int argc, char **argv, struct command *acm
 			/* print the version returned from the log page */
 			printf("HyperScale Boot Version: %d.%d\n", major, minor);
 		} else {
-			fprintf(stderr, "ERROR: WDC: Unable to read Extended Smart/C0 Log Page data\n");
+			nvme_show_error("ERROR: WDC: Unable to read Extended Smart/C0 Log Page data");
 			ret = -1;
 		}
 
 		free(data);
 	} else {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 	}
 
 	return ret;
@@ -12328,7 +12328,7 @@ static int wdc_enc_get_log(int argc, char **argv, struct command *acmd, struct p
 		return -EINVAL;
 
 	if (cfg.log_id > 0xff) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Invalid log identifier: %d. Valid 0xd1, 0xd2, 0xd3, 0xd4, 0xe2, 0xe4\n",
 			cfg.log_id);
 		return -EINVAL;
@@ -12337,7 +12337,7 @@ static int wdc_enc_get_log(int argc, char **argv, struct command *acmd, struct p
 	if (cfg.xfer_size) {
 		xfer_size = cfg.xfer_size;
 			if (!wdc_check_power_of_2(cfg.xfer_size)) {
-				fprintf(stderr, "%s: ERROR: xfer-size (%d) must be a power of 2\n",
+				nvme_show_error("%s: ERROR: xfer-size (%d) must be a power of 2",
 					__func__, cfg.xfer_size);
 				return -EINVAL;
 			}
@@ -12350,7 +12350,7 @@ static int wdc_enc_get_log(int argc, char **argv, struct command *acmd, struct p
 		if (len > 0) {
 			output_fd = fopen(cfg.file, "wb");
 			if (!output_fd) {
-				fprintf(stderr, "%s: ERROR: opening:%s: %s\n", __func__, cfg.file,
+				nvme_show_error("%s: ERROR: opening:%s: %s", __func__, cfg.file,
 					libnvme_strerror(errno));
 				return -EINVAL;
 			}
@@ -12361,22 +12361,22 @@ static int wdc_enc_get_log(int argc, char **argv, struct command *acmd, struct p
 		    cfg.log_id == WDC_ENC_NIC_CRASH_DUMP_ID_SLOT_2 ||
 		    cfg.log_id == WDC_ENC_NIC_CRASH_DUMP_ID_SLOT_3 ||
 		    cfg.log_id == WDC_ENC_NIC_CRASH_DUMP_ID_SLOT_4) {
-			fprintf(stderr, "args - sz:%x logid:%x of:%s\n", xfer_size, cfg.log_id,
+			nvme_show_error("args - sz:%x logid:%x of:%s", xfer_size, cfg.log_id,
 				cfg.file);
 			err = wdc_enc_get_nic_log(hdl, cfg.log_id, xfer_size,
 						  WDC_NVME_ENC_NIC_LOG_SIZE, output_fd);
 		} else {
-			fprintf(stderr, "args - sz:%x logid:%x of:%s\n", xfer_size, cfg.log_id,
+			nvme_show_error("args - sz:%x logid:%x of:%s", xfer_size, cfg.log_id,
 				cfg.file);
 			err = wdc_enc_submit_move_data(hdl, NULL, 0, xfer_size, output_fd,
 						       cfg.log_id, 0, 0);
 		}
 
 		if (err == WDC_RESULT_NOT_AVAILABLE) {
-			fprintf(stderr, "No Log/Crashdump available\n");
+			nvme_show_error("No Log/Crashdump available");
 			err = 0;
 		} else if (err) {
-			fprintf(stderr, "ERROR: 0x%x Failed to collect log-id:%x\n", err,
+			nvme_show_error("ERROR: 0x%x Failed to collect log-id:%x", err,
 				cfg.log_id);
 		}
 	}
@@ -12396,7 +12396,7 @@ static int wdc_enc_submit_move_data(struct libnvme_transport_handle *hdl, char *
 
 	buf = malloc(xfer_size);
 	if (!buf) {
-		fprintf(stderr, "%s: ERROR: malloc: %s\n", __func__, libnvme_strerror(errno));
+		nvme_show_error("%s: ERROR: malloc: %s", __func__, libnvme_strerror(errno));
 		return -1;
 	}
 	/* send something no matter what */
@@ -12437,9 +12437,9 @@ static int wdc_enc_submit_move_data(struct libnvme_transport_handle *hdl, char *
 	nvme_cmd.result = 0;
 	err = libnvme_exec_admin_passthru(hdl, &nvme_cmd);
 	if (nvme_status_equals(err, NVME_STATUS_TYPE_NVME, NVME_SC_INTERNAL)) {
-		fprintf(stderr, "%s: WARNING : WDC: No log ID:x%x available\n", __func__, log_id);
+		nvme_show_error("%s: WARNING : WDC: No log ID:x%x available", __func__, log_id);
 	} else if (err) {
-		fprintf(stderr, "%s: ERROR: WDC: NVMe Snd Mgmt\n", __func__);
+		nvme_show_error("%s: ERROR: WDC: NVMe Snd Mgmt", __func__);
 		nvme_show_status(err);
 	} else {
 		if (nvme_cmd.result == WDC_RESULT_NOT_AVAILABLE) {
@@ -12463,7 +12463,7 @@ static int wdc_enc_submit_move_data(struct libnvme_transport_handle *hdl, char *
 			err = libnvme_exec_admin_passthru(hdl, &nvme_cmd);
 			if (err) {
 				more = 0;
-				fprintf(stderr, "%s: ERROR: WDC: NVMe Rcv Mgmt ", __func__);
+				nvme_show_error("%s: ERROR: WDC: NVMe Rcv Mgmt ", __func__);
 				nvme_show_status(err);
 			} else {
 				more = nvme_cmd.result & WDC_RESULT_MORE_DATA;
@@ -12471,7 +12471,7 @@ static int wdc_enc_submit_move_data(struct libnvme_transport_handle *hdl, char *
 				fwrite(buf, response_size, 1, out);
 				offset += response_size;
 				if (more && (response_size & (sizeof(uint32_t)-1))) {
-					fprintf(stderr, "%s: ERROR: WDC: NVMe Rcv Mgmt response size:x%x not LW aligned\n",
+					nvme_show_error("%s: ERROR: WDC: NVMe Rcv Mgmt response size:x%x not LW aligned",
 						__func__, response_size);
 				}
 			}
@@ -12494,7 +12494,7 @@ static int wdc_enc_get_nic_log(struct libnvme_transport_handle *hdl, __u8 log_id
 
 	dump_data = (__u8 *)malloc(sizeof(__u8) * dump_length);
 	if (!dump_data) {
-		fprintf(stderr, "%s: ERROR: malloc: %s\n", __func__, libnvme_strerror(errno));
+		nvme_show_error("%s: ERROR: malloc: %s", __func__, libnvme_strerror(errno));
 		return -1;
 	}
 	memset(dump_data, 0, sizeof(__u8) * dump_length);
@@ -12515,7 +12515,7 @@ static int wdc_enc_get_nic_log(struct libnvme_transport_handle *hdl, __u8 log_id
 
 	while (curr_data_offset < data_len) {
 #ifdef WDC_NVME_CLI_DEBUG
-		fprintf(stderr,
+		nvme_show_error(
 			"nsid 0x%08x addr 0x%08llx, data_len 0x%08x, cdw10 0x%08x, cdw11 0x%08x, cdw12 0x%08x, cdw13 0x%08x, cdw14 0x%08x\n",
 			admin_cmd.nsid, admin_cmd.addr, admin_cmd.data_len, admin_cmd.cdw10,
 			admin_cmd.cdw11, admin_cmd.cdw12, admin_cmd.cdw13, admin_cmd.cdw14);
@@ -12523,7 +12523,7 @@ static int wdc_enc_get_nic_log(struct libnvme_transport_handle *hdl, __u8 log_id
 		ret = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (ret) {
 			nvme_show_status(ret);
-			fprintf(stderr, "%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx\n",
+			nvme_show_error("%s: ERROR: WDC: Get chunk %d, size = 0x%x, offset = 0x%x, addr = 0x%lx",
 				 __func__, i, admin_cmd.data_len, curr_data_offset, (unsigned long)admin_cmd.addr);
 			break;
 		}
@@ -12647,7 +12647,7 @@ int wdc_set_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 	capabilities = wdc_get_drive_capabilities(ctx, hdl);
 
 	if (!(capabilities & WDC_DRIVE_CAP_SET_LATENCY_MONITOR)) {
-		fprintf(stderr, "ERROR: WDC: unsupported device for this command\n");
+		nvme_show_error("ERROR: WDC: unsupported device for this command");
 		return -1;
 	}
 
@@ -12687,7 +12687,7 @@ int wdc_set_latency_monitor_feature(int argc, char **argv, struct command *acmd,
 		printf("latency monitor feature enable: 0x%x\n",
 			buf.latency_monitor_feature_enable);
 	} else if (ret > 0)
-		fprintf(stderr, "NVMe Status:%s(%x)\n",
+		nvme_show_error("NVMe Status:%s(%x)",
 				libnvme_status_to_string(ret, false), ret);
 
 	return ret;

--- a/plugins/wdc/wdc-utils.c
+++ b/plugins/wdc/wdc-utils.c
@@ -178,7 +178,7 @@ bool wdc_CheckUuidListSupport(struct libnvme_transport_handle *hdl,
 	memset(&ctrl, 0, sizeof(struct nvme_id_ctrl));
 	err = nvme_identify_ctrl(hdl, &ctrl);
 	if (err) {
-		fprintf(stderr, "ERROR: WDC: nvme_identify_ctrl() failed 0x%x\n", err);
+		nvme_show_error("ERROR: WDC: nvme_identify_ctrl() failed 0x%x", err);
 		return false;
 	}
 

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -108,14 +108,14 @@ static int list(int argc, char **argv, struct command *acmd,
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx) {
-		fprintf(stderr, "Failed to create root object\n");
+		nvme_show_error("Failed to create root object");
 		return -ENOMEM;
 	}
 	libnvme_set_logging_file(ctx, stdout);
 
 	err = libnvme_scan_topology(ctx, NULL, NULL);
 	if (err) {
-		fprintf(stderr, "Failed to scan nvme subsystems\n");
+		nvme_show_error("Failed to scan nvme subsystems");
 		return err;
 	}
 
@@ -275,7 +275,7 @@ static int zns_mgmt_send(int argc, char **argv, struct command *acmd, struct plu
 		if (zsa == NVME_ZNS_ZSA_RESET)
 			zcapc = cmd.result & 0x1;
 
-		printf("%s: Success, action:%d zone:%"PRIx64" all:%d zcapc:%u nsid:%d\n",
+		nvme_show_verbose_result("%s: Success, action:%d zone:%"PRIx64" all:%d zcapc:%u nsid:%d",
 			cmdstr, zsa, (uint64_t)cfg.zslba, (int)cfg.select_all,
 			zcapc, cfg.namespace_id);
 	} else if (err > 0) {
@@ -368,7 +368,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 	}
 
 	if (!cfg.zsa) {
-		fprintf(stderr, "zone send action must be specified\n");
+		nvme_show_error("zone send action must be specified");
 		return -EINVAL;
 	}
 
@@ -378,7 +378,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 						      cfg.namespace_id);
 
 			if (data_len == 0) {
-				fprintf(stderr, "Zone Descriptor Extensions are not supported\n");
+				nvme_show_error("Zone Descriptor Extensions are not supported");
 				return -EINVAL;
 			} else if (data_len < 0) {
 				return data_len;
@@ -387,7 +387,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 		}
 		buf = libnvme_alloc(cfg.data_len);
 		if (!buf) {
-			fprintf(stderr, "can not allocate feature payload\n");
+			nvme_show_error("can not allocate feature payload");
 			return -ENOMEM;
 		}
 
@@ -406,7 +406,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 		}
 	} else {
 		if (cfg.file || cfg.data_len) {
-			fprintf(stderr, "data, data_len only valid with set extended descriptor\n");
+			nvme_show_error("data, data_len only valid with set extended descriptor");
 			return -EINVAL;
 		}
 	}
@@ -416,7 +416,7 @@ static int zone_mgmt_send(int argc, char **argv, struct command *acmd, struct pl
 				cfg.data_len);
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
-		printf("zone-mgmt-send: Success, action:%d zone:%"PRIx64" all:%d nsid:%d\n",
+		nvme_show_verbose_result("zone-mgmt-send: Success, action:%d zone:%"PRIx64" all:%d nsid:%d",
 		       cfg.zsa, (uint64_t)cfg.zslba, (int)cfg.select_all, cfg.namespace_id);
 	else if (err > 0)
 		nvme_show_status(err);
@@ -487,7 +487,7 @@ static int open_zone(int argc, char **argv, struct command *acmd, struct plugin 
 				NULL, 0);
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
-		printf("zns-open-zone: Success zone slba:%"PRIx64" nsid:%d\n",
+		nvme_show_verbose_result("zns-open-zone: Success zone slba:%"PRIx64" nsid:%d",
 		       (uint64_t)cfg.zslba, cfg.namespace_id);
 	else if (err > 0)
 		nvme_show_status(err);
@@ -555,7 +555,7 @@ static int set_zone_desc(int argc, char **argv, struct command *acmd, struct plu
 	data_len = get_zdes_bytes(hdl, cfg.namespace_id);
 
 	if (!data_len || data_len < 0) {
-		fprintf(stderr,
+		nvme_show_error(
 			"zone format does not provide descriptor extension\n");
 		return -EINVAL;
 	}
@@ -586,7 +586,7 @@ static int set_zone_desc(int argc, char **argv, struct command *acmd, struct plu
 				data_len);
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
-		printf("set-zone-desc: Success, zone:%"PRIx64" nsid:%d\n",
+		nvme_show_verbose_result("set-zone-desc: Success, zone:%"PRIx64" nsid:%d",
 		       (uint64_t)cfg.zslba, cfg.namespace_id);
 	else if (err > 0)
 		nvme_show_status(err);
@@ -638,7 +638,7 @@ static int zrwa_flush_zone(int argc, char **argv, struct command *acmd, struct p
 				NVME_ZNS_ZSA_ZRWA_FLUSH, 0, 0, 0, NULL, 0);
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
-		printf("zrwa-flush-zone: Success, lba:%"PRIx64" nsid:%d\n",
+		nvme_show_verbose_result("zrwa-flush-zone: Success, lba:%"PRIx64" nsid:%d",
 		       (uint64_t)cfg.lba, cfg.namespace_id);
 	else if (err > 0)
 		nvme_show_status(err);
@@ -700,7 +700,7 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *acmd, struct pl
 	}
 
 	if (cfg.zra == NVME_ZNS_ZRA_REPORT_ZONES && !cfg.data_len) {
-		fprintf(stderr, "error: data len is needed for NVME_ZRA_ZONE_REPORT\n");
+		nvme_show_error("error: data len is needed for NVME_ZRA_ZONE_REPORT");
 		return -EINVAL;
 	}
 	if (cfg.data_len) {
@@ -715,7 +715,7 @@ static int zone_mgmt_recv(int argc, char **argv, struct command *acmd, struct pl
 				cfg.zrasf, cfg.partial, data, cfg.data_len);
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (!err)
-		printf("zone-mgmt-recv: Success, action:%d zone:%"PRIx64" nsid:%d\n",
+		nvme_show_verbose_result("zone-mgmt-recv: Success, action:%d zone:%"PRIx64" nsid:%d",
 		       cfg.zra, (uint64_t)cfg.zslba, cfg.namespace_id);
 	else if (err > 0)
 		nvme_show_status(err);
@@ -961,7 +961,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 		return errno;
 
 	if (!cfg.data_size) {
-		fprintf(stderr, "Append size not provided\n");
+		nvme_show_error("Append size not provided");
 		return -EINVAL;
 	}
 
@@ -982,7 +982,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 	nvme_id_ns_flbas_to_lbaf_inuse(ns.flbas, &lba_index);
 	lba_size = 1 << ns.lbaf[lba_index].ds;
 	if (cfg.data_size & (lba_size - 1)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Data size:%#"PRIx64" not aligned to lba size:%#x\n",
 			(uint64_t)cfg.data_size, lba_size);
 		return -EINVAL;
@@ -991,14 +991,14 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 	meta_size = ns.lbaf[lba_index].ms;
 	if (meta_size && !(meta_size == 8 && (cfg.prinfo & 0x8)) &&
 	    (!cfg.metadata_size || cfg.metadata_size % meta_size)) {
-		fprintf(stderr,
+		nvme_show_error(
 			"Metadata size:%#"PRIx64" not aligned to metadata size:%#x\n",
 			(uint64_t)cfg.metadata_size, meta_size);
 		return -EINVAL;
 	}
 
 	if (cfg.prinfo > 0xf) {
-		fprintf(stderr, "Invalid value for prinfo:%#x\n", cfg.prinfo);
+		nvme_show_error("Invalid value for prinfo:%#x", cfg.prinfo);
 		return -EINVAL;
 	}
 
@@ -1012,7 +1012,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 
 	buf = libnvme_alloc(cfg.data_size);
 	if (!buf) {
-		fprintf(stderr, "No memory for data size:%"PRIx64"\n",
+		nvme_show_error("No memory for data size:%"PRIx64"\n",
 			(uint64_t)cfg.data_size);
 		goto close_dfd;
 	}
@@ -1034,7 +1034,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 	if (cfg.metadata_size) {
 		mbuf = libnvme_alloc(meta_size);
 		if (!mbuf) {
-			fprintf(stderr, "No memory for metadata size:%d\n",
+			nvme_show_error("No memory for metadata size:%d",
 				meta_size);
 			err = -1;
 			goto close_mfd;
@@ -1067,7 +1067,7 @@ static int zone_append(int argc, char **argv, struct command *acmd, struct plugi
 		       elapsed_utime(start_time, end_time));
 
 	if (!err)
-		printf("Success appended data to LBA %"PRIx64"\n",
+		nvme_show_verbose_result("Success appended data to LBA %"PRIx64,
 		       (uint64_t)cmd.result);
 	else if (err > 0)
 		nvme_show_status(err);


### PR DESCRIPTION
Unix tools should remain silent on success and produce output only when it is part of their functional result. Emitting status messages by default violates the long-established convention that stdout is reserved for machine-consumable data, while diagnostics and optional progress reporting belong on stderr or behind an explicit verbose flag.

A core strength of Unix tooling is composability: commands are routinely used in pipelines, shell scripts, automation frameworks, and other programs. Unsolicited status output contaminates stdout, forcing consumers to implement fragile filtering logic and making the tool harder to integrate reliably. The absence of default status messages is therefore not merely a stylistic preference but an interoperability requirement.

This follows the traditional Unix principle that "no news is good news": successful execution is indicated by the exit status, not by human-readable confirmation text. Users who need operational visibility can opt into it through verbose or progress-reporting options, while automation and existing workflows continue to receive clean, deterministic output.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/2025

[note: there are plenty more places where nvme-cli still prints directly to stdout. this needs to be updated as well. but given the size of this tasks, let's go incrementatlly]