### PR TITLE
nvme-types-base: add padding to nvme_lm_nvme_controller_state_data union

### DIFF
--- a/libnvme/src/nvme/nvme-types-base.h
+++ b/libnvme/src/nvme/nvme-types-base.h
@@ -8825,6 +8825,7 @@ struct nvme_lm_nvme_controller_state_data {
 	union {
 		struct nvme_lm_io_submission_queue_data sqs[0];
 		struct nvme_lm_io_completion_queue_data cqs[0];
+		__u8 queue_data_buf[4088];
 	};
 };
 


### PR DESCRIPTION
The union needs to be padded, so that the union doesn't have zero size. gcc complains with "union has size 0 in C, non-zero size in C++ [-Werror,-Wextern-c-compat]"