### PR TITLE
micron: Fix command injection vulnerabilities

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -203,6 +203,71 @@ static enum eDriveModel GetDriveModel(
 }
 
 /*
+ * sanitize_serial - trim trailing spaces, null-terminate, and replace any
+ * characters that are not alphanumeric, hyphen, or underscore with underscores.
+ */
+static void sanitize_serial(char *sn, size_t len)
+{
+	size_t i;
+	size_t end;
+
+	if (!sn || len == 0)
+		return;
+
+	end = len - 1;
+	while (end > 0 && isblank((unsigned char)sn[end - 1]))
+		end--;
+	sn[end] = '\0';
+
+	for (i = 0; i < end; i++) {
+		if (!((sn[i] >= 'A' && sn[i] <= 'Z') ||
+		      (sn[i] >= 'a' && sn[i] <= 'z') ||
+		      (sn[i] >= '0' && sn[i] <= '9') ||
+		      sn[i] == '-' || sn[i] == '_'))
+			sn[i] = '_';
+	}
+}
+
+/*
+ * is_safe_path - validate that a path string is safe for use as a filename.
+ *
+ * Rejects control characters (0x00-0x1F), characters invalid on Windows
+ * filesystems (<>"|?*), paths starting with '-' which could be
+ * misinterpreted as flags by tar/zip, and trailing backslashes which
+ * would escape the closing quote in Windows command-line argument parsing.
+ */
+static bool is_safe_path(const char *path)
+{
+	/* Lookup table: 1 = rejected character */
+	static const unsigned char rejected[256] = {
+		[0x01 ... 0x1F] = 1,	/* control characters */
+		['<']  = 1,
+		['>']  = 1,
+		['"']  = 1,
+		['|']  = 1,
+		['?']  = 1,
+		['*']  = 1,
+	};
+	const unsigned char *p = (const unsigned char *)path;
+
+	if (!path || !*path)
+		return false;
+
+	if (path[0] == '-')
+		return false;
+
+	for (; *p; p++) {
+		if (rejected[*p])
+			return false;
+	}
+
+	if (p > (const unsigned char *)path && p[-1] == '\\')
+		return false;
+
+	return true;
+}
+
+/*
  * Recursively remove a directory and its contents.
  * Since this is only used for temporary directories that we create that
  * have no symlinks, it is safe to not check for and handle symlinks here.
@@ -234,7 +299,12 @@ static int RemoveDirRecursive(const char *path)
 		if (unlink(child) == 0 || errno == ENOENT)
 			continue;
 
-		if (errno != EISDIR && errno != EPERM) {
+		/*
+		 * On Linux, unlinking a directory fails with EISDIR or EPERM.
+		 * On Windows, it fails with EACCES. In all cases, fall through
+		 * to attempt recursive removal.
+		 */
+		if (errno != EISDIR && errno != EPERM && errno != EACCES) {
 			closedir(dir);
 			return -1;
 		}
