### PR TITLE
nvme: fix inverted null check in is_ns_mgmt_support()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -2899,7 +2899,7 @@ static bool is_ns_mgmt_support(struct libnvme_transport_handle *hdl)
 
 	__cleanup_libnvme_free struct nvme_id_ctrl *ctrl = libnvme_alloc(sizeof(*ctrl));
 
-	if (ctrl)
+	if (!ctrl)
 		return false;
 
 	err = nvme_identify_ctrl(hdl, ctrl);


### PR DESCRIPTION
The is_ns_mgmt_support() function allocates @ctrl and checks the result before calling nvme_identify_ctrl(). However, the null check was inverted, causing the function to return early on successful allocation and continue with a NULL @ctrl.

Accessing @ctrl->oacs with a NULL pointer causes a crash.

Fix the inverted null check to correctly return on allocation failure and only proceed when @ctrl is valid.