### PR TITLE
plugins/sandisk: fix memory leak in sndk_get_enc_drive_capabilities()

### DIFF
--- a/plugins/sandisk/sandisk-utils.c
+++ b/plugins/sandisk/sandisk-utils.c
@@ -843,6 +843,7 @@ __u64 sndk_get_enc_drive_capabilities(struct libnvme_global_ctx *ctx,
 	}
 
 out:
+	free(dev_mng_log);
 	return capabilities;
 }
 


### PR DESCRIPTION
Fix memory leak in sndk_get_enc_drive_capabilities() where the
dev_mng_log pointer allocated by sndk_get_dev_mgment_data() was
never freed before the function returns.

Add free(dev_mng_log) at the out label to properly release the
allocated memory in both success and error paths.

Signed-off-by: LaraibJaved <LaraibJaved@ibm.com>