### PR TITLE
micron: Add Windows support to Micron plugin commands

### DIFF
--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -14,7 +14,11 @@ all_plugins = {
   'intel': ['plugins/intel/intel-nvme.c'],
   'mangoboost': ['plugins/mangoboost/mangoboost-nvme.c'],
   'memblaze': ['plugins/memblaze/memblaze-nvme.c'],
-  'micron': ['plugins/micron/micron-nvme.c'],
+  'micron': [
+      'plugins/micron/micron-nvme.c',
+      'plugins/micron/micron-utils.c',
+      'plugins/micron/micron-utils-linux.c'
+    ],
   'netapp': ['plugins/netapp/netapp-nvme.c'],
   'nvidia': ['plugins/nvidia/nvidia-nvme.c'],
   'sandisk': ['plugins/sandisk/sandisk-nvme.c', 'plugins/sandisk/sandisk-utils.c'],

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -2068,49 +2068,16 @@ static void GetNSIDDInfo(struct libnvme_transport_handle *hdl, const char *dir, 
 
 static void GetOSConfig(const char *strOSDirName)
 {
-	FILE *fpOSConfig = NULL;
-	char strBuffer[1024];
-	char strFileName[PATH_MAX];
-	int i;
-
-	struct {
-		char *strcmdHeader;
-		char *strCommand;
-	} cmdArray[] = {
-		{ (char *)"SYSTEM INFORMATION", (char *)"uname -a >> %s" },
-		{ (char *)"LINUX KERNEL MODULE INFORMATION", (char *)"lsmod >> %s" },
-		{ (char *)"LINUX SYSTEM MEMORY INFORMATION", (char *)"cat /proc/meminfo >> %s" },
-		{ (char *)"SYSTEM INTERRUPT INFORMATION", (char *)"cat /proc/interrupts >> %s" },
-		{ (char *)"CPU INFORMATION", (char *)"cat /proc/cpuinfo >> %s" },
-		{ (char *)"IO MEMORY MAP INFORMATION", (char *)"cat /proc/iomem >> %s" },
-		{ (char *)"MAJOR NUMBER AND DEVICE GROUP", (char *)"cat /proc/devices >> %s" },
-		{ (char *)"KERNEL DMESG", (char *)"dmesg >> %s" },
-		{ (char *)"/VAR/LOG/MESSAGES", (char *)"cat /var/log/messages >> %s" }
-	};
-
+	char strFileName[4096];
 	sprintf(strFileName, "%s/%s", strOSDirName, "os_config.txt");
-
-	for (i = 0; i < 7; i++) {
-		fpOSConfig = fopen(strFileName, "a+");
-		if (fpOSConfig) {
-			fprintf(fpOSConfig,
-				"\n\n\n\n%s\n-----------------------------------------------\n",
-				cmdArray[i].strcmdHeader);
-			fclose(fpOSConfig);
-			fpOSConfig = NULL;
-		}
-		snprintf(strBuffer, sizeof(strBuffer) - 1,
-				 cmdArray[i].strCommand, strFileName);
-		if (system(strBuffer))
-			fprintf(stderr, "Failed to send \"%s\"\n", strBuffer);
-	}
+	micron_write_os_config_to_file(strFileName);
 }
 
 static int micron_telemetry_log(struct libnvme_transport_handle *hdl, __u8 type, __u8 **data,
 				int *logSize, int da)
 {
 	int err, bs = 512, offset = bs;
-	unsigned short data_area[5];
+	unsigned short data_area[5] = { 0 };
 	unsigned char  ctrl_init = (type == 0x8);
 
 	__u8 *buffer = (unsigned char *)libnvme_alloc(bs);

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -24,6 +24,7 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <dirent.h>
 
 #include <libnvme.h>
 
@@ -201,6 +202,101 @@ static enum eDriveModel GetDriveModel(
 	return eModel;
 }
 
+/*
+ * Recursively remove a directory and its contents.
+ * Since this is only used for temporary directories that we create that
+ * have no symlinks, it is safe to not check for and handle symlinks here.
+ */
+static int RemoveDirRecursive(const char *path)
+{
+	DIR *dir = NULL;
+	struct dirent *entry;
+	char child[PATH_MAX];
+
+	dir = opendir(path);
+	if (!dir) {
+		if (errno == ENOENT)
+			return 0;
+		return -1;
+	}
+
+	while ((entry = readdir(dir))) {
+		if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+			continue;
+
+		if (snprintf(child, sizeof(child), "%s/%s", path, entry->d_name) >=
+		    (int)sizeof(child)) {
+			errno = ENAMETOOLONG;
+			closedir(dir);
+			return -1;
+		}
+
+		if (unlink(child) == 0 || errno == ENOENT)
+			continue;
+
+		if (errno != EISDIR && errno != EPERM) {
+			closedir(dir);
+			return -1;
+		}
+
+		if (RemoveDirRecursive(child) < 0) {
+			if (errno == ENOENT)
+				continue;
+			closedir(dir);
+			return -1;
+		}
+	}
+
+	closedir(dir);
+
+	if (rmdir(path) < 0 && errno != ENOENT)
+		return -1;
+
+	return 0;
+}
+
+/*
+ * bsdtar-based versions of tar support creating zip archives when -a is used
+ * with a .zip extension. Check if bsdtar is available and use it to create the
+ * requested zip archive.
+ *
+ * Returns 0 on success, or a negative errno value if tar is not bsdtar
+ * or if the command fails.
+ */
+static int ZipWithBsdTar(char *strDirName, char *strFileName)
+{
+	__cleanup_free char *cmd_buf = NULL;
+	FILE *fpVersion = NULL;
+	char version_buf[256] = { 0 };
+	bool is_bsdtar = false;
+
+	fpVersion = popen("tar --version 2>&1", "r");
+	if (!fpVersion)
+		return -EINVAL;
+
+	while (fgets(version_buf, sizeof(version_buf), fpVersion)) {
+		if (strstr(version_buf, "bsdtar")) {
+			is_bsdtar = true;
+			break;
+		}
+	}
+
+	if (pclose(fpVersion))
+		return -EINVAL;
+	fpVersion = NULL;
+
+	if (!is_bsdtar)
+		return -EINVAL;
+
+	if (asprintf(&cmd_buf, "tar -caf \"%s\" \"%s\"",
+			strFileName, strDirName) < 0)
+		return -ENOMEM;
+
+	if (system(cmd_buf))
+		return -EIO;
+	return 0;
+}
+
 static int ZipAndRemoveDir(char *strDirName, char *strFileName)
 {
 	int  err = 0;
@@ -217,11 +313,14 @@ static int ZipAndRemoveDir(char *strDirName, char *strFileName)
 				strDirName);
 	}
 
-	err = EINVAL;
 	nRet = system(strBuffer);
+	if (nRet && !is_tgz)
+		/* if zip is not available, see if tar can be used instead */
+		nRet = ZipWithBsdTar(strDirName, strFileName);
 
 	/* check if log file is created, if not print error message */
-	if (nRet < 0 || (stat(strFileName, &sb) == -1)) {
+	if (nRet || (stat(strFileName, &sb) == -1)) {
+		err = -EINVAL;
 		if (is_tgz)
 			snprintf(strBuffer, sizeof(strBuffer), "check if tar and gzip commands are installed");
 		else
@@ -230,12 +329,11 @@ static int ZipAndRemoveDir(char *strDirName, char *strFileName)
 		fprintf(stderr, "Failed to create log data package, %s!\n", strBuffer);
 	}
 
-	snprintf(strBuffer, sizeof(strBuffer), "rm -f -R \"%s\" >temp.txt 2>&1", strDirName);
-	nRet = system(strBuffer);
-	if (nRet < 0)
+	if (RemoveDirRecursive(strDirName) < 0)
 		printf("Failed to remove temporary files!\n");
 
-	err = system("rm -f temp.txt");
+	if (unlink("temp.txt") < 0 && errno != ENOENT)
+		printf("Failed to remove temporary file temp.txt!\n");
 	return err;
 }
 

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -37,6 +37,7 @@
 
 #define CREATE_CMD
 #include "micron-nvme.h"
+#include "micron-utils.h"
 
 /* Supported Vendor specific feature ids */
 #define MICRON_FEATURE_CLEAR_PCI_CORRECTABLE_ERRORS    0xC3
@@ -89,10 +90,6 @@ enum eDriveModel {
 
 #define MICRON_VENDOR_ID 0x1344
 
-static char *fvendorid1 = "/sys/class/nvme/nvme%d/device/vendor";
-static char *fvendorid2 = "/sys/class/misc/nvme%d/device/vendor";
-static char *fdeviceid1 = "/sys/class/nvme/nvme%d/device/device";
-static char *fdeviceid2 = "/sys/class/misc/nvme%d/device/device";
 static unsigned short vendor_id;
 static unsigned short device_id;
 
@@ -130,42 +127,14 @@ static void WriteData(__u8 *data, __u32 len, const char *dir, const char *file, 
 	}
 }
 
-static int ReadSysFile(const char *file, unsigned short *id)
-{
-	int ret = 0;
-	char idstr[32] = { '\0' };
-	int fd = open(file, O_RDONLY);
-
-	if (fd < 0) {
-		perror(file);
-		return fd;
-	}
-
-	ret = read(fd, idstr, sizeof(idstr));
-	close(fd);
-	if (ret < 0)
-		perror("read");
-	else
-		*id = strtol(idstr, NULL, 16);
-
-	return ret;
-}
-
-static enum eDriveModel GetDriveModel(int idx)
+static enum eDriveModel GetDriveModel(
+	struct libnvme_global_ctx *ctx,
+	struct libnvme_transport_handle *hdl)
 {
 	enum eDriveModel eModel = UNKNOWN_MODEL;
-	char path[512];
 
-	sprintf(path, fvendorid1, idx);
-	if (ReadSysFile(path, &vendor_id) < 0) {
-		sprintf(path, fvendorid2, idx);
-		ReadSysFile(path, &vendor_id);
-	}
-	sprintf(path, fdeviceid1, idx);
-	if (ReadSysFile(path, &device_id) < 0) {
-		sprintf(path, fdeviceid2, idx);
-		ReadSysFile(path, &device_id);
-	}
+	micron_get_pci_ids(ctx, hdl, &vendor_id, &device_id);
+
 	if (vendor_id == MICRON_VENDOR_ID) {
 		switch (device_id) {
 		case 0x5196:
@@ -515,7 +484,6 @@ static int GetCommonLogPage(struct libnvme_transport_handle *hdl, unsigned char 
 	pTempPtr = (unsigned char *)libnvme_alloc(nBuffSize);
 	if (!pTempPtr)
 		goto exit_status;
-	memset(pTempPtr, 0, nBuffSize);
 	err = nvme_get_log_simple(hdl, ucLogID, pTempPtr, nBuffSize);
 	*pBuffer = pTempPtr;
 
@@ -532,7 +500,6 @@ static int micron_parse_options(struct libnvme_global_ctx **ctx,
 				struct argconfig_commandline_options *opts,
 				enum eDriveModel *modelp)
 {
-	int idx;
 	int err = parse_and_open(ctx, hdl, argc, argv, desc, opts);
 
 	if (err) {
@@ -540,11 +507,8 @@ static int micron_parse_options(struct libnvme_global_ctx **ctx,
 		return -1;
 	}
 
-	if (modelp) {
-		if (sscanf(argv[optind], "/dev/nvme%d", &idx) != 1)
-			idx = 0;
-		*modelp = GetDriveModel(idx);
-	}
+	if (modelp)
+		*modelp = GetDriveModel(*ctx, *hdl);
 
 	return 0;
 }
@@ -905,7 +869,7 @@ struct {
 static int micron_pcie_stats(int argc, char **argv,
 				 struct command *command, struct plugin *plugin)
 {
-	int  i, err = 0, bus = 0, domain = 0, device = 0, function = 0, ctrlIdx;
+	int  i, err = 0, bus = 0, domain = 0, device = 0, function = 0;
 	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
@@ -950,9 +914,7 @@ static int micron_pcie_stats(int argc, char **argv,
 	}
 
 	/* pull log details based on the model name */
-	if (sscanf(argv[optind], "/dev/nvme%d", &ctrlIdx) != 1)
-		ctrlIdx = 0;
-	eModel = GetDriveModel(ctrlIdx);
+	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == UNKNOWN_MODEL) {
 		printf("Unsupported drive model for vs-pcie-stats command\n");
 		goto out;
@@ -1809,7 +1771,7 @@ static int micron_nand_stats(int argc, char **argv,
 	struct nvme_id_ctrl ctrl;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
-	int err, ctrlIdx;
+	int err;
 	__u8 nsze;
 	bool has_d0_log = true;
 	bool has_fb_log = false;
@@ -1836,9 +1798,7 @@ static int micron_nand_stats(int argc, char **argv,
 		is_json = false;
 
 	/* pull log details based on the model name */
-	if (sscanf(argv[optind], "/dev/nvme%d", &ctrlIdx) != 1)
-		ctrlIdx = 0;
-	eModel = GetDriveModel(ctrlIdx);
+	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == UNKNOWN_MODEL) {
 		printf("Unsupported drive model for vs-nand-stats command\n");
 		return -1;
@@ -1945,7 +1905,7 @@ static int micron_smart_ext_log(int argc, char **argv,
 	const char *desc = "Retrieve extended SMART logs for the given device ";
 	unsigned int extSmartLog[E1_log_size/sizeof(int)] = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
-	int err = 0, ctrlIdx = 0;
+	int err = 0;
 	__u8 log_id;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
@@ -1968,9 +1928,7 @@ static int micron_smart_ext_log(int argc, char **argv,
 	if (!strcmp(cfg.fmt, "normal"))
 		is_json = false;
 
-	if (sscanf(argv[optind], "/dev/nvme%d", &ctrlIdx) != 1)
-		ctrlIdx = 0;
-	eModel = GetDriveModel(ctrlIdx);
+	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == M51CX || eModel == M51BY || eModel == M51CY || eModel == M6003 ||
 								eModel == M6004) {
 		log_id = 0xE1;
@@ -1999,7 +1957,7 @@ static int micron_work_load_log(int argc, char **argv, struct command *acmd, str
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
-	int err = 0, ctrlIdx = 0;
+	int err = 0;
 	bool is_json = true;
 	struct format {
 		char *fmt;
@@ -2019,10 +1977,7 @@ static int micron_work_load_log(int argc, char **argv, struct command *acmd, str
 	if (strcmp(cfg.fmt, "normal") == 0)
 		is_json = false;
 
-	err = sscanf(argv[optind], "/dev/nvme%d", &ctrlIdx);
-	if (err)
-		ctrlIdx = 0;
-	eModel = GetDriveModel(ctrlIdx);
+	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == M6001 || eModel == M6004 || eModel == M6003) {
 		err =  nvme_get_log_simple(hdl, 0xC5,
 		micronWorkLoadLog, C5_MicronWorkLoad_log_size);
@@ -2046,7 +2001,7 @@ static int micron_vendor_telemetry_log(int argc, char **argv,
 	const char *desc = "Retrieve Vendor Telemetry logs for the given device ";
 	unsigned int vendorTelemetryLog[C6_log_size/sizeof(int)] = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
-	int err = 0, ctrlIdx = 0;
+	int err = 0;
 	bool is_json = true;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
@@ -2069,11 +2024,7 @@ static int micron_vendor_telemetry_log(int argc, char **argv,
 	if (strcmp(cfg.fmt, "normal") == 0)
 		is_json = false;
 
-	err = sscanf(argv[optind], "/dev/nvme%d", &ctrlIdx);
-	if (err)
-		ctrlIdx = 0;
-
-	eModel = GetDriveModel(ctrlIdx);
+	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == M6001 || eModel == M6004 || eModel == M6003) {
 		err =  nvme_get_log_simple(hdl, 0xC6, vendorTelemetryLog, C6_log_size);
 		if (!err)
@@ -3689,13 +3640,14 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 	}
 
 	/* pull log details based on the model name */
-	if (sscanf(argv[optind], "/dev/nvme%d", &ctrlIdx) != 1)
-		ctrlIdx = 0;
-	eModel = GetDriveModel(ctrlIdx);
+	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == UNKNOWN_MODEL) {
 		printf("Unsupported drive model for vs-internal-log collection\n");
 		goto out;
 	}
+
+	if (sscanf(libnvme_transport_handle_get_name(hdl), "nvme%d", &ctrlIdx) != 1)
+		ctrlIdx = 0;
 
 	err = nvme_identify_ctrl(hdl, &ctrl);
 	if (err)

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -869,21 +869,12 @@ struct {
 static int micron_pcie_stats(int argc, char **argv,
 				 struct command *command, struct plugin *plugin)
 {
-	int  i, err = 0, bus = 0, domain = 0, device = 0, function = 0;
-	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
+	int  i, err = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	nvme_print_flags_t flags;
-	char *businfo = NULL;
-	char *devicename = NULL;
-	char tdevice[NAME_MAX] = { 0 };
-	ssize_t sLinkSize = 0;
-	FILE *fp;
-	char correctable[8] = { 0 };
-	char uncorrectable[8] = { 0 };
 	struct libnvme_passthru_cmd admin_cmd = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
-	char *res;
 	bool is_json = true;
 	bool counters = false;
 	struct format {
@@ -895,8 +886,8 @@ static int micron_pcie_stats(int argc, char **argv,
 		.fmt = "json",
 	};
 
-	__u32 correctable_errors;
-	__u32 uncorrectable_errors;
+	__u32 correctable_errors = 0;
+	__u32 uncorrectable_errors = 0;
 
 	NVME_ARGS(opts,
 		OPT_FMT("format", 'f', &cfg.fmt, fmt));
@@ -937,70 +928,10 @@ static int micron_pcie_stats(int argc, char **argv,
 		}
 	}
 
-	if (strstr(argv[optind], "/dev/nvme") && strstr(argv[optind], "n1")) {
-		devicename = strrchr(argv[optind], '/');
-	} else if (strstr(argv[optind], "/dev/nvme")) {
-		devicename = strrchr(argv[optind], '/');
-		sprintf(tdevice, "%s%s", devicename, "n1");
-		devicename = tdevice;
-	} else {
-		printf("Invalid device specified!\n");
+	err = micron_get_pcie_aer_errors(hdl, &correctable_errors,
+					&uncorrectable_errors);
+	if (err)
 		goto out;
-	}
-	sprintf(strTempFile, "/sys/block/%s/device", devicename);
-	memset(strTempFile2, 0x0, 1024);
-	sLinkSize = readlink(strTempFile, strTempFile2, 1023);
-	if (sLinkSize < 0) {
-		err = -errno;
-		printf("Failed to read device\n");
-		goto out;
-	}
-	if (strstr(strTempFile2, "../../nvme")) {
-		sprintf(strTempFile, "/sys/block/%s/device/device", devicename);
-		memset(strTempFile2, 0x0, 1024);
-		sLinkSize = readlink(strTempFile, strTempFile2, 1023);
-		if (sLinkSize < 0) {
-			err = -errno;
-			printf("Failed to read device\n");
-			goto out;
-		}
-	}
-	businfo = strrchr(strTempFile2, '/');
-	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
-		domain = bus = device = function = 0;
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+10.L", bus, device,
-			function);
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
-		printf("Failed to retrieve error count\n");
-		goto out;
-	}
-	res = fgets(correctable, sizeof(correctable), fp);
-	if (!res) {
-		printf("Failed to retrieve error count\n");
-		pclose(fp);
-		goto out;
-	}
-	pclose(fp);
-
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x4.L", bus, device,
-			function);
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
-		printf("Failed to retrieve error count\n");
-		goto out;
-	}
-	res = fgets(uncorrectable, sizeof(uncorrectable), fp);
-	if (!res) {
-		printf("Failed to retrieve error count\n");
-		pclose(fp);
-		goto out;
-	}
-	pclose(fp);
-
-	correctable_errors = (__u32)strtol(correctable, NULL, 16);
-	uncorrectable_errors = (__u32)strtol(uncorrectable, NULL, 16);
-
 print_stats:
 	if (is_json) {
 		struct json_object *root = json_create_object();
@@ -1044,8 +975,10 @@ print_stats:
 				   pcie_uncorrectable_errors[i].bit) & 1));
 	} else {
 		printf("PCIE Stats:\n");
-		printf("Device correctable errors detected: %s\n", correctable);
-		printf("Device uncorrectable errors detected: %s\n", uncorrectable);
+		printf("Device correctable errors detected: 0x%x\n",
+		       correctable_errors);
+		printf("Device uncorrectable errors detected: 0x%x\n",
+		       uncorrectable_errors);
 	}
 
 out:
@@ -1056,19 +989,11 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 		struct command *command,
 		struct plugin *plugin)
 {
-	int err = -EINVAL, bus, domain, device, function;
-	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
+	int err = -EINVAL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
-	char *businfo = NULL;
-	char *devicename = NULL;
-	char tdevice[PATH_MAX] = { 0 };
-	ssize_t sLinkSize = 0;
 	enum eDriveModel model = UNKNOWN_MODEL;
 	struct libnvme_passthru_cmd admin_cmd = { 0 };
-	char correctable[8] = { 0 };
-	FILE *fp;
-	char *res;
 	const char *desc = "Clear PCIe Device Correctable Errors";
 	__u64 result = 0;
 	__u8 fid = MICRON_FEATURE_CLEAR_PCI_CORRECTABLE_ERRORS;
@@ -1090,7 +1015,7 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 			err = (int)result;
 		if (!err) {
 			printf("Device correctable errors are cleared!\n");
-			goto out;
+			return 0;
 		}
 	} else if (model == M5407) {
 		admin_cmd.opcode = 0xD6;
@@ -1099,78 +1024,13 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 		err = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (!err) {
 			printf("Device correctable error counters are cleared!\n");
-			goto out;
-		} else {
-			/* proceed to clear status bits using sysfs interface */
+			return 0;
 		}
 	}
 
-	if (strstr(argv[optind], "/dev/nvme") && strstr(argv[optind], "n1")) {
-		devicename = strrchr(argv[optind], '/');
-	} else if (strstr(argv[optind], "/dev/nvme")) {
-		devicename = strrchr(argv[optind], '/');
-		sprintf(tdevice, "%s%s", devicename, "n1");
-		devicename = tdevice;
-	} else {
-		printf("Invalid device specified!\n");
-		goto out;
-	}
-	err = snprintf(strTempFile, sizeof(strTempFile),
-				   "/sys/block/%s/device", devicename);
-	if (err < 0)
-		goto out;
+	/* clear status bits using system commands */
+	err = micron_clear_pcie_aer_correctable_errors(hdl);
 
-	memset(strTempFile2, 0x0, 1024);
-	sLinkSize = readlink(strTempFile, strTempFile2, 1023);
-	if (sLinkSize < 0) {
-		err = -errno;
-		printf("Failed to read device\n");
-		goto out;
-	}
-	if (strstr(strTempFile2, "../../nvme")) {
-		err = snprintf(strTempFile, sizeof(strTempFile),
-					   "/sys/block/%s/device/device", devicename);
-		if (err < 0)
-			goto out;
-		memset(strTempFile2, 0x0, 1024);
-		sLinkSize = readlink(strTempFile, strTempFile2, 1023);
-		if (sLinkSize < 0) {
-			err = -errno;
-			printf("Failed to read device\n");
-			goto out;
-		}
-	}
-	businfo = strrchr(strTempFile2, '/');
-	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
-		domain = bus = device = function = 0;
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x10.L=0xffffffff", bus,
-			device, function);
-	err = -1;
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
-		printf("Failed to clear error count\n");
-		goto out;
-	}
-	pclose(fp);
-
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x10.L", bus, device,
-			function);
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
-		printf("Failed to retrieve error count\n");
-		goto out;
-	}
-	res = fgets(correctable, sizeof(correctable), fp);
-	if (!res) {
-		printf("Failed to retrieve error count\n");
-		pclose(fp);
-		goto out;
-	}
-	pclose(fp);
-	printf("Device correctable errors cleared!\n");
-	printf("Device correctable errors detected: %s\n", correctable);
-	err = 0;
-out:
 	return err;
 }
 

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -67,7 +67,7 @@
 
 /* Plugin version major_number.minor_number.patch */
 static const char *__version_major = "2";
-static const char *__version_minor = "0";
+static const char *__version_minor = "1";
 static const char *__version_patch = "0";
 
 /*

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -39,11 +39,11 @@
 #include "micron-nvme.h"
 
 /* Supported Vendor specific feature ids */
-#define MICRON_FEATURE_CLEAR_PCI_CORRECTABLE_ERRORS	0xC3
-#define MICRON_FEATURE_CLEAR_FW_ACTIVATION_HISTORY	0xC1
-#define MICRON_FEATURE_TELEMETRY_CONTROL_OPTION		0xCF
-#define MICRON_FEATURE_SMBUS_OPTION					0xD5
-#define MICRON_FEATURE_OCP_ENHANCED_TELEMETRY		0x16
+#define MICRON_FEATURE_CLEAR_PCI_CORRECTABLE_ERRORS    0xC3
+#define MICRON_FEATURE_CLEAR_FW_ACTIVATION_HISTORY     0xC1
+#define MICRON_FEATURE_TELEMETRY_CONTROL_OPTION        0xCF
+#define MICRON_FEATURE_SMBUS_OPTION                    0xD5
+#define MICRON_FEATURE_OCP_ENHANCED_TELEMETRY          0x16
 
 /* Micron Supported Customer ID*/
 #define MICRON_CUST_ID_GENERAL 0x10
@@ -61,7 +61,6 @@
 #define C6_log_size 512
 #define C5_MicronWorkLoad_log_size 256
 
-#define min(x, y) ((x) > (y) ? (y) : (x))
 #define SensorCount 8
 
 /* Plugin version major_number.minor_number.patch */
@@ -843,29 +842,29 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 }
 
 struct pcie_error_counters {
-		__u16 receiver_error;
-		__u16 bad_tlp;
-		__u16 bad_dllp;
-		__u16 replay_num_rollover;
-		__u16 replay_timer_timeout;
-		__u16 advisory_non_fatal_error;
-		__u16 DLPES;
-		__u16 poisoned_tlp;
-		__u16 FCPC;
-		__u16 completion_timeout;
-		__u16 completion_abort;
-		__u16 unexpected_completion;
-		__u16 receiver_overflow;
-		__u16 malformed_tlp;
-		__u16 ecrc_error;
-		__u16 unsupported_request_error;
-	} pcie_error_counters = { 0 };
+	__u16 receiver_error;
+	__u16 bad_tlp;
+	__u16 bad_dllp;
+	__u16 replay_num_rollover;
+	__u16 replay_timer_timeout;
+	__u16 advisory_non_fatal_error;
+	__u16 DLPES;
+	__u16 poisoned_tlp;
+	__u16 FCPC;
+	__u16 completion_timeout;
+	__u16 completion_abort;
+	__u16 unexpected_completion;
+	__u16 receiver_overflow;
+	__u16 malformed_tlp;
+	__u16 ecrc_error;
+	__u16 unsupported_request_error;
+} pcie_error_counters = { 0 };
 
-	struct {
-		const char *err;
-		int  bit;
-		int  val;
-	} pcie_correctable_errors[] = {
+struct {
+	const char *err;
+	int  bit;
+	int  val;
+} pcie_correctable_errors[] = {
 		{ (char *)"Unsupported Request Error Status (URES)", 20,
 		offsetof(struct pcie_error_counters, unsupported_request_error)},
 		{ (char *)"ECRC Error Status (ECRCES)", 19,
@@ -2155,7 +2154,7 @@ static void GetTimestampInfo(const char *strOSDirName)
 		return;
 
 	num = strftime((char *)outstr, sizeof(outstr),
-				   "Timestamp (UTC): %a, %d %b %Y %T %z", tmp);
+			"Timestamp (UTC): %a, %d %b %Y %H:%M:%S %z", tmp);
 	num += sprintf((char *)(outstr + num), "\nPackage Version: 1.4");
 	if (num) {
 		strPDir = strdup(strOSDirName);
@@ -3025,7 +3024,7 @@ static int micron_latency_stats_logs(int argc, char **argv, struct command *acmd
 	memset(&log, 0, sizeof(log));
 	err = nvme_get_log_simple(hdl, 0xD1, &log, sizeof(log));
 	if (err) {
-		nvme_show_err(err, "Unable to retrieve latency stats log the drive");
+		nvme_show_err(err, "Unable to retrieve the latency stats log");
 		return err;
 	}
 	/* print header and each log entry */

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -60,3 +60,146 @@ int micron_get_pci_ids(
 
 	return 0;
 }
+
+int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
+	__u32 *correctable_errors, __u32 *uncorrectable_errors)
+{
+	int bus = 0, domain = 0, device = 0, function = 0;
+	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
+	char buf[8] = { 0 };
+	char *businfo = NULL;
+	__cleanup_free char *devicename = NULL;
+	ssize_t sLinkSize = 0;
+	FILE *fp;
+	char *res;
+
+	devicename = micron_get_ns_name(hdl);
+	if (!strstr(devicename, "nvme")) {
+		printf("Invalid device specified!\n");
+		return -EINVAL;
+	}
+	sprintf(strTempFile, "/sys/block/%s/device", devicename);
+	memset(strTempFile2, 0x0, 1024);
+	sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+	if (sLinkSize < 0) {
+		printf("Failed to read device\n");
+		return -errno;
+	}
+	if (strstr(strTempFile2, "../../nvme")) {
+		sprintf(strTempFile, "/sys/block/%s/device/device", devicename);
+		memset(strTempFile2, 0x0, 1024);
+		sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+		if (sLinkSize < 0) {
+			printf("Failed to read device\n");
+			return -errno;
+		}
+	}
+	businfo = strrchr(strTempFile2, '/');
+	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device,
+		   &function) != 4)
+		domain = bus = device = function = 0;
+	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+10.L", bus, device,
+		function);
+	fp = popen(cmdbuf, "r");
+	if (!fp) {
+		printf("Failed to retrieve error count\n");
+		return -EIO;
+	}
+	res = fgets(buf, sizeof(buf), fp);
+	if (!res) {
+		printf("Failed to retrieve error count\n");
+		pclose(fp);
+		return -EIO;
+	}
+	pclose(fp);
+	*correctable_errors = (__u32)strtol(buf, NULL, 16);
+
+	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x4.L", bus, device,
+		function);
+	fp = popen(cmdbuf, "r");
+	if (!fp) {
+		printf("Failed to retrieve error count\n");
+		return -EIO;
+	}
+	res = fgets(buf, sizeof(buf), fp);
+	if (!res) {
+		printf("Failed to retrieve error count\n");
+		pclose(fp);
+		return -EIO;
+	}
+	pclose(fp);
+	*uncorrectable_errors = (__u32)strtol(buf, NULL, 16);
+
+	return 0;
+}
+
+int micron_clear_pcie_aer_correctable_errors(
+	struct libnvme_transport_handle *hdl)
+{
+	int err, bus = 0, domain = 0, device = 0, function = 0;
+	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
+	char *businfo = NULL;
+	__cleanup_free char *devicename = NULL;
+	ssize_t sLinkSize = 0;
+	char correctable[8] = { 0 };
+	FILE *fp;
+	char *res;
+
+	devicename = micron_get_ns_name(hdl);
+	if (!strstr(devicename, "nvme")) {
+		printf("Invalid device specified!\n");
+		return -EINVAL;
+	}
+	err = snprintf(strTempFile, sizeof(strTempFile),
+				   "/sys/block/%s/device", devicename);
+	if (err < 0)
+		return err;
+
+	memset(strTempFile2, 0x0, 1024);
+	sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+	if (sLinkSize < 0) {
+		printf("Failed to read device\n");
+		return -errno;
+	}
+	if (strstr(strTempFile2, "../../nvme")) {
+		err = snprintf(strTempFile, sizeof(strTempFile),
+					   "/sys/block/%s/device/device", devicename);
+		if (err < 0)
+			return err;
+		memset(strTempFile2, 0x0, 1024);
+		sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+		if (sLinkSize < 0) {
+			printf("Failed to read device\n");
+			return -errno;
+		}
+	}
+	businfo = strrchr(strTempFile2, '/');
+	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
+		domain = bus = device = function = 0;
+	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x10.L=0xffffffff", bus,
+			device, function);
+	fp = popen(cmdbuf, "r");
+	if (!fp) {
+		printf("Failed to clear error count\n");
+		return -1;
+	}
+	pclose(fp);
+
+	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x10.L", bus, device,
+			function);
+	fp = popen(cmdbuf, "r");
+	if (!fp) {
+		printf("Failed to retrieve error count\n");
+		return -1;
+	}
+	res = fgets(correctable, sizeof(correctable), fp);
+	if (!res) {
+		printf("Failed to retrieve error count\n");
+		pclose(fp);
+		return -1;
+	}
+	pclose(fp);
+	printf("Device correctable errors cleared!\n");
+	printf("Device correctable errors detected: %s\n", correctable);
+	return 0;
+}

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -203,3 +203,40 @@ int micron_clear_pcie_aer_correctable_errors(
 	printf("Device correctable errors detected: %s\n", correctable);
 	return 0;
 }
