### PR TITLE
micron: Use new nvme-pci-ids to get PCI IDs

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -30,6 +30,7 @@
 
 #include "common.h"
 #include "nvme-cmds.h"
+#include "nvme-pci-ids.h"
 #include "nvme-print.h"
 #include "nvme.h"
 #include "util/cleanup.h"
@@ -136,8 +137,11 @@ static enum eDriveModel GetDriveModel(
 	struct libnvme_transport_handle *hdl)
 {
 	enum eDriveModel eModel = UNKNOWN_MODEL;
+	uint32_t vid = 0, did = 0;
 
-	micron_get_pci_ids(ctx, hdl, &vendor_id, &device_id);
+	nvme_get_pci_ids(ctx, hdl, &vid, &did, NULL, NULL, NULL);
+	vendor_id = (unsigned short)vid;
+	device_id = (unsigned short)did;
 
 	if (vendor_id == MICRON_VENDOR_ID) {
 		switch (device_id) {

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -19,50 +19,6 @@
 #include "micron-utils.h"
 #include "util/cleanup.h"
 
-static int ReadSysFile(const char *file, unsigned short *id)
-{
-	int ret = 0;
-	char idstr[32] = { '\0' };
-	int fd = open(file, O_RDONLY);
-
-	if (fd < 0) {
-		nvme_show_perror("%s", file);
-		return fd;
-	}
-
-	ret = read(fd, idstr, sizeof(idstr) - 1);
-	close(fd);
-	if (ret < 0)
-		nvme_show_perror("read");
-	else
-		*id = strtol(idstr, NULL, 16);
-
-	return ret;
-}
-
-int micron_get_pci_ids(
-	struct libnvme_global_ctx *ctx, struct libnvme_transport_handle *hdl,
-	unsigned short *vid, unsigned short *did)
-{
-	char id_path[512];
-	__cleanup_free char *ctrl_sysfs_dir = micron_get_ctrl_sysfs_dir(ctx, hdl);
-
-	if (ctrl_sysfs_dir) {
-		snprintf(id_path, sizeof(id_path), "%s/device/vendor",
-			ctrl_sysfs_dir);
-		ReadSysFile(id_path, vid);
-
-		snprintf(id_path, sizeof(id_path), "%s/device/device",
-			ctrl_sysfs_dir);
-		ReadSysFile(id_path, did);
-	} else {
-		nvme_show_error("Unable to find sysfs dir for %s",
-			libnvme_transport_handle_get_name(hdl));
-		return -EINVAL;
-	}
-
-	return 0;
-}
 
 int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 	__u32 *correctable_errors, __u32 *uncorrectable_errors)

--- a/plugins/micron/micron-utils-win.c
+++ b/plugins/micron/micron-utils-win.c
@@ -68,37 +68,6 @@ int micron_run_spawn(char *const argv[], const char *outfile, bool append)
 	return exit_code == 0 ? 0 : -EIO;
 }
 
-int micron_get_pci_ids(struct libnvme_global_ctx *ctx,
-			struct libnvme_transport_handle *hdl,
-			unsigned short *vid, unsigned short *did)
-{
-	const char *p;
-	unsigned int val;
-
-	/* Windows sysfs dir for controller contains VID and DID */
-	__cleanup_free char *ctrl_sysfs_dir = micron_get_ctrl_sysfs_dir(ctx, hdl);
-
-	*vid = 0;
-	*did = 0;
-
-	if (!ctrl_sysfs_dir)
-		return -EINVAL;
-
-	p = strstr(ctrl_sysfs_dir, "ven_");
-	if (p && sscanf(p, "ven_%x", &val) == 1)
-		*vid = (unsigned short)val;
-	else
-		return -EINVAL;
-
-	p = strstr(ctrl_sysfs_dir, "dev_");
-	if (p && sscanf(p, "dev_%x", &val) == 1)
-		*did = (unsigned short)val;
-	else
-		return -EINVAL;
-
-	return 0;
-}
-
 int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 	__u32 *correctable_errors, __u32 *uncorrectable_errors)
 {

--- a/plugins/micron/micron-utils.c
+++ b/plugins/micron/micron-utils.c
@@ -42,20 +42,3 @@ char *micron_get_ns_name(struct libnvme_transport_handle *hdl)
 
 	return ns_name;
 }
-
-char *micron_get_ctrl_sysfs_dir(
-	struct libnvme_global_ctx *ctx,
-	struct libnvme_transport_handle *hdl)
-{
-	libnvme_ctrl_t c = NULL;
-	__cleanup_free char *ctrl_name = NULL;
-	char *sysfs_dir = NULL;
-
-	ctrl_name = micron_get_ctrl_name(hdl);
-	if (ctrl_name && libnvme_scan_ctrl(ctx, ctrl_name, &c) == 0) {
-		sysfs_dir = strdup(libnvme_ctrl_get_sysfs_dir(c));
-		libnvme_free_ctrl(c);
-	}
-
-	return sysfs_dir;
-}

--- a/plugins/micron/micron-utils.h
+++ b/plugins/micron/micron-utils.h
@@ -37,36 +37,6 @@ char *micron_get_ctrl_name(struct libnvme_transport_handle *hdl);
 char *micron_get_ns_name(struct libnvme_transport_handle *hdl);
 
 /**
- * micron_get_ctrl_sysfs_dir() - Get the sysfs directory path for a controller
- * @ctx:	struct libnvme_global_ctx object
- * @hdl:	Transport handle
- *
- * Looks up the sysfs directory for the controller associated with @hdl
- * by scanning the NVMe subsystem.
- *
- * Return: Allocated string containing the sysfs directory path on
- * success, or NULL on failure. The caller is responsible for freeing
- * the returned string.
- */
-char *micron_get_ctrl_sysfs_dir(struct libnvme_global_ctx *ctx,
-				struct libnvme_transport_handle *hdl);
-
-/**
- * micron_get_pci_ids() - Read PCI vendor and device IDs for a controller
- * @ctx:	struct libnvme_global_ctx object
- * @hdl:	Transport handle
- * @vid:	Output PCI vendor ID
- * @did:	Output PCI device ID
- *
- * Gets the PCI vendor and device IDs for the controller associated with @hdl.
- *
- * Return: 0 on success, negative errno on failure.
- */
-int micron_get_pci_ids(struct libnvme_global_ctx *ctx,
-			struct libnvme_transport_handle *hdl,
-			unsigned short *vid, unsigned short *did);
-
-/**
  * micron_get_pcie_aer_errors() - Retrieve PCIe AER error counts
  * @hdl:			Transport handle
  * @correctable_errors:		Output correctable error register value


### PR DESCRIPTION
Removes PCI ID reading utility and related methods from micron-utils and updates the micron-nvme plugin to use nvme-pci-ids to read the IDs.