### PR TITLE
wdc-nvme: fix null dereference of sph in get_dev_mgmt_log_page_lid_data()

### DIFF
--- a/libnvme/src/nvme/nvme-types-base.h
+++ b/libnvme/src/nvme/nvme-types-base.h
@@ -8825,6 +8825,7 @@ struct nvme_lm_nvme_controller_state_data {
 	union {
 		struct nvme_lm_io_submission_queue_data sqs[0];
 		struct nvme_lm_io_completion_queue_data cqs[0];
+		__u8 queue_data_buf[4088];
 	};
 };
 

--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -2695,7 +2695,7 @@ static bool get_dev_mgmt_log_page_lid_data(struct libnvme_transport_handle *hdl,
 	hdr_ptr = (struct wdc_c2_log_page_header *)data;
 	sph = (struct wdc_c2_log_subpage_header *)(data + length);
 	found = wdc_get_dev_mng_log_entry(le32_to_cpu(hdr_ptr->length), log_id, hdr_ptr, &sph);
-	if (found) {
+	if (found && sph) {
 		*cbs_data = calloc(le32_to_cpu(sph->length), sizeof(__u8));
 		if (!*cbs_data) {
 			fprintf(stderr, "ERROR: WDC: calloc: %s\n", libnvme_strerror(errno));
@@ -2703,6 +2703,9 @@ static bool get_dev_mgmt_log_page_lid_data(struct libnvme_transport_handle *hdl,
 			goto end;
 		}
 		memcpy((void *)*cbs_data, (void *)&sph->data, le32_to_cpu(sph->length));
+	} else if(found && !sph) {
+		fprintf(stderr, "ERROR: WDC: C2 log id 0x%x not present in log page with uuid index %d\n",log_id, uuid_ix);
+		found = false;
 	} else {
 		fprintf(stderr, "ERROR: WDC: C2 log id 0x%x not found with uuid index %d\n",
 			log_id, uuid_ix);


### PR DESCRIPTION
wdc_get_dev_mng_log_entry() may be able to find valid log entries but
fail to find desired log page id leaving @sph to NULL.

Continuing to use @sph in this case may result in a NULL pointer
dereference.

Validate both the return value from wdc_get_dev_mng_log_entry() and
the @sph pointer before dereferencing it. Split the error handling
into separate paths so callers receive an appropriate return code and
a meaningful diagnostic depending on the failure.

This issue was reported by the clang static analyzer.

Signed-off-by: Sarah Ahmed <sarah.ahmed@ibm.com>