### PR TITLE
nvme-models: Add cross-platform support for reading PCI IDs and use in nvme-models

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -543,6 +543,7 @@ if want_nvme
         'logging.c',
         'nvme-cmds.c',
         'nvme-models.c',
+        'nvme-pci-ids.c',
         'nvme-print-binary.c',
         'nvme-print-stdout.c',
         'nvme-print.c',
@@ -550,6 +551,15 @@ if want_nvme
         'nvme.c',
         'plugin.c',
     ]
+    if host_system == 'windows'
+        sources += [
+            'nvme-pci-ids-win.c',
+        ]
+    else
+        sources += [
+            'nvme-pci-ids-linux.c',
+        ]
+    endif
 
     if json_c_dep.found()
         sources += [

--- a/nvme-models.c
+++ b/nvme-models.c
@@ -7,25 +7,14 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <sys/stat.h>
-#include <sys/types.h>
-#include "nvme-models.h"
+#include <nvme/lib-types.h>
+
 #include "nvme.h"
+#include "nvme-models.h"
+#include "nvme-pci-ids.h"
 #include "nvme-print.h"
 
-static char *_fmt1 = "/sys/class/nvme/nvme%d/device/subsystem_vendor";
-static char *_fmt2 = "/sys/class/nvme/nvme%d/device/subsystem_device";
-static char *_fmt3 = "/sys/class/nvme/nvme%d/device/vendor";
-static char *_fmt4 = "/sys/class/nvme/nvme%d/device/device";
-static char *_fmt5 = "/sys/class/nvme/nvme%d/device/class";
-
 #define LINE_BUF_SIZE 1024
-
-static char fmt1[78];
-static char fmt2[78];
-static char fmt3[78];
-static char fmt4[78];
-static char fmt5[78];
 
 static char *device_top;
 static char *device_mid;
@@ -33,7 +22,6 @@ static char *device_final;
 static char *class_top;
 static char *class_mid;
 static char *class_final;
-
 
 
 static void free_all(void)
@@ -240,32 +228,6 @@ static void pull_class_info(char *line, FILE *file, char *class)
 	}
 }
 
-static int read_sys_node(char *where, char *save, size_t savesz)
-{
-	char *new;
-	int fd, ret = 0, len;
-	fd = open(where, O_RDONLY);
-	if (fd < 0) {
-		if (errno != ENOENT) {
-			nvme_show_error("Failed to open %s with errno %s",
-				where, libnvme_strerror(errno));
-		}
-		return 1;
-	}
-	/* -1 so we can safely use strstr below */
-	len = read(fd, save, savesz - 1);
-	if (!len)
-		ret = 1;
-	else {
-		save[len] = '\0';
-		new = strstr(save, "\n");
-		if (new)
-			new[0] = '\0';
-	}
-	close(fd);
-	return ret;
-}
-
 static FILE *open_pci_ids(void)
 {
 	int i;
@@ -273,7 +235,7 @@ static FILE *open_pci_ids(void)
 	FILE *fp;
 
 	const char* pci_ids[] = {
-		"/usr/share/hwdata/pci.ids",  /* RHEL */
+		"/usr/share/hwdata/pci.ids",	  /* RHEL */
 		"/usr/share/pci.ids",		  /* SLES */
 		"/usr/share/misc/pci.ids",	  /* Ubuntu */
 		NULL
@@ -296,39 +258,30 @@ static FILE *open_pci_ids(void)
 			return fp;
 	}
 
-	nvme_show_error("Could not find pci.ids file");
 	return NULL;
 }
 
