### PR TITLE
libnvme/test: fix exit-code capture in config-diff.sh

### DIFF
--- a/libnvme/test/config/config-diff.sh
+++ b/libnvme/test/config/config-diff.sh
@@ -53,10 +53,11 @@ echo "Running command:"
 printf '%q ' "${cmd[@]}"
 printf '> %q\n' "$output"
 
-if ! "${cmd[@]}" > "$output"; then
-    rc=$?
+"${cmd[@]}" > "$output"
+rc=$?
+if [ "$rc" -ne 0 ]; then
     echo "test failed (exit code $rc)"
-    exit $rc
+    exit "$rc"
 fi
 
 diff -u "${expected_output}" "${output}"


### PR DESCRIPTION
The test runner wrapped the command in "if ! cmd; then rc=$?". Because $? reflects the result of the negated expression rather than the command itself, it was always 0 when the branch was taken: a test binary that genuinely failed was reported as passing, masking real command-level failures.

Run the command first, capture its status, then test it, so the real exit code is preserved and propagated.