### PR TITLE
libnvme/python: add config_read() and config_validate()

### DIFF
--- a/libnvme/libnvme3/README.md
+++ b/libnvme/libnvme3/README.md
@@ -52,6 +52,37 @@ Topology can be traversed with iterators: `ctx.hosts()`, `host.subsystems()`,
 | `rescan()` | method | Rescan the controller and refresh its namespace list |
 | `registration_control(tas)` | method | Register / deregister / update with the DIM service |
 
+## Connection configuration
+
+`nvme.config_read(ctx, file=None)` reads and resolves the NVMe-oF connection configuration (`/etc/nvme/nvme-fabrics.conf` plus its `.d/` drop-ins, or `file` plus `<file>.d/`) and returns a list of dicts, one per resolved connection, in file order. An absent configuration is not an error — it yields an empty list.
+
+`trsvcid`, `host_traddr`, `host_iface`, `hostnqn`, `hostid`, `hostsymname`, and `params` are omitted from the dict entirely when unset, rather than set to `None` or an empty dict — use `.get()` or `in` to check for them.
+
+| Key | Description |
+|---|---|
+| `is_dc` | `True` for a Discovery Controller, `False` for an I/O Controller |
+| `transport`, `traddr`, `trsvcid` | Addressing. `traddr` may be a hostname — resolve before connecting |
+| `subsysnqn` | Subsystem NQN (the well-known discovery NQN for a DC with none configured) |
+| `host_traddr`, `host_iface` | Per-path host binding |
+| `hostnqn`, `hostid` | Host identity (the connect path's usual fallback applies when absent) |
+| `hostsymname` | The persona's symbolic name |
+| `source` | The file this connection came from |
+| `params` | dict of resolved connection parameters, e.g. `{'ctrl-loss-tmo': '600'}` |
+
+`nvme.config_validate(ctx, file=None)` dry-runs the same read, raising on the first error without returning a configuration. Diagnostics (file:line) are logged through `ctx`; raise `ctx.log_level('debug')` beforehand to see them.
+
+Both functions raise `OSError` on failure. This is a read-only API — there is no binding to write a configuration.
+
+```python
+from libnvme3 import nvme
+
+ctx = nvme.GlobalCtx()
+for conn in nvme.config_read(ctx):
+    kind = 'DC' if conn['is_dc'] else 'IOC'
+    print(f"{kind} {conn['transport']} {conn['traddr']}:{conn['trsvcid']} "
+          f"({conn['subsysnqn']})")
+```
+
 ## Exceptions
 All libnvme3 errors are reported through a small exception hierarchy:
 
@@ -77,8 +108,7 @@ except nvme.NotConnectedError:
     print("not connected")
 ```
 
-`NvmeError` is also raised by `get_supported_log_pages()` and
-`registration_control()` on failure.
+`NvmeError` is also raised by `get_supported_log_pages()` and `registration_control()` on failure.
 
 ## How to use
 

--- a/libnvme/libnvme3/meson.build
+++ b/libnvme/libnvme3/meson.build
@@ -96,6 +96,7 @@ if want_python
         [ 'read-nbft-file', [ files('tests/test-nbft.py'), '--filename', join_paths(meson.current_source_dir(), 'tests', 'NBFT') ] ],
         [ 'object-properties-and-errors', [ files('tests/test-objects.py'), ] ],
         [ 'registry', [ files('tests/test-registry.py'), ] ],
+        [ 'config', [ files('tests/test-config.py'), ] ],
         [ 'setattr-guards', [ files('tests/test-setattr.py'), ] ],
     ]
     foreach test: py_tests

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -85,6 +85,7 @@ PyObject *read_hostid();
 #include <ccan/list/list.h>
 #include <ccan/endian/endian.h>
 #include <libnvme.h>
+#include "nvme/cleanup.h"
 #include "nvme/private.h"
 #include "nvme/private-fabrics.h"
 #include "fctx_field_tables.h"
@@ -505,6 +506,136 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char *filename)
 	libnvmf_free_nbft(ctx, nbft);
 	return output;
 }
+
+/* ---- Config ---- */
+static void _config_collect_param(const char *key, const char *value,
+				  void *user_data)
+{
+	PyObject *val = PyUnicode_FromString(value);
+
+	if (val) {
+		PyDict_SetItemString((PyObject *)user_data, key, val);
+		Py_DECREF(val);
+	}
+}
+
+static PyObject *_config_conn_to_dict(const struct libnvmf_config_conn *conn)
+{
+	const struct libnvmf_params *params;
+	PyObject *params_dict;
+	PyObject *dict = PyDict_New();
+	const char *val;
+
+	if (!dict)
+		return NULL;
+
+	PyDict_SetItemStringDecRef(dict, "is_dc",
+				   PyBool_FromLong(libnvmf_config_conn_is_dc(conn)));
+	PyDict_SetItemStringDecRef(dict, "transport",
+				   PyUnicode_FromString(libnvmf_config_conn_get_transport(conn)));
+	PyDict_SetItemStringDecRef(dict, "traddr",
+				   PyUnicode_FromString(libnvmf_config_conn_get_traddr(conn)));
+	PyDict_SetItemStringDecRef(dict, "subsysnqn",
+				   PyUnicode_FromString(libnvmf_config_conn_get_subsysnqn(conn)));
+	PyDict_SetItemStringDecRef(dict, "source",
+				   PyUnicode_FromString(libnvmf_config_conn_get_source(conn)));
+
+	val = libnvmf_config_conn_get_trsvcid(conn);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "trsvcid", PyUnicode_FromString(val));
+
+	val = libnvmf_config_conn_get_host_traddr(conn);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "host_traddr", PyUnicode_FromString(val));
+
+	val = libnvmf_config_conn_get_host_iface(conn);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "host_iface", PyUnicode_FromString(val));
+
+	val = libnvmf_config_conn_get_hostnqn(conn);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "hostnqn", PyUnicode_FromString(val));
+
+	val = libnvmf_config_conn_get_hostid(conn);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "hostid", PyUnicode_FromString(val));
+
+	val = libnvmf_config_conn_get_hostsymname(conn);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "hostsymname", PyUnicode_FromString(val));
+
+	params = libnvmf_config_conn_get_params(conn);
+	if (params) {
+		params_dict = PyDict_New();
+		if (params_dict) {
+			libnvmf_params_for_each(params, _config_collect_param,
+						params_dict);
+			if (PyDict_Size(params_dict) > 0)
+				PyDict_SetItemStringDecRef(dict, "params", params_dict);
+			else
+				Py_DECREF(params_dict);
+		}
+	}
+
+	return dict;
+}
+
+static void _config_collect_conn(const struct libnvmf_config_conn *conn,
+				 void *user_data)
+{
+	PyObject *list = (PyObject *)user_data;
+	PyObject *dict;
+
+	if (PyErr_Occurred())
+		return;
+
+	dict = _config_conn_to_dict(conn);
+	if (dict) {
+		PyList_Append(list, dict);
+		Py_DECREF(dict);
+	}
+}
+
+static DEFINE_CLEANUP_FUNC(cleanup_libnvmf_config, struct libnvmf_config *,
+			   libnvmf_config_free)
+#define __cleanup_config __cleanup(cleanup_libnvmf_config)
+
+PyObject *config_read(struct libnvme_global_ctx *ctx, const char *file)
+{
+	__cleanup_config struct libnvmf_config *config = NULL;
+	PyObject *list;
+	int ret;
+
+	ret = libnvmf_config_read(ctx, file, &config);
+	if (ret < 0) {
+		PyErr_Format(PyExc_OSError, "config_read failed: %s",
+			     strerror(-ret));
+		return NULL;
+	}
+
+	list = PyList_New(0);
+	if (!list)
+		return NULL;
+
+	libnvmf_config_conn_for_each(config, _config_collect_conn, list);
+
+	if (PyErr_Occurred()) {
+		Py_DECREF(list);
+		return NULL;
+	}
+	return list;
+}
+
+void config_validate(struct libnvme_global_ctx *ctx, const char *file)
+{
+	int ret;
+
+	ret = libnvmf_config_validate(ctx, file);
+	if (ret < 0)
+		PyErr_Format(PyExc_OSError, "config_validate failed: %s",
+			     strerror(-ret));
+}
+
 void registry_update(struct libnvme_global_ctx *ctx,
 		     const char *device, const char *attr, const char *value)
 {
@@ -1094,6 +1225,18 @@ def exclusion_match(ctx, transport=None, traddr=None, trsvcid=None,
 		"Returns:\n"
 		"    A dict containing the NBFT data, or None on failure.") nbft_get;
 PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char *filename);
+
+%exception config_read {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+PyObject *config_read(struct libnvme_global_ctx *ctx, const char *file = NULL);
+
+%exception config_validate {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+void config_validate(struct libnvme_global_ctx *ctx, const char *file = NULL);
 
 %exception registry_update {
 	$action

--- a/libnvme/libnvme3/tests/test-config.py
+++ b/libnvme/libnvme3/tests/test-config.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Unit tests for the connection configuration read-side Python bindings
+(nvme.config_read() / nvme.config_validate()).
+
+Each test points at a throwaway file under /tmp -- the config file is reached
+by an explicit path, so no sandbox rerouting (set_test_base_dir()) is needed,
+per libnvme/design/CONFIG.md.
+"""
+import os
+import tempfile
+import unittest
+
+from libnvme3 import nvme
+
+
+def _write(path, text):
+    with open(path, 'w') as f:
+        f.write(text)
+
+
+class TestConfigRead(unittest.TestCase):
+    def setUp(self):
+        self.ctx = nvme.GlobalCtx()
+        self.tmpdir = tempfile.TemporaryDirectory(prefix='nvme-config-test-',
+                                                    dir='/tmp')
+        self.conf = os.path.join(self.tmpdir.name, 'nvme-fabrics.conf')
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        self.ctx = None
+
+    def test_absent_config_returns_empty_list(self):
+        missing = os.path.join(self.tmpdir.name, 'does-not-exist.conf')
+        self.assertEqual(nvme.config_read(self.ctx, missing), [])
+
+    def test_read_dc_and_subsystem(self):
+        _write(self.conf, """
+[Discovery Controller Defaults]
+keep-alive-tmo = 30
+ctrl-loss-tmo  = 600
+
+[I/O Controller Defaults]
+keep-alive-tmo = 5
+ctrl-loss-tmo  = 600
+
+[Host]
+hostsymname = lab-host-01
+
+[Discovery Controller]
+controller = transport=tcp;traddr=192.168.1.10;trsvcid=8009
+
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        conns = nvme.config_read(self.ctx, self.conf)
+        self.assertEqual(len(conns), 2)
+
+        dc, ioc = conns
+        self.assertTrue(dc['is_dc'])
+        self.assertEqual(dc['transport'], 'tcp')
+        self.assertEqual(dc['traddr'], '192.168.1.10')
+        self.assertEqual(dc['trsvcid'], '8009')
+        self.assertEqual(dc['subsysnqn'], 'nqn.2014-08.org.nvmexpress.discovery')
+        self.assertEqual(dc['hostsymname'], 'lab-host-01')
+        self.assertEqual(dc['source'], self.conf)
+        self.assertEqual(dc['params'], {'ctrl-loss-tmo': '600',
+                                        'keep-alive-tmo': '30'})
+
+        self.assertFalse(ioc['is_dc'])
+        self.assertEqual(ioc['subsysnqn'], 'nqn.2024-01.com.example:data.vol1')
+        self.assertEqual(ioc['params'], {'ctrl-loss-tmo': '600',
+                                         'keep-alive-tmo': '5'})
+
+    def test_unset_optional_fields_are_omitted(self):
+        _write(self.conf, """
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        conn, = nvme.config_read(self.ctx, self.conf)
+        for key in ('host_traddr', 'host_iface', 'hostnqn', 'hostid',
+                    'hostsymname', 'params'):
+            self.assertNotIn(key, conn)
+
+    def test_drop_in_adds_a_persona(self):
+        os.mkdir(self.conf + '.d')
+        _write(self.conf, """
+[Host]
+hostsymname = default-persona
+
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        _write(os.path.join(self.conf + '.d', 'prod.conf'), """
+[Host]
+hostnqn     = nqn.2014-08.org.nvmexpress:uuid:1111
+hostid      = 46ba5037-7ce5-41fa-9452-48477bf00080
+hostsymname = prod-persona
+
+[Subsystem]
+nqn        = nqn.2024-01.com.example:prod.vol1
+controller = transport=tcp;traddr=10.0.0.9;trsvcid=4420
+""")
+        conns = nvme.config_read(self.ctx, self.conf)
+        self.assertEqual(len(conns), 2)
+        self.assertEqual(conns[0]['hostsymname'], 'default-persona')
+        self.assertEqual(conns[1]['hostsymname'], 'prod-persona')
+        self.assertEqual(conns[1]['hostnqn'],
+                         'nqn.2014-08.org.nvmexpress:uuid:1111')
+        self.assertTrue(conns[1]['source'].endswith('prod.conf'))
+
+    def test_multipath_yields_one_connection_per_controller_line(self):
+        _write(self.conf, """
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=10.0.0.9;trsvcid=4420;host-iface=eth0
+controller = transport=tcp;traddr=10.0.0.10;trsvcid=4420;host-iface=eth1
+""")
+        conns = nvme.config_read(self.ctx, self.conf)
+        self.assertEqual(len(conns), 2)
+        self.assertEqual(conns[0]['host_iface'], 'eth0')
+        self.assertEqual(conns[1]['host_iface'], 'eth1')
+
+    def test_invalid_file_raises_oserror(self):
+        _write(self.conf, """
+[Subsystem]
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        with self.assertRaises(OSError):
+            nvme.config_read(self.ctx, self.conf)
+
+
+class TestConfigValidate(unittest.TestCase):
+    def setUp(self):
+        self.ctx = nvme.GlobalCtx()
+        self.tmpdir = tempfile.TemporaryDirectory(prefix='nvme-config-test-',
+                                                    dir='/tmp')
+        self.conf = os.path.join(self.tmpdir.name, 'nvme-fabrics.conf')
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        self.ctx = None
+
+    def test_validate_absent_config_returns_none(self):
+        missing = os.path.join(self.tmpdir.name, 'does-not-exist.conf')
+        self.assertIsNone(nvme.config_validate(self.ctx, missing))
+
+    def test_validate_valid_config_returns_none(self):
+        _write(self.conf, """
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        self.assertIsNone(nvme.config_validate(self.ctx, self.conf))
+
+    def test_validate_invalid_config_raises_oserror(self):
+        _write(self.conf, """
+[Subsystem]
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        with self.assertRaises(OSError):
+            nvme.config_validate(self.ctx, self.conf)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds Python bindings for the read side of the INI connection configuration API added in #3566/#3587: `config_read()` and `config_validate()`.

`config_read(ctx, file=None)` returns the resolved connection list as a list of dicts (one per connection, in file order), the same shape as `libnvmf_config_conn_for_each()`'s fields. 

`config_validate(ctx, file=None)` dry-runs the same read for diagnostics only.

Only the reader is bound -- the configuration emitter (write) API from #3587 has no Python binding here. 
