### PR TITLE
doc: remove human-readable option

### DIFF
--- a/Documentation/nvme-cmdset-ind-id-ns.txt
+++ b/Documentation/nvme-cmdset-ind-id-ns.txt
@@ -10,7 +10,6 @@ SYNOPSIS
 [verse]
 'nvme' [<global-options>] 'cmdset-ind-id-ns' <device>
 			[--namespace-id=<nsid> | -n <nsid>]
-			[--human-readable | -H]
 			[--raw-binary | -b]
 
 DESCRIPTION
@@ -41,11 +40,6 @@ OPTIONS
 --raw-binary::
 	Print the raw buffer to stdout. Structure is not parsed by
 	program. This overrides the vendor specific and human readable options.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-dir-receive.txt
+++ b/Documentation/nvme-dir-receive.txt
@@ -14,9 +14,7 @@ SYNOPSIS
 			[--dir-type=<dtype> | -D <dtype>]
 			[--dir-spec=<dspec> | -S <dspec>]
 			[--dir-oper=<doper> | -O <doper>]
-			[--req-resource=<nsr> | -r <nsr>]
-			[--human-readable | -H]
-			[--raw-binary | -b]
+			[--req-resource=<nsr> | -r <nsr>] [--raw-binary | -b]
 
 DESCRIPTION
 -----------
@@ -77,11 +75,6 @@ OPTIONS
 	Print the raw receive buffer to stdout if the command returns
 	a structure.
 
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
-
 include::global-options.txt[]
 
 EXAMPLES
@@ -89,28 +82,28 @@ EXAMPLES
 * Identify directive type supported :
 +
 ------------
-# nvme dir-receive /dev/nvme0 --dir-type 0 --dir-oper 1 --human-readable
+# nvme dir-receive /dev/nvme0 --dir-type 0 --dir-oper 1 --verbose
 ------------
 +
 
 * Get stream directive parameters : 
 +
 ------------
-# nvme dir-receive /dev/nvme0 --dir-type 1 --dir-oper 1 --human-readable 
+# nvme dir-receive /dev/nvme0 --dir-type 1 --dir-oper 1 --verbose
 ------------
 +
 
 * Allocate 3 streams for namespace 1
 +
 ------------
-# nvme dir-receive /dev/nvme0n1 --dir-type 1 --dir-oper 3 --req-resource 3 --human-readable 
+# nvme dir-receive /dev/nvme0n1 --dir-type 1 --dir-oper 3 --req-resource 3 --verbose
 ------------
 +
 
 * Get streams directive status :
 +
 ------------
-# nvme dir-receive /dev/nvme0 --dir-type 1 --dir-oper 2 --human-readable 
+# nvme dir-receive /dev/nvme0 --dir-type 1 --dir-oper 2 --verbose
 ------------
 +
 It is probably a bad idea to not redirect stdout when using this mode.

--- a/Documentation/nvme-dir-send.txt
+++ b/Documentation/nvme-dir-send.txt
@@ -15,9 +15,7 @@ SYNOPSIS
 			[--dir-spec=<dspec> | -S <dspec>]
 			[--dir-oper=<doper> | -O <doper>]
 			[--endir=<endir> | -e <endir>]
-			[--target-dir=<tdir> | -T <tdir>]
-			[--human-readable | -H]
-			[--raw-binary | -b]
+			[--target-dir=<tdir> | -T <tdir>] [--raw-binary | -b]
 
 DESCRIPTION
 -----------
@@ -81,11 +79,6 @@ OPTIONS
 --raw-binary::
 	Print the raw receive buffer to stdout if the command returns
 	a structure.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-effects-log.txt
+++ b/Documentation/nvme-effects-log.txt
@@ -10,7 +10,6 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'effects-log' <device> [--raw-binary | -b]
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -28,12 +27,7 @@ OPTIONS
 -b::
 --raw-binary::
 	This option will print the raw buffer to stdout. Structure is not
-	parsed by program. This overrides the human-readable option.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
+	parsed by program. This overrides the verbose option.
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-fid-support-effects-log.txt
+++ b/Documentation/nvme-fid-support-effects-log.txt
@@ -9,7 +9,6 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'fid-support-effects-log' <device>
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -25,11 +24,6 @@ raw buffer may be printed to stdout.
 
 OPTIONS
 -------
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
-
 include::global-options.txt[]
 
 EXAMPLES

