### PR TITLE
libnvme/tid: numeric-only, sanitizing Transport ID (TID)

### DIFF
--- a/libnvme/design/INTEGRATION.md
+++ b/libnvme/design/INTEGRATION.md
@@ -1,0 +1,39 @@
+# Integrating libnvme into an application
+
+> **libnvme owns NVMe protocol I/O. The caller owns policy, non-determinism, and its own concurrency.**
+
+The code is the source of truth; this document explains the boundary and the reasoning behind it. For exact signatures see the kdoc in `src/nvme/*.h`.
+
+## Why this needs stating
+
+The CLI/library split extracted code by mechanical convenience, not by a stated rule, so some caller responsibilities ended up inside the library. Hostname resolution is the clearest example — it sits inside libnvme today even though it was always the caller's job. This document is the rule that the boundary should have had from the start.
+
+## The boundary
+
+- **NVMe protocol I/O** — ioctls to `/dev/nvmeX`, the `/dev/nvme-fabrics` connect write, log pages, Identify, sysfs enumeration. If it *is* NVMe, it belongs in the library.
+- **Policy** — any choice with more than one defensible answer (which resolved address to use, which source address to bind, how hard to retry). The right answer depends on the deployment, not on NVMe, so policy belongs to the caller.
+- **Non-determinism** — anything not a pure function of its inputs (DNS is the archetype). It poisons anything downstream that needs to be reproducible.
+- **Concurrency** — *when* and on which thread a call runs relative to the application's event loop. Only the application knows its loop.
+
+Hostname resolution fails the policy and non-determinism tests outright, and (below) also blocks — three independent reasons it belongs to the caller, not the library.
+
+## libnvme is synchronous and blocking
+
+Every libnvme API blocks the calling thread by default: connect blocks on the `/dev/nvme-fabrics` write, Get Log Page and Identify block on ioctls, and even device-tree enumeration is real sysfs I/O. The one opt-in exception is I/O passthru over io_uring: `libnvme_submit_io_passthru()` queues a command without blocking, though `libnvme_reap_passthru()` still blocks to collect the result — a caller has to explicitly build that path. No file descriptors to poll for the default synchronous path, no callbacks, no loop of its own — deliberately: integrating with every event-loop implementation in existence (sd_event, GLib, raw epoll, libuv, ...) doesn't scale, and would lock every caller into whichever one libnvme picked.
+
+## The main-loop contract
+
+A process with a main loop must never call libnvme from the loop thread. Offload it:
+
+- **Worker thread** — for in-process blocking calls (Discovery Log Page, Identify, sysfs scan); post the result back via an eventfd/pipe the loop already watches. This is how nvme-stas drives nearly every libnvme call.
+- **Subprocess or systemd unit** — for connect, when isolation and lifecycle supervision are wanted too.
+
+nvme-discoverd uses both: it retrieves Discovery Log Pages on a worker thread but performs connects by starting a systemd unit, so the fully-blocking call never touches its loop.
+
+## Worked example: hostname resolution
+
+A hostname can only enter through `traddr`, from a CLI argument or a config file — a Discovery Log Page's address family is numeric-only by spec, `host_traddr` is a source address a hostname can't sensibly name, and `host_iface` is a kernel-resolved interface name. The caller resolves `traddr` before calling libnvme — inline for a one-shot CLI, on a worker thread for a daemon — and picks among the results itself (e.g. IPv4 vs. IPv6). Internally, libnvme's Transport ID (TID) constructors enforce this by rejecting hostnames outright (`design/TID.md`).
+
+## Rule of thumb
+
+*Is it NVMe protocol I/O?* → the library. *Is it policy, non-deterministic, or event-loop-aware?* → the caller. Something that's both: split it, keep the protocol part in the library, leave policy and scheduling to the caller.

