### PR TITLE
netapp: fix dead store in netapp_smdevices_get_info() and netapp_ontapdevices_get_info()

### DIFF
--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -775,8 +775,12 @@ static int netapp_smdevices_get_info(struct libnvme_transport_handle *hdl,
 		return 0; /* not the right model of controller */
 
 	err = libnvme_get_nsid(hdl, &item->nsid);
-	if (err)
-		return err;
+	if (err) {
+		nvme_show_error("Unable to get nsid for %s (%s)",
+			dev, err < 0 ? libnvme_strerror(-err) :
+			libnvme_status_to_string(err, false));
+		return 0;
+	}
 
 	err = nvme_identify_ns(hdl, item->nsid, &item->ns);
 	if (err) {
@@ -811,6 +815,12 @@ static int netapp_ontapdevices_get_info(struct libnvme_transport_handle *hdl,
 		return 0;
 
 	err = libnvme_get_nsid(hdl, &item->nsid);
+	if (err) {
+		nvme_show_error("Unable to get nsid for %s (%s)",
+			dev, err < 0 ? libnvme_strerror(-err) :
+			libnvme_status_to_string(err, false));
+		return 0;
+	}
 
 	err = nvme_identify_ns(hdl, item->nsid, &item->ns);
 	if (err) {


### PR DESCRIPTION
Both netapp_smdevices_get_info() and netapp_ontapdevices_get_info()
call libnvme_get_nsid() and store the result in @err, but never
check @err before proceeding. The return value is immediately
overwritten by the next assignment, making it a dead store.

If libnvme_get_nsid() fails, the functions silently continue
with an uninitialized @item->nsid, leading to undefined behavior.

Check the return value of libnvme_get_nsid() in both functions,
log the error with nvme_show_error() and return 0 on failure to
match the existing error handling pattern in those functions.

Signed-off-by: Laraib Javed <laraibjaved@ibm.com>