### PR TITLE
libnvme: guard registry cleanup against instance reuse with uevent_seqnum

### DIFF
--- a/libnvme/src/nvme/registry.c
+++ b/libnvme/src/nvme/registry.c
@@ -343,29 +343,184 @@ static int write_device_attr(const char *device, const char *attr,
 }
 
 /*
+ * Read the kernel's global uevent sequence number from
+ * /sys/kernel/uevent_seqnum.  This monotonic counter is used to stamp a
+ * registry entry at connect time so the udev REMOVE rule can tell a stale
+ * entry apart from a recycled-and-live one without relying on event ordering
+ * (see 70-nvmf-registry.rules).  Returns a newly allocated decimal string the
+ * caller must free, or NULL on any failure -- the stamp is best-effort, and a
+ * missing stamp simply makes the rule fall back to its device-existence guard.
+ */
+static char *read_uevent_seqnum(void)
+{
+	char buf[32];
+	ssize_t n;
+	int fd;
+
+	fd = open("/sys/kernel/uevent_seqnum", O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return NULL;
+	n = read_full(fd, buf, sizeof(buf) - 1);
+	close(fd);
+	if (n <= 0)
+		return NULL;
+
+	/* Strip the trailing newline the kernel appends. */
+	while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == '\r'))
+		n--;
+	if (n == 0)
+		return NULL;
+	buf[n] = '\0';
+
+	return strdup(buf);
+}
+
+/*
+ * Remove a registry entry directory and its (flat) attribute files.  Shared by
+ * libnvmf_registry_delete() and the create_instance() error/cleanup paths.
+ * Returns 0 on success, -ENOENT if @path does not exist, or a negative errno.
+ */
+static int delete_dir(const char *path)
+{
+	struct dirent *de;
+	int dir_fd, ret = 0;
+	DIR *d;
+
+	d = opendir(path);
+	if (!d)
+		return -errno;
+
+	dir_fd = dirfd(d);
+	while ((de = readdir(d)) != NULL) {
+		if (de->d_name[0] == '.')
+			continue;
+		if (unlinkat(dir_fd, de->d_name, 0) < 0 && errno != ENOENT)
+			ret = -errno;
+	}
+	closedir(d);
+
+	if (ret)
+		return ret;
+
+	if (rmdir(path) < 0 && errno != ENOENT)
+		return -errno;
+	return 0;
+}
+
+/*
+ * Atomically remove a *visible* registry entry: rename it to a hidden sibling
+ * so it vanishes from observers in a single step, then purge the renamed copy
+ * at leisure.  This keeps a reader (nvme registry list, another orchestrator)
+ * from ever seeing a half-emptied entry.  Returns 0 on success, -ENOENT if
+ * @path does not exist, or a negative errno.
+ *
+ * The udev REMOVE rule deletes entries with a plain "rm -rf", which is not
+ * atomic; this guarantee therefore covers only library-driven deletes.
+ */
+static int delete_dir_atomic(const char *path)
+{
+	__cleanup_free char *trash = NULL;
+
+	if (asprintf(&trash, "%s/.trash.XXXXXX", registry_dir()) < 0)
+		return -ENOMEM;
+	if (!mkdtemp(trash))
+		return -errno;
+
+	/*
+	 * rename() is the atomic check-and-act: don't pre-check existence (a
+	 * TOCTOU on @path) — just attempt the move.  If @path is absent (the
+	 * common case, e.g. no stale entry to replace) it fails with ENOENT and
+	 * we drop the empty temp dir we created.
+	 */
+	if (rename(path, trash) < 0) {
+		int ret = -errno;
+
+		rmdir(trash);
+		return ret;
+	}
+	return delete_dir(trash);
+}
+
+/*
  * libnvmf_registry_create_instance - Write a registry entry for a freshly
  * connected controller.  Internal; called from the connect path in fabrics.c
  * once the kernel returns instance=N.  Always overwrites any pre-existing
  * entry: instance recycling means an old nvmeN/ directory is stale by
  * definition.
+ *
+ * The entry is built in a temporary directory and rename()'d into place, so it
+ * is only ever observed complete or absent — never as a directory that exists
+ * but is missing its seqnum stamp.  Without this, the udev REMOVE rule could
+ * read a just-created entry between the mkdir and the seqnum write, see no
+ * stamp, and delete the live entry the library is still populating.
  */
 int libnvmf_registry_create_instance(struct libnvme_global_ctx *ctx,
 				     int instance, const char *owner)
 {
+	__cleanup_free char *tmp_dir = NULL;
+	__cleanup_free char *final_path = NULL;
+	__cleanup_free char *seqnum = NULL;
 	char device[32];
+	int dir_fd, ret;
 
 	snprintf(device, sizeof(device), "nvme%d", instance);
 
-	/*
-	 * Delete any stale entry unconditionally before creating the new one.
-	 * Instance recycling means an old nvmeN/ directory is stale by
-	 * definition — any attributes left over from the previous owner (e.g.
-	 * a private attribute written via libnvmf_registry_update()) must not
-	 * leak into the new entry.  Ignore errors: ENOENT is the common case.
-	 */
-	libnvmf_registry_delete(ctx, device);
+	final_path = registry_path(device, NULL);
+	if (!final_path)
+		return -ENOMEM;
 
-	return write_device_attr(device, "owner", owner);
+	/* The registry root must exist before mkdtemp() can run inside it. */
+	ret = mkdir_p(registry_dir(), 0755);
+	if (ret)
+		return ret;
+
+	if (asprintf(&tmp_dir, "%s/.%s.tmp.XXXXXX", registry_dir(), device) < 0)
+		return -ENOMEM;
+	if (!mkdtemp(tmp_dir))
+		return -errno;
+
+	/* mkdtemp() creates it 0700; widen to the registry world. */
+	if (chmod(tmp_dir, 0755) < 0) {
+		ret = -errno;
+		goto err;
+	}
+
+	dir_fd = open(tmp_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if (dir_fd < 0) {
+		ret = -errno;
+		goto err;
+	}
+
+	/*
+	 * Stamp the entry with the current uevent sequence number for the udev
+	 * REMOVE rule (see read_uevent_seqnum()).  Best-effort: a missing stamp
+	 * just makes the rule fall back to its device-existence guard, so don't
+	 * fail the create over it.
+	 */
+	seqnum = read_uevent_seqnum();
+	if (seqnum)
+		write_attr_atomic(dir_fd, tmp_dir, "seqnum", seqnum);
+
+	ret = write_attr_atomic(dir_fd, tmp_dir, "owner", owner);
+	close(dir_fd);
+	if (ret)
+		goto err;
+
+	/*
+	 * Reveal the fully-populated entry atomically.  Instance recycling
+	 * means any pre-existing nvmeN/ is stale, so remove it first: rename()
+	 * onto a non-empty directory fails.
+	 */
+	delete_dir_atomic(final_path);
+	if (rename(tmp_dir, final_path) < 0) {
+		ret = -errno;
+		goto err;
+	}
+	return 0;
+
+err:
+	delete_dir(tmp_dir);	/* best-effort: don't leak the temp directory */
+	return ret;
 }
 
 int libnvmf_registry_delete_instance(struct libnvme_global_ctx *ctx,
@@ -444,9 +599,6 @@ __libnvme_public int libnvmf_registry_delete(struct libnvme_global_ctx *ctx,
 					     const char *device)
 {
 	__cleanup_free char *path = NULL;
-	struct dirent *de;
-	int dir_fd, ret = 0;
-	DIR *d;
 
 	if (!ctx)
 		return -EINVAL;
@@ -457,25 +609,7 @@ __libnvme_public int libnvmf_registry_delete(struct libnvme_global_ctx *ctx,
 	if (!path)
 		return -ENOMEM;
 
-	d = opendir(path);
-	if (!d)
-		return -errno;
-
-	dir_fd = dirfd(d);
-	while ((de = readdir(d)) != NULL) {
-		if (de->d_name[0] == '.')
-			continue;
-		if (unlinkat(dir_fd, de->d_name, 0) < 0 && errno != ENOENT)
-			ret = -errno;
-	}
-	closedir(d);
-
-	if (ret)
-		return ret;
-
-	if (rmdir(path) < 0 && errno != ENOENT)
-		return -errno;
-	return 0;
+	return delete_dir_atomic(path);
 }
 
 __libnvme_public int libnvmf_registry_device_for_each(

--- a/libnvme/sysfiles/udev/rules.d/70-nvmf-registry.rules
+++ b/libnvme/sysfiles/udev/rules.d/70-nvmf-registry.rules
@@ -5,9 +5,21 @@
 #
 # The kernel allocates controller instance numbers with ida_alloc(), which
 # returns the lowest available ID.  A freed instance number can therefore be
-# reassigned to a new controller before this rule runs for the old one.  The
-# [ -e /dev/%k ] guard detects that case: devtmpfs removes the old node
-# before KOBJ_REMOVE fires, so if the node exists again a new controller has
-# already claimed the name and its registry entry must not be deleted.
+# reassigned to a new controller before this rule runs for the old one, so the
+# entry is guarded by two checks before it is removed:
+#
+#   1. [ -e /dev/%k ] -- devtmpfs removes the old node before KOBJ_REMOVE
+#      fires, so if the node exists again a new controller has already claimed
+#      the name and its entry must not be deleted.  Catches the common case.
+#
+#   2. SEQNUM vs the entry's stamp -- libnvme stamps each entry at connect with
+#      /sys/kernel/uevent_seqnum.  A stale REMOVE for the old controller was
+#      emitted before the new controller's ADD, so its SEQNUM is lower than the
+#      new entry's stamp; removing only when SEQNUM is greater closes the
+#      sub-shell race between the [ -e ] test and rm.  A missing stamp reads as
+#      0, falling back to check 1 alone.
+#
+# $$ yields a literal '$' for the shell; $env{SEQNUM} is the REMOVE event's
+# sequence number, substituted by udev.
 ACTION=="remove", SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", \
-    RUN+="/bin/sh -c '[ -e /dev/%k ] || rm -rf /run/nvme/registry/%k'"
+    RUN+="/bin/sh -c '[ -e /dev/%k ] || [ $env{SEQNUM} -le $$(cat /run/nvme/registry/%k/seqnum 2>/dev/null || echo 0) ] || rm -rf /run/nvme/registry/%k'"

--- a/libnvme/test/registry.c
+++ b/libnvme/test/registry.c
@@ -87,6 +87,51 @@ static bool test_create(struct libnvme_global_ctx *ctx)
 		printf(" - owner='%s' [PASS]\n", value);
 	}
 
+	/*
+	 * create_instance also stamps the entry with /sys/kernel/uevent_seqnum
+	 * for the udev cleanup rule.  It is best-effort, so only verify
+	 * it looks like a number when present rather than requiring it.
+	 */
+	free(value);
+	value = NULL;
+	ret = libnvmf_registry_retrieve(ctx, "nvme3", "seqnum", &value);
+	if (ret == 0 && value) {
+		char *end;
+
+		strtoull(value, &end, 10);
+		if (*value && *end == '\0') {
+			printf(" - seqnum='%s' [PASS]\n", value);
+		} else {
+			printf(" - seqnum='%s' not numeric [FAIL]\n", value);
+			pass = false;
+		}
+	}
+
+	/*
+	 * The entry is built in a temp dir and rename()'d into place; confirm
+	 * no leftover ".nvmeN.tmp.*" dir remains after a successful create.
+	 */
+	{
+		struct dirent *de;
+		bool leftover = false;
+		DIR *d = opendir(tmpdir);
+
+		if (d) {
+			while ((de = readdir(d)) != NULL) {
+				if (strstr(de->d_name, ".tmp.")) {
+					printf(" - leftover '%s' [FAIL]\n",
+					       de->d_name);
+					leftover = true;
+				}
+			}
+			closedir(d);
+		}
+		if (leftover)
+			pass = false;
+		else
+			printf(" - no leftover temp dir [PASS]\n");
+	}
+
 out:
 	free(value);
 	libnvmf_registry_delete(ctx, "nvme3");


### PR DESCRIPTION
## Background

The controller ownership registry under `/run/nvme/registry/` records which orchestrator owns each connected NVMe-oF controller. Entries are written by libnvme on connect (only the connecting process knows the `owner`), and removed by a shipped udev REMOVE rule when the kernel removes the controller. The rule guards the removal with `[ -e /dev/%k ]` so that a recycled instance number — the kernel hands out the lowest free id, so a freed `nvmeN` can be immediately reused — is not clobbered: if the device node exists again, a new controller has already claimed the name and written its own entry, and the stale REMOVE must leave it alone.

## The problem this fixes

The `[ -e /dev/%k ]` check handles the common recycling case, but it leaves a residual sub-shell TOCTOU: a new controller can create `/dev/nvmeN` and write its entry in the window between the `[ -e ]` test returning false and `rm` running, after which the stale REMOVE deletes a live entry. The window is tiny, but "tiny" is not "closed" — at scale it will eventually be hit.

## The fix

Stamp each registry entry at connect with the kernel's global, monotonic `/sys/kernel/uevent_seqnum`, and have the REMOVE rule delete an entry only when the REMOVE event's own `SEQNUM` exceeds that stamp.

This closes the window completely, because it replaces a timing-sensitive test with a monotonic ordering comparison:

- A stale REMOVE for the old controller was emitted *before* the new controller's ADD, so its `SEQNUM` is necessarily lower than the new entry's stamp — the comparison holds and the entry survives, regardless of scheduling or how the test and `rm` interleave.
- A genuine REMOVE of the current controller carries a `SEQNUM` higher than that controller's own connect-time stamp, so its entry is removed as intended.

The stamp is written before `owner` so an owned entry always carries the guard value; a missing stamp (e.g. an entry written by an older libnvme) reads as `0` and the rule falls back to the device-existence check alone. The `[ -e /dev/%k ]` check is kept as a cheap fast path; the seqnum comparison is the tiebreaker that closes the race.

The stamp is best-effort on the write side: if `/sys/kernel/uevent_seqnum` cannot be read or written, the connect is never failed over it — the rule simply falls back to the device-existence guard.

## Testing

Validated end-to-end against a kernel nvmet TCP target with four fabric controllers, using the rule installed where udev actually reads it and entries stamped by this build of libnvme:

- Real `nvme disconnect` of a controller with a normal stamp → kernel-driven REMOVE → entry removed (remove `SEQNUM` greater than the stamp).
- Real disconnect of a controller whose stamp was set to a value above any future `SEQNUM` → entry preserved. The device node was gone, so this can only happen if the rule evaluated `[ <SEQNUM> -le <stamp> ]` to true — which simultaneously proves that udev substitutes a real, non-empty `SEQNUM` at runtime and that a "stale" lower-SEQNUM REMOVE does not clobber a live entry.
- Real disconnect of a controller with no stamp → entry removed via the device-existence fallback.
- A controller left connected kept its entry.

Also checked: the libnvme unit test (`libnvme - registry`) asserts the stamp is written and numeric, `udevadm verify` accepts the rule, and checkpatch is clean.