@@ -265,7 +335,6 @@ static int RemoveDirRecursive(const char *path)
  */
 static int ZipWithBsdTar(char *strDirName, char *strFileName)
 {
-	__cleanup_free char *cmd_buf = NULL;
 	FILE *fpVersion = NULL;
 	char version_buf[256] = { 0 };
 	bool is_bsdtar = false;
@@ -288,32 +357,29 @@ static int ZipWithBsdTar(char *strDirName, char *strFileName)
 	if (!is_bsdtar)
 		return -EINVAL;
 
-	if (asprintf(&cmd_buf, "tar -caf \"%s\" \"%s\"",
-			strFileName, strDirName) < 0)
-		return -ENOMEM;
+	char *argv[] = {"tar", "-caf", strFileName, "--", strDirName, NULL};
 
-	if (system(cmd_buf))
-		return -EIO;
-	return 0;
+	return micron_run_spawn(argv, NULL, false);
 }
 
 static int ZipAndRemoveDir(char *strDirName, char *strFileName)
 {
 	int  err = 0;
-	char strBuffer[PATH_MAX + 128];	/* cmd + path */
 	int  nRet;
 	bool is_tgz = false;
 	struct stat sb;
 
 	if (strstr(strFileName, ".tar.gz") || strstr(strFileName, ".tgz")) {
-		snprintf(strBuffer, sizeof(strBuffer), "tar -zcf \"%s\" \"%s\"", strFileName, strDirName);
+		char *argv[] = {"tar", "-zcf", strFileName, "--", strDirName, NULL};
+
 		is_tgz = true;
+		nRet = micron_run_spawn(argv, NULL, false);
 	} else {
-		snprintf(strBuffer, sizeof(strBuffer), "zip -r \"%s\" \"%s\" >temp.txt 2>&1", strFileName,
-				strDirName);
+		char *argv[] = {"zip", "-r", strFileName, "--", strDirName, NULL};
+
+		nRet = micron_run_spawn(argv, NULL, false);
 	}
 
-	nRet = system(strBuffer);
 	if (nRet && !is_tgz)
 		/* if zip is not available, see if tar can be used instead */
 		nRet = ZipWithBsdTar(strDirName, strFileName);
@@ -322,18 +388,16 @@ static int ZipAndRemoveDir(char *strDirName, char *strFileName)
 	if (nRet || (stat(strFileName, &sb) == -1)) {
 		err = -EINVAL;
 		if (is_tgz)
-			snprintf(strBuffer, sizeof(strBuffer), "check if tar and gzip commands are installed");
+			fprintf(stderr, "Failed to create log data package, "
+				"check if tar and gzip commands are installed!\n");
 		else
-			snprintf(strBuffer, sizeof(strBuffer), "check if zip command is installed");
-
-		fprintf(stderr, "Failed to create log data package, %s!\n", strBuffer);
+			fprintf(stderr, "Failed to create log data package, "
+				"check if zip command is installed!\n");
 	}
 
 	if (RemoveDirRecursive(strDirName) < 0)
 		printf("Failed to remove temporary files!\n");
 
-	if (unlink("temp.txt") < 0 && errno != ENOENT)
-		printf("Failed to remove temporary file temp.txt!\n");
 	return err;
 }
 
@@ -3442,7 +3506,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 	unsigned int *puiIDDBuf;
 	unsigned int uiMask;
 	struct nvme_id_ctrl ctrl;
-	char sn[20] = { 0 };
+	char safe_sn[sizeof(ctrl.sn) + 1] = { 0 };
 	char msg[256] = { 0 };
 	int  c_logs_index = 8; /* should be current size of aVendorLogs */
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
@@ -3564,6 +3628,12 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 		goto out;
 	}
 
