### PR TITLE
nvme: call nvme_show_finish by closing transport handle

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -337,6 +337,14 @@ static int get_transport_handle(struct libnvme_global_ctx *ctx, int argc,
 	return ret;
 }
 
+void put_transport_handle(struct libnvme_transport_handle *hdl)
+{
+	libnvme_close(hdl);
+
+	if (log_level >= LIBNVME_LOG_DEBUG)
+		nvme_show_finish();
+}
+
 static int parse_args(int argc, char *argv[], const char *desc,
 		      struct argconfig_commandline_options *opts)
 {

--- a/nvme.h
+++ b/nvme.h
@@ -135,9 +135,11 @@ int parse_and_open(struct libnvme_global_ctx **ctx,
 		struct libnvme_transport_handle **hdl, int argc, char **argv,
 		const char *desc, struct argconfig_commandline_options *clo);
 
+void put_transport_handle(struct libnvme_transport_handle *hdl);
+
 // TODO: unsure if we need a double ptr here
-static inline DEFINE_CLEANUP_FUNC(
-	cleanup_nvme_transport_handle, struct libnvme_transport_handle *, libnvme_close)
+static inline DEFINE_CLEANUP_FUNC(cleanup_nvme_transport_handle,
+	struct libnvme_transport_handle *, put_transport_handle)
 #define __cleanup_nvme_transport_handle __cleanup(cleanup_nvme_transport_handle)
 
 extern const char *uuid_index;


### PR DESCRIPTION
Since previously done by closing device for the debug log level. But currently only calls nvme_show_init by opening tranceport handle.