### PR TITLE
nvme: disconnect-all --transport short option + add --owner option

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -18,6 +18,7 @@ SYNOPSIS
 			[--nbft]
 			[--no-nbft]
 			[--nbft-path=<STR>]
+			[--owner=<NAME>]
 			[<fabrics-options>]
 			[<global-options>]
 
@@ -81,6 +82,12 @@ OPTIONS
 
 --nbft-path=<STR>::
 	Use a user-defined path to the NBFT tables
+
+--owner=<NAME>::
+	Record NAME as the owner of connected controllers in the NVMe
+	ownership registry, so other orchestrators (and nvme-disconnect-all)
+	leave them alone.  See nvme-disconnect-all(1).  When --nbft is also
+	given, --owner takes precedence over its default owner of 'nbft'.
 
 include::fabrics-options.txt[]
 

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -9,6 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'connect' [--config=<filename>]
+			[--owner=<NAME>]
 			[<fabrics-options>]
 
 DESCRIPTION
@@ -21,6 +22,11 @@ OPTIONS
 -------
 --config=<filename>::
 	Use the specified JSON configuration file instead of the default.
+
+--owner=<NAME>::
+	Record NAME as the owner of the connected controller in the NVMe
+	ownership registry, so other orchestrators (and nvme-disconnect-all)
+	leave it alone.  See nvme-disconnect-all(1).
 
 include::fabrics-options.txt[]
 

--- a/Documentation/nvme-disconnect-all.txt
+++ b/Documentation/nvme-disconnect-all.txt
@@ -9,7 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'disconnect-all'
-			[--transport=<STR> | -r <STR>]
+			[--transport=<STR> | -t <STR>]
 			[--owner=<NAME> | -O <NAME>]
 			[--force]
 
@@ -31,7 +31,7 @@ background.
 
 OPTIONS
 -------
--r <STR>::
+-t <STR>::
 --transport=<STR>::
 	Limit disconnection to controllers using the specified transport
 	(e.g. tcp, rdma, fc).

--- a/Documentation/nvme-disconnect-all.txt
+++ b/Documentation/nvme-disconnect-all.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 [verse]
 'nvme' [<global-options>] 'disconnect-all'
 			[--transport=<STR> | -t <STR>]
-			[--owner=<NAME> | -O <NAME>]
+			[--owner=<NAME>]
 			[--force]
 
 DESCRIPTION
@@ -36,7 +36,6 @@ OPTIONS
 	Limit disconnection to controllers using the specified transport
 	(e.g. tcp, rdma, fc).
 
--O <NAME>::
 --owner=<NAME>::
 	Disconnect only controllers owned by NAME in the registry.
 	Requires interactive confirmation when stdin is a terminal.

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -19,6 +19,7 @@ SYNOPSIS
 			[--nbft]
 			[--no-nbft]
 			[--nbft-path=<STR>]
+			[--owner=<NAME>]
 			[<fabrics-options>]
 
 DESCRIPTION
@@ -107,6 +108,12 @@ OPTIONS
 
 --nbft-path=<STR>::
 	Use a user-defined path to the NBFT tables
+
+--owner=<NAME>::
+	Record NAME as the owner of connected controllers in the NVMe
+	ownership registry, so other orchestrators (and nvme-disconnect-all)
+	leave them alone.  See nvme-disconnect-all(1).  When --nbft is also
+	given, --owner takes precedence over its default owner of 'nbft'.
 
 include::fabrics-options.txt[]
 

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -2394,7 +2394,7 @@ _nvme () {
 			local _disconnect_all
 			_disconnect_all=(
 			--transport=':transport type'
-			-r':alias for --transport'
+			-t':alias for --transport'
 			--verbose':Increase logging verbosity'
 			-v':alias for --verbose'
 			)

--- a/completions/_nvme
+++ b/completions/_nvme
@@ -2227,6 +2227,7 @@ _nvme () {
 			--nbft':Only look at NBFT tables'
 			--no-nbft':Do not look at NBFT tables'
 			--nbft-patch=':user-defined path for NBFT tables'
+			--owner=':record this owner in the registry'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme discover options" _discover
@@ -2297,6 +2298,7 @@ _nvme () {
 			--nbft':Only look at NBFT tables'
 			--no-nbft':Do not look at NBFT tables'
 			--nbft-patch=':user-defined path for NBFT tables'
+			--owner=':record this owner in the registry'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme connect-all options" _connect_all
@@ -2358,6 +2360,7 @@ _nvme () {
 			-O':alias for --dump-config'
 			--output-format=':Output format: normal|json'
 			-o':alias for --output-format'
+			--owner=':record this owner in the registry'
 			)
 			_arguments '*:: :->subcmds'
 			_describe -t commands "nvme connect options" _connect

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -405,7 +405,7 @@ nvme_list_opts () {
 			--nr-io-queues= -i --nr-write-queues= -W \
 			--nr-poll-queues= -P --queue-size= -Q \
 			--persistent -p --quiet \
-			--output-format= -o"
+			--owner= --output-format= -o"
 			;;
 		"connect-all")
 		opts+=" --transport= -t -traddr= -a -trsvcid= -s \
@@ -417,7 +417,7 @@ nvme_list_opts () {
 			--nr-io-queues= -i --nr-write-queues= -W \
 			--nr-poll-queues= -P --queue-size= -Q \
 			--persistent -p --quiet \
-			--output-format= -o"
+			--owner= --output-format= -o"
 			;;
 		"connect")
 		opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid -s \
@@ -426,7 +426,8 @@ nvme_list_opts () {
 			--keep-alive-tmo= -k --reconnect-delay= -r \
 			--ctrl-loss-tmo= -l --fast-io-fail-tmo= -f \
 			--tos= -T --duplicate-connect -D --disable-sqflow \
-			--hdr-digest -g --data-digest -G --output-format= -o"
+			--hdr-digest -g --data-digest -G --owner= \
+			--output-format= -o"
 			;;
 		"dim")
 		opts+=" --task -t --nqn -n --device -d"

--- a/fabrics.c
+++ b/fabrics.c
@@ -924,7 +924,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 	struct config cfg = { 0 };
 
 	NVME_ARGS(opts,
-		OPT_STRING("transport", 'r', "STR", (char *)&cfg.transport, nvmf_tport),
+		OPT_STRING("transport", 't', "STR", &cfg.transport, nvmf_tport),
 		OPT_STRING("owner", 'O', "NAME", &cfg.owner, owner_help),
 		OPT_FLAG("force", 0, &cfg.force, force_help));
 

--- a/fabrics.c
+++ b/fabrics.c
@@ -559,6 +559,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	bool json_config = false;
 	bool nbft = false, nonbft = false;
 	char *nbft_path = NBFT_SYSFS_PATH;
+	char *owner = NULL;
 
 	NVMF_ARGS(opts, fa,
 		  OPT_STRING("device",     'd', "DEV", &device,       "use existing discovery controller device"),
@@ -570,6 +571,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 		  OPT_FLAG("force",          0, &force,               "Force persistent discovery controller creation"),
 		  OPT_FLAG("nbft",           0, &nbft,                "Only look at NBFT tables"),
 		  OPT_FLAG("no-nbft",        0, &nonbft,              "Do not look at NBFT tables"),
+		  OPT_STRING("owner",        0, "NAME", &owner,       "record this owner in the registry"),
 		  OPT_STRING("nbft-path",    0, "STR", &nbft_path,    "user-defined path for NBFT tables"));
 
 	nvmf_default_args(&fa);
@@ -597,8 +599,19 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 			libnvme_strerror(errno));
 		return -ENOMEM;
 	}
