### PR TITLE
fabrics: Fix next_line parser.

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -324,7 +324,8 @@ static int hook_parser_next_line(struct libnvmf_context *fctx, void *user_data)
 {
 	struct hook_fabrics_data *hfd = user_data;
 	struct nvmf_args fa;
-	char *ptr, *p, line[4096];
+	char *ptr, *p;
+	static char line[4096];
 	int argc, ret = 0;
 	bool force = false;
 
@@ -363,6 +364,9 @@ next:
 	ret = set_fabrics_options(fctx, &fa);
 	if (ret)
 		return ret;
+
+	libnvmf_context_set_discovery_hooks(fctx, hook_discovery_log,
+		hook_parser_init, hook_parser_cleanup, hook_parser_next_line);
 
 	return 0;
 }

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2458,46 +2458,18 @@ __libnvme_public int libnvmf_discovery_config_file(
 		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
 		bool connect, bool force)
 {
-	struct libnvme_host *h;
-	struct libnvme_ctrl *c;
 	int err;
-
-	err = lookup_host(ctx, fctx, &h);
-	if (err)
-		return err;
-
-	err = setup_connection(fctx, h, false);
-	if (err)
-		return err;
 
 	err = fctx->hooks.parser_init(fctx, fctx->hooks.user_data);
 	if (err)
 		return err;
 
 	do {
-		err = fctx->hooks.parser_next_line(fctx, fctx->hooks.user_data);
+		struct libnvmf_context nfctx = *fctx;
+		err = fctx->hooks.parser_next_line(&nfctx, fctx->hooks.user_data);
 		if (err)
 			break;
-
-		struct libnvmf_context nfctx = *fctx;
-
-		if (!force) {
-			c = lookup_ctrl(h, &nfctx);
-			if (c) {
-				_nvmf_discovery(ctx, &nfctx, connect, c);
-				continue;
-			}
-		}
-
-		err = nvmf_create_discovery_ctrl(ctx, &nfctx, h, &c);
-		if (err)
-			continue;
-
-		_nvmf_discovery(ctx, &nfctx, connect, c);
-		if (!(nfctx.persistent ||
-		      is_persistent_discovery_ctrl(h, c)))
-			err = libnvmf_disconnect_ctrl(c);
-		libnvme_free_ctrl(c);
+		libnvmf_discovery(ctx, &nfctx, connect, force);
 	} while (!err);
 
 	fctx->hooks.parser_cleanup(fctx, fctx->hooks.user_data);


### PR DESCRIPTION
There was a stack-use-after return in the next_line parser. Change the line buffer to be static.
Printing was not working as hook_disovery_log was not populated. Set all hooks using libnvmf_context_set_discovery_hooks. Simplify libnvmf_discovery_config_file by calling
libnvmf_discovery directly.

Closes: #3437