### PR TITLE
nvme: remove dead initialization of data_written in get_telemetry_log()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -860,7 +860,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 	int err = 0;
 	size_t total_size = 0;
 	__u8 *data_ptr = NULL;
-	int data_written = 0, data_remaining = 0;
+	int data_written, data_remaining = 0;
 	nvme_print_flags_t flags;
 	bool da4_support = false,
 	host_behavior_changed = false;
@@ -970,7 +970,6 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 		return err;
 	}
 
-	data_written = 0;
 	data_remaining = total_size;
 	data_ptr = (__u8 *)log;
 


### PR DESCRIPTION
The get_telemetry_log() function declares @data_written with an
initial value of 0. Before @data_written is read, it is always
assigned again inside the write loop. The initial assignment is
never read and has no effect.

Remove the dead initialization to clean up the code.

Signed-off-by: Laraib Javed <laraibjaved@ibm.com>