### PR TITLE
python-ci: run the unit tests a second time without valgrind

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,40 @@ jobs:
           path: |
             .build-ci/meson-logs/*.txt
 
+  # Second test pass: the build matrix above runs the suite under valgrind,
+  # which skips the fork-based tests (e.g. the python multiprocessing registry
+  # test is skipIf(_under_valgrind)).  Run the suite once more WITHOUT valgrind
+  # so those tests actually execute.  fedora:latest tracks the newest Python,
+  # where interpreter-default changes (e.g. the 3.14 forkserver default that
+  # broke a fork-based test) surface before the other CI distros.
+  nvme-cli-no-valgrind:
+    name: nvme-cli unit tests without valgrind
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/linux-nvme/fedora:latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Mark repo as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Report interpreter/toolchain versions
+        run: |
+          grep -E '^(NAME|VERSION)=' /etc/os-release
+          python3 --version
+          gcc --version | head -1
+          meson --version
+      - name: build
+        # No -x: scripts/build.sh runs plain "meson test" (default setup, no
+        # valgrind), so the fork-based tests valgrind skips actually run.
+        run: |
+          scripts/build.sh -b release -c gcc
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        name: upload logs
+        if: failure()
+        with:
+          name: no-valgrind logs files
+          path: |
+            .build-ci/meson-logs/*.txt
+
   libnvme:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The build matrix runs the test suite under valgrind (`build.sh -x`), which skips the fork-based tests: the python `multiprocessing` registry test is `@unittest.skipIf(_under_valgrind)`, because forked children misbehave under valgrind. Nothing else exercised that path, so a regression in it — for example Python 3.14 making `forkserver` the default `multiprocessing` start method — could land unnoticed.

This adds a single job that builds on `ghcr.io/linux-nvme/fedora:latest` and runs the suite without valgrind (no `-x`), so the skipped tests execute. Fedora tracks the newest Python, where interpreter-default changes surface before the other CI distros.

Notes:

- A dedicated job rather than a second `meson test` step across the build matrix: the un-skipped tests are Python-only and their outcome depends on the Python runtime, not on the compiler or buildtype, so one build on the newest-Python image gives the coverage without multiplying CI cost. The C side continues to run across the full matrix under valgrind.
- Uses the pre-built `ghcr.io/linux-nvme/fedora:latest` container, which now tracks the latest Fedora release (and its Python), so no manual dependency install is needed.

Verified locally that the gap is real and the new pass closes it: `test_parallel_writes_no_corruption` is skipped when `VALGRIND_OPTS` is set and runs otherwise.
