### PR TITLE
fabrics: add --idempotent and --devid-file to nvme connect

### DIFF
--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -9,6 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'connect' [--config=<filename>]
+			[--idempotent]
 			[--owner=<NAME>]
 			[<fabrics-options>]
 
@@ -22,6 +23,10 @@ OPTIONS
 -------
 --config=<filename>::
 	Use the specified JSON configuration file instead of the default.
+
+--idempotent::
+	Exit with status 0 if the requested controller is already
+	connected instead of reporting an error.
 
 --owner=<NAME>::
 	Record NAME as the owner of the connected controller in the NVMe

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -9,6 +9,7 @@ SYNOPSIS
 --------
 [verse]
 'nvme' [<global-options>] 'connect' [--config=<filename>]
+			[--devid-file=<filename>]
 			[--idempotent]
 			[--owner=<NAME>]
 			[<fabrics-options>]
@@ -23,6 +24,22 @@ OPTIONS
 -------
 --config=<filename>::
 	Use the specified JSON configuration file instead of the default.
+
+--devid-file=<filename>::
+	Write the kernel-assigned device name (for example, nvme0) to
+	<filename>. If the controller is already connected, the existing
+	device name is written. Otherwise, the device name is written
+	after the controller is connected.
+
+	When used with --idempotent, the existing device name is written
+	before the command exits successfully. This allows a supervising
+	process, such as a systemd service, to identify the device for a
+	later disconnect operation.
+
+	The output file is created before attempting the connection. If
+	the file cannot be created, for example because the parent
+	directory does not exist, the command fails without attempting
+	the connection.
 
 --idempotent::
 	Exit with status 0 if the requested controller is already

--- a/fabrics.c
+++ b/fabrics.c
@@ -796,6 +796,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	__cleanup_free char *hid = NULL;
 	char *config_file = NULL;
 	char *owner = NULL;
+	char *devid_file = NULL;
 	bool idempotent = false;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
@@ -807,6 +808,8 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	NVMF_ARGS(opts, fa,
 		  OPT_STRING("config",             'J', "FILE", &config_file, nvmf_config_file),
 		  OPT_STRING("owner",                0, "NAME", &owner,           "record this owner in the registry"),
+		  OPT_STRING("devid-file", 0, "FILE", &devid_file,
+			     "write connected device name to FILE"),
 		  OPT_FLAG("idempotent", 0, &idempotent,
 			   "exit 0 if already connected"),
 		  OPT_FLAG("dump-config",          'O', &dump_config,             "Dump JSON configuration to stdout"));
@@ -893,6 +896,9 @@ do_connect:
 	ret = create_common_context(ctx, persistent, &fa, &hfd, &fctx);
 	if (ret)
 		return ret;
+
+	if (devid_file)
+		libnvmf_context_set_devid_file(fctx, devid_file);
 
 	if (config_file)
 		return libnvmf_connect_config_json(ctx, fctx);