--- a/Documentation/nvme-get-feature.txt
+++ b/Documentation/nvme-get-feature.txt
@@ -13,11 +13,8 @@ SYNOPSIS
 			[--feature-id=<fid> | -f <fid>]
 			[--uuid-index=<uuid-index> | -U <uuid_index>]
 			[--data-len=<data-len> | -l <data-len>]
-			[--sel=<select> | -s <select>]
-			[--raw-binary | -b]
-			[--cdw11=<cdw11> | -c <cdw11>]
-			[--human-readable | -H]
-			[--changed | -C]
+			[--sel=<select> | -s <select>] [--raw-binary | -b]
+			[--cdw11=<cdw11> | -c <cdw11>] [--changed | -C]
 
 DESCRIPTION
 -----------
@@ -128,11 +125,6 @@ OPTIONS
 --raw-binary::
 	Print the raw feature buffer to stdout if the feature returns
 	a structure.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 -C::
 --changed::

--- a/Documentation/nvme-get-property.txt
+++ b/Documentation/nvme-get-property.txt
@@ -11,7 +11,6 @@ SYNOPSIS
 [verse]
 'nvme' [<global-options>] 'get-property' <device>
 			[--offset=<offset> | -O <offset>]
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -23,11 +22,6 @@ OPTIONS
 --offset=<offset>::
 	The offset of the property. One of CAP=0x0, VS=0x8, CC=0x14, CSTS=0x1c, NSSR=0x20
 
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
-
 include::global-options.txt[]
 
 EXAMPLES
@@ -35,7 +29,7 @@ EXAMPLES
 * The following will run the get-property command with offset 0
 +
 ------------
-# nvme get-property /dev/nvme0 --offset=0x0 --human-readable
+# nvme get-property /dev/nvme0 --offset=0x0 --verbose
 ------------
 
 BUGS

--- a/Documentation/nvme-get-reg.txt
+++ b/Documentation/nvme-get-reg.txt
@@ -15,7 +15,6 @@ SYNOPSIS
 			[--cc] [--csts] [--nssr] [--aqa] [--asq] [--acq]
 			[--bprsel] [--bpmbl] [--cmbmsc] [--nssd] [--pmrctl]
 			[--pmrmscl] [--pmrmscu]
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -113,11 +112,6 @@ OPTIONS
 
 --pmrmscu::
 	PMRMSCU=0xe18 register offset
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-id-ctrl.txt
+++ b/Documentation/nvme-id-ctrl.txt
@@ -11,7 +11,6 @@ SYNOPSIS
 'nvme' [<global-options>] 'id-ctrl' <device>
 			[--vendor-specific | -V]
 			[--raw-binary | -b]
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -37,11 +36,6 @@ OPTIONS
 	In addition to parsing known fields, this option will dump
 	the vendor specific region of the structure in hex with ascii
 	interpretation.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-id-iocs.txt
+++ b/Documentation/nvme-id-iocs.txt
@@ -10,7 +10,6 @@ SYNOPSIS
 [verse]
 'nvme' [<global-options>] 'id-iocs' <device>
 			[--controller-id=<cntid> | -c <cntid>]
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -26,11 +25,6 @@ OPTIONS
 --controller-id=<cntid>::
 	Retrieve the identify I/O Command set data structure for the given
 	cntid. If this value is not given, cntid will be 0xffff.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-id-ns.txt
+++ b/Documentation/nvme-id-ns.txt
@@ -13,7 +13,6 @@ SYNOPSIS
 			[--raw-binary | -b]
 			[--namespace-id=<nsid> | -n <nsid>]
 			[--force]
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -58,11 +57,6 @@ OPTIONS
 	In addition to parsing known fields, this option will dump
 	the vendor specific region of the structure in hex with ascii
 	interpretation.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-id-uuid.txt
+++ b/Documentation/nvme-id-uuid.txt
@@ -9,7 +9,6 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'id-uuid' <device> [--raw-binary | -b]
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -27,11 +26,6 @@ OPTIONS
 --raw-binary::
 	Print the raw buffer to stdout. Structure is not parsed by
 	program. This overrides the vendor specific and human readable options.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-primary-ctrl-caps.txt
