### PR TITLE
completions: add power-measurement-log command

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -84,6 +84,7 @@ _nvme () {
 	'ns-rescan:rescan the NVMe namespaces'
 	'show-regs:show the controller registers; require admin character device'
 	'boot-part-log:retrieve boot partition log'
+	'power-measurement-log:retrieve power measurement log'
 	'fid-support-effects-log:retrieve fid support and effects log'
 	'supported-log-pages:retrieve support log pages details'
 	'lockdown:submit a lockdown command'
@@ -1349,6 +1350,21 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme boot-part-log options" _bootpartlog
+			;;
+		(power-measurement-log)
+			local _powermeaslog
+			_powermeaslog=(
+			/dev/nvme':supply a device to use (required)'
+			--raw-binary':output in binary format'
+			-b':alias for --raw-binary'
+			--output-format=':output format: normal|json|binary'
+			-o':alias for --output-format'
+			--verbose':increase output verbosity'
+			-v':alias for --verbose'
+			--timeout=':timeout value, in milliseconds'
+			)
+			_arguments '*:: :->subcmds'
+			_describe -t commands "nvme power-measurement-log options" _powermeaslog
 			;;
 		(get-feature)
 			local _getf

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -196,6 +196,10 @@ nvme_list_opts () {
 		opts+=" --lsp -s --output-file= -f \
 			--output-format= -o"
 			;;
+		"power-measurement-log")
+		opts+=" --raw-binary -b --output-format= -o \
+			--verbose -v --timeout="
+			;;
 		"media-unit-stat-log")
 		opts+=" --dom-id= -d --output-format= -o \
 			--raw-binary -b"
@@ -1799,7 +1803,7 @@ _nvme_subcmds () {
 		error-log effects-log endurance-log \
 		predictable-lat-log pred-lat-event-agg-log \
 		persistent-event-log endurance-agg-log \
-		lba-status-log resv-notif-log get-feature \
+		lba-status-log resv-notif-log power-measurement-log get-feature \
 		device-self-test self-test-log set-feature \
 		set-property get-property format fw-commit \
 		fw-download admin-passthru io-passthru \


### PR DESCRIPTION
Add shell completion support for the power-measurement-log command to both bash and zsh completions.