### PR TITLE
ioctl-win: Assert ctrl handle for Windows format nvm

### DIFF
--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -1482,6 +1482,12 @@ static int submit_admin_format_nvm(struct libnvme_transport_handle *hdl,
 	if (get_is_win_pe())
 		return submit_storage_protocol_command(hdl, cmd);
 
+	if (!libnvme_transport_handle_is_ns(hdl)) {
+		libnvme_msg(hdl->ctx, LIBNVME_LOG_ERR, "Windows only supports "
+			"format on namespace devices (e.g. nvme0n1)\n");
+		return -ENOTSUP;
+	}
+
 	/*
 	 * Extract the Secure Erase Settings (SES) from CDW10 and call the
 	 * appropriate implementation based on the requested erase type.


### PR DESCRIPTION
Windows only supports format operations on namespace handles. Adds  handle type check before executing disk-based format operations. Fails with -ENOTSUP if not a namespace handle.