### PR TITLE
Additional Windows build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ and [muon](https://github.com/annacrombie/muon). Both build tools have only a
 minimal dependency on the build environment. To ease this step, there is a build
 script which helps to setup a build environment.
 
+### Building on Windows
+
+nvme-cli can be built on Windows using the [msys2](https://www.msys2.org/)
+UCRT64 environment. After installing MSYS2 (`winget install MSYS2.MSYS2`), the
+`win-ucrt64-setup.sh` script can be run within the UCRT64 environment to install
+the required build system and nvme-cli dependencies.
+
 ### nvme-cli dependencies (3.x and later):
 
 Starting with nvme-cli 3.x, the libnvme library is fully integrated into the

--- a/meson.build
+++ b/meson.build
@@ -619,6 +619,19 @@ if want_nvme
         install_dir: sbindir,
     )
 
+    if host_system == 'windows' and want_libnvme and not is_static
+        # Copy libnvme DLL next to nvme.exe so it can be found at
+        # runtime without modifying PATH.
+        cp = find_program('cp')
+        custom_target('copy-libnvme-dll',
+            input: libnvme,
+            output: fs.name(libnvme.full_path()),
+            command: [cp, '@INPUT@', '@OUTPUT@'],
+            depends: [libnvme, nvme_exe],
+            build_by_default: true,
+        )
+    endif
+
     if host_system != 'windows'
         subdir('unit')
     endif

--- a/meson.build
+++ b/meson.build
@@ -596,6 +596,16 @@ if want_nvme
             kernel32_dep,
             bcrypt_dep,
         ]
+
+        if is_static
+            # Keep these MinGW runtime dependencies in-process to avoid
+            # requiring extra DLLs in PATH for static Windows builds.
+            link_args_list += ['-Wl,-Bstatic']
+            if json_c_dep.found()
+                link_args_list += ['-ljson-c']
+            endif
+            link_args_list += ['-lwinpthread', '-Wl,-Bdynamic']
+        endif
     else
         link_args_list = ['-ldl']
     endif

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -7,39 +7,47 @@ all_plugins = {
   'dell': ['plugins/dell/dell-nvme.c'],
   'dera': ['plugins/dera/dera-nvme.c'],
   'fdp': ['plugins/fdp/fdp.c'],
-  'huawei': ['plugins/huawei/huawei-nvme.c'],
   'ibm': ['plugins/ibm/ibm-nvme.c'],
   'innogrit': ['plugins/innogrit/innogrit-nvme.c'],
   'inspur': ['plugins/inspur/inspur-nvme.c'],
   'intel': ['plugins/intel/intel-nvme.c'],
   'mangoboost': ['plugins/mangoboost/mangoboost-nvme.c'],
   'memblaze': ['plugins/memblaze/memblaze-nvme.c'],
-  'micron': [
-      'plugins/micron/micron-nvme.c',
-      'plugins/micron/micron-utils.c',
-      'plugins/micron/micron-utils-linux.c'
-    ],
-  'netapp': ['plugins/netapp/netapp-nvme.c'],
   'nvidia': ['plugins/nvidia/nvidia-nvme.c'],
-  'sandisk': ['plugins/sandisk/sandisk-nvme.c', 'plugins/sandisk/sandisk-utils.c'],
-  'scaleflux': ['plugins/scaleflux/sfx-nvme.c'],
   'seagate': ['plugins/seagate/seagate-nvme.c'],
   'shannon': ['plugins/shannon/shannon-nvme.c'],
   'ssstc': ['plugins/ssstc/ssstc-nvme.c'],
   'toshiba': ['plugins/toshiba/toshiba-nvme.c'],
   'transcend': ['plugins/transcend/transcend-nvme.c'],
   'virtium': ['plugins/virtium/virtium-nvme.c'],
-  'wdc': ['plugins/wdc/wdc-nvme.c', 'plugins/wdc/wdc-utils.c'],
   'ymtc': ['plugins/ymtc/ymtc-nvme.c'],
-  'zns': ['plugins/zns/zns.c'],
 }
+if host_system != 'windows'
+  all_plugins += {
+    'huawei': ['plugins/huawei/huawei-nvme.c'],
+    'micron': [
+      'plugins/micron/micron-nvme.c',
+      'plugins/micron/micron-utils.c',
+      'plugins/micron/micron-utils-linux.c'
+      ],
+    'netapp': ['plugins/netapp/netapp-nvme.c'],
+    'sandisk': ['plugins/sandisk/sandisk-nvme.c', 'plugins/sandisk/sandisk-utils.c'],
+    'scaleflux': ['plugins/scaleflux/sfx-nvme.c'],
+    'wdc': ['plugins/wdc/wdc-nvme.c', 'plugins/wdc/wdc-utils.c'],
+    'zns': ['plugins/zns/zns.c'],
+  }
+else
+  all_plugins += {
+    'micron': [
+      'plugins/micron/micron-nvme.c',
+      'plugins/micron/micron-utils.c',
+      'plugins/micron/micron-utils-win.c'
+      ],
+  }
+endif
 
 # Get the list of plugins to build
-if host_system != 'windows'
-  selected_plugins = get_option('plugins')
-else
-  selected_plugins = []
-endif
+selected_plugins = get_option('plugins')
 
 # Build the plugin_sources list from simple plugins
 plugin_sources = []
@@ -66,11 +74,11 @@ if 'feat' in selected_plugins
   subdir('feat')
 endif
 
-if 'lm' in selected_plugins
+if 'lm' in selected_plugins and host_system != 'windows'
   subdir('lm')
 endif
 
-if 'ocp' in selected_plugins
+if 'ocp' in selected_plugins and json_c_dep.found()
   subdir('ocp')
 endif
 

--- a/scripts/win-ucrt64-setup.sh
+++ b/scripts/win-ucrt64-setup.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Utility for installing the UCRT64 MinGW build toolchain and nvme-cli
+# dependencies within an MSYS2 environment on Windows.
+#
+# This file is part of nvme.
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+# Authors: Broc Going <bgoing@micron.com>
+
+set -e
+
+usage() {
+    echo "Usage: win-ucrt64-setup.sh [-u]"
+    echo ""
+    echo "Install UCRT64 MinGW build toolchain and nvme-cli dependencies."
+    echo ""
+    echo " -u   refresh package database and upgrade all packages"
+}
+
+PACMAN_CMD="-S"
+
+while getopts "u" o; do
+    case "${o}" in
+        u)
+            PACMAN_CMD="-Syu"
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Install the UCRT64 MinGW build toolchain, meson build system, and nvme-cli
+# dependencies. Use -u to also refresh and upgrade all packages.
+pacman $PACMAN_CMD --noconfirm --needed \
+    mingw-w64-ucrt-x86_64-toolchain \
+    mingw-w64-ucrt-x86_64-meson \
+    mingw-w64-ucrt-x86_64-ninja \
+    mingw-w64-ucrt-x86_64-ccache \
+    mingw-w64-ucrt-x86_64-json-c


### PR DESCRIPTION
These changes add the rest of the build support required for Windows and adds information and a helper utility for configuring a build system on Windows.
- Adds support for building on Windows with statically linked libraries.
- Improves build support for running and testing builds that use shared libraries.
- Adds build configuration for building plugins on Windows.
- Adds readme section regarding building on Windows, as well as a utility for configuring an MSYS2 environment on Windows for building nvme-cli.