+	if (!is_safe_path(cfg.package)) {
+		fprintf(stderr,
+			"Invalid package path: contains unsafe characters\n");
+		goto out;
+	}
+
 	/* pull log details based on the model name */
 	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == UNKNOWN_MODEL) {
@@ -3598,19 +3668,10 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 
 	printf("Preparing log package. This will take a few seconds...\n");
 
-	/* trim spaces out of serial number string */
-	int i, j = 0;
-
-	for (i = 0; i < sizeof(ctrl.sn); i++) {
-		if (isblank((int)ctrl.sn[i]))
-			continue;
-		sn[j++] = ctrl.sn[i];
-	}
-	sn[j] = '\0';
-	strcpy(ctrl.sn, sn);
-
-	SetupDebugDataDirectories(ctrl.sn, cfg.package, strMainDirName, strOSDirName,
-										strCtrlDirName);
+	strncpy(safe_sn, ctrl.sn, sizeof(safe_sn) - 1);
+	sanitize_serial(safe_sn, sizeof(safe_sn));
+	SetupDebugDataDirectories(safe_sn, cfg.package,
+			strMainDirName, strOSDirName, strCtrlDirName);
 
 	GetTimestampInfo(strOSDirName);
 	GetCtrlIDDInfo(strCtrlDirName, &ctrl);

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -8,7 +8,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <spawn.h>
 #include <stdio.h>
+#include <sys/wait.h>
 
 #include <libnvme.h>
 
@@ -204,39 +206,108 @@ int micron_clear_pcie_aer_correctable_errors(
 	return 0;
 }
 
+extern char **environ;
+
+int micron_run_spawn(char *const argv[], const char *outfile, bool append)
+{
+	posix_spawn_file_actions_t actions;
+	posix_spawn_file_actions_t *actionsp = NULL;
+	pid_t pid;
+	int status, ret;
+	int oflags = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
+
+	if (outfile) {
+		ret = posix_spawn_file_actions_init(&actions);
+		if (ret)
+			return -ret;
+		actionsp = &actions;
+
+		ret = posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO,
+						       outfile, oflags, 0644);
+		if (ret)
+			goto out_destroy;
+
+		ret = posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
+						       STDERR_FILENO);
+		if (ret)
+			goto out_destroy;
+	}
+
+	ret = posix_spawnp(&pid, argv[0], actionsp, NULL, argv, environ);
+
+	if (actionsp)
+		posix_spawn_file_actions_destroy(actionsp);
+
+	if (ret)
+		return -ret;
+	while (waitpid(pid, &status, 0) == -1) {
+		if (errno != EINTR)
+			return -errno;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		return -EIO;
+	return 0;
+
+out_destroy:
+	posix_spawn_file_actions_destroy(actionsp);
+	return -ret;
+}
+
 void micron_write_os_config_to_file(const char *file_name)
 {
 	FILE *fpOSConfig = NULL;
-	char strBuffer[1024];
+	int ret;
 	int i;
 
 	struct {
-		const char *strcmdHeader;
-		const char *strCommand;
-	} cmdArray[] = {
-		{ "SYSTEM INFORMATION", "uname -a >> %s" },
-		{ "LINUX KERNEL MODULE INFORMATION", "lsmod >> %s" },
-		{ "LINUX SYSTEM MEMORY INFORMATION", "cat /proc/meminfo >> %s" },
-		{ "SYSTEM INTERRUPT INFORMATION", "cat /proc/interrupts >> %s" },
-		{ "CPU INFORMATION", "cat /proc/cpuinfo >> %s" },
-		{ "IO MEMORY MAP INFORMATION", "cat /proc/iomem >> %s" },
-		{ "MAJOR NUMBER AND DEVICE GROUP", "cat /proc/devices >> %s" },
-		{ "KERNEL DMESG", "dmesg >> %s" },
-		{ "/VAR/LOG/MESSAGES", "cat /var/log/messages >> %s" }
+		const char *header;
+		char *const *argv;
+	} cmds[] = {
+		{ "SYSTEM INFORMATION",
+			(char *const []){"uname", "-a", NULL} },
+		{ "LINUX KERNEL MODULE INFORMATION",
+			(char *const []){"lsmod", NULL} },
+		{ "LINUX SYSTEM MEMORY INFORMATION",
+			(char *const []){"cat", "/proc/meminfo", NULL} },
+		{ "SYSTEM INTERRUPT INFORMATION",
+			(char *const []){"cat", "/proc/interrupts", NULL} },
+		{ "CPU INFORMATION",
+			(char *const []){"cat", "/proc/cpuinfo", NULL} },
+		{ "IO MEMORY MAP INFORMATION",
+			(char *const []){"cat", "/proc/iomem", NULL} },
+		{ "MAJOR NUMBER AND DEVICE GROUP",
+			(char *const []){"cat", "/proc/devices", NULL} },
+		{ "KERNEL DMESG",
+			(char *const []){"dmesg", NULL} },
+		{ "/VAR/LOG/MESSAGES",
+			(char *const []){"cat", "/var/log/messages", NULL} },
 	};
 
-	for (i = 0; i < (int)(ARRAY_SIZE(cmdArray)); i++) {
+	for (i = 0; i < (int)(ARRAY_SIZE(cmds)); i++) {
 		fpOSConfig = fopen(file_name, "a+");
 		if (fpOSConfig) {
 			fprintf(fpOSConfig,
 				"\n\n\n\n%s\n-----------------------------------------------\n",
-				cmdArray[i].strcmdHeader);
+				cmds[i].header);
 			fclose(fpOSConfig);
 			fpOSConfig = NULL;
 		}
-		snprintf(strBuffer, sizeof(strBuffer) - 1,
-				 cmdArray[i].strCommand, file_name);
-		if (system(strBuffer))
-			fprintf(stderr, "Failed to send \"%s\"\n", strBuffer);
+		ret = micron_run_spawn(cmds[i].argv, file_name, true);
+		if (ret) {
+			char cmdline[512] = "";
+			int pos = 0;
+
+			for (int j = 0; cmds[i].argv[j] && pos < (int)sizeof(cmdline); j++) {
+				int n = snprintf(cmdline + pos,
+						 sizeof(cmdline) - pos, "%s%s",
+						 j ? " " : "", cmds[i].argv[j]);
+
+				if (n < 0 || n >= (int)(sizeof(cmdline) - pos))
+					break;
+				pos += n;
+			}
+			fprintf(stderr, "Failed to run \"%s\": %s\n",
+				cmdline, strerror(-ret));
+		}
 	}
 }

