### PR TITLE
nvme: fix potential use of uninitialized flags in passthru()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -9573,7 +9573,7 @@ static int passthru(int argc, char **argv, bool admin,
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_fd int dfd = -1, mfd = -1;
-	int flags = 0;
+	int flags = -1;
 	int mode = 0644;
 	void *data = NULL;
 	__cleanup_free void *mdata = NULL;
@@ -9658,7 +9658,26 @@ static int passthru(int argc, char **argv, bool admin,
 		dfd = mfd = STDOUT_FILENO;
 	}
 
+	/*
+	 * Fallback to user specified data direction in case from opcode
+	 * we can't decode direction.
+	 */
+	if (cfg.write && flags < 0) {
+		flags = O_RDONLY;
+		dfd = mfd = STDIN_FILENO;
+	}
+
+	if (cfg.read && flags < 0) {
+		flags = O_WRONLY | O_CREAT | O_TRUNC;
+		dfd = mfd = STDOUT_FILENO;
+	}
 	if (strlen(cfg.input_file)) {
+		if (flags < 0) {
+			nvme_show_error("input file specified for opcode 0x%x "
+				"without a data transfer direction",
+					cfg.opcode);
+			return -EINVAL;
+		}
 		dfd = nvme_open_rawdata(cfg.input_file, flags, mode);
 		if (dfd < 0) {
 			nvme_show_perror(cfg.input_file);
@@ -9667,6 +9686,12 @@ static int passthru(int argc, char **argv, bool admin,
 	}
 
 	if (cfg.metadata && strlen(cfg.metadata)) {
+		if (flags < 0) {
+			nvme_show_error("metadata file specified for opcode 0x%x "
+				"without a data transfer direction",
+					cfg.opcode);
+			return -EINVAL;
+		}
 		mfd = nvme_open_rawdata(cfg.metadata, flags, mode);
 		if (mfd < 0) {
 			nvme_show_perror(cfg.metadata);


### PR DESCRIPTION
The passthru() command derives the file open mode from the data transfer direction encoded in the opcode. However, not all opcodes imply a data transfer direction, leaving the local @flags variable uninitialized.

If an input or metadata file is specified for such commands, nvme_open_rawdata() may be called with an uninitialized @flags value.

Initialize @flags to an invalid value and fall back to the optional user-specified direction provided through "--read" or "--write" when the direction cannot be inferred from the opcode. Reject input or metadata files if no data transfer direction can be determined and log the appropriate error.