### PR TITLE
solidigm: Apply fixes to allow compilation on Windows

### DIFF
--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -242,7 +242,7 @@ static int ilog_dump_assert_logs(struct libnvme_transport_handle *hdl, struct il
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
 		.nsid = NVME_NSID_ALL,
-		.addr = (__u64)(void *)head_buf,
+		.addr = (__u64)(uintptr_t)head_buf,
 		.cdw12 = ASSERTLOG,
 		.cdw13 = 0,
 	};
@@ -265,7 +265,7 @@ static int ilog_dump_assert_logs(struct libnvme_transport_handle *hdl, struct il
 		close(output);
 		return err;
 	}
-	cmd.addr = (__u64)(void *)buf;
+	cmd.addr = (__u64)(uintptr_t)buf;
 
 	if (ilog->cfg->verbose) {
 		printf("Assert Log, cores: %d log size: %d header size: %d\n", ad->header.numcores,
@@ -299,7 +299,7 @@ static int ilog_dump_event_logs(struct libnvme_transport_handle *hdl, struct ilo
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
 		.nsid = NVME_NSID_ALL,
-		.addr = (__u64)(void *)head_buf,
+		.addr = (__u64)(uintptr_t)head_buf,
 		.cdw12 = EVENTLOG,
 		.cdw13 = 0,
 	};
@@ -322,7 +322,7 @@ static int ilog_dump_event_logs(struct libnvme_transport_handle *hdl, struct ilo
 		close(output);
 		return err;
 	}
-	cmd.addr = (__u64)(void *)buf;
+	cmd.addr = (__u64)(uintptr_t)buf;
 
 	if (ilog->cfg->verbose)
 		printf("Event Log, cores: %d log size: %d\n", core_num, ehdr->header.log_size * 4);
@@ -374,7 +374,7 @@ static int ilog_dump_nlogs(struct libnvme_transport_handle *hdl, struct ilog *il
 	struct libnvme_passthru_cmd cmd = {
 		.opcode = 0xd2,
 		.nsid = NVME_NSID_ALL,
-		.addr = (__u64)(void *)buf
+		.addr = (__u64)(uintptr_t)buf
 	};
 
 	struct dump_select {

--- a/plugins/solidigm/solidigm-smart.c
+++ b/plugins/solidigm/solidigm-smart.c
@@ -163,7 +163,7 @@ static void smart_log_item_print(struct nvme_additional_smart_log_item *item,
 			le32_to_cpu(item->thermal_throttle.count));
 		return;
 	case 0xF3:
-		printf("gain0: %u, loss0: %u, gain1: %u, loss1: %u, legacy:%lu\n",
+		printf("gain0: %u, loss0: %u, gain1: %u, loss1: %u, legacy:%"PRIu64"\n",
 			le16_to_cpu(pll_item->gainCount0),
 			le16_to_cpu(pll_item->lossCount0),
 			le16_to_cpu(pll_item->gainCount1),

--- a/plugins/solidigm/solidigm-workload-tracker.c
+++ b/plugins/solidigm/solidigm-workload-tracker.c
@@ -244,8 +244,8 @@ static void wltracker_print_header(struct wltracker *wlt)
 	printf("%-24s %u.%u\n", "Log page version:", le16_to_cpu(log->majorVersion),
 	       le16_to_cpu(log->minorVersion));
 	printf("%-24s %u\n", "Sample period(ms):", le32_to_cpu(log->samplePeriodInMilliseconds));
-	printf("%-24s %lu\n", "timestamp_lastChange:", le64_to_cpu(log->timestamp_lastEntry));
-	printf("%-24s %lu\n", "timestamp_triggered:", le64_to_cpu(log->timestamp_triggered));
+	printf("%-24s %"PRIu64"\n", "timestamp_lastChange:", le64_to_cpu(log->timestamp_lastEntry));
+	printf("%-24s %"PRIu64"\n", "timestamp_triggered:", le64_to_cpu(log->timestamp_triggered));
 	printf("%-24s 0x%x\n", "config:", le32_to_cpu(log->config.dword));
 	printf("%-24s %u\n", "Triggerthreshold:", le32_to_cpu(log->triggerthreshold));
 	printf("%-24s %u\n", "ValueTriggered:", le32_to_cpu(log->triggeredValue));
@@ -253,7 +253,7 @@ static void wltracker_print_header(struct wltracker *wlt)
 	printf("%-24s %u\n", "Total log page entries:", le32_to_cpu(log->workloadLogCount));
 	printf("%-24s %u\n", "Trigger count:", log->triggeredEvents);
 	if (nvme_args.verbose > 1)
-		printf("%-24s %ld\n", "Poll count:", wlt->poll_count);
+		printf("%-24s %zu\n", "Poll count:", wlt->poll_count);
 	if (wlt->poll_count != 0)
 		wltracker_print_field_names(wlt);
 }
@@ -436,7 +436,7 @@ void wltracker_run_time_update(struct wltracker *wlt)
 		printf("run_time: %lluus\n", wlt->run_time_us);
 }
 
-static int stricmp(char const *a, char const *b)
+static int sldgm_stricmp(char const *a, char const *b)
 {
 	if (!a || !b)
 		return 1;
@@ -449,7 +449,7 @@ static int stricmp(char const *a, char const *b)
 static int find_option(char const *list[], int size, const char *val)
 {
 	for (int i = 0; i < size; i++) {
-		if (!stricmp(val, list[i]))
+		if (!sldgm_stricmp(val, list[i]))
 			return i;
 	}
 	return -EINVAL;
@@ -467,7 +467,7 @@ static void join_options(char *dest, char const *list[], size_t list_size)
 static int find_field(struct field *fields, const char *val)
 {
 	for (int i = 0; i < MAX_FIELDS; i++) {
-		if (!stricmp(val, fields[i].name))
+		if (!sldgm_stricmp(val, fields[i].name))
 			return i;
 	}
 	return -EINVAL;


### PR DESCRIPTION
No functional changes.

Changes pointer casts and format strings to
support type size differences accross platforms.
- Uses %"PRIu64" for platform-agnostic 64-bit value handling.
- Uses %zu for platform-agnostic size_t handling
- Uses uintptr_t for pointer casts

Renames internal stricmp to sldgm_stricmp to avoid conflicts with native stricmp implementations on some platforms.