### PR TITLE
nvme: Open files using nvme_open_rawdata to fix Windows issues

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -171,7 +171,7 @@ static int read_file(const char *file, unsigned char **data, unsigned int *len)
 
 	if (file == NULL) return err;
 
-	if ((fd = open(file, O_RDONLY)) < 0) {
+	if ((fd = nvme_open_rawdata(file, O_RDONLY)) < 0) {
 		fprintf(stderr, "Failed to open %s: %s\n", file, libnvme_strerror(errno));
 		return fd;
 	}

--- a/nvme.c
+++ b/nvme.c
@@ -2196,7 +2196,7 @@ static int io_mgmt_send(int argc, char **argv, struct command *acmd, struct plug
 	}
 
 	if (cfg.file) {
-		dfd = open(cfg.file, O_RDONLY);
+		dfd = nvme_open_rawdata(cfg.file, O_RDONLY);
 		if (dfd < 0) {
 			nvme_show_perror(cfg.file);
 			return -errno;
@@ -5221,7 +5221,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 		return err;
 	}
 
-	fw_fd = open(cfg.fw, O_RDONLY);
+	fw_fd = nvme_open_rawdata(cfg.fw, O_RDONLY);
 	cfg.offset <<= 2;
 	if (fw_fd < 0) {
 		nvme_show_error("Failed to open firmware file %s: %s", cfg.fw, libnvme_strerror(errno));
@@ -7184,7 +7184,7 @@ static int set_feature(int argc, char **argv, struct command *acmd, struct plugi
 			memcpy(buf, &cfg.value, NVME_FEAT_TIMESTAMP_DATA_SIZE);
 		} else {
 			if (strlen(cfg.file))
-				ffd = open(cfg.file, O_RDONLY);
+				ffd = nvme_open_rawdata(cfg.file, O_RDONLY);
 
 			if (ffd < 0) {
 				nvme_show_error("Failed to open file %s: %s",
@@ -7296,7 +7296,7 @@ static int sec_send(int argc, char **argv, struct command *acmd, struct plugin *
 		sec_fd = STDIN_FILENO;
 		sec_size = cfg.tl;
 	} else {
-		sec_fd = open(cfg.file, O_RDONLY);
+		sec_fd = nvme_open_rawdata(cfg.file, O_RDONLY);
 		if (sec_fd < 0) {
 			nvme_show_error("Failed to open %s: %s", cfg.file, libnvme_strerror(errno));
 			return -EINVAL;
@@ -7433,7 +7433,7 @@ static int dir_send(int argc, char **argv, struct command *acmd, struct plugin *
 
 	if (buf) {
 		if (strlen(cfg.file)) {
-			ffd = open(cfg.file, O_RDONLY);
+			ffd = nvme_open_rawdata(cfg.file, O_RDONLY);
 			if (ffd <= 0) {
 				nvme_show_error("Failed to open file %s: %s",
 						cfg.file, libnvme_strerror(errno));


### PR DESCRIPTION
Reading files that may have raw binary data on Windows without using the O_BINARY flag when opening can cause some bytes to be misinterpreted or mishandled.  This can lead to bad data or truncated reads. Use nvme_open_rawdata to ensure that O_BINARY is added if supported.

Fixes firmware file reading issues found during testing on Windows, as well as other potential issues on Windows.