### PR TITLE
ioctl-win: Implement reset_ctrl_device using a PnP-level reset.

### DIFF
--- a/libnvme/src/nvme/ctrl-map.c
+++ b/libnvme/src/nvme/ctrl-map.c
@@ -408,8 +408,10 @@ static int get_adapter_bus_type(libnvme_fd_t h, STORAGE_BUS_TYPE *out_bus_type)
  *   -ENOMEM  allocation failure
  *   -ENOENT  no more items (enumeration complete)
  */
-static int get_device_interface_path(HDEVINFO hdev, DWORD index,
-		WCHAR **device_interface_path)
+static int get_device_interface_path(HDEVINFO hdev,
+		DWORD index,
+		WCHAR **device_interface_path,
+		SP_DEVINFO_DATA *devinfo_data_out)
 {
 	SP_DEVICE_INTERFACE_DATA if_data = {
 		.cbSize = sizeof(if_data),
@@ -450,6 +452,9 @@ static int get_device_interface_path(HDEVINFO hdev, DWORD index,
 	if (!*device_interface_path)
 		return -ENOMEM;
 
+	if (devinfo_data_out)
+		*devinfo_data_out = dev_info_data;
+
 	return 0;
 }
 
@@ -481,7 +486,7 @@ int libnvme_ctrl_map_init(struct libnvme_global_ctx *ctx)
 		h = INVALID_HANDLE_VALUE;
 		ctrl_path = NULL;
 
-		ret = get_device_interface_path(hdev, index, &ctrl_path);
+		ret = get_device_interface_path(hdev, index, &ctrl_path, NULL);
 		if (ret == -ENOENT)
 			break;
 		if (ret == -ENOMEM)
@@ -983,4 +988,44 @@ char *libnvme_ctrl_map_entry_get_firmware(const struct ctrl_map_entry *entry)
 	if (!entry)
 		return NULL;
 	return copy_and_rtrim(entry->id_ctrl.fr, sizeof(entry->id_ctrl.fr));
+}
+
+HDEVINFO libnvme_ctrl_map_entry_get_devinfo(
+	const struct ctrl_map_entry *entry,
+	SP_DEVINFO_DATA *dev_info_data)
+{
+	HDEVINFO hdev;
+	DWORD index;
+	PWSTR ctrl_path = NULL;
+
+	if (!dev_info_data || !entry || !entry->ctrl_path)
+		return INVALID_HANDLE_VALUE;
+
+	dev_info_data->cbSize = sizeof(*dev_info_data);
+
+	hdev = SetupDiGetClassDevsW(&GUID_DEVINTERFACE_STORAGEPORT, NULL, NULL,
+				    DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+	if (hdev == INVALID_HANDLE_VALUE)
+		return INVALID_HANDLE_VALUE;
+
+	for (index = 0;; index++) {
+		get_device_interface_path(hdev, index, &ctrl_path,
+			dev_info_data);
+
+		if (_wcsicmp(ctrl_path, entry->ctrl_path) == 0) {
+			free(ctrl_path);
+			return hdev;
+		}
+		free(ctrl_path);
+		ctrl_path = NULL;
+	}
+
+	SetupDiDestroyDeviceInfoList(hdev);
+	return INVALID_HANDLE_VALUE;
+}
+
+void libnvme_ctrl_map_entry_free_devinfo(HDEVINFO hdev)
+{
+	if (hdev != INVALID_HANDLE_VALUE)
+		SetupDiDestroyDeviceInfoList(hdev);
 }

--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -8,13 +8,17 @@
  * Windows-specific implementations of ioctl-based functions.
  */
 
+#include <winsock2.h>
 #include <windows.h>
 #include <winioctl.h>
 #include <errno.h>
 #include <ntddscsi.h>
+#include <setupapi.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include <ccan/minmax/minmax.h>
 
@@ -23,6 +27,7 @@
 #include "cleanup.h"
 #include "ioctl.h"
 #include "private.h"
+#include "private-ctrl-map.h"
 #include "types.h"
 
 #include "compiler-attributes.h"
@@ -131,11 +136,70 @@ __libnvme_public int libnvme_reset_subsystem(struct libnvme_transport_handle *hd
 	return -errno;
 }
 
+static int reset_ctrl_device(HDEVINFO hdev, SP_DEVINFO_DATA *devinfo)
+{
+	/*
+	 * Windows doesn't have a direct equivalent to resetting an NVMe
+	 * controller, but we can cause a PnP-level reset by disabling, then
+	 * re-enabling the device.
+	 */
+	SP_PROPCHANGE_PARAMS params = {
+		.ClassInstallHeader = {
+			.cbSize = sizeof(SP_CLASSINSTALL_HEADER),
+			.InstallFunction = DIF_PROPERTYCHANGE
+		},
+		.StateChange = DICS_DISABLE,
+		.Scope = DICS_FLAG_CONFIGSPECIFIC,
+		.HwProfile = 0
+	};
+
+	if (!SetupDiSetClassInstallParamsW(hdev, devinfo,
+			&params.ClassInstallHeader, sizeof(params))) {
+		errno = get_errno_from_error(GetLastError());
+		return -errno;
+	}
+	if (!SetupDiCallClassInstaller(DIF_PROPERTYCHANGE, hdev, devinfo)) {
+		errno = get_errno_from_error(GetLastError());
+		return -errno;
+	}
+
+	params.StateChange = DICS_ENABLE;
+	if (!SetupDiSetClassInstallParamsW(hdev, devinfo,
+			&params.ClassInstallHeader, sizeof(params))) {
+		errno = get_errno_from_error(GetLastError());
+		return -errno;
+	}
+	if (!SetupDiCallClassInstaller(DIF_PROPERTYCHANGE, hdev, devinfo)) {
+		errno = get_errno_from_error(GetLastError());
+		return -errno;
+	}
+
+	return 0;
+}
+
 __libnvme_public int libnvme_reset_ctrl(struct libnvme_transport_handle *hdl)
 {
-	(void)hdl;
-	errno = ENOTSUP;
-	return -errno;
+	const struct ctrl_map_entry *entry;
+	SP_DEVINFO_DATA dev_info_data = { 0 };
+	HDEVINFO hdev;
+	int ret;
+
+	if (!libnvme_transport_handle_is_ctrl(hdl))
+		return -EINVAL;
+
+	entry = libnvme_ctrl_map_lookup(hdl->ctx,
+					libnvme_transport_handle_get_name(hdl));
+	if (!entry)
+		return -ENODEV;
+
+	hdev = libnvme_ctrl_map_entry_get_devinfo(entry, &dev_info_data);
+	if (hdev == INVALID_HANDLE_VALUE)
+		return -EIO;
+
+	ret = reset_ctrl_device(hdev, &dev_info_data);
+	libnvme_ctrl_map_entry_free_devinfo(hdev);
+
+	return ret;
 }
 
 __libnvme_public int libnvme_rescan_ns(struct libnvme_transport_handle *hdl)

--- a/libnvme/src/nvme/private-ctrl-map.h
+++ b/libnvme/src/nvme/private-ctrl-map.h
@@ -9,6 +9,9 @@
 
 #if defined(_WIN32)
 
+#include <winsock2.h>
+#include <windows.h>
+#include <setupapi.h>
 #include "nvme-types.h"
 
 struct ctrl_map_entry;
@@ -194,5 +197,31 @@ char *libnvme_ctrl_map_entry_get_model(const struct ctrl_map_entry *entry);
  * Return: UTF-8 firmware revision string, or NULL if unavailable
  */
 char *libnvme_ctrl_map_entry_get_firmware(const struct ctrl_map_entry *entry);
+
+/**
+ * libnvme_ctrl_map_entry_get_devinfo() - Look up the SP_DEVINFO_DATA for a
+ * controller entry
+ * @entry: controller map entry whose interface path is matched
+ * @dev_info_data: output SP_DEVINFO_DATA populated on success
+ *
+ * Enumerates all GUID_DEVINTERFACE_STORAGEPORT interfaces and populates
+ * @dev_info_data for the interface whose device path matches
+ * @entry->ctrl_path (case-insensitive).
+ *
+ * Return: a valid HDEVINFO handle on success, which the caller must release
+ * with libnvme_ctrl_map_entry_free_devinfo(); INVALID_HANDLE_VALUE on
+ * failure.
+ */
+HDEVINFO libnvme_ctrl_map_entry_get_devinfo(
+		const struct ctrl_map_entry *entry,
+		SP_DEVINFO_DATA *dev_info_data);
+
+/**
+ * libnvme_ctrl_map_entry_free_devinfo() - Release a device information set
+ * @hdev: Device information set handle returned by
+ *        libnvme_ctrl_map_entry_get_devinfo().  Safe to call with
+ *        INVALID_HANDLE_VALUE (no-op).
+ */
+void libnvme_ctrl_map_entry_free_devinfo(HDEVINFO hdev);
 
 #endif /* defined(_WIN32) */


### PR DESCRIPTION
Windows doesn't have an IOCTL for resetting an NVMe controller, but a plug-and-play-level reset can be used to accomplish an equivalent reset of the controller.  Implements PnP-level reset for reset_ctrl_device on Windows and adds helper methods to ctrl-map.