-static char *__nvme_product_name(int id)
+static char *__nvme_product_name(__u32 *vid, __u32 *did,
+		__u32 *subsys_vid, __u32 *subsys_did, __u32 *class_code)
 {
 	char readbuf[LINE_BUF_SIZE];
 	char vendor[7] = { 0 };
 	char device[7] = { 0 };
 	char sub_device[7] = { 0 };
 	char sub_vendor[7] = { 0 };
-	char class[13] = { 0 };
+	char class[9] = { 0 };
 	size_t len;
-	int ret = 0;
 	char *result;
 	FILE *file = open_pci_ids();
 
 	if (!file)
 		goto error1;
 
-	snprintf(fmt1, 78, _fmt1, id);
-	snprintf(fmt2, 78, _fmt2, id);
-	snprintf(fmt3, 78, _fmt3, id);
-	snprintf(fmt4, 78, _fmt4, id);
-	snprintf(fmt5, 78, _fmt5, id);
-
-	ret = read_sys_node(fmt1, sub_vendor, 7);
-	ret |= read_sys_node(fmt2, sub_device, 7);
-	ret |= read_sys_node(fmt3, vendor, 7);
-	ret |= read_sys_node(fmt4, device, 7);
-	ret |= read_sys_node(fmt5, class, 13);
-	if (ret)
-		goto error0;
+	sprintf(vendor, "0x%04x", *vid & 0xFFFF);
+	sprintf(device, "0x%04x", *did & 0xFFFF);
+	sprintf(sub_vendor, "0x%04x", *subsys_vid & 0xFFFF);
+	sprintf(sub_device, "0x%04x", *subsys_did & 0xFFFF);
+	sprintf(class, "0x%06x", *class_code & 0xFFFFFF);
 
 	while (fgets(readbuf, sizeof(readbuf), file) != NULL) {
 		len = strlen(readbuf);
@@ -358,29 +311,19 @@ static char *__nvme_product_name(int id)
 	format_all(result, vendor, device);
 	free_all();
 	return result;
-error0:
-	fclose(file);
 error1:
 	return NULL;
 }
 
-char *nvme_product_name(const char *devname)
+char *nvme_product_name(struct libnvme_global_ctx *ctx,
+		struct libnvme_transport_handle *hdl)
 {
-	const char *base;
-	int id;
+	__u32 vid = 0, did = 0, subsys_vid = 0, subsys_did = 0, class_code = 0;
 
-	if (!devname)
+	if (nvme_get_pci_ids(ctx, hdl, &vid, &did, &subsys_vid,
+			&subsys_did, &class_code) < 0)
 		return NULL;
 
-	base = strrchr(devname, '/');
-	if (base) {
-		if (!base[1])
-			return NULL;
-		devname = base + 1;
-	}
-
-	if (sscanf(devname, "nvme%d", &id) != 1)
-		return NULL;
-
-	return __nvme_product_name(id);
+	return __nvme_product_name(&vid, &did, &subsys_vid, &subsys_did,
+				&class_code);
 }

--- a/nvme-models.h
+++ b/nvme-models.h
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 #pragma once
 
-char *nvme_product_name(const char *devname);
+char *nvme_product_name(struct libnvme_global_ctx *ctx,
+		struct libnvme_transport_handle *hdl);

--- a/nvme-pci-ids-linux.c
+++ b/nvme-pci-ids-linux.c
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <nvme/types.h>
+
+#include "nvme-print.h"
+
+static int read_pci_attr(const char *dir, const char *attr, __u32 *out)
+{
+	char path[512];
+	char buf[32] = { '\0' };
+	char *endptr;
+	int len, fd, ret;
+	unsigned long val;
+
+	if (!out)
+		return 0;
+
+	snprintf(path, sizeof(path), "%s/device/%s", dir, attr);
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		ret = -errno;
+		if (errno != ENOENT)
+			nvme_show_error("Failed to open %s: %s", path,
+				libnvme_strerror(errno));
+		return ret;
+	}
+
+	len = read(fd, buf, sizeof(buf) - 1);
+	if (len < 0) {
+		ret = -errno;
+		nvme_show_error("Failed to read %s: %s", path,
+			libnvme_strerror(errno));
+		close(fd);
+		return ret;
+	}
+	close(fd);
+
+	val = strtoul(buf, &endptr, 16);
+	if (endptr == buf) {
+		nvme_show_error("Failed to parse hex value from %s: %s",
+			path, buf);
+		return -EINVAL;
+	}
+	*out = (__u32)val;
+
+	return 0;
+}
+
+int __nvme_get_sysfs_dir(__attribute__((__unused__)) struct libnvme_global_ctx *ctx,
+		const char *ctrl_name, char **sysfs_dir)
+{
+	if (asprintf(sysfs_dir, "/sys/class/nvme/%s", ctrl_name) < 0)
+		return -ENOMEM;
+
+	return 0;
+}
+
+int __nvme_get_pci_ids(const char *sysfs_dir,
+		__u32 *vid, __u32 *did,
+		__u32 *subsys_vid, __u32 *subsys_did,
+		__u32 *class_code)
+{
+	int res, ret = 0;
+
+	/* Attempt all reads. Return the first error encountered, if any. */
+	ret = read_pci_attr(sysfs_dir, "vendor", vid);
+	res = read_pci_attr(sysfs_dir, "device", did);
+	ret = ret ? ret : res;
+	res = read_pci_attr(sysfs_dir, "subsystem_vendor", subsys_vid);
+	ret = ret ? ret : res;
+	res = read_pci_attr(sysfs_dir, "subsystem_device", subsys_did);
+	ret = ret ? ret : res;
+	res = read_pci_attr(sysfs_dir, "class", class_code);
+	ret = ret ? ret : res;
+
+	return ret;
+}

