### PR TITLE
build: install libnvme as versioned libnvme3 artifacts

### DIFF
--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -48,7 +48,7 @@ else
         # When prefix points to a standard location, meson can use
         # standard methods (e.g. pkg-config) to find the library.
         libnvme_dep = dependency(
-            'libnvme',
+            libnvme_api_name,
             version: '>=@0@'.format(libnvme_so_version),
             required: want_nvme,
         )
@@ -56,10 +56,9 @@ else
         # When prefix points to a non-standard location
         # let's ask the C compiler to find the library for us.
         libnvme_dep = cc.find_library(
-            'nvme',
+            libnvme_link_name,
             dirs: prefixdir / get_option('libdir'),
             required: want_nvme,
         )
     endif
 endif
-

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -159,7 +159,7 @@ libnvme_header = configure_file(
 )
 
 libnvme = library(
-    'nvme', # produces libnvme.so
+    libnvme_link_name, # produces libnvme<major>.so
     sources,
     version: libnvme_so_version,
     c_args: ['-fvisibility=hidden'],
@@ -170,8 +170,8 @@ libnvme = library(
 
 pkg = import('pkgconfig')
 pkg.generate(libnvme,
-    filebase: 'libnvme',
-    name: 'libnvme',
+    filebase: libnvme_api_name,
+    name: libnvme_api_name,
     version: libnvme_so_version,
     description: 'Manage "libnvme" subsystem devices (Non-volatile Memory Express)',
     url: 'https://github.com/linux-nvme/nvme-cli/',
@@ -213,4 +213,3 @@ if want_mi
         install_mode: mode,
     )
 endif
-

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,10 @@ if get_option('pypi')
     libnvme_so_version = libnvme_so_version.split('.')[0]
 endif
 
+libnvme_so_major = libnvme_so_version.split('.')[0]
+libnvme_api_name = 'libnvme@0@'.format(libnvme_so_major)
+libnvme_link_name = 'nvme@0@'.format(libnvme_so_major)
+
 ################################################################################
 prefixdir      = get_option('prefix')
 datadir        = join_paths(prefixdir, get_option('datadir'))
@@ -516,7 +520,7 @@ substs.set('SYSTEMDDIR', systemddir)
 substs.set('SYSTEMCTL', get_option('systemctl'))
 substs.set('PREFIX', prefixdir)
 substs.set('URL', 'https://github.com/linux-nvme/nvme-cli/')
-substs.set('VERSION_MAJOR', libnvme_so_version.split('.')[0])
+substs.set('VERSION_MAJOR', libnvme_so_major)
 
 
 ################################################################################


### PR DESCRIPTION
Allow the library to be installed alongside libnvme v1. This allows distributions to install both version until all projects depending on libnvme v1 have been updated to v3.