### PR TITLE
libnvme: move fabrics include list into its own file

### DIFF
--- a/libnvme/src/fabrics-includes.h.in
+++ b/libnvme/src/fabrics-includes.h.in
@@ -1,0 +1,4 @@
+#include <nvme/fabrics.h>
+#include <nvme/nbft.h>
+#include <nvme/accessors-fabrics.h>
+#include <nvme/registry.h>

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -146,7 +146,7 @@ if want_fabrics
         '-Wl,--version-script=@0@'.format(nvmf_accessors_ld),
     ]
     libconf.set('FABRICS_INCLUDE',
-                '#include <nvme/fabrics.h>\n#include <nvme/nbft.h>\n#include <nvme/accessors-fabrics.h>\n#include <nvme/registry.h>')
+                fs.read('fabrics-includes.h.in').strip())
 else
     libconf.set('FABRICS_INCLUDE', '')
 endif


### PR DESCRIPTION
The fabrics-only headers appended to the generated `libnvme.h` were carried as a single `\n`-escaped string passed to `libconf.set()` in `libnvme/src/meson.build`. That form is hard to read and easy to get wrong when an include is added or removed.

This moves the list into `libnvme/src/fabrics-includes.h.in` (one `#include` per line) and pulls it in with `fs.read().strip()`. The generated `libnvme.h` is byte-identical.

Suggested by @igaw during the registry PR (#3425) review as a small, standalone preparation patch.
