### PR TITLE
nbft: capture errno immediately after I/O failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ tests/*.pyc
 dist/
 
 .vscode/
+*.save
+*.save.1

--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -758,13 +758,21 @@ __libnvme_public int libnvmf_read_nbft(
 
 	i = fseek(raw_nbft_fp, 0L, SEEK_END);
 	if (i) {
+		int saved_errno = errno;
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to read from %s: %s\n",
-			 filename, libnvme_strerror(errno));
+			 filename, libnvme_strerror(saved_errno));
 		fclose(raw_nbft_fp);
 		return -EINVAL;
 	}
 
 	raw_nbft_size = ftell(raw_nbft_fp);
+	if (raw_nbft_size == (size_t)-1L) {
+		int saved_errno = errno;
+		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to get file size for %s: %s\n",
+			filename, libnvme_strerror(saved_errno));
+		fclose(raw_nbft_fp);
+		return -EINVAL;
+	}
 	rewind(raw_nbft_fp);
 
 	raw_nbft = malloc(raw_nbft_size);
@@ -777,8 +785,9 @@ __libnvme_public int libnvmf_read_nbft(
 
 	i = fread(raw_nbft, sizeof(*raw_nbft), raw_nbft_size, raw_nbft_fp);
 	if (i != raw_nbft_size) {
+		int saved_errno = errno;
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to read from %s: %s\n",
-			 filename, libnvme_strerror(errno));
+			 filename, libnvme_strerror(saved_errno));
 		fclose(raw_nbft_fp);
 		free(raw_nbft);
 		return -EINVAL;


### PR DESCRIPTION
The libnvmf_read_nbft() function uses errno in error messages after
failed I/O operations. However, intervening function calls may overwrite
errno before it is read, leading to incorrect error reporting.

If fseek(), ftell(), or fread() fails, libnvme_msg() or fclose() may be
called before errno is captured, potentially overwriting the original
error value.

Capture errno immediately after each failed I/O operation before any
other function calls. Also add missing error check for ftell() which
can return -1L on failure.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>