--- a/fabrics.c
+++ b/fabrics.c
@@ -209,6 +209,7 @@ struct hook_fabrics_data {
 	char *raw;
 	char **argv;
 	FILE *f;
+	bool idempotent;
 };
 
 static bool hook_decide_retry(struct libnvmf_context *fctx, int err,
@@ -256,8 +257,18 @@ static void hook_already_connected(struct libnvmf_context *fctx,
 		const char *transport, const char *traddr,
 		const char *trsvcid, void *user_data)
 {
+	struct hook_fabrics_data *hfd = user_data;
+
 	if (quiet)
 		return;
+
+	if (hfd->idempotent) {
+		nvme_show_verbose_info(
+			"already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
+			libnvme_host_get_hostnqn(host), subsysnqn,
+			transport, traddr, trsvcid);
+		return;
+	}
 
 	nvme_show_error("already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
 		libnvme_host_get_hostnqn(host), subsysnqn,
@@ -785,6 +796,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	__cleanup_free char *hid = NULL;
 	char *config_file = NULL;
 	char *owner = NULL;
+	bool idempotent = false;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 	__cleanup_nvme_ctrl libnvme_ctrl_t c = NULL;
@@ -795,6 +807,8 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 	NVMF_ARGS(opts, fa,
 		  OPT_STRING("config",             'J', "FILE", &config_file, nvmf_config_file),
 		  OPT_STRING("owner",                0, "NAME", &owner,           "record this owner in the registry"),
+		  OPT_FLAG("idempotent", 0, &idempotent,
+			   "exit 0 if already connected"),
 		  OPT_FLAG("dump-config",          'O', &dump_config,             "Dump JSON configuration to stdout"));
 
 	nvmf_default_args(&fa);
@@ -874,6 +888,7 @@ do_connect:
 		.flags = flags,
 		.quiet = dump_config,
 		.raw = raw,
+		.idempotent = idempotent,
 	};
 	ret = create_common_context(ctx, persistent, &fa, &hfd, &fctx);
 	if (ret)
@@ -903,6 +918,8 @@ do_connect:
 	}
 
 	ret = libnvmf_connect(ctx, fctx);
+	if (idempotent && (ret == -EALREADY || ret == -ENVME_CONNECT_ALREADY))
+		ret = 0;
 	if (ret) {
 		nvme_show_error("failed to connect: %s",
 			libnvme_strerror(-ret));

--- a/libnvme/src/accessors-fabrics.ld
+++ b/libnvme/src/accessors-fabrics.ld
@@ -17,6 +17,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_default_keep_alive_timeout;
 		libnvmf_context_get_default_max_discovery_retries;
 		libnvmf_context_get_device;
+		libnvmf_context_get_devid_file;
 		libnvmf_context_get_disable_sqflow;
 		libnvmf_context_get_duplicate_connect;
 		libnvmf_context_get_fast_io_fail_tmo;

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -32,6 +32,7 @@ LIBNVMF_3 {
 		libnvmf_context_set_connection;
 		libnvmf_context_set_crypto;
 		libnvmf_context_set_device;
+		libnvmf_context_set_devid_file;
 		libnvmf_context_set_discovery_hooks;
 		libnvmf_context_set_hostnqn;
 		libnvmf_context_set_io_queues;

--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -342,6 +342,12 @@ __libnvme_public bool libnvmf_context_get_persistent(
 	return p->persistent;
 }
 
+__libnvme_public const char *libnvmf_context_get_devid_file(
+		const struct libnvmf_context *p)
+{
+	return p->devid_file;
+}
+
 __libnvme_public const char *libnvmf_context_get_hostnqn(
 		const struct libnvmf_context *p)
 {

--- a/libnvme/src/nvme/accessors-fabrics.h
+++ b/libnvme/src/nvme/accessors-fabrics.h
@@ -438,6 +438,14 @@ void libnvmf_context_set_persistent(struct libnvmf_context *p, bool persistent);
 bool libnvmf_context_get_persistent(const struct libnvmf_context *p);
 
 /**
+ * libnvmf_context_get_devid_file() - Get devid_file.
+ * @p: The &struct libnvmf_context instance to query.
+ *
+ * Return: The value of the devid_file field, or NULL if not set.
+ */
+const char *libnvmf_context_get_devid_file(const struct libnvmf_context *p);
+
+/**
  * libnvmf_context_get_hostnqn() - Get hostnqn.
  * @p: The &struct libnvmf_context instance to query.
  *

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -681,6 +681,50 @@ __libnvme_public int libnvmf_context_set_device(
 	return 0;
 }
 
+__libnvme_public int libnvmf_context_set_devid_file(
+		struct libnvmf_context *fctx, const char *devid_file)
+{
+	fctx->devid_file = devid_file;
+
+	return 0;
+}
+
+/*
+ * O_NOFOLLOW guards the one hazard the caller can't see: a symlink at the
+ * final path component. O_TRUNC is deliberately absent -- a name recorded
+ * by an earlier successful connect must survive a failed one.
+ *
+ * Return: an open fd, or -errno.
+ */
+static int open_devid_file(struct libnvmf_context *fctx)
+{
+	int fd;
+
+	fd = open(fctx->devid_file,
+		O_WRONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0644);
+	if (fd < 0) {
+		libnvme_msg(fctx->ctx, LIBNVME_LOG_ERR,
+			"failed to open devid-file %s: %s\n",
+			fctx->devid_file, libnvme_strerror(errno));
+		return -errno;
+	}
+
+	return fd;
+}
+
+static void write_devid_file(struct libnvmf_context *fctx, int fd,
+		libnvme_ctrl_t c)
+{
+	if (fd < 0 || !c)
+		return;
+
+	if (ftruncate(fd, 0) < 0 ||
+	    dprintf(fd, "%s\n", libnvme_ctrl_get_name(c)) < 0)
+		libnvme_msg(fctx->ctx, LIBNVME_LOG_WARN,
+			"failed to write devid-file %s: %s\n",
+			fctx->devid_file, libnvme_strerror(errno));
+}
+
 __libnvme_public int libnvmf_context_set_io_queues(
 		struct libnvmf_context *fctx, int nr_io_queues,
 		int nr_write_queues, int nr_poll_queues,
@@ -3620,9 +3664,17 @@ __libnvme_public int libnvmf_discovery(
 __libnvme_public int libnvmf_connect(
 		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx)
 {
+	__cleanup_fd int devid_fd = -1;
 	struct libnvme_host *h;
 	struct libnvme_ctrl *c;
 	int err;
+
+	/* Open before touching kernel state, so a bad path fails fast. */
+	if (fctx->devid_file) {
+		devid_fd = open_devid_file(fctx);
+		if (devid_fd < 0)
+			return devid_fd;
+	}
 
 	err = lookup_host(ctx, fctx, &h);
 	if (err)
@@ -3635,6 +3687,7 @@ __libnvme_public int libnvmf_connect(
 	c = lookup_ctrl(h, fctx);
 	if (c && libnvme_ctrl_get_name(c) &&
 	    !fctx->ctrl_params.cfg.duplicate_connect) {
+		write_devid_file(fctx, devid_fd, c);
 		fctx->hooks.already_connected(fctx, h,
 			libnvme_ctrl_get_subsysnqn(c),
 			libnvme_ctrl_get_transport(c),
@@ -3669,12 +3722,22 @@ __libnvme_public int libnvmf_connect(
 
 	err = libnvme_add_ctrl(fctx, h, c);
 	if (err) {
+		/*
+		 * Kernel-level race: something else connected between our
+		 * scan and this ioctl. @c is our own unconnected draft, not
+		 * the winner -- rescan to find it.
+		 */
+		if (err == -ENVME_CONNECT_ALREADY &&
+		    libnvme_scan_topology(ctx, NULL, NULL) == 0)
+			write_devid_file(fctx, devid_fd, lookup_ctrl(h, fctx));
+
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "could not add new controller: %s\n",
 			libnvme_strerror(-err));
 		libnvme_free_ctrl(c);
 		return err;
 	}
 
+	write_devid_file(fctx, devid_fd, c);
 	fctx->hooks.connected(fctx, c, fctx->hooks.user_data);
 
 	return 0;

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -421,6 +421,30 @@ int libnvmf_context_set_crypto(struct libnvmf_context *fctx,
 int libnvmf_context_set_device(struct libnvmf_context *fctx, const char *device);
 
 /**
+ * libnvmf_context_set_devid_file() - Set devid file for context
+ * @fctx: Fabrics context
+ * @devid_file: Path to the output file
+ *
+ * Configure a file that libnvmf_connect() uses to record the
+ * kernel-assigned device name (for example, "nvme0").
+ *
+ * If the controller is already connected, the existing device name is
+ * written. Otherwise, the device name is written after the controller is
+ * connected.
+ *
+ * The output file is created before attempting the connection. If the
+ * file cannot be created, for example because the parent directory does
+ * not exist, libnvmf_connect() fails without attempting the connection.
+ *
+ * This is intended for applications that need to identify the device
+ * associated with a connection, for example to disconnect it later.
+ *
+ * Return: 0 on success, negative error code otherwise.
+ */
+int libnvmf_context_set_devid_file(struct libnvmf_context *fctx,
+		const char *devid_file);
+
+/**
  * libnvmf_context_set_io_queues() - Set I/O queue topology for context
  * @fctx: Fabrics context
  * @nr_io_queues: Number of I/O queues

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -56,6 +56,7 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 	/* common fabrics configuration */
 	const char *device;
 	bool persistent;
+	const char *devid_file; // !access:write=custom
 
 	/* host configuration */
 	const char *hostnqn; // !access:write=custom


### PR DESCRIPTION
nvme connect gets two new options for supervised use (systemd transient units, nvme-discoverd): `--idempotent` makes connect succeed instead of failing when the target is already connected, and `--devid-file` saves the connected device name to a file so a supervising process can find it again later, e.g. to disconnect.

Two commits, each a complete, independent feature:
- `nvme-cli/fabrics: add --idempotent to nvme connect`
- `libnvme/fabrics: add --devid-file to nvme connect`

Replaces #3573, closed in favor of this PR: same two features, split more deliberately (one commit each, rather than bundled).