### PR TITLE
libnvme/config: add the INI configuration write side

### DIFF
--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -18,6 +18,10 @@ LIBNVMF_3 {
 		libnvmf_config_conn_get_transport;
 		libnvmf_config_conn_get_trsvcid;
 		libnvmf_config_conn_is_dc;
+		libnvmf_config_emit_add;
+		libnvmf_config_emit_free;
+		libnvmf_config_emit_install;
+		libnvmf_config_emit_new;
 		libnvmf_config_free;
 		libnvmf_config_modify;
 		libnvmf_config_read;
@@ -80,7 +84,10 @@ LIBNVMF_3 {
 		libnvmf_nbft_free;
 		libnvmf_nbft_read_files;
 		libnvmf_params_for_each;
+		libnvmf_params_free;
 		libnvmf_params_get;
+		libnvmf_params_new;
+		libnvmf_params_set;
 		libnvmf_prtype_str;
 		libnvmf_qptype_str;
 		libnvmf_read_hostid;

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -64,6 +64,7 @@ if want_fabrics
         'nvme/accessors-fabrics.c',
         'nvme/crypto.c',
         'nvme/config.c',
+        'nvme/config-emit.c',
         'nvme/config-ini.c',
         'nvme/config-resolve.c',
         'nvme/exclusion.c',

--- a/libnvme/src/nvme/config-emit.c
+++ b/libnvme/src/nvme/config-emit.c
@@ -36,8 +36,6 @@
 #include "private.h"
 #include "private-fabrics.h"
 
-#define CONFIG_MAIN_PATH SYSCONFDIR "/nvme/nvme-fabrics.conf"
-
 #define emit_err(ctx, fmt, ...) \
 	libnvme_msg(ctx, LIBNVME_LOG_ERR, fmt "\n", ##__VA_ARGS__)
 

--- a/libnvme/src/nvme/config-emit.c
+++ b/libnvme/src/nvme/config-emit.c
@@ -1,0 +1,579 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026, Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ */
+
+/*
+ * Builds an NVMe Fabrics configuration from a flat list of connections.
+ *
+ * Intended for configuration migration. Existing configurations are not
+ * merged; installation fails if a configuration already exists.
+ *
+ * Input is validated before writing. The generated configuration is parsed
+ * again before installation to ensure it can be read successfully.
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <ccan/list/list.h>
+
+#include <nvme/config.h>
+#include <nvme/nvme-types-fabrics.h>
+
+#include "cleanup.h"
+#include "compiler-attributes.h"
+#include "config-ini.h"
+#include "lib.h"
+#include "private.h"
+#include "private-fabrics.h"
+
+#define CONFIG_MAIN_PATH SYSCONFDIR "/nvme/nvme-fabrics.conf"
+
+#define emit_err(ctx, fmt, ...) \
+	libnvme_msg(ctx, LIBNVME_LOG_ERR, fmt "\n", ##__VA_ARGS__)
+
+struct emit_conn {
+	struct list_node entry;
+	bool is_dc;
+	char *transport;
+	char *traddr;
+	char *trsvcid;		/* NULL = unset */
+	char *subsysnqn;	/* NULL = default discovery NQN, DC only */
+	char *host_traddr;	/* NULL = unset */
+	char *host_iface;	/* NULL = unset */
+	struct libnvmf_params *params;	/* NULL = no parameters */
+};
+
+/* One output file containing a persona and its connections. */
+struct emit_persona {
+	struct list_node entry;
+	char *hostnqn;			/* NULL on the default persona */
+	char *hostid;
+	char *hostsymname;
+	struct list_head conns;	/* struct emit_conn */
+};
+
+struct libnvmf_config_emitter {
+	struct libnvme_global_ctx *ctx;
+	struct list_head personas;	/* struct emit_persona, first-appearance order */
+};
+
+__libnvme_public struct libnvmf_config_emitter *libnvmf_config_emit_new(
+		struct libnvme_global_ctx *ctx)
+{
+	struct libnvmf_config_emitter *emitter;
+
+	if (!ctx)
+		return NULL;
+
+	emitter = calloc(1, sizeof(*emitter));
+	if (!emitter)
+		return NULL;
+	emitter->ctx = ctx;
+	list_head_init(&emitter->personas);
+
+	return emitter;
+}
+
+__libnvme_public void libnvmf_config_emit_free(
+		struct libnvmf_config_emitter *emitter)
+{
+	struct emit_persona *p, *pnext;
+	struct emit_conn *c, *cnext;
+
+	if (!emitter)
+		return;
+
+	list_for_each_safe(&emitter->personas, p, pnext, entry) {
+		list_for_each_safe(&p->conns, c, cnext, entry) {
+			free(c->transport);
+			free(c->traddr);
+			free(c->trsvcid);
+			free(c->subsysnqn);
+			free(c->host_traddr);
+			free(c->host_iface);
+			libnvmf_params_free(c->params);
+			free(c);
+		}
+		free(p->hostnqn);
+		free(p->hostid);
+		free(p->hostsymname);
+		free(p);
+	}
+	free(emitter);
+}
+
+static struct emit_persona *persona_for(struct libnvmf_config_emitter *emitter,
+					const char *hostnqn, const char *hostid)
+{
+	struct emit_persona *p;
+
+	list_for_each(&emitter->personas, p, entry) {
+		if (streq0(p->hostnqn, hostnqn) &&
+		    streq0(p->hostid, hostid))
+			return p;
+	}
+
+	p = calloc(1, sizeof(*p));
+	if (!p)
+		return NULL;
+	p->hostnqn = hostnqn ? strdup(hostnqn) : NULL;
+	p->hostid = hostid ? strdup(hostid) : NULL;
+	if ((hostnqn && !p->hostnqn) || (hostid && !p->hostid)) {
+		free(p->hostnqn);
+		free(p->hostid);
+		free(p);
+		return NULL;
+	}
+	list_head_init(&p->conns);
+	list_add_tail(&emitter->personas, &p->entry);
+
+	return p;
+}
+
+/*
+ * Validate persona identity.
+ *
+ * A host is identified by the (hostnqn, hostid) pair. A hostnqn cannot be
+ * associated with multiple hostids, and a hostid cannot be associated with
+ * multiple hostnqns. A hostid requires a hostnqn. Checked here so the
+ * emitter never writes a tree its own reader would reject.
+ */
+static int check_persona_identity(struct libnvmf_config_emitter *emitter,
+				  const char *hostnqn, const char *hostid)
+{
+	struct emit_persona *p;
+
+	if (hostid && !hostnqn) {
+		emit_err(emitter->ctx,
+			 "config emit: hostid %s without a hostnqn", hostid);
+		return -EINVAL;
+	}
+
+	list_for_each(&emitter->personas, p, entry) {
+		if (hostnqn && p->hostnqn && !strcmp(hostnqn, p->hostnqn) &&
+		    !streq0(hostid, p->hostid)) {
+			emit_err(emitter->ctx,
+				 "config emit: hostnqn %s used with two hostids",
+				 hostnqn);
+			return -EINVAL;
+		}
+		if (hostid && p->hostid && !strcmp(hostid, p->hostid) &&
+		    !streq0(hostnqn, p->hostnqn)) {
+			emit_err(emitter->ctx,
+				 "config emit: hostid %s shared by two hostnqns",
+				 hostid);
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+__libnvme_public int libnvmf_config_emit_add(
+		struct libnvmf_config_emitter *emitter, bool is_dc,
+		const char *transport, const char *traddr,
+		const char *trsvcid, const char *subsysnqn,
+		const char *host_traddr, const char *host_iface,
+		const char *hostnqn, const char *hostid,
+		const struct libnvmf_params *params, const char *hostsymname)
+{
+	struct emit_persona *persona;
+	struct emit_conn *conn;
+	int ret;
+
+	if (!emitter)
+		return -EINVAL;
+
+	if (!transport || !traddr) {
+		emit_err(emitter->ctx,
+			 "config emit: transport and traddr are required");
+		return -EINVAL;
+	}
+	if (!is_dc && !subsysnqn) {
+		emit_err(emitter->ctx,
+			 "config emit: an I/O controller requires a subsysnqn");
+		return -EINVAL;
+	}
+
+	ret = check_persona_identity(emitter, hostnqn, hostid);
+	if (ret)
+		return ret;
+
+	persona = persona_for(emitter, hostnqn, hostid);
+	if (!persona)
+		return -ENOMEM;
+
+	if (hostsymname) {
+		if (persona->hostsymname &&
+		    strcmp(persona->hostsymname, hostsymname)) {
+			emit_err(emitter->ctx,
+				 "config emit: conflicting hostsymname '%s' for persona %s",
+				 hostsymname, persona->hostnqn ?
+					      persona->hostnqn : "(default)");
+			return -EINVAL;
+		}
+		if (!persona->hostsymname) {
+			persona->hostsymname = strdup(hostsymname);
+			if (!persona->hostsymname)
+				return -ENOMEM;
+		}
+	}
+
+	conn = calloc(1, sizeof(*conn));
+	if (!conn)
+		return -ENOMEM;
+	conn->is_dc = is_dc;
+	conn->transport = strdup(transport);
+	conn->traddr = strdup(traddr);
+	conn->trsvcid = xstrdup(trsvcid);
+	conn->subsysnqn = xstrdup(subsysnqn);
+	conn->host_traddr = xstrdup(host_traddr);
+	conn->host_iface = xstrdup(host_iface);
+	if (params)
+		conn->params = libnvmf_params_dup(params);
+	if (!conn->transport || !conn->traddr ||
+	    (trsvcid && !conn->trsvcid) || (subsysnqn && !conn->subsysnqn) ||
+	    (host_traddr && !conn->host_traddr) ||
+	    (host_iface && !conn->host_iface) ||
+	    (params && !conn->params)) {
+		free(conn->transport);
+		free(conn->traddr);
+		free(conn->trsvcid);
+		free(conn->subsysnqn);
+		free(conn->host_traddr);
+		free(conn->host_iface);
+		libnvmf_params_free(conn->params);
+		free(conn);
+		return -ENOMEM;
+	}
+
+	list_add_tail(&persona->conns, &conn->entry);
+
+	return 0;
+}
+
+static void write_param(const char *key, const char *value, void *user_data)
+{
+	FILE *fp = user_data;
+
+	if (*value)
+		fprintf(fp, "%s = %s\n", key, value);
+	else
+		fprintf(fp, "%s =\n", key);
+}
+
+static void write_conn(FILE *fp, const struct emit_conn *conn)
+{
+	if (conn->is_dc) {
+		fprintf(fp, "[Discovery Controller]\n");
+		/* Omit the default well-known discovery NQN. */
+		if (conn->subsysnqn &&
+		    strcmp(conn->subsysnqn, NVME_DISC_SUBSYS_NAME))
+			fprintf(fp, "nqn = %s\n", conn->subsysnqn);
+	} else {
+		fprintf(fp, "[Subsystem]\n");
+		fprintf(fp, "nqn = %s\n", conn->subsysnqn);
+	}
+
+	if (conn->params)
+		libnvmf_params_for_each(conn->params, write_param, fp);
+
+	fprintf(fp, "controller = transport=%s;traddr=%s",
+		conn->transport, conn->traddr);
+	if (conn->trsvcid)
+		fprintf(fp, ";trsvcid=%s", conn->trsvcid);
+	if (conn->host_traddr)
+		fprintf(fp, ";host-traddr=%s", conn->host_traddr);
+	if (conn->host_iface)
+		fprintf(fp, ";host-iface=%s", conn->host_iface);
+	fprintf(fp, "\n");
+}
+
+static void write_persona(FILE *fp, const struct emit_persona *persona)
+{
+	const struct emit_conn *conn;
+	bool first = true;
+
+	if (persona->hostnqn || persona->hostid || persona->hostsymname) {
+		fprintf(fp, "[Host]\n");
+		if (persona->hostnqn)
+			fprintf(fp, "hostnqn = %s\n", persona->hostnqn);
+		if (persona->hostid)
+			fprintf(fp, "hostid = %s\n", persona->hostid);
+		if (persona->hostsymname)
+			fprintf(fp, "hostsymname = %s\n", persona->hostsymname);
+		first = false;
+	}
+
+	list_for_each(&persona->conns, conn, entry) {
+		if (!first)
+			fprintf(fp, "\n");
+		write_conn(fp, conn);
+		first = false;
+	}
+}
+
+/*
+ * Write @persona to a temporary file and validate it by parsing it.
+ *
+ * On success, *@tmp_out receives the temporary file path. The caller is
+ * responsible for renaming it to @final. On failure, the temporary file
+ * is removed.
+ */
+static int emit_tmpfile(struct libnvme_global_ctx *ctx, const char *final,
+			const struct emit_persona *persona, char **tmp_out)
+{
+	struct libnvmf_conf_file *raw;
+	char *tmp;
+	FILE *fp;
+	int fd, ret;
+
+	if (asprintf(&tmp, "%s.XXXXXX", final) < 0)
+		return -ENOMEM;
+
+	fd = libnvmf_mkstemp(tmp);
+	if (fd < 0) {
+		ret = fd;
+		goto err_free;
+	}
+	if (fchmod(fd, 0644) < 0) {
+		ret = -errno;
+		close(fd);
+		goto err_unlink;
+	}
+	fp = fdopen(fd, "w");
+	if (!fp) {
+		ret = -errno;
+		close(fd);
+		goto err_unlink;
+	}
+
+	write_persona(fp, persona);
+
+	if (fflush(fp) != 0 || ferror(fp)) {
+		fclose(fp);
+		ret = -EIO;
+		goto err_unlink;
+	}
+	if (fsync(fileno(fp)) != 0) {
+		ret = -errno;
+		fclose(fp);
+		goto err_unlink;
+	}
+	if (fclose(fp) != 0) {
+		ret = -errno;
+		goto err_unlink;
+	}
+
+	ret = libnvmf_conf_file_parse(ctx, tmp, &raw);
+	if (ret) {
+		emit_err(ctx, "config emit: wrote an unreadable file");
+		goto err_unlink;
+	}
+	libnvmf_conf_file_free(raw);
+
+	*tmp_out = tmp;
+
+	return 0;
+
+err_unlink:
+	unlink(tmp);
+err_free:
+	free(tmp);
+
+	return ret;
+}
+
+/*
+ * A configuration exists if the main file exists or the drop-in directory
+ * contains at least one .conf file. Installation is one-shot migration,
+ * by design never a merge into what's already there.
+ */
+static int target_occupied(const char *file, const char *dropin_dir)
+{
+	struct dirent **entries;
+	struct stat st;
+	bool occupied;
+	int n;
+
+	if (stat(file, &st) == 0)
+		return -EEXIST;
+	if (errno != ENOENT)
+		return -errno;
+
+	n = scandir(dropin_dir, &entries, libnvmf_conf_dropin_filter,
+		    alphasort);
+	if (n < 0)
+		return errno == ENOENT ? 0 : -errno;
+	occupied = n > 0;
+	while (n > 0)
+		free(entries[--n]);
+	free(entries);
+
+	return occupied ? -EEXIST : 0;
+}
+
+/*
+ * Generate a drop-in file name.
+ *
+ * The numeric prefix preserves persona order. The persona's identity lives
+ * inside the file ([Host]), so the name itself carries no user-controlled
+ * text -- nothing to sanitize, nothing that can collide.
+ */
+static char *dropin_name(const char *dropin_dir, unsigned int index)
+{
+	char *path;
+
+	if (asprintf(&path, "%s/%03u-persona.conf", dropin_dir,
+		     100 + index) < 0)
+		return NULL;
+
+	return path;
+}
+
+/* Temporary and final paths for one output file. */
+struct outfile {
+	char *tmp;
+	char *final;
+};
+
+static void outfiles_free(struct outfile *out, size_t n, bool rollback)
+{
+	size_t i;
+
+	for (i = 0; i < n; i++) {
+		if (rollback) {
+			/*
+			 * Roll back a partial install: each entry was either
+			 * already renamed into place (only @final exists) or
+			 * never got that far (only @tmp exists). Removing
+			 * both is safe -- whichever one isn't there just
+			 * fails with a harmless ENOENT.
+			 */
+			unlink(out[i].final);
+			unlink(out[i].tmp);
+		}
+		free(out[i].tmp);
+		free(out[i].final);
+	}
+	free(out);
+}
+
+__libnvme_public int libnvmf_config_emit_install(
+		struct libnvmf_config_emitter *emitter, const char *file,
+		bool force)
+{
+	__cleanup_free char *ddir = NULL;
+	struct emit_persona empty_main = { 0 };
+	const struct emit_persona *persona, *def = NULL;
+	struct outfile *out;
+	unsigned int index = 0;
+	bool made_ddir = false;
+	size_t nout = 0, npersona = 0, i;
+	int ret;
+
+	if (!emitter)
+		return -EINVAL;
+	if (!file)
+		file = CONFIG_MAIN_PATH;
+
+	list_head_init(&empty_main.conns);
+
+	if (asprintf(&ddir, "%s.d", file) < 0)
+		return -ENOMEM;
+
+	if (!force) {
+		ret = target_occupied(file, ddir);
+		if (ret) {
+			if (ret == -EEXIST)
+				emit_err(emitter->ctx,
+					 "%s: a configuration already exists",
+					 file);
+			return ret;
+		}
+	}
+
+	list_for_each(&emitter->personas, persona, entry)
+		npersona++;
+
+	/* Write named personas first. Write the main file last. */
+	out = calloc(npersona + 1, sizeof(*out));
+	if (!out)
+		return -ENOMEM;
+
+	list_for_each(&emitter->personas, persona, entry) {
+		if (!persona->hostnqn && !persona->hostid) {
+			def = persona;
+			continue;
+		}
+		if (!made_ddir) {
+			if (mkdir(ddir, 0755) < 0 && errno != EEXIST) {
+				ret = -errno;
+				goto rollback;
+			}
+			made_ddir = true;
+		}
+		out[nout].final = dropin_name(ddir, index++);
+		if (!out[nout].final) {
+			ret = -ENOMEM;
+			goto rollback;
+		}
+		ret = emit_tmpfile(emitter->ctx, out[nout].final, persona,
+				   &out[nout].tmp);
+		if (ret) {
+			/* emit_tmpfile removed its temp; free the final. */
+			free(out[nout].final);
+			out[nout].final = NULL;
+			goto rollback;
+		}
+		nout++;
+	}
+
+	/*
+	 * Write the main configuration file. If no default persona exists,
+	 * write an empty main file.
+	 */
+	out[nout].final = strdup(file);
+	if (!out[nout].final) {
+		ret = -ENOMEM;
+		goto rollback;
+	}
+	ret = emit_tmpfile(emitter->ctx, out[nout].final,
+			   def ? def : &empty_main, &out[nout].tmp);
+	if (ret) {
+		free(out[nout].final);
+		out[nout].final = NULL;
+		goto rollback;
+	}
+	nout++;
+
+	/* Install validated files. */
+	for (i = 0; i < nout; i++) {
+		if (rename(out[i].tmp, out[i].final) < 0) {
+			ret = -errno;
+			goto rollback;
+		}
+	}
+
+	outfiles_free(out, nout, false);
+
+	return 0;
+
+rollback:
+	/* out[0..nout-1] are complete; any partial slot was freed inline. */
+	outfiles_free(out, nout, true);
+	if (made_ddir)
+		rmdir(ddir);	/* only succeeds if we left it empty */
+
+	return ret;
+}

--- a/libnvme/src/nvme/config-ini.c
+++ b/libnvme/src/nvme/config-ini.c
@@ -128,6 +128,10 @@ int libnvmf_key_check_value(const struct libnvmf_key *key, const char *value)
 	if (!*value)
 		return 0;
 
+	/* A value must survive a round trip through a line-based file. */
+	if (strpbrk(value, "\n\r"))
+		return -EINVAL;
+
 	switch (key->type) {
 	case LIBNVMF_KEY_INT:
 		return check_int(value);
@@ -150,7 +154,7 @@ struct libnvmf_params {
 	struct list_head list;
 };
 
-struct libnvmf_params *libnvmf_params_new(void)
+__libnvme_public struct libnvmf_params *libnvmf_params_new(void)
 {
 	struct libnvmf_params *p = calloc(1, sizeof(*p));
 
@@ -161,7 +165,7 @@ struct libnvmf_params *libnvmf_params_new(void)
 	return p;
 }
 
-void libnvmf_params_free(struct libnvmf_params *p)
+__libnvme_public void libnvmf_params_free(struct libnvmf_params *p)
 {
 	struct kv *e, *next;
 
@@ -205,13 +209,27 @@ static int kv_append(struct libnvmf_params *p, const char *key, char *value)
 	return 0;
 }
 
-int libnvmf_params_set(struct libnvmf_params *p, const char *key,
-		const char *value)
+__libnvme_public int libnvmf_params_set(struct libnvmf_params *p,
+		const char *key, const char *value)
 {
+	const struct libnvmf_key *k;
 	struct kv *e;
 	char *copy;
 
 	if (!p || !key || !value)
+		return -EINVAL;
+
+	/*
+	 * Only connection parameters live in the store.  Addressing and
+	 * identity belong to the TID (and hostsymname to the persona), so
+	 * their keys are rejected here along with unknown keys and
+	 * type-invalid values.
+	 */
+	k = libnvmf_key_lookup(key);
+	if (!k || (k->class != LIBNVMF_KEY_TUNABLE &&
+		   k->class != LIBNVMF_KEY_SECURITY))
+		return -EINVAL;
+	if (libnvmf_key_check_value(k, value))
 		return -EINVAL;
 
 	copy = strdup(value);

--- a/libnvme/src/nvme/config-ini.h
+++ b/libnvme/src/nvme/config-ini.h
@@ -27,20 +27,13 @@
  *   value == ""     -> reset: stop inheriting and use the kernel default;
  *   value == "..."  -> set to the specified value.
  *
- * Keeping these states separate allows the precedence rules and the
- * reset-to-kernel-default form ("key =") to be represented without ambiguity.
- *
  * Values are stored as strings from the configuration file. They are
  * validated when added (libnvmf_key_check_value) and interpreted when
  * emitted. Iteration order follows the order in which keys were inserted.
+ * The store itself is public (new/set/get/for_each/free live in
+ * <nvme/config.h>); only the whole-store operations below stay internal.
  */
-struct libnvmf_params *libnvmf_params_new(void);
 struct libnvmf_params *libnvmf_params_dup(const struct libnvmf_params *p);
-void libnvmf_params_free(struct libnvmf_params *p);
-
-/* Set @key to @value (replacing an earlier value); "" records a reset. */
-int libnvmf_params_set(struct libnvmf_params *p, const char *key,
-		const char *value);
 
 /* Overlay @src onto @dst: every key present in @src wins. */
 int libnvmf_params_merge(struct libnvmf_params *dst,
@@ -212,3 +205,7 @@ struct libnvmf_config {
  */
 int libnvmf_config_load(struct libnvme_global_ctx *ctx, const char *path,
 		struct libnvmf_config **out);
+
+/* The scandir() filter selecting *.conf drop-ins. */
+struct dirent;
+int libnvmf_conf_dropin_filter(const struct dirent *d);

--- a/libnvme/src/nvme/config-ini.h
+++ b/libnvme/src/nvme/config-ini.h
@@ -13,6 +13,8 @@
 
 #include <nvme/config.h>
 
+#define CONFIG_MAIN_PATH SYSCONFDIR "/nvme/nvme-fabrics.conf"
+
 /*
  * Internal building blocks for the INI connection configuration:
  * the connection-parameter store that tracks unset, reset, and explicit

--- a/libnvme/src/nvme/config-resolve.c
+++ b/libnvme/src/nvme/config-resolve.c
@@ -298,7 +298,7 @@ static int check_personas(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-static int dropin_filter(const struct dirent *d)
+int libnvmf_conf_dropin_filter(const struct dirent *d)
 {
 	const char *dot = strrchr(d->d_name, '.');
 
@@ -327,7 +327,7 @@ int libnvmf_config_load(struct libnvme_global_ctx *ctx, const char *path,
 		goto out;
 	}
 
-	n = scandir(dirname, &entries, dropin_filter, alphasort);
+	n = scandir(dirname, &entries, libnvmf_conf_dropin_filter, alphasort);
 	if (n < 0) {
 		if (errno != ENOENT) {
 			ret = -errno;

--- a/libnvme/src/nvme/config.c
+++ b/libnvme/src/nvme/config.c
@@ -27,8 +27,6 @@
 #include "compiler-attributes.h"
 #include "config-ini.h"
 
-#define CONFIG_MAIN_PATH SYSCONFDIR "/nvme/nvme-fabrics.conf"
-
 __libnvme_public int libnvmf_config_read(struct libnvme_global_ctx *ctx,
 		const char *file, struct libnvmf_config **out)
 {

--- a/libnvme/src/nvme/config.h
+++ b/libnvme/src/nvme/config.h
@@ -304,6 +304,119 @@ int libnvmf_connect_args_emit(const struct libnvmf_tid *tid,
 		void *user_data);
 
 /**
+ * struct libnvmf_config_emitter - Configuration emitter.
+ *
+ * Opaque type used to build and write an NVMe Fabrics configuration.
+ */
+struct libnvmf_config_emitter;
+
+/**
+ * libnvmf_config_emit_new() - Create a configuration emitter.
+ * @ctx: libnvme global context. Must not be NULL.
+ *
+ * Return: A new emitter on success, or NULL on failure.
+ * Free the emitter with libnvmf_config_emit_free().
+ */
+struct libnvmf_config_emitter *libnvmf_config_emit_new(
+		struct libnvme_global_ctx *ctx);
+
+/**
+ * libnvmf_config_emit_free() - Free a configuration emitter.
+ * @emitter: Emitter to free. NULL is ignored.
+ */
+void libnvmf_config_emit_free(struct libnvmf_config_emitter *emitter);
+
+/**
+ * libnvmf_config_emit_add() - Add a connection to a configuration emitter.
+ * @emitter:     Configuration emitter.
+ * @is_dc:       Discovery controller if true, I/O controller if false.
+ * @transport:   Transport type. Required.
+ * @traddr:      Transport address. Required. Written verbatim, even if a
+ *               hostname; resolution happens at connect time, not here.
+ * @trsvcid:     Transport service ID, or NULL.
+ * @subsysnqn:   Subsystem NQN. Required unless @is_dc is true.
+ * @host_traddr: Host transport address, or NULL.
+ * @host_iface:  Host interface, or NULL.
+ * @hostnqn:     Host NQN, or NULL.
+ * @hostid:      Host identifier, or NULL.
+ * @params:      Connection parameters, or NULL.
+ * @hostsymname: Host symbolic name, or NULL.
+ *
+ * The parameter set is copied by the emitter.
+ *
+ * Return:
+ * * 0 on success.
+ * * -EINVAL if a required parameter is missing or if @hostsymname
+ *   conflicts with an existing persona.
+ * * -ENOMEM if memory allocation fails.
+ */
+int libnvmf_config_emit_add(struct libnvmf_config_emitter *emitter,
+		bool is_dc, const char *transport, const char *traddr,
+		const char *trsvcid, const char *subsysnqn,
+		const char *host_traddr, const char *host_iface,
+		const char *hostnqn, const char *hostid,
+		const struct libnvmf_params *params, const char *hostsymname);
+
+/**
+ * libnvmf_config_emit_install() - Write a configuration to disk.
+ * @emitter: Configuration emitter.
+ * @file:  Destination configuration file, or NULL to use the default
+ *         configuration file.
+ * @force: Overwrite an existing configuration if true.
+ *
+ * The default persona is written to the main configuration file. Each
+ * named persona is written to a separate drop-in file.
+ *
+ * The generated configuration is validated by reading it back through the
+ * standard parser before it is installed. Files are written atomically
+ * (temporary file followed by rename). If any step fails, no configuration
+ * is installed.
+ *
+ * Return:
+ * * 0 on success.
+ * * -EEXIST if a configuration already exists and @force is false.
+ * * -EINVAL if @emitter is NULL.
+ * * A negative errno value on other failures.
+ */
+int libnvmf_config_emit_install(struct libnvmf_config_emitter *emitter,
+		const char *file, bool force);
+
+/**
+ * libnvmf_params_new() - Create a connection parameter set.
+ *
+ * Return: A new parameter set on success, or NULL on failure.
+ * Free the parameter set with libnvmf_params_free().
+ */
+struct libnvmf_params *libnvmf_params_new(void);
+
+/**
+ * libnvmf_params_free() - Free a connection parameter set.
+ * @params: Parameter set to free. NULL is ignored.
+ *
+ * Only free a set obtained from libnvmf_params_new(); never call this on
+ * a set borrowed from a configuration.
+ */
+void libnvmf_params_free(struct libnvmf_params *params);
+
+/**
+ * libnvmf_params_set() - Set a connection parameter.
+ * @params: Caller-owned parameter set.
+ * @key:   Parameter name.
+ * @value: Parameter value as a string. An empty string restores the
+ *         kernel default for the parameter.
+ *
+ * If the parameter already exists, its value is replaced.
+ *
+ * Return:
+ * * 0 on success.
+ * * -EINVAL if @key is unknown, is not a connection parameter,
+ *   or if @value is invalid for the parameter type.
+ * * -ENOMEM if memory allocation fails.
+ */
+int libnvmf_params_set(struct libnvmf_params *params, const char *key,
+		const char *value);
+
+/**
  * libnvmf_params_get() - look up one connection parameter.
  * @params: a resolved parameter set
  * @key:    the configuration key name (the "nvme connect" long-option name,

--- a/libnvme/test/config-emit.c
+++ b/libnvme/test/config-emit.c
@@ -1,0 +1,549 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/**
+ * This file is part of libnvme.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ *
+ * Tests for the configuration write side (<nvme/config.h>): build a set of
+ * connections, install them, and read the result back through the public
+ * API.  Linked against the real shared library, so it also proves the
+ * emitter symbols are exported.
+ */
+
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <nvme/lib.h>
+#include <nvme/config.h>
+#include <nvme/nvme-types-fabrics.h>
+#include <nvme/accessors-fabrics.h>
+
+static const char *g_hostid = "46ba5037-7ce5-41fa-9452-48477bf00080";
+
+struct fixture {
+	char dir[32];
+	char main_path[288];
+	char dropin_dir[288];
+};
+
+static void fixture_create(struct fixture *fx)
+{
+	snprintf(fx->dir, sizeof(fx->dir), "/tmp/nvme-config-emit-XXXXXX");
+	assert(mkdtemp(fx->dir));
+	snprintf(fx->main_path, sizeof(fx->main_path), "%s/nvme-fabrics.conf",
+		 fx->dir);
+	snprintf(fx->dropin_dir, sizeof(fx->dropin_dir),
+		 "%s/nvme-fabrics.conf.d", fx->dir);
+}
+
+/* Recursively remove the fixture tree between subtests. */
+static void fixture_wipe(struct fixture *fx)
+{
+	char path[600];
+	struct dirent **e;
+	int n;
+
+	n = scandir(fx->dropin_dir, &e, NULL, alphasort);
+	while (n > 0) {
+		if (strcmp(e[--n]->d_name, ".") && strcmp(e[n]->d_name, "..")) {
+			snprintf(path, sizeof(path), "%s/%s", fx->dropin_dir,
+				 e[n]->d_name);
+			unlink(path);
+		}
+		free(e[n]);
+	}
+	if (n == 0)
+		free(e);
+	rmdir(fx->dropin_dir);
+	unlink(fx->main_path);
+}
+
+static void fixture_destroy(struct fixture *fx)
+{
+	fixture_wipe(fx);
+	rmdir(fx->dir);
+}
+
+struct conn_list {
+	const struct libnvmf_config_conn *conn[8];
+	size_t n;
+};
+
+static void collect(const struct libnvmf_config_conn *conn, void *user_data)
+{
+	struct conn_list *list = user_data;
+
+	assert(list->n < 8);
+	list->conn[list->n++] = conn;
+}
+
+/* Add one connection, params from key/value pairs. */
+static int add(struct libnvmf_config_emitter *e, bool is_dc,
+	       const char *traddr, const char *nqn, const char *hostnqn,
+	       const char *hostid, const char *hostsymname,
+	       const char *pkey, const char *pval)
+{
+	struct libnvmf_params *params = NULL;
+	int ret;
+
+	if (pkey) {
+		params = libnvmf_params_new();
+		assert(params);
+		assert(libnvmf_params_set(params, pkey, pval) == 0);
+	}
+	ret = libnvmf_config_emit_add(e, is_dc, "tcp", traddr, "4420", nqn,
+				      NULL, NULL, hostnqn, hostid, params,
+				      hostsymname);
+	libnvmf_params_free(params);
+
+	return ret;
+}
+
+static bool test_roundtrip(struct libnvme_global_ctx *ctx, struct fixture *fx)
+{
+	const struct libnvmf_config_conn *dc, *mv, *pv;
+	struct libnvmf_config_emitter *e;
+	struct conn_list list = { 0 };
+	struct libnvmf_config *config;
+	const struct libnvmf_params *params;
+	bool pass = true;
+
+	printf("test_roundtrip:\n");
+
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+
+	/* Default persona: a DC and an I/O controller in the main file. */
+	assert(add(e, true, "10.0.0.5", NULL, NULL, NULL, NULL,
+		   NULL, NULL) == 0);
+	assert(add(e, false, "10.0.0.9",
+		   "nqn.2014-08.org.nvmexpress:main-vol", NULL, NULL, NULL,
+		   "ctrl-loss-tmo", "600") == 0);
+	/* A named persona: goes to its own drop-in. */
+	assert(add(e, false, "10.0.0.7",
+		   "nqn.2014-08.org.nvmexpress:prod-vol",
+		   "nqn.2014-08.org.nvmexpress:prod-host",
+		   g_hostid, "prod", "tls", "true") == 0);
+
+	if (libnvmf_config_emit_install(e, fx->main_path, false)) {
+		printf(" - install failed [FAIL]\n");
+		libnvmf_config_emit_free(e);
+		return false;
+	}
+	libnvmf_config_emit_free(e);
+	printf(" - install succeeded [PASS]\n");
+
+	/* The main file and one drop-in exist. */
+	if (access(fx->main_path, F_OK) || access(fx->dropin_dir, F_OK)) {
+		printf(" - expected tree not created [FAIL]\n");
+		return false;
+	}
+	printf(" - main file + drop-in directory created [PASS]\n");
+
+	if (libnvmf_config_read(ctx, fx->main_path, &config)) {
+		printf(" - read-back failed [FAIL]\n");
+		return false;
+	}
+
+	libnvmf_config_conn_for_each(config, collect, &list);
+	if (list.n != 3) {
+		printf(" - expected 3 connections, got %zu [FAIL]\n", list.n);
+		libnvmf_config_free(config);
+		return false;
+	}
+	printf(" - three connections read back [PASS]\n");
+
+	/* Main file first: the DC, then the I/O controller. */
+	dc = list.conn[0];
+	mv = list.conn[1];
+	pv = list.conn[2];
+
+	if (!libnvmf_config_conn_is_dc(dc) ||
+	    strcmp(libnvmf_config_conn_get_traddr(dc), "10.0.0.5") ||
+	    strcmp(libnvmf_config_conn_get_subsysnqn(dc), NVME_DISC_SUBSYS_NAME)) {
+		printf(" - DC round-trip [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - DC kept its address and default NQN [PASS]\n");
+	}
+
+	params = libnvmf_config_conn_get_params(mv);
+	if (libnvmf_config_conn_get_hostnqn(mv) ||
+	    strcmp(libnvmf_config_conn_get_subsysnqn(mv),
+		   "nqn.2014-08.org.nvmexpress:main-vol") ||
+	    strcmp(libnvmf_params_get(params, "ctrl-loss-tmo"), "600")) {
+		printf(" - default-persona subsystem round-trip [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - default persona in the main file, param kept [PASS]\n");
+	}
+
+	params = libnvmf_config_conn_get_params(pv);
+	if (strcmp(libnvmf_config_conn_get_hostnqn(pv),
+		   "nqn.2014-08.org.nvmexpress:prod-host") ||
+	    strcmp(libnvmf_config_conn_get_hostid(pv), g_hostid) ||
+	    strcmp(libnvmf_config_conn_get_hostsymname(pv), "prod") ||
+	    strcmp(libnvmf_params_get(params, "tls"), "true")) {
+		printf(" - named-persona drop-in round-trip [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - named persona in its drop-in, identity kept [PASS]\n");
+	}
+
+	if (!strstr(libnvmf_config_conn_get_source(pv), ".conf.d/")) {
+		printf(" - drop-in provenance [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - named persona's source is the drop-in [PASS]\n");
+	}
+
+	libnvmf_config_free(config);
+
+	return pass;
+}
+
+/*
+ * A hostname traddr must survive unresolved -- an INI file is a human
+ * interface, and resolution happens at connect time, not emit time.
+ */
+static bool test_hostname_traddr_verbatim(struct libnvme_global_ctx *ctx,
+					  struct fixture *fx)
+{
+	struct conn_list list = { 0 };
+	struct libnvmf_config_emitter *e;
+	struct libnvmf_config *config;
+	bool pass = true;
+
+	printf("test_hostname_traddr_verbatim:\n");
+
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+
+	if (libnvmf_config_emit_add(e, false, "tcp", "nas.example.com", "4420",
+				    "nqn.2014-08.org.nvmexpress:main-vol",
+				    NULL, NULL, NULL, NULL, NULL, NULL)) {
+		printf(" - hostname traddr rejected [FAIL]\n");
+		libnvmf_config_emit_free(e);
+		return false;
+	}
+
+	if (libnvmf_config_emit_install(e, fx->main_path, false)) {
+		printf(" - install failed [FAIL]\n");
+		libnvmf_config_emit_free(e);
+		return false;
+	}
+	libnvmf_config_emit_free(e);
+	printf(" - hostname traddr accepted and installed [PASS]\n");
+
+	assert(libnvmf_config_read(ctx, fx->main_path, &config) == 0);
+	libnvmf_config_conn_for_each(config, collect, &list);
+	if (list.n != 1 ||
+	    strcmp(libnvmf_config_conn_get_traddr(list.conn[0]),
+		   "nas.example.com")) {
+		printf(" - hostname not preserved verbatim [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - hostname preserved verbatim on read-back [PASS]\n");
+	}
+	libnvmf_config_free(config);
+
+	return pass;
+}
+
+static bool test_refuse_existing(struct libnvme_global_ctx *ctx,
+				 struct fixture *fx)
+{
+	struct libnvmf_config_emitter *e;
+	char path[600];
+	int ret;
+
+	printf("test_refuse_existing:\n");
+
+	/* An empty main file alone is enough to occupy the target. */
+	assert(fclose(fopen(fx->main_path, "w")) == 0);
+
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+	assert(add(e, false, "10.0.0.9", "nqn.vol", NULL, NULL, NULL,
+		   NULL, NULL) == 0);
+	ret = libnvmf_config_emit_install(e, fx->main_path, false);
+	libnvmf_config_emit_free(e);
+
+	if (ret != -EEXIST) {
+		printf(" - expected -EEXIST, got %d [FAIL]\n", ret);
+		return false;
+	}
+	printf(" - refuses when the main file exists [PASS]\n");
+
+	fixture_wipe(fx);
+
+	/* A lone .conf drop-in also counts as an existing configuration. */
+	assert(mkdir(fx->dropin_dir, 0755) == 0);
+	snprintf(path, sizeof(path), "%s/10-x.conf", fx->dropin_dir);
+	assert(fclose(fopen(path, "w")) == 0);
+
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+	assert(add(e, false, "10.0.0.9", "nqn.vol", NULL, NULL, NULL,
+		   NULL, NULL) == 0);
+	ret = libnvmf_config_emit_install(e, fx->main_path, false);
+	libnvmf_config_emit_free(e);
+
+	if (ret != -EEXIST) {
+		printf(" - expected -EEXIST for drop-in, got %d [FAIL]\n", ret);
+		return false;
+	}
+	printf(" - refuses when a drop-in exists [PASS]\n");
+
+	return true;
+}
+
+static bool test_force_overwrite(struct libnvme_global_ctx *ctx,
+				 struct fixture *fx)
+{
+	const struct libnvmf_config_conn *conn;
+	struct libnvmf_config_emitter *e;
+	struct conn_list list = { 0 };
+	struct libnvmf_config *config;
+	bool pass = true;
+
+	printf("test_force_overwrite:\n");
+
+	/* A stale configuration occupies the target. */
+	assert(fclose(fopen(fx->main_path, "w")) == 0);
+
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+	assert(add(e, false, "10.0.0.9",
+		   "nqn.2014-08.org.nvmexpress:force-vol", NULL, NULL, NULL,
+		   NULL, NULL) == 0);
+
+	if (libnvmf_config_emit_install(e, fx->main_path, true)) {
+		printf(" - force install failed [FAIL]\n");
+		libnvmf_config_emit_free(e);
+		return false;
+	}
+	libnvmf_config_emit_free(e);
+	printf(" - force overwrites an existing target [PASS]\n");
+
+	if (libnvmf_config_read(ctx, fx->main_path, &config)) {
+		printf(" - read-back failed [FAIL]\n");
+		return false;
+	}
+
+	libnvmf_config_conn_for_each(config, collect, &list);
+	if (list.n != 1) {
+		printf(" - expected 1 connection, got %zu [FAIL]\n", list.n);
+		libnvmf_config_free(config);
+		return false;
+	}
+
+	conn = list.conn[0];
+	if (strcmp(libnvmf_config_conn_get_subsysnqn(conn),
+		   "nqn.2014-08.org.nvmexpress:force-vol")) {
+		printf(" - overwritten content [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - target holds the new configuration [PASS]\n");
+	}
+
+	libnvmf_config_free(config);
+
+	return pass;
+}
+
+static bool test_all_dropins(struct libnvme_global_ctx *ctx, struct fixture *fx)
+{
+	struct libnvmf_config_emitter *e;
+	struct conn_list list = { 0 };
+	struct libnvmf_config *config;
+	bool pass = true;
+
+	printf("test_all_dropins:\n");
+
+	/* No default persona: every connection is a named persona. */
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+	assert(add(e, false, "10.0.0.9", "nqn.2014-08.org.nvmexpress:a",
+		   "nqn.2014-08.org.nvmexpress:host-a", NULL, "a",
+		   NULL, NULL) == 0);
+	assert(add(e, false, "10.0.0.10", "nqn.2014-08.org.nvmexpress:b",
+		   "nqn.2014-08.org.nvmexpress:host-b", NULL, "b",
+		   NULL, NULL) == 0);
+
+	if (libnvmf_config_emit_install(e, fx->main_path, false)) {
+		printf(" - install failed [FAIL]\n");
+		libnvmf_config_emit_free(e);
+		return false;
+	}
+	libnvmf_config_emit_free(e);
+
+	/* The anchor main file is written even with no default persona. */
+	if (access(fx->main_path, F_OK)) {
+		printf(" - anchor main file missing [FAIL]\n");
+		return false;
+	}
+	printf(" - empty anchor main file written [PASS]\n");
+
+	assert(libnvmf_config_read(ctx, fx->main_path, &config) == 0);
+	libnvmf_config_conn_for_each(config, collect, &list);
+	if (list.n != 2) {
+		printf(" - expected 2 connections, got %zu [FAIL]\n", list.n);
+		pass = false;
+	} else {
+		printf(" - two personas, two drop-ins, read back [PASS]\n");
+	}
+	libnvmf_config_free(config);
+
+	return pass;
+}
+
+static bool test_add_validation(struct libnvme_global_ctx *ctx)
+{
+	struct libnvmf_config_emitter *e;
+	bool pass = true;
+
+	printf("test_add_validation:\n");
+
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+
+	/* An I/O controller with no subsysnqn is rejected. */
+	if (libnvmf_config_emit_add(e, false, "tcp", "10.0.0.9", "4420",
+				    NULL, NULL, NULL, NULL, NULL, NULL,
+				    NULL) != -EINVAL) {
+		printf(" - IOC without nqn accepted [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - IOC without a subsysnqn rejected [PASS]\n");
+	}
+
+	/* Transport is required. */
+	if (libnvmf_config_emit_add(e, false, NULL, "10.0.0.9", "4420",
+				    "nqn.v", NULL, NULL, NULL, NULL, NULL,
+				    NULL) != -EINVAL) {
+		printf(" - missing transport accepted [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - missing transport rejected [PASS]\n");
+	}
+
+	/* Conflicting hostsymname for the same persona is rejected. */
+	assert(add(e, false, "10.0.0.9", "nqn.a", "nqn.host", g_hostid, "one",
+		   NULL, NULL) == 0);
+	if (add(e, false, "10.0.0.10", "nqn.b", "nqn.host", g_hostid, "two",
+		NULL, NULL) != -EINVAL) {
+		printf(" - conflicting hostsymname accepted [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - conflicting hostsymname rejected [PASS]\n");
+	}
+	libnvmf_config_emit_free(e);
+
+	/* A hostid without a hostnqn cannot become a valid drop-in. */
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+	if (add(e, false, "10.0.0.9", "nqn.v", NULL, g_hostid, NULL,
+		NULL, NULL) != -EINVAL) {
+		printf(" - hostid without hostnqn accepted [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - hostid without hostnqn rejected [PASS]\n");
+	}
+	libnvmf_config_emit_free(e);
+
+	/* One hostnqn must not appear with two different hostids. */
+	e = libnvmf_config_emit_new(ctx);
+	assert(e);
+	assert(add(e, false, "10.0.0.9", "nqn.a", "nqn.host", g_hostid, NULL,
+		   NULL, NULL) == 0);
+	if (add(e, false, "10.0.0.10", "nqn.b", "nqn.host",
+		"00000000-0000-0000-0000-000000000002", NULL, NULL, NULL)
+	    != -EINVAL) {
+		printf(" - one hostnqn with two hostids accepted [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - one hostnqn with two hostids rejected [PASS]\n");
+	}
+	libnvmf_config_emit_free(e);
+
+	return pass;
+}
+
+static bool test_params_set_validation(void)
+{
+	struct libnvmf_params *p = libnvmf_params_new();
+	bool pass = true;
+
+	printf("test_params_set_validation:\n");
+	assert(p);
+
+	if (libnvmf_params_set(p, "ctrl-loss-tmo", "600") ||
+	    libnvmf_params_set(p, "tls", "true") ||
+	    libnvmf_params_set(p, "reconnect-delay", "")) {
+		printf(" - valid keys rejected [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - valid tunable/security/reset keys accepted [PASS]\n");
+	}
+
+	/* Unknown key, an identity key (belongs to the TID), and a bad int. */
+	if (libnvmf_params_set(p, "no-such-key", "x") != -EINVAL ||
+	    libnvmf_params_set(p, "hostnqn", "nqn.x") != -EINVAL ||
+	    libnvmf_params_set(p, "ctrl-loss-tmo", "notanint") != -EINVAL) {
+		printf(" - invalid set accepted [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - unknown/identity/bad-value keys rejected [PASS]\n");
+	}
+
+	/* A value with an embedded newline can't survive an INI round trip. */
+	if (libnvmf_params_set(p, "dhchap-secret", "abc\ndef") != -EINVAL) {
+		printf(" - value with newline accepted [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - value with embedded newline rejected [PASS]\n");
+	}
+
+	libnvmf_params_free(p);
+
+	return pass;
+}
+
+int main(void)
+{
+	struct libnvme_global_ctx *ctx;
+	struct fixture fx;
+	bool pass = true;
+
+	ctx = libnvme_create_global_ctx();
+	assert(ctx);
+	fixture_create(&fx);
+
+	pass &= test_roundtrip(ctx, &fx);
+	fixture_wipe(&fx);
+	pass &= test_hostname_traddr_verbatim(ctx, &fx);
+	fixture_wipe(&fx);
+	pass &= test_refuse_existing(ctx, &fx);
+	fixture_wipe(&fx);
+	pass &= test_force_overwrite(ctx, &fx);
+	fixture_wipe(&fx);
+	pass &= test_all_dropins(ctx, &fx);
+	fixture_wipe(&fx);
+	pass &= test_add_validation(ctx);
+	pass &= test_params_set_validation();
+
+	fixture_destroy(&fx);
+	libnvme_free_global_ctx(ctx);
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/libnvme/test/meson.build
+++ b/libnvme/test/meson.build
@@ -215,6 +215,18 @@ if want_fabrics
 
     test('libnvme - config-api', config_api)
 
+    config_emit = executable(
+        'test-config-emit',
+        ['config-emit.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_dep,
+        ],
+    )
+
+    test('libnvme - config-emit', config_emit)
+
     uriparser = executable(
         'test-uriparser',
         ['uriparser.c'],


### PR DESCRIPTION
New code, not yet wired into anything: `libnvmf_config_emit_new/add/install()` builds and atomically installs an INI configuration tree from a flat list of (role, TID, params, persona) connections.

This exists specifically to support converting an old-format config (JSON `config.json`/`discovery.conf`) to the new INI format. Given a legacy config parsed into that flat connection list, this is the write side that turns it into a valid INI format (e.g. `nvme-fabrics.conf` + drop-ins) -- the actual JSON reader and the `nvme config convert` command that will call this are a separate, later PR.

Write-side counterpart to #3566 (merged, the read side). 