+
+void micron_write_os_config_to_file(const char *file_name)
+{
+	FILE *fpOSConfig = NULL;
+	char strBuffer[1024];
+	int i;
+
+	struct {
+		const char *strcmdHeader;
+		const char *strCommand;
+	} cmdArray[] = {
+		{ "SYSTEM INFORMATION", "uname -a >> %s" },
+		{ "LINUX KERNEL MODULE INFORMATION", "lsmod >> %s" },
+		{ "LINUX SYSTEM MEMORY INFORMATION", "cat /proc/meminfo >> %s" },
+		{ "SYSTEM INTERRUPT INFORMATION", "cat /proc/interrupts >> %s" },
+		{ "CPU INFORMATION", "cat /proc/cpuinfo >> %s" },
+		{ "IO MEMORY MAP INFORMATION", "cat /proc/iomem >> %s" },
+		{ "MAJOR NUMBER AND DEVICE GROUP", "cat /proc/devices >> %s" },
+		{ "KERNEL DMESG", "dmesg >> %s" },
+		{ "/VAR/LOG/MESSAGES", "cat /var/log/messages >> %s" }
+	};
+
+	for (i = 0; i < (int)(ARRAY_SIZE(cmdArray)); i++) {
+		fpOSConfig = fopen(file_name, "a+");
+		if (fpOSConfig) {
+			fprintf(fpOSConfig,
+				"\n\n\n\n%s\n-----------------------------------------------\n",
+				cmdArray[i].strcmdHeader);
+			fclose(fpOSConfig);
+			fpOSConfig = NULL;
+		}
+		snprintf(strBuffer, sizeof(strBuffer) - 1,
+				 cmdArray[i].strCommand, file_name);
+		if (system(strBuffer))
+			fprintf(stderr, "Failed to send \"%s\"\n", strBuffer);
+	}
+}

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * Copyright (c) 2025 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+
+#include <libnvme.h>
+
+#include "common.h"
+#include "micron-utils.h"
+#include "util/cleanup.h"
+
+static int ReadSysFile(const char *file, unsigned short *id)
+{
+	int ret = 0;
+	char idstr[32] = { '\0' };
+	int fd = open(file, O_RDONLY);
+
+	if (fd < 0) {
+		perror(file);
+		return fd;
+	}
+
+	ret = read(fd, idstr, sizeof(idstr));
+	close(fd);
+	if (ret < 0)
+		perror("read");
+	else
+		*id = strtol(idstr, NULL, 16);
+
+	return ret;
+}
+
+int micron_get_pci_ids(
+	struct libnvme_global_ctx *ctx, struct libnvme_transport_handle *hdl,
+	unsigned short *vid, unsigned short *did)
+{
+	char id_path[512];
+	__cleanup_free char *ctrl_sysfs_dir = micron_get_ctrl_sysfs_dir(ctx, hdl);
+
+	if (ctrl_sysfs_dir) {
+		snprintf(id_path, sizeof(id_path), "%s/device/vendor",
+			ctrl_sysfs_dir);
+		ReadSysFile(id_path, vid);
+
+		snprintf(id_path, sizeof(id_path), "%s/device/device",
+			ctrl_sysfs_dir);
+		ReadSysFile(id_path, did);
+	} else {
+		fprintf(stderr, "Unable to find sysfs dir for %s\n",
+			libnvme_transport_handle_get_name(hdl));
+		return -EINVAL;
+	}
+
+	return 0;
+}

