### PR TITLE
libnvme: add CIU and CIRN to Identify Controller data structure

### DIFF
--- a/libnvme/src/nvme/nvme-types-base.h
+++ b/libnvme/src/nvme/nvme-types-base.h
@@ -1298,7 +1298,10 @@ struct nvme_id_psd {
  *	       field is 3
  * @crcap:     Controller Reachability Capabilities (CRCAP), see
  *	       &enum nvme_id_ctrl_crcap
- * @rsvd135:   Reserved
+ * @ciu:       Controller Instance Uniquifier (CIU)
+ * @cirn:      Controller Instance Random Number (CIRN)
+ * @rsvd144:   Reserved
+ * @rsvd240:   Reserved for the NVMe Management Interface specification
  * @nvmsr:     NVM Subsystem Report, see &enum nvme_id_ctrl_nvmsr
  * @vwci:      VPD Write Cycle Information, see &enum nvme_id_ctrl_vwci
  * @mec:       Management Endpoint Capabilities, see &enum nvme_id_ctrl_mec
@@ -1573,7 +1576,10 @@ struct nvme_id_ctrl {
 	__le16			crdt2;
 	__le16			crdt3;
 	__u8			crcap;
-	__u8			rsvd135[118];
+	__u8			ciu;
+	__u8			cirn[8];
+	__u8			rsvd144[96];
+	__u8			rsvd240[13];
 	__u8			nvmsr;
 	__u8			vwci;
 	__u8			mec;


### PR DESCRIPTION
@igaw As we discussed at Lund Linux Conference, I took the spec and cross-referenced it with the code base to an LLM. It found some discrepancies. Here is the first one. Please let me know if this is useful, I will then continue sending the next ones in batches after manually checking the mismatches. :)


Commit description :

The I/O Command Set Independent Identify Controller data structure (Figure 328 in NVM Express Base Specification 2.3) defines two fields that were previously hidden inside the rsvd135[118] reserved block:

  - byte 135    Controller Instance Uniquifier (CIU)
  - bytes 143:136 Controller Instance Random Number (CIRN)

Split rsvd135[118] into ciu, cirn[8], and the two remaining reserved ranges.


Assisted-by: Claude:claude-opus-4-8 [devin]