### PR TITLE
libnvme: move hostname resolution out of the library and drop netdb

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -36,6 +36,13 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifdef NVME_HAVE_NETDB
+#include <netdb.h>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#endif
+
 #include <libnvme.h>
 
 #ifdef NVME_HAVE_LIBKMOD
@@ -296,6 +303,95 @@ static void hook_parser_cleanup(struct libnvmf_context *fctx, void *user_data)
 	fclose(hfd->f);
 }
 
+/*
+ * Resolve *addr in place if it names a tcp/rdma hostname; left untouched for
+ * any other transport, a NULL/"none" address, or one that is already
+ * numeric. Resolution is the caller's job, not libnvme's -- this is where
+ * that happens.
+ *
+ * Deliberately crude and sequential: one blocking getaddrinfo() call at a
+ * time, no threads. nvme-cli is a one-shot tool, so multiple discovery.conf
+ * lines simply resolve one after another.
+ */
+static int nvmf_resolve_addr(const char *transport, const char **addr)
+{
+#ifdef NVME_HAVE_NETDB
+	struct addrinfo hints = { .ai_family = AF_UNSPEC };
+	struct addrinfo *host_info = NULL;
+	char addrstr[NVMF_TRADDR_SIZE];
+	const char *p = NULL;
+	char *resolved;
+	int ret;
+#endif
+
+	if (!*addr || !transport)
+		return 0;
+	if (strcmp(transport, "tcp") && strcmp(transport, "rdma"))
+		return 0;
+	if (!strcmp(*addr, "none"))
+		return 0;
+	if (libnvmf_traddr_is_numeric(*addr))
+		return 0;
+
+#ifdef NVME_HAVE_NETDB
+	ret = getaddrinfo(*addr, NULL, &hints, &host_info);
+	if (ret) {
+		nvme_show_error("failed to resolve host '%s': %s",
+			*addr, gai_strerror(ret));
+		return -EINVAL;
+	}
+
+	switch (host_info->ai_family) {
+	case AF_INET:
+		p = inet_ntop(host_info->ai_family,
+			&(((struct sockaddr_in *)host_info->ai_addr)->sin_addr),
+			addrstr, NVMF_TRADDR_SIZE);
+		break;
+	case AF_INET6:
+		p = inet_ntop(host_info->ai_family,
+			&(((struct sockaddr_in6 *)
+				host_info->ai_addr)->sin6_addr),
+			addrstr, NVMF_TRADDR_SIZE);
+		break;
+	default:
+		break;
+	}
+
+	if (!p) {
+		nvme_show_error(
+			"failed to resolve host '%s': unrecognized address family",
+			*addr);
+		freeaddrinfo(host_info);
+		return -EINVAL;
+	}
+
+	freeaddrinfo(host_info);
+
+	resolved = strdup(addrstr);
+	if (!resolved)
+		return -ENOMEM;
+
+	*addr = resolved;
+
+	return 0;
+#else /* NVME_HAVE_NETDB */
+	nvme_show_error(
+		"hostname resolution is not available in this build; use a numeric address");
+	return -ENOTSUP;
+#endif /* NVME_HAVE_NETDB */
+}
+
+static int nvmf_resolve_args(struct nvmf_args *fa)
+{
+	int ret;
+
+	ret = nvmf_resolve_addr(fa->transport, &fa->traddr);
+	if (ret)
+		return ret;
+
+	return nvmf_resolve_addr(fa->transport, &fa->host_traddr);
+}
+
 static int set_fabrics_options(struct libnvmf_context *fctx,
 		struct nvmf_args *fa)
 {
@@ -334,25 +430,33 @@ static int hook_parser_next_line(struct libnvmf_context *fctx, void *user_data)
 
 	memcpy(&fa, hfd->fa, sizeof(fa));
 	do {
-		if (fgets(line, sizeof(line), hfd->f) == NULL)
-			return -EOF;
+		do {
+			if (fgets(line, sizeof(line), hfd->f) == NULL)
+				return -EOF;
 
-		if (line[0] == '#' || line[0] == '\n')
-			continue;
+			if (line[0] == '#' || line[0] == '\n')
+				continue;
 
-		argc = 1;
-		p = line;
-		while ((ptr = strsep(&p, " =\n")) != NULL)
-			hfd->argv[argc++] = ptr;
-		hfd->argv[argc] = NULL;
+			argc = 1;
+			p = line;
+			while ((ptr = strsep(&p, " =\n")) != NULL)
+				hfd->argv[argc++] = ptr;
+			hfd->argv[argc] = NULL;
 
-		fa.subsysnqn = NVME_DISC_SUBSYS_NAME;
-		if (argconfig_parse(argc, hfd->argv, "config", opts))
-			continue;
-	} while (!fa.transport && !fa.traddr);
+			fa.subsysnqn = NVME_DISC_SUBSYS_NAME;
+			if (argconfig_parse(argc, hfd->argv, "config", opts))
+				continue;
+		} while (!fa.transport && !fa.traddr);
 
-	if (!fa.trsvcid)
-		fa.trsvcid = libnvmf_get_default_trsvcid(fa.transport, true);
+		if (!fa.trsvcid)
+			fa.trsvcid = libnvmf_get_default_trsvcid(fa.transport,
+								 true);
+
+		/*
+		 * An unresolvable hostname fails only its own line; keep
+		 * connecting the remaining ones.
+		 */
+	} while (nvmf_resolve_args(&fa));
 
 	ret = setup_common_context(fctx, &fa);
 	if (ret)
