### PR TITLE
fabrics: fix inverted child controller check in _nvmf_discovery()

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2100,11 +2100,11 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 
 		nfctx.ctrl_params.cfg.keep_alive_tmo = tmo;
 
-		if (!child) {
+		if (child) {
 			if (discover)
 				_nvmf_discovery(ctx, &nfctx, true, child);
 
-			if (child && disconnect) {
+			if (disconnect) {
 				libnvmf_disconnect_ctrl(child);
 				libnvme_free_ctrl(child);
 			}


### PR DESCRIPTION
When processing discovery log entries, _nvmf_discovery() may recurse into another discovery service after successfully creating a child discovery controller via nvmf_connect_disc_entry().

However, the recursive discovery path is currently guarded by:

if (!child) {
        ...
        _nvmf_discovery(ctx, &nfctx, true, child);
        ...
}

which is the opposite of what is intended. The recursion is only attempted when @child is NULL, while the recursive call expects a valid @child pointer. Here @child is  a pointer to libnvme controller.

As a result, _nvmf_discovery() may be invoked with a NULL @child argument and subsequently dereference it.

Fix this by inverting the condition so that recursive discovery and the associated cleanup logic are only executed when a valid child controller has been created.

This issue was reported by the clang static analyzer.
Signed-off-by: Sarah Ahmed <sarah.ahmed@ibm.com>