### PR TITLE
nbft: fix missing error checks for ftell() and rewind()

### DIFF
--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -765,8 +765,21 @@ __libnvme_public int libnvmf_read_nbft(
 	}
 
 	raw_nbft_size = ftell(raw_nbft_fp);
+	if (raw_nbft_size == (size_t)-1L) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR,
+			"Failed to get file size for %s: %s\n",
+			filename, libnvme_strerror(errno));
+		fclose(raw_nbft_fp);
+		return -EINVAL;
+	}
+	errno = 0;
 	rewind(raw_nbft_fp);
-
+	if (errno) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Failed to seek in %s: %s\n",
+			filename, libnvme_strerror(errno));
+		fclose(raw_nbft_fp);
+		return -EINVAL;
+	}
 	raw_nbft = malloc(raw_nbft_size);
 	if (!raw_nbft) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,


### PR DESCRIPTION
The libnvmf_read_nbft() function did not check whether ftell()
returned (size_t)-1L, leaving a case where an invalid file size could
be used silently. Additionally, rewind() failures were not detected.

Check if ftell() returns (size_t)-1L and detect rewind() failures via 
errno, closing the file and returning -EINVAL in both cases.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>