### PR TITLE
cli/libnvme: add --idempotent and --devid-file to nvme connect

### DIFF
--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -9,6 +9,8 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'connect' [--config=<filename>]
+			[--devid-file=<filename>]
+			[--idempotent]
 			[--owner=<NAME>]
 			[<fabrics-options>]
 
@@ -22,6 +24,22 @@ OPTIONS
 -------
 --config=<filename>::
 	Use the specified JSON configuration file instead of the default.
+
+--devid-file=<filename>::
+	Write the kernel-assigned device name (for example, nvme0) to
+	<filename> once the controller is available.  If the controller
+	is already connected, the existing device name is written
+	instead.  When used with --idempotent, the existing device name
+	is written before the command exits successfully.  This allows a
+	supervising process (for example, a systemd unit) to determine
+	which device to disconnect later.  The output file is created
+	before attempting the connection.  If it cannot be created (for
+	example, because the parent directory does not exist), the
+	command fails without attempting the connection.
+
+--idempotent::
+	Exit with status 0 if the requested controller is already
+	connected instead of reporting an error.
 
 --owner=<NAME>::
 	Record NAME as the owner of the connected controller in the NVMe

--- a/fabrics.c
+++ b/fabrics.c
@@ -209,6 +209,7 @@ struct hook_fabrics_data {
 	char *raw;
 	char **argv;
 	FILE *f;
+	bool idempotent; /* nvme connect only, false when unused */
 };
 
 static bool hook_decide_retry(struct libnvmf_context *fctx, int err,
@@ -256,8 +257,23 @@ static void hook_already_connected(struct libnvmf_context *fctx,
 		const char *transport, const char *traddr,
 		const char *trsvcid, void *user_data)
 {
+	struct hook_fabrics_data *hfd = user_data;
+
 	if (quiet)
 		return;
+
+	/*
+	 * Under --idempotent this is the success path (libnvmf_connect()
+	 * already wrote the devid file, if requested) -- downgrade from an
+	 * error to an informational note.
+	 */
+	if (hfd->idempotent) {
+		nvme_show_verbose_info(
+			"already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
+			libnvme_host_get_hostnqn(host), subsysnqn,
+			transport, traddr, trsvcid);
+		return;
+	}
 
 	nvme_show_error("already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
 		libnvme_host_get_hostnqn(host), subsysnqn,
@@ -785,6 +801,8 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	__cleanup_free char *hid = NULL;
 	char *config_file = NULL;
 	char *owner = NULL;
+	char *devid_file = NULL;
+	bool idempotent = false;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 	__cleanup_nvme_ctrl libnvme_ctrl_t c = NULL;
@@ -795,6 +813,10 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	NVMF_ARGS(opts, fa,
 		  OPT_STRING("config",             'J', "FILE", &config_file, nvmf_config_file),
 		  OPT_STRING("owner",                0, "NAME", &owner,           "record this owner in the registry"),
+		  OPT_STRING("devid-file", 0, "FILE", &devid_file,
+			     "write connected device name to FILE"),
+		  OPT_FLAG("idempotent", 0, &idempotent,
+			   "exit 0 if already connected"),
 		  OPT_FLAG("dump-config",          'O', &dump_config,             "Dump JSON configuration to stdout"));
 
 	nvmf_default_args(&fa);
@@ -874,10 +896,14 @@ do_connect:
 		.flags = flags,
 		.quiet = dump_config,
 		.raw = raw,
+		.idempotent = idempotent,
 	};
 	ret = create_common_context(ctx, persistent, &fa, &hfd, &fctx);
 	if (ret)
 		return ret;
+
+	if (devid_file)
+		libnvmf_context_set_devid_file(fctx, devid_file);
 
 	if (config_file)
 		return libnvmf_connect_config_json(ctx, fctx);
@@ -903,6 +929,16 @@ do_connect:
 	}
 
 	ret = libnvmf_connect(ctx, fctx);
+	/*
+	 * -EALREADY is libnvmf_connect()'s own pre-check against the topology
+	 * we already scanned above; -ENVME_CONNECT_ALREADY is the kernel
+	 * itself reporting a race. Either way libnvmf_connect() has already
+	 * written the devid file (if requested) before returning -- it owns
+	 * the controller matching logic (including the kernel-race rescan),
+	 * so there is nothing left to resolve here.
+	 */
+	if (idempotent && (ret == -EALREADY || ret == -ENVME_CONNECT_ALREADY))
+		ret = 0;
 	if (ret) {
 		nvme_show_error("failed to connect: %s",
 			libnvme_strerror(-ret));

--- a/libnvme/src/accessors-fabrics.ld
+++ b/libnvme/src/accessors-fabrics.ld
@@ -17,6 +17,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_default_keep_alive_timeout;
 		libnvmf_context_get_default_max_discovery_retries;
 		libnvmf_context_get_device;
+		libnvmf_context_get_devid_file;
 		libnvmf_context_get_disable_sqflow;
 		libnvmf_context_get_duplicate_connect;
 		libnvmf_context_get_fast_io_fail_tmo;

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -14,6 +14,7 @@ LIBNVMF_3 {
 		libnvmf_context_set_connection;
 		libnvmf_context_set_crypto;
 		libnvmf_context_set_device;
+		libnvmf_context_set_devid_file;
 		libnvmf_context_set_discovery_hooks;
 		libnvmf_context_set_hostnqn;
 		libnvmf_context_set_io_queues;

--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -342,6 +342,12 @@ __libnvme_public bool libnvmf_context_get_persistent(
 	return p->persistent;
 }
 
+__libnvme_public const char *libnvmf_context_get_devid_file(
+		const struct libnvmf_context *p)
+{
+	return p->devid_file;
+}
+
 __libnvme_public const char *libnvmf_context_get_hostnqn(
 		const struct libnvmf_context *p)
 {

--- a/libnvme/src/nvme/accessors-fabrics.h
+++ b/libnvme/src/nvme/accessors-fabrics.h
@@ -438,6 +438,14 @@ void libnvmf_context_set_persistent(struct libnvmf_context *p, bool persistent);
 bool libnvmf_context_get_persistent(const struct libnvmf_context *p);
 
 /**
+ * libnvmf_context_get_devid_file() - Get devid_file.
+ * @p: The &struct libnvmf_context instance to query.
+ *
+ * Return: The value of the devid_file field, or NULL if not set.
+ */
+const char *libnvmf_context_get_devid_file(const struct libnvmf_context *p);
+
+/**
  * libnvmf_context_get_hostnqn() - Get hostnqn.
  * @p: The &struct libnvmf_context instance to query.
  *

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -681,6 +681,67 @@ __libnvme_public int libnvmf_context_set_device(
 	return 0;
 }
 
+__libnvme_public int libnvmf_context_set_devid_file(
+		struct libnvmf_context *fctx, const char *devid_file)
+{
+	fctx->devid_file = devid_file;
+
+	return 0;
+}
+
+/*
+ * Open fctx->devid_file for a later write_devid_file(). Called by
+ * libnvmf_connect() BEFORE the connect is attempted, so a bad path refuses
+ * the connection up front: the flag exists for supervised use (systemd
+ * transient units), where a connection whose device name was never recorded
+ * cannot be found again at stop time -- worse than no connection at all.
+ *
+ * The path is the caller's choice and the caller's responsibility, like
+ * every other file-writing option (--raw, --dump-config, ...); connecting
+ * already requires root. O_NOFOLLOW guards the one hazard the caller cannot
+ * see: a symlink planted at the final component of an otherwise-sane path.
+ * O_TRUNC is deliberately absent: if this connect attempt fails, a device
+ * name recorded by an earlier successful start must survive -- the file is
+ * truncated only when there is a new name to write.
+ *
+ * Return: an open fd, or -errno.
+ */
+static int open_devid_file(struct libnvmf_context *fctx)
+{
+	int fd;
+
+	fd = open(fctx->devid_file,
+		O_WRONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0644);
+	if (fd < 0) {
+		libnvme_msg(fctx->ctx, LIBNVME_LOG_ERR,
+			"failed to open devid-file %s: %s\n",
+			fctx->devid_file, libnvme_strerror(errno));
+		return -errno;
+	}
+
+	return fd;
+}
+
+/*
+ * Write @c's kernel-assigned device name through the fd from
+ * open_devid_file(). Used on every path out of libnvmf_connect() that ends
+ * with a live, connected controller -- freshly connected, found already
+ * connected in the topology we already had, or found already connected
+ * after a kernel-race rescan.
+ */
+static void write_devid_file(struct libnvmf_context *fctx, int fd,
+		libnvme_ctrl_t c)
+{
+	if (fd < 0 || !c)
+		return;
+
+	if (ftruncate(fd, 0) < 0 ||
+	    dprintf(fd, "%s\n", libnvme_ctrl_get_name(c)) < 0)
+		libnvme_msg(fctx->ctx, LIBNVME_LOG_WARN,
+			"failed to write devid-file %s: %s\n",
+			fctx->devid_file, libnvme_strerror(errno));
+}
+
 __libnvme_public int libnvmf_context_set_io_queues(
 		struct libnvmf_context *fctx, int nr_io_queues,
 		int nr_write_queues, int nr_poll_queues,
@@ -3620,9 +3681,20 @@ __libnvme_public int libnvmf_discovery(
 __libnvme_public int libnvmf_connect(
 		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx)
 {
+	__cleanup_fd int devid_fd = -1;
 	struct libnvme_host *h;
 	struct libnvme_ctrl *c;
 	int err;
+
+	/*
+	 * Fail fast on a bad devid-file path, before any kernel state
+	 * changes -- see open_devid_file().
+	 */
+	if (fctx->devid_file) {
+		devid_fd = open_devid_file(fctx);
+		if (devid_fd < 0)
+			return devid_fd;
+	}
 
 	err = lookup_host(ctx, fctx, &h);
 	if (err)
@@ -3635,6 +3707,7 @@ __libnvme_public int libnvmf_connect(
 	c = lookup_ctrl(h, fctx);
 	if (c && libnvme_ctrl_get_name(c) &&
 	    !fctx->ctrl_params.cfg.duplicate_connect) {
+		write_devid_file(fctx, devid_fd, c);
 		fctx->hooks.already_connected(fctx, h,
 			libnvme_ctrl_get_subsysnqn(c),
 			libnvme_ctrl_get_transport(c),
@@ -3669,12 +3742,23 @@ __libnvme_public int libnvmf_connect(
 
 	err = libnvme_add_ctrl(fctx, h, c);
 	if (err) {
+		/*
+		 * A genuine kernel-level race: some other connect beat us to
+		 * it between our topology scan above and this ioctl. @c is
+		 * only our own unconnected draft, not the winning
+		 * controller, so rescan and re-resolve to find it.
+		 */
+		if (err == -ENVME_CONNECT_ALREADY &&
+		    libnvme_scan_topology(ctx, NULL, NULL) == 0)
+			write_devid_file(fctx, devid_fd, lookup_ctrl(h, fctx));
+
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "could not add new controller: %s\n",
 			libnvme_strerror(-err));
 		libnvme_free_ctrl(c);
 		return err;
 	}
 
+	write_devid_file(fctx, devid_fd, c);
 	fctx->hooks.connected(fctx, c, fctx->hooks.user_data);
 
 	return 0;

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -421,6 +421,33 @@ int libnvmf_context_set_crypto(struct libnvmf_context *fctx,
 int libnvmf_context_set_device(struct libnvmf_context *fctx, const char *device);
 
 /**
+ * libnvmf_context_set_devid_file() - Set devid file for context
+ * @fctx: Fabrics context
+ * @devid_file: Path to write the kernel-assigned device name to on connect
+ *
+ * When set, libnvmf_connect() writes the kernel-assigned device name (e.g.
+ * "nvme0") to @devid_file once a controller is connected -- whether newly
+ * connected or already connected (including the rare case where the kernel
+ * itself reports the target as already connected due to a race). This lets
+ * a caller that manages the connection as a supervised process (e.g. a
+ * systemd transient unit) recover the device name later, e.g. to disconnect.
+ *
+ * libnvmf_connect() opens (creates) the file BEFORE attempting the
+ * connection and fails the connect if it cannot -- a supervised connection
+ * whose device name was never recorded cannot be found again at stop time,
+ * so a bad path is refused up front rather than discovered after the
+ * connection is live. The containing directory must already exist. The file
+ * is opened with O_NOFOLLOW (a symlink at the final path component is not
+ * followed) and is truncated only when a device name is actually written,
+ * so a name recorded by an earlier successful connect survives a failed
+ * attempt.
+ *
+ * Return: 0 on success, negative error code otherwise.
+ */
+int libnvmf_context_set_devid_file(struct libnvmf_context *fctx,
+		const char *devid_file);
+
+/**
  * libnvmf_context_set_io_queues() - Set I/O queue topology for context
  * @fctx: Fabrics context
  * @nr_io_queues: Number of I/O queues

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -56,6 +56,7 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 	/* common fabrics configuration */
 	const char *device;
 	bool persistent;
+	const char *devid_file; // !access:write=custom
 
 	/* host configuration */
 	const char *hostnqn; // !access:write=custom

--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,15 @@ udevrulesdir   = join_paths(prefixdir, get_option('udevrulesdir'))
 dracutrulesdir = join_paths(prefixdir, get_option('dracutrulesdir'))
 systemddir     = join_paths(prefixdir, get_option('systemddir'))
 nmdispatchdir  = join_paths(prefixdir, get_option('nmdispatchdir'))
-rundir         = join_paths(prefixdir, get_option('rundir'))
+
+# /run is normally a kernel-mounted tmpfs whose location the FHS fixes
+# system-wide, but some distributions still only provide the legacy
+# /var/run path, so this is a configurable option -- unlike the dirs
+# above, it must never scale with --prefix (a build under
+# --prefix=/usr/local still runs against the one real runtime directory
+# on the machine). Test isolation is a separate, runtime concern already
+# handled by libnvme_set_test_base_dir()/LIBNVME_TEST_BASE_DIR.
+rundir         = get_option('rundir')
 
 std_prefix = prefixdir == '/usr' or prefixdir == '/usr/local'
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -97,9 +97,9 @@ option(
 )
 option(
   'rundir',
-  type: 'string',
-  value: 'run',
-  description: 'directory for volatile configuration files',
+  type : 'string',
+  value : '/run',
+  description : 'absolute path to the runtime directory (e.g. /run or /var/run)'
 )
 option(
   'systemctl',


### PR DESCRIPTION
Prep patch for nvme-discoverd (not yet upstreamed). discoverd manages each fabrics connection as a systemd transient unit whose `ExecStart=` is `nvme connect`:

- `--idempotent` exits 0 when the target is already connected, instead of 1 — otherwise a harmless race with an existing connection fails the unit.
- `--devid-file FILE` names a file `libnvmf_connect()` writes the kernel-assigned device name (e.g. `nvme0`) to on success, so the unit's `ExecStop=` can find it again to disconnect.

Three commits:

1. **libnvme/fabrics**: write the connected device name to a file on request. 
2. **cli/fabrics**: add `--idempotent` and `--devid-file` to `nvme connect` — the CLI options themselves.
3. **meson**: stop deriving `RUNDIR` from `--prefix` — found while testing: `RUNDIR` was `join_paths(prefix, get_option('rundir'))`, so any build silently got `<prefix>/run` instead of the real `/run` tmpfs. `/run` isn't an install path, so it's now hardcoded, the same way systemd does it.
