### PR TITLE
File and output stream line ending compatibility changes

### DIFF
--- a/common.h
+++ b/common.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
+#include <fcntl.h>
 #include <string.h>
 #include <stdbool.h>
 
@@ -38,6 +39,16 @@ static inline int getpagesize(void)
 	GetSystemInfo(&si);
 	return si.dwPageSize;
 }
+#endif
+
+/*
+ * Open file for reading or writing raw data with no line-ending translations
+ * or other interpretation or decoding.
+ */
+#ifdef O_BINARY
+#define nvme_open_rawdata(path, flags, ...) open((path), (flags) | O_BINARY, ##__VA_ARGS__)
+#else
+#define nvme_open_rawdata(path, flags, ...) open((path), (flags), ##__VA_ARGS__)
 #endif
 
 /*

--- a/libnvme/examples/telemetry-listen.c
+++ b/libnvme/examples/telemetry-listen.c
@@ -26,6 +26,7 @@
 
 #include <libnvme.h>
 
+#include "common.h"
 #include "nvme/tree.h"
 
 struct events {
@@ -63,7 +64,7 @@ static void save_telemetry(libnvme_ctrl_t c)
 		return;
 	}
 
-	fd = open(buf, O_CREAT|O_WRONLY, S_IRUSR|S_IRGRP);
+	fd = nvme_open_rawdata(buf, O_CREAT|O_WRONLY, S_IRUSR|S_IRGRP);
 	if (fd < 0) {
 		free(log);
 		return;

--- a/nvme.c
+++ b/nvme.c
@@ -942,7 +942,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 		}
 	}
 
-	output = open(cfg.file_name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(cfg.file_name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		nvme_show_error("Failed to open output file %s: %s!",
 				cfg.file_name, libnvme_strerror(errno));
@@ -1919,7 +1919,7 @@ static int get_boot_part_log(int argc, char **argv, struct command *acmd, struct
 		return -1;
 	}
 
-	output = open(cfg.file_name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(cfg.file_name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		nvme_show_error("Failed to open output file %s: %s!",
 				cfg.file_name, libnvme_strerror(errno));
@@ -2292,7 +2292,7 @@ static int io_mgmt_recv(int argc, char **argv, struct command *acmd, struct plug
 	       cfg.nsid);
 
 	if (cfg.file) {
-		dfd = open(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+		dfd = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
 		if (dfd < 0) {
 			nvme_show_perror(cfg.file);
 			return -errno;
@@ -8845,7 +8845,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	}
 
 	if (strlen(cfg.data)) {
-		dfd = open(cfg.data, flags, mode);
+		dfd = nvme_open_rawdata(cfg.data, flags, mode);
 		if (dfd < 0) {
 			nvme_show_perror(cfg.data);
 			return -EINVAL;
@@ -8853,7 +8853,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	}
 
 	if (strlen(cfg.metadata)) {
-		mfd = open(cfg.metadata, flags, mode);
+		mfd = nvme_open_rawdata(cfg.metadata, flags, mode);
 		if (mfd < 0) {
 			nvme_show_perror(cfg.metadata);
 			return -EINVAL;
@@ -9724,7 +9724,7 @@ static int passthru(int argc, char **argv, bool admin,
 	}
 
 	if (strlen(cfg.input_file)) {
-		dfd = open(cfg.input_file, flags, mode);
+		dfd = nvme_open_rawdata(cfg.input_file, flags, mode);
 		if (dfd < 0) {
 			nvme_show_perror(cfg.input_file);
 			return -EINVAL;
@@ -9732,7 +9732,7 @@ static int passthru(int argc, char **argv, bool admin,
 	}
 
 	if (cfg.metadata && strlen(cfg.metadata)) {
-		mfd = open(cfg.metadata, flags, mode);
+		mfd = nvme_open_rawdata(cfg.metadata, flags, mode);
 		if (mfd < 0) {
 			nvme_show_perror(cfg.metadata);
 			return -EINVAL;
@@ -10844,7 +10844,7 @@ static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc
 	}
 
 	if (strlen(cfg.input_file)) {
-		fd = open(cfg.input_file, flags, mode);
+		fd = nvme_open_rawdata(cfg.input_file, flags, mode);
 		if (fd < 0) {
 			nvme_show_perror(cfg.input_file);
 			return -EINVAL;

--- a/nvme.c
+++ b/nvme.c
@@ -11662,6 +11662,15 @@ int main(int argc, char **argv)
 {
 	int err;
 
+#ifdef _WIN32
+	/*
+	 * Set stdout and stderr to binary mode to prevent Windows text-mode
+	 * translation from converting LF to CRLF and corrupting binary output.
+	 */
+	_setmode(_fileno(stdout), O_BINARY);
+	_setmode(_fileno(stderr), O_BINARY);
+#endif
+
 	nvme.extensions->parent = &nvme;
 	if (argc < 2) {
 		general_help(&builtin, NULL);

--- a/plugins/intel/intel-nvme.c
+++ b/plugins/intel/intel-nvme.c
@@ -1406,7 +1406,7 @@ static int get_internal_log(int argc, char **argv, struct command *acmd,
 	cdlog.u.fields.selectCore = cfg.core < 0 ? 0 : cfg.core;
 	cdlog.u.fields.selectNlog = cfg.lnum < 0 ? 0 : cfg.lnum;
 
-	output = open(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		err = output;
 		goto out_free;

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -829,7 +829,7 @@ static int extract_dump_get_log(struct libnvme_transport_handle *hdl, char *feat
 
 		if (i != total_loop_cnt - 1) {
 			if (!i) {
-				output = open(filepath, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+				output = nvme_open_rawdata(filepath, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 				if (output < 0) {
 					err = -13;
 					goto end;
@@ -1187,7 +1187,7 @@ static int get_telemetry_log_page_data(struct libnvme_transport_handle *hdl,
 	}
 	memset(hdr, 0, bs);
 
-	fd = open(output_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	fd = nvme_open_rawdata(output_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (fd < 0) {
 		fprintf(stderr, "Failed to open output file %s: %s!\n",
 				output_file, libnvme_strerror(errno));
@@ -1333,7 +1333,7 @@ static int get_c9_log_page_data(struct libnvme_transport_handle *hdl,
 	}
 
 	if (save_bin) {
-		fd = open(output_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+		fd = nvme_open_rawdata(output_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (fd < 0) {
 			fprintf(stderr, "Failed to open output file %s: %s!\n", output_file,
 				libnvme_strerror(errno));

--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -107,7 +107,7 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 		return -EINVAL;
 	}
 
-	output = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		fprintf(stderr, "%s: Failed to open output file %s: %s!\n",
 				__func__, file, libnvme_strerror(errno));
@@ -309,7 +309,7 @@ static int sndk_do_cap_udui(struct libnvme_transport_handle *hdl, char *file,
 
 	log = (struct nvme_telemetry_log *)realloc(log, chunk_size);
 
-	output = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		fprintf(stderr, "%s: Failed to open output file %s: %s!\n", __func__, file,
 			libnvme_strerror(errno));
@@ -458,7 +458,7 @@ static int sndk_vs_internal_fw_log(int argc, char **argv,
 		int verify_file;
 
 		/* verify file name and path is valid before getting dump data */
-		verify_file = open(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+		verify_file = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (verify_file < 0) {
 			fprintf(stderr, "ERROR: SNDK: open: %s\n", libnvme_strerror(errno));
 			goto out;

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1785,7 +1785,7 @@ static int vs_internal_log(int argc, char **argv, struct command *acmd, struct p
 
 	dump_fd = STDOUT_FILENO;
 	if (strlen(cfg.file)) {
-		dump_fd = open(cfg.file, flags, mode);
+		dump_fd = nvme_open_rawdata(cfg.file, flags, mode);
 		if (dump_fd < 0) {
 			perror(cfg.file);
 			return -EINVAL;

--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -256,7 +256,7 @@ static int ilog_dump_assert_logs(struct libnvme_transport_handle *hdl, struct il
 		 (int) (sizeof(file_path) - sizeof(file_name) - 1),
 		 ilog->cfg->out_dir, file_name) < 0)
 		return -errno;
-	output = open(file_path, O_WRONLY | O_CREAT | O_TRUNC, LOG_FILE_PERMISSION);
+	output = nvme_open_rawdata(file_path, O_WRONLY | O_CREAT | O_TRUNC, LOG_FILE_PERMISSION);
 	if (output < 0)
 		return -errno;
 	err = write_header((__u8 *)ad, output, ad->header.header_size * DWORD_SIZE);
@@ -311,7 +311,7 @@ static int ilog_dump_event_logs(struct libnvme_transport_handle *hdl, struct ilo
 		return err;
 	if (asprintf(&file_path, "%s/EventLog.bin", ilog->cfg->out_dir))
 		return -errno;
-	output = open(file_path, O_WRONLY | O_CREAT | O_TRUNC, LOG_FILE_PERMISSION);
+	output = nvme_open_rawdata(file_path, O_WRONLY | O_CREAT | O_TRUNC, LOG_FILE_PERMISSION);
 	if (output < 0)
 		return -errno;
 	err = write_header(head_buf, output, INTERNAL_LOG_MAX_BYTE_TRANSFER);
@@ -407,7 +407,7 @@ static int ilog_dump_nlogs(struct libnvme_transport_handle *hdl, struct ilog *il
 			core_num = core < 0 ? nlog_header->corecount : 0;
 			if (!header_size) {
 				if (asprintf(&file_path, "%s/NLog.bin", ilog->cfg->out_dir) >= 0) {
-					output = open(file_path, O_WRONLY | O_CREAT | O_TRUNC,
+					output = nvme_open_rawdata(file_path, O_WRONLY | O_CREAT | O_TRUNC,
 							LOG_FILE_PERMISSION);
 					if (output < 0)
 						return -errno;
@@ -474,7 +474,7 @@ static int log_save(struct log *log, const char *parent_dir_name, const char *su
 	if (asprintf(&file_path, "%s/%s/%s", parent_dir_name, subdir_name, file_name) < 0)
 		return -errno;
 
-	output = open(file_path, O_WRONLY | O_CREAT | O_TRUNC, LOG_FILE_PERMISSION);
+	output = nvme_open_rawdata(file_path, O_WRONLY | O_CREAT | O_TRUNC, LOG_FILE_PERMISSION);
 	if (output < 0)
 		return -errno;
 

--- a/plugins/toshiba/toshiba-nvme.c
+++ b/plugins/toshiba/toshiba-nvme.c
@@ -10,6 +10,7 @@
 
 #include <libnvme.h>
 
+#include "common.h"
 #include "nvme-cmds.h"
 #include "nvme-print.h"
 #include "nvme.h"
@@ -252,7 +253,7 @@ static int nvme_get_internal_log(struct libnvme_transport_handle *hdl,
 		d(page_data, page_data_len, 16, 1);
 	} else {
 		progress_runner(progress);
-		o_fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+		o_fd = nvme_open_rawdata(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (o_fd < 0) {
 			fprintf(stderr, "%s: couldn't output file %s\n", __func__, filename);
 			err = -EINVAL;
@@ -379,7 +380,7 @@ static int nvme_get_vendor_log(struct libnvme_transport_handle *hdl,
 		return err;
 	}
 	if (filename) {
-		int o_fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+		int o_fd = nvme_open_rawdata(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 
 		if (o_fd < 0) {
 			fprintf(stderr, "%s: couldn't output file %s\n",

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -2257,7 +2257,7 @@ static int wdc_create_log_file(const char *file, const __u8 *drive_log_data,
 		return -1;
 	}
 
-	fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	fd = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (fd < 0) {
 		fprintf(stderr, "ERROR: WDC: open: %s\n", libnvme_strerror(errno));
 		return -1;
@@ -3319,7 +3319,7 @@ static int wdc_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 		return -EINVAL;
 	}
 
-	output = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		fprintf(stderr, "%s: Failed to open output file %s: %s!\n",
 				__func__, file, libnvme_strerror(errno));
@@ -3497,7 +3497,7 @@ static int wdc_do_cap_dui_v1(struct libnvme_transport_handle *hdl, char *file, _
 	}
 	memset(dump_data, 0, sizeof(__u8) * xfer_size);
 
-	output = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		fprintf(stderr, "%s: Failed to open output file %s: %s!\n", __func__, file,
 			libnvme_strerror(errno));
@@ -3631,7 +3631,7 @@ static int wdc_do_cap_dui_v2_v3(struct libnvme_transport_handle *hdl, char *file
 	}
 	memset(dump_data, 0, sizeof(__u8) * xfer_size_long);
 
-	output = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		fprintf(stderr, "%s: Failed to open output file %s: %s!\n",
 				__func__, file, libnvme_strerror(errno));
@@ -3772,7 +3772,7 @@ static int wdc_do_cap_dui_v4(struct libnvme_transport_handle *hdl, char *file, _
 	}
 	memset(dump_data, 0, sizeof(__u8) * xfer_size_long);
 
-	output = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		fprintf(stderr, "%s: Failed to open output file %s: %s!\n", __func__, file,
 			libnvme_strerror(errno));
@@ -4214,7 +4214,7 @@ static int dump_internal_logs(struct libnvme_transport_handle *hdl, const char *
 	memset(hdr, 0, bs);
 
 	sprintf(file_path, "%s/telemetry.bin", dir_name);
-	output = open(file_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	output = nvme_open_rawdata(file_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (output < 0) {
 		fprintf(stderr, "Failed to open output file %s: %s!\n", file_path, libnvme_strerror(errno));
 		err = output;
@@ -4381,7 +4381,7 @@ static int wdc_vs_internal_fw_log(int argc, char **argv, struct command *acmd,
 			int verify_file;
 
 			/* verify file name and path is valid before getting dump data */
-			verify_file = open(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+			verify_file = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 			if (verify_file < 0) {
 				fprintf(stderr, "ERROR: WDC: open: %s\n", libnvme_strerror(errno));
 				goto out;
@@ -10594,7 +10594,7 @@ static int wdc_reason_identifier(int argc, char **argv,
 		int verify_file;
 
 		/* verify the passed in file name and path is valid before getting the dump data */
-		verify_file = open(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+		verify_file = nvme_open_rawdata(cfg.file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 		if (verify_file < 0) {
 			fprintf(stderr, "ERROR: WDC: open: %s\n", libnvme_strerror(errno));
 			return -1;
@@ -11067,7 +11067,7 @@ static int wdc_clear_reason_id(struct libnvme_transport_handle *hdl)
 		return -ENOMEM;
 
 	/* verify the drive reason id file name and path is valid */
-	verify_file = open(reason_id_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	verify_file = nvme_open_rawdata(reason_id_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (verify_file < 0) {
 		ret = -1;
 		goto free;


### PR DESCRIPTION
Makes Windows output behavior match other platforms by using O_BINARY to prevent text-mode line ending translation (LF to CRLF) that can corrupt binary output.

* Introduces O_NVME_WRONLY, which includes O_BINARY when O_BINARY is defined, and updates file-open calls to use it.
* Configures stdout and stderr to use O_BINARY on Windows
