### PR TITLE
Fix parallel installation of libnvme v1 and v3

### DIFF
--- a/libnvme/doc/meson.build
+++ b/libnvme/doc/meson.build
@@ -73,7 +73,7 @@ if want_docs != 'false'
                     doc_tgts += custom_target(
                         page.underscorify() + '_man',
                         input: apif,
-                        output: page + '.2',
+                        output: page + '-' + libnvme_api_name + '.2',
                         capture: true,
                         command: [
                             kernel_doc,
@@ -99,7 +99,7 @@ if want_docs != 'false'
     endif
 
     if want_docs == 'all' or want_docs == 'html'
-        htmldir = join_paths(get_option('htmldir'), 'nvme')
+        htmldir = join_paths(get_option('htmldir'), libnvme_api_name, 'nvme')
         sphinx_build = find_program('sphinx-build-3', 'sphinx-build')
         if sphinx_build.found() and want_docs_build
             doc_tgts += custom_target(

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -160,7 +160,7 @@ libnvme_header = configure_file(
     output: 'libnvme.h',
     configuration: libconf,
     install: true,
-    install_dir: prefixdir / get_option('includedir')
+    install_dir: prefixdir / get_option('includedir') / libnvme_api_name
 )
 
 libnvme = library(
@@ -180,6 +180,7 @@ pkg.generate(libnvme,
     version: libnvme_so_version,
     description: 'Manage "libnvme" subsystem devices (Non-volatile Memory Express)',
     url: 'https://github.com/linux-nvme/nvme-cli/',
+    subdirs: libnvme_api_name,
 )
 
 libnvme_dep = declare_dependency(
@@ -207,7 +208,7 @@ libnvme_test_dep = declare_dependency(
 mode = 'rw-r--r--'
 install_headers(
     headers,
-    subdir: 'nvme',
+    subdir: libnvme_api_name / 'nvme',
     install_mode: mode,
 )
 if want_mi
@@ -215,6 +216,7 @@ if want_mi
         [
            'libnvme-mi.h',
         ],
+        subdir: libnvme_api_name,
         install_mode: mode,
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -496,7 +496,7 @@ add_project_arguments(
 # which only supports relative paths, while the libnvme include path is
 # absolute.
 if not want_libnvme and not std_prefix
-    libnvme_hdr_location = prefixdir / get_option('includedir')
+    libnvme_hdr_location = prefixdir / get_option('includedir') / libnvme_api_name
     message(
         'Using non-standard libnvme headers location: ',
         libnvme_hdr_location


### PR DESCRIPTION
Parallel installation fails because the headers and man pages collide:

```
  found conflict of libnvme-devel-1.16.2-2.1.x86_64 with libnvme3-devel-3.0.b.1-1.1.x86_64
  /usr/include/libnvme-mi.h
  /usr/include/libnvme.h
  /usr/share/man/man2/nbft_control.2.gz
  /usr/share/man/man2/nbft_control_flags.2.gz
  /usr/share/man/man2/nbft_desc_type.2.gz
  /usr/share/man/man2/nbft_discovery.2.gz
  /usr/share/man/man2/nbft_discovery_flags.2.gz
  /usr/share/man/man2/nbft_header.2.gz
  /usr/share/man/man2/nbft_heap_obj.2.gz
  /usr/share/man/man2/nbft_hfi.2.gz
```

Install the headers into a versioned directly and also add a postfix to the man pages, which seems to be the distro choice to handle the versioning. 

https://en.opensuse.org/openSUSE:Packaging_conflicts