### PR TITLE
build: use fedora container for analyzer workflow

### DIFF
--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -26,7 +26,7 @@ jobs:
     name: build with clang analyzer
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/linux-nvme/debian:latest
+      image: ghcr.io/linux-nvme/fedora:latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Run the analyzer workflow inside the Fedora container image instead of the Debian image. Fedora ships a newer Clang Static Analyzer release, allowing the workflow to use the latest analyzer improvements.