### PR TITLE
Proposed test structure for adding plugin tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@ subprojects/*
 cscope.*
 compile_commands.json
 
-tests/__pycache__
+tests/**/__pycache__
 tests/nvmetests
-tests/*.pyc
+tests/**/*.pyc
 
 .build
 .build-ci

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -183,3 +183,10 @@ option(
             'transcend', 'virtium', 'wdc', 'ymtc', 'zns'],
   description : 'comma-separated list of plugins to build (all plugins are included if unset, [] = no plugins)'
 )
+option(
+  'plugin-tests',
+  type : 'array',
+  choices : ['micron', 'ocp'],
+  value : [],
+  description : 'comma-separated list of plugin test suites to run against real hardware ([] = none)'
+)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -95,6 +95,8 @@ else
 endif
 
 
+subdir('plugins')
+
 autopep8 = find_program(
     'autopep8',
     required : false,

--- a/tests/plugins/README.md
+++ b/tests/plugins/README.md
@@ -1,0 +1,121 @@
+# Plugin Tests
+
+This directory contains hardware tests for nvme-cli vendor plugins. Each plugin
+has its own subdirectory with tests that exercise plugin commands against real
+hardware.
+
+## Architecture
+
+```
+tests/plugins/
+├── plugin_test.py            # Base class for all plugin tests
+└── <plugin>/
+    ├── meson.build           # Meson test definitions for a specific plugin
+    ├── <plugin>_test.py      # plugin-specific base class
+    └── *_test.py             # Individual test files
+```
+
+### Class Hierarchy
+
+```
+unittest.TestCase
+└── TestNVMe (tests/nvme_test.py)
+    └── TestPlugin (tests/plugins/plugin_test.py)
+        └── Test<Plugin> (tests/plugins/<plugin>/<plugin>_test.py)
+```
+
+- **TestNVMe** — provides device config loading, `run_cmd()`, `exec_cmd()`,
+  JSON parsing helpers, and log directory management.
+- **TestPlugin** — adds `run_plugin_cmd()` and `run_plugin_cmd_check()` which
+  invoke `nvme <plugin> <command> <device> <args>`. Automatically skips tests
+  if the plugin is not available.
+- **Test&lt;Plugin&gt;** — set the `<plugin>_name` attribute and provide a
+  place for plugin-specific helpers.
+
+## Meson Options
+
+Plugin test suites are gated by the `plugin-tests` array option:
+
+| Option          | Default | Choices          | Description                                   |
+|-----------------|---------|------------------|-----------------------------------------------|
+| `plugin-tests`  | `[]`    | `micron`, `ocp`  | List of plugin test suites to run against real hardware |
+
+A plugin test suite is included in the build when these three conditions
+are met:
+
+1. `nvme-tests=true` (gates the entire `tests/` subtree)
+2. The plugin name is listed in `plugin-tests` (e.g., `-Dplugin-tests=ocp`)
+3. The plugin is listed in the `plugins` build option
+
+## Configuration
+
+Plugin tests reuse the same `tests/config.json` as the core tests. Ensure it
+points to the correct controller and namespace for your hardware:
+
+## Building and Running
+
+### Configure with plugin tests enabled (comma separated list)
+
+```bash
+meson setup .build -Dnvme-tests=true -Dplugin-tests=ocp,micron
+```
+
+### Run all enabled test suites
+
+```bash
+meson test -C .build
+```
+
+### Run a specific plugin suite
+
+```bash
+meson test -C .build --suite ocp
+```
+
+### Run a single test by name
+
+```bash
+meson test -C .build "ocp - ocp_smart_add_log_test"
+```
+
+## Writing a New Test
+
+1. Create a file in the appropriate plugin directory (e.g.,
+   `tests/plugins/ocp/ocp_smart_add_log_test.py`).
+
+2. Inherit from the plugin base class and write test methods.
+
+3. Add the test filename to the plugin's `meson.build`.
+
+
+### Key Helper Methods
+
+| Method | Description |
+|--------|-------------|
+| `self.run_plugin_cmd(cmd, device=None, args="")` | Run a plugin command, return `CompletedProcess` |
+| `self.run_plugin_cmd_check(cmd, device=None, args="")` | Same as above but asserts `returncode == 0` |
+| `self.run_cmd(cmd)` | Run an arbitrary shell command |
+| `self.exec_cmd(cmd)` | Run a shell command, return only the returncode |
+
+## Adding a New Plugin Test Suite
+
+To add tests for another plugin:
+
+1. Add the plugin name to the `choices` list of the `plugin-tests` option in `meson_options.txt`
+
+2. Add a conditional `subdir()` in `tests/plugins/meson.build`.
+
+
+3. Create the directory structure:
+
+```
+tests/plugins/<plugin>/
+├── meson.build
+├── <plugin>_test.py
+└── <plugin>_<command>_test.py
+```
+
+4. In `<plugin>_test.py`, inherit from `TestPlugin` and set `plugin_name`.
+
+5. Copy one of the existing `meson.build` files (e.g., from `ocp/`) and
+   adapt the variable names and test list.

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/plugins/meson.build
+++ b/tests/plugins/meson.build
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Plugin test suites — each is gated by the plugin being present in both the
+# plugin-tests array option and in selected_plugins.
+
+plugin_tests = get_option('plugin-tests')
+
+if 'micron' in plugin_tests and 'micron' in selected_plugins
+    subdir('micron')
+endif
+
+if 'ocp' in plugin_tests and 'ocp' in selected_plugins
+    subdir('ocp')
+endif

--- a/tests/plugins/micron/__init__.py
+++ b/tests/plugins/micron/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/plugins/micron/meson.build
+++ b/tests/plugins/micron/meson.build
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Micron plugin tests
+
+micron_tests = [
+    'micron_vs_drive_info_test.py',
+]
+
+python_module = import('python')
+python3 = python_module.find_installation('python3')
+
+test_env = environment()
+test_env.prepend('PATH', meson.project_build_root())
+
+tap_runner = meson.project_source_root() / 'tests' / 'tap_runner.py'
+
+foreach t : micron_tests
+    t_name = t.split('.')[0]
+    test(
+        'micron - @0@'.format(t_name),
+        python3,
+        args: [
+            tap_runner,
+            '--start-dir', meson.project_source_root(),
+            'tests.plugins.micron.@0@'.format(t_name),
+        ],
+        env: test_env,
+        timeout: 500,
+        protocol: 'tap',
+        is_parallel: false,
+        suite: 'micron',
+    )
+endforeach

--- a/tests/plugins/micron/micron_test.py
+++ b/tests/plugins/micron/micron_test.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Base class for Micron plugin tests."""
+
+from tests.plugins.plugin_test import TestPlugin
+
+
+class TestMicron(TestPlugin):
+    """Base class for Micron plugin tests.
+
+    Provides the plugin_name and any Micron-specific helpers.
+    """
+
+    plugin_name = "micron"

--- a/tests/plugins/micron/micron_vs_drive_info_test.py
+++ b/tests/plugins/micron/micron_vs_drive_info_test.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+"""Test for Micron vs-drive-info plugin command."""
+
+from tests.plugins.micron.micron_test import TestMicron
+
+
+class TestMicronDriveInfo(TestMicron):
+    """Verify that the micron vs-drive-info command executes successfully."""
+
+    def test_vs_drive_info(self):
+        """Run micron vs-drive-info and verify it returns success."""
+        self.run_plugin_cmd_check("vs-drive-info")

--- a/tests/plugins/ocp/__init__.py
+++ b/tests/plugins/ocp/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/plugins/ocp/meson.build
+++ b/tests/plugins/ocp/meson.build
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# OCP plugin tests
+
+ocp_tests = [
+    'ocp_smart_add_log_test.py',
+]
+
+python_module = import('python')
+python3 = python_module.find_installation('python3')
+
+test_env = environment()
+test_env.prepend('PATH', meson.project_build_root())
+
+tap_runner = meson.project_source_root() / 'tests' / 'tap_runner.py'
+
+foreach t : ocp_tests
+    t_name = t.split('.')[0]
+    test(
+        'ocp - @0@'.format(t_name),
+        python3,
+        args: [
+            tap_runner,
+            '--start-dir', meson.project_source_root(),
+            'tests.plugins.ocp.@0@'.format(t_name),
+        ],
+        env: test_env,
+        timeout: 500,
+        protocol: 'tap',
+        is_parallel: false,
+        suite: 'ocp',
+    )
+endforeach

--- a/tests/plugins/ocp/ocp_smart_add_log_test.py
+++ b/tests/plugins/ocp/ocp_smart_add_log_test.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+"""Test for OCP smart-add-log plugin command."""
+
+from tests.plugins.ocp.ocp_test import TestOCP
+
+
+class TestOCPSmartAddLog(TestOCP):
+    """Verify that the ocp smart-add-log command executes successfully."""
+
+    def test_smart_add_log(self):
+        """Run ocp smart-add-log and verify it returns success."""
+        self.run_plugin_cmd_check("smart-add-log")

--- a/tests/plugins/ocp/ocp_test.py
+++ b/tests/plugins/ocp/ocp_test.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Base class for OCP plugin tests."""
+
+from tests.plugins.plugin_test import TestPlugin
+
+
+class TestOCP(TestPlugin):
+    """Base class for OCP plugin tests.
+
+    Provides the plugin_name and any OCP-specific helpers.
+    """
+
+    plugin_name = "ocp"

--- a/tests/plugins/plugin_test.py
+++ b/tests/plugins/plugin_test.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Base class for plugin tests."""
+
+import logging
+
+from tests.nvme_test import TestNVMe
+
+logger = logging.getLogger(__name__)
+
+
+class TestPlugin(TestNVMe):
+    """Base class for all plugin tests.
+
+    Subclasses must set the `plugin_name` class attribute to the plugin
+    name as registered with nvme-cli (e.g., "micron", "ocp").
+    """
+
+    plugin_name = None
+
+    def setUp(self):
+        if self.plugin_name is None:
+            self.fail("TestPlugin subclass must set plugin_name")
+        super().setUp()
+        self.setup_log_dir(self.__class__.__name__)
+        # Verify the plugin is available
+        ret = self.exec_cmd(f"{self.nvme_bin} {self.plugin_name} help")
+        if ret != 0:
+            self.skipTest(f"Plugin '{self.plugin_name}' not available")
+
+    def run_plugin_cmd(self, command, device=None, args=""):
+        """Run a plugin command and return the CompletedProcess result.
+
+        Usage:
+            result = self.run_plugin_cmd("vs-drive-info")
+            result = self.run_plugin_cmd("smart-add-log", args="-o json")
+            result = self.run_plugin_cmd("id-ctrl", device=self.ctrl)
+
+        Args:
+            command: The plugin subcommand name.
+            device: Device path to operate on (defaults to self.ctrl).
+            args: Additional arguments string.
+
+        Returns:
+            subprocess.CompletedProcess with returncode, stdout, stderr.
+        """
+        if device is None:
+            device = self.ctrl
+        cmd = f"{self.nvme_bin} {self.plugin_name} {command} {device} {args}".strip()
+        return self.run_cmd(cmd)
+
+    def run_plugin_cmd_check(self, command, device=None, args=""):
+        """Run a plugin command and assert it succeeds (returncode == 0).
+
+        Returns the CompletedProcess result on success.
+        """
+        result = self.run_plugin_cmd(command, device=device, args=args)
+        self.assertEqual(result.returncode, 0,
+                         f"Plugin command '{self.plugin_name} {command}' failed: "
+                         f"rc={result.returncode}, stderr={result.stderr}")
+        return result

--- a/tests/run_py_linters.py
+++ b/tests/run_py_linters.py
@@ -72,9 +72,8 @@ def get_all_python_files() -> List[Path]:
 
     for python_module in all_python_modules:
         if python_module.is_dir():
-            for a_file in python_module.iterdir():
-                if a_file.suffix == '.py':
-                    python_files.append(a_file)
+            for a_file in python_module.rglob('*.py'):
+                python_files.append(a_file)
         else:
             python_files.append(python_module)
 


### PR DESCRIPTION
Expands the python testing framework to support defining and enabling tests for individual plugins.  Adds simple Micron and OCP plugin tests as examples.