### PR TITLE
Enable testing support on Windows

### DIFF
--- a/libnvme/test/meson.build
+++ b/libnvme/test/meson.build
@@ -70,25 +70,27 @@ if cxx_available
 
 endif
 
-register = executable(
-    'test-register',
-    ['register.c'],
-    dependencies: [
-        config_dep,
-        ccan_dep,
-        libnvme_dep,
-    ],
-)
+if host_system != 'windows'
+    register = executable(
+        'test-register',
+        ['register.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_dep,
+        ],
+    )
 
-zns = executable(
-    'test-zns',
-    ['zns.c'],
-    dependencies: [
-        config_dep,
-        ccan_dep,
-        libnvme_test_dep,
-    ],
-)
+    zns = executable(
+        'test-zns',
+        ['zns.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_test_dep,
+        ],
+    )
+endif # host_system != 'windows'
 
 if want_mi
     mi = executable(
@@ -259,22 +261,24 @@ if conf.get('NVME_HAVE_NETDB')
     test('libnvme - util', test_util)
 endif
 
-subdir('ioctl')
-if want_fabrics
-    subdir('nbft')
-endif
+if host_system != 'windows'
+    subdir('ioctl')
+    if want_fabrics
+        subdir('nbft')
+    endif
 
-if json_c_dep.found()
-    subdir('sysfs')
-    subdir('config')
-endif
+    if json_c_dep.found()
+        subdir('sysfs')
+        subdir('config')
+    endif
 
-if openssl_dep.found()
-    hkdf_add1 = executable(
-        'hkdf_add1',
-        ['hkdf_add1.c'],
-        dependencies: openssl_dep,
-    )
+    if openssl_dep.found()
+        hkdf_add1 = executable(
+            'hkdf_add1',
+            ['hkdf_add1.c'],
+            dependencies: openssl_dep,
+        )
+    endif
 endif
 
 foreach hdr : [

--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,7 @@ want_mi = get_option('mi').disabled() == false and host_system != 'windows'
 want_top = get_option('top').disabled() == false and host_system != 'windows'
 want_json_c = get_option('json-c').disabled() == false
 want_libkmod = get_option('libkmod').disabled() == false and host_system != 'windows'
-want_tests = get_option('tests') and host_system != 'windows'
+want_tests = get_option('tests')
 want_examples = get_option('examples') and host_system != 'windows'
 want_docs = get_option('docs')
 want_docs_build = get_option('docs-build')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -42,6 +42,9 @@ python_module = import('python')
 
 python = python_module.find_installation('python3')
 
+test_env = environment()
+test_env.prepend('PATH', meson.project_build_root())
+
 foreach t : tests
     t_name = t.split('.')[0]
     test(
@@ -52,7 +55,7 @@ foreach t : tests
             '--start-dir', meson.current_source_dir(),
             t_name,
         ],
-        env: ['PATH=' + meson.project_build_root() + ':/usr/bin:/usr/sbin'],
+        env: test_env,
         timeout: 500,
         protocol: 'tap',
         is_parallel: false,

--- a/tests/nvme_compare_test.py
+++ b/tests/nvme_compare_test.py
@@ -58,6 +58,8 @@ class TestNVMeCompareCmd(TestNVMeIO):
     def setUp(self):
         """ Pre Section for TestNVMeCompareCmd """
         super().setUp()
+        if self.is_windows():
+            self.skipTest("Compare command not supported by Windows")
         if not self.compare_cmd_supported():
             self.skipTest("because: Optional NVM Command 'Compare' (NVMCMPS) not supported")
         self.start_block = 1023

--- a/tests/nvme_dsm_test.py
+++ b/tests/nvme_dsm_test.py
@@ -29,6 +29,8 @@ class TestNVMeDsm(TestNVMe):
     def setUp(self):
         """ Pre Section for TestNVMeDsm """
         super().setUp()
+        if self.is_windows():
+            self.skipTest("Dataset Management command not supported by Windows")
         self.start_block = 0
         self.range = 0
         self.namespace = 1

--- a/tests/nvme_get_features_test.py
+++ b/tests/nvme_get_features_test.py
@@ -52,13 +52,21 @@ class TestNVMeGetMandatoryFeatures(TestNVMe):
         """ Pre Section for TestNVMeGetMandatoryFeatures """
         super().setUp()
         self.setup_log_dir(self.__class__.__name__)
-        self.feature_id_list = ["0x01", "0x02", "0x04", "0x05", "0x07",
-                                "0x08", "0x09", "0x0A", "0x0B"]
-        device = self.ctrl.split('/')[-1]
-        get_vector_list_cmd = "grep " + device + "q /proc/interrupts |" \
-                              " cut -d : -f 1 | tr -d ' ' | tr '\n' ' '"
-        result = self.run_cmd(get_vector_list_cmd)
-        self.vector_list_len = len(result.stdout.strip().split(" "))
+
+        if self.is_windows():
+            # FIDs 5 and 7 are not supported by Windows.
+            self.feature_id_list = ["0x01", "0x02", "0x04",
+                                    "0x08", "0x09", "0x0A", "0x0B"]
+            # Interrupt vector discovery not available on Windows.
+            self.vector_list_len = 1
+        else:
+            self.feature_id_list = ["0x01", "0x02", "0x04", "0x05", "0x07",
+                                    "0x08", "0x09", "0x0A", "0x0B"]
+            device = self.ctrl.split('/')[-1]
+            get_vector_list_cmd = "grep " + device + "q /proc/interrupts |" \
+                                " cut -d : -f 1 | tr -d ' ' | tr '\n' ' '"
+            result = self.run_cmd(get_vector_list_cmd)
+            self.vector_list_len = len(result.stdout.strip().split(" "))
 
     def tearDown(self):
         """ Post Section for TestNVMeGetMandatoryFeatures

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -26,6 +26,7 @@ import json
 import logging
 import mmap
 import os
+import platform
 import re
 import shutil
 import stat
@@ -69,6 +70,9 @@ class TestNVMe(unittest.TestCase):
             - config_file : configuration file.
             - clear_log_dir : default log directory.
     """
+
+    def is_windows(self):
+        return platform.system() == 'Windows'
 
     def setUp(self):
         """ Pre Section for TestNVMe. """
@@ -119,6 +123,7 @@ class TestNVMe(unittest.TestCase):
         """
         self.dps = 0
         self.flbas = 0
+
         (ds, ms) = self.get_lba_format_size()
         ncap = int(self.get_ncap() / (ds+ms))
         self.nsze = ncap
@@ -140,6 +145,9 @@ class TestNVMe(unittest.TestCase):
             - Returns:
                 - None
         """
+        if self.is_windows():
+            return
+
         x1, x2, dev = self.ctrl.split('/')
         cmd = "find /sys/devices -name \\*" + dev + " | grep -i pci"
         err = self.run_cmd(cmd).returncode
@@ -250,9 +258,11 @@ class TestNVMe(unittest.TestCase):
         nvme_reset_cmd = f"{self.nvme_bin} reset {self.ctrl}"
         err = self.run_cmd(nvme_reset_cmd).returncode
         self.assertEqual(err, 0, "ERROR : nvme reset failed")
-        rescan_cmd = "echo 1 > /sys/bus/pci/rescan"
-        result = self.run_cmd(rescan_cmd)
-        self.assertEqual(result.returncode, 0, "ERROR : pci rescan failed")
+
+        if not self.is_windows():   # Rescan occurs during reset on Windows
+            rescan_cmd = "echo 1 > /sys/bus/pci/rescan"
+            result = self.run_cmd(rescan_cmd)
+            self.assertEqual(result.returncode, 0, "ERROR : pci rescan failed")
 
     def get_ctrl_id(self):
         """ Wrapper for extracting the first controller id.
@@ -295,6 +305,9 @@ class TestNVMe(unittest.TestCase):
             bool: True if both Namespace Management and Namespace Attachment
             are supported, False otherwise.
         """
+        if self.is_windows():
+            return False    # Namespace management not supported on Windows
+
         oacs = to_decimal(self.get_id_ctrl_field_value("oacs"))
 
         ns_mgmt_supported = bool(oacs & (1 << 3))

--- a/tests/nvme_verify_test.py
+++ b/tests/nvme_verify_test.py
@@ -37,6 +37,8 @@ class TestNVMeVerify(TestNVMe):
     def setUp(self):
         """ Pre Section for TestNVMeVerify """
         super().setUp()
+        if self.is_windows():
+            self.skipTest("Verify command not supported by Windows")
         if not self.verify_cmd_supported():
             self.skipTest(
                 "because: Optional NVM Command 'Verify' (NVMVFYS) not supported")

--- a/tests/nvme_writeuncor_test.py
+++ b/tests/nvme_writeuncor_test.py
@@ -46,6 +46,8 @@ class TestNVMeUncor(TestNVMeIO):
     def setUp(self):
         """ Constructor TestNVMeUncor """
         super().setUp()
+        if self.is_windows():
+            self.skipTest("Write Uncorrectable command not supported by Windows")
         self.start_block = 1023
         self.setup_log_dir(self.__class__.__name__)
         self.write_file = self.test_log_dir + "/" + self.write_file

--- a/tests/nvme_writezeros_test.py
+++ b/tests/nvme_writezeros_test.py
@@ -50,6 +50,8 @@ class TestNVMeWriteZeros(TestNVMeIO):
     def setUp(self):
         """ Pre Section for TestNVMeWriteZeros """
         super().setUp()
+        if self.is_windows():
+            self.skipTest("Write Zeroes command not supported by Windows")
         self.start_block = 1023
         self.block_count = 0
         self.setup_log_dir(self.__class__.__name__)

--- a/unit/test-uint128.c
+++ b/unit/test-uint128.c
@@ -43,13 +43,14 @@ static struct tostr_test tostr_tests[] = {
 		U128(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff),
 		"340282366920938463463374607431768211455"
 	},
-	{ "fr_FR.utf-8", U128(0, 0, 0, 1000), "1\u202f000" },
+	{ "fr_FR.utf-8", U128(0, 0, 0, 1000), "1%s000" },
 };
 
 void tostr_test(struct tostr_test *test)
 {
 	char *str;
 	const char *exp = test->exp;
+	char exp_buf[64];
 
 	if (!setlocale(LC_NUMERIC, test->locale))
 		return;
@@ -66,6 +67,11 @@ void tostr_test(struct tostr_test *test)
 				"this system's %s locale! Skipping test...\n",
 				test->locale);
 			return;
+		}
+
+		if (strstr(test->exp, "%s")) {
+			snprintf(exp_buf, sizeof(exp_buf), test->exp, sep);
+			exp = exp_buf;
 		}
 		str = uint128_t_to_l10n_string(test->val);
 	} else {


### PR DESCRIPTION
Enables testing support on Windows and updates tests to run on Windows.
- Adds support for enabling tests and nvme-tests options
- Excludes linux-specific unit tests when building on Windows
- Adds support in nvme tests for detecting Windows and skipping tests for commands that are not supported on Windows
- Updates some tests to work on Windows