--- a/libnvme/design/TID.md
+++ b/libnvme/design/TID.md
@@ -1,0 +1,87 @@
+# The NVMe-oF Transport ID (TID)
+
+A **TID** identifies one NVMe-oF connection: the transport tuple plus the subsystem and host identifiers that together name one host-to-controller association. `libnvmf_tid_get_canonical()` renders it as a deterministic, fixed-field-order string. A caller that wants a compact name (e.g. nvme-discoverd deriving a systemd unit name) hashes that string itself — libnvme doesn't hash it (see "Naming is the caller's job").
+
+> The code is the source of truth; for exact signatures see the kdoc in `src/nvme/tid.h`.
+
+## Fields
+
+A TID carries eight fields:
+
+- **Addressing** — `transport`, `traddr`, `trsvcid`, `host_traddr`, `host_iface`.
+- **Subsystem** — `subsysnqn`.
+- **Host identity** — `hostnqn`, `hostid`.
+
+`libnvmf_tid_get_canonical()` renders these in fixed field order (`transport=tcp;traddr=1.2.3.4;trsvcid=8009;…`), omitting unset fields, so the same logical TID always yields the same string regardless of set order.
+
+## Addressing is numeric-only
+
+`traddr`/`host_traddr` must be numeric IP addresses; a hostname makes construction fail — libnvme never resolves, defers, or carries one (rationale: `design/INTEGRATION.md`). `libnvmf_traddr_is_numeric(traddr)` checks a candidate address up front, using the same numeric definition the constructors enforce internally (an IPv6 scope suffix like `fe80::1%eth0` counts as numeric).
+
+## Sanitization
+
+Sanitization normalizes an address that *will* be accepted into one consistent spelling — it is not validation. It makes the canonical form deterministic per producer, and gives the connection-identity matcher (below) cheap string equality instead of a semantic address comparison.
+
+This is structural, not a convention to remember: addressing fields are only ever set via `libnvmf_tid_from_fields()`, `libnvmf_tid_parse()`, or `libnvmf_tid_dup()` — the per-field addressing setters are gone from the public API — and `transport` is an immutable constructor argument, since sanitizing an address requires knowing the transport.
+
+| Field | tcp / rdma | fc | loop |
+|---|---|---|---|
+| `traddr` | numeric → canonicalize; hostname → **fails** | as-is | as-is |
+| `host_traddr` | numeric → canonicalize; hostname → **fails** | as-is | (n/a) |
+| `trsvcid` / `host_iface` | as-is | (n/a) | (n/a) |
+
+Canonicalization is `inet_pton()`/`inet_ntop()` — numeric only, never blocking. An IPv6 scope stays in `traddr` (`fe80::1%eth0`) rather than moving to `host_iface`, since that field is TCP-only.
+
+Sanitization guarantees one spelling per producer — not that two canonical forms agree iff they name the same connection. `::ffff:1.2.3.4` and `1.2.3.4` canonicalize differently even though the kernel may route them identically; not treated as a defect, since the TID was never a unique connection identifier to begin with (see below).
+
+**Deferred, not yet enforced:** FC WWN syntax validation, and dropping a field a transport has no use for (e.g. `host_iface` on RDMA). Until then an inapplicable or malformed field is carried as written rather than rejected.
+
+## Identity: subsysnqn, hostnqn, hostid
+
+Set together via one call, applied after addressing:
+
+```c
+int libnvmf_tid_set_identity(struct libnvmf_tid *tid, const char *subsysnqn,
+                             const char *hostnqn, const char *hostid);
+```
+
+`NULL` leaves a field unset. Two rules enforced here:
+
+- **One host is one `(hostnqn, hostid)` pair** — mirrors the kernel's `nvmf_host_add()`.
+- **hostid must be stable across connects.** What breaks trackability is regenerating a value on every connect, not how the value was chosen — a hostid randomly generated once and persisted (e.g. `/etc/nvme/hostid`) is fine. Deterministic alternatives per spec: `0h` (TP4110, but collides across personas) or derived from a UUID-format HostNQN (TP4126 method b, via `libnvme_hostid_from_hostnqn()`).
+
+Resolution order for an absent hostid: explicit → `/etc/nvme/hostid` → derive from HostNQN UUID → `0h`. `set_identity()` performs only the UUID derivation itself; it never reads a file or invents `0h`, and leaves the field unset if it can't derive one.
+
+## Naming is the caller's job
+
+`libnvmf_tid_get_canonical()` is the naming primitive; libnvme does not hash it. A caller that wants a compact, stable name — e.g. nvme-discoverd deriving its `nvme-discoverd-<hash>.service` unit name — hashes the canonical string itself. Two producers only agree on the resulting name if they built the TID from byte-identical fields — the IPv4-mapped-vs-bare-IPv4 case above is one way that can silently fail.
+
+## The canonical form is not connection identity
+
+The canonical form (or a hash of it) names a *candidate* connection, not a live one — that's decided by the kernel. On TCP, `traddr` drives routing which picks the interface, and the interface determines the source address. So, a TID pinning `host_traddr` or `host_iface` and one leaving them unset can canonicalize differently yet resolve to the same connection. The kernel reports its actual source in a separate sysfs attribute, `src_addr`.
+
+A candidate TID must go through a **connection-identity matcher** that reads sysfs, including `src_addr`, before connecting — never a canonical-string or hash comparison. libnvme already has this logic internally (`tree-fabrics.c`); exposing it publicly is prep work for nvme-discoverd, not part of the TID.
+
+## API summary
+
+Construct (sanitizing, numeric-only):
+
+- `libnvmf_tid_from_fields(transport, …)` — fails if `traddr`/`host_traddr` isn't numeric on an IP transport.
+- `libnvmf_tid_parse(ctx, "transport=…;…")` — same rule; a malformed token is logged and skipped.
+- `libnvmf_tid_parse_strict(ctx, …)` — same, but a malformed token fails the whole parse.
+- `libnvmf_tid_dup(tid)` — copy.
+- `libnvmf_traddr_is_numeric(traddr)` — check before resolving/building.
+
+Identify: `libnvmf_tid_set_identity(tid, subsysnqn, hostnqn, hostid)`.
+
+Consume:
+
+- `libnvmf_tid_get_canonical(tid)` — full 8-field identity string, for matching/dedup/hashing, never a log line.
+- `libnvmf_tid_str(tid)` — compact rendering for log lines, `(transport, traddr, trsvcid[, subsysnqn][, host_iface][, host_traddr])`, hostnqn/hostid omitted (matches nvme-stas). Never swap with `get_canonical()`.
+- `libnvmf_tid_is_empty(tid)` — true if NULL or no fields set.
+- Field getters.
+
+## Still open
+
+- Transport-applicability checks (drop/reject inapplicable fields, FC WWN syntax) — deferred, not yet enforced.
+- Whether the CLI's connect-arg path (`nvme-cli/fabrics.c`) should build/canonicalize a TID the same way, so `nvme connect` names a connection identically to config.

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -80,11 +80,9 @@ LIBNVMF_3 {
 		libnvmf_set_keyring;
 		libnvmf_subtype_str;
 		libnvmf_tid_dup;
-		libnvmf_tid_equal;
 		libnvmf_tid_is_empty;
 		libnvmf_tid_from_fields;
 		libnvmf_tid_get_canonical;
-		libnvmf_tid_get_hash;
 		libnvmf_tid_parse;
 		libnvmf_tid_parse_strict;
 		libnvmf_tid_set_host_iface;

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -96,6 +96,7 @@ LIBNVMF_3 {
 		libnvmf_tid_set_transport;
 		libnvmf_tid_set_trsvcid;
 		libnvmf_tid_str;
+		libnvmf_traddr_is_numeric;
 		libnvmf_treq_str;
 		libnvmf_trtype_str;
 		libnvmf_update_key;

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -85,14 +85,7 @@ LIBNVMF_3 {
 		libnvmf_tid_get_canonical;
 		libnvmf_tid_parse;
 		libnvmf_tid_parse_strict;
-		libnvmf_tid_set_host_iface;
-		libnvmf_tid_set_hostnqn;
-		libnvmf_tid_set_hostid;
-		libnvmf_tid_set_host_traddr;
-		libnvmf_tid_set_subsysnqn;
-		libnvmf_tid_set_traddr;
-		libnvmf_tid_set_transport;
-		libnvmf_tid_set_trsvcid;
+		libnvmf_tid_set_identity;
 		libnvmf_tid_str;
 		libnvmf_traddr_is_numeric;
 		libnvmf_treq_str;

--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -409,7 +409,6 @@ __libnvme_public void libnvmf_tid_free(struct libnvmf_tid *p)
 	free(p->hostnqn);
 	free(p->hostid);
 	free(p->_canonical);
-	free(p->_hash);
 	free(p->_str);
 	free(p);
 }

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1552,7 +1552,6 @@ static bool nvmf_excluded(struct libnvme_global_ctx *ctx,
 			  const char *hostnqn, const char *hostid)
 {
 	struct libnvmf_tid *tid;
-	const char *canonical;
 	bool excluded;
 
 	tid = libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
@@ -1563,10 +1562,10 @@ static bool nvmf_excluded(struct libnvme_global_ctx *ctx,
 
 	excluded = libnvmf_exclusion_match(ctx, tid);
 	if (excluded) {
-		canonical = libnvmf_tid_get_canonical(tid);
+		const char *rendered = libnvmf_tid_str(tid);
 		libnvme_msg(ctx, LIBNVME_LOG_INFO,
 			 "skipping excluded controller %s\n",
-			 canonical ? canonical : subsysnqn);
+			 rendered ? rendered : subsysnqn);
 	}
 	libnvmf_tid_free(tid);
 

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -99,13 +99,12 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
  * rather than a spec guarantee; carrying hostid keeps the TID correct anyway.
  *
  * This is deliberately a separate type from struct libnvme_ctrl_params, not a
- * reuse of it. libnvmf_tid is a pure, owned, hashable *identity*: it owns its
- * strings, caches derived values (canonical form, hash, string rendering), and
- * carries hostnqn/hostid, which libnvme_ctrl_params does not.
- * libnvme_ctrl_params is a controller-*creation* parameter bag: borrowed
- * pointers, no hashing, and it carries the fabrics tuning config (struct
- * libnvme_fabrics_config) that the TID intentionally excludes. Merging them
- * would force one role onto the other.
+ * reuse of it. libnvmf_tid is a pure, owned *identity*: it owns its strings,
+ * caches derived values (canonical form, string rendering), and carries
+ * hostnqn/hostid, which libnvme_ctrl_params does not. libnvme_ctrl_params is a
+ * controller-*creation* parameter bag: borrowed pointers and it carries the
+ * fabrics tuning config (struct libnvme_fabrics_config) that the TID
+ * intentionally excludes. Merging them would force one role onto the other.
  *
  * Addressing is numeric-only: a traddr/host_traddr must be a numeric IP (the
  * constructors reject a hostname). Resolving a name can block on DNS and is a
@@ -114,8 +113,8 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
  * TID a numeric address.
  *
  * All string fields are owned (strdup'd) by the struct. The leading-underscore
- * members cache derived values (canonical form, hash, string rendering),
- * recomputed lazily and cleared by any setter.
+ * members cache derived values (canonical form, string rendering), recomputed
+ * lazily and cleared by any setter.
  */
 struct libnvmf_tid { // !generate-accessors !generate-lifecycle
 	char *transport;    // !access:write=custom
@@ -128,7 +127,6 @@ struct libnvmf_tid { // !generate-accessors !generate-lifecycle
 	char *hostid;       // !access:write=custom
 	/* cached derived values — recomputed lazily, cleared by any setter */
 	char *_canonical;   // !access:read=none,write=none
-	char *_hash;        // !access:read=none,write=none
 	char *_str;         // !access:read=none,write=none
 };
 

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -107,6 +107,12 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
  * libnvme_fabrics_config) that the TID intentionally excludes. Merging them
  * would force one role onto the other.
  *
+ * Addressing is numeric-only: a traddr/host_traddr must be a numeric IP (the
+ * constructors reject a hostname). Resolving a name can block on DNS and is a
+ * policy choice about which address to use, so it belongs to the caller, not
+ * the library (see design/INTEGRATION.md). The caller resolves and hands the
+ * TID a numeric address.
+ *
  * All string fields are owned (strdup'd) by the struct. The leading-underscore
  * members cache derived values (canonical form, hash, string rendering),
  * recomputed lazily and cleared by any setter.

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -114,18 +114,23 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
  *
  * All string fields are owned (strdup'd) by the struct. The leading-underscore
  * members cache derived values (canonical form, string rendering), recomputed
- * lazily and cleared by any setter.
+ * lazily and cleared by any identity change.
  */
 struct libnvmf_tid { // !generate-accessors !generate-lifecycle
-	char *transport;    // !access:write=custom
-	char *traddr;       // !access:write=custom
-	char *trsvcid;      // !access:write=custom
-	char *subsysnqn;    // !access:write=custom
-	char *host_traddr;  // !access:write=custom
-	char *host_iface;   // !access:write=custom
-	char *hostnqn;      // !access:write=custom
-	char *hostid;       // !access:write=custom
-	/* cached derived values — recomputed lazily, cleared by any setter */
+	/*
+	 * Addressing is construction-only (from_fields/parse/dup); the identity
+	 * triplet is set together via libnvmf_tid_set_identity(). No per-field
+	 * setters, so every mutation goes through a sanitizing path.
+	 */
+	char *transport;    // !access:write=none
+	char *traddr;       // !access:write=none
+	char *trsvcid;      // !access:write=none
+	char *subsysnqn;    // !access:write=none
+	char *host_traddr;  // !access:write=none
+	char *host_iface;   // !access:write=none
+	char *hostnqn;      // !access:write=none
+	char *hostid;       // !access:write=none
+	/* cached values; recomputed lazily, cleared on identity edits */
 	char *_canonical;   // !access:read=none,write=none
 	char *_str;         // !access:read=none,write=none
 };

--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -26,70 +26,75 @@ static void invalidate_cache(struct libnvmf_tid *p)
 	p->_str = NULL;
 }
 
-// Custom setters: strdup the new value and invalidate the derived-value cache
-
-__libnvme_public void libnvmf_tid_set_transport(
-		struct libnvmf_tid *p, const char *val)
+/*
+ * Set the subsysnqn/hostnqn/hostid identity in one call (a NULL argument
+ * leaves that field unchanged).  There are no per-field setters -- addressing
+ * is construction-only -- so this is the sole post-construction mutator.
+ */
+__libnvme_public int libnvmf_tid_set_identity(struct libnvmf_tid *tid,
+					      const char *subsysnqn,
+					      const char *hostnqn,
+					      const char *hostid)
 {
-	invalidate_cache(p);
-	free(p->transport);
-	p->transport = xstrdup(val);
-}
+	char *new_subsysnqn, *new_hostnqn, *new_hostid;
+	const char *eff_hostnqn, *eff_hostid;
+	char *derived = NULL;
 
-__libnvme_public void libnvmf_tid_set_traddr(
-		struct libnvmf_tid *p, const char *val)
-{
-	invalidate_cache(p);
-	free(p->traddr);
-	p->traddr = xstrdup(val);
-}
+	if (!tid)
+		return -EINVAL;
 
-__libnvme_public void libnvmf_tid_set_trsvcid(
-		struct libnvmf_tid *p, const char *val)
-{
-	invalidate_cache(p);
-	free(p->trsvcid);
-	p->trsvcid = xstrdup(val);
-}
+	/* The hostnqn/hostid this call will end up with (before deriving). */
+	eff_hostnqn = hostnqn ? hostnqn : tid->hostnqn;
+	eff_hostid  = hostid ? hostid : tid->hostid;
 
-__libnvme_public void libnvmf_tid_set_subsysnqn(
-		struct libnvmf_tid *p, const char *val)
-{
-	invalidate_cache(p);
-	free(p->subsysnqn);
-	p->subsysnqn = xstrdup(val);
-}
+	/*
+	 * No hostid but a UUID-format hostnqn: derive the hostid from it
+	 * (TP4126) -- deterministic and unique per host, never random.
+	 */
+	if (!eff_hostid && eff_hostnqn) {
+		derived = libnvme_hostid_from_hostnqn(eff_hostnqn);
+		eff_hostid = derived;
+	}
 
-__libnvme_public void libnvmf_tid_set_host_traddr(
-		struct libnvmf_tid *p, const char *val)
-{
-	invalidate_cache(p);
-	free(p->host_traddr);
-	p->host_traddr = xstrdup(val);
-}
+	/* One host is one (hostnqn, hostid) pair. */
+	if (eff_hostid && !eff_hostnqn) {
+		free(derived);
+		return -EINVAL;
+	}
 
-__libnvme_public void libnvmf_tid_set_host_iface(
-		struct libnvmf_tid *p, const char *val)
-{
-	invalidate_cache(p);
-	free(p->host_iface);
-	p->host_iface = xstrdup(val);
-}
+	/* Stage every copy up front so a failure leaves the TID untouched. */
+	new_subsysnqn = xstrdup(subsysnqn);
+	new_hostnqn   = xstrdup(hostnqn);
+	new_hostid    = xstrdup(hostid);
+	if ((subsysnqn && !new_subsysnqn) || (hostnqn && !new_hostnqn) ||
+	    (hostid && !new_hostid)) {
+		free(new_subsysnqn);
+		free(new_hostnqn);
+		free(new_hostid);
+		free(derived);
+		return -ENOMEM;
+	}
 
-__libnvme_public void libnvmf_tid_set_hostnqn(
-		struct libnvmf_tid *p, const char *val)
-{
-	invalidate_cache(p);
-	free(p->hostnqn);
-	p->hostnqn = xstrdup(val);
-}
+	invalidate_cache(tid);
+	if (new_subsysnqn) {
+		free(tid->subsysnqn);
+		tid->subsysnqn = new_subsysnqn;
+	}
+	if (new_hostnqn) {
+		free(tid->hostnqn);
+		tid->hostnqn = new_hostnqn;
+	}
+	if (new_hostid) {
+		free(tid->hostid);
+		tid->hostid = new_hostid;
+	} else if (derived) {
+		free(tid->hostid);
+		tid->hostid = derived;	/* transfer ownership */
+		derived = NULL;
+	}
+	free(derived);
 
-__libnvme_public void libnvmf_tid_set_hostid(
-		struct libnvmf_tid *p, const char *val)
-{
-	invalidate_cache(p);
-	free(p->hostid);
-	p->hostid = xstrdup(val);
+	return 0;
 }
 
 /*

--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -27,204 +27,6 @@ static void invalidate_cache(struct libnvmf_tid *p)
 }
 
 /*
- * Set the subsysnqn/hostnqn/hostid identity in one call (a NULL argument
- * leaves that field unchanged).  There are no per-field setters -- addressing
- * is construction-only -- so this is the sole post-construction mutator.
- */
-__libnvme_public int libnvmf_tid_set_identity(struct libnvmf_tid *tid,
-					      const char *subsysnqn,
-					      const char *hostnqn,
-					      const char *hostid)
-{
-	char *new_subsysnqn, *new_hostnqn, *new_hostid;
-	const char *eff_hostnqn, *eff_hostid;
-	char *derived = NULL;
-
-	if (!tid)
-		return -EINVAL;
-
-	/* The hostnqn/hostid this call will end up with (before deriving). */
-	eff_hostnqn = hostnqn ? hostnqn : tid->hostnqn;
-	eff_hostid  = hostid ? hostid : tid->hostid;
-
-	/*
-	 * No hostid but a UUID-format hostnqn: derive the hostid from it
-	 * (TP4126) -- deterministic and unique per host, never random.
-	 */
-	if (!eff_hostid && eff_hostnqn) {
-		derived = libnvme_hostid_from_hostnqn(eff_hostnqn);
-		eff_hostid = derived;
-	}
-
-	/* One host is one (hostnqn, hostid) pair. */
-	if (eff_hostid && !eff_hostnqn) {
-		free(derived);
-		return -EINVAL;
-	}
-
-	/* Stage every copy up front so a failure leaves the TID untouched. */
-	new_subsysnqn = xstrdup(subsysnqn);
-	new_hostnqn   = xstrdup(hostnqn);
-	new_hostid    = xstrdup(hostid);
-	if ((subsysnqn && !new_subsysnqn) || (hostnqn && !new_hostnqn) ||
-	    (hostid && !new_hostid)) {
-		free(new_subsysnqn);
-		free(new_hostnqn);
-		free(new_hostid);
-		free(derived);
-		return -ENOMEM;
-	}
-
-	invalidate_cache(tid);
-	if (new_subsysnqn) {
-		free(tid->subsysnqn);
-		tid->subsysnqn = new_subsysnqn;
-	}
-	if (new_hostnqn) {
-		free(tid->hostnqn);
-		tid->hostnqn = new_hostnqn;
-	}
-	if (new_hostid) {
-		free(tid->hostid);
-		tid->hostid = new_hostid;
-	} else if (derived) {
-		free(tid->hostid);
-		tid->hostid = derived;	/* transfer ownership */
-		derived = NULL;
-	}
-	free(derived);
-
-	return 0;
-}
-
-/*
- * Build "key=val;key=val;..." in fixed field order, skipping NULL fields.
- * Max canonical length: 2 NQNs (223 chars each) + short fields + keys +
- * separators = ~700 chars.  CANONICAL_MAX of 1024 is a safe upper bound.
- */
-#define CANONICAL_MAX 1024
-
-__libnvme_public const char *libnvmf_tid_get_canonical(
-		const struct libnvmf_tid *tid)
-{
-	struct libnvmf_tid *p = (struct libnvmf_tid *)tid;
-	char buf[CANONICAL_MAX];
-	int n = 0;
-
-	if (!tid)
-		return NULL;
-
-	if (p->_canonical)
-		return p->_canonical;
-
-	/* n stays < CANONICAL_MAX so (CANONICAL_MAX - n) cannot wrap. */
-#define APPEND(key, field) \
-	do { \
-		if (p->field && n < (int)CANONICAL_MAX) \
-			n += snprintf(buf + n, CANONICAL_MAX - n, "%s%s=%s", \
-				      n ? ";" : "", key, p->field); \
-	} while (0)
-
-	APPEND("transport",   transport);
-	APPEND("traddr",      traddr);
-	APPEND("trsvcid",     trsvcid);
-	APPEND("nqn",         subsysnqn);
-	APPEND("host-traddr", host_traddr);
-	APPEND("host-iface",  host_iface);
-	APPEND("hostnqn",     hostnqn);
-	APPEND("hostid",      hostid);
-
-#undef APPEND
-
-	p->_canonical = strdup(buf);
-	return p->_canonical;
-}
-
-/*
- * Human-readable, log-friendly rendering of a TID:
- * "(transport, traddr, trsvcid[, subsysnqn][, host_iface][, host_traddr])".
- * Matches nvme-stas's TID string form so the two tools' journals line up.
- * hostnqn and hostid are intentionally omitted -- they are rarely the
- * distinguishing field and would only add noise.  Cached like the other
- * derived values.
- */
-__libnvme_public const char *libnvmf_tid_str(const struct libnvmf_tid *tid)
-{
-	struct libnvmf_tid *p = (struct libnvmf_tid *)tid;
-	char buf[CANONICAL_MAX];
-	const char *sep = "";
-	int n = 1;
-
-	if (!tid)
-		return NULL;
-
-	if (p->_str)
-		return p->_str;
-
-	buf[0] = '(';
-
-#define APPEND(field) \
-	do { \
-		if (p->field && p->field[0] && n < (int)CANONICAL_MAX) { \
-			n += snprintf(buf + n, CANONICAL_MAX - n, "%s%s", \
-				      sep, p->field); \
-			sep = ", "; \
-		} \
-	} while (0)
-
-	APPEND(transport);
-	APPEND(traddr);
-	APPEND(trsvcid);
-	APPEND(subsysnqn);
-	APPEND(host_iface);
-	APPEND(host_traddr);
-	if (n < (int)CANONICAL_MAX)
-		snprintf(buf + n, CANONICAL_MAX - n, ")");
-
-#undef APPEND
-
-	p->_str = strdup(buf);
-	return p->_str;
-}
-
-__libnvme_public struct libnvmf_tid *libnvmf_tid_dup(
-		const struct libnvmf_tid *tid)
-{
-	struct libnvmf_tid *t;
-
-	if (!tid)
-		return NULL;
-	if (libnvmf_tid_new(&t) < 0)
-		return NULL;
-
-	/*
-	 * Copy verbatim: the source is already sanitized, so re-running it
-	 * through from_fields() would only re-canonicalize and re-allocate
-	 * addresses that are already in their canonical form.
-	 */
-	t->transport   = xstrdup(tid->transport);
-	t->traddr      = xstrdup(tid->traddr);
-	t->trsvcid     = xstrdup(tid->trsvcid);
-	t->subsysnqn   = xstrdup(tid->subsysnqn);
-	t->host_traddr = xstrdup(tid->host_traddr);
-	t->host_iface  = xstrdup(tid->host_iface);
-	t->hostnqn     = xstrdup(tid->hostnqn);
-	t->hostid      = xstrdup(tid->hostid);
-
-	return t;
-}
-
-__libnvme_public bool libnvmf_tid_is_empty(const struct libnvmf_tid *tid)
-{
-	if (!tid)
-		return true;
-
-	return !tid->transport && !tid->traddr && !tid->trsvcid &&
-	       !tid->subsysnqn && !tid->host_traddr && !tid->host_iface &&
-	       !tid->hostnqn && !tid->hostid;
-}
-
-/*
  * Canonicalize a numeric IP so one endpoint always spells the same way (a
  * compressed vs. expanded IPv6, an IPv4-mapped form, ... all collapse to one
  * string).  Non-blocking: inet_pton()/inet_ntop() only, never DNS.
@@ -341,29 +143,101 @@ __libnvme_public struct libnvmf_tid *libnvmf_tid_from_fields(
 }
 
 /*
- * libnvmf_traddr_is_numeric() - Would this address survive TID construction?
- * @traddr: A candidate traddr/host_traddr, or NULL.
- *
- * The TID constructors accept a numeric IP only and reject a hostname; this
- * lets a caller check a candidate address before resolving it, using the same
- * definition of "numeric" the constructors use internally (including an IPv6
- * scope suffix, which is numeric).
- *
- * Return: true if @traddr is a numeric address, false otherwise (including a
- * NULL @traddr or an allocation failure while checking).
+ * Set the subsysnqn/hostnqn/hostid identity in one call (a NULL argument
+ * leaves that field unchanged).  There are no per-field setters -- addressing
+ * is construction-only -- so this is the sole post-construction mutator.
  */
-__libnvme_public bool libnvmf_traddr_is_numeric(const char *traddr)
+__libnvme_public int libnvmf_tid_set_identity(struct libnvmf_tid *tid,
+					      const char *subsysnqn,
+					      const char *hostnqn,
+					      const char *hostid)
 {
-	char *canon;
-	int rc;
+	char *new_subsysnqn, *new_hostnqn, *new_hostid;
+	const char *eff_hostnqn, *eff_hostid;
+	char *derived = NULL;
 
-	if (!traddr)
-		return false;
+	if (!tid)
+		return -EINVAL;
 
-	rc = canon_ip(traddr, &canon);
-	free(canon);
+	/* The hostnqn/hostid this call will end up with (before deriving). */
+	eff_hostnqn = hostnqn ? hostnqn : tid->hostnqn;
+	eff_hostid  = hostid ? hostid : tid->hostid;
 
-	return rc == 0;
+	/*
+	 * No hostid but a UUID-format hostnqn: derive the hostid from it
+	 * (TP4126) -- deterministic and unique per host, never random.
+	 */
+	if (!eff_hostid && eff_hostnqn) {
+		derived = libnvme_hostid_from_hostnqn(eff_hostnqn);
+		eff_hostid = derived;
+	}
+
+	/* One host is one (hostnqn, hostid) pair. */
+	if (eff_hostid && !eff_hostnqn) {
+		free(derived);
+		return -EINVAL;
+	}
+
+	/* Stage every copy up front so a failure leaves the TID untouched. */
+	new_subsysnqn = xstrdup(subsysnqn);
+	new_hostnqn   = xstrdup(hostnqn);
+	new_hostid    = xstrdup(hostid);
+	if ((subsysnqn && !new_subsysnqn) || (hostnqn && !new_hostnqn) ||
+	    (hostid && !new_hostid)) {
+		free(new_subsysnqn);
+		free(new_hostnqn);
+		free(new_hostid);
+		free(derived);
+		return -ENOMEM;
+	}
+
+	invalidate_cache(tid);
+	if (new_subsysnqn) {
+		free(tid->subsysnqn);
+		tid->subsysnqn = new_subsysnqn;
+	}
+	if (new_hostnqn) {
+		free(tid->hostnqn);
+		tid->hostnqn = new_hostnqn;
+	}
+	if (new_hostid) {
+		free(tid->hostid);
+		tid->hostid = new_hostid;
+	} else if (derived) {
+		free(tid->hostid);
+		tid->hostid = derived;	/* transfer ownership */
+		derived = NULL;
+	}
+	free(derived);
+
+	return 0;
+}
+
+__libnvme_public struct libnvmf_tid *libnvmf_tid_dup(
+		const struct libnvmf_tid *tid)
+{
+	struct libnvmf_tid *t;
+
+	if (!tid)
+		return NULL;
+	if (libnvmf_tid_new(&t) < 0)
+		return NULL;
+
+	/*
+	 * Copy verbatim: the source is already sanitized, so re-running it
+	 * through from_fields() would only re-canonicalize and re-allocate
+	 * addresses that are already in their canonical form.
+	 */
+	t->transport   = xstrdup(tid->transport);
+	t->traddr      = xstrdup(tid->traddr);
+	t->trsvcid     = xstrdup(tid->trsvcid);
+	t->subsysnqn   = xstrdup(tid->subsysnqn);
+	t->host_traddr = xstrdup(tid->host_traddr);
+	t->host_iface  = xstrdup(tid->host_iface);
+	t->hostnqn     = xstrdup(tid->hostnqn);
+	t->hostid      = xstrdup(tid->hostid);
+
+	return t;
 }
 
 /*
@@ -466,4 +340,130 @@ __libnvme_public struct libnvmf_tid *libnvmf_tid_parse_strict(
 		struct libnvme_global_ctx *ctx, const char *str)
 {
 	return tid_parse(ctx, str, true);
+}
+
+/*
+ * libnvmf_traddr_is_numeric() - Would this address survive TID construction?
+ * @traddr: A candidate traddr/host_traddr, or NULL.
+ *
+ * The TID constructors accept a numeric IP only and reject a hostname; this
+ * lets a caller check a candidate address before resolving it, using the same
+ * definition of "numeric" the constructors use internally (including an IPv6
+ * scope suffix, which is numeric).
+ *
+ * Return: true if @traddr is a numeric address, false otherwise (including a
+ * NULL @traddr or an allocation failure while checking).
+ */
+__libnvme_public bool libnvmf_traddr_is_numeric(const char *traddr)
+{
+	char *canon;
+	int rc;
+
+	if (!traddr)
+		return false;
+
+	rc = canon_ip(traddr, &canon);
+	free(canon);
+
+	return rc == 0;
+}
+
+__libnvme_public bool libnvmf_tid_is_empty(const struct libnvmf_tid *tid)
+{
+	if (!tid)
+		return true;
+
+	return !tid->transport && !tid->traddr && !tid->trsvcid &&
+	       !tid->subsysnqn && !tid->host_traddr && !tid->host_iface &&
+	       !tid->hostnqn && !tid->hostid;
+}
+
+/*
+ * Build "key=val;key=val;..." in fixed field order, skipping NULL fields.
+ * Max canonical length: 2 NQNs (223 chars each) + short fields + keys +
+ * separators = ~700 chars.  CANONICAL_MAX of 1024 is a safe upper bound.
+ */
+#define CANONICAL_MAX 1024
+
+__libnvme_public const char *libnvmf_tid_get_canonical(
+		const struct libnvmf_tid *tid)
+{
+	struct libnvmf_tid *p = (struct libnvmf_tid *)tid;
+	char buf[CANONICAL_MAX];
+	int n = 0;
+
+	if (!tid)
+		return NULL;
+
+	if (p->_canonical)
+		return p->_canonical;
+
+	/* n stays < CANONICAL_MAX so (CANONICAL_MAX - n) cannot wrap. */
+#define APPEND(key, field) \
+	do { \
+		if (p->field && n < (int)CANONICAL_MAX) \
+			n += snprintf(buf + n, CANONICAL_MAX - n, "%s%s=%s", \
+				      n ? ";" : "", key, p->field); \
+	} while (0)
+
+	APPEND("transport",   transport);
+	APPEND("traddr",      traddr);
+	APPEND("trsvcid",     trsvcid);
+	APPEND("nqn",         subsysnqn);
+	APPEND("host-traddr", host_traddr);
+	APPEND("host-iface",  host_iface);
+	APPEND("hostnqn",     hostnqn);
+	APPEND("hostid",      hostid);
+
+#undef APPEND
+
+	p->_canonical = strdup(buf);
+	return p->_canonical;
+}
+
+/*
+ * Human-readable, log-friendly rendering of a TID:
+ * "(transport, traddr, trsvcid[, subsysnqn][, host_iface][, host_traddr])".
+ * Matches nvme-stas's TID string form so the two tools' journals line up.
+ * hostnqn and hostid are intentionally omitted -- they are rarely the
+ * distinguishing field and would only add noise.  Cached like the other
+ * derived values.
+ */
+__libnvme_public const char *libnvmf_tid_str(const struct libnvmf_tid *tid)
+{
+	struct libnvmf_tid *p = (struct libnvmf_tid *)tid;
+	char buf[CANONICAL_MAX];
+	const char *sep = "";
+	int n = 1;
+
+	if (!tid)
+		return NULL;
+
+	if (p->_str)
+		return p->_str;
+
+	buf[0] = '(';
+
+#define APPEND(field) \
+	do { \
+		if (p->field && p->field[0] && n < (int)CANONICAL_MAX) { \
+			n += snprintf(buf + n, CANONICAL_MAX - n, "%s%s", \
+				      sep, p->field); \
+			sep = ", "; \
+		} \
+	} while (0)
+
+	APPEND(transport);
+	APPEND(traddr);
+	APPEND(trsvcid);
+	APPEND(subsysnqn);
+	APPEND(host_iface);
+	APPEND(host_traddr);
+	if (n < (int)CANONICAL_MAX)
+		snprintf(buf + n, CANONICAL_MAX - n, ")");
+
+#undef APPEND
+
+	p->_str = strdup(buf);
+	return p->_str;
 }

--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -6,6 +6,8 @@
  * Authors: Martin Belanger <martin.belanger@dell.com>
  */
 
+#include <arpa/inet.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -218,13 +220,28 @@ __libnvme_public const char *libnvmf_tid_str(const struct libnvmf_tid *tid)
 __libnvme_public struct libnvmf_tid *libnvmf_tid_dup(
 		const struct libnvmf_tid *tid)
 {
+	struct libnvmf_tid *t;
+
 	if (!tid)
 		return NULL;
+	if (libnvmf_tid_new(&t) < 0)
+		return NULL;
 
-	return libnvmf_tid_from_fields(tid->transport, tid->traddr,
-				       tid->trsvcid, tid->subsysnqn,
-				       tid->host_traddr, tid->host_iface,
-				       tid->hostnqn, tid->hostid);
+	/*
+	 * Copy verbatim: the source is already sanitized, so re-running it
+	 * through from_fields() would only re-canonicalize and re-allocate
+	 * addresses that are already in their canonical form.
+	 */
+	t->transport   = xstrdup(tid->transport);
+	t->traddr      = xstrdup(tid->traddr);
+	t->trsvcid     = xstrdup(tid->trsvcid);
+	t->subsysnqn   = xstrdup(tid->subsysnqn);
+	t->host_traddr = xstrdup(tid->host_traddr);
+	t->host_iface  = xstrdup(tid->host_iface);
+	t->hostnqn     = xstrdup(tid->hostnqn);
+	t->hostid      = xstrdup(tid->hostid);
+
+	return t;
 }
 
 __libnvme_public bool libnvmf_tid_equal(
@@ -255,6 +272,94 @@ __libnvme_public bool libnvmf_tid_is_empty(const struct libnvmf_tid *tid)
 	       !tid->hostnqn && !tid->hostid;
 }
 
+/*
+ * Canonicalize a numeric IP so one endpoint always spells the same way (a
+ * compressed vs. expanded IPv6, an IPv4-mapped form, ... all collapse to one
+ * string).  Non-blocking: inet_pton()/inet_ntop() only, never DNS.
+ *
+ * Returns 0 and stores a malloc'd canonical form in *out when @in is numeric;
+ * -EINVAL (with *out = NULL) when @in is not numeric -- i.e. a hostname;
+ * -ENOMEM on allocation failure.  An IPv6 scope suffix ("fe80::1%eth0") is
+ * kept verbatim -- as a name, not an interface index -- so the result stays
+ * reproducible.  (That verbatim scope is why inet_pton_with_scope() is not
+ * reused here: it numericizes the scope via if_nametoindex() and yields a
+ * sockaddr, not a stable string.)
+ */
+static int canon_ip(const char *in, char **out)
+{
+	char host[INET6_ADDRSTRLEN];
+	char canon[INET6_ADDRSTRLEN];
+	unsigned char addr6[16];
+	struct in_addr addr4;
+	const char *scope;
+	size_t hostlen;
+
+	*out = NULL;
+
+	scope = strchr(in, '%');
+	hostlen = scope ? (size_t)(scope - in) : strlen(in);
+	if (hostlen >= sizeof(host))
+		return -EINVAL;
+	memcpy(host, in, hostlen);
+	host[hostlen] = '\0';
+
+	if (inet_pton(AF_INET, host, &addr4) == 1) {
+		if (!inet_ntop(AF_INET, &addr4, canon, sizeof(canon)))
+			return -EINVAL;
+		*out = strdup(canon);	/* IPv4 has no scope */
+		return *out ? 0 : -ENOMEM;
+	}
+
+	if (inet_pton(AF_INET6, host, addr6) == 1) {
+		if (!inet_ntop(AF_INET6, addr6, canon, sizeof(canon)))
+			return -EINVAL;
+		if (asprintf(out, "%s%s", canon, scope ? scope : "") < 0) {
+			*out = NULL;
+			return -ENOMEM;
+		}
+		return 0;
+	}
+
+	return -EINVAL;
+}
+
+/*
+ * Sanitize the addressing fields once the transport is known: canonicalize a
+ * numeric traddr/host_traddr via canon_ip(); a hostname is rejected outright
+ * -- resolving one is the caller's job, not libnvme's.  IP addressing
+ * applies only to the IP transports; fc and loop are left untouched.
+ *
+ * Return: 0 on success; -EINVAL if traddr or host_traddr is set but not
+ * numeric; -ENOMEM on allocation failure.
+ */
+static int tid_sanitize_addr(struct libnvmf_tid *t)
+{
+	char *canon;
+	int rc;
+
+	if (!t->transport ||
+	    (strcmp(t->transport, "tcp") && strcmp(t->transport, "rdma")))
+		return 0;
+
+	if (t->traddr) {
+		rc = canon_ip(t->traddr, &canon);
+		if (rc)
+			return rc;
+		free(t->traddr);
+		t->traddr = canon;
+	}
+
+	if (t->host_traddr) {
+		rc = canon_ip(t->host_traddr, &canon);
+		if (rc)
+			return rc;
+		free(t->host_traddr);
+		t->host_traddr = canon;
+	}
+
+	return 0;
+}
+
 __libnvme_public struct libnvmf_tid *libnvmf_tid_from_fields(
 		const char *transport, const char *traddr,
 		const char *trsvcid, const char *subsysnqn,
@@ -275,7 +380,38 @@ __libnvme_public struct libnvmf_tid *libnvmf_tid_from_fields(
 	t->hostnqn     = xstrdup(hostnqn);
 	t->hostid      = xstrdup(hostid);
 
+	if (tid_sanitize_addr(t)) {
+		libnvmf_tid_free(t);
+		return NULL;
+	}
+
 	return t;
+}
+
+/*
+ * libnvmf_traddr_is_numeric() - Would this address survive TID construction?
+ * @traddr: A candidate traddr/host_traddr, or NULL.
+ *
+ * The TID constructors accept a numeric IP only and reject a hostname; this
+ * lets a caller check a candidate address before resolving it, using the same
+ * definition of "numeric" the constructors use internally (including an IPv6
+ * scope suffix, which is numeric).
+ *
+ * Return: true if @traddr is a numeric address, false otherwise (including a
+ * NULL @traddr or an allocation failure while checking).
+ */
+__libnvme_public bool libnvmf_traddr_is_numeric(const char *traddr)
+{
+	char *canon;
+	int rc;
+
+	if (!traddr)
+		return false;
+
+	rc = canon_ip(traddr, &canon);
+	free(canon);
+
+	return rc == 0;
 }
 
 /*
@@ -361,7 +497,7 @@ static struct libnvmf_tid *tid_parse(struct libnvme_global_ctx *ctx,
 	}
 
 	free(buf);
-	if (bad) {
+	if (bad || tid_sanitize_addr(t)) {
 		libnvmf_tid_free(t);
 		return NULL;
 	}

--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -8,8 +8,6 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
-#include <inttypes.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -24,8 +22,6 @@ static void invalidate_cache(struct libnvmf_tid *p)
 {
 	free(p->_canonical);
 	p->_canonical = NULL;
-	free(p->_hash);
-	p->_hash = NULL;
 	free(p->_str);
 	p->_str = NULL;
 }
@@ -139,37 +135,6 @@ __libnvme_public const char *libnvmf_tid_get_canonical(
 	return p->_canonical;
 }
 
-__libnvme_public const char *libnvmf_tid_get_hash(
-		const struct libnvmf_tid *tid)
-{
-	struct libnvmf_tid *p = (struct libnvmf_tid *)tid;
-	const char *canon;
-	uint64_t h;
-
-	if (!tid)
-		return NULL;
-
-	if (p->_hash)
-		return p->_hash;
-
-	canon = libnvmf_tid_get_canonical(tid);
-	if (!canon)
-		return NULL;
-
-	/*
-	 * Truncate the 64-bit FNV-1a value to 48 bits / 12 hex chars.  This
-	 * keeps the derived unit name short while keeping collisions negligible
-	 * at realistic scale: for ~200 concurrently-connected controllers the
-	 * birthday-bound collision probability is on the order of 1 in 1e10.
-	 */
-	h = libnvmf_fnv1a_64(canon, strlen(canon)) & 0xffffffffffffULL;
-	if (asprintf(&p->_hash, "%012" PRIx64, h) < 0) {
-		p->_hash = NULL;
-		return NULL;
-	}
-	return p->_hash;
-}
-
 /*
  * Human-readable, log-friendly rendering of a TID:
  * "(transport, traddr, trsvcid[, subsysnqn][, host_iface][, host_traddr])".
@@ -242,24 +207,6 @@ __libnvme_public struct libnvmf_tid *libnvmf_tid_dup(
 	t->hostid      = xstrdup(tid->hostid);
 
 	return t;
-}
-
-__libnvme_public bool libnvmf_tid_equal(
-		const struct libnvmf_tid *a, const struct libnvmf_tid *b)
-{
-	if (a == b)
-		return true;
-	if (!a || !b)
-		return false;
-
-	return streq0(a->transport, b->transport) &&
-	       streq0(a->traddr, b->traddr) &&
-	       streq0(a->trsvcid, b->trsvcid) &&
-	       streq0(a->subsysnqn, b->subsysnqn) &&
-	       streq0(a->host_traddr, b->host_traddr) &&
-	       streq0(a->host_iface, b->host_iface) &&
-	       streq0(a->hostnqn, b->hostnqn) &&
-	       streq0(a->hostid, b->hostid);
 }
 
 __libnvme_public bool libnvmf_tid_is_empty(const struct libnvmf_tid *tid)

--- a/libnvme/src/nvme/tid.h
+++ b/libnvme/src/nvme/tid.h
@@ -13,19 +13,28 @@
 struct libnvme_global_ctx;
 
 /**
- * Custom setters for struct libnvmf_tid.
+ * libnvmf_tid_set_identity() - Set the subsystem and host identity together.
+ * @tid:       The transport ID.
+ * @subsysnqn: Subsystem NQN, or NULL to leave it unchanged.
+ * @hostnqn:   Host NQN, or NULL to leave it unchanged.
+ * @hostid:    Host Identifier, or NULL to leave it unchanged (or derive it).
  *
- * Each setter strdup()s the new value, frees the previous one, and invalidates
- * the cached canonical string and hash.  NULL is accepted and stored as NULL.
+ * Identity is applied after addressing -- which subsystem, and which host
+ * persona, are decided by context.  A NULL argument leaves that field as-is,
+ * which is why the three are set through one call rather than per-field
+ * setters (addressing has none: it is construction-only).
+ *
+ * hostid is never left to chance: when no hostid is set but the resulting
+ * hostnqn carries a UUID (nqn.2014-08.org.nvmexpress:uuid:<X>), the hostid is
+ * derived from it -- the deterministic, per-host value (TP4126), never a
+ * random one.  A hostid without a hostnqn is rejected: one host is one
+ * (hostnqn, hostid) pair.
+ *
+ * Return: 0 on success; -EINVAL for a NULL @tid or a hostid without a hostnqn;
+ * -ENOMEM on allocation failure.
  */
-void libnvmf_tid_set_transport(struct libnvmf_tid *p, const char *val);
-void libnvmf_tid_set_traddr(struct libnvmf_tid *p, const char *val);
-void libnvmf_tid_set_trsvcid(struct libnvmf_tid *p, const char *val);
-void libnvmf_tid_set_subsysnqn(struct libnvmf_tid *p, const char *val);
-void libnvmf_tid_set_host_traddr(struct libnvmf_tid *p, const char *val);
-void libnvmf_tid_set_host_iface(struct libnvmf_tid *p, const char *val);
-void libnvmf_tid_set_hostnqn(struct libnvmf_tid *p, const char *val);
-void libnvmf_tid_set_hostid(struct libnvmf_tid *p, const char *val);
+int libnvmf_tid_set_identity(struct libnvmf_tid *tid, const char *subsysnqn,
+			     const char *hostnqn, const char *hostid);
 
 /**
  * libnvmf_tid_dup() - Allocate a copy of an existing TID.
@@ -132,7 +141,7 @@ struct libnvmf_tid *libnvmf_tid_parse_strict(struct libnvme_global_ctx *ctx,
  * Returns a deterministic, fixed-field-order semicolon-separated key=value
  * string (e.g. "transport=tcp;traddr=1.2.3.4;trsvcid=8009").  Only non-NULL
  * fields are included.  The string is lazily computed and cached; it is
- * invalidated by any setter call.
+ * invalidated by any identity change.
  *
  * The fixed field order makes the output independent of the order fields
  * were set, so the same logical TID always yields the same canonical string.

--- a/libnvme/src/nvme/tid.h
+++ b/libnvme/src/nvme/tid.h
@@ -13,6 +13,33 @@
 struct libnvme_global_ctx;
 
 /**
+ * libnvmf_tid_from_fields() - Allocate a TID from individual field strings.
+ * @transport:   Transport type (e.g. "tcp", "rdma", "fc").
+ * @traddr:      Transport address.
+ * @trsvcid:     Transport service ID (e.g. "8009").
+ * @subsysnqn:   Subsystem NQN.
+ * @host_traddr: Host transport address, or NULL.
+ * @host_iface:  Host interface name, or NULL.
+ * @hostnqn:     Host NQN, or NULL.
+ * @hostid:      Host Identifier, or NULL.
+ *
+ * Convenience constructor.  NULL fields are stored as NULL.  For an IP
+ * transport (tcp, rdma) a numeric traddr/host_traddr is canonicalized; a
+ * hostname is rejected -- resolving it is the caller's job, not libnvme's.
+ *
+ * Return: Allocated TID, or NULL if traddr/host_traddr is not numeric on an
+ * IP transport, or on allocation failure.
+ */
+struct libnvmf_tid *libnvmf_tid_from_fields(const char *transport,
+					    const char *traddr,
+					    const char *trsvcid,
+					    const char *subsysnqn,
+					    const char *host_traddr,
+					    const char *host_iface,
+					    const char *hostnqn,
+					    const char *hostid);
+
+/**
  * libnvmf_tid_set_identity() - Set the subsystem and host identity together.
  * @tid:       The transport ID.
  * @subsysnqn: Subsystem NQN, or NULL to leave it unchanged.
@@ -43,56 +70,6 @@ int libnvmf_tid_set_identity(struct libnvmf_tid *tid, const char *subsysnqn,
  * Return: Allocated copy, or NULL if @tid is NULL or on allocation failure.
  */
 struct libnvmf_tid *libnvmf_tid_dup(const struct libnvmf_tid *tid);
-
-/**
- * libnvmf_tid_is_empty() - Test whether a TID sets no fields.
- * @tid: The transport ID, or NULL.
- *
- * Return: true if @tid is NULL or every field is unset, false otherwise.
- */
-bool libnvmf_tid_is_empty(const struct libnvmf_tid *tid);
-
-/**
- * libnvmf_tid_from_fields() - Allocate a TID from individual field strings.
- * @transport:   Transport type (e.g. "tcp", "rdma", "fc").
- * @traddr:      Transport address.
- * @trsvcid:     Transport service ID (e.g. "8009").
- * @subsysnqn:   Subsystem NQN.
- * @host_traddr: Host transport address, or NULL.
- * @host_iface:  Host interface name, or NULL.
- * @hostnqn:     Host NQN, or NULL.
- * @hostid:      Host Identifier, or NULL.
- *
- * Convenience constructor.  NULL fields are stored as NULL.  For an IP
- * transport (tcp, rdma) a numeric traddr/host_traddr is canonicalized; a
- * hostname is rejected -- resolving it is the caller's job, not libnvme's.
- *
- * Return: Allocated TID, or NULL if traddr/host_traddr is not numeric on an
- * IP transport, or on allocation failure.
- */
-struct libnvmf_tid *libnvmf_tid_from_fields(const char *transport,
-					    const char *traddr,
-					    const char *trsvcid,
-					    const char *subsysnqn,
-					    const char *host_traddr,
-					    const char *host_iface,
-					    const char *hostnqn,
-					    const char *hostid);
-
-/**
- * libnvmf_traddr_is_numeric() - Would this address survive TID construction?
- * @traddr: A candidate traddr/host_traddr, or NULL.
- *
- * The TID constructors accept a numeric IP only and reject a hostname; this
- * lets a caller check a candidate address -- and decide whether it must
- * resolve it first -- before building the TID, using the same definition of
- * "numeric" the constructors use internally (including an IPv6 scope
- * suffix, which is numeric).
- *
- * Return: true if @traddr is a numeric address, false otherwise (including a
- * NULL @traddr or an allocation failure while checking).
- */
-bool libnvmf_traddr_is_numeric(const char *traddr);
 
 /**
  * libnvmf_tid_parse() - Allocate a TID from a semicolon-separated key=value
@@ -133,6 +110,29 @@ struct libnvmf_tid *libnvmf_tid_parse(struct libnvme_global_ctx *ctx,
  */
 struct libnvmf_tid *libnvmf_tid_parse_strict(struct libnvme_global_ctx *ctx,
 					     const char *str);
+
+/**
+ * libnvmf_traddr_is_numeric() - Would this address survive TID construction?
+ * @traddr: A candidate traddr/host_traddr, or NULL.
+ *
+ * The TID constructors accept a numeric IP only and reject a hostname; this
+ * lets a caller check a candidate address -- and decide whether it must
+ * resolve it first -- before building the TID, using the same definition of
+ * "numeric" the constructors use internally (including an IPv6 scope
+ * suffix, which is numeric).
+ *
+ * Return: true if @traddr is a numeric address, false otherwise (including a
+ * NULL @traddr or an allocation failure while checking).
+ */
+bool libnvmf_traddr_is_numeric(const char *traddr);
+
+/**
+ * libnvmf_tid_is_empty() - Test whether a TID sets no fields.
+ * @tid: The transport ID, or NULL.
+ *
+ * Return: true if @tid is NULL or every field is unset, false otherwise.
+ */
+bool libnvmf_tid_is_empty(const struct libnvmf_tid *tid);
 
 /**
  * libnvmf_tid_get_canonical() - Return the canonical string form of a TID.

--- a/libnvme/src/nvme/tid.h
+++ b/libnvme/src/nvme/tid.h
@@ -36,19 +36,6 @@ void libnvmf_tid_set_hostid(struct libnvmf_tid *p, const char *val);
 struct libnvmf_tid *libnvmf_tid_dup(const struct libnvmf_tid *tid);
 
 /**
- * libnvmf_tid_equal() - Compare two TIDs for equality.
- * @a: First TID, or NULL.
- * @b: Second TID, or NULL.
- *
- * Compares all eight fields with exact string equality.  Two NULL TIDs are
- * considered equal.
- *
- * Return: true if all fields match, false otherwise.
- */
-bool libnvmf_tid_equal(const struct libnvmf_tid *a,
-		       const struct libnvmf_tid *b);
-
-/**
  * libnvmf_tid_is_empty() - Test whether a TID sets no fields.
  * @tid: The transport ID, or NULL.
  *
@@ -147,50 +134,24 @@ struct libnvmf_tid *libnvmf_tid_parse_strict(struct libnvme_global_ctx *ctx,
  * fields are included.  The string is lazily computed and cached; it is
  * invalidated by any setter call.
  *
- * Stability is the whole point of this form, because the hash returned by
- * libnvmf_tid_get_hash() is computed directly from this string.  The fixed
- * field order makes the output independent of the order fields were set, so
- * the same logical TID always yields the same canonical string and therefore
- * the same hash.  Conversely, *any* difference in the bytes here -- a field
- * present vs. absent, or the same field spelled differently -- changes the
- * hash.  Two producers (e.g. discoverd and a udev helper) only agree on a
- * TID's hash if they build the TID with byte-identical field values.
+ * The fixed field order makes the output independent of the order fields
+ * were set, so the same logical TID always yields the same canonical string.
+ * This is the stable primitive libnvme provides for naming a connection; a
+ * caller that wants a compact hash (e.g. for a systemd unit name) derives it
+ * from this string itself -- libnvme does not hash it.
  *
  * IMPORTANT -- address text is a known foot-gun here.  This function does no
- * normalization: it hashes the address exactly as stored.  The same endpoint
- * can be written several ways that are semantically equal but textually
- * different, e.g. a hostname vs. its resolved IP, an IPv4-mapped IPv6 address
- * ("::ffff:1.2.3.4") vs. dotted IPv4 ("1.2.3.4"), or a compressed vs.
- * fully-expanded IPv6 address.  Each spelling produces a different canonical
- * string and hash.
- *
- * This variation comes from *user space*, not the kernel.  The nvme fabrics
- * driver stores traddr/host_traddr verbatim and reports them back through
- * sysfs unchanged; it parses numeric addresses only (inet_pton) and never
- * resolves hostnames.  So a value read from sysfs matches exactly what was
- * written to /dev/nvme-fabrics -- the divergence is strictly between producers
- * that spell the same endpoint differently (e.g. a daemon that resolves a
- * hostname, or normalizes IPv6) before handing it to the kernel.  Callers that
- * rely on hashes matching across producers (or across a connect/reconnect)
- * must build the TID from the same textual form that is handed to the kernel.
+ * normalization beyond what the constructors already applied: the address is
+ * numeric (constructors reject a hostname), but a compressed vs.
+ * fully-expanded IPv6 address, or an IPv4-mapped IPv6 address
+ * ("::ffff:1.2.3.4") vs. dotted IPv4 ("1.2.3.4"), can still spell the same
+ * endpoint differently and yield different canonical strings.  Two producers
+ * only agree on a TID's canonical form if they build the TID from
+ * byte-identical field values.
  *
  * Return: Cached canonical string, or NULL on allocation failure.
  */
 const char *libnvmf_tid_get_canonical(const struct libnvmf_tid *tid);
-
-/**
- * libnvmf_tid_get_hash() - Return a stable hash string for a TID.
- * @tid: The transport ID.
- *
- * Returns a 12-character lowercase hex string derived from the FNV-1a 64-bit
- * hash (truncated to 48 bits) of the canonical TID string.  The hash is lazily
- * computed and cached; it is invalidated by any setter call.
- *
- * Suitable for use as a dictionary key or compact log identifier.
- *
- * Return: Cached hash string, or NULL on allocation failure.
- */
-const char *libnvmf_tid_get_hash(const struct libnvmf_tid *tid);
 
 /**
  * libnvmf_tid_str() - Human-readable string form of a TID, for logging.

--- a/libnvme/src/nvme/tid.h
+++ b/libnvme/src/nvme/tid.h
@@ -67,9 +67,12 @@ bool libnvmf_tid_is_empty(const struct libnvmf_tid *tid);
  * @hostnqn:     Host NQN, or NULL.
  * @hostid:      Host Identifier, or NULL.
  *
- * Convenience constructor.  NULL fields are stored as NULL.
+ * Convenience constructor.  NULL fields are stored as NULL.  For an IP
+ * transport (tcp, rdma) a numeric traddr/host_traddr is canonicalized; a
+ * hostname is rejected -- resolving it is the caller's job, not libnvme's.
  *
- * Return: Allocated TID, or NULL on allocation failure.
+ * Return: Allocated TID, or NULL if traddr/host_traddr is not numeric on an
+ * IP transport, or on allocation failure.
  */
 struct libnvmf_tid *libnvmf_tid_from_fields(const char *transport,
 					    const char *traddr,
@@ -79,6 +82,21 @@ struct libnvmf_tid *libnvmf_tid_from_fields(const char *transport,
 					    const char *host_iface,
 					    const char *hostnqn,
 					    const char *hostid);
+
+/**
+ * libnvmf_traddr_is_numeric() - Would this address survive TID construction?
+ * @traddr: A candidate traddr/host_traddr, or NULL.
+ *
+ * The TID constructors accept a numeric IP only and reject a hostname; this
+ * lets a caller check a candidate address -- and decide whether it must
+ * resolve it first -- before building the TID, using the same definition of
+ * "numeric" the constructors use internally (including an IPv6 scope
+ * suffix, which is numeric).
+ *
+ * Return: true if @traddr is a numeric address, false otherwise (including a
+ * NULL @traddr or an allocation failure while checking).
+ */
+bool libnvmf_traddr_is_numeric(const char *traddr);
 
 /**
  * libnvmf_tid_parse() - Allocate a TID from a semicolon-separated key=value
@@ -94,8 +112,11 @@ struct libnvmf_tid *libnvmf_tid_from_fields(const char *transport,
  * C-identifier convention.)  Unknown keys, bare keys (no '='), and empty
  * values are logged at WARN level (when @ctx is non-NULL) and skipped.
  * Whitespace around keys and values is trimmed.  NULL input returns NULL.
+ * Like libnvmf_tid_from_fields(), a traddr/host-traddr that is not numeric on
+ * an IP transport fails the whole parse.
  *
- * Return: Allocated TID, or NULL on allocation failure.
+ * Return: Allocated TID, or NULL on a non-numeric address or allocation
+ * failure.
  */
 struct libnvmf_tid *libnvmf_tid_parse(struct libnvme_global_ctx *ctx,
 				      const char *str);

--- a/libnvme/test/test-tid.c
+++ b/libnvme/test/test-tid.c
@@ -6,9 +6,9 @@
  * Authors: Martin Belanger <martin.belanger@dell.com>
  *
  * Unit tests for the libnvmf_tid API — libnvmf_tid_parse() (valid input,
- * rejected aliases, garbage tokens, duplicate keys, whitespace), plus equal(),
- * dup(), get_canonical(), get_hash(), setter cache invalidation, numeric-only
- * address sanitization, and traddr_is_numeric().
+ * rejected aliases, garbage tokens, duplicate keys, whitespace), plus dup(),
+ * get_canonical(), setter cache invalidation, numeric-only address
+ * sanitization, and traddr_is_numeric().
  *
  * Note: garbage-input tests intentionally trigger error messages on stderr;
  * that output is expected and does not indicate a test failure.
@@ -304,52 +304,6 @@ static bool test_tid_parse_whitespace(void)
 }
 
 /* -------------------------------------------------------------------------
- * libnvmf_tid_equal() — including NULL handling (regression for the NULL crash)
- * -------------------------------------------------------------------------
- */
-static bool test_tid_equal(void)
-{
-	struct libnvme_global_ctx *ctx;
-	struct libnvmf_tid *a, *b;
-	bool pass = true, p;
-
-	ctx = libnvme_create_global_ctx();
-
-	printf("\ntest_tid_equal:\n");
-
-	p = libnvmf_tid_equal(NULL, NULL);
-	CHECK(p, "equal(NULL, NULL) → true");
-	pass &= p;
-
-	a = libnvmf_tid_parse(ctx,
-			      "transport=tcp;traddr=1.2.3.4;trsvcid=4420");
-
-	p = !libnvmf_tid_equal(a, NULL) && !libnvmf_tid_equal(NULL, a);
-	CHECK(p, "equal(t, NULL) and equal(NULL, t) → false (no crash)");
-	pass &= p;
-
-	p = libnvmf_tid_equal(a, a);
-	CHECK(p, "equal(t, t) → true");
-	pass &= p;
-
-	b = libnvmf_tid_parse(ctx,
-			      "transport=tcp;traddr=1.2.3.4;trsvcid=4420");
-	p = libnvmf_tid_equal(a, b);
-	CHECK(p, "identical TIDs → equal");
-	pass &= p;
-
-	libnvmf_tid_set_traddr(b, "5.6.7.8");
-	p = !libnvmf_tid_equal(a, b);
-	CHECK(p, "differing field → not equal");
-	pass &= p;
-
-	libnvmf_tid_free(a);
-	libnvmf_tid_free(b);
-	libnvme_free_global_ctx(ctx);
-	return pass;
-}
-
-/* -------------------------------------------------------------------------
  * libnvmf_tid_dup()
  * -------------------------------------------------------------------------
  */
@@ -370,8 +324,9 @@ static bool test_tid_dup(void)
 	t = libnvmf_tid_parse(ctx,
 			      "transport=tcp;traddr=1.2.3.4;nqn=nqn.test");
 	d = libnvmf_tid_dup(t);
-	p = d && libnvmf_tid_equal(t, d) && d != t;
-	CHECK(p, "dup is a distinct but equal copy");
+	p = d && d != t &&
+	    streq(libnvmf_tid_get_canonical(t), libnvmf_tid_get_canonical(d));
+	CHECK(p, "dup is a distinct copy with the same canonical form");
 	pass &= p;
 
 	libnvmf_tid_free(t);
@@ -420,65 +375,15 @@ static bool test_tid_canonical(void)
 }
 
 /* -------------------------------------------------------------------------
- * libnvmf_tid_get_hash() — format, stability, caching
- * -------------------------------------------------------------------------
- */
-static bool test_tid_hash(void)
-{
-	struct libnvme_global_ctx *ctx;
-	struct libnvmf_tid *a, *b, *c;
-	const char *h1, *h2;
-	bool pass = true, p;
-
-	ctx = libnvme_create_global_ctx();
-
-	printf("\ntest_tid_hash:\n");
-
-	p = (libnvmf_tid_get_hash(NULL) == NULL);
-	CHECK(p, "hash(NULL) → NULL");
-	pass &= p;
-
-	a = libnvmf_tid_parse(ctx,
-			      "transport=tcp;traddr=1.2.3.4;trsvcid=4420");
-	h1 = libnvmf_tid_get_hash(a);
-	p = h1 && strlen(h1) == 12 && strspn(h1, "0123456789abcdef") == 12;
-	CHECK(p, "hash is 12 lowercase hex chars");
-	pass &= p;
-
-	h2 = libnvmf_tid_get_hash(a);
-	p = (h1 == h2);
-	CHECK(p, "hash is cached (same pointer on 2nd call)");
-	pass &= p;
-
-	b = libnvmf_tid_parse(ctx,
-			      "transport=tcp;traddr=1.2.3.4;trsvcid=4420");
-	p = streq(libnvmf_tid_get_hash(a), libnvmf_tid_get_hash(b));
-	CHECK(p, "equal TIDs → equal hash");
-	pass &= p;
-
-	c = libnvmf_tid_parse(ctx,
-			      "transport=tcp;traddr=9.9.9.9;trsvcid=4420");
-	p = !streq(libnvmf_tid_get_hash(a), libnvmf_tid_get_hash(c));
-	CHECK(p, "different TIDs → different hash");
-	pass &= p;
-
-	libnvmf_tid_free(a);
-	libnvmf_tid_free(b);
-	libnvmf_tid_free(c);
-	libnvme_free_global_ctx(ctx);
-	return pass;
-}
-
-/* -------------------------------------------------------------------------
- * Setters invalidate the canonical/hash caches
+ * Setters invalidate the canonical cache
  * -------------------------------------------------------------------------
  */
 static bool test_tid_setter_invalidates_cache(void)
 {
 	struct libnvme_global_ctx *ctx;
 	struct libnvmf_tid *t;
-	char before[64], h_before[32];
-	const char *after, *h_after;
+	char before[64];
+	const char *after;
 	bool pass = true, p;
 
 	ctx = libnvme_create_global_ctx();
@@ -487,20 +392,14 @@ static bool test_tid_setter_invalidates_cache(void)
 
 	t = libnvmf_tid_parse(ctx, "transport=tcp;traddr=1.2.3.4");
 
-	/* Prime the caches, mutate, then confirm they were rebuilt. */
+	/* Prime the cache, mutate, then confirm it was rebuilt. */
 	snprintf(before, sizeof(before), "%s", libnvmf_tid_get_canonical(t));
-	snprintf(h_before, sizeof(h_before), "%s", libnvmf_tid_get_hash(t));
 
 	libnvmf_tid_set_traddr(t, "5.6.7.8");
 
 	after = libnvmf_tid_get_canonical(t);
 	p = after && !streq(before, after) && strstr(after, "traddr=5.6.7.8");
 	CHECK(p, "setter invalidates canonical cache");
-	pass &= p;
-
-	h_after = libnvmf_tid_get_hash(t);
-	p = h_after && !streq(h_before, h_after);
-	CHECK(p, "setter invalidates hash cache");
 	pass &= p;
 
 	libnvmf_tid_free(t);
@@ -718,13 +617,11 @@ int main(int argc, char *argv[])
 	test_tid_parse_garbage();
 	test_tid_parse_duplicate_key();
 	test_tid_parse_whitespace();
-	test_tid_equal();
 	test_tid_is_empty();
 	test_tid_dup();
 	test_tid_sanitize();
 	test_tid_traddr_is_numeric();
 	test_tid_canonical();
-	test_tid_hash();
 	test_tid_setter_invalidates_cache();
 
 	if (test_rc == EXIT_SUCCESS)

--- a/libnvme/test/test-tid.c
+++ b/libnvme/test/test-tid.c
@@ -7,7 +7,8 @@
  *
  * Unit tests for the libnvmf_tid API — libnvmf_tid_parse() (valid input,
  * rejected aliases, garbage tokens, duplicate keys, whitespace), plus equal(),
- * dup(), get_canonical(), get_hash(), and setter cache invalidation.
+ * dup(), get_canonical(), get_hash(), setter cache invalidation, numeric-only
+ * address sanitization, and traddr_is_numeric().
  *
  * Note: garbage-input tests intentionally trigger error messages on stderr;
  * that output is expected and does not indicate a test failure.
@@ -598,6 +599,114 @@ static bool test_tid_is_empty(void)
 	return pass;
 }
 
+/* -------------------------------------------------------------------------
+ * Address sanitization by the constructors, and rejection of a hostname
+ * -------------------------------------------------------------------------
+ */
+static bool test_tid_sanitize(void)
+{
+	struct libnvme_global_ctx *ctx;
+	struct libnvmf_tid *t;
+	bool pass = true, p;
+
+	ctx = libnvme_create_global_ctx();
+
+	printf("\ntest_tid_sanitize:\n");
+	printf("  (error messages on stderr below are expected)\n");
+
+	/* An expanded IPv6 traddr is canonicalized to its compressed form. */
+	t = libnvmf_tid_from_fields("tcp", "2001:db8:0:0:0:0:0:1", "4420",
+				    "nqn.t", NULL, NULL, NULL, NULL);
+	p = t && streq(libnvmf_tid_get_traddr(t), "2001:db8::1");
+	CHECK(p, "expanded IPv6 traddr → compressed");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* A numeric host_traddr is canonicalized too. */
+	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", "nqn.t",
+				    "2001:db8:0:0:0:0:0:2", NULL, NULL, NULL);
+	p = t && streq(libnvmf_tid_get_host_traddr(t), "2001:db8::2");
+	CHECK(p, "host_traddr IPv6 canonicalized");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* An IPv6 scope suffix is kept verbatim after the canonical address. */
+	t = libnvmf_tid_from_fields("tcp", "fe80:0:0:0:0:0:0:1%eth0", "4420",
+				    "nqn.t", NULL, NULL, NULL, NULL);
+	p = t && streq(libnvmf_tid_get_traddr(t), "fe80::1%eth0");
+	CHECK(p, "IPv6 scope preserved: fe80::1%%eth0");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* A hostname traddr is rejected outright: construction fails. */
+	t = libnvmf_tid_from_fields("tcp", "dc.example.com", "8009", "nqn.t",
+				    NULL, NULL, NULL, NULL);
+	p = (t == NULL);
+	CHECK(p, "hostname traddr rejected by from_fields()");
+	libnvmf_tid_free(t);
+	pass &= p;
+
+	/* A hostname host_traddr is rejected too. */
+	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "8009", "nqn.t",
+				    "dc.example.com", NULL, NULL, NULL);
+	p = (t == NULL);
+	CHECK(p, "hostname host_traddr rejected by from_fields()");
+	libnvmf_tid_free(t);
+	pass &= p;
+
+	/* parse() rejects the same way. */
+	t = libnvmf_tid_parse(ctx, "transport=tcp;traddr=dc.example.com");
+	p = (t == NULL);
+	CHECK(p, "parse() rejects a hostname traddr");
+	libnvmf_tid_free(t);
+	pass &= p;
+
+	/* Non-IP transports are untouched: no canonicalize, no rejection. */
+	t = libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
+				    NULL, NULL, NULL, NULL);
+	p = t && streq(libnvmf_tid_get_traddr(t), "nn-0x1:pn-0x2");
+	CHECK(p, "fc traddr untouched");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	libnvme_free_global_ctx(ctx);
+
+	return pass;
+}
+
+/* -------------------------------------------------------------------------
+ * libnvmf_traddr_is_numeric()
+ * -------------------------------------------------------------------------
+ */
+static bool test_tid_traddr_is_numeric(void)
+{
+	bool pass = true, p;
+
+	printf("\ntest_tid_traddr_is_numeric:\n");
+
+	p = libnvmf_traddr_is_numeric("1.2.3.4");
+	CHECK(p, "dotted IPv4 is numeric");
+	pass &= p;
+
+	p = libnvmf_traddr_is_numeric("2001:db8::1");
+	CHECK(p, "IPv6 is numeric");
+	pass &= p;
+
+	p = libnvmf_traddr_is_numeric("fe80::1%eth0");
+	CHECK(p, "IPv6 with scope is numeric");
+	pass &= p;
+
+	p = !libnvmf_traddr_is_numeric("dc.example.com");
+	CHECK(p, "hostname is not numeric");
+	pass &= p;
+
+	p = !libnvmf_traddr_is_numeric(NULL);
+	CHECK(p, "NULL is not numeric");
+	pass &= p;
+
+	return pass;
+}
+
 int main(int argc, char *argv[])
 {
 	test_rc = EXIT_SUCCESS;
@@ -612,6 +721,8 @@ int main(int argc, char *argv[])
 	test_tid_equal();
 	test_tid_is_empty();
 	test_tid_dup();
+	test_tid_sanitize();
+	test_tid_traddr_is_numeric();
 	test_tid_canonical();
 	test_tid_hash();
 	test_tid_setter_invalidates_cache();

--- a/libnvme/test/test-tid.c
+++ b/libnvme/test/test-tid.c
@@ -7,13 +7,14 @@
  *
  * Unit tests for the libnvmf_tid API — libnvmf_tid_parse() (valid input,
  * rejected aliases, garbage tokens, duplicate keys, whitespace), plus dup(),
- * get_canonical(), setter cache invalidation, numeric-only address
- * sanitization, and traddr_is_numeric().
+ * get_canonical(), numeric-only address sanitization, traddr_is_numeric(),
+ * and set_identity() (including cache invalidation).
  *
  * Note: garbage-input tests intentionally trigger error messages on stderr;
  * that output is expected and does not indicate a test failure.
  */
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -375,7 +376,7 @@ static bool test_tid_canonical(void)
 }
 
 /* -------------------------------------------------------------------------
- * Setters invalidate the canonical cache
+ * set_identity() invalidates the canonical cache
  * -------------------------------------------------------------------------
  */
 static bool test_tid_setter_invalidates_cache(void)
