### PR TITLE
nvme-print: Fix nvme_bar_cap cps field alignment

### DIFF
--- a/nvme-print.h
+++ b/nvme-print.h
@@ -152,7 +152,7 @@ struct nvme_bar_cap {
 	__u16	nssrs:1;
 	__u16	css:8;
 	__u16	bps:1;
-	__u8	cps:2;
+	__u16	cps:2;
 	__u8	mpsmin:4;
 	__u8	mpsmax:4;
 	__u8	pmrs:1;


### PR DESCRIPTION
Fixes field alignments of the nvme_bar_cap struct by making cps part of the __u16 that was missing those two bits. This change fixes warnings regarding the struct size encountered when compiling on Windows.