### PR TITLE
ioctl-linux: fix uninitialized cmd32.result in ioctl_passthru32()

### DIFF
--- a/libnvme/src/nvme/ioctl-linux.c
+++ b/libnvme/src/nvme/ioctl-linux.c
@@ -121,7 +121,7 @@ __libnvme_public int libnvme_update_block_size(
 static int ioctl_passthru32(struct libnvme_transport_handle *hdl,
 		unsigned long ioctl_cmd, struct libnvme_passthru_cmd *cmd)
 {
-	struct linux_passthru_cmd32 cmd32;
+	struct linux_passthru_cmd32 cmd32 = {};
 	void *user_data;
 	int err = 0;
 


### PR DESCRIPTION
When hdl->ctx->dry_run is true, the goto skips the memcpy and explicit assignment of cmd32.result, leaving it uninitialized when assigned to cmd->result at the out label.

Fix by zero-initializing cmd32 at declaration to ensure deterministic behavior on all code paths.

Signed-off-by: Sarah Ahmed <sarah.ahmed@ibm.com>