@@ -392,18 +393,78 @@ static bool test_tid_setter_invalidates_cache(void)
 
 	t = libnvmf_tid_parse(ctx, "transport=tcp;traddr=1.2.3.4");
 
-	/* Prime the cache, mutate, then confirm it was rebuilt. */
+	/* Prime the cache, mutate via set_identity, confirm it rebuilt. */
 	snprintf(before, sizeof(before), "%s", libnvmf_tid_get_canonical(t));
 
-	libnvmf_tid_set_traddr(t, "5.6.7.8");
+	libnvmf_tid_set_identity(t, "nqn.sub", NULL, NULL);
 
 	after = libnvmf_tid_get_canonical(t);
-	p = after && !streq(before, after) && strstr(after, "traddr=5.6.7.8");
-	CHECK(p, "setter invalidates canonical cache");
+	p = after && !streq(before, after) && strstr(after, "nqn=nqn.sub");
+	CHECK(p, "set_identity invalidates canonical cache");
 	pass &= p;
 
 	libnvmf_tid_free(t);
 	libnvme_free_global_ctx(ctx);
+	return pass;
+}
+
+/* -------------------------------------------------------------------------
+ * libnvmf_tid_set_identity()
+ * -------------------------------------------------------------------------
+ */
+static bool test_tid_set_identity(void)
+{
+	struct libnvme_global_ctx *ctx;
+	struct libnvmf_tid *t;
+	bool pass = true, p;
+
+	ctx = libnvme_create_global_ctx();
+
+	printf("\ntest_tid_set_identity:\n");
+
+	/* Sets the triplet. */
+	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
+				    NULL, NULL, NULL, NULL);
+	p = t && libnvmf_tid_set_identity(t, "nqn.sub", "nqn.host",
+		"46ba5037-7ce5-41fa-9452-48477bf00080") == 0 &&
+	    streq(libnvmf_tid_get_subsysnqn(t), "nqn.sub") &&
+	    streq(libnvmf_tid_get_hostnqn(t), "nqn.host") &&
+	    streq(libnvmf_tid_get_hostid(t),
+		  "46ba5037-7ce5-41fa-9452-48477bf00080");
+	CHECK(p, "set_identity sets the triplet");
+	pass &= p;
+
+	/* A NULL argument leaves that field unchanged. */
+	p = t && libnvmf_tid_set_identity(t, "nqn.sub2", NULL, NULL) == 0 &&
+	    streq(libnvmf_tid_get_subsysnqn(t), "nqn.sub2") &&
+	    streq(libnvmf_tid_get_hostnqn(t), "nqn.host");
+	CHECK(p, "NULL args leave fields unchanged");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* hostid derived from a UUID-format hostnqn when none is given. */
+	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
+				    NULL, NULL, NULL, NULL);
+	p = t && libnvmf_tid_set_identity(t, "nqn.sub",
+		"nqn.2014-08.org.nvmexpress:uuid:46ba5037-7ce5-41fa-9452-48477bf00080",
+		NULL) == 0 &&
+	    streq(libnvmf_tid_get_hostid(t),
+		  "46ba5037-7ce5-41fa-9452-48477bf00080");
+	CHECK(p, "hostid derived from a UUID hostnqn");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* A hostid without any hostnqn is rejected. */
+	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
+				    NULL, NULL, NULL, NULL);
+	p = t && libnvmf_tid_set_identity(t, "nqn.sub", NULL,
+		"46ba5037-7ce5-41fa-9452-48477bf00080") == -EINVAL;
+	CHECK(p, "hostid without hostnqn rejected");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	libnvme_free_global_ctx(ctx);
+
 	return pass;
 }
 
