### PR TITLE
sfx-nvme: fix sizeof mismatch in calloc in nvme_dump_evtlog()

### DIFF
--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1225,7 +1225,7 @@ static int nvme_dump_evtlog(struct libnvme_transport_handle *hdl, __u32 namespac
 		single_len = 32 * 1024;
 	}
 
-	pevent = calloc(sizeof(*pevent), sizeof(__u8));
+	pevent = calloc(1, sizeof(*pevent));
 	if (!pevent) {
 		err = -ENOMEM;
 		goto ret;


### PR DESCRIPTION
The nvme_dump_evtlog() function allocates memory for @pevent using calloc() with the nmemb and size arguments swapped. sizeof(*pevent) was passed as the element count instead of as the allocation size.

Fix this by using calloc(1, sizeof(*pevent)) to correctly allocate a single instance of the struct.

Signed-off-by: Sarah Ahmed <sarah.ahmed@ibm.com>