### PR TITLE
micron: Fix more security vulnerabilities

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -480,7 +480,7 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 	nIndex = strlen(strMainDirName);
 
 	j = 1;
-	while (mkdir(strMainDirName, 0777) < 0) {
+	while (mkdir(strMainDirName, 0700) < 0) {
 		if (errno != EEXIST) {
 			err = -1;
 			goto exit_status;
@@ -492,7 +492,7 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 
 	if (strOSDirName) {
 		snprintf(strOSDirName, osDirSize, "%s/%s", strMainDirName, "OS");
-		if (mkdir(strOSDirName, 0777) < 0) {
+		if (mkdir(strOSDirName, 0700) < 0) {
 			rmdir(strMainDirName);
 			err = -1;
 			goto exit_status;
@@ -500,7 +500,7 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 	}
 	if (strCtrlDirName) {
 		snprintf(strCtrlDirName, ctrlDirSize, "%s/%s", strMainDirName, "Controller");
-		if (mkdir(strCtrlDirName, 0777) < 0) {
+		if (mkdir(strCtrlDirName, 0700) < 0) {
 			if (strOSDirName)
 				rmdir(strOSDirName);
 			rmdir(strMainDirName);

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -114,10 +114,13 @@ struct MICRON_WORKLOAD_LOG_HDR {
 
 static void WriteData(__u8 *data, __u32 len, const char *dir, const char *file, const char *msg)
 {
-	char tempFolder[8192] = { 0 };
+	__cleanup_free char *tempFolder = NULL;
 	FILE *fpOutFile = NULL;
 
-	sprintf(tempFolder, "%s/%s", dir, file);
+	if (asprintf(&tempFolder, "%s/%s", dir, file) < 0) {
+		printf("Failed to allocate memory for temp folder path\n");
+		return;
+	}
 	fpOutFile = fopen(tempFolder, "ab+");
 	if (fpOutFile) {
 		if (fwrite(data, 1, len,  fpOutFile) != len)
@@ -402,11 +405,11 @@ static int ZipAndRemoveDir(char *strDirName, char *strFileName)
 }
 
 static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
-					 char *strMainDirName, char *strOSDirName,
-					 char *strCtrlDirName)
+					 char *strMainDirName, size_t mainDirSize,
+					 char *strOSDirName, size_t osDirSize,
+					 char *strCtrlDirName, size_t ctrlDirSize)
 {
 	int err = 0;
-	char strAppend[250];
 	struct stat st;
 	char *fileLocation = NULL;
 	char *fileName;
@@ -415,7 +418,6 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 	char *strTemp = NULL;
 	int j;
 	int k = 0;
-	int i = 0;
 
 	if (strchr(strFilePath, '/')) {
 		fileName = strrchr(strFilePath, '\\');
@@ -452,24 +454,16 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 			length = (int)strlen(fileLocation);
 
 			if (':' == fileLocation[length - 1]) {
-				strTemp = (char *)malloc(length + 2);
+				strTemp = realloc(fileLocation, length + 2);
+
 				if (!strTemp) {
 					free(fileLocation);
 					goto exit_status;
 				}
-				strcpy(strTemp, fileLocation);
-				strcat(strTemp, "/");
-				free(fileLocation);
-
-				length = (int)strlen(strTemp);
-				fileLocation = (char *)malloc(length + 1);
-				if (!fileLocation) {
-					free(strTemp);
-					goto exit_status;
-				}
-
-				memcpy(fileLocation, strTemp, length + 1);
-				free(strTemp);
+				fileLocation = strTemp;
+				fileLocation[length] = '/';
+				fileLocation[length + 1] = '\0';
+				length++;
 			}
 
 			if (stat(fileLocation, &st)) {
@@ -482,12 +476,8 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 		}
 	}
 
-	nIndex = 0;
-	for (i = 0; i < (int)strlen(strSN); i++) {
-		if (strSN[i] != ' ' && strSN[i] != '\n' && strSN[i] != '\t' && strSN[i] != '\r')
-			strMainDirName[nIndex++] = strSN[i];
-	}
-	strMainDirName[nIndex] = '\0';
+	snprintf(strMainDirName, mainDirSize, "%s", strSN);
+	nIndex = strlen(strMainDirName);
 
 	j = 1;
 	while (mkdir(strMainDirName, 0777) < 0) {
@@ -496,13 +486,12 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 			goto exit_status;
 		}
 		strMainDirName[nIndex] = '\0';
-		sprintf(strAppend, "-%d", j);
-		strcat(strMainDirName, strAppend);
+		snprintf(strMainDirName + nIndex, mainDirSize - nIndex, "-%d", j);
 		j++;
 	}
 
 	if (strOSDirName) {
-		sprintf(strOSDirName, "%s/%s", strMainDirName, "OS");
+		snprintf(strOSDirName, osDirSize, "%s/%s", strMainDirName, "OS");
 		if (mkdir(strOSDirName, 0777) < 0) {
 			rmdir(strMainDirName);
 			err = -1;
@@ -510,7 +499,7 @@ static int SetupDebugDataDirectories(char *strSN, char *strFilePath,
 		}
 	}
 	if (strCtrlDirName) {
-		sprintf(strCtrlDirName, "%s/%s", strMainDirName, "Controller");
+		snprintf(strCtrlDirName, ctrlDirSize, "%s/%s", strMainDirName, "Controller");
 		if (mkdir(strCtrlDirName, 0777) < 0) {
 			if (strOSDirName)
 				rmdir(strOSDirName);
@@ -2067,19 +2056,21 @@ static void GetDriveInfo(const char *strOSDirName, int nFD,
 						 struct nvme_id_ctrl *ctrlp)
 {
 	FILE *fpOutFile = NULL;
-	char tempFile[256] = { 0 };
+	__cleanup_free char *tempFile = NULL;
 	char strBuffer[1024] = { 0 };
 	char model[41] = { 0 };
 	char serial[21] = { 0 };
 	char fwrev[9] = { 0 };
-	char *strPDir = strdup(strOSDirName);
+	__cleanup_free char *strPDir = strdup(strOSDirName);
 	char *strDest = dirname(strPDir);
 
-	sprintf(tempFile, "%s/%s", strDest, "drive-info.txt");
+	if (asprintf(&tempFile, "%s/%s", strDest, "drive-info.txt") < 0) {
+		printf("Failed to allocate memory for temp file name\n");
+		return;
+	}
 	fpOutFile = fopen(tempFile, "w+");
 	if (!fpOutFile) {
 		printf("Failed to create %s\n", tempFile);
-		free(strPDir);
 		return;
 	}
 
@@ -2087,11 +2078,11 @@ static void GetDriveInfo(const char *strOSDirName, int nFD,
 	strncpy(serial, ctrlp->sn, 20);
 	strncpy(fwrev, ctrlp->fr, 8);
 
-	sprintf(strBuffer,
+	snprintf(strBuffer, sizeof(strBuffer),
 			"********************\nDrive Info\n********************\n");
 
 	fprintf(fpOutFile, "%s", strBuffer);
-	sprintf(strBuffer,
+	snprintf(strBuffer, sizeof(strBuffer),
 			"%-20s : /dev/nvme%d\n%-20s : %s\n%-20s : %-20s\n%-20s : %-20s\n",
 			"Device Name", nFD,
 			"Model No", (char *)model,
@@ -2099,17 +2090,16 @@ static void GetDriveInfo(const char *strOSDirName, int nFD,
 
 	fprintf(fpOutFile, "%s", strBuffer);
 
-	sprintf(strBuffer,
+	snprintf(strBuffer, sizeof(strBuffer),
 			"\n********************\nPCI Info\n********************\n");
 
 	fprintf(fpOutFile, "%s", strBuffer);
 
-	sprintf(strBuffer,
+	snprintf(strBuffer, sizeof(strBuffer),
 			"%-22s : %04X\n%-22s : %04X\n",
 			"VendorId", vendor_id, "DeviceId", device_id);
 	fprintf(fpOutFile, "%s", strBuffer);
 	fclose(fpOutFile);
-	free(strPDir);
 }
 
 static void GetTimestampInfo(const char *strOSDirName)
@@ -2118,6 +2108,8 @@ static void GetTimestampInfo(const char *strOSDirName)
 	time_t t;
 	struct tm *tmp;
 	size_t num;
+	size_t remaining;
+	int n;
 	char *strPDir;
 	char *strDest;
 
@@ -2128,7 +2120,10 @@ static void GetTimestampInfo(const char *strOSDirName)
 
 	num = strftime((char *)outstr, sizeof(outstr),
 			"Timestamp (UTC): %a, %d %b %Y %H:%M:%S %z", tmp);
-	num += sprintf((char *)(outstr + num), "\nPackage Version: 1.4");
+	remaining = sizeof(outstr) - num;
+	n = snprintf((char *)(outstr + num), remaining, "\nPackage Version: 1.4");
+	if (n > 0)
+		num += (size_t)n < remaining ? (size_t)n : remaining - 1;
 	if (num) {
 		strPDir = strdup(strOSDirName);
 		strDest = dirname(strPDir);
@@ -2223,15 +2218,17 @@ static void GetNSIDDInfo(struct libnvme_transport_handle *hdl, const char *dir, 
 	struct nvme_id_ns ns;
 
 	if (!nvme_identify_ns(hdl, nsid, &ns)) {
-		sprintf(file, "identify_namespace_%d_data.bin", nsid);
+		snprintf(file, sizeof(file), "identify_namespace_%d_data.bin", nsid);
 		WriteData((__u8 *)&ns, sizeof(ns), dir, file, "id-ns");
 	}
 }
 
 static void GetOSConfig(const char *strOSDirName)
 {
-	char strFileName[4096];
-	sprintf(strFileName, "%s/%s", strOSDirName, "os_config.txt");
+	__cleanup_free char *strFileName = NULL;
+
+	if (asprintf(&strFileName, "%s/%s", strOSDirName, "os_config.txt") < 0)
+		return;
 	micron_write_os_config_to_file(strFileName);
 }
 
@@ -2312,7 +2309,7 @@ static int GetTelemetryData(struct libnvme_transport_handle *hdl, const char *di
 	for (i = 0; i < (int)(ARRAY_SIZE(tmap)); i++) {
 		err = micron_telemetry_log(hdl, tmap[i].log, &buffer, &logSize, 0);
 		if (!err && logSize > 0 && buffer) {
-			sprintf(msg, "telemetry log: 0x%X", tmap[i].log);
+			snprintf(msg, sizeof(msg), "telemetry log: 0x%X", tmap[i].log);
 			WriteData(buffer, logSize, dir, tmap[i].file, msg);
 		}
 		libnvme_free(buffer);
@@ -2358,7 +2355,7 @@ static int GetFeatureSettings(struct libnvme_transport_handle *hdl, const char *
 		err = nvme_get_features(hdl, 1, fmap[i].id, 0, 0x0, 0, bufp, len,
 				&attrVal);
 		if (!err) {
-			sprintf(msg, "feature: 0x%X", fmap[i].id);
+			snprintf(msg, sizeof(msg), "feature: 0x%X", fmap[i].id);
 			WriteData((__u8 *)&attrVal, sizeof(attrVal), dir, fmap[i].file, msg);
 			if (bufp)
 				WriteData(bufp, len, dir, fmap[i].file, msg);
@@ -2592,7 +2589,8 @@ struct __packed micron_fw_activation_history_table {
 };
 
 static int display_fw_activate_entry(int entry_count, struct fw_activation_history_entry *entry,
-					 char *formatted_entry, struct json_object *stats)
+					 char *formatted_entry, size_t buf_size,
+					 struct json_object *stats)
 {
 	time_t timestamp, hours;
 	char buffer[32];
@@ -2600,6 +2598,7 @@ static int display_fw_activate_entry(int entry_count, struct fw_activation_histo
 	static const char * const ca[] = {"000b", "001b", "010b", "011b"};
 	char *ptr = formatted_entry;
 	int index = 0, entry_size = 82;
+	int remaining;
 	bool      is_json = false;
 
 	if ((entry->version != 1 && entry->version != 2) || entry->length != 64)
@@ -2608,7 +2607,8 @@ static int display_fw_activate_entry(int entry_count, struct fw_activation_histo
 	if (stats)
 		is_json = true;
 
-	sprintf(ptr, "%d", entry_count);
+	remaining = buf_size - (ptr - formatted_entry);
+	snprintf(ptr, remaining, "%d", entry_count);
 	if (is_json)
 		json_object_add_value_int(stats, "Entry Number", le32_to_cpu(entry_count));
 
@@ -2618,13 +2618,15 @@ static int display_fw_activate_entry(int entry_count, struct fw_activation_histo
 	hours = timestamp / 3600;
 	minutes = (timestamp % 3600) / 60;
 	seconds = (timestamp % 3600) % 60;
-	sprintf(ptr, "|%"PRIu64":%hhu:%hhu", (uint64_t)hours, minutes, seconds);
+	remaining = buf_size - (ptr - formatted_entry);
+	snprintf(ptr, remaining, "|%"PRIu64":%hhu:%hhu", (uint64_t)hours, minutes, seconds);
 	if (is_json)
 		json_object_add_value_string(stats, "Power On Hour", ptr+1);
 
 	ptr += 16;
 
-	sprintf(ptr, "| %"PRIu64, le64_to_cpu(entry->power_cycle_count));
+	remaining = buf_size - (ptr - formatted_entry);
+	snprintf(ptr, remaining, "| %"PRIu64, le64_to_cpu(entry->power_cycle_count));
 	if (is_json)
 		json_object_add_value_int(stats, "Power cycle count",
 			le32_to_cpu(entry->power_cycle_count));
@@ -2634,7 +2636,8 @@ static int display_fw_activate_entry(int entry_count, struct fw_activation_histo
 	/* firmware details */
 	memset(buffer, 0, sizeof(buffer));
 	memcpy(buffer, entry->previous_fw, sizeof(entry->previous_fw));
-	sprintf(ptr, "| %s", buffer);
+	remaining = buf_size - (ptr - formatted_entry);
+	snprintf(ptr, remaining, "| %s", buffer);
 	if (is_json)
 		json_object_add_value_string(stats, "Previous firmware", buffer);
 
@@ -2642,23 +2645,26 @@ static int display_fw_activate_entry(int entry_count, struct fw_activation_histo
 
 	memset(buffer, 0, sizeof(buffer));
 	memcpy(buffer, entry->activated_fw, sizeof(entry->activated_fw));
-	sprintf(ptr, "| %s", buffer);
+	remaining = buf_size - (ptr - formatted_entry);
+	snprintf(ptr, remaining, "| %s", buffer);
 	if (is_json)
 		json_object_add_value_string(stats, "New FW activated", buffer);
 
 	ptr += 12;
 
 	/* firmware slot and commit action*/
-	sprintf(ptr, "| %d", entry->slot);
+	remaining = buf_size - (ptr - formatted_entry);
+	snprintf(ptr, remaining, "| %d", entry->slot);
 	if (is_json)
 		json_object_add_value_int(stats, "Slot number", entry->slot);
 
 	ptr += 9;
 
+	remaining = buf_size - (ptr - formatted_entry);
 	if (entry->commit_action_type <= 3)
-		sprintf(ptr, "| %s", ca[entry->commit_action_type]);
+		snprintf(ptr, remaining, "| %s", ca[entry->commit_action_type]);
 	else
-		sprintf(ptr, "| xxxb");
+		snprintf(ptr, remaining, "| xxxb");
 
 	if (is_json)
 		json_object_add_value_string(stats, "Commit Action Type", ptr+2);
@@ -2666,10 +2672,11 @@ static int display_fw_activate_entry(int entry_count, struct fw_activation_histo
 	ptr += 9;
 
 	/* result */
+	remaining = buf_size - (ptr - formatted_entry);
 	if (entry->result)
-		sprintf(ptr, "| Fail #%d", entry->result);
+		snprintf(ptr, remaining, "| Fail #%d", entry->result);
 	else
-		sprintf(ptr, "| pass");
+		snprintf(ptr, remaining, "| pass");
 
 	if (is_json) {
 		json_object_add_value_string(stats, "Result", ptr+2);
@@ -2771,10 +2778,10 @@ static int micron_fw_activation_history(int argc, char **argv, struct command *a
 			json_object_add_value_array(fw_act, "Entry", entry);
 			for (count = 0; count < table->num_entries; count++) {
 				element = json_create_object();
-				if (display_fw_activate_entry(count, &table->entries[count],
-					formatted_output, element) == 0) {
+				if (!display_fw_activate_entry(count, &table->entries[count],
+						formatted_output, sizeof(formatted_output),
+						element))
 					json_array_add_value_object(entry, element);
-				}
 			}
 			json_print_object(root, NULL);
 			printf("\n");
@@ -2784,7 +2791,8 @@ static int micron_fw_activation_history(int argc, char **argv, struct command *a
 		for (count = 0; count < table->num_entries; count++) {
 			memset(formatted_output, '\0', 100);
 			if (!display_fw_activate_entry(count, &table->entries[count],
-						formatted_output, NULL))
+						formatted_output,
+						sizeof(formatted_output), NULL))
 				printf("%s\n", formatted_output);
 		}
 	}
@@ -3467,7 +3475,7 @@ static int GetOcpEnhancedTelemetryLog(struct libnvme_transport_handle *hdl, cons
 			char strBuffer[256] = { 0 };
 
 			if (nLogID == NVME_LOG_LID_TELEMETRY_HOST) {
-				sprintf(strBuffer, "%s", "nvme_host_telemetry_log.bin");
+				snprintf(strBuffer, sizeof(strBuffer), "%s", "nvme_host_telemetry_log.bin");
 				if (bTeleheaderWrite) {
 					WriteData(pTelemetryDataHeader, 512, dir,
 						"nvme_host_telemetry_log.bin", strBuffer);
@@ -3476,7 +3484,7 @@ static int GetOcpEnhancedTelemetryLog(struct libnvme_transport_handle *hdl, cons
 				WriteData(pTelemetryBuffer, nallocSize, dir,
 					"nvme_host_telemetry_log.bin", strBuffer);
 			} else if (nLogID == NVME_LOG_LID_TELEMETRY_CTRL) {
-				sprintf(strBuffer, "%s", "nvme_controller_telemetry_log.bin");
+				snprintf(strBuffer, sizeof(strBuffer), "%s", "nvme_controller_telemetry_log.bin");
 				if (bTeleheaderWrite) {
 					WriteData(pTelemetryDataHeader, 512, dir,
 						"nvme_controller_telemetry_log.bin", strBuffer);
@@ -3659,7 +3667,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 		err = micron_telemetry_log(hdl, cfg.log,  &buffer, &logSize,
 				   cfg.data_area);
 		if (!err && logSize > 0 && buffer) {
-			sprintf(msg, "telemetry log: 0x%X", cfg.log);
+			snprintf(msg, sizeof(msg), "telemetry log: 0x%X", cfg.log);
 			WriteData(buffer, logSize, dir, cfg.package, msg);
 			libnvme_free(buffer);
 		}
@@ -3670,8 +3678,14 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 
 	strncpy(safe_sn, ctrl.sn, sizeof(safe_sn) - 1);
 	sanitize_serial(safe_sn, sizeof(safe_sn));
-	SetupDebugDataDirectories(safe_sn, cfg.package,
-			strMainDirName, strOSDirName, strCtrlDirName);
+	err = SetupDebugDataDirectories(safe_sn, cfg.package,
+			strMainDirName, sizeof(strMainDirName),
+			strOSDirName, sizeof(strOSDirName),
+			strCtrlDirName, sizeof(strCtrlDirName));
+	if (err) {
+		fprintf(stderr, "Failed to create debug data directories\n");
+		goto out;
+	}
 
 	GetTimestampInfo(strOSDirName);
 	GetCtrlIDDInfo(strCtrlDirName, &ctrl);
@@ -3831,7 +3845,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 					  dataBuffer, bSize);
 			maxSize = aVendorLogs[i].nMaxSize - bSize;
 			while (!err && maxSize > 0 && ((unsigned int *)dataBuffer)[0] != 0xdeadbeef) {
-				sprintf(msg, "log 0x%x", aVendorLogs[i].ucLogPage);
+				snprintf(msg, sizeof(msg), "log 0x%x", aVendorLogs[i].ucLogPage);
 				WriteData(dataBuffer, bSize, strCtrlDirName, aVendorLogs[i].strFileName, msg);
 				err = nvme_get_log_simple(hdl,
 					  aVendorLogs[i].ucLogPage,
@@ -3844,7 +3858,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 		}
 
 		if (!err && dataBuffer && ((unsigned int *)dataBuffer)[0] != 0xdeadbeef) {
-			sprintf(msg, "log 0x%x", aVendorLogs[i].ucLogPage);
+			snprintf(msg, sizeof(msg), "log 0x%x", aVendorLogs[i].ucLogPage);
 			WriteData(dataBuffer, bSize, strCtrlDirName, aVendorLogs[i].strFileName, msg);
 		}
 

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -633,8 +633,10 @@ static int GetCommonLogPage(struct libnvme_transport_handle *hdl, unsigned char 
 	int err = 0;
 
 	pTempPtr = (unsigned char *)libnvme_alloc(nBuffSize);
-	if (!pTempPtr)
+	if (!pTempPtr) {
+		err = -ENOMEM;
 		goto exit_status;
+	}
 	err = nvme_get_log_simple(hdl, ucLogID, pTempPtr, nBuffSize);
 	*pBuffer = pTempPtr;
 
@@ -2061,8 +2063,15 @@ static void GetDriveInfo(const char *strOSDirName, int nFD,
 	char model[41] = { 0 };
 	char serial[21] = { 0 };
 	char fwrev[9] = { 0 };
-	__cleanup_free char *strPDir = strdup(strOSDirName);
-	char *strDest = dirname(strPDir);
+	__cleanup_free char *strPDir = NULL;
+	char *strDest = NULL;
+
+	strPDir = strdup(strOSDirName);
+	if (!strPDir) {
+		printf("Failed to allocate memory for directory name\n");
+		return;
+	}
+	strDest = dirname(strPDir);
 
 	if (asprintf(&tempFile, "%s/%s", strDest, "drive-info.txt") < 0) {
 		printf("Failed to allocate memory for temp file name\n");
@@ -2110,8 +2119,8 @@ static void GetTimestampInfo(const char *strOSDirName)
 	size_t num;
 	size_t remaining;
 	int n;
-	char *strPDir;
-	char *strDest;
+	__cleanup_free char *strPDir = NULL;
+	char *strDest = NULL;
 
 	t = time(NULL);
 	tmp = localtime(&t);
@@ -2126,9 +2135,10 @@ static void GetTimestampInfo(const char *strOSDirName)
 		num += (size_t)n < remaining ? (size_t)n : remaining - 1;
 	if (num) {
 		strPDir = strdup(strOSDirName);
+		if (!strPDir)
+			return;
 		strDest = dirname(strPDir);
 		WriteData(outstr, num, strDest, "timestamp_info.txt", "timestamp");
-		free(strPDir);
 	}
 }
 
@@ -3741,14 +3751,18 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 					sizeof(struct MICRON_WORKLOAD_LOG_HDR), 0);
 			if (err == 0) {
 				bSize =  stWllHdr.uiLength;
-				if (bSize > 0) {
-					dataBuffer = (unsigned char *)libnvme_alloc(bSize);
-					if (!dataBuffer) {
-						printf(
-							" Memory allocation failed for log id : 0x%02X\n"
-							, aVendorLogs[i].ucLogPage);
-						continue;
-					}
+				if (bSize < (int)sizeof(struct MICRON_WORKLOAD_LOG_HDR)) {
+					printf("Invalid log size for log id : 0x%02X\n",
+						aVendorLogs[i].ucLogPage);
+					err = -1;
+					break;
+				}
+				dataBuffer = (unsigned char *)libnvme_alloc(bSize);
+				if (!dataBuffer) {
+					printf(
+						" Memory allocation failed for log id : 0x%02X\n"
+						, aVendorLogs[i].ucLogPage);
+					continue;
 				}
 				memcpy(dataBuffer, &stWllHdr,
 					sizeof(struct MICRON_WORKLOAD_LOG_HDR));

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -76,7 +76,7 @@ int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 	char *res;
 
 	devicename = micron_get_ns_name(hdl);
-	if (!strstr(devicename, "nvme")) {
+	if (!devicename || !strstr(devicename, "nvme")) {
 		printf("Invalid device specified!\n");
 		return -EINVAL;
 	}
@@ -97,8 +97,7 @@ int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 		strTempFile2[sLinkSize] = '\0';
 	}
 	businfo = strrchr(strTempFile2, '/');
-	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device,
-		   &function) != 4)
+	if (!businfo || sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
 		domain = bus = device = function = 0;
 	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+10.L", bus, device,
 		function);
@@ -148,7 +147,7 @@ int micron_clear_pcie_aer_correctable_errors(
 	char *res;
 
 	devicename = micron_get_ns_name(hdl);
-	if (!strstr(devicename, "nvme")) {
+	if (!devicename || !strstr(devicename, "nvme")) {
 		printf("Invalid device specified!\n");
 		return -EINVAL;
 	}
@@ -176,7 +175,7 @@ int micron_clear_pcie_aer_correctable_errors(
 		strTempFile2[sLinkSize] = '\0';
 	}
 	businfo = strrchr(strTempFile2, '/');
-	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
+	if (!businfo || sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
 		domain = bus = device = function = 0;
 	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+0x10.L=0xffffffff", bus,
 			device, function);

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -29,7 +29,7 @@ static int ReadSysFile(const char *file, unsigned short *id)
 		return fd;
 	}
 
-	ret = read(fd, idstr, sizeof(idstr));
+	ret = read(fd, idstr, sizeof(idstr) - 1);
 	close(fd);
 	if (ret < 0)
 		perror("read");
@@ -80,27 +80,27 @@ int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 		printf("Invalid device specified!\n");
 		return -EINVAL;
 	}
-	sprintf(strTempFile, "/sys/block/%s/device", devicename);
-	memset(strTempFile2, 0x0, 1024);
-	sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+	snprintf(strTempFile, sizeof(strTempFile), "/sys/block/%s/device", devicename);
+	sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
 	if (sLinkSize < 0) {
 		printf("Failed to read device\n");
 		return -errno;
 	}
+	strTempFile2[sLinkSize] = '\0';
 	if (strstr(strTempFile2, "../../nvme")) {
-		sprintf(strTempFile, "/sys/block/%s/device/device", devicename);
-		memset(strTempFile2, 0x0, 1024);
-		sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+		snprintf(strTempFile, sizeof(strTempFile), "/sys/block/%s/device/device", devicename);
+		sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
 		if (sLinkSize < 0) {
 			printf("Failed to read device\n");
 			return -errno;
 		}
+		strTempFile2[sLinkSize] = '\0';
 	}
 	businfo = strrchr(strTempFile2, '/');
 	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device,
 		   &function) != 4)
 		domain = bus = device = function = 0;
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+10.L", bus, device,
+	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+10.L", bus, device,
 		function);
 	fp = popen(cmdbuf, "r");
 	if (!fp) {
@@ -116,7 +116,7 @@ int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 	pclose(fp);
 	*correctable_errors = (__u32)strtol(buf, NULL, 16);
 
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x4.L", bus, device,
+	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+0x4.L", bus, device,
 		function);
 	fp = popen(cmdbuf, "r");
 	if (!fp) {
@@ -157,28 +157,28 @@ int micron_clear_pcie_aer_correctable_errors(
 	if (err < 0)
 		return err;
 
-	memset(strTempFile2, 0x0, 1024);
-	sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+	sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
 	if (sLinkSize < 0) {
 		printf("Failed to read device\n");
 		return -errno;
 	}
+	strTempFile2[sLinkSize] = '\0';
 	if (strstr(strTempFile2, "../../nvme")) {
 		err = snprintf(strTempFile, sizeof(strTempFile),
 					   "/sys/block/%s/device/device", devicename);
 		if (err < 0)
 			return err;
-		memset(strTempFile2, 0x0, 1024);
-		sLinkSize = readlink(strTempFile, strTempFile2, 1023);
+		sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
 		if (sLinkSize < 0) {
 			printf("Failed to read device\n");
 			return -errno;
 		}
+		strTempFile2[sLinkSize] = '\0';
 	}
 	businfo = strrchr(strTempFile2, '/');
 	if (sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
 		domain = bus = device = function = 0;
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x10.L=0xffffffff", bus,
+	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+0x10.L=0xffffffff", bus,
 			device, function);
 	fp = popen(cmdbuf, "r");
 	if (!fp) {
@@ -187,7 +187,7 @@ int micron_clear_pcie_aer_correctable_errors(
 	}
 	pclose(fp);
 
-	sprintf(cmdbuf, "setpci -s %x:%x.%x ECAP_AER+0x10.L", bus, device,
+	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+0x10.L", bus, device,
 			function);
 	fp = popen(cmdbuf, "r");
 	if (!fp) {


### PR DESCRIPTION
Fixes security vulnerabilityies in the Micron plugin.
- Fixes buffer overflow vulnerabilities due to sprintf, read, and readlink handling.
- Fixes NULL pointer dereference vulnerabilities.
- Makes temporary data directories write-protected.