### PR TITLE
tree: replace strdup with xstrdup in nvme_alloc_subsystem()

### DIFF
--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -407,7 +407,12 @@ struct libnvme_subsystem *nvme_alloc_subsystem(struct libnvme_host *h,
 		return NULL;
 
 	s->h = h;
-	s->subsysnqn = strdup(subsysnqn);
+	s->subsysnqn = xstrdup(subsysnqn);
+	if (!s->subsysnqn) {
+		free(s);
+		return NULL;
+	}
+
 	if (name)
 		libnvme_init_subsystem(s, name);
 	list_head_init(&s->ctrls);


### PR DESCRIPTION
Replace strdup() with xstrdup() when duplicating the subsystem NQN.
Unlike strdup(), xstrdup() safely returns NULL when passed a NULL
pointer, avoiding undefined behavior if subsysnqn is NULL.

Also check the return value from xstrdup() and bail out early if
duplicating the subsystem NQN fails, either because the input pointer
is NULL or because memory allocation was unsuccessful.

This issue was reported by the clang static analyzer.

Signed-off-by: Sarah Ahmed <sarah.ahmed@ibm.com>