--- a/nvme-pci-ids-win.c
+++ b/nvme-pci-ids-win.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <libnvme.h>
+#include <nvme/types.h>
+
+#include "nvme-print.h"
+
+int __nvme_get_sysfs_dir(struct libnvme_global_ctx *ctx,
+		const char *ctrl_name, char **sysfs_dir)
+{
+	libnvme_ctrl_t c = NULL;
+	const char *path;
+	int ret;
+
+	ret = libnvme_scan_ctrl(ctx, ctrl_name, &c);
+	if (ret != 0) {
+		nvme_show_error("Unable to find device path for %s", ctrl_name);
+		return ret;
+	}
+
+	path = libnvme_ctrl_get_sysfs_dir(c);
+	if (!path) {
+		nvme_show_error("No device path found for %s", ctrl_name);
+		libnvme_free_ctrl(c);
+		return -ENOENT;
+	}
+
+	*sysfs_dir = strdup(path);
+	libnvme_free_ctrl(c);
+	return *sysfs_dir ? 0 : -ENOMEM;
+}
+
+int __nvme_get_pci_ids(const char *sysfs_dir,
+		__u32 *vid, __u32 *did,
+		__u32 *subsys_vid, __u32 *subsys_did,
+		__u32 *class_code)
+{
+	const char *p;
+	unsigned int val;
+	int ret = 0;
+
+	/*
+	 * On Windows, sysfs_dir is the SetupDI device interface path, e.g.:
+	 *   \\?\pci#ven_1344&dev_5196&subsys_51961344&rev_02#...
+	 * VID, DID, and subsystem IDs are embedded as tokens in the path.
+	 * Class code is not available from the path string.
+	 */
+
+	if (vid) {
+		p = strstr(sysfs_dir, "ven_");
+		if (p && sscanf(p, "ven_%x", &val) == 1)
+			*vid = val;
+		else
+			ret = -ENOENT;
+	}
+
+	if (did) {
+		p = strstr(sysfs_dir, "dev_");
+		if (p && sscanf(p, "dev_%x", &val) == 1)
+			*did = val;
+		else
+			ret = -ENOENT;
+	}
+
+	/*
+	 * subsys_DDDDVVVV:
+	 * high 16 bits = subsystem DID, low 16 bits = subsystem VID
+	 */
+	if (subsys_vid || subsys_did) {
+		p = strstr(sysfs_dir, "subsys_");
+		if (p && sscanf(p, "subsys_%8x", &val) == 1) {
+			if (subsys_did)
+				*subsys_did = val >> 16;
+			if (subsys_vid)
+				*subsys_vid = val & 0xFFFF;
+		} else {
+			ret = -ENOENT;
+		}
+	}
+
+	/*
+	 * nvme-cli on Windows only opens NVMe devices, so the PCI class code
+	 * is always 0x010802 (Mass Storage / NVM Express).
+	 */
+	if (class_code)
+		*class_code = 0x010802;
+
+	return ret;
+}

--- a/nvme-pci-ids.c
+++ b/nvme-pci-ids.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libnvme.h>
+
+#include "nvme-pci-ids.h"
+#include "nvme-print.h"
+#include "util/cleanup.h"
+
+int nvme_get_pci_ids(struct libnvme_global_ctx *ctx,
+		struct libnvme_transport_handle *hdl,
+		__u32 *vid, __u32 *did,
+		__u32 *subsys_vid, __u32 *subsys_did,
+		__u32 *class_code)
+{
+	int ret;
+	const char *name;
+
+	__cleanup_free char *ctrl_name = NULL;
+	__cleanup_free char *sysfs_dir = NULL;
+
+	name = libnvme_transport_handle_get_name(hdl);
+	if (libnvme_transport_handle_is_ctrl(hdl)) {
+		ctrl_name = strdup(name);
+	} else {
+		/* Strip the 'nY' namespace suffix: "nvme0n1" -> "nvme0" */
+		const char *p = strlen(name) > 4 ? strchr(name + 4, 'n') : NULL;
+
+		ctrl_name = p ? strndup(name, p - name) : strdup(name);
+	}
+
+	if (!ctrl_name)
+		return -ENOMEM;
+
+	ret = __nvme_get_sysfs_dir(ctx, ctrl_name, &sysfs_dir);
+	if (ret != 0)
+		return ret;
+
+	return __nvme_get_pci_ids(sysfs_dir, vid, did, subsys_vid, subsys_did,
+		class_code);
+}