@@ -635,6 +739,10 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 			device += 5;
 	}
 
+	ret = nvmf_resolve_args(&fa);
+	if (ret)
+		return ret;
+
 	struct hook_fabrics_data dld = {
 		.fa = &fa,
 		.flags = flags,
@@ -726,6 +834,10 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 			return -EINVAL;
 		}
 	}
+
+	ret = nvmf_resolve_args(&fa);
+	if (ret)
+		return ret;
 
 do_connect:
 	log_level = map_log_level(nvme_args.verbose, quiet);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1059,19 +1059,14 @@ static int inet_pton_with_scope(struct libnvme_global_ctx *ctx, int af,
 bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
 		const char *transport, const char *traddr)
 {
-	struct sockaddr_storage addr;
-
 	if (!traddr || !transport)
 		return false;
 	if (!strcmp(traddr, "none"))
 		return false;
 	if (strcmp(transport, "tcp") && strcmp(transport, "rdma"))
 		return false;
-	if (inet_pton_with_scope(ctx, AF_UNSPEC,
-			traddr, NULL, &addr) == 0)  /* scope-aware */
-		return false;
 
-	return true;
+	return !libnvmf_traddr_is_numeric(traddr);
 }
 
 /*

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -25,7 +25,6 @@
 #include <linux/if_ether.h>
 #include <net/if.h>
 #include <netpacket/packet.h>
-#include <netdb.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -1075,6 +1074,65 @@ bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
 	return true;
 }
 
+/*
+ * Reject a hostname traddr/host_traddr and canonicalize a numeric one,
+ * routing the check through the TID constructor so the tree keeps one
+ * definition of acceptable and canonical addressing.  Resolving a
+ * hostname is the caller's job, not libnvme's, so the connect paths
+ * simply refuse one instead of resolving it.
+ */
+static int nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx, libnvme_ctrl_t c)
+{
+	struct libnvmf_tid *tid;
+	const char *canon;
+	char *dup;
+
+	if (traddr_is_hostname(ctx, c->transport, c->traddr)) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR,
+			"traddr '%s' is not a numeric address; hostname resolution is the caller's responsibility\n",
+			c->traddr);
+		return -ENVME_CONNECT_TRADDR;
+	}
+
+	if (traddr_is_hostname(ctx, c->transport, c->host_traddr)) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR,
+			"host-traddr '%s' is not a numeric address; hostname resolution is the caller's responsibility\n",
+			c->host_traddr);
+		return -ENVME_CONNECT_TRADDR;
+	}
+
+	tid = libnvmf_tid_from_fields(c->transport, c->traddr, c->trsvcid,
+			NULL, c->host_traddr, c->host_iface, NULL, NULL);
+	if (!tid)
+		return -ENOMEM;
+
+	canon = libnvmf_tid_get_traddr(tid);
+	if (canon) {
+		dup = strdup(canon);
+		if (!dup) {
+			libnvmf_tid_free(tid);
+			return -ENOMEM;
+		}
+		free(c->traddr);
+		c->traddr = dup;
+	}
+
+	canon = libnvmf_tid_get_host_traddr(tid);
+	if (canon) {
+		dup = strdup(canon);
+		if (!dup) {
+			libnvmf_tid_free(tid);
+			return -ENOMEM;
+		}
+		free(c->host_traddr);
+		c->host_traddr = dup;
+	}
+
+	libnvmf_tid_free(tid);
+
+	return 0;
+}
+
 static int build_options(libnvme_host_t h, libnvme_ctrl_t c, char **argstr)
 {
 	const char *transport = libnvme_ctrl_get_transport(c);
@@ -1450,15 +1508,9 @@ __libnvme_public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
 	}
 
 	libnvme_ctrl_set_discovered(c, true);
