### PR TITLE
wdc-nvme: validate PCI ID lookup in wdc_log_page_directory()

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10864,6 +10864,9 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 
 
 		ret = wdc_get_pci_ids(ctx, hdl, &device_id, &read_vendor_id);
+		if (ret) 
+			return ret;
+		
 		log_id = wdc_is_zn350(device_id) ?
 			WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_ID_C8 :
 			WDC_NVME_GET_DEV_MGMNT_LOG_PAGE_ID;


### PR DESCRIPTION
wdc_get_pci_ids() returns an error if it fails to retieve the PCI device ID. In that case, device_id remains uninitialized, and using it later in wdc_log_page_directory() results in undefined behavior.

Check the return value from wdc_get_pci_ids() and bail out early if the PCI ID lookup fails.

This issue was reported by the clang static analyzer.

 Signed-off-by: Sarah Ahmed <sarah.ahmed@ibm.com>