### PR TITLE
libnvme: fix null pointer dereference in _discovery_config_json()

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2652,7 +2652,7 @@ int _discovery_config_json(struct libnvme_global_ctx *ctx,
 	nfctx.ctrl_params.host_traddr = libnvme_ctrl_get_host_traddr(c);
 	nfctx.ctrl_params.host_iface = libnvme_ctrl_get_host_iface(c);
 
-	if (!nfctx.ctrl_params.transport && !nfctx.ctrl_params.traddr)
+	if (!nfctx.ctrl_params.transport || !nfctx.ctrl_params.traddr)
 		return 0;
 
 	/* ignore none fabric transports */


### PR DESCRIPTION
The _discovery_config_json() function retrieves the transport and
traddr parameters from a controller. The early return only triggers
when both @transport and @traddr are NULL, allowing execution to
continue with a NULL @transport.

Passing a NULL @transport to strcmp(), which has a nonnull attribute,
causes undefined behavior.

Change the condition to return early if either @transport or @traddr
is NULL, preventing the NULL pointer from being passed to strcmp().

Signed-off-by: Laraib Javed <laraibjaved@ibm.com>