### PR TITLE
fabrics: create handle for existing discovery controller

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3594,8 +3594,17 @@ __libnvme_public int libnvmf_discovery(
 
 	if (!c && !force) {
 		c = lookup_ctrl(h, fctx);
-		if (c)
+		if (c) {
 			fctx->persistent = true;
+			if (!libnvme_ctrl_get_transport_handle(c)) {
+				ret = libnvme_open(ctx, c->name, &c->hdl);
+				if (ret) {
+					libnvme_msg(ctx, LIBNVME_LOG_ERR,
+						"failed to open %s\n", c->name);
+					return ret;
+				}
+			}
+		}
 	}
 	if (!c) {
 		/* No device or non-matching device, create a new controller */


### PR DESCRIPTION
If the discovery controller already exists, the transport handle must be created before the discovery process can start. The existing controller may disappear at any time, but this case is handled by checking whether each operation succeeds.

Fixes: #3575 