### PR TITLE
Allow config.json to act like discovery.conf 

### DIFF
--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -130,13 +130,12 @@ static void json_parse_subsys(libnvme_host_t h, struct json_object *subsys_obj)
 {
 	struct json_object *nqn_obj, *app_obj, *port_array;
 	libnvme_subsystem_t s;
-	const char *nqn;
+	const char *nqn = "";
 	int p;
 
 	nqn_obj = json_object_object_get(subsys_obj, "nqn");
-	if (!nqn_obj)
-		return;
-	nqn = json_object_get_string(nqn_obj);
+	if (nqn_obj)
+		nqn = json_object_get_string(nqn_obj);
 	s = libnvme_lookup_subsystem(h, NULL, nqn);
 	if (!s)
 		return;

--- a/libnvme/src/nvme/json.c
+++ b/libnvme/src/nvme/json.c
@@ -160,17 +160,16 @@ static void json_parse_host(struct libnvme_global_ctx *ctx, struct json_object *
 {
 	struct json_object *attr_obj, *subsys_array, *subsys_obj;
 	libnvme_host_t h;
-	const char *hostnqn, *hostid = NULL;
+	const char *hostnqn = NULL, *hostid = NULL;
 	int s;
 
 	attr_obj = json_object_object_get(host_obj, "hostnqn");
-	if (!attr_obj)
-		return;
-	hostnqn = json_object_get_string(attr_obj);
+	if (attr_obj)
+		hostnqn = json_object_get_string(attr_obj);
 	attr_obj = json_object_object_get(host_obj, "hostid");
 	if (attr_obj)
 		hostid = json_object_get_string(attr_obj);
-	h = libnvme_lookup_host(ctx, hostnqn, hostid);
+	libnvme_get_host(ctx, hostnqn, hostid, &h);
 	attr_obj = json_object_object_get(host_obj, "dhchap_key");
 	if (attr_obj)
 		libnvme_host_set_dhchap_host_key(h, json_object_get_string(attr_obj));


### PR DESCRIPTION
In  discovery.conf hostnqn and nqn are not required. to allow a seamless transition between the two formats make them also not required in config.json. This also allows a default config.json to be shipped without conflicting hostnqns.

Signed-off-by: Jesse Taube <jtaubepe@redhat.com>