### PR TITLE
nvme: fix uninitialized variable in get_feature_id_changed()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4914,7 +4914,7 @@ static int get_feature_id_changed(struct libnvme_transport_handle *hdl, struct f
 	__cleanup_libnvme_free void *buf_def = NULL;
 	__cleanup_libnvme_free void *buf = NULL;
 	__u64 result_def = 0;
-	__u64 result = 0;
+	__u64 result = -EINVAL;
 	int err_def = 0;
 	int err;
 


### PR DESCRIPTION
The get_feature_id_changed() function retrieves and compares NVMe feature values. The local @result variable was left uninitialized before being passed to get_feature_id().

If get_feature_id() fails early, @result may be used without ever being assigned a valid value, leading to undefined behavior.

Initialize @result to -EINVAL to indicate no feature value has been retrieved and prevent undefined behavior.