--- a/plugins/micron/micron-utils-win.c
+++ b/plugins/micron/micron-utils-win.c
@@ -14,6 +14,59 @@
 #include "micron-utils.h"
 #include "util/cleanup.h"
 
+int micron_run_spawn(char *const argv[], const char *outfile, bool append)
+{
+	STARTUPINFOA si = { .cb = sizeof(si) };
+	PROCESS_INFORMATION pi = { 0 };
+	HANDLE hFile = INVALID_HANDLE_VALUE;
+	char cmdline[MAX_PATH + 256] = { 0 };
+	int i, off = 0;
+	DWORD exit_code;
+
+	for (i = 0; argv[i]; i++) {
+		int ret = snprintf(cmdline + off, sizeof(cmdline) - off,
+				   "%s\"%s\"", i ? " " : "", argv[i]);
+		if (ret < 0 || (size_t)ret >= sizeof(cmdline) - off)
+			return -ENOMEM;
+		off += ret;
+	}
+
+	if (outfile) {
+		SECURITY_ATTRIBUTES sa = {
+			.nLength = sizeof(sa),
+			.bInheritHandle = TRUE,
+		};
+
+		hFile = CreateFileA(outfile, GENERIC_WRITE, 0, &sa,
+				    append ? OPEN_ALWAYS : CREATE_ALWAYS,
+				    FILE_ATTRIBUTE_NORMAL, NULL);
+		if (hFile == INVALID_HANDLE_VALUE)
+			return -EIO;
+		if (append)
+			SetFilePointer(hFile, 0, NULL, FILE_END);
+		si.dwFlags = STARTF_USESTDHANDLES;
+		si.hStdOutput = hFile;
+		si.hStdError = hFile;
+		si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+	}
+
+	if (!CreateProcessA(NULL, cmdline, NULL, NULL, outfile ? TRUE : FALSE,
+			    0, NULL, NULL, &si, &pi)) {
+		if (hFile != INVALID_HANDLE_VALUE)
+			CloseHandle(hFile);
+		return -EIO;
+	}
+
+	WaitForSingleObject(pi.hProcess, INFINITE);
+	GetExitCodeProcess(pi.hProcess, &exit_code);
+	CloseHandle(pi.hProcess);
+	CloseHandle(pi.hThread);
+	if (hFile != INVALID_HANDLE_VALUE)
+		CloseHandle(hFile);
+
+	return exit_code == 0 ? 0 : -EIO;
+}
+
 int micron_get_pci_ids(struct libnvme_global_ctx *ctx,
 			struct libnvme_transport_handle *hdl,
 			unsigned short *vid, unsigned short *did)

--- a/plugins/micron/micron-utils.h
+++ b/plugins/micron/micron-utils.h
@@ -94,6 +94,20 @@ int micron_clear_pcie_aer_correctable_errors(
 		struct libnvme_transport_handle *hdl);
 
 /**
+ * micron_run_spawn() - Run a command without invoking a shell
+ * @argv:	NULL-terminated argument vector (argv[0] is the program)
+ * @outfile:	If non-NULL, redirect stdout and stderr to this file
+ * @append:	If true, append to outfile; if false, truncate it
+ *
+ * Executes the program specified by argv[0] with the given arguments.
+ * The program is searched in PATH. No shell is invoked, preventing
+ * command injection via metacharacters in arguments.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+int micron_run_spawn(char *const argv[], const char *outfile, bool append);
+
+/**
  * micron_write_os_config_to_file() - Dump OS configuration to a file
  * @file_name:	Path of the output file
  *


### PR DESCRIPTION
Fixes shell and path-related command injection vulnerabilities in the micron plugin:
- Replaces system() calls that rely on user-supplied or drive-supplied strings with spawning a new process with a fixed argv array.
- Trims and sanitizes the drive-provided serial number string before using it in path strings.
- Checks the user-provided zip/tar package path for unsafe or unsupported characters before using it.