### PR TITLE
build: handle should_faild deprecation

### DIFF
--- a/libnvme/test/nbft/meson.build
+++ b/libnvme/test/nbft/meson.build
@@ -85,12 +85,23 @@ if diffcmd.found()
 endif
 
 foreach table: tables_bad
-    test(
-        'libnvme - @0@'.format(table),
-        nbft_dump,
-        args: [
-            files(tables_bad_dir/table),
-        ],
-        should_fail: true,
-    )
+    if meson.version().version_compare('>=1.11.0')
+        test(
+            'libnvme - @0@'.format(table),
+            nbft_dump,
+            args: [
+                files(tables_bad_dir/table),
+            ],
+            expected_fail: true,
+        )
+    else
+        test(
+            'libnvme - @0@'.format(table),
+            nbft_dump,
+            args: [
+                files(tables_bad_dir/table),
+            ],
+            should_fail: true,
+        )
+    endif
 endforeach


### PR DESCRIPTION
meson v1.11 issues deprecation warnings for should_fail. Since meson v1.11 is really a young release, don't update the dependency to it instead add a workaround for the time being.