### PR TITLE
nvme: fix null pointer dereference in get_log_offset()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -11129,7 +11129,7 @@ static int get_log_offset(struct libnvme_transport_handle *hdl,
 			NVME_LOG_CDW14_OT_MASK);
 
 	err = libnvme_get_log(hdl, &cmd, args->rae, NVME_LOG_PAGE_PDU_SIZE);
-	if (*args->result)
+	if (args->result)
 		*args->result = cmd.result;
 	return err;
 }


### PR DESCRIPTION
The get_log_offset() function stores the command result via args->result after retrieving the log page. However, the pointer args->result was dereferenced without first checking if it is NULL.

Dereferencing a NULL args->result pointer causes a crash when callers pass NULL to indicate they do not need the result value.

Check if args->result is non-NULL before dereferencing it to store the command result.