+++ b/Documentation/nvme-primary-ctrl-caps.txt
@@ -9,7 +9,6 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'primary-ctrl-caps' <device>
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -25,11 +24,6 @@ raw buffer may be printed to stdout.
 
 OPTIONS
 -------
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
-
 include::global-options.txt[]
 
 EXAMPLES
@@ -43,8 +37,8 @@ EXAMPLES
 fields in a human readable format:
 +
 ------------
-# nvme primary-ctrl-caps /dev/nvme0 --human-readable
-# nvme primary-ctrl-caps /dev/nvme0 -H
+# nvme primary-ctrl-caps /dev/nvme0 --verbose
+# nvme primary-ctrl-caps /dev/nvme0 -v
 ------------
 NVME
 ----

--- a/Documentation/nvme-sanitize.txt
+++ b/Documentation/nvme-sanitize.txt
@@ -13,8 +13,7 @@ SYNOPSIS
 			<overwrite-pass-count>]
 			[--ause | -u] [--sanact=<action> | -a <action>]
 			[--ovrpat=<overwrite-pattern> | -p <overwrite-pattern>]
-			[--emvs | -e] [--force]
-			[--human-readable | -H] [--wait | -w]
+			[--emvs | -e] [--force] [--wait | -w]
 			[--repeat=<repeat-count> | -r <repeat-count>]
 
 DESCRIPTION
@@ -98,11 +97,6 @@ OPTIONS
 --force::
 	Ignore namespace is currently busy and performed the operation
 	even though.
-
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
 
 -w::
 --wait::

--- a/Documentation/nvme-show-regs.txt
+++ b/Documentation/nvme-show-regs.txt
@@ -10,7 +10,6 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'show-regs' <device>
-			[--human-readable | -H]
 
 DESCRIPTION
 -----------
@@ -28,11 +27,6 @@ Only the supported properties are displayed.
 
 OPTIONS
 -------
--H::
---human-readable::
-	Display values in a human-readable format where possible.
-	(deprecated, use --verbose)
-
 include::global-options.txt[]
 
 EXAMPLES

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -777,8 +777,6 @@ _nvme () {
 			/dev/nvme':supply a device to use (required)'
 			--raw-binary':dump infos in binary format'
 			-b':alias of --raw-binary'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			--vendor-specific':also dump binary vendor infos'
 			-V':alias of --vendor-specific'
 			)
@@ -793,8 +791,6 @@ _nvme () {
 			-n':alias of --namespace-id'
 			--raw-binary':dump infos in binary format'
 			-b':alias of --raw-binary'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			--vendor-specific':also dump binary vendor infos'
 			-V':alias of --vendor-specific'
 			)