--- a/plugins/micron/micron-utils-win.c
+++ b/plugins/micron/micron-utils-win.c
@@ -44,3 +44,19 @@ int micron_get_pci_ids(struct libnvme_global_ctx *ctx,
 
 	return 0;
 }
+
+int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
+	__u32 *correctable_errors, __u32 *uncorrectable_errors)
+{
+	*correctable_errors = 0;
+	*uncorrectable_errors = 0;
+	printf("register reads not supported on the current platform\n");
+	return -ENOTSUP;
+}
+
+int micron_clear_pcie_aer_correctable_errors(
+	struct libnvme_transport_handle *hdl)
+{
+	printf("register writes not supported on the current platform\n");
+	return -ENOTSUP;
+}

--- a/plugins/micron/micron-utils-win.c
+++ b/plugins/micron/micron-utils-win.c
@@ -60,3 +60,127 @@ int micron_clear_pcie_aer_correctable_errors(
 	printf("register writes not supported on the current platform\n");
 	return -ENOTSUP;
 }
+
+static void write_section_header(FILE *fp, const char *header)
+{
+	fprintf(fp, "\n\n\n\n%s\n-----------------------------------------------\n",
+		header);
+}
+
+void micron_write_os_config_to_file(const char *file_name)
+{
+	FILE *fp = NULL;
+	OSVERSIONINFOEXA osvi;
+	SYSTEM_INFO si;
+	MEMORYSTATUSEX memstat;
+	DWORD bufSize;
+	char compName[256] = { 0 };
+	HKEY hKey;
+	LONG rc;
+
+	fp = fopen(file_name, "w+");
+	if (!fp) {
+		fprintf(stderr, "Failed to create %s\n", file_name);
+		return;
+	}
+
+	/* System Information */
+	write_section_header(fp, "SYSTEM INFORMATION");
+
+	memset(&osvi, 0, sizeof(osvi));
+	osvi.dwOSVersionInfoSize = sizeof(osvi);
+	/*
+	 * GetVersionExA is deprecated but available everywhere.
+	 * It returns capped values on newer Windows unless the
+	 * application is manifested, which is acceptable here.
+	 */
+	if (GetVersionExA((OSVERSIONINFOA *)&osvi)) {
+		fprintf(fp, "Windows Version   : %lu.%lu Build %lu",
+			osvi.dwMajorVersion, osvi.dwMinorVersion,
+			osvi.dwBuildNumber);
+		if (osvi.szCSDVersion[0])
+			fprintf(fp, " %s", osvi.szCSDVersion);
+		fprintf(fp, "\n");
+	}
+
+	bufSize = sizeof(compName);
+	if (GetComputerNameExA(ComputerNameDnsFullyQualified,
+			       compName, &bufSize))
+		fprintf(fp, "Computer Name     : %s\n", compName);
+
+	GetNativeSystemInfo(&si);
+	fprintf(fp, "Processor Arch    : ");
+	switch (si.wProcessorArchitecture) {
+	case PROCESSOR_ARCHITECTURE_AMD64:
+		fprintf(fp, "x64 (AMD64)\n");
+		break;
+	case PROCESSOR_ARCHITECTURE_ARM64:
+		fprintf(fp, "ARM64\n");
+		break;
+	case PROCESSOR_ARCHITECTURE_INTEL:
+		fprintf(fp, "x86\n");
+		break;
+	default:
+		fprintf(fp, "Unknown (%u)\n", si.wProcessorArchitecture);
+		break;
+	}
+	fprintf(fp, "Number of Processors : %lu\n", si.dwNumberOfProcessors);
+	fprintf(fp, "Page Size         : %lu\n", si.dwPageSize);
+
+	/* Memory Information */
+	write_section_header(fp, "SYSTEM MEMORY INFORMATION");
+
+	memstat.dwLength = sizeof(memstat);
+	if (GlobalMemoryStatusEx(&memstat)) {
+		fprintf(fp, "Memory Load       : %lu%%\n", memstat.dwMemoryLoad);
+		fprintf(fp, "Total Physical    : %llu MB\n",
+			memstat.ullTotalPhys / (1024 * 1024));
+		fprintf(fp, "Available Physical: %llu MB\n",
+			memstat.ullAvailPhys / (1024 * 1024));
+		fprintf(fp, "Total Page File   : %llu MB\n",
+			memstat.ullTotalPageFile / (1024 * 1024));
+		fprintf(fp, "Available Page File: %llu MB\n",
+			memstat.ullAvailPageFile / (1024 * 1024));
+		fprintf(fp, "Total Virtual     : %llu MB\n",
+			memstat.ullTotalVirtual / (1024 * 1024));
+		fprintf(fp, "Available Virtual : %llu MB\n",
+			memstat.ullAvailVirtual / (1024 * 1024));
+	}
+
+	/* CPU Information from registry */
+	write_section_header(fp, "CPU INFORMATION");
+
+	rc = RegOpenKeyExA(
+		HKEY_LOCAL_MACHINE,
+		"HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+		0, KEY_READ, &hKey);
+	if (rc == ERROR_SUCCESS) {
+		char cpuName[256] = { 0 };
+		char cpuVendor[64] = { 0 };
+		DWORD cpuMHz = 0;
+		DWORD dataSize;
+
+		dataSize = sizeof(cpuName);
+		if (RegQueryValueExA(hKey, "ProcessorNameString", NULL,
+				     NULL, (LPBYTE)cpuName,
+				     &dataSize) == ERROR_SUCCESS)
+			fprintf(fp, "Processor         : %s\n", cpuName);
+
+		dataSize = sizeof(cpuVendor);
+		if (RegQueryValueExA(hKey, "VendorIdentifier", NULL,
+				     NULL, (LPBYTE)cpuVendor,
+				     &dataSize) == ERROR_SUCCESS)
+			fprintf(fp, "Vendor            : %s\n", cpuVendor);
+
+		dataSize = sizeof(cpuMHz);
+		if (RegQueryValueExA(hKey, "~MHz", NULL, NULL,
+				     (LPBYTE)&cpuMHz,
+				     &dataSize) == ERROR_SUCCESS)
+			fprintf(fp, "Speed             : %lu MHz\n", cpuMHz);
+
+		RegCloseKey(hKey);
+	}
+	fprintf(fp, "Logical Processors: %lu\n", si.dwNumberOfProcessors);
+
+	fclose(fp);
+}

--- a/plugins/micron/micron-utils-win.c
+++ b/plugins/micron/micron-utils-win.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * Copyright (c) 2025 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <windows.h>
+
+#include <libnvme.h>
+
+#include "micron-utils.h"
+#include "util/cleanup.h"
+
+int micron_get_pci_ids(struct libnvme_global_ctx *ctx,
+			struct libnvme_transport_handle *hdl,
+			unsigned short *vid, unsigned short *did)
+{
+	const char *p;
+	unsigned int val;
+
+	/* Windows sysfs dir for controller contains VID and DID */
+	__cleanup_free char *ctrl_sysfs_dir = micron_get_ctrl_sysfs_dir(ctx, hdl);
+
+	*vid = 0;
+	*did = 0;
+
+	if (!ctrl_sysfs_dir)
+		return -EINVAL;
+
+	p = strstr(ctrl_sysfs_dir, "ven_");
+	if (p && sscanf(p, "ven_%x", &val) == 1)
+		*vid = (unsigned short)val;
+	else
+		return -EINVAL;
+
+	p = strstr(ctrl_sysfs_dir, "dev_");
+	if (p && sscanf(p, "dev_%x", &val) == 1)
+		*did = (unsigned short)val;
+	else
+		return -EINVAL;
+
+	return 0;
+}

--- a/plugins/micron/micron-utils.c
+++ b/plugins/micron/micron-utils.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * Copyright (c) 2025 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+
+#include <string.h>
+
+#include <libnvme.h>
+
+#include "micron-utils.h"
+#include "util/cleanup.h"
+
+char *micron_get_ctrl_name(struct libnvme_transport_handle *hdl)
+{
+	const char *name = libnvme_transport_handle_get_name(hdl);
+	char *ctrl_name = NULL;
+
+	if (libnvme_transport_handle_is_ctrl(hdl)) {
+		ctrl_name = strdup(name);
+	} else {
+		const char *p = strlen(name) > 4 ? strchr(name + 4, 'n') : NULL;
+
+		ctrl_name = p ? strndup(name, p - name) : strdup(name);
+	}
+
+	return ctrl_name;
+}
+
+char *micron_get_ns_name(struct libnvme_transport_handle *hdl)
+{
+	const char *name = libnvme_transport_handle_get_name(hdl);
+	char *ns_name = NULL;
+
+	if (libnvme_transport_handle_is_ns(hdl)) {
+		ns_name = strdup(name);
+	} else {
+		if (asprintf(&ns_name, "%sn1", name) < 0)
+			return NULL;
+	}
+
+	return ns_name;
+}
+
+char *micron_get_ctrl_sysfs_dir(
+	struct libnvme_global_ctx *ctx,
+	struct libnvme_transport_handle *hdl)
+{
+	libnvme_ctrl_t c = NULL;
+	__cleanup_free char *ctrl_name = NULL;
+	char *sysfs_dir = NULL;
+
+	ctrl_name = micron_get_ctrl_name(hdl);
+	if (ctrl_name && libnvme_scan_ctrl(ctx, ctrl_name, &c) == 0) {
+		sysfs_dir = strdup(libnvme_ctrl_get_sysfs_dir(c));
+		libnvme_free_ctrl(c);
+	}
+
+	return sysfs_dir;
+}

--- a/plugins/micron/micron-utils.h
+++ b/plugins/micron/micron-utils.h
@@ -92,3 +92,12 @@ int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
  */
 int micron_clear_pcie_aer_correctable_errors(
 		struct libnvme_transport_handle *hdl);
+
+/**
+ * micron_write_os_config_to_file() - Dump OS configuration to a file
+ * @file_name:	Path of the output file
+ *
+ * Writes platform-appropriate system configuration details (kernel version,
+ * modules, memory, interrupts, CPU info, dmesg, etc.) to the specified file.
+ */
+void micron_write_os_config_to_file(const char *file_name);

--- a/plugins/micron/micron-utils.h
+++ b/plugins/micron/micron-utils.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * Copyright (c) 2025 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+#pragma once
+
+#include <nvme/lib-types.h>
+
+/**
+ * micron_get_ctrl_name() - Get the controller name from the device
+ * transport handle
+ * @hdl:	Transport handle
+ *
+ * Returns the controller name for the handle (e.g., "nvme0").
+ * For namespace handles, the namespace indicator is stripped from the
+ * name to derive the controller name.
+ *
+ * Return: Allocated string containing the controller name on success,
+ * or NULL on failure. The caller is responsible for freeing the returned
+ * string.
+ */
+char *micron_get_ctrl_name(struct libnvme_transport_handle *hdl);
+
+/**
+ * micron_get_ns_name() - Get the namespace name from a transport handle
+ * @hdl:	Transport handle
+ *
+ * Returns the namespace name for the handle. For controller handles,
+ * "n1" is appended to derive a default namespace name.
+ *
+ * Return: Allocated string containing the namespace name on success,
+ * or NULL on failure. The caller is responsible for freeing the returned
+ * string.
+ */
+char *micron_get_ns_name(struct libnvme_transport_handle *hdl);
+
+/**
+ * micron_get_ctrl_sysfs_dir() - Get the sysfs directory path for a controller
+ * @ctx:	struct libnvme_global_ctx object
+ * @hdl:	Transport handle
+ *
+ * Looks up the sysfs directory for the controller associated with @hdl
+ * by scanning the NVMe subsystem.
+ *
+ * Return: Allocated string containing the sysfs directory path on
+ * success, or NULL on failure. The caller is responsible for freeing
+ * the returned string.
+ */
+char *micron_get_ctrl_sysfs_dir(struct libnvme_global_ctx *ctx,
+				struct libnvme_transport_handle *hdl);
+
+/**
+ * micron_get_pci_ids() - Read PCI vendor and device IDs for a controller
+ * @ctx:	struct libnvme_global_ctx object
+ * @hdl:	Transport handle
+ * @vid:	Output PCI vendor ID
+ * @did:	Output PCI device ID
+ *
+ * Gets the PCI vendor and device IDs for the controller associated with @hdl.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+int micron_get_pci_ids(struct libnvme_global_ctx *ctx,
+			struct libnvme_transport_handle *hdl,
+			unsigned short *vid, unsigned short *did);

--- a/plugins/micron/micron-utils.h
+++ b/plugins/micron/micron-utils.h
@@ -65,3 +65,30 @@ char *micron_get_ctrl_sysfs_dir(struct libnvme_global_ctx *ctx,
 int micron_get_pci_ids(struct libnvme_global_ctx *ctx,
 			struct libnvme_transport_handle *hdl,
 			unsigned short *vid, unsigned short *did);
+
+/**
+ * micron_get_pcie_aer_errors() - Retrieve PCIe AER error counts
+ * @hdl:			Transport handle
+ * @correctable_errors:		Output correctable error register value
+ * @uncorrectable_errors:	Output uncorrectable error register value
+ *
+ * Reads the PCIe Advanced Error Reporting (AER) correctable and
+ * uncorrectable error registers for the device associated with @hdl using
+ * setpci.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
+		__u32 *correctable_errors, __u32 *uncorrectable_errors);
+
+/**
+ * micron_clear_pcie_aer_correctable_errors() - Clear PCIe correctable errors
+ * @hdl:	Transport handle
+ *
+ * Clears the PCIe AER correctable error register for the device
+ * associated with @hdl by writing all ones to the register via setpci.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+int micron_clear_pcie_aer_correctable_errors(
+		struct libnvme_transport_handle *hdl);


### PR DESCRIPTION
Adds Windows support to Micron plugin commands and updates plugin version to 2.1.0.
Adds new micron-utils files for implementation of utility methods that have platform-specific implementations.

Updated functionality:
* Adds cross-platform support for getting the drive model.
* Adds cross-platform handling of PCIe-register-based correctable error functionality. Windows does not support accessing PCIe registers and will return an error if correctable error commands are used.
* Adds cross-platform support for logging OS configuration information.
* Fixes Windows .zip file generation.