### PR TITLE
libnvme: replace environment options with explicit APIs

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -697,11 +697,11 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 
 	log_level = map_log_level(nvme_args.verbose, quiet);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret) {
 		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(errno));
-		return -ENOMEM;
+			libnvme_strerror(-ret));
+		return ret;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -842,11 +842,11 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 do_connect:
 	log_level = map_log_level(nvme_args.verbose, quiet);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret) {
 		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(errno));
-		return -ENOMEM;
+			libnvme_strerror(-ret));
+		return ret;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -998,11 +998,11 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 
 	log_level = map_log_level(nvme_args.verbose, false);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret) {
 		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(errno));
-		return -ENOMEM;
+			libnvme_strerror(-ret));
+		return ret;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -1154,11 +1154,11 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 
 	log_level = map_log_level(nvme_args.verbose, false);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret) {
 		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(errno));
-		return -ENOMEM;
+			libnvme_strerror(-ret));
+		return ret;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -1221,11 +1221,11 @@ int fabrics_config(const char *desc, int argc, char **argv)
 
 	log_level = map_log_level(nvme_args.verbose, quiet);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret) {
 		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(errno));
-		return -ENOMEM;
+			libnvme_strerror(-ret));
+		return ret;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -1237,7 +1237,7 @@ int fabrics_config(const char *desc, int argc, char **argv)
 		if (ret < 0) {
 			nvme_show_error("Failed to scan topology: %s",
 				libnvme_strerror(-ret));
-			return -ret;
+			return ret;
 		}
 	}
 
@@ -1353,11 +1353,11 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 
 	log_level = map_log_level(nvme_args.verbose, false);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret) {
 		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(errno));
-		return -ENODEV;
+			libnvme_strerror(-ret));
+		return ret;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 

--- a/libnvme/design/EXCLUSIONS.md
+++ b/libnvme/design/EXCLUSIONS.md
@@ -118,7 +118,7 @@ nvme exclusion delete -N maintenance      # remove a whole list
 
 The C API mirrors the commands (`libnvmf_exclusion_create` / `_delete` / `_add` / `_add_ctrl` / `_add_subsysnqn` / `_remove` / `_list_for_each` / `_entry_for_each` / `_match`, plus `_read` / `_write` for the read-modify-write editor), and SWIG exposes `exclusion_lists()`, `exclusion_entries()`, and `exclusion_match()` to Python. `libnvmf_exclusion_add_ctrl()` and `libnvmf_exclusion_add_subsysnqn()` build the entry inside libnvme so callers never encode the on-disk format themselves.
 
-For testing, `libnvme_set_test_base_dir()` reroots the exclusion files (and the registry) under a throwaway `/tmp` sandbox; the shell-invoked `nvme` binary uses the `LIBNVME_TEST_BASE_DIR` environment variable for the same purpose. Both are confined to `/tmp` so a test can never redirect writes onto a production path.
+   * [ ] For testing, `libnvme_set_test_base_dir()` reroots the exclusion files (and the registry) under a throwaway `/tmp` sandbox; the shell-invoked `nvme` binary uses `--set-options test-base-dir=/tmp/<sandbox>` for the same purpose. Both are confined to `/tmp` so a test can never redirect writes onto a production path.
 
 ## Relationship to the registry
 

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -145,11 +145,14 @@ LIBNVME_3 {
 		libnvme_scan_topology;
 		libnvme_set_dry_run;
 		libnvme_set_etdas;
+		libnvme_set_force_4k;
 		libnvme_set_ioctl_probing;
 		libnvme_set_logging_file;
 		libnvme_set_logging_level;
 		libnvme_set_owner;
+		libnvme_set_probe_enabled;
 		libnvme_set_test_base_dir;
+		libnvme_set_test_sysfs_dir;
 		libnvme_skip_namespaces;
 		libnvme_status_to_errno;
 		libnvme_status_to_string;

--- a/libnvme/src/nvme/lib.c
+++ b/libnvme/src/nvme/lib.c
@@ -25,20 +25,6 @@
 #include "private-mi.h"
 #include "compiler-attributes.h"
 
-static bool libnvme_mi_probe_enabled_default(void)
-{
-	char *val;
-
-	val = getenv("LIBNVME_MI_PROBE_ENABLED");
-	if (!val)
-		return true;
-
-	return strcmp(val, "0") &&
-		strcasecmp(val, "false") &&
-		strncasecmp(val, "disable", 7);
-
-}
-
 /*
  * A test base directory is accepted only when it is confined to /tmp and free
  * of ".." components, so it can never redirect libnvme onto a production or
@@ -52,7 +38,6 @@ static bool is_valid_test_base_dir(const char *path)
 __libnvme_public struct libnvme_global_ctx *libnvme_create_global_ctx(void)
 {
 	struct libnvme_global_ctx *ctx;
-	const char *base;
 
 	ctx = calloc(1, sizeof(*ctx));
 	if (!ctx)
@@ -65,17 +50,7 @@ __libnvme_public struct libnvme_global_ctx *libnvme_create_global_ctx(void)
 	list_head_init(&ctx->endpoints);
 
 	ctx->ioctl_probing = true;
-	ctx->mi_probe_enabled = libnvme_mi_probe_enabled_default();
-
-	/*
-	 * Optional test sandbox: LIBNVME_TEST_BASE_DIR reroots libnvme's
-	 * on-disk files (exclusion list, registry, ...) under a throwaway
-	 * directory.  This is the injection point for the shell-invoked nvme
-	 * binary's functional tests; code should prefer the setter below.
-	 */
-	base = getenv("LIBNVME_TEST_BASE_DIR");
-	if (is_valid_test_base_dir(base))
-		ctx->test_base_dir = strdup(base); /* NULL on OOM = prod */
+	ctx->mi_probe_enabled = true;
 
 	return ctx;
 }