@@ -852,8 +848,6 @@ _nvme () {
 			-n':alias of --namespace-id'
 			--raw-binary':dump infos in binary format'
 			-b':alias of --raw-binary'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme cmdset-ind-id-ns options" _cmdset_ind_idns
@@ -926,8 +920,6 @@ _nvme () {
 			-c':alias of --cntlid'
 			--output-format=':Output format: normal|json|binary'
 			-o':alias for --output-format'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme primary-ctrl-caps options" _primary_ctrl_caps
@@ -982,8 +974,6 @@ _nvme () {
 			-o':alias for --output-format'
 			--raw-binary':dump infos in binary format'
 			-b':alias of --raw-binary'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme id-uuid options" _id_uuid
@@ -1284,8 +1274,6 @@ _nvme () {
 			/dev/nvme':supply a device to use (required)'
 			--output-format=':Output format: normal|json|binary'
 			-o':alias for --output-format'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			--raw-binary':dump infos in binary format'
 			-b':alias to --raw-binary'
 			--csi=':command set identifier'
@@ -1384,8 +1372,6 @@ _nvme () {
 			--raw-binary':dump infos in binary format'
 			-b':alias to --raw-binary'
 			--timeout=':value for timeout'
-			--human-readable':show feature in readable format'
-			-H':alias of --human-readable'
 			--changed':show feature changed'
 			-C':alias of --changed'
 			)
@@ -1480,8 +1466,6 @@ _nvme () {
 			/dev/nvme':supply a device to use (required)'
 			--offset=':the offset of the property'
 			-O':alias to --offset'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			--timeout=':value for timeout'
 			)
 			_arguments '*:: :->subcmds'
@@ -1676,8 +1660,6 @@ _nvme () {
 			-r':alias of --rae'
 			--output-format=':Output format: normal|json|binary'
 			-o':alias for --output-format'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			--raw-binary':dump infos in binary format'
 			-b':alias of --raw-binary'
 			)
@@ -1712,8 +1694,6 @@ _nvme () {
 			local _support
 			_support=(
 			/dev/nvme':supply a device to use (required)'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme supported-log-pages options" _support
@@ -2475,8 +2455,6 @@ _nvme () {
 			-O':alias of --dir-oper'
 			--req-resource=':namespace stream requested'
 			-r':alias of --req-resource'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			--timeout=':value for timeout'
 			)
 			_arguments '*:: :->subcmds'
@@ -2500,8 +2478,6 @@ _nvme () {
 			-O':alias of --dir-oper'
 			--endir=':directive enable'
 			-e':alias of --endir'
-			--human-readable':show infos in readable format'
-			-H':alias of --human-readable'
 			--raw-binary':dump output in binary format'
 			-b':alias for --raw-binary'
 			--input-file=':write/send file (default stdin)'
@@ -2615,8 +2591,6 @@ _nvme () {
 			/dev/nvme':supply a device to use (required)'
 			--offset=':offset of the requested register'
 			-O':alias for --offset'
-			--human-readable':show register in readable format'
-			-H':alias for --human-readable'
 			--cap':CAP=0x0 register offset'
 			--vs':VS=0x8 register offset'
 			--cmbloc':CMBLOC=0x38 register offset'

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -46,12 +46,12 @@ nvme_list_opts () {
 		opts=+=" --output-format= -o --verbose -v"
 			;;
 		"id-ctrl")
-		opts+=" --raw-binary -b --human-readable -H \
+		opts+=" --raw-binary -b \
 			--vendor-specific -V --output-format= -o"
 			;;
 		"id-ns")
 		opts+=" --namespace-id= -n --raw-binary -b \
-			--human-readable -H --vendor-specific -V \
+			--vendor-specific -V \
 			--force -f --output-format= -o"
 			;;
 		"id-ns-granularity")
@@ -71,7 +71,7 @@ nvme_list_opts () {
 			;;
 		"cmdset-ind-id-ns")
 		opts+=" --namespace-id= -n --raw-binary -b \
-			--human-readable -H --output-format= -o"
+			--output-format= -o"
 			;;
 		"nvm-id-ctrl")
 		opts+=" --output-format= -o"
@@ -85,7 +85,7 @@ nvme_list_opts () {
 			--verbose -v --output-format= -o"
 			;;
 		"primary-ctrl-caps")
-		opts+=" --output-format= -o --human-readable -H"
+		opts+=" --output-format= -o"
 			;;
 		"list-secondary")
 		opts+=" --cntid= -c --namespace-id= n --num-entries -e \
@@ -98,7 +98,7 @@ nvme_list_opts () {
 		opts+=" --nvmeset-id= -i --output-format= -o"
 			;;
 		"id-uuid")
-		opts+=" --output-format= -o --raw-binary -b --human-readable -H"
+		opts+=" --output-format= -o --raw-binary -b"
 			;;
 		"list-endgrp")
 		opts+=" --endgrp-id= -i --output-format= -o"
@@ -135,7 +135,7 @@ nvme_list_opts () {
 			--raw-binary -b"
 			;;
 		"supported-log-pages")
-		opts+=" --output-format= -o --human-readable -H"
+		opts+=" --output-format= -o"
 			;;
 		"telemetry-log")
 		opts+=" --output-file= -O --host-generate= -g \
@@ -164,7 +164,7 @@ nvme_list_opts () {
 			--csi= -c --opcode= -O"
 			;;
 		"effects-log")
-		opts+=" --output-format= -o --human-readable -H \
+		opts+=" --output-format= -o \
 			--raw-binary -b --timeout="
 			;;
 		"endurance-log")
@@ -211,7 +211,7 @@ nvme_list_opts () {
 		"get-feature")
 		opts+=" --namespace-id= -n --feature-id= -f --sel= -s \
 			--data-len= -l --cdw11= --c -uuid-index= -U --raw-binary -b \
-			--human-readable -H --timeout= --changed -C"
+			--timeout= --changed -C"
 			;;
 		"device-self-test")
 		opts+=" --namespace-id= -n --self-test-code= -s --timeout="
