### PR TITLE
nvmf-autoconnect: tag connections with --owner=autoconnect

### DIFF
--- a/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
@@ -21,7 +21,7 @@ MemoryDenyWriteExecute=yes
 RemoveIPC=yes
 RestrictAddressFamilies=AF_INET AF_INET6
 Type=oneshot
-ExecStart=@SBINDIR@/nvme connect-all
+ExecStart=@SBINDIR@/nvme connect-all --owner=autoconnect
 
 [Install]
 WantedBy=default.target

--- a/nvmf-autoconnect/systemd/nvmf-connect@.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-connect@.service.in
@@ -25,4 +25,4 @@ RemoveIPC=yes
 RestrictAddressFamilies=AF_INET AF_INET6
 Type=simple
 Environment="CONNECT_ARGS=%i"
-ExecStart=/bin/sh -c "@SBINDIR@/nvme connect-all --quiet `/bin/echo -e '${CONNECT_ARGS}'`"
+ExecStart=/bin/sh -c "@SBINDIR@/nvme connect-all --owner=autoconnect --quiet `/bin/echo -e '${CONNECT_ARGS}'`"


### PR DESCRIPTION
The autoconnect systemd units run `nvme connect-all` to bring up NVMe-oF controllers at boot and on discovery events. They are the fallback boot-time connection path — used when `nvme-discoverd` is not installed, reverting to the udev rules plus one-shot boot service.

Now that nvme-cli has a controller ownership registry, a connection made without an owner is recorded as unowned — which makes it a target for a plain `nvme disconnect-all` (ownership-aware by default: it only tears down unowned controllers).

This passes `--owner=autoconnect` from the two units that connect:

- `nvmf-autoconnect.service` — `nvme connect-all`
- `nvmf-connect@.service` — `nvme connect-all --quiet ...`

so the controllers they create are attributed to the autoconnect machinery and survive an ownership-aware `disconnect-all`.

The `--nbft` unit already records `owner=nbft` and is left unchanged; the FC boot-connections unit only triggers discovery, with the actual connect flowing through `nvmf-connect@.service`.

Coincidentally, `--owner=autoconnect` lands where these units once carried `--context=autoconnect`. The two are unrelated: `--context` was a config-file filter (match entries by context) that went unused and was removed; `--owner` attributes the connection in the registry.
