### PR TITLE
libnvme/registry: substitute RUNDIR into the registry udev rule

### DIFF
--- a/libnvme/meson.build
+++ b/libnvme/meson.build
@@ -42,9 +42,11 @@ if want_libnvme
     endif
 
     if want_fabrics
-        install_data(
-            'sysfiles/udev/rules.d/70-nvmf-registry.rules',
-            install_dir: udevrulesdir,
+        configure_file(
+            input:         'sysfiles/udev/rules.d/70-nvmf-registry.rules.in',
+            output:        '70-nvmf-registry.rules',
+            configuration: substs,
+            install_dir:   udevrulesdir,
         )
     endif
 

--- a/libnvme/sysfiles/udev/rules.d/70-nvmf-registry.rules.in
+++ b/libnvme/sysfiles/udev/rules.d/70-nvmf-registry.rules.in
@@ -22,4 +22,4 @@
 # $$ yields a literal '$' for the shell; $env{SEQNUM} is the REMOVE event's
 # sequence number, substituted by udev.
 ACTION=="remove", SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", \
-    RUN+="/bin/sh -c '[ -e /dev/%k ] || [ $env{SEQNUM} -le $$(cat /run/nvme/registry/%k/seqnum 2>/dev/null || echo 0) ] || rm -rf /run/nvme/registry/%k'"
+    RUN+="/bin/sh -c '[ -e /dev/%k ] || [ $env{SEQNUM} -le $$(cat @RUNDIR@/nvme/registry/%k/seqnum 2>/dev/null || echo 0) ] || rm -rf @RUNDIR@/nvme/registry/%k'"


### PR DESCRIPTION
Follow-up to #3523 (the round-6 `RUNDIR` change to `REGISTRY_DIR_DEFAULT`). The library now derives the registry path from the build's `rundir` setting (`RUNDIR "/nvme/registry"`), but the udev cleanup rule still hardcoded `/run/nvme/registry` — the rule file was installed as static text, so a build that relocates `rundir` left udev cleaning a directory the library no longer writes.

Fix: the rule becomes a `70-nvmf-registry.rules.in` template with `@RUNDIR@` in the `RUN+=` line, generated via `configure_file(configuration: substs)` — the same pattern `libnvme.spec.in` already uses two stanzas above. Both sides of the registry (library and rule) now derive the path from the single meson setting.

No behavior change for a default build: the generated rule is identical modulo the prefix the build already applies everywhere else.