### PR TITLE
plugins/exclusion: operate on the default list when --name is omitted

### DIFF
--- a/Documentation/nvme-exclusion-add.txt
+++ b/Documentation/nvme-exclusion-add.txt
@@ -8,7 +8,7 @@ nvme-exclusion-add - Add an entry to an NVMe-oF exclusion list
 SYNOPSIS
 --------
 [verse]
-'nvme' [<global-options>] 'exclusion add' --name=<NAME> | -N <NAME>
+'nvme' [<global-options>] 'exclusion add' [--name=<NAME> | -N <NAME>]
 			--entry=<ENTRY> | -e <ENTRY>
 
 DESCRIPTION
@@ -32,7 +32,8 @@ OPTIONS
 -------
 -N <NAME>::
 --name=<NAME>::
-	Name of the exclusion list to add to.
+	Name of the exclusion list to add to.  Omit to add to the
+	default list (/etc/nvme/exclusions.conf).
 
 -e <ENTRY>::
 --entry=<ENTRY>::

--- a/Documentation/nvme-exclusion-create.txt
+++ b/Documentation/nvme-exclusion-create.txt
@@ -8,7 +8,7 @@ nvme-exclusion-create - Create a new NVMe-oF exclusion list
 SYNOPSIS
 --------
 [verse]
-'nvme' [<global-options>] 'exclusion create' --name=<NAME> | -N <NAME>
+'nvme' [<global-options>] 'exclusion create' [--name=<NAME> | -N <NAME>]
 
 DESCRIPTION
 -----------
@@ -24,7 +24,8 @@ OPTIONS
 -------
 -N <NAME>::
 --name=<NAME>::
-	Name of the exclusion list to create.
+	Name of the exclusion list to create.  Omit to create the
+	default list (/etc/nvme/exclusions.conf).
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-exclusion-delete.txt
+++ b/Documentation/nvme-exclusion-delete.txt
@@ -8,7 +8,7 @@ nvme-exclusion-delete - Delete an NVMe-oF exclusion list
 SYNOPSIS
 --------
 [verse]
-'nvme' [<global-options>] 'exclusion delete' --name=<NAME> | -N <NAME>
+'nvme' [<global-options>] 'exclusion delete' [--name=<NAME> | -N <NAME>]
 
 DESCRIPTION
 -----------
@@ -22,7 +22,8 @@ OPTIONS
 -------
 -N <NAME>::
 --name=<NAME>::
-	Name of the exclusion list to delete.
+	Name of the exclusion list to delete.  Omit to delete the
+	default list (/etc/nvme/exclusions.conf).
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-exclusion-edit.txt
+++ b/Documentation/nvme-exclusion-edit.txt
@@ -8,7 +8,7 @@ nvme-exclusion-edit - Edit an NVMe-oF exclusion list in an editor
 SYNOPSIS
 --------
 [verse]
-'nvme' [<global-options>] 'exclusion edit' --name=<NAME> | -N <NAME>
+'nvme' [<global-options>] 'exclusion edit' [--name=<NAME> | -N <NAME>]
 
 DESCRIPTION
 -----------
@@ -30,7 +30,8 @@ OPTIONS
 -------
 -N <NAME>::
 --name=<NAME>::
-	Name of the exclusion list to edit.
+	Name of the exclusion list to edit.  Omit to edit the default
+	list (/etc/nvme/exclusions.conf).
 
 include::global-options.txt[]
 

--- a/Documentation/nvme-exclusion-remove.txt
+++ b/Documentation/nvme-exclusion-remove.txt
@@ -8,7 +8,7 @@ nvme-exclusion-remove - Remove an entry from an NVMe-oF exclusion list
 SYNOPSIS
 --------
 [verse]
-'nvme' [<global-options>] 'exclusion remove' --name=<NAME> | -N <NAME>
+'nvme' [<global-options>] 'exclusion remove' [--name=<NAME> | -N <NAME>]
 
 DESCRIPTION
 -----------
@@ -23,7 +23,8 @@ OPTIONS
 -------
 -N <NAME>::
 --name=<NAME>::
-	Name of the exclusion list to remove an entry from.
+	Name of the exclusion list to remove an entry from.  Omit to
+	remove from the default list (/etc/nvme/exclusions.conf).
 
 include::global-options.txt[]
 

