### PR TITLE
top: Make top a conditional feature and disable by default on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,7 @@ want_nvme = get_option('nvme').disabled() == false
 want_libnvme = get_option('libnvme').disabled() == false
 want_fabrics = get_option('fabrics').disabled() == false and host_system != 'windows'
 want_mi = get_option('mi').disabled() == false and host_system != 'windows'
+want_top = get_option('top').disabled() == false and host_system != 'windows'
 want_json_c = get_option('json-c').disabled() == false
 want_libkmod = get_option('libkmod').disabled() == false and host_system != 'windows'
 want_tests = get_option('tests') and host_system != 'windows'
@@ -145,6 +146,7 @@ conf.set('RUNDIR', '"@0@"'.format(rundir))
 
 conf.set('CONFIG_FABRICS', want_fabrics, description: 'Is fabrics enabled')
 conf.set('CONFIG_MI', want_mi, description: 'Is MI enabled')
+conf.set('CONFIG_TOP', want_top, description: 'Is nvme top enabled')
 
 if host_system == 'windows'
     kernel32_dep = cc.find_library('kernel32', required: true)
@@ -550,7 +552,6 @@ if want_nvme
             'nvme-rpmb.c',
             'nvme.c',
             'plugin.c',
-            'nvme-print-stdout-top.c',
         ]
 
         if json_c_dep.found()
@@ -562,6 +563,10 @@ if want_nvme
 
     if want_fabrics
         sources += 'fabrics.c'
+    endif
+
+    if want_top
+        sources += 'nvme-print-stdout-top.c'
     endif
 
     sources += plugin_sources

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,6 +24,12 @@ option(
   description : 'MI support'
 )
 option(
+  'top',
+  type : 'feature',
+  value: 'enabled',
+  description : 'nvme top support'
+)
+option(
   'python',
   type : 'feature',
   value: 'auto',

--- a/nvme-builtin.h
+++ b/nvme-builtin.h
@@ -103,7 +103,9 @@ COMMAND_LIST(
 	ENTRY("show-regs", "Shows the controller registers or properties. Requires character device", show_registers)
 	ENTRY("set-reg", "Set a register and show the resulting value", set_register)
 	ENTRY("get-reg", "Get a register and show the resulting value", get_register)
+#ifdef CONFIG_TOP
 	ENTRY("top", "nvme top", top)
+#endif
 #ifdef CONFIG_FABRICS
 	ENTRY("discover", "Discover NVMeoF subsystems", discover_cmd)
 	ENTRY("connect-all", "Discover and Connect to NVMeoF subsystems", connect_all_cmd)

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -7097,7 +7097,12 @@ static struct print_ops stdout_print_ops = {
 	.topology_tabular		= stdout_topology_tabular,
 
 	/* nvme top */
+#ifdef CONFIG_TOP
 	.top				= stdout_top,
+#else
+	.top				= NULL,
+#endif
+
 	/* status and error messages */
 	.connect_msg			= stdout_connect_msg,
 	.show_message			= stdout_message,

--- a/nvme.c
+++ b/nvme.c
@@ -3597,6 +3597,7 @@ static int list_subsys(int argc, char **argv, struct command *acmd,
 	return 0;
 }
 
+#ifdef CONFIG_TOP
 static int top(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
@@ -3641,6 +3642,7 @@ static int top(int argc, char **argv, struct command *acmd,
 
 	return err;
 }
+#endif
 
 static int list(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {


### PR DESCRIPTION
Adds a 'top' configuration option that is enabled by default, and makes compilation of nvme-top code conditional on the feature enablement. Disables the top feature by default on Windows due to compatibility issues.