### PR TITLE
Completions: remove -j and --json from top level sub-commands

### DIFF
--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -542,7 +542,7 @@ nvme_list_opts () {
 			;;
 	esac
 
-	opts+=" -h --help -j --json"
+	opts+=" -h --help"
 
 	if [[ $vals == " " ]]; then
 		COMPREPLY+=( $( compgen $compargs -W "$opts" -- $cur ) )


### PR DESCRIPTION
None of the top-level sub-commands support the -j or --json option. However, the bash completions included -j and --json. Removing those options from the completions code to be consistent with actual code behavior.