### PR TITLE
meson: stop deriving RUNDIR from --prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,10 @@ udevrulesdir   = join_paths(prefixdir, get_option('udevrulesdir'))
 dracutrulesdir = join_paths(prefixdir, get_option('dracutrulesdir'))
 systemddir     = join_paths(prefixdir, get_option('systemddir'))
 nmdispatchdir  = join_paths(prefixdir, get_option('nmdispatchdir'))
-rundir         = join_paths(prefixdir, get_option('rundir'))
+
+# /run's location is fixed by the FHS -- unlike the dirs above, it must
+# never scale with --prefix.
+rundir         = get_option('rundir')
 
 std_prefix = prefixdir == '/usr' or prefixdir == '/usr/local'
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -97,9 +97,9 @@ option(
 )
 option(
   'rundir',
-  type: 'string',
-  value: 'run',
-  description: 'directory for volatile configuration files',
+  type : 'string',
+  value : '/run',
+  description : 'absolute path to the runtime directory (e.g. /run or /var/run)'
 )
 option(
   'systemctl',


### PR DESCRIPTION
`RUNDIR` was `join_paths(prefix, get_option('rundir'))`, with `rundir` defaulting to the bare string `run` -- so a default build silently got `<prefix>/run` (e.g. `/usr/local/run`) instead of the real `/run` tmpfs. `/run`'s location is fixed by the FHS, not something `--prefix` should scale. `rundir` stays a configurable option (some distros only have `/var/run`), it just no longer joins with `--prefix`.