### PR TITLE
libnvme: update diag attribute paths

### DIFF
--- a/libnvme/libnvme/accessors.i
+++ b/libnvme/libnvme/accessors.i
@@ -37,13 +37,13 @@ def _nvme_guarded_setattr(self, name, value):
 %rename(Namespace) libnvme_ns;
 %rename(libnvme_ns_command_retry_count_get) libnvme_ns_get_command_retry_count;
 %rename(libnvme_ns_command_error_count_get) libnvme_ns_get_command_error_count;
-%rename(libnvme_ns_requeue_no_usable_path_count_get) libnvme_ns_get_requeue_no_usable_path_count;
-%rename(libnvme_ns_fail_no_available_path_count_get) libnvme_ns_get_fail_no_available_path_count;
+%rename(libnvme_ns_io_requeue_no_usable_path_count_get) libnvme_ns_get_io_requeue_no_usable_path_count;
+%rename(libnvme_ns_io_fail_no_available_path_count_get) libnvme_ns_get_io_fail_no_available_path_count;
 %{
 	#define libnvme_ns_command_retry_count_get libnvme_ns_get_command_retry_count
 	#define libnvme_ns_command_error_count_get libnvme_ns_get_command_error_count
-	#define libnvme_ns_requeue_no_usable_path_count_get libnvme_ns_get_requeue_no_usable_path_count
-	#define libnvme_ns_fail_no_available_path_count_get libnvme_ns_get_fail_no_available_path_count
+	#define libnvme_ns_io_requeue_no_usable_path_count_get libnvme_ns_get_io_requeue_no_usable_path_count
+	#define libnvme_ns_io_fail_no_available_path_count_get libnvme_ns_get_io_fail_no_available_path_count
 %}
 struct libnvme_ns {
 	__u32 nsid;
@@ -68,10 +68,10 @@ struct libnvme_ns {
 		long command_retry_count;
 		%immutable command_error_count;
 		long command_error_count;
-		%immutable requeue_no_usable_path_count;
-		long requeue_no_usable_path_count;
-		%immutable fail_no_available_path_count;
-		long fail_no_available_path_count;
+		%immutable io_requeue_no_usable_path_count;
+		long io_requeue_no_usable_path_count;
+		%immutable io_fail_no_available_path_count;
+		long io_fail_no_available_path_count;
 	}
 };
 

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -316,8 +316,8 @@ struct libnvme_ns {  // !generate-accessors:read=generated,write=none !generate-
 
 	long command_retry_count;	     // !access:read=custom
 	long command_error_count;	     // !access:read=custom
-	long requeue_no_usable_path_count;   // !access:read=custom
-	long fail_no_available_path_count;   // !access:read=custom
+	long io_requeue_no_usable_path_count;// !access:read=custom
+	long io_fail_no_available_path_count;// !access:read=custom
 };
 
 struct libnvme_ctrl {  // !generate-accessors:read=generated,write=none !generate-python:alias=Ctrl

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -703,7 +703,8 @@ __libnvme_public long libnvme_path_get_multipath_failover_count(
 {
 	__cleanup_free char *failover_count = NULL;
 
-	failover_count = libnvme_get_path_attr(p, "multipath_failover_count");
+	failover_count = libnvme_get_path_attr(p,
+				"diag/multipath_failover_count");
 	if (failover_count)
 		sscanf(failover_count, "%ld", &p->multipath_failover_count);
 
@@ -714,7 +715,7 @@ __libnvme_public long libnvme_path_get_command_retry_count(libnvme_path_t p)
 {
 	__cleanup_free char *retry_count = NULL;
 
-	retry_count = libnvme_get_path_attr(p, "command_retry_count");
+	retry_count = libnvme_get_path_attr(p, "diag/command_retry_count");
 	if (retry_count)
 		sscanf(retry_count, "%ld", &p->command_retry_count);
 
@@ -725,7 +726,7 @@ __libnvme_public long libnvme_path_get_command_error_count(libnvme_path_t p)
 {
 	__cleanup_free char *error_count = NULL;
 
-	error_count = libnvme_get_path_attr(p, "command_error_count");
+	error_count = libnvme_get_path_attr(p, "diag/command_error_count");
 	if (error_count)
 		sscanf(error_count, "%ld", &p->command_error_count);
 
@@ -1270,7 +1271,7 @@ __libnvme_public long libnvme_ctrl_get_command_error_count(libnvme_ctrl_t c)
 {
 	__cleanup_free char *error_count = NULL;
 
-	error_count = libnvme_get_ctrl_attr(c, "command_error_count");
+	error_count = libnvme_get_ctrl_attr(c, "diag/command_error_count");
 	if (error_count)
 		sscanf(error_count, "%ld", &c->command_error_count);
 
@@ -1281,7 +1282,7 @@ __libnvme_public long libnvme_ctrl_get_reset_count(libnvme_ctrl_t c)
 {
 	__cleanup_free char *reset_count = NULL;
 
-	reset_count = libnvme_get_ctrl_attr(c, "reset_count");
+	reset_count = libnvme_get_ctrl_attr(c, "diag/reset_count");
 	if (reset_count)
 		sscanf(reset_count, "%ld", &c->reset_count);
 
@@ -1292,7 +1293,7 @@ __libnvme_public long libnvme_ctrl_get_reconnect_count(libnvme_ctrl_t c)
 {
 	__cleanup_free char *reconnect_count = NULL;
 
-	reconnect_count = libnvme_get_ctrl_attr(c, "reconnect_count");
+	reconnect_count = libnvme_get_ctrl_attr(c, "diag/reconnect_count");
 	if (reconnect_count)
 		sscanf(reconnect_count, "%ld", &c->reconnect_count);
 
@@ -1687,7 +1688,7 @@ __libnvme_public long libnvme_ns_get_command_retry_count(libnvme_ns_t n)
 {
 	__cleanup_free char *retry_count = NULL;
 
-	retry_count = libnvme_get_ns_attr(n, "command_retry_count");
+	retry_count = libnvme_get_ns_attr(n, "diag/command_retry_count");
 	if (retry_count)
 		sscanf(retry_count, "%ld", &n->command_retry_count);
 
@@ -1698,7 +1699,7 @@ __libnvme_public long libnvme_ns_get_command_error_count(libnvme_ns_t n)
 {
 	__cleanup_free char *error_count = NULL;
 
-	error_count = libnvme_get_ns_attr(n, "command_error_count");
+	error_count = libnvme_get_ns_attr(n, "diag/command_error_count");
 	if (error_count)
 		sscanf(error_count, "%ld", &n->command_error_count);
 
@@ -1710,11 +1711,13 @@ __libnvme_public long libnvme_ns_get_requeue_no_usable_path_count(
 {
 	__cleanup_free char *requeue_count = NULL;
 
-	requeue_count = libnvme_get_ns_attr(n, "requeue_no_usable_path_count");
+	requeue_count = libnvme_get_ns_attr(n,
+			"diag/io_requeue_no_usable_path_count");
 	if (requeue_count)
-		sscanf(requeue_count, "%ld", &n->requeue_no_usable_path_count);
+		sscanf(requeue_count, "%ld",
+			&n->io_requeue_no_usable_path_count);
 
-	return n->requeue_no_usable_path_count;
+	return n->io_requeue_no_usable_path_count;
 }
 
 __libnvme_public long libnvme_ns_get_fail_no_available_path_count(
@@ -1722,11 +1725,12 @@ __libnvme_public long libnvme_ns_get_fail_no_available_path_count(
 {
 	__cleanup_free char *fail_count = NULL;
 
-	fail_count = libnvme_get_ns_attr(n, "fail_no_available_path_count");
+	fail_count = libnvme_get_ns_attr(n,
+			"diag/io_fail_no_available_path_count");
 	if (fail_count)
-		sscanf(fail_count, "%ld", &n->fail_no_available_path_count);
+		sscanf(fail_count, "%ld", &n->io_fail_no_available_path_count);
 
-	return n->fail_no_available_path_count;
+	return n->io_fail_no_available_path_count;
 }
 
 __libnvme_public int libnvme_ns_identify(libnvme_ns_t n, struct nvme_id_ns *ns)


### PR DESCRIPTION
The upstream kernel commit 37afebc79a11 ("nvme: add diag attribute group under sysfs") groups all diag attributes under a new directory /sys/block/.../diag/.

Update the libnvme diag attribute accessors to use the new paths. The following attributs path have been updated:
- command_retry_count
- command_error_count
- multipath_failover_count
- reset_count
- reconnect_count

In addition, the following attributes were renamed as well as their path were also changed. So update the corresponding attribute names and paths for:
- io_requeue_no_usable_path_count
- io_fail_no_available_path_count

These attributes are used by the nvme-top dashboard to display real-time controller and multipath diagnostic statistics.