### PR TITLE
Fix uninitialized variables

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -9570,7 +9570,7 @@ static int passthru(int argc, char **argv, bool admin,
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_fd int dfd = -1, mfd = -1;
-	int flags;
+	int flags = 0;
 	int mode = 0644;
 	void *data = NULL;
 	__cleanup_free void *mdata = NULL;

--- a/nvme.c
+++ b/nvme.c
@@ -4914,7 +4914,7 @@ static int get_feature_id_changed(struct libnvme_transport_handle *hdl, struct f
 	__cleanup_libnvme_free void *buf_def = NULL;
 	__cleanup_libnvme_free void *buf = NULL;
 	__u64 result_def = 0;
-	__u64 result;
+	__u64 result = 0;
 	int err_def = 0;
 	int err;
 


### PR DESCRIPTION
The result variable in get_feature_id_changed() and the flags variable in passthru() were uninitialized before use, which could cause undefined behavior. Initialize both to 0 to prevent this.