@@ -229,7 +229,7 @@ nvme_list_opts () {
 		opts+=" --offset= -O --value= -V --timeout="
 			;;
 		"get-property")
-		opts=+" --offset= -O --human-readable -H --timeout="
+		opts=+" --offset= -O --timeout="
 			;;
 		"format")
 		opts+=" --namespace-id= -n --timeout= --lbaf= -l \
@@ -380,7 +380,7 @@ nvme_list_opts () {
 		esac
 			;;
 		"sanitize-log")
-		opts+=" --rae -r --output-format= -o --human-readable -H \
+		opts+=" --rae -r --output-format= -o \
 			--raw-binary -b"
 			;;
 		"reset")
@@ -393,7 +393,7 @@ nvme_list_opts () {
 		opts+=$NO_OPTS
 			;;
 		"show-regs")
-		opts+=" --output-format= -o --human-readable -H --timeout="
+		opts+=" --output-format= -o --timeout="
 			;;
 		"discover")
 		opts+=" --transport= -t -traddr= -a -trsvcid= -s \
@@ -451,12 +451,12 @@ nvme_list_opts () {
 		"dir-receive")
 		opts+=" --namespace-id= -n --data-len= -l --raw-binary -b \
 			--dir-type= -D --dir-spec= -S --dir-oper= -O \
-			--req-resource= -r --human-readable -H --timeout="
+			--req-resource= -r --timeout="
 			;;
 		"dir-send")
 		opts+=" --namespace-id= -n --data-len= -l --dir-type= -D \
 			--target-dir= -T --dir-spec= -S --dir-oper= -O \
-			--endir= -e --human-readable -H --raw-binary -b \
+			--endir= -e --raw-binary -b \
 			--timeout="
 			;;
 		"virt-mgmt")
@@ -479,7 +479,7 @@ nvme_list_opts () {
 			--nmimt= -m --nmd0= -0 --nmd1= -1 --input-file= -i"
 			;;
 		"get-reg")
-		opts+=" --offset= -O --human-readable -H --cap --vs --cmbloc \
+		opts+=" --offset= -O --cap --vs --cmbloc \
 			--cmbsz --bpinfo --cmbsts --cmbebs --cmbswtp --crto \
 			--pmrcap --pmrsts --pmrebs --pmrswtp --intms --intmc \
 			--cc --csts --nssr --aqa --asq --acq --bprsel --bpmbl \

--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -78,11 +78,11 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
             for vector in range(self.vector_list_len):
                 get_feat_cmd = f"{self.nvme_bin} get-feature {self.ctrl} " + \
                     f"--feature-id={str(feature_id)} " + \
-                    f"--cdw11={str(vector)} --human-readable"
+                    f"--cdw11={str(vector)} --verbose"
                 self.assertEqual(self.exec_cmd(get_feat_cmd), 0)
         else:
             get_feat_cmd = f"{self.nvme_bin} get-feature {self.ctrl} " + \
-                f"--feature-id={str(feature_id)} --human-readable"
+                f"--feature-id={str(feature_id)} --verbose"
             if str(feature_id) == "0x05":
                 get_feat_cmd += f" --namespace-id={self.default_nsid}"
             self.assertEqual(self.exec_cmd(get_feat_cmd), 0)

--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -307,10 +307,11 @@ static int argconfig_parse_val(struct argconfig_commandline_options *s)
 	return 0;
 }
 
-static bool argconfig_check_human_readable(struct argconfig_commandline_options *s)
+static bool argconfig_check_verbose(struct argconfig_commandline_options *s)
 {
 	for (; s && s->option; s++) {
-		if (!strcmp(s->option, "human-readable") && s->config_type == CFG_FLAG)
+		if (!strcmp(s->option, "verbose") &&
+		    s->config_type == CFG_INCREMENT)
 			return s->seen;
 	}
 
@@ -395,7 +396,7 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 			break;
 	}
 
-	if (!argconfig_check_human_readable(options))
+	if (!argconfig_check_verbose(options))
 		setlocale(LC_ALL, "C");
 
 	return ret;


### PR DESCRIPTION
Since the option is duplicated with the verbose option.