### PR TITLE
tree: fix store uuid/nguid from sysfs

### DIFF
--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -548,7 +548,12 @@ static int libnvme_strtoeuid(const char *str, void *res)
 
 static int libnvme_strtouuid(const char *str, void *res)
 {
-	memcpy(res, str, NVME_UUID_LEN);
+	unsigned char uuid[NVME_UUID_LEN];
+
+	if (libnvme_uuid_from_string(str, uuid))
+		return -EINVAL;
+
+	memcpy(res, uuid, NVME_UUID_LEN);
 	return 0;
 }
 


### PR DESCRIPTION
In sysfs, the UUID is stored as a string with hyphens. You don't need to save the hyphens in the binary representation of the UUID otherwise you'll get truncated output.

port from https://github.com/linux-nvme/libnvme/pull/1115