### PR TITLE
libnvme: validate context in libnvme_rescan_ctrl()

### DIFF
--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1570,7 +1570,7 @@ int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,
 __libnvme_public void libnvme_rescan_ctrl(struct libnvme_ctrl *c)
 {
 	struct libnvme_global_ctx *ctx = c->s && c->s->h ? c->s->h->ctx : NULL;
-	if (!c->s)
+	if (!ctx)
 		return;
 	libnvme_ctrl_scan_namespaces(ctx, c);
 	libnvme_ctrl_scan_paths(ctx, c);


### PR DESCRIPTION
libnvme_rescan_ctrl() derives the global context from the controller. The derived @ctx is then passed to libnvme_ctrl_scan_namespaces() and libnvme_ctrl_scan_paths(), both of which expect a valid context.

Instead of adding NULL checks in each callee, validate @ctx in libnvme_rescan_ctrl() and return early if no valid context is available.

This avoids propagating an invalid context to the namespace and path scan helpers.