--- a/libnvme/test/exclusion.c
+++ b/libnvme/test/exclusion.c
@@ -442,6 +442,73 @@ static bool test_section_semantics(struct libnvme_global_ctx *ctx)
 	return pass;
 }
 
+
+/*
+ * The default (main) list: name == NULL addresses exclusions.conf itself.
+ * This is the path "nvme exclusion <cmd>" without --name and
+ * "nvme disconnect --exclude" rely on.
+ */
+static bool test_default_list(struct libnvme_global_ctx *ctx)
+{
+	char path[512];
+	struct libnvmf_tid *tid;
+	struct stat st;
+	bool pass = true;
+	int ret;
+
+	printf("test_default_list:\n");
+
+	/* create(NULL) makes the main file at 0644 with the header. */
+	ret = libnvmf_exclusion_create(ctx, NULL);
+	snprintf(path, sizeof(path), "%s/exclusions.conf", tmpdir);
+	if (ret || stat(path, &st) < 0 || (st.st_mode & 07777) != 0644) {
+		printf(" - create(NULL) ret=%d [FAIL]\n", ret);
+		pass = false;
+	} else {
+		printf(" - create(NULL) -> exclusions.conf at 0644 [PASS]\n");
+	}
+
+	ret = libnvmf_exclusion_add(ctx, NULL, "transport=tcp;traddr=7.7.7.7");
+	if (ret || entry_count(ctx, NULL) != 1) {
+		printf(" - add(NULL) ret=%d count=%d [FAIL]\n",
+		       ret, entry_count(ctx, NULL));
+		pass = false;
+	} else {
+		printf(" - add(NULL) -> 1 entry in the default list [PASS]\n");
+	}
+
+	tid = libnvmf_tid_from_fields("tcp", "7.7.7.7", "4420", "nqn.x",
+				      NULL, NULL, NULL, NULL);
+	if (libnvmf_exclusion_match(ctx, tid)) {
+		printf(" - default-list entry matches [PASS]\n");
+	} else {
+		printf(" - default-list entry matches [FAIL]\n");
+		pass = false;
+	}
+	libnvmf_tid_free(tid);
+
+	ret = libnvmf_exclusion_remove(ctx, NULL,
+				       "transport=tcp;traddr=7.7.7.7");
+	if (ret || entry_count(ctx, NULL) != 0) {
+		printf(" - remove(NULL) ret=%d count=%d [FAIL]\n",
+		       ret, entry_count(ctx, NULL));
+		pass = false;
+	} else {
+		printf(" - remove(NULL) -> default list empty again [PASS]\n");
+	}
+
+	/* delete(NULL) removes the main file itself. */
+	ret = libnvmf_exclusion_delete(ctx, NULL);
+	if (ret || stat(path, &st) == 0) {
+		printf(" - delete(NULL) ret=%d [FAIL]\n", ret);
+		pass = false;
+	} else {
+		printf(" - delete(NULL) removes exclusions.conf [PASS]\n");
+	}
+
+	return pass;
+}
+
 int main(void)
 {
 	struct libnvme_global_ctx *ctx;
@@ -458,6 +525,7 @@ int main(void)
 	pass &= test_invalid_entry_rejected(ctx);
 	pass &= test_missing_then_create(ctx);
 	pass &= test_section_semantics(ctx);
+	pass &= test_default_list(ctx);
 	pass &= test_null_args(ctx);
 
 	cleanup_tmpdir(ctx);

--- a/plugins/exclusion/exclusion-nvme.c
+++ b/plugins/exclusion/exclusion-nvme.c
@@ -43,7 +43,7 @@ static int excl_create(int argc, char **argv, struct command *acmd,
 		       struct plugin *plugin)
 {
 	const char *desc = "Create a new NVMeoF exclusion list.";
-	const char *name_help = "exclusion list name";
+	const char *name_help = "exclusion list name (omit for the default list)";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int ret;
 
@@ -57,11 +57,6 @@ static int excl_create(int argc, char **argv, struct command *acmd,
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
-
-	if (!cfg.name) {
-		fprintf(stderr, "--name required\n");
-		return -EINVAL;
-	}
 
 	ret = require_root();
 	if (ret)
@@ -80,7 +75,7 @@ static int excl_delete(int argc, char **argv, struct command *acmd,
 		       struct plugin *plugin)
 {
 	const char *desc = "Delete an NVMeoF exclusion list entirely.";
-	const char *name_help = "exclusion list name";
+	const char *name_help = "exclusion list name (omit for the default list)";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int ret;
 
@@ -94,11 +89,6 @@ static int excl_delete(int argc, char **argv, struct command *acmd,
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
-
-	if (!cfg.name) {
-		fprintf(stderr, "--name required\n");
-		return -EINVAL;
-	}
 
 	ret = require_root();
 	if (ret)
@@ -163,7 +153,7 @@ static int excl_add(int argc, char **argv, struct command *acmd,
 		    struct plugin *plugin)
 {
 	const char *desc = "Add an entry to an NVMeoF exclusion list.";
-	const char *name_help = "exclusion list name";
+	const char *name_help = "exclusion list name (omit for the default list)";
 	const char *entry_help = "semicolon-separated key=value entry "
 		"(e.g. \"transport=tcp;traddr=192.168.1.1\")";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
@@ -182,8 +172,8 @@ static int excl_add(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	if (!cfg.name || !cfg.entry) {
-		fprintf(stderr, "--name and --entry required\n");
+	if (!cfg.entry) {
+		fprintf(stderr, "--entry required\n");
 		return -EINVAL;
 	}
 
@@ -192,9 +182,14 @@ static int excl_add(int argc, char **argv, struct command *acmd,
 		return ret;
 
 	ctx = libnvme_create_global_ctx();
+	if (!libnvmf_exclusion_entry_valid(ctx, cfg.entry)) {
+		fprintf(stderr, "invalid entry: %s\n", cfg.entry);
+		return -EINVAL;
+	}
+
 	ret = libnvmf_exclusion_add(ctx, cfg.name, cfg.entry);
 	if (ret == -EINVAL)
-		fprintf(stderr, "invalid entry (unknown key): %s\n", cfg.entry);
+		fprintf(stderr, "invalid list name: %s\n", cfg.name);
 	else if (ret)
 		fprintf(stderr, "add failed: %s\n", libnvme_strerror(-ret));
 	return ret;
@@ -232,7 +227,7 @@ static int excl_remove(int argc, char **argv, struct command *acmd,
 		       struct plugin *plugin)
 {
 	const char *desc = "Interactively remove an entry from an NVMeoF exclusion list.";
-	const char *name_help = "exclusion list name";
+	const char *name_help = "exclusion list name (omit for the default list)";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct entry_collection ec = { 0 };
 	char answer[32];
@@ -249,11 +244,6 @@ static int excl_remove(int argc, char **argv, struct command *acmd,
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
-
-	if (!cfg.name) {
-		fprintf(stderr, "--name required\n");
-		return -EINVAL;
-	}
 
 	ret = require_root();
 	if (ret)
@@ -490,7 +480,7 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 		     struct plugin *plugin)
 {
 	const char *desc = "Interactively edit an NVMeoF exclusion list.";
-	const char *name_help = "exclusion list name";
+	const char *name_help = "exclusion list name (omit for the default list)";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free char *text = NULL;
 	const char *tmpdir;
@@ -508,11 +498,6 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
-
-	if (!cfg.name) {
-		fprintf(stderr, "--name required\n");
-		return -EINVAL;
-	}
 
 	ret = require_root();
 	if (ret)


### PR DESCRIPTION
Bug fix for the `nvme exclusion` CLI (merged in #3523). The library treats a NULL list name as the **default list** (`/etc/nvme/exclusions.conf` — the one `nvme disconnect --exclude` writes to), but every mutating `nvme exclusion` subcommand rejected a missing `--name`, so the CLI could not manage the most commonly written list at all: the only ways to touch it were `disconnect --exclude` or a hand edit.

`--name` is now optional on `create`, `delete`, `add`, `remove` and `edit`; omitting it targets the default list. The help texts and the five man pages say so, and the synopsis shows the option as optional.

Also fixes a misleading error: an invalid list *name* was reported as `invalid entry (unknown key): <entry>`, pointing the user at a perfectly valid entry. The entry is now validated first (`invalid entry: …`) and a remaining `-EINVAL` is attributed to the name (`invalid list name: …`).

New unit tests cover the NULL-name operations end to end (create/add/match/remove/delete on the default list), alongside the existing exclusion suite. All tests green on glibc and musl.