-	if (traddr_is_hostname(h->ctx, c->transport, c->traddr)) {
-		char *traddr = c->traddr;
-
-		if (hostname2traddr(h->ctx, traddr, &c->traddr)) {
-			c->traddr = traddr;
-			return -ENVME_CONNECT_TRADDR;
-		}
-		free(traddr);
-	}
+	ret = nvmf_sanitize_addrs(h->ctx, c);
+	if (ret)
+		return ret;
 
 	ret = build_options(h, c, &argstr);
 	if (ret)
@@ -1477,6 +1529,10 @@ __libnvme_public int libnvmf_connect_ctrl(libnvme_ctrl_t c)
 {
 	__cleanup_free char *argstr = NULL;
 	int ret;
+
+	ret = nvmf_sanitize_addrs(c->s->h->ctx, c);
+	if (ret)
+		return ret;
 
 	ret = build_options(c->s->h, c, &argstr);
 	if (ret)

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#if defined(NVME_HAVE_NETDB) || defined(CONFIG_FABRICS)
+#ifdef CONFIG_FABRICS
 #include <ifaddrs.h>
 #endif
 
@@ -195,7 +195,7 @@ static inline __u16 libnvmf_exat_size(size_t val_len)
 	return (__u16)(sizeof(struct nvmf_ext_attr) + libnvmf_exat_len(val_len));
 }
 
-#if defined(NVME_HAVE_NETDB) || defined(CONFIG_FABRICS)
+#ifdef CONFIG_FABRICS
 /**
  * libnvmf_getifaddrs - Cached wrapper around getifaddrs()
  * @ctx: pointer to the global context
@@ -209,7 +209,7 @@ static inline __u16 libnvmf_exat_size(size_t val_len)
  * Return: Pointer to I/F data, NULL on error.
  */
 const struct ifaddrs *libnvmf_getifaddrs(struct libnvme_global_ctx *ctx);
-#endif /* NVME_HAVE_NETDB || CONFIG_FABRICS */
+#endif /* CONFIG_FABRICS */
 
 /**
  * struct candidate_args - Parameters used to match an existing controller
@@ -230,7 +230,7 @@ struct candidate_args {
 	const char *subsysnqn;
 	const char *host_traddr;
 	const char *host_iface;
-#if defined(NVME_HAVE_NETDB) || defined(CONFIG_FABRICS)
+#ifdef CONFIG_FABRICS
 	const struct ifaddrs *iface_list;
 #endif
 	bool (*addreq)(const char *, const char *);

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -11,7 +11,7 @@
 #include <sys/types.h>
 #include <string.h>
 
-#if defined(NVME_HAVE_NETDB) || defined(CONFIG_FABRICS)
+#ifdef CONFIG_FABRICS
 #include <ifaddrs.h>
 #endif
 
@@ -594,9 +594,6 @@ const char *libnvme_iface_matching_addr(const struct ifaddrs *iface_list,
 bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
 		const char *iface, const char *addr);
 #endif /* CONFIG_FABRICS */
-
-int hostname2traddr(struct libnvme_global_ctx *ctx, const char *traddr,
-		char **hostname);
 
 /**
  * startswith - Checks that a string starts with a given prefix.

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -563,7 +563,7 @@ static inline bool streqcase0(const char *s1, const char *s2)
  */
 bool libnvme_ipaddrs_eq(const char *addr1, const char *addr2);
 
-#if defined(NVME_HAVE_NETDB) || defined(CONFIG_FABRICS)
+#ifdef CONFIG_FABRICS
 /**
  * libnvme_iface_matching_addr - Get interface matching @addr
  * @iface_list: Interface list returned by getifaddrs()
@@ -593,7 +593,7 @@ const char *libnvme_iface_matching_addr(const struct ifaddrs *iface_list,
  */
 bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
 		const char *iface, const char *addr);