--- a/nvme-pci-ids.h
+++ b/nvme-pci-ids.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+#pragma once
+
+#include <nvme/lib-types.h>
+
+/**
+ * nvme_get_pci_ids() - Read PCI IDs for a controller
+ * @ctx:	Global context
+ * @hdl:	Transport handle
+ * @vid:	Output vendor ID (may be NULL)
+ * @did:	Output device ID (may be NULL)
+ * @subsys_vid:	Output subsystem vendor ID (may be NULL)
+ * @subsys_did:	Output subsystem device ID (may be NULL)
+ * @class_code:	Output PCI class code (may be NULL)
+ *
+ * Gets the PCI IDs for the controller associated with @hdl.
+ * Any output pointer that is NULL is silently skipped.
+ * If any error occurs when reading an ID, the value of that ID
+ * is left unchanged.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+int nvme_get_pci_ids(struct libnvme_global_ctx *ctx,
+		struct libnvme_transport_handle *hdl,
+		__u32 *vid, __u32 *did,
+		__u32 *subsys_vid, __u32 *subsys_did,
+		__u32 *class_code);
+
+
+int __nvme_get_pci_ids(const char *sysfs_dir,
+		__u32 *vid, __u32 *did,
+		__u32 *subsys_vid, __u32 *subsys_did,
+		__u32 *class_code);
+
+int __nvme_get_sysfs_dir(struct libnvme_global_ctx *ctx,
+		const char *ctrl_name, char **sysfs_dir);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -611,11 +611,12 @@ void nvme_show_id_ns_descs(void *data, unsigned int nsid, nvme_print_flags_t fla
 	nvme_print(id_ns_descs, flags, data, nsid);
 }
 
-void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, const char *devname,
-		       nvme_print_flags_t flags,
-		       void (*vendor_show)(__u8 *vs, struct json_object *root))
+void nvme_show_id_ctrl(struct libnvme_global_ctx *ctx,
+		struct libnvme_transport_handle *hdl, struct nvme_id_ctrl *ctrl,
+		nvme_print_flags_t flags,
+		void (*vendor_show)(__u8 *vs, struct json_object *root))
 {
-	__cleanup_free char *product_name = nvme_product_name(devname);
+	__cleanup_free char *product_name = nvme_product_name(ctx, hdl);
 
 	nvme_print(id_ctrl, flags, ctrl, product_name, vendor_show);
 }

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -190,7 +190,8 @@ void nvme_show_lba_status_info(__u64 result);
 void nvme_show_relatives(struct libnvme_global_ctx *ctx, const char *name, nvme_print_flags_t flags);
 
 void nvme_show_id_iocs(struct nvme_id_iocs *iocs, nvme_print_flags_t flags);
-void nvme_show_id_ctrl(struct nvme_id_ctrl *ctrl, const char *devname,
+void nvme_show_id_ctrl(struct libnvme_global_ctx *ctx,
+	struct libnvme_transport_handle *hdl, struct nvme_id_ctrl *ctrl,
 	nvme_print_flags_t flags, void (*vendor_show)(__u8 *vs,
 	struct json_object *root));
 void nvme_show_id_ctrl_rpmbs(__le32 ctrl_rpmbs, nvme_print_flags_t flags);

--- a/nvme.c
+++ b/nvme.c
@@ -3710,7 +3710,7 @@ int __id_ctrl(int argc, char **argv, struct command *acmd, struct plugin *plugin
 		return err;
 	}
 
-	nvme_show_id_ctrl(ctrl, libnvme_transport_handle_get_name(hdl), flags, vs);
+	nvme_show_id_ctrl(ctx, hdl, ctrl, flags, vs);
 
 	return err;
 }

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -4429,8 +4429,7 @@ static int micron_id_ctrl(int argc, char **argv, struct command *acmd,
 		return err;
 	}
 
-	nvme_show_id_ctrl(&ctrl, libnvme_transport_handle_get_name(hdl),
-			  flags, micron_id_ctrl_vs);
+	nvme_show_id_ctrl(ctx, hdl, &ctrl, flags, micron_id_ctrl_vs);
 
 	return 0;
 }


### PR DESCRIPTION
Adds new, cross-platform support for reading PCI IDs and refactors nvme-models to use the new functionality. This allows nvme_product_name to work on Windows if a PCI IDs file is specified in the PCI_IDS_PATH environment variable.  The cross-platform PCI ID utility will also be useful for plugins that currently implement this functionality internally for Linux only.