### PR TITLE
plugins/wdc: json output format not actually json

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -8571,6 +8571,8 @@ static int wdc_vs_cloud_log(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
+	cfg.output_format = nvme_args.output_format;
+
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
 		return ret;
@@ -8637,6 +8639,8 @@ static int wdc_vs_hw_rev_log(int argc, char **argv, struct command *acmd,
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
@@ -8725,6 +8729,8 @@ static int wdc_vs_device_waf(int argc, char **argv, struct command *acmd,
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
@@ -8830,6 +8836,8 @@ static int wdc_get_latency_monitor_log(int argc, char **argv, struct command *ac
 	if (ret)
 		return ret;
 
+	cfg.output_format = nvme_args.output_format;
+
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
 		return ret;
@@ -8871,6 +8879,8 @@ static int wdc_get_error_recovery_log(int argc, char **argv, struct command *acm
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
@@ -8915,6 +8925,8 @@ static int wdc_get_dev_capabilities_log(int argc, char **argv, struct command *a
 	if (ret)
 		return ret;
 
+	cfg.output_format = nvme_args.output_format;
+
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
 		return ret;
@@ -8957,6 +8969,8 @@ static int wdc_get_unsupported_reqs_log(int argc, char **argv, struct command *a
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
@@ -9446,6 +9460,8 @@ static int wdc_vs_fw_activate_history(int argc, char **argv, struct command *acm
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
@@ -10839,6 +10855,8 @@ static int wdc_log_page_directory(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
+	cfg.output_format = nvme_args.output_format;
+
 	ret = validate_output_format(cfg.output_format, &fmt);
 	if (ret < 0) {
 		nvme_show_error("%s: ERROR: WDC: invalid output format", __func__);
@@ -11592,6 +11610,8 @@ static int wdc_vs_nand_stats(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
+	cfg.output_format = nvme_args.output_format;
+
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
 		return ret;
@@ -11668,6 +11688,8 @@ static int wdc_vs_pcie_stats(int argc, char **argv, struct command *acmd,
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)
@@ -11755,6 +11777,8 @@ static int wdc_vs_drive_info(int argc, char **argv,
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = validate_output_format(cfg.output_format, &fmt);
 	if (ret < 0) {
@@ -12005,6 +12029,8 @@ static int wdc_vs_temperature_stats(int argc, char **argv,
 	ret = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	cfg.output_format = nvme_args.output_format;
 
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret)

--- a/plugins/wdc/wdc-nvme.h
+++ b/plugins/wdc/wdc-nvme.h
@@ -5,7 +5,7 @@
 #if !defined(WDC_NVME) || defined(CMD_HEADER_MULTI_READ)
 #define WDC_NVME
 
-#define WDC_PLUGIN_VERSION   "2.15.0"
+#define WDC_PLUGIN_VERSION   "2.15.1"
 #include "cmd.h"
 
 PLUGIN(NAME("wdc", "Western Digital vendor specific extensions", WDC_PLUGIN_VERSION),


### PR DESCRIPTION
While doing some testing/evaluation of the 2.16 version of nvme-cli, I noticed that the json output was being ignored.  It looks like the plugin never assigns the desired output format to the cfg object, leaving it always on normal

Check we have a json option for --output-format
```
/tmp/nvme wdc vs-smart-add-log --help
Usage: nvme wdc vs-smart-add-log <device> [OPTIONS]

Retrieve additional performance statistics.

Options:
  [  --verbose, -v ]                    --- Increase output verbosity
  [  --output-format=<FMT>, -o <FMT> ]  --- Output format:
                                            normal|json|binary|tabular
  [  --interval=<NUM>, -i <NUM> ]       --- Interval to read the statistics
                                            from [1, 15].
  [  --log-page-version=<NUM>, -l <NUM> ] --- Log Page Version: 0 = vendor, 1 =
                                            WDC
  [  --log-page-mask=<LIST>, -p <LIST> ] --- Log Page Mask, comma separated
                                            list: 0xC0, 0xC1, 0xCA, 0xD0
  [  --namespace-id=<NUM>, -n <NUM> ]   --- desired namespace id
  [  --timeout=<NUM>, -t <NUM> ]        --- timeout value, in milliseconds
  [  --dry-run ]                        --- show command instead of executing
  [  --no-retries ]                     --- disable retry logic on errors
  [  --no-ioctl-probing ]               --- disable 64-bit IOCTL support
                                            probing
  [  --output-format-version=<NUM> ]    --- output format version: 1|2
```

BEFORE
```
 /tmp/nvme wdc vs-nand-stats /dev/nvme0n1 -o json
   NAND Statistics :-
   NAND Writes TLC (Bytes)                        106085484331008
   NAND Writes SLC (Bytes)                        218599812464640
   NAND Program Failures                          0
   NAND Erase Failures                            0
   Bad Block Count                                0
   NAND XOR/RAID Recovery Trigger Events          0
   E2E Error Counter                              0
   Number Successful NS Resizing Events           1
   log page version                               0
```

AFTER
```
 /tmp/nvme_patch wdc vs-nand-stats /dev/nvme0n1 -o json
 {
   "NAND Writes TLC (Bytes)":106085769805824,
   "NAND Writes SLC (Bytes)":218600448131072,
   "NAND Program Failures":0,
   "NAND Erase Failures":0,
   "Bad Block Count":0,
   "NAND XOR/RAID Recovery Trigger Events":0,
   "E2E Error Counter":0,
   "Number Successful NS Resizing Events":1
 }
```