-#endif /* NVME_HAVE_NETDB || CONFIG_FABRICS */
+#endif /* CONFIG_FABRICS */
 
 int hostname2traddr(struct libnvme_global_ctx *ctx, const char *traddr,
 		char **hostname);

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1407,14 +1407,8 @@ int libnvme_create_ctrl(struct libnvme_global_ctx *ctx,
 	c->subsysnqn = strdup(params->subsysnqn);
 	if (params->traddr)
 		c->traddr = strdup(params->traddr);
-	if (params->host_traddr) {
-		if (traddr_is_hostname(ctx, params->transport,
-				params->host_traddr))
-			hostname2traddr(ctx, params->host_traddr,
-					&c->host_traddr);
-		if (!c->host_traddr)
-			c->host_traddr = strdup(params->host_traddr);
-	}
+	if (params->host_traddr)
+		c->host_traddr = strdup(params->host_traddr);
 	if (params->host_iface)
 		c->host_iface = strdup(params->host_iface);
 	if (params->trsvcid)

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -23,6 +23,10 @@
 #include <netdb.h>
 #endif
 
+#ifdef CONFIG_FABRICS
+#include <net/if.h>
+#endif
+
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -718,7 +722,52 @@ __libnvme_public int libnvme_find_uuid(struct nvme_id_uuid_list *uuid_list,
 	return -ENOENT;
 }
 
-#ifdef NVME_HAVE_NETDB
+#ifdef CONFIG_FABRICS
+/*
+ * Parse @addr as a numeric IPv4 or IPv6 address into @ss.  An IPv6 address
+ * may carry a "%<iface>" zone suffix (e.g. "fe80::1%eth0"); the interface
+ * name is resolved to a scope id via if_nametoindex().  Never touches DNS --
+ * inet_pton()/if_nametoindex() only.  Mirrors fabrics.c's
+ * inet_pton_with_scope() family, but this one has no port/trsvcid concept
+ * (a pure address parser for comparison), so it is kept separate rather
+ * than merged with it.
+ *
+ * Return: 0 on success; -EINVAL if @addr is not numeric; -ENOMEM on
+ * allocation failure.
+ */
+static int nvme_parse_numeric_addr(const char *addr,
+		struct sockaddr_storage *ss)
+{
+	struct sockaddr_in *addr4 = (struct sockaddr_in *)ss;
+	struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)ss;
+	__cleanup_free char *tmp = NULL;
+	char *scope;
+
+	memset(ss, 0, sizeof(*ss));
+
+	if (inet_pton(AF_INET, addr, &addr4->sin_addr) == 1) {
+		addr4->sin_family = AF_INET;
+		return 0;
+	}
+
+	tmp = strdup(addr);
+	if (!tmp)
+		return -ENOMEM;
+
+	scope = strchr(tmp, '%');
+	if (scope)
+		*scope++ = '\0';
+
+	if (inet_pton(AF_INET6, tmp, &addr6->sin6_addr) != 1)
+		return -EINVAL;
+
+	addr6->sin6_family = AF_INET6;
+	if (scope && IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr))
+		addr6->sin6_scope_id = if_nametoindex(scope);
+
+	return 0;
+}
+
 static bool _nvme_ipaddrs_eq(struct sockaddr *addr1, struct sockaddr *addr2)
 {
 	struct sockaddr_in *sockaddr_v4;
@@ -761,9 +810,7 @@ static bool _nvme_ipaddrs_eq(struct sockaddr *addr1, struct sockaddr *addr2)
 
 bool libnvme_ipaddrs_eq(const char *addr1, const char *addr2)
 {
-	bool result = false;
-	struct addrinfo *info1 = NULL, hint1 = { .ai_flags=AI_NUMERICHOST, .ai_family=AF_UNSPEC };
-	struct addrinfo *info2 = NULL, hint2 = { .ai_flags=AI_NUMERICHOST, .ai_family=AF_UNSPEC };
+	struct sockaddr_storage ss1, ss2;
 
 	if (addr1 == addr2)
 		return true;
@@ -771,37 +818,31 @@ bool libnvme_ipaddrs_eq(const char *addr1, const char *addr2)
 	if (!addr1 || !addr2)
 		return false;
 
-	if (getaddrinfo(addr1, 0, &hint1, &info1) || !info1)
-		goto ipaddrs_eq_fail;
+	if (nvme_parse_numeric_addr(addr1, &ss1))
+		return false;
 
-	if (getaddrinfo(addr2, 0, &hint2, &info2) || !info2)
-		goto ipaddrs_eq_fail;
+	if (nvme_parse_numeric_addr(addr2, &ss2))
+		return false;
 
-	result = _nvme_ipaddrs_eq(info1->ai_addr, info2->ai_addr);
-
-ipaddrs_eq_fail:
-	if (info1)
-		freeaddrinfo(info1);
-	if (info2)
-		freeaddrinfo(info2);
-	return result;
+	return _nvme_ipaddrs_eq((struct sockaddr *)&ss1,
+			(struct sockaddr *)&ss2);
 }
-#else /* NVME_HAVE_NETDB */
+#else /* CONFIG_FABRICS */
 bool libnvme_ipaddrs_eq(const char *addr1, const char *addr2)
 {
 	return false;
 }
-#endif /* NVME_HAVE_NETDB */
+#endif /* CONFIG_FABRICS */
 
-#ifdef NVME_HAVE_NETDB
+#ifdef CONFIG_FABRICS
 const char *libnvme_iface_matching_addr(const struct ifaddrs *iface_list,
 		const char *addr)
 {
 	const struct ifaddrs *iface_it;
-	struct addrinfo *info = NULL, hint = { .ai_flags = AI_NUMERICHOST, .ai_family = AF_UNSPEC };
+	struct sockaddr_storage ss;
 	const char *iface_name = NULL;
 
-	if (!iface_list || !addr || getaddrinfo(addr, 0, &hint, &info) || !info)
+	if (!iface_list || !addr || nvme_parse_numeric_addr(addr, &ss))
 		return NULL;
 
 	/* Walk through the linked list */
@@ -809,13 +850,11 @@ const char *libnvme_iface_matching_addr(const struct ifaddrs *iface_list,
 		struct sockaddr *ifaddr = iface_it->ifa_addr;
 
 		if (ifaddr && (ifaddr->sa_family == AF_INET || ifaddr->sa_family == AF_INET6) &&
-		    _nvme_ipaddrs_eq(info->ai_addr, ifaddr)) {
+		    _nvme_ipaddrs_eq((struct sockaddr *)&ss, ifaddr)) {
 			iface_name = iface_it->ifa_name;
 			break;
 		}
 	}
-
-	freeaddrinfo(info);
 
 	return iface_name;
 }
@@ -824,10 +863,10 @@ bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
 		const char *iface, const char *addr)
 {
 	const struct ifaddrs *iface_it;
-	struct addrinfo *info = NULL, hint = { .ai_flags = AI_NUMERICHOST, .ai_family = AF_UNSPEC };
+	struct sockaddr_storage ss;
 	bool match_found = false;
 
-	if (!iface_list || !addr || getaddrinfo(addr, 0, &hint, &info) || !info)
+	if (!iface_list || !addr || nvme_parse_numeric_addr(addr, &ss))
 		return false;
 
 	/* Walk through the linked list */
@@ -840,32 +879,17 @@ bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
 		 * matches the family of the address we're looking for, we
 		 * have found the primary address for that family.
 		 */
-		if (iface_it->ifa_addr && (iface_it->ifa_addr->sa_family == info->ai_addr->sa_family)) {
-			match_found = _nvme_ipaddrs_eq(info->ai_addr, iface_it->ifa_addr);
+		if (iface_it->ifa_addr &&
+		    (iface_it->ifa_addr->sa_family == ss.ss_family)) {
+			match_found = _nvme_ipaddrs_eq((struct sockaddr *)&ss,
+					iface_it->ifa_addr);
 			break;
 		}
 	}
 
-	freeaddrinfo(info);
-
 	return match_found;
 }