@@ -114,6 +89,41 @@ __libnvme_public int libnvme_set_test_base_dir(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
+__libnvme_public int libnvme_set_test_sysfs_dir(struct libnvme_global_ctx *ctx,
+					       const char *path)
+{
+	char *dup = NULL;
+
+	if (!ctx)
+		return -EINVAL;
+	if (path) {
+		dup = strdup(path);
+		if (!dup)
+			return -ENOMEM;
+	}
+	free(ctx->test_sysfs_dir);
+	ctx->test_sysfs_dir = dup;
+	return 0;
+}
+
+__libnvme_public void libnvme_set_force_4k(struct libnvme_global_ctx *ctx,
+					   bool enable)
+{
+	if (!ctx)
+		return;
+
+	ctx->force_4k = enable;
+}
+
+__libnvme_public void libnvme_set_probe_enabled(struct libnvme_global_ctx *ctx,
+						bool enabled)
+{
+	if (!ctx)
+		return;
+
+	ctx->mi_probe_enabled = enabled;
+}
+
 __libnvme_public void libnvme_free_global_ctx(struct libnvme_global_ctx *ctx)
 {
 	struct libnvme_host *h, *_h;
@@ -139,6 +149,7 @@ __libnvme_public void libnvme_free_global_ctx(struct libnvme_global_ctx *ctx)
 	free(ctx->config_file);
 	free(ctx->owner);
 	free(ctx->test_base_dir);
+	free(ctx->test_sysfs_dir);
 	free(ctx);
 }
 

--- a/libnvme/src/nvme/lib.h
+++ b/libnvme/src/nvme/lib.h
@@ -71,9 +71,19 @@ int libnvme_set_owner(struct libnvme_global_ctx *ctx, const char *owner);
  * Passing NULL clears a previously set override.
  *
  * Return: 0 on success, -EINVAL if @ctx is NULL or @path is not a valid
- *         sandbox path, -ENOMEM on allocation failure.
+ * sandbox path, -ENOMEM on allocation failure.
  */
 int libnvme_set_test_base_dir(struct libnvme_global_ctx *ctx, const char *path);
+
+/**
+ * libnvme_set_test_sysfs_dir() - Set libnvme's lookup sysfs path for testing
+ * @ctx:	&struct libnvme_global_ctx object
+ * @path:	Directory with sysfs or NULL to restore defaults
+ *
+ * Return: 0 on success, -EINVAL if @ctx is NULL, -ENOMEM on allocation
+ * failure.
+ */
+int libnvme_set_test_sysfs_dir(struct libnvme_global_ctx *ctx, const char *path);
 
 /**
  * libnvme_set_logging_level() - Set current logging level
@@ -323,3 +333,14 @@ void libnvme_set_dry_run(struct libnvme_global_ctx *ctx, bool enable);
  * IOCTL probing is enabled per default.
  */
 void libnvme_set_ioctl_probing(struct libnvme_global_ctx *ctx, bool enable);
+
+/**
+ * libnvme_set_force_4k() - Force 4k transfer size for log page retrieval
+ * @ctx:	&struct libnvme_global_ctx object
+ * @enable:	Enable/disable 4k-forced transfer size
+ *
+ * When enabled, all Get Log Page commands are issued in 4k chunks regardless
+ * of the controller's MDTS.  Useful for controllers that misbehave with larger
+ * transfers.
+ */
+void libnvme_set_force_4k(struct libnvme_global_ctx *ctx, bool enable);

--- a/libnvme/src/nvme/nvme-cmds.c
+++ b/libnvme/src/nvme/nvme-cmds.c
@@ -16,22 +16,6 @@
 #include "private.h"
 #include "compiler-attributes.h"
 
-static bool force_4k;
-
-__attribute__((constructor))
-static void nvme_init_env(void)
-{
-	char *val;
-
-	val = getenv("LIBNVME_FORCE_4K");
-	if (!val)
-		return;
-	if (!strcmp(val, "1") ||
-	    !strcasecmp(val, "true") ||
-	    !strncasecmp(val, "enable", 6))
-		force_4k = true;
-}
-
 static int submit_get_log_cmd(struct libnvme_transport_handle *hdl,
 	struct libnvme_passthru_cmd *cmd)
 {
@@ -80,7 +64,7 @@ __libnvme_public int libnvme_get_log(struct libnvme_transport_handle *hdl,
 				    NVME_VAL(LOG_CDW10_LSP));
 	__u32 cdw11 = cmd->cdw11 & NVME_VAL(LOG_CDW11_LSI);
 
-	if (force_4k)
+	if (hdl->ctx->force_4k)
 		xfer_len = NVME_LOG_PAGE_PDU_SIZE;
 
 	/*
@@ -88,7 +72,7 @@ __libnvme_public int libnvme_get_log(struct libnvme_transport_handle *hdl,
 	 * avoids having to check the MDTS value of the controller.
 	 */
 	do {
-		if (!force_4k) {
+		if (!hdl->ctx->force_4k) {
 			xfer = data_len - offset;
 			if (xfer > xfer_len)
 				xfer  = xfer_len;
@@ -146,7 +130,7 @@ __libnvme_public int libnvme_get_log_dynamic_chunk(
 	__u32 cdw11 = cmd->cdw11 & NVME_VAL(LOG_CDW11_LSI);
 
 
-	if (force_4k)
+	if (hdl->ctx->force_4k)
 		xfer_len = NVME_LOG_PAGE_PDU_SIZE;
 
 	do {

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -25,10 +25,10 @@
 struct libnvme_passthru_completion;
 struct libnvme_async_req;
 
-const char *libnvme_subsys_sysfs_dir(void);
-const char *libnvme_ctrl_sysfs_dir(void);
-const char *libnvme_ns_sysfs_dir(void);
-const char *libnvme_slots_sysfs_dir(void);
+const char *libnvme_subsys_sysfs_dir(struct libnvme_global_ctx *ctx);
+const char *libnvme_ctrl_sysfs_dir(struct libnvme_global_ctx *ctx);
+const char *libnvme_ns_sysfs_dir(struct libnvme_global_ctx *ctx);
+const char *libnvme_slots_sysfs_dir(struct libnvme_global_ctx *ctx);
 const char *libnvme_uuid_ibm_filename(void);
 const char *libnvme_dmi_entries_dir(void);
 
@@ -433,14 +433,19 @@ struct libnvme_fabric_options { // !generate-accessors
 struct libnvme_global_ctx { // !generate-python:alias=GlobalCtx
 	char *config_file;
 	char *owner; /* orchestrator identity; NULL = unowned */
-	char *test_base_dir; /* test sandbox under /tmp; NULL = prod */
 	struct list_head endpoints; /* MI endpoints */
 	struct list_head hosts;
 	struct libnvme_log log;
-	bool mi_probe_enabled;
-	bool ioctl_probing;
 	bool create_only;
 	bool dry_run;
+
+	/* global options to steer libnvme behavior or overwrite defaults */
+	bool force_4k;
+	bool mi_probe_enabled;
+	bool ioctl_probing;
+	char *test_base_dir;
+	char *test_sysfs_dir;
+
 #ifdef CONFIG_FABRICS
 	struct libnvme_fabric_options *options;
 	struct ifaddrs *ifaddrs_cache; /* init with libnvmf_getifaddrs() */

--- a/libnvme/src/nvme/scan-linux.c
+++ b/libnvme/src/nvme/scan-linux.c
@@ -80,7 +80,7 @@ static int filter_subsys(const struct dirent *d)
 __libnvme_public int libnvme_scan_subsystems(struct libnvme_global_ctx *ctx,
 		struct dirent ***subsys)
 {
-	const char *dir = libnvme_subsys_sysfs_dir();
+	const char *dir = libnvme_subsys_sysfs_dir(ctx);
 	int ret;
 
 	ret = scandir(dir, subsys, filter_subsys, alphasort);
@@ -106,7 +106,7 @@ __libnvme_public int libnvme_scan_subsystem_namespaces(libnvme_subsystem_t s,
 __libnvme_public int libnvme_scan_ctrls(struct libnvme_global_ctx *ctx,
 		struct dirent ***ctrls)
 {
-	const char *dir = libnvme_ctrl_sysfs_dir();
+	const char *dir = libnvme_ctrl_sysfs_dir(ctx);
 	int ret;
 
 	ret = scandir(dir, ctrls, filter_ctrls, alphasort);

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -39,58 +39,58 @@
 #define PATH_SYSFS_NVME			"/sys/class/nvme"
 #define PATH_DMI_ENTRIES		"/sys/firmware/dmi/entries"
 
-static const char *make_sysfs_dir(const char *path)
+static const char *make_sysfs_dir(struct libnvme_global_ctx *ctx,
+		const char *path)
 {
-	char *basepath = getenv("LIBNVME_SYSFS_PATH");
 	char *str;
 
-	if (!basepath)
+	if (!ctx || !ctx->test_sysfs_dir)
 		return path;
 
-	if (asprintf(&str, "%s%s", basepath, path) < 0)
+	if (asprintf(&str, "%s%s", ctx->test_sysfs_dir, path) < 0)
 		return NULL;
 
 	return str;
 }
 
-const char *libnvme_subsys_sysfs_dir(void)
+const char *libnvme_subsys_sysfs_dir(struct libnvme_global_ctx *ctx)
 {
 	static const char *str;
 
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(PATH_SYSFS_NVME_SUBSYSTEM);
+	return str = make_sysfs_dir(ctx, PATH_SYSFS_NVME_SUBSYSTEM);
 }
 
-const char *libnvme_ctrl_sysfs_dir(void)
+const char *libnvme_ctrl_sysfs_dir(struct libnvme_global_ctx *ctx)
 {
 	static const char *str;
 
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(PATH_SYSFS_NVME);
+	return str = make_sysfs_dir(ctx, PATH_SYSFS_NVME);
 }
 
-const char *libnvme_ns_sysfs_dir(void)
+const char *libnvme_ns_sysfs_dir(struct libnvme_global_ctx *ctx)
 {
 	static const char *str;
 
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(PATH_SYSFS_BLOCK);
+	return str = make_sysfs_dir(ctx, PATH_SYSFS_BLOCK);
 }
 
-const char *libnvme_slots_sysfs_dir(void)
+const char *libnvme_slots_sysfs_dir(struct libnvme_global_ctx *ctx)
 {
 	static const char *str;
 
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(PATH_SYSFS_SLOTS);
+	return str = make_sysfs_dir(ctx, PATH_SYSFS_SLOTS);
 }
 
 const char *libnvme_uuid_ibm_filename(void)
@@ -100,7 +100,7 @@ const char *libnvme_uuid_ibm_filename(void)
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(PATH_UUID_IBM);
+	return str = make_sysfs_dir(NULL, PATH_UUID_IBM);
 }
 
 const char *libnvme_dmi_entries_dir(void)
@@ -110,7 +110,7 @@ const char *libnvme_dmi_entries_dir(void)
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(PATH_DMI_ENTRIES);
+	return str = make_sysfs_dir(NULL, PATH_DMI_ENTRIES);
 }
 
 static int __nvme_set_attr(const char *path, const char *value)
@@ -237,7 +237,7 @@ __libnvme_public const char *libnvme_ctrl_get_state(libnvme_ctrl_t c)
 static int libnvme_ctrl_lookup_subsystem_name(struct libnvme_global_ctx *ctx,
 		const char *ctrl_name, char **name)
 {
-	const char *subsys_dir = libnvme_subsys_sysfs_dir();
+	const char *subsys_dir = libnvme_subsys_sysfs_dir(ctx);
 	__cleanup_dirents struct dirents subsys = {};
 	int i;
 
@@ -269,7 +269,7 @@ static int libnvme_ctrl_lookup_subsystem_name(struct libnvme_global_ctx *ctx,
 static int libnvme_ctrl_lookup_phy_slot(struct libnvme_global_ctx *ctx,
 		libnvme_ctrl_t c)
 {
-	const char *slots_sysfs_dir = libnvme_slots_sysfs_dir();
+	const char *slots_sysfs_dir = libnvme_slots_sysfs_dir(ctx);
 	__cleanup_free char *target_addr = NULL;
 	__cleanup_dir DIR *slots_dir = NULL;
 	struct dirent *entry;
@@ -379,7 +379,7 @@ __libnvme_public int libnvme_init_ctrl(
 	if (ret < 0)
 		return -ENOMEM;
 
-	ret = asprintf(&path, "%s/%s", libnvme_ctrl_sysfs_dir(), name);
+	ret = asprintf(&path, "%s/%s", libnvme_ctrl_sysfs_dir(h->ctx), name);
 	if (ret < 0)
 		return -ENOMEM;
 
@@ -426,7 +426,7 @@ __libnvme_public int libnvme_scan_ctrl(
 	int ret;
 
 	libnvme_msg(ctx, LIBNVME_LOG_DEBUG, "scan controller %s\n", name);
-	ret = asprintf(&path, "%s/%s", libnvme_ctrl_sysfs_dir(), name);
+	ret = asprintf(&path, "%s/%s", libnvme_ctrl_sysfs_dir(ctx), name);
 	if (ret < 0)
 		return -ENOMEM;
 
@@ -851,7 +851,8 @@ int libnvme_init_subsystem(libnvme_subsystem_t s, const char *name)
 {
 	char *path;
 
-	if (asprintf(&path, "%s/%s", libnvme_subsys_sysfs_dir(), name) < 0)
+	if (asprintf(&path, "%s/%s",
+			libnvme_subsys_sysfs_dir(s->h->ctx), name) < 0)
 		return -ENOMEM;
 
 	s->model = libnvme_get_attr(path, "model");

--- a/libnvme/src/nvme/tree-win.c
+++ b/libnvme/src/nvme/tree-win.c
@@ -324,12 +324,14 @@ __libnvme_public char *libnvme_get_ns_attr(
 	return NULL;
 }
 
-const char *libnvme_subsys_sysfs_dir(void)
+const char *libnvme_subsys_sysfs_dir(
+		__libnvme_unused struct libnvme_global_ctx *ctx)
 {
 	return NULL;
 }
 
-const char *libnvme_ns_sysfs_dir(void)
+const char *libnvme_ns_sysfs_dir(
+		__libnvme_unused struct libnvme_global_ctx *ctx)
 {
 	return NULL;
 }

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -576,7 +576,7 @@ static int libnvme_scan_subsystem(struct libnvme_global_ctx *ctx,
 	int ret;
 
 	libnvme_msg(ctx, LIBNVME_LOG_DEBUG, "scan subsystem %s\n", name);
-	ret = asprintf(&path, "%s/%s", libnvme_subsys_sysfs_dir(), name);
+	ret = asprintf(&path, "%s/%s", libnvme_subsys_sysfs_dir(ctx), name);
 	if (ret < 0)
 		return -ENOMEM;
 
@@ -1883,7 +1883,8 @@ __libnvme_public int libnvme_ns_flush(libnvme_ns_t n)
 __libnvme_public int libnvme_scan_namespace(struct libnvme_global_ctx *ctx,
 		const char *name, libnvme_ns_t *ns)
 {
-	return __libnvme_scan_namespace(ctx, libnvme_ns_sysfs_dir(), name, ns);
+	return __libnvme_scan_namespace(ctx,
+		libnvme_ns_sysfs_dir(ctx), name, ns);
 }
 
 

--- a/libnvme/test/config/config-diff.sh
+++ b/libnvme/test/config/config-diff.sh
@@ -6,23 +6,28 @@ sysfs_tar=""
 config_json=""
 
 while [[ $# -gt 0 ]]; do
-    case $1 in
+	case "$1" in
 	--sysfs-tar)
-	    sysfs_tar=$2
-	    shift 1
-	    ;;
+		sysfs_tar=$2
+		shift 2
+		;;
 	--config-json)
-	    config_json=$2
-	    shift 1
-	    ;;
-    *)
-        positional_args+=("$1")
-        shift
-        ;;
-    esac
+		config_json=$2
+		shift 2
+		;;
+	*)
+		positional_args+=("$1")
+		shift
+		;;
+	esac
 done
 
 set -- "${positional_args[@]}"
+
+if [[ $# -lt 3 ]]; then
+	echo "usage: $0 [--sysfs-tar file] [--config-json file] <test-binary> <build-dir> <expected-output>"
+	exit 1
+fi
 
 test_binary="$1"
 build_dir="$2"
@@ -30,34 +35,41 @@ expected_output="$3"
 
 sysfs_path=""
 if [[ -n "${sysfs_tar}" ]]; then
-   test_name="$(basename -s .tar.xz ${sysfs_tar})"
-   sysfs_path="${build_dir}/${test_name}"
+	test_name="$(basename -s .tar.xz "${sysfs_tar}")"
+	sysfs_path="${build_dir}/${test_name}"
 
-   rm -rf "${sysfs_path}"
-   mkdir "${sysfs_path}"
-   tar -x -f "${sysfs_tar}" -C "${sysfs_path}"
+	rm -rf "${sysfs_path}"
+	mkdir -p "${sysfs_path}"
+	tar -x -f "${sysfs_tar}" -C "${sysfs_path}"
 fi
 
-output="${build_dir}"/$(basename "${expected_output}")
+output="${build_dir}/$(basename "${expected_output}")"
 
 cmd=(
-  env
-  LIBNVME_SYSFS_PATH="$sysfs_path"
-  LIBNVME_HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:ce4fee3e-c02c-11ee-8442-830d068a36c6"
-  LIBNVME_HOSTID="ce4fee3e-c02c-11ee-8442-830d068a36c6"
-  "$test_binary"
-  "$config_json"
+	env
+	LIBNVME_HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:ce4fee3e-c02c-11ee-8442-830d068a36c6"
+	LIBNVME_HOSTID="ce4fee3e-c02c-11ee-8442-830d068a36c6"
+	"$test_binary"
 )
+
+if [[ -n "${sysfs_path}" ]]; then
+	cmd+=(--set-options "test-sysfs-dir=${sysfs_path}")
+fi
+
+if [[ -n "${config_json}" ]]; then
+	cmd+=("${config_json}")
+fi
 
 echo "Running command:"
 printf '%q ' "${cmd[@]}"
 printf '> %q\n' "$output"
 
-"${cmd[@]}" > "$output"
-rc=$?
-if [ "$rc" -ne 0 ]; then
-    echo "test failed (exit code $rc)"
-    exit "$rc"
+if "${cmd[@]}" > "$output"; then
+	:
+else
+	rc=$?
+	echo "test failed (exit code $rc)"
+	exit "$rc"
 fi
 
 diff -u "${expected_output}" "${output}"

--- a/libnvme/test/config/config-dump.c
+++ b/libnvme/test/config/config-dump.c
@@ -5,23 +5,70 @@
  */
 
 #include <errno.h>
+#include <getopt.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
 #include <libnvme.h>
 
-static bool config_dump(const char *file)
+enum {
+	OPT_SET_OPTIONS = 1000,
+};
+
+static void usage(const char *prog)
 {
-	struct libnvme_global_ctx *ctx;
+	fprintf(stderr,
+		"Usage: %s [OPTIONS] <config-file>\n"
+		"\n"
+		"Options:\n"
+		"  --set-options key=value[,key=value...]\n",
+		prog);
+}
+
+static int set_options(struct libnvme_global_ctx *ctx,
+		      const char *key, const char *value)
+{
+	if (!strcmp(key, "test-sysfs-dir"))
+		return libnvme_set_test_sysfs_dir(ctx, value);
+
+	fprintf(stderr, "Unknown option '%s'\n", key);
+	return -EINVAL;
+}
+
+static int parse_set_options(struct libnvme_global_ctx *ctx, char *arg)
+{
+	char *tok;
+
+	while ((tok = strsep(&arg, ","))) {
+		char *val;
+		int err;
+
+		if (!*tok)
+			continue;
+
+		val = strchr(tok, '=');
+		if (!val) {
+			fprintf(stderr, "Invalid option '%s'\n", tok);
+			return -EINVAL;
+		}
+
+		*val++ = '\0';
+
+		err = set_options(ctx, tok, val);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
+static bool config_dump(struct libnvme_global_ctx *ctx, const char *file)
+{
 	bool pass = false;
 	int err;
-
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return false;
-	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
 	err = libnvme_scan_topology(ctx, NULL, NULL);
 	if (err < 0 && err != -ENOENT)
@@ -38,15 +85,54 @@ static bool config_dump(const char *file)
 	pass = true;
 
 out:
-	libnvme_free_global_ctx(ctx);
 	return pass;
 }
 
 int main(int argc, char *argv[])
 {
-	bool pass;
+	static const struct option long_options[] = {
+		{ "set-options", required_argument, NULL, OPT_SET_OPTIONS },
+		{ NULL, 0, NULL, 0 }
+	};
 
-	pass = config_dump(argv[1]);
+	struct libnvme_global_ctx *ctx;
+	const char *config_file = NULL;
+	bool pass;
+	int c;
+
+	ctx = libnvme_create_global_ctx();
+	if (!ctx)
+		return EXIT_FAILURE;
+
+	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
+
+	while ((c = getopt_long(argc, argv, "", long_options, NULL)) != -1) {
+		switch (c) {
+		case OPT_SET_OPTIONS:
+			if (parse_set_options(ctx, optarg)) {
+				libnvme_free_global_ctx(ctx);
+				return EXIT_FAILURE;
+			}
+			break;
+
+		default:
+			usage(argv[0]);
+			libnvme_free_global_ctx(ctx);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind >= argc) {
+		usage(argv[0]);
+		libnvme_free_global_ctx(ctx);
+		return EXIT_FAILURE;
+	}
+
+	config_file = argv[optind];
+
+	pass = config_dump(ctx, config_file);
+
+	libnvme_free_global_ctx(ctx);
 	fflush(stdout);
 
 	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);

--- a/libnvme/test/config/hostnqn-order.c
+++ b/libnvme/test/config/hostnqn-order.c
@@ -5,6 +5,7 @@
  */
 
 #include <errno.h>
+#include <getopt.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,104 +15,131 @@
 #include "nvme/private.h"
 #include "nvme/private-fabrics.h"
 
-static bool command_line(void)
+enum {
+	OPT_SET_OPTIONS = 1000,
+};
+
+static void usage(const char *prog)
 {
-	struct libnvme_global_ctx *ctx;
-	bool pass = false;
-	int err;
-	char *hostnqn, *hostid, *hnqn, *hid;
-
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return false;
-	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
-
-	err = libnvme_scan_topology(ctx, NULL, NULL);
-	if (err && err != ENOENT)
-		goto out;
-
-	hostnqn = "nqn.2014-08.org.nvmexpress:uuid:ce4fee3e-c02c-11ee-8442-830d068a36c6";
-	hostid = "ce4fee3e-c02c-11ee-8442-830d068a36c6";
-
-	err = libnvmf_host_get_ids(ctx, hostnqn, hostid, &hnqn, &hid);
-	if (err)
-		goto out;
-
-	if (strcmp(hostnqn, hnqn)) {
-		printf("json config hostnqn '%s' does not match '%s'\n", hostnqn, hnqn);
-		goto out;
-	}
-	if (strcmp(hostid, hid)) {
-		printf("json config hostid '%s' does not match '%s'\n", hostid, hid);
-		goto out;
-	}
-
-	free(hnqn);
-	free(hid);
-
-	pass = true;
-
-out:
-	libnvme_free_global_ctx(ctx);
-	return pass;
+	fprintf(stderr,
+		"Usage: %s [OPTIONS] <config-file>\n"
+		"\n"
+		"Options:\n"
+		"  --set-options key=value[,key=value...]\n",
+		prog);
 }
 
-static bool json_config(char *file)
+static int set_options(struct libnvme_global_ctx *ctx,
+		      const char *key, const char *value)
 {
-	struct libnvme_global_ctx *ctx;
-	bool pass = false;
-	int err;
+	if (!strcmp(key, "test-sysfs-dir"))
+		return libnvme_set_test_sysfs_dir(ctx, value);
+
+	fprintf(stderr, "Unknown option '%s'\n", key);
+	return -EINVAL;
+}
+
+static int parse_set_options(struct libnvme_global_ctx *ctx, char *arg)
+{
+	char *tok;
+
+	while ((tok = strsep(&arg, ","))) {
+		char *val;
+		int err;
+
+		if (!*tok)
+			continue;
+
+		val = strchr(tok, '=');
+		if (!val) {
+			fprintf(stderr, "Invalid option '%s'\n", tok);
+			return -EINVAL;
+		}
+
+		*val++ = '\0';
+
+		err = set_options(ctx, tok, val);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
+static bool json_config(struct libnvme_global_ctx *ctx, char *file)
+{
 	char *hostnqn, *hostid, *hnqn, *hid;
+	int err;
 
 	setenv("LIBNVME_HOSTNQN", "", 1);
 	setenv("LIBNVME_HOSTID", "", 1);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return false;
-	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
-
 	/* We need to read the config in before we scan */
 	err = libnvme_read_config(ctx, file);
 	if (err)
-		goto out;
+		return false;
 
 	err = libnvme_scan_topology(ctx, NULL, NULL);
-	if (err && err != ENOENT)
-		goto out;
+	if (err && err != -ENOENT)
+		return false;
 
 	hostnqn = "nqn.2014-08.org.nvmexpress:uuid:2cd2c43b-a90a-45c1-a8cd-86b33ab273b5";
 	hostid = "2cd2c43b-a90a-45c1-a8cd-86b33ab273b5";
 
 	err = libnvmf_host_get_ids(ctx, NULL, NULL, &hnqn, &hid);
 	if (err)
-		goto out;
+		return false;
 
 	if (strcmp(hostnqn, hnqn)) {
 		printf("json config hostnqn '%s' does not match '%s'\n", hostnqn, hnqn);
-		goto out;
+		return false;
 	}
 	if (strcmp(hostid, hid)) {
 		printf("json config hostid '%s' does not match '%s'\n", hostid, hid);
-		goto out;
+		return false;
 	}
 
 	free(hnqn);
 	free(hid);
 
-	pass = true;
-
-out:
-	libnvme_free_global_ctx(ctx);
-	return pass;
+	return true;
 }
 
-static bool from_file(void)
+static bool command_line(struct libnvme_global_ctx *ctx)
 {
-	struct libnvme_global_ctx *ctx;
-	bool pass = false;
-	int err;
 	char *hostnqn, *hostid, *hnqn, *hid;
+	int err;
+
+	err = libnvme_refresh_topology(ctx);
+	if (err && err != -ENOENT)
+		return false;
+
+	hostnqn = "nqn.2014-08.org.nvmexpress:uuid:ce4fee3e-c02c-11ee-8442-830d068a36c6";
+	hostid = "ce4fee3e-c02c-11ee-8442-830d068a36c6";
+
+	err = libnvmf_host_get_ids(ctx, hostnqn, hostid, &hnqn, &hid);
+	if (err)
+		return false;
+
+	if (strcmp(hostnqn, hnqn)) {
+		printf("json config hostnqn '%s' does not match '%s'\n", hostnqn, hnqn);
+		return false;
+	}
+	if (strcmp(hostid, hid)) {
+		printf("json config hostid '%s' does not match '%s'\n", hostid, hid);
+		return false;
+	}
+
+	free(hnqn);
+	free(hid);
+
+	return true;
+}
+
+static bool from_file(struct libnvme_global_ctx *ctx)
+{
+	char *hostnqn, *hostid, *hnqn, *hid;
+	int err;
 
 	hostnqn = "nqn.2014-08.org.nvmexpress:uuid:ce4fee3e-c02c-11ee-8442-830d068a36c6";
 	hostid = "ce4fee3e-c02c-11ee-8442-830d068a36c6";
@@ -119,46 +147,71 @@ static bool from_file(void)
 	setenv("LIBNVME_HOSTNQN", hostnqn, 1);
 	setenv("LIBNVME_HOSTID", hostid, 1);
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return false;
-	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
-
-	err = libnvme_scan_topology(ctx, NULL, NULL);
+	err = libnvme_refresh_topology(ctx);
 	if (err && err != ENOENT)
-		goto out;
+		return false;
 
 	err = libnvmf_host_get_ids(ctx, NULL, NULL, &hnqn, &hid);
 	if (err)
-		goto out;
+		return false;
 
 	if (strcmp(hostnqn, hnqn)) {
 		printf("json config hostnqn '%s' does not match '%s'\n", hostnqn, hnqn);
-		goto out;
+		return false;
 	}
 	if (strcmp(hostid, hid)) {
 		printf("json config hostid '%s' does not match '%s'\n", hostid, hid);
-		goto out;
+		return false;
 	}
 
 	free(hnqn);
 	free(hid);
 
-	pass = true;
-
-out:
-	libnvme_free_global_ctx(ctx);
-	return pass;
+	return true;
 }
 
 int main(int argc, char *argv[])
 {
-	bool pass;
+	static const struct option long_options[] = {
+		{ "set-options", required_argument, NULL, OPT_SET_OPTIONS },
+		{ NULL, 0, NULL, 0 }
+	};
 
-	pass = command_line();
-	pass &= json_config(argv[1]);
-	pass &= from_file();
+	struct libnvme_global_ctx *ctx;
+	bool pass;
+	int c;
+
+	ctx = libnvme_create_global_ctx();
+	if (!ctx)
+		return EXIT_FAILURE;
+
+	while ((c = getopt_long(argc, argv, "", long_options, NULL)) != -1) {
+		switch (c) {
+		case OPT_SET_OPTIONS:
+			if (parse_set_options(ctx, optarg)) {
+				libnvme_free_global_ctx(ctx);
+				return EXIT_FAILURE;
+			}
+			break;
+		default:
+			usage(argv[0]);
+			libnvme_free_global_ctx(ctx);
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (optind >= argc) {
+		usage(argv[0]);
+		libnvme_free_global_ctx(ctx);
+		return EXIT_FAILURE;
+	}
+
+	pass = json_config(ctx, argv[optind]);
+	pass &= command_line(ctx);
+	pass &= from_file(ctx);
 	fflush(stdout);
+
+	libnvme_free_global_ctx(ctx);
 
 	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/libnvme/test/sysfs/tree-diff.sh
+++ b/libnvme/test/sysfs/tree-diff.sh
@@ -6,7 +6,7 @@ TREE_DUMP=$2
 SYSFS_INPUT=$3
 EXPECTED_OUTPUT=$4
 
-TEST_NAME="$(basename -s .tar.xz ${SYSFS_INPUT})"
+TEST_NAME="$(basename -s .tar.xz "$SYSFS_INPUT")"
 TEST_DIR="${BUILD_DIR}/${TEST_NAME}"
 ACTUAL_OUTPUT="${TEST_DIR}.out"
 
@@ -15,21 +15,23 @@ mkdir "${TEST_DIR}"
 tar -x -f "${SYSFS_INPUT}" -C "${TEST_DIR}"
 
 cmd=(
-  env
-  LIBNVME_SYSFS_PATH="$TEST_DIR"
-  LIBNVME_HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:ce4fee3e-c02c-11ee-8442-830d068a36c6"
-  LIBNVME_HOSTID="ce4fee3e-c02c-11ee-8442-830d068a36c6"
-  "$TREE_DUMP"
+	env
+	LIBNVME_HOSTNQN="nqn.2014-08.org.nvmexpress:uuid:ce4fee3e-c02c-11ee-8442-830d068a36c6"
+	LIBNVME_HOSTID="ce4fee3e-c02c-11ee-8442-830d068a36c6"
+	"${TREE_DUMP}"
+	--set-options "test-sysfs-dir=${TEST_DIR}"
 )
 
 echo "Running command:"
 printf '%q ' "${cmd[@]}"
 printf '> %q\n' "$ACTUAL_OUTPUT"
 
-if ! "${cmd[@]}" > "$ACTUAL_OUTPUT"; then
-    rc=$?
-    echo "test failed (exit code $rc)"
-    exit $rc
+if "${cmd[@]}" > "$ACTUAL_OUTPUT"; then
+	:
+else
+	rc=$?
+	echo "test failed (exit code $rc)"
+	exit "$rc"
 fi
 
 diff -u "${EXPECTED_OUTPUT}" "${ACTUAL_OUTPUT}"

--- a/libnvme/test/sysfs/tree-dump.c
+++ b/libnvme/test/sysfs/tree-dump.c
@@ -4,48 +4,125 @@
  * Copyright (c) 2024 Daniel Wagner, SUSE LLC
  */
 
-#include <string.h>
-#include <stdbool.h>
-#include <stdlib.h>
 #include <errno.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <libnvme.h>
 
-static bool tree_dump(void)
+enum {
+	OPT_SET_OPTIONS = 1000,
+};
+
+static void usage(const char *prog)
 {
-	struct libnvme_global_ctx *ctx;
+	fprintf(stderr,
+		"Usage: %s [OPTIONS]\n"
+		"\n"
+		"Options:\n"
+		"  --set-options key=value[,key=value...]\n",
+		prog);
+}
+
+static int set_options(struct libnvme_global_ctx *ctx,
+		      const char *key, const char *value)
+{
+	if (!strcmp(key, "test-sysfs-dir"))
+		return libnvme_set_test_sysfs_dir(ctx, value);
+
+	fprintf(stderr, "Unknown option '%s'\n", key);
+	return -EINVAL;
+}
+
+static int parse_set_options(struct libnvme_global_ctx *ctx, char *arg)
+{
+	char *tok;
+
+	while ((tok = strsep(&arg, ","))) {
+		char *val;
+		int err;
+
+		if (!*tok)
+			continue;
+
+		val = strchr(tok, '=');
+		if (!val) {
+			fprintf(stderr, "Invalid option '%s'\n", tok);
+			return -EINVAL;
+		}
+
+		*val++ = '\0';
+
+		err = set_options(ctx, tok, val);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
+static bool tree_dump(struct libnvme_global_ctx *ctx)
+{
 	bool pass = false;
 	int err;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return false;
-	libnvme_set_logging_file(ctx, stdout);
-	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
-
 	err = libnvme_scan_topology(ctx, NULL, NULL);
-	if (err && !(err == ENOENT || err == EACCES)) {
-		fprintf(stderr, "libnvme_scan_topology failed %d\n", err);
+	if (err && err != -ENOENT && err != -EACCES) {
+		fprintf(stderr, "libnvme_scan_topology failed: %d\n", err);
 		goto out;
 	}
 
 	if (libnvme_dump_tree(ctx))
 		goto out;
-	printf("\n");
 
+	printf("\n");
 	pass = true;
 
 out:
-	libnvme_free_global_ctx(ctx);
 	return pass;
 }
 
 int main(int argc, char *argv[])
 {
-	bool pass = true;
+	static const struct option long_options[] = {
+		{ "set-options", required_argument, NULL, OPT_SET_OPTIONS },
+		{ NULL, 0, NULL, 0 }
+	};
 
-	pass = tree_dump();
+	struct libnvme_global_ctx *ctx;
+	bool pass;
+	int c;
+
+	ctx = libnvme_create_global_ctx();
+	if (!ctx)
+		return EXIT_FAILURE;
+
+	libnvme_set_logging_file(ctx, stdout);
+	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
+
+	while ((c = getopt_long(argc, argv, "", long_options, NULL)) != -1) {
+		switch (c) {
+		case OPT_SET_OPTIONS:
+			if (parse_set_options(ctx, optarg)) {
+				libnvme_free_global_ctx(ctx);
+				return EXIT_FAILURE;
+			}
+			break;
+
+		default:
+			usage(argv[0]);
+			libnvme_free_global_ctx(ctx);
+			return EXIT_FAILURE;
+		}
+	}
+
+	pass = tree_dump(ctx);
+
+	libnvme_free_global_ctx(ctx);
 	fflush(stdout);
 
-	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+	return pass ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/meson.build
+++ b/meson.build
@@ -287,6 +287,21 @@ conf.set(
     ),
     description: 'Does struct tm have a tm_gmtoff field?'
 )
+conf.set('HAVE_STRSEP',
+    cc.compiles(
+        '''
+            #include <string.h>
+
+            int main(void) {
+                char *s = NULL;
+                char *p = strsep(&s, ",");
+                return p != NULL;
+            }
+        ''',
+        name: 'strsep'
+    ),
+    description: 'Is strsep available?'
+)
 
 if cc.has_function_attribute('fallthrough')
     conf.set('fallthrough', '__attribute__((fallthrough))')

--- a/nvme-print-stdout-top.c
+++ b/nvme-print-stdout-top.c
@@ -1471,9 +1471,10 @@ void stdout_top(int refresh_interval)
 	__cleanup_free libnvme_subsystem_t *subsys_arr = NULL;
 	int data_start, frame_rows, quit = 0, scroll = 0;
 	int num_subsys = 0, subsys_idx = 0;
+	int err;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
 		return;
 	}

--- a/nvme.c
+++ b/nvme.c
@@ -298,6 +298,27 @@ static OPT_VALS(feature_name) = {
 	VAL_END()
 };
 
+#ifndef HAVE_STRSEP
+static char *strsep(char **stringp, const char *delim)
+{
+	char *s, *end;
+
+	if (!stringp || !*stringp)
+		return NULL;
+
+	s = *stringp;
+	end = s + strcspn(s, delim);
+
+	if (*end)
+		*end++ = '\0';
+	else
+		end = NULL;
+
+	*stringp = end;
+	return s;
+}
+#endif
+
 static int check_arg_dev(int argc, char **argv)
 {
 	if (optind >= argc) {
@@ -371,6 +392,91 @@ static void setup_transport_handle(struct libnvme_global_ctx *ctx,
 		libnvme_transport_handle_set_timeout(hdl, nvme_args.timeout);
 }
 
+static bool is_true(const char *val)
+{
+	return !strcmp(val, "1") ||
+		!strcasecmp(val, "true") ||
+		!strncasecmp(val, "enable", 6);
+}
+
+/*
+ * nvme_apply_option() - apply a single "key=value" pair to @ctx.
+ *
+ * Returns 0 on success, -EINVAL for unknown keys or missing '='.
+ */
+static int nvme_apply_option(struct libnvme_global_ctx *ctx, const char *kv)
+{
+	__cleanup_free char *str = NULL;
+	char *key, *val;
+	int ret = 0;
+
+	str = strdup(kv);
+	if (!str)
+		return -ENOMEM;
+
+	val = strchr(str, '=');
+	if (!val) {
+		nvme_show_error("--set-options: missing '=' in '%s'", kv);
+		return -EINVAL;
+	}
+	*val++ = '\0';
+	key = str;
+
+	if (!strcmp(key, "force-4k")) {
+		libnvme_set_force_4k(ctx, is_true(val));
+	} else if (!strcmp(key, "mi-probe-enabled")) {
+		libnvme_set_probe_enabled(ctx, is_true(val));
+	} else if (!strcmp(key, "test-base-dir")) {
+		ret = libnvme_set_test_base_dir(ctx, val);
+	} else if (!strcmp(key, "test-sysfs-dir")) {
+		ret = libnvme_set_test_sysfs_dir(ctx, val);
+	} else {
+		nvme_show_error("--set-options: unknown key '%s'", key);
+		return -EINVAL;
+	}
+
+	if (ret)
+ 		nvme_show_error("--set-options: failed to set '%s=%s': %s",
+			key, val, libnvme_strerror(-ret));
+
+	return ret;
+}
+
+int nvme_create_global_ctx(struct libnvme_global_ctx **pctx)
+{
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_free char *buf = NULL;
+	const char *opt;
+	char *p;
+	int err;
+
+	ctx = libnvme_create_global_ctx();
+	if (!ctx)
+		return -ENOMEM;
+
+	if (!nvme_args.set_options)
+		goto out;
+
+	buf = strdup(nvme_args.set_options);
+	if (!buf)
+		return -ENOMEM;
+
+	p = buf;
+	while ((opt = strsep(&p, ",")) != NULL) {
+		if (!*opt)
+			continue;
+		err = nvme_apply_option(ctx, opt);
+		if (err)
+			return err;
+	}
+
+out:
+	*pctx = ctx;
+	ctx = NULL;
+
+	return 0;
+}
+
 int parse_and_open(struct libnvme_global_ctx **ctx,
 		   struct libnvme_transport_handle **hdl, int argc, char **argv,
 		   const char *desc, struct argconfig_commandline_options *opts)
@@ -383,9 +489,9 @@ int parse_and_open(struct libnvme_global_ctx **ctx,
 	if (ret)
 		return ret;
 
-	ctx_new = libnvme_create_global_ctx();
-	if (!ctx_new)
-		return -ENOMEM;
+	ret = nvme_create_global_ctx(&ctx_new);
+	if (ret)
+		return ret;
 	libnvme_set_logging_file(ctx_new, stdout);
 	libnvme_set_logging_level(ctx_new, log_level, false, false);
 
@@ -420,9 +526,9 @@ int open_exclusive(struct libnvme_global_ctx **ctx,
 	if (!ignore_exclusive)
 		flags |= O_EXCL;
 
-	ctx_new = libnvme_create_global_ctx();
-	if (!ctx_new)
-		return -ENOMEM;
+	ret = nvme_create_global_ctx(&ctx_new);
+	if (ret)
+		return ret;
 	libnvme_set_logging_file(ctx_new, stdout);
 	libnvme_set_logging_level(ctx_new, log_level, false, false);
 
@@ -3534,13 +3640,13 @@ static int list_subsys(int argc, char **argv, struct command *acmd,
 	if (nvme_args.verbose)
 		flags |= VERBOSE;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		if (devname)
 			nvme_show_error("Failed to scan nvme subsystem for %s", devname);
 		else
 			nvme_show_error("Failed to scan nvme subsystem");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, log_level, false, false);
@@ -3634,10 +3740,10 @@ static int list(int argc, char **argv, struct command *acmd, struct plugin *plug
 	if (nvme_args.verbose)
 		flags |= VERBOSE;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, log_level, false, false);
@@ -6801,8 +6907,8 @@ static void show_relatives(const char *name, nvme_print_flags_t flags)
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx;
 	int err;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
 		return;
 	}
@@ -9911,10 +10017,10 @@ static int gen_dhchap_key(int argc, char **argv, struct command *acmd, struct pl
 	if (err)
 		return err;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -10234,10 +10340,10 @@ static int gen_tls_key(int argc, char **argv, struct command *acmd, struct plugi
 	if (cfg.hmac == 2)
 		key_len = 48;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -10349,10 +10455,10 @@ static int check_tls_key(int argc, char **argv, struct command *acmd, struct plu
 		return -EINVAL;
 	}
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -10539,10 +10645,10 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 	if (err)
 		return err;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
@@ -10664,10 +10770,10 @@ static int show_topology_cmd(int argc, char **argv, struct command *acmd, struct
 		return -EINVAL;
 	}
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create global context");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 

--- a/nvme.h
+++ b/nvme.h
@@ -58,6 +58,7 @@ struct nvme_args {
 	bool no_retries;
 	bool no_ioctl_probing;
 	unsigned int output_format_ver;
+	const char *set_options;
 };
 
 #ifdef CONFIG_JSONC
@@ -90,6 +91,9 @@ struct nvme_args {
 		OPT_UINT("output-format-version", 0, &nvme_args.output_format_ver,     \
 			 "output format version: 1|2"),                                \
 		OPT_FLAG("human-readable", 'H', &nvme_args.verbose, NULL, NULL, true), \
+		OPT_STRING("set-options",    0, "KEY=VALUE",                           \
+			 &nvme_args.set_options,                                       \
+			 "set a libnvme library option (key=value[,key=value,...]);"), \
 		OPT_END()                                                              \
 	}
 
@@ -146,6 +150,17 @@ static inline DEFINE_CLEANUP_FUNC(cleanup_nvme_transport_handle,
 extern const char *uuid_index;
 extern const char *namespace_id_desired;
 extern struct nvme_args nvme_args;
+
+/*
+ * nvme_create_global_ctx() - Create a global context and apply --set-options
+ *
+ * Wrapper around libnvme_create_global_ctx() that additionally applies any
+ * key=value pairs passed via --set-options.  All code in nvme-cli that creates
+ * a context should call this instead of libnvme_create_global_ctx() directly.
+ *
+ * This function has to be called after @parse_args.
+ */
+int nvme_create_global_ctx(struct libnvme_global_ctx **ctx);
 
 int validate_output_format(const char *format, nvme_print_flags_t *flags);
 bool nvme_is_output_format_json(void);

--- a/plugins/exclusion/exclusion-nvme.c
+++ b/plugins/exclusion/exclusion-nvme.c
@@ -63,7 +63,9 @@ static int excl_create(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	ctx = libnvme_create_global_ctx();
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	ret = libnvmf_exclusion_create(ctx, cfg.name);
 	if (ret == -EEXIST)
 		nvme_show_error("exclusion list '%s' already exists", cfg.name);
@@ -95,7 +97,9 @@ static int excl_delete(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	ctx = libnvme_create_global_ctx();
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	ret = libnvmf_exclusion_delete(ctx, cfg.name);
 	if (ret == -ENOENT)
 		nvme_show_error("exclusion list '%s' not found", cfg.name);
@@ -133,7 +137,9 @@ static int excl_list(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	ctx = libnvme_create_global_ctx();
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 
 	if (!cfg.name) {
 		ret = libnvmf_exclusion_list_for_each(ctx, print_list_name, NULL);
@@ -182,7 +188,9 @@ static int excl_add(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	ctx = libnvme_create_global_ctx();
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	if (!libnvmf_exclusion_entry_valid(ctx, cfg.entry)) {
 		nvme_show_error("invalid entry: %s", cfg.entry);
 		return -EINVAL;
@@ -250,7 +258,9 @@ static int excl_remove(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	ctx = libnvme_create_global_ctx();
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	ret = libnvmf_exclusion_entry_for_each(ctx, cfg.name, collect_entry, &ec);
 	if (ret) {
 		if (ret == -ENOENT)
@@ -504,7 +514,9 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	ctx = libnvme_create_global_ctx();
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 
 	/*
 	 * Read the current list through libnvme: the plugin never needs to know

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -311,20 +311,16 @@ static int filter_namespace(const struct dirent *d)
 static int huawei_list(int argc, char **argv, struct command *acmd,
 		       struct plugin *plugin)
 {
-	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = libnvme_create_global_ctx();
+	const char *desc = "Retrieve basic information for the given huawei device";
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	char path[264];
 	struct dirent **devices;
 	struct huawei_list_item *list_items;
 	unsigned int i, n, ret;
 	unsigned int huawei_num = 0;
 	nvme_print_flags_t fmt;
-	const char *desc = "Retrieve basic information for the given huawei device";
 
 	NVME_ARGS(opts);
-
-	if (!ctx)
-		return -ENOMEM;
-	libnvme_set_logging_file(ctx, stdout);
 
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
@@ -333,6 +329,12 @@ static int huawei_list(int argc, char **argv, struct command *acmd,
 	ret = validate_output_format(nvme_args.output_format, &fmt);
 	if (ret < 0 || (fmt != JSON && fmt != NORMAL))
 		return ret;
+
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
+
+	libnvme_set_logging_file(ctx, stdout);
 
 	n = scandir("/dev", &devices, filter_namespace, alphasort);
 	if (n <= 0)

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -559,10 +559,10 @@ int show_nbft(int argc, char **argv, struct command *acmd, struct plugin *plugin
 	if (ret < 0)
 		return ret;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret) {
 		nvme_show_error("Failed to create global context");
-		return -ENOMEM;
+		return ret;
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -895,7 +895,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 			    struct plugin *plugin)
 {
 	const char *desc = "Display information about E-Series volumes.";
-	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = libnvme_create_global_ctx();
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct dirent **devices;
 	int num, i, ret, fmt;
 	struct smdevice_info *smdevices;
@@ -906,13 +906,15 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 
 	NVME_ARGS(opts);
 
-	if (!ctx)
-		return -ENOMEM;
-	libnvme_set_logging_file(ctx, stdout);
-
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret < 0)
 		return ret;
+
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
+	libnvme_set_logging_file(ctx, stdout);
+
 
 	fmt = netapp_output_format(nvme_args.output_format);
 	if (fmt != NNORMAL && fmt != NCOLUMN && fmt != NJSON) {
@@ -994,7 +996,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
-	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = libnvme_create_global_ctx();
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	const char *desc = "Display information about ONTAP devices.";
 	struct dirent **devices;
 	int num, i, ret, fmt;
@@ -1006,13 +1008,15 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 
 	NVME_ARGS(opts);
 
-	if (!ctx)
-		return -ENOMEM;
-	libnvme_set_logging_file(ctx, stdout);
-
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret < 0)
 		return ret;
+
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
+	libnvme_set_logging_file(ctx, stdout);
+
 
 	fmt = netapp_output_format(nvme_args.output_format);
 	if (fmt != NNORMAL && fmt != NCOLUMN && fmt != NJSON) {

--- a/plugins/registry/registry-nvme.c
+++ b/plugins/registry/registry-nvme.c
@@ -84,17 +84,18 @@ static void print_device(const char *device, void *user_data)
 static int registry_list(int argc, char **argv, struct command *acmd,
 			  struct plugin *plugin)
 {
-	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	const char *desc = "List all live NVMeoF controller ownership registry entries.";
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
+	int ret;
 
 	NVME_ARGS(opts);
 
 	if (argconfig_parse(argc, argv, desc, opts))
 		return -EINVAL;
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return -ENOMEM;
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	libnvme_set_logging_file(ctx, stdout);
 
 	return libnvmf_registry_device_for_each(ctx, print_device, ctx);
@@ -133,9 +134,9 @@ static int registry_retrieve(int argc, char **argv, struct command *acmd,
 		return -EINVAL;
 	}
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return -ENOMEM;
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	libnvme_set_logging_file(ctx, stdout);
 
 	ret = libnvmf_registry_retrieve(ctx, device, cfg.attr, &value);
@@ -192,9 +193,9 @@ static int registry_update(int argc, char **argv, struct command *acmd,
 		return 0;
 	}
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return -ENOMEM;
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	libnvme_set_logging_file(ctx, stdout);
 
 	ret = libnvmf_registry_update(ctx, device, cfg.attr, cfg.value);
@@ -242,9 +243,9 @@ static int registry_delete(int argc, char **argv, struct command *acmd,
 		return 0;
 	}
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx)
-		return -ENOMEM;
+	ret = nvme_create_global_ctx(&ctx);
+	if (ret)
+		return ret;
 	libnvme_set_logging_file(ctx, stdout);
 
 	if (cfg.attr)

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -106,10 +106,10 @@ static int list(int argc, char **argv, struct command *acmd,
 	};
 	struct table *t = table_init_with_columns(columns, ARRAY_SIZE(columns));
 
-	ctx = libnvme_create_global_ctx();
-	if (!ctx) {
+	err = nvme_create_global_ctx(&ctx);
+	if (err) {
 		nvme_show_error("Failed to create root object");
-		return -ENOMEM;
+		return err;
 	}
 	libnvme_set_logging_file(ctx, stdout);
 

--- a/tests/nvme_registry_test.py
+++ b/tests/nvme_registry_test.py
@@ -7,10 +7,11 @@
 # Authors: Martin Belanger <martin.belanger@dell.com>
 """CLI integration tests for the 'nvme registry' plugin.
 
-Tests invoke the nvme binary directly with LIBNVME_TEST_BASE_DIR pointing at a
-temporary sandbox, so no real NVMe hardware is needed.
+Tests invoke the nvme binary directly with --set-options test-base-dir pointing
+at a temporary sandbox, so no real NVMe hardware is needed.
 
 Usage: python3 nvme_registry_test.py <path-to-nvme-binary>
+
 """
 import os
 import subprocess
@@ -33,7 +34,6 @@ class RegistryCLITest(unittest.TestCase):
         # The registry lives under <base>/registry within the sandbox.
         self.regdir = os.path.join(self.tmpdir, 'registry')
         self.env = os.environ.copy()
-        self.env['LIBNVME_TEST_BASE_DIR'] = self.tmpdir
 
     def tearDown(self):
         if os.path.isdir(self.regdir):
@@ -46,7 +46,7 @@ class RegistryCLITest(unittest.TestCase):
         os.rmdir(self.tmpdir)
 
     def _run(self, *args, expect_fail=False):
-        cmd = [_NVME_BIN] + list(args)
+        cmd = [_NVME_BIN, '--set-options', f'test-base-dir={self.tmpdir}'] + list(args)
         # stdin is /dev/null so the owner-change confirmation prompt sees a
         # non-interactive caller and proceeds without asking.
         result = subprocess.run(cmd, env=self.env,


### PR DESCRIPTION
Before the introduction of the global context, the library's behavior could be adjusted using environment variables. Replace these environment-based configuration knobs with explicit setter APIs that operate on the global context. This streamlines the API and makes the configuration mechanism more explicit.

This is the first part for #3530. It still misses the LIBNVME_HOSTNQN and LIBNVME_HOSTID parts. These two variable are such a mess that we first have to factor out `libnvmf_host_get_ids`.