@@ -623,6 +684,7 @@ int main(int argc, char *argv[])
 	test_tid_traddr_is_numeric();
 	test_tid_canonical();
 	test_tid_setter_invalidates_cache();
+	test_tid_set_identity();
 
 	if (test_rc == EXIT_SUCCESS)
 		printf("\nAll tests passed.\n");


### PR DESCRIPTION
# libnvme/tid: numeric-only, sanitizing Transport ID (TID)

Cleanup/prep for the upcoming INI connection-config parser, not a feature. That parser needs a TID that's a pure function of numeric input. Removes `get_hash()`/`equal()` (upstream API, zero production callers) and formalizes numeric-only, sanitizing construction. A `hostname` member with deferred resolution was prototyped while designing the config parser but never merged upstream -- rejected, see `TID.md`.

**Follow-up (not in this PR):** drop `hostname2traddr()`, the last real `getaddrinfo()` caller in libnvme (the other 3 call sites use `AI_NUMERICHOST`, no DNS). Push resolution to CLI/discoverd, drop `NVME_HAVE_NETDB`/`<netdb.h>` entirely. `libnvmf_traddr_is_numeric()` (added here) is what that follow-up will use.

## Commits (review order)

1. `design/INTEGRATION.md` -- library/app boundary: libnvme owns protocol I/O, caller owns policy/non-determinism/concurrency.
2. `design/TID.md` -- design authority for the TID.
3. `tid: reject hostnames, canonicalize numeric addresses` -- `traddr`/`host_traddr` canonicalized via `inet_pton`/`inet_ntop`; hostname fails construction. New `libnvmf_traddr_is_numeric()`.
4. `tid: drop get_hash() and equal()` -- dead public API; hashing moves to the one caller that needs it (discoverd, via `get_canonical()`).
5. `tid: replace per-field setters with a set_identity triplet` -- addressing construction-only; `set_identity()` owns host-identity rules.
6. `fabrics: use str(), not get_canonical(), in the exclusion log` -- fixes a log line that could exceed 500 chars.
7. `tid: group functions by role` -- pure reorder, no content change.

## Numbers

- Code: +409/-328 | Tests: +171/-101 | Docs: +170
- `meson test`: 81/0 fail | checkpatch + valgrind clean