-
-#elif defined(CONFIG_FABRICS)
-
-const char *libnvme_iface_matching_addr(const struct ifaddrs *iface_list,
-		const char *addr)
-{
-	return NULL;
-}
-
-bool libnvme_iface_primary_addr_matches(const struct ifaddrs *iface_list,
-		const char *iface, const char *addr)
-{
-	return false;
-}
-
-#endif /* NVME_HAVE_NETDB || CONFIG_FABRICS */
+#endif /* CONFIG_FABRICS */
 
 /* This used instead of basename() due to behavioral differences between
  * the POSIX and the GNU version. This is the glibc implementation.

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -16,14 +16,10 @@
 #include <string.h>
 #include <unistd.h>
 
-#if defined(NVME_HAVE_NETDB) || defined(CONFIG_FABRICS)
+#ifdef CONFIG_FABRICS
 #include <ifaddrs.h>
 
 #include <arpa/inet.h>
-#include <netdb.h>
-#endif
-
-#ifdef CONFIG_FABRICS
 #include <net/if.h>
 #endif
 
@@ -499,65 +495,6 @@ __libnvme_public const char *libnvme_strerror(int errnum)
 		return libnvme_errno_to_string(errnum);
 	return strerror(errnum);
 }
-
-#ifdef NVME_HAVE_NETDB
-static inline DEFINE_CLEANUP_FUNC(cleanup_addrinfo, struct addrinfo *,
-		freeaddrinfo)
-#define __cleanup_addrinfo __cleanup(cleanup_addrinfo)
-
-int hostname2traddr(struct libnvme_global_ctx *ctx, const char *traddr,
-		    char **hostname)
-{
-	__cleanup_addrinfo struct addrinfo *host_info = NULL;
-	struct addrinfo hints = {.ai_family = AF_UNSPEC};
-	char addrstr[NVMF_TRADDR_SIZE];
-	const char *p;
-	int ret;
-
-	ret = getaddrinfo(traddr, NULL, &hints, &host_info);
-	if (ret) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR, "failed to resolve host %s info\n",
-			 traddr);
-		return -errno;
-	}
-
-	switch (host_info->ai_family) {
-	case AF_INET:
-		p = inet_ntop(host_info->ai_family,
-			&(((struct sockaddr_in *)host_info->ai_addr)->sin_addr),
-			addrstr, NVMF_TRADDR_SIZE);
-		break;
-	case AF_INET6:
-		p = inet_ntop(host_info->ai_family,
-			&(((struct sockaddr_in6 *)host_info->ai_addr)->sin6_addr),
-			addrstr, NVMF_TRADDR_SIZE);
-		break;
-	default:
-		libnvme_msg(ctx, LIBNVME_LOG_ERR, "unrecognized address family (%d) %s\n",
-			 host_info->ai_family, traddr);
-		return -EINVAL;
-	}
-
-	if (!p) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR, "failed to get traddr for %s\n",
-			 traddr);
-		return -EIO;
-	}
-	*hostname = strdup(addrstr);
-	if (!*hostname)
-		return -ENOMEM;
-
-	return 0;
-}
-#else /* NVME_HAVE_NETDB */
-int hostname2traddr(struct libnvme_global_ctx *ctx, const char *traddr, char **hostname)
-{
-	libnvme_msg(ctx, LIBNVME_LOG_ERR, "No support for hostname IP address resolution; " \
-		"recompile with libnss support.\n");
-
-	return -ENOTSUP;
-}
-#endif /* NVME_HAVE_NETDB */
 
 char *startswith(const char *s, const char *prefix)
 {

--- a/libnvme/test/meson.build
+++ b/libnvme/test/meson.build
@@ -223,7 +223,7 @@ if want_fabrics
     test('libnvme - psk', psk)
 endif
 
-if conf.get('NVME_HAVE_NETDB')
+if want_fabrics
     mock_ifaddrs = library(
         'mock-ifaddrs',
         ['mock-ifaddrs.c', ],
@@ -234,20 +234,18 @@ if conf.get('NVME_HAVE_NETDB')
     mock_ifaddrs_env.append('LD_PRELOAD', mock_ifaddrs.full_path())
     mock_ifaddrs_env.set('ASAN_OPTIONS', 'verify_asan_link_order=0')
 
-    if want_fabrics
-        tree_fabrics = executable(
-            'tree-fabrics',
-            ['tree-fabrics.c'],
-            dependencies: [
-                config_dep,
-                ccan_dep,
-                libnvme_test_dep,
-            ],
-            link_with: mock_ifaddrs,
-        )
+    tree_fabrics = executable(
+        'tree-fabrics',
+        ['tree-fabrics.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_test_dep,
+        ],
+        link_with: mock_ifaddrs,
+    )
 
-        test('libnvme - tree-fabrics', tree_fabrics, env: mock_ifaddrs_env)
-    endif
+    test('libnvme - tree-fabrics', tree_fabrics, env: mock_ifaddrs_env)
 
     test_util = executable(
         'test-util',

--- a/libnvme/test/test-fabrics.c
+++ b/libnvme/test/test-fabrics.c
@@ -461,6 +461,104 @@ static bool test_traddr_is_hostname(struct libnvme_global_ctx *ctx)
 }
 
 /* -------------------------------------------------------------------------
+ * nvmf_sanitize_addrs — reject hostnames, canonicalize numeric addresses
+ * -------------------------------------------------------------------------
+ */
+static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
+{
+	struct libnvme_ctrl_params params = { .transport = "tcp" };
+	libnvme_ctrl_t c;
+	bool pass = true, p;
+	int ret;
+
+	printf("\ntest_nvmf_sanitize_addrs:\n");
+
+	/*
+	 * Creation never resolves and never rejects -- a hostname host_traddr
+	 * is stored verbatim; rejection happens at connect (single policy
+	 * point).
+	 */
+	params.subsysnqn = "nqn.2024-01.com.example:test";
+	params.traddr = "192.168.1.10";
+	params.host_traddr = "storage.example.com";
+	ret = libnvme_create_ctrl(ctx, &params, &c);
+	p = !ret && c && !strcmp(libnvme_ctrl_get_host_traddr(c),
+			"storage.example.com");
+	CHECK(p, "hostname host_traddr stored verbatim at creation");
+	pass &= p;
+
+	ret = nvmf_sanitize_addrs(ctx, c);
+	p = ret == -ENVME_CONNECT_TRADDR;
+	CHECK(p, "hostname host_traddr rejected at connect: %d", ret);
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	/* A hostname traddr is rejected the same way. */
+	params.traddr = "storage.example.com";
+	params.host_traddr = NULL;
+	ret = libnvme_create_ctrl(ctx, &params, &c);
+	p = !ret && c != NULL;
+	CHECK(p, "ctrl created with hostname traddr");
+	pass &= p;
+
+	ret = nvmf_sanitize_addrs(ctx, c);
+	p = ret == -ENVME_CONNECT_TRADDR;
+	CHECK(p, "hostname traddr rejected at connect: %d", ret);
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	/* An uncompressed IPv6 traddr is canonicalized. */
+	params.traddr = "2001:0db8:0000:0000:0000:0000:0000:0001";
+	ret = libnvme_create_ctrl(ctx, &params, &c);
+	p = !ret && c != NULL;
+	CHECK(p, "ctrl created with uncompressed IPv6 traddr");
+	pass &= p;
+
+	ret = nvmf_sanitize_addrs(ctx, c);
+	p = !ret && !strcmp(libnvme_ctrl_get_traddr(c), "2001:db8::1");
+	CHECK(p, "uncompressed IPv6 traddr canonicalized: %s",
+	      libnvme_ctrl_get_traddr(c));
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	/* fc: a WWN traddr is left untouched (not an IP transport). */
+	params.transport = "fc";
+	params.traddr = "nn-0x1:pn-0x2";
+	ret = libnvme_create_ctrl(ctx, &params, &c);
+	p = !ret && c != NULL;
+	CHECK(p, "ctrl created with fc WWN traddr");
+	pass &= p;
+
+	ret = nvmf_sanitize_addrs(ctx, c);
+	p = !ret && !strcmp(libnvme_ctrl_get_traddr(c), "nn-0x1:pn-0x2");
+	CHECK(p, "fc WWN traddr left untouched: %s",
+	      libnvme_ctrl_get_traddr(c));
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	/* loop: no traddr at all -- nothing to sanitize. */
+	params.transport = "loop";
+	params.traddr = NULL;
+	ret = libnvme_create_ctrl(ctx, &params, &c);
+	p = !ret && c != NULL;
+	CHECK(p, "ctrl created for loop transport");
+	pass &= p;
+
+	ret = nvmf_sanitize_addrs(ctx, c);
+	p = ret == 0;
+	CHECK(p, "loop transport (no traddr) sanitizes cleanly: %d", ret);
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	return pass;
+}
+
+/* -------------------------------------------------------------------------
  * unescape_uri — decode percent-encoded characters in a URI fragment
  * -------------------------------------------------------------------------
  */
@@ -546,6 +644,7 @@ int main(int argc, char *argv[])
 	test_inet4_pton();
 	test_inet_pton_with_scope(ctx);
 	test_traddr_is_hostname(ctx);
+	test_nvmf_sanitize_addrs(ctx);
 	test_unescape_uri();
 
 	libnvme_free_global_ctx(ctx);

--- a/libnvme/test/test-fabrics.c
+++ b/libnvme/test/test-fabrics.c
@@ -438,6 +438,13 @@ static bool test_traddr_is_hostname(struct libnvme_global_ctx *ctx)
 	TRADDR_TEST("tcp",  "fe80::1%lo", false, "scoped IPv6 (lo, exists)");
 	TRADDR_TEST("rdma", "fe80::1%lo", false, "scoped IPv6 (lo, rdma)");
 
+	/*
+	 * A zone naming a nonexistent interface is still numeric; zone
+	 * validity is the kernel's call, same as host_iface.
+	 */
+	TRADDR_TEST("tcp", "fe80::1%nonexistent0", false,
+		    "scoped IPv6 (bad zone)");
+
 	/* Hostnames */
 	TRADDR_TEST("tcp",  "storage.example.com", true, "FQDN hostname");
 	TRADDR_TEST("tcp",  "nvme-target",         true, "short hostname");
@@ -519,6 +526,25 @@ static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
 	ret = nvmf_sanitize_addrs(ctx, c);
 	p = !ret && !strcmp(libnvme_ctrl_get_traddr(c), "2001:db8::1");
 	CHECK(p, "uncompressed IPv6 traddr canonicalized: %s",
+	      libnvme_ctrl_get_traddr(c));
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	/*
+	 * A scoped IPv6 traddr passes through verbatim even when the zone
+	 * names a nonexistent interface -- zone validity is the kernel's
+	 * call, same as host_iface.
+	 */
+	params.traddr = "fe80::1%nonexistent0";
+	ret = libnvme_create_ctrl(ctx, &params, &c);
+	p = !ret && c != NULL;
+	CHECK(p, "ctrl created with bad-zone scoped IPv6 traddr");
+	pass &= p;
+
+	ret = nvmf_sanitize_addrs(ctx, c);
+	p = !ret && !strcmp(libnvme_ctrl_get_traddr(c), "fe80::1%nonexistent0");
+	CHECK(p, "bad-zone scoped IPv6 traddr accepted verbatim: %s",
 	      libnvme_ctrl_get_traddr(c));
 	pass &= p;
 

--- a/libnvme/test/test-util.c
+++ b/libnvme/test/test-util.c
@@ -55,6 +55,25 @@ static bool test_ipaddrs_eq() {
 		{"192.168.56.101", "!@#$", false},
 		{"2001:0db8:0001:0000:0000:ff00:0042:8329", "2001:0db8::ff00:0042:8329", false},
 		{"2001:0db8:0001:0000:0000:ff00:0042:8329", NULL, false},
+		/*
+		 * scoped link-local IPv6: "lo" always exists, so its ifindex
+		 * is stable across machines without depending on a specific
+		 * value.
+		 */
+		{"fe80::1%lo", "fe80::1%lo", true},
+		{"fe80::1%lo", "fe80::2%lo", false},
+		/*
+		 * the comparator (_nvme_ipaddrs_eq) matches on address bytes
+		 * only, never sin6_scope_id -- a scoped and unscoped spelling
+		 * of the same address are still "equal" by its definition.
+		 */
+		{"fe80::1%lo", "fe80::1", true},
+		/*
+		 * legacy getaddrinfo(AI_NUMERICHOST) shortforms no longer
+		 * parse -- inet_pton() is strict dotted-quad; sysfs never
+		 * emits shortforms.
+		 */
+		{"127.1", "127.0.0.1", false},
 	};
 
 	size_t i;

--- a/libnvme/test/test-util.c
+++ b/libnvme/test/test-util.c
@@ -14,7 +14,6 @@
  * the libnvme.so.
  */
 
-#include <netdb.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary

Pulls hostname resolution out of libnvme entirely, along with the netdb dependency itself -- no `<netdb.h>`, no `NVME_HAVE_NETDB`, anywhere in libnvme or its tests. The CLI resolves `-a`/`--host-traddr` before libnvme ever sees the address. libnvme rejects a hostname at connect time, canonicalizing a numeric address through the TID constructor.

This is policy moving where it belongs: which address a hostname resolves to (IPv4/IPv6), and when to block on DNS to find out, is a caller decision, not a library one.

## Why now

Prep-patch for the INI config parser: config entries are user-authored and may legitimately contain a hostname. The consumer side needs to resolve raw entries itself before building a TID, and that only works if the resolve-in-the-caller model already exists. This PR establishes it.

## What changed

- `libnvme_ipaddrs_eq()` and friends: `getaddrinfo(AI_NUMERICHOST)` → `inet_pton()`. Side effect: these silently no-op'd on every static build (`NVME_HAVE_NETDB` is always false there) -- now they work.
- `nvmf_sanitize_addrs()`: rejects a hostname traddr/host_traddr at connect time, canonicalizes a numeric one via the TID constructor.
- CLI `nvmf_resolve_addr()`: resolves before handing off to libnvme. Crude and sequential, one blocking `getaddrinfo()` at a time -- nvme-cli is a one-shot tool.
- Test gating moved off `NVME_HAVE_NETDB` (always false on static builds) onto `want_fabrics`, which is what these tests actually depend on now.

## Behavior deltas

- `nvme connect`/`connect-all` with a hostname: unchanged for users, resolution just happens earlier.
- Passing a hostname straight into a libnvme fabrics API (Python bindings, `libnvmf_add_ctrl()`) now fails with a clear error instead of resolving. nvme-stas resolves before calling, so no real impact there.
- A numeric address is now canonicalized before reaching the kernel, so sysfs reports the same spelling the TID does.

## Verified

Build (default, `-Dfabrics=disabled`, `--default-library=static`), full test suite, checkpatch, valgrind, and manual connect/connect-all against a live nvmet target with a hostname traddr.