-	if (nbft)
-		libnvme_set_owner(ctx, "nbft");
+	/*
+	 * --nbft defaults the owner to "nbft" so legacy boot scripts that
+	 * call "connect-all --nbft" record ownership unchanged.  An explicit
+	 * --owner overrides that default.
+	 */
+	if (owner || nbft) {
+		ret = libnvme_set_owner(ctx, owner ? owner : "nbft");
+		if (ret) {
+			fprintf(stderr, "failed to set owner: %s\n",
+				libnvme_strerror(-ret));
+			return ret;
+		}
+	}
 
 	if (!nvme_read_config_checked(ctx, config_file))
 		json_config = true;
@@ -661,6 +674,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	__cleanup_free char *hnqn = NULL;
 	__cleanup_free char *hid = NULL;
 	char *config_file = NULL;
+	char *owner = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 	__cleanup_nvme_ctrl libnvme_ctrl_t c = NULL;
@@ -670,6 +684,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 
 	NVMF_ARGS(opts, fa,
 		  OPT_STRING("config",             'J', "FILE", &config_file, nvmf_config_file),
+		  OPT_STRING("owner",                0, "NAME", &owner,           "record this owner in the registry"),
 		  OPT_FLAG("dump-config",          'O', &dump_config,             "Dump JSON configuration to stdout"));
 
 	nvmf_default_args(&fa);
@@ -718,6 +733,14 @@ do_connect:
 		fprintf(stderr, "Failed to create topology root: %s\n",
 			libnvme_strerror(errno));
 		return -ENOMEM;
+	}
+	if (owner) {
+		ret = libnvme_set_owner(ctx, owner);
+		if (ret) {
+			fprintf(stderr, "failed to set owner: %s\n",
+				libnvme_strerror(-ret));
+			return ret;
+		}
 	}
 
 	libnvme_read_config(ctx, config_file);
@@ -925,7 +948,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 
 	NVME_ARGS(opts,
 		OPT_STRING("transport", 't', "STR", &cfg.transport, nvmf_tport),
-		OPT_STRING("owner", 'O', "NAME", &cfg.owner, owner_help),
+		OPT_STRING("owner", 0, "NAME", &cfg.owner, owner_help),
 		OPT_FLAG("force", 0, &cfg.force, force_help));
 
 	ret = argconfig_parse(argc, argv, desc, opts);


### PR DESCRIPTION
Two small, independent fabrics CLI changes building on the ownership registry (#3425).

### 1. disconnect-all: `-r` → `-t` for `--transport`

Every other fabrics command spells `--transport` as `-t` (the shared `NVMF_ARGS` macro), but `disconnect-all` defined its own option set and used `-r`. `-t` is the canonical transport short form and is now free on `disconnect-all` since `--timeout` no longer claims a short form. This is a deliberate break with no `-r` alias. Also drops a stray `(char *)` cast on the option's value argument.

### 2. Add `--owner NAME` to connect, connect-all and discover

These commands establish controller connections through libnvme but had no way to record the connecting orchestrator's identity, so the controllers they created always looked unowned and `disconnect-all` would tear them down. A new long-only `--owner NAME` option records ownership in the registry (via `libnvme_set_owner()`) before connecting.

- `--owner` has no short form on any command. To keep that consistent, `disconnect-all`'s `--owner` also loses its `-O` short form.
- For `connect-all`/`discover`, `--nbft` already records `owner=nbft` so legacy boot scripts get ownership for free. An explicit `--owner` now overrides that default; a plain `--nbft` (no `--owner`) still records `nbft`, so the boot path is unchanged.

Man pages and shell completions are updated to match.
