### PR TITLE
nvme-print: Update generic name listing to be platform independent

### DIFF
--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5646,7 +5646,7 @@ static void stdout_generic_full_path(libnvme_ns_t n, char *path, size_t len)
 	 * We could start trying to search for it but let's make
 	 * it simple and just don't show the path at all.
 	 */
-	snprintf(path, len, "ng%dn%d", instance, head_instance);
+	snprintf(path, len, "%s", libnvme_ns_get_generic_name(n));
 }
 
 static void list_item(libnvme_ns_t n, struct table *t)
@@ -5797,7 +5797,7 @@ static void stdout_ns_details(libnvme_ns_t n)
 	nvme_dev_full_path(n, devname, sizeof(devname));
 	nvme_generic_full_path(n, genname, sizeof(genname));
 
-	printf("%-17s %-17s %#-10x %-21s %-25s %-16s ", devname,
+	printf("%-17s %-20s %#-10x %-21s %-25s %-16s ", devname,
 		genname, libnvme_ns_get_nsid(n), usage, usage_binary, format);
 }
 
@@ -5955,9 +5955,9 @@ static void stdout_detailed_list(struct libnvme_global_ctx *ctx)
 	strset_iterate(&res.ctrls, stdout_detailed_ctrl, &res);
 	printf("\n");
 
-	printf("%-17s %-17s %-10s %-49s %-16s %-16s\n", "Device", "Generic",
+	printf("%-17s %-20s %-10s %-49s %-16s %-16s\n", "Device", "Generic",
 		"NSID", "Usage", "Format", "Controllers");
-	printf("%-.17s %-.17s %-.10s %-.49s %-.16s %-.16s\n", dash, dash, dash,
+	printf("%-.17s %-.20s %-.10s %-.49s %-.16s %-.16s\n", dash, dash, dash,
 		dash, dash, dash);
 	strset_iterate(&res.namespaces, stdout_detailed_ns, &res);
 

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1683,7 +1683,9 @@ void nvme_generic_full_path(libnvme_ns_t n, char *path, size_t len)
 	if (strncmp(path, "/dev/spdk/", 10) == 0 && stat(path, &st) == 0)
 		return;
 
-	sscanf(libnvme_ns_get_name(n), "nvme%dn%d", &instance, &head_instance);
+	if (sscanf(libnvme_ns_get_name(n), "nvme%dn%d", &instance, &head_instance) != 2)
+		return;
+
 	snprintf(path, len, "/dev/ng%dn%d", instance, head_instance);
 
 	if (stat(path, &st) == 0)
@@ -1692,7 +1694,7 @@ void nvme_generic_full_path(libnvme_ns_t n, char *path, size_t len)
 	 * We could start trying to search for it but let's make
 	 * it simple and just don't show the path at all.
 	 */
-	snprintf(path, len, "ng%dn%d", instance, head_instance);
+	snprintf(path, len, "%s", libnvme_ns_get_generic_name(n));
 }
 
 void nvme_show_list_item(libnvme_ns_t n, struct table *t)


### PR DESCRIPTION
Refactors generic path discover in nvme-print and nvme-print-stdout to fall back to using livnvme_ns_get_generic name.  Allows platform independent generic name behavior, and removes duplicated "ng%dn%d" string building on Linux.  Also widens Generic list section of detailed list slightly to provide enough space for Windows generic names.