### PR TITLE
nvme-cli/fabrics: consume the INI config directly from the CLI

### DIFF
--- a/config-convert.c
+++ b/config-convert.c
@@ -475,6 +475,89 @@ static int install_converted(struct libnvmf_config_emitter *emitter,
 	return 0;
 }
 
+int nvme_config_convert_auto(struct libnvme_global_ctx *ctx,
+		const char *config_file, char **ini_path)
+{
+	struct libnvmf_config_emitter *emitter;
+	const char *json_path = config_file;
+	const char *ext;
+	bool is_default;
+	bool have_json, have_disc;
+	bool converted_json = false, converted_disc = false;
+	int ret;
+
+	*ini_path = NULL;
+
+	is_default = !strcmp(config_file, PATH_NVMF_INI);
+	if (is_default) {
+		json_path = PATH_NVMF_CONFIG;
+		*ini_path = strdup(PATH_NVMF_INI);
+	} else {
+		ext = strrchr(config_file, '.');
+		if (!ext || strcmp(ext, ".json")) {
+			*ini_path = strdup(config_file);
+			return *ini_path ? 0 : -ENOMEM;
+		}
+
+		if (asprintf(ini_path, "%.*s.conf",
+			     (int)(ext - config_file), config_file) < 0)
+			return -ENOMEM;
+	}
+	if (!*ini_path)
+		return -ENOMEM;
+
+	if (!access(*ini_path, F_OK))
+		return 0;
+
+	have_json = !access(json_path, F_OK);
+	have_disc = is_default && !access(PATH_NVMF_DISC, F_OK);
+	if (!have_json && !have_disc) {
+		/* Default path: nothing to convert is fine, proceed empty.
+		 * Custom path: never existed and never converted is a
+		 * real error, not silent-empty.
+		 */
+		if (!is_default && !already_converted(json_path)) {
+			nvme_show_error("%s: no such file", json_path);
+			return -ENOENT;
+		}
+		return 0;
+	}
+
+	emitter = libnvmf_config_emit_new(ctx);
+	if (!emitter)
+		return -ENOMEM;
+
+	if (have_json) {
+		ret = nvme_config_convert_json(emitter, json_path);
+		if (ret)
+			goto out;
+		converted_json = true;
+	}
+
+	if (have_disc) {
+		ret = nvme_config_convert_discovery(emitter, PATH_NVMF_DISC);
+		if (ret)
+			goto out;
+		converted_disc = true;
+	}
+
+	ret = install_converted(emitter, *ini_path, json_path, PATH_NVMF_DISC,
+				 converted_json, converted_disc, false);
+	if (ret)
+		goto out;
+
+	nvme_show_error(
+		"no %s found; converted legacy %s%s%s to it -- the original is renamed to *.converted, use %s from now on",
+		*ini_path, converted_json ? json_path : "",
+		(converted_json && converted_disc) ? " and " : "",
+		converted_disc ? PATH_NVMF_DISC : "", *ini_path);
+
+out:
+	libnvmf_config_emit_free(emitter);
+
+	return ret;
+}
+
 int nvme_config_convert(const char *desc, int argc, char **argv)
 {
 	char *config_file = NULL;

--- a/config-convert.h
+++ b/config-convert.h
@@ -33,6 +33,23 @@ int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
 		const struct nvmf_args *fa);
 
 /*
+ * Auto-convert on first use, called by connect-all/discover/connect
+ * before reading @config_file.
+ *
+ * @ini_path is always a fresh, caller-owned allocation, even when
+ * nothing converted. No-op if @config_file isn't a legacy ".json" or
+ * the destination already exists.
+ *
+ * The default path (@config_file == PATH_NVMF_INI) converts config.json
+ * and discovery.conf together; any other (an explicit "--config
+ * x.json") converts only that file, leaving discovery.conf alone.
+ *
+ * Prints a notice to stderr on success; stdout stays silent.
+ */
+int nvme_config_convert_auto(struct libnvme_global_ctx *ctx,
+		const char *config_file, char **ini_path);
+
+/*
  * Implement the "nvme config-convert" command.
  *
  * Convert the legacy config.json and/or discovery.conf configuration files

--- a/fabrics.c
+++ b/fabrics.c
@@ -19,7 +19,6 @@
  * Fabrics specification standard.
  */
 
-#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
@@ -58,7 +57,6 @@
 #include "logging.h"
 #include "util/sighdl.h"
 
-#define PATH_NVMF_RUNDIR	RUNDIR "/nvme"
 #define MAX_DISC_ARGS		32
 #define MAX_DISC_RETRIES	10
 
@@ -99,7 +97,7 @@ static const char *nvmf_hdr_digest	= "enable transport protocol header digest (T
 static const char *nvmf_data_digest	= "enable transport protocol data digest (TCP transport)";
 static const char *nvmf_tls		= "enable TLS";
 static const char *nvmf_concat		= "enable secure concatenation";
-static const char *nvmf_config_file	= "Use specified JSON configuration file or 'none' to disable";
+static const char *nvmf_config_file	= "Use specified INI configuration file (auto-converts a legacy .json) or 'none' to disable";
 
 #define NVMF_ARGS(n, f, ...)                                                                  \
 	NVME_ARGS(n,                                                                              \
@@ -168,12 +166,9 @@ static int setup_common_context(struct libnvmf_context *fctx,
 		struct nvmf_args *fa);
 
 struct hook_fabrics_data {
-	struct nvmf_args *fa;
 	nvme_print_flags_t flags;
 	bool quiet;
 	char *raw;
-	char **argv;
-	FILE *f;
 	bool idempotent;
 };
 
@@ -250,33 +245,6 @@ static void hook_discovery_log(struct libnvmf_context *fctx,
 		save_discovery_log(hfd->raw, log);
 	else if (!connect)
 		nvme_show_discovery_log(log, numrec, hfd->flags);
-}
-
-static int hook_parser_init(struct libnvmf_context *dctx, void *user_data)
-{
-	struct hook_fabrics_data *hfd = user_data;
-
-	hfd->f = fopen(PATH_NVMF_DISC, "r");
-	if (hfd->f == NULL) {
-		nvme_show_error("No params given and no %s", PATH_NVMF_DISC);
-		return -ENOENT;
-	}
-
-	hfd->argv = calloc(MAX_DISC_ARGS, sizeof(char *));
-	if (!hfd->argv)
-		return -1;
-
-	hfd->argv[0] = "discover";
-
-	return 0;
-}
-
-static void hook_parser_cleanup(struct libnvmf_context *fctx, void *user_data)
-{
-	struct hook_fabrics_data *hfd = user_data;
-
-	free(hfd->argv);
-	fclose(hfd->f);
 }
 
 /*
@@ -391,57 +359,131 @@ static int set_fabrics_options(struct libnvmf_context *fctx,
 	return 0;
 }
 
-static int hook_parser_next_line(struct libnvmf_context *fctx, void *user_data)
+enum consume_mode {
+	/* connect-all/discover: DC entries discover; IOC entries connect,
+	 * but only for connect-all.
+	 */
+	CONSUME_ROLE_BASED,
+	/* nvme connect -J: every entry connects directly, no discovery. */
+	CONSUME_CONNECT_ONLY,
+};
+
+struct consume_state {
+	struct libnvme_global_ctx *ctx;
+	enum consume_mode mode;
+	bool connect;
+	bool force;
+	nvme_print_flags_t flags;
+	char *raw;
+	const char *hostnqn;
+	const char *hostid;
+	int err;
+};
+
+/*
+ * Resolve traddr (if it's a hostname), settle host identity (falling back
+ * to @default_hostnqn/@default_hostid when @conn's own persona doesn't set
+ * one), then build the TID -- which doubles as validator/sanitizer:
+ * rejects a non-numeric traddr or host_traddr on tcp/rdma, canonicalizes a
+ * numeric one.
+ */
+static int build_conn_tid(const struct libnvmf_config_conn *conn,
+		const char *default_hostnqn, const char *default_hostid,
+		struct libnvmf_tid **tid)
 {
-	struct hook_fabrics_data *hfd = user_data;
-	struct nvmf_args fa;
-	char *ptr, *p;
-	static char line[4096];
-	int argc, ret = 0;
-	bool force = false;
+	const char *transport, *traddr, *hostnqn, *hostid;
+	int err;
 
-	NVMF_ARGS(opts, fa,
-		  OPT_FLAG("persistent",   'p', &persistent, "persistent discovery connection"),
-		  OPT_FLAG("force",          0, &force,      "Force persistent discovery controller creation"));
+	transport = libnvmf_config_conn_get_transport(conn);
+	traddr = libnvmf_config_conn_get_traddr(conn);
 
-	memcpy(&fa, hfd->fa, sizeof(fa));
-	do {
-		do {
-			if (fgets(line, sizeof(line), hfd->f) == NULL)
-				return -EOF;
+	/* Only traddr (remote target) may be a hostname (not host_traddr) */
+	err = nvmf_resolve_addr(transport, &traddr);
+	if (err)
+		return err;
 
-			if (line[0] == '#' || line[0] == '\n')
-				continue;
+	hostnqn = libnvmf_config_conn_get_hostnqn(conn);
+	if (!hostnqn)
+		hostnqn = default_hostnqn;
+	hostid = libnvmf_config_conn_get_hostid(conn);
+	if (!hostid)
+		hostid = default_hostid;
 
-			argc = 1;
-			p = line;
-			while ((ptr = strsep(&p, " =\n")) != NULL)
-				hfd->argv[argc++] = ptr;
-			hfd->argv[argc] = NULL;
+	*tid = libnvmf_tid_from_fields(transport, traddr,
+			libnvmf_config_conn_get_trsvcid(conn),
+			libnvmf_config_conn_get_subsysnqn(conn),
+			libnvmf_config_conn_get_host_traddr(conn),
+			libnvmf_config_conn_get_host_iface(conn),
+			hostnqn, hostid);
 
-			fa.subsysnqn = NVME_DISC_SUBSYS_NAME;
-			if (argconfig_parse(argc, hfd->argv, "config", opts))
-				continue;
-		} while (!fa.transport && !fa.traddr);
+	return *tid ? 0 : -EINVAL;
+}
 
-		if (!fa.trsvcid)
-			fa.trsvcid = libnvmf_get_default_trsvcid(fa.transport,
-								 true);
+/* libnvmf_config_conn_for_each() callback: settle addressing/identity,
+ * check exclusion, then discover or connect.
+ */
+static void consume_conn(const struct libnvmf_config_conn *conn,
+		void *user_data)
+{
+	struct consume_state *st = user_data;
+	bool is_dc = libnvmf_config_conn_is_dc(conn);
+	struct hook_fabrics_data hfd = { .flags = st->flags, .raw = st->raw };
+	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
+	__cleanup_nvmf_tid struct libnvmf_tid *tid = NULL;
+	int err;
 
-		/*
-		 * An unresolvable hostname fails only its own line; keep
-		 * connecting the remaining ones.
-		 */
-	} while (nvmf_resolve_args(&fa));
+	if (st->mode == CONSUME_ROLE_BASED && !is_dc && !st->connect)
+		return;
 
-	ret = setup_common_context(fctx, &fa);
-	if (ret)
-		return ret;
+	err = build_conn_tid(conn, st->hostnqn, st->hostid, &tid);
+	if (err)
+		goto record_err;
 
-	libnvmf_context_set_discovery_hooks(fctx, hook_discovery_log,
-		hook_parser_init, hook_parser_cleanup, hook_parser_next_line);
+	/* Auto-connect (both modes) enforces exclusion, unlike a single
+	 * explicit "nvme connect" (see fabrics_connect()'s exempt-with-note
+	 * case).
+	 */
+	if (libnvmf_exclusion_match(st->ctx, tid)) {
+		nvme_show_verbose_info("%s: on the exclusion list, skipping",
+				libnvmf_config_conn_get_source(conn));
+		return;
+	}
 
-	return 0;
+	err = libnvmf_context_create(st->ctx, hook_decide_retry, hook_connected,
+			hook_already_connected, &hfd, &fctx);
+	if (err)
+		goto record_err;
+
+	err = libnvmf_context_set_connection_from_tid(fctx, tid);
+	if (!err)
+		err = libnvmf_context_apply_params(fctx,
+				libnvmf_config_conn_get_params(conn));
+	if (err)
+		goto record_err;
+
+	if (st->mode == CONSUME_CONNECT_ONLY) {
+		err = libnvmf_connect(st->ctx, fctx);
+	} else if (is_dc) {
+		libnvmf_context_set_discovery_hooks(fctx, hook_discovery_log,
+				NULL, NULL, NULL);
+		libnvmf_context_set_default_max_discovery_retries(fctx,
+				MAX_DISC_RETRIES);
+		libnvmf_context_set_default_keep_alive_timeout(fctx,
+				NVMF_DEF_DISC_TMO);
+		err = libnvmf_discovery(st->ctx, fctx, st->connect, st->force);
+	} else {
+		err = libnvmf_connect(st->ctx, fctx);
+	}
+	if (err == -ENVME_CONNECT_ALREADY)
+		err = 0;
+
+record_err:
+	if (err) {
+		nvme_show_error("%s: %s", libnvmf_config_conn_get_source(conn),
+				libnvme_strerror(-err));
+		if (!st->err)
+			st->err = err;
+	}
 }
 
 /*
@@ -562,7 +604,7 @@ static int create_discovery_context(struct libnvme_global_ctx *ctx,
 		return err;
 
 	err = libnvmf_context_set_discovery_hooks(fctx, hook_discovery_log,
-		hook_parser_init, hook_parser_cleanup, hook_parser_next_line);
+		NULL, NULL, NULL);
 	if (err)
 		goto err;
 
@@ -580,49 +622,6 @@ static int create_discovery_context(struct libnvme_global_ctx *ctx,
 err:
 	libnvmf_context_free(fctx);
 	return err;
-}
-
-static int nvme_read_volatile_config(struct libnvme_global_ctx *ctx)
-{
-	char *filename, *ext;
-	struct dirent *dir;
-	DIR *d;
-	int ret = -ENOENT;
-
-	d = opendir(PATH_NVMF_RUNDIR);
-	if (!d)
-		return -ENOTDIR;
-
-	while ((dir = readdir(d))) {
-		if (dir->d_type != DT_REG)
-			continue;
-
-		ext = strchr(dir->d_name, '.');
-		if (!ext || strcmp("json", ext + 1))
-			continue;
-
-		if (asprintf(&filename, "%s/%s", PATH_NVMF_RUNDIR, dir->d_name) < 0) {
-			ret = -ENOMEM;
-			break;
-		}
-
-		if (libnvme_read_config(ctx, filename))
-			ret = 0;
-
-		free(filename);
-	}
-	closedir(d);
-
-	return ret;
-}
-
-static int nvme_read_config_checked(struct libnvme_global_ctx *ctx,
-				    const char *filename)
-{
-	if (access(filename, F_OK))
-		return -errno;
-
-	return libnvme_read_config(ctx, filename);
 }
 
 static void load_nvme_fabrics_module(void)
@@ -669,21 +668,82 @@ unref:
 #endif
 }
 
+/*
+ * The config-driven half of a bare "connect-all"/"discover": auto-convert
+ * a legacy file if needed, settle host identity once, then discover or
+ * connect every resolved connection in @config_file.
+ */
+static int fabrics_discovery_config(struct libnvme_global_ctx *ctx,
+		char *config_file, const char *hostnqn_arg,
+		const char *hostid_arg, bool connect, bool force,
+		nvme_print_flags_t flags)
+{
+	__cleanup_free char *ini_path = NULL;
+	__cleanup_free char *hostnqn = NULL;
+	__cleanup_free char *hostid = NULL;
+	struct libnvmf_config *cfg;
+	struct consume_state st;
+	bool is_default_config;
+	int ret;
+
+	/* Custom --config failing is fatal (explicit ask). Default path
+	 * failing isn't: boot-time connect-all must keep going.
+	 */
+	is_default_config = !strcmp(config_file, PATH_NVMF_INI);
+
+	ret = nvme_config_convert_auto(ctx, config_file, &ini_path);
+	if (ret) {
+		nvme_show_error("auto-conversion failed: %s",
+			libnvme_strerror(-ret));
+		if (!is_default_config)
+			return ret;
+	}
+	config_file = ini_path;
+
+	ret = libnvmf_host_get_ids(ctx, hostnqn_arg, hostid_arg,
+		&hostnqn, &hostid);
+	if (ret) {
+		nvme_show_error("failed to determine host identity: %s",
+			libnvme_strerror(-ret));
+		return ret;
+	}
+
+	ret = libnvmf_config_read(ctx, config_file, &cfg);
+	if (ret) {
+		nvme_show_error("failed to read %s: %s", config_file,
+			libnvme_strerror(-ret));
+		return ret;
+	}
+
+	st = (struct consume_state){
+		.ctx = ctx,
+		.mode = CONSUME_ROLE_BASED,
+		.connect = connect,
+		.force = force,
+		.flags = flags,
+		.raw = raw,
+		.hostnqn = hostnqn,
+		.hostid = hostid,
+	};
+	libnvmf_config_conn_for_each(cfg, consume_conn, &st);
+	libnvmf_config_free(cfg);
+
+	return st.err;
+}
+
 #define NBFT_SYSFS_PATH		"/sys/firmware/acpi/tables"
 
 int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 {
 	__cleanup_free char *hnqn = NULL;
 	__cleanup_free char *hid = NULL;
-	char *config_file = PATH_NVMF_CONFIG;
+	char *config_file = PATH_NVMF_INI;
 	nvme_print_flags_t flags;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 	int ret;
 	struct nvmf_args fa = { .subsysnqn = NVME_DISC_SUBSYS_NAME };
 	char *device = NULL;
 	bool force = false;
-	bool json_config = false;
 	bool nbft = false, nonbft = false;
 	char *nbft_path = NBFT_SYSFS_PATH;
 	char *owner = NULL;
@@ -742,11 +802,6 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 		}
 	}
 
-	if (!nvme_read_config_checked(ctx, config_file))
-		json_config = true;
-	if (!nvme_read_volatile_config(ctx))
-		json_config = true;
-
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret < 0) {
@@ -776,39 +831,98 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	fa.hostid = hid;
 
 	struct hook_fabrics_data dld = {
-		.fa = &fa,
 		.flags = flags,
 		.raw = raw,
 	};
-	ret = create_discovery_context(ctx, persistent, device, &fa,
-		&dld, &fctx);
-	if (ret)
-		return ret;
 
 	if (!device && !fa.transport && !fa.traddr) {
-		if (!nonbft)
-			ret = libnvmf_discovery_nbft(ctx, fctx,
-				connect, nbft_path);
-		if (nbft)
-			goto out_free;
+		if (!nonbft) {
+			__cleanup_nvmf_context
+				struct libnvmf_context *fctx = NULL;
 
-		if (json_config)
-			ret = libnvmf_discovery_config_json(ctx, fctx,
-				connect, force);
-		if (ret || access(PATH_NVMF_DISC, F_OK))
-			goto out_free;
+			ret = create_discovery_context(ctx, persistent, NULL,
+				&fa, &dld, &fctx);
+			if (ret)
+				return ret;
+			ret = libnvmf_discovery_nbft(ctx, fctx, connect,
+				nbft_path);
+		}
+		if (!nbft && config_file)
+			ret = fabrics_discovery_config(ctx, config_file,
+				fa.hostnqn, fa.hostid, connect, force, flags);
+	} else {
+		__cleanup_nvmf_context struct libnvmf_context *fctx = NULL;
 
-		ret = libnvmf_discovery_config_file(ctx, fctx, connect, force);
-		goto out_free;
+		ret = create_discovery_context(ctx, persistent, device, &fa,
+			&dld, &fctx);
+		if (ret)
+			return ret;
+		ret = libnvmf_discovery(ctx, fctx, connect, force);
 	}
 
-	ret = libnvmf_discovery(ctx, fctx, connect, force);
-
-out_free:
 	if (dump_config)
 		libnvme_dump_config(ctx, STDOUT_FILENO);
 
 	return ret;
+}
+
+/*
+ * The config-driven half of "nvme connect -J": auto-convert a legacy file
+ * if needed, settle host identity once, then connect every resolved
+ * connection in @config_file.
+ */
+static int fabrics_connect_config(struct libnvme_global_ctx *ctx,
+		char *config_file, const char *hostnqn_arg,
+		const char *hostid_arg, nvme_print_flags_t flags)
+{
+	__cleanup_free char *ini_path = NULL;
+	__cleanup_free char *hostnqn = NULL;
+	__cleanup_free char *hostid = NULL;
+	struct libnvmf_config *cfg;
+	struct consume_state st;
+	int ret;
+
+	/* Always explicit here (no implicit default read), so a
+	 * conversion failure is always fatal.
+	 */
+	ret = nvme_config_convert_auto(ctx, config_file, &ini_path);
+	if (ret) {
+		nvme_show_error("auto-conversion failed: %s",
+			libnvme_strerror(-ret));
+		return ret;
+	}
+	config_file = ini_path;
+
+	ret = libnvmf_host_get_ids(ctx, hostnqn_arg, hostid_arg,
+		&hostnqn, &hostid);
+	if (ret) {
+		nvme_show_error("failed to determine host identity: %s",
+			libnvme_strerror(-ret));
+		return ret;
+	}
+
+	ret = libnvmf_config_read(ctx, config_file, &cfg);
+	if (ret) {
+		nvme_show_error("failed to read %s: %s", config_file,
+			libnvme_strerror(-ret));
+		return ret;
+	}
+
+	st = (struct consume_state){
+		.ctx = ctx,
+		.mode = CONSUME_CONNECT_ONLY,
+		.flags = flags,
+		.raw = raw,
+		.hostnqn = hostnqn,
+		.hostid = hostid,
+	};
+	libnvmf_config_conn_for_each(cfg, consume_conn, &st);
+	libnvmf_config_free(cfg);
+
+	if (dump_config)
+		libnvme_dump_config(ctx, STDOUT_FILENO);
+
+	return st.err;
 }
 
 int fabrics_connect(const char *desc, int argc, char **argv)
@@ -849,7 +963,10 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 		return ret;
 	}
 
-	if (config_file && strcmp(config_file, "none"))
+	if (config_file && !strcmp(config_file, "none"))
+		config_file = NULL;
+
+	if (config_file)
 		goto do_connect;
 
 	if (!fa.subsysnqn) {
@@ -897,9 +1014,6 @@ do_connect:
 		}
 	}
 
-	libnvme_read_config(ctx, config_file);
-	nvme_read_volatile_config(ctx);
-
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
 	if (ret < 0) {
@@ -907,6 +1021,10 @@ do_connect:
 			libnvme_strerror(-ret));
 		return ret;
 	}
+
+	if (config_file)
+		return fabrics_connect_config(ctx, config_file, fa.hostnqn,
+			fa.hostid, flags);
 
 	ret = libnvmf_host_get_ids(ctx, fa.hostnqn, fa.hostid, &hnqn, &hid);
 	if (ret) {
@@ -929,9 +1047,6 @@ do_connect:
 
 	if (devid_file)
 		libnvmf_context_set_devid_file(fctx, devid_file);
-
-	if (config_file)
-		return libnvmf_connect_config_json(ctx, fctx);
 
 	/*
 	 * The exclusion list governs auto-connecting orchestrators, not an

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -31,6 +31,7 @@ LIBNVMF_3 {
 		libnvmf_connect_args_emit;
 		libnvmf_connect_config_json;
 		libnvmf_connect_ctrl;
+		libnvmf_context_apply_params;
 		libnvmf_context_create;
 		libnvmf_context_free;
 		libnvmf_context_set_connection;

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -35,6 +35,7 @@ LIBNVMF_3 {
 		libnvmf_context_create;
 		libnvmf_context_free;
 		libnvmf_context_set_connection;
+		libnvmf_context_set_connection_from_tid;
 		libnvmf_context_set_crypto;
 		libnvmf_context_set_device;
 		libnvmf_context_set_devid_file;
@@ -71,11 +72,11 @@ LIBNVMF_3 {
 		libnvmf_generate_hostid;
 		libnvmf_generate_hostnqn;
 		libnvmf_generate_hostnqn_from_hostid;
-		libnvmf_host_get_ids;
 		libnvmf_generate_tls_key_identity;
 		libnvmf_generate_tls_key_identity_compat;
 		libnvmf_get_default_trsvcid;
 		libnvmf_get_discovery_log;
+		libnvmf_host_get_ids;
 		libnvmf_import_tls_key;
 		libnvmf_import_tls_key_versioned;
 		libnvmf_insert_tls_key;

--- a/libnvme/src/nvme/config.c
+++ b/libnvme/src/nvme/config.c
@@ -18,14 +18,17 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <nvme/config.h>
+#include <nvme/fabrics.h>
 #include <nvme/tid.h>
 
 #include <ccan/list/list.h>
 
 #include "compiler-attributes.h"
 #include "config-ini.h"
+#include "private-fabrics.h"
 
 __libnvme_public int libnvmf_config_read(struct libnvme_global_ctx *ctx,
 		const char *file, struct libnvmf_config **out)
@@ -243,4 +246,107 @@ __libnvme_public int libnvmf_connect_args_emit(const struct libnvmf_tid *tid,
 		libnvmf_params_for_each(params, emit_param, &state);
 
 	return state.err;
+}
+
+struct apply_state {
+	struct libnvmf_context *fctx;
+};
+
+static void apply_param(const char *key, const char *value, void *user_data)
+{
+	struct apply_state *state = user_data;
+	struct libnvmf_context *fctx = state->fctx;
+	struct libnvme_fabrics_config *cfg = &fctx->ctrl_params.cfg;
+	bool bval;
+
+	/* An explicit reset (the empty string) is left unapplied -- @cfg
+	 * keeps whatever it already had. That's usually zero; a couple of
+	 * fields get a library-chosen default from libnvmf_default_config()
+	 * instead, not anything from the kernel.
+	 */
+	if (!*value)
+		return;
+
+	/* base 0 matches check_int()'s parsing in config-ini.c. */
+	if (!strcmp(key, "nr-io-queues"))
+		cfg->nr_io_queues = strtol(value, NULL, 0);
+	else if (!strcmp(key, "nr-write-queues"))
+		cfg->nr_write_queues = strtol(value, NULL, 0);
+	else if (!strcmp(key, "nr-poll-queues"))
+		cfg->nr_poll_queues = strtol(value, NULL, 0);
+	else if (!strcmp(key, "queue-size"))
+		cfg->queue_size = strtol(value, NULL, 0);
+	else if (!strcmp(key, "keep-alive-tmo"))
+		/* Applied verbatim; set_discovery_kato() may still
+		 * override it at connect time for persistent discovery
+		 * controllers.
+		 */
+		cfg->keep_alive_tmo = strtol(value, NULL, 0);
+	else if (!strcmp(key, "reconnect-delay"))
+		cfg->reconnect_delay = strtol(value, NULL, 0);
+	else if (!strcmp(key, "ctrl-loss-tmo"))
+		cfg->ctrl_loss_tmo = strtol(value, NULL, 0);
+	else if (!strcmp(key, "fast-io-fail-tmo"))
+		cfg->fast_io_fail_tmo = strtol(value, NULL, 0);
+	else if (!strcmp(key, "tos"))
+		cfg->tos = strtol(value, NULL, 0);
+	else if (!strcmp(key, "duplicate-connect")) {
+		if (!libnvmf_parse_bool(value, &bval))
+			cfg->duplicate_connect = bval;
+	} else if (!strcmp(key, "disable-sqflow")) {
+		if (!libnvmf_parse_bool(value, &bval))
+			cfg->disable_sqflow = bval;
+	} else if (!strcmp(key, "hdr-digest")) {
+		if (!libnvmf_parse_bool(value, &bval))
+			cfg->hdr_digest = bval;
+	} else if (!strcmp(key, "data-digest")) {
+		if (!libnvmf_parse_bool(value, &bval))
+			cfg->data_digest = bval;
+	} else if (!strcmp(key, "tls")) {
+		if (!libnvmf_parse_bool(value, &bval))
+			cfg->tls = bval;
+	} else if (!strcmp(key, "concat")) {
+		if (!libnvmf_parse_bool(value, &bval))
+			cfg->concat = bval;
+	}
+	/* Identity/addressing and crypto keys never reach here -- only
+	 * tunable keys are handled in this loop. Crypto keys are read
+	 * directly in libnvmf_context_apply_params(), via
+	 * libnvmf_config_conn_get_params().
+	 */
+}
+
+/* Same "an explicit reset is left unapplied" rule apply_param() uses for
+ * the tunable keys, applied here to a direct libnvmf_params_get() lookup.
+ */
+static const char *get_param_nonempty(const struct libnvmf_params *params,
+		const char *key)
+{
+	const char *value = libnvmf_params_get(params, key);
+
+	return (value && *value) ? value : NULL;
+}
+
+__libnvme_public int libnvmf_context_apply_params(struct libnvmf_context *fctx,
+		const struct libnvmf_params *params)
+{
+	struct apply_state state = { .fctx = fctx };
+	const char *hostkey, *ctrlkey, *keyring, *tls_key, *tls_key_identity;
+
+	if (!fctx || !params)
+		return -EINVAL;
+
+	libnvmf_params_for_each(params, apply_param, &state);
+
+	hostkey = get_param_nonempty(params, "dhchap-secret");
+	ctrlkey = get_param_nonempty(params, "dhchap-ctrl-secret");
+	keyring = get_param_nonempty(params, "keyring");
+	tls_key = get_param_nonempty(params, "tls-key");
+	tls_key_identity = get_param_nonempty(params, "tls-key-identity");
+
+	if (hostkey || ctrlkey || keyring || tls_key || tls_key_identity)
+		return libnvmf_context_set_crypto(fctx, hostkey, ctrlkey,
+				keyring, tls_key, tls_key_identity);
+
+	return 0;
 }

--- a/libnvme/src/nvme/config.h
+++ b/libnvme/src/nvme/config.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 
 struct libnvme_global_ctx;
+struct libnvmf_context;
 struct libnvmf_tid;
 
 /**
@@ -302,6 +303,21 @@ int libnvmf_connect_args_emit(const struct libnvmf_tid *tid,
 		const struct libnvmf_params *params,
 		void (*callback)(const char *arg, void *user_data),
 		void *user_data);
+
+/**
+ * libnvmf_context_apply_params() - apply a parameter set to a connect
+ * context.
+ * @fctx:   fabrics context to update
+ * @params: a resolved parameter set
+ *
+ * Applies every set key via its typed setter. An unset key is left
+ * untouched, and an explicit reset (empty string) is skipped, since
+ * @fctx already carries the kernel default either way.
+ *
+ * Return: 0 on success, -EINVAL if @fctx or @params is NULL.
+ */
+int libnvmf_context_apply_params(struct libnvmf_context *fctx,
+		const struct libnvmf_params *params);
 
 /**
  * struct libnvmf_config_emitter - Configuration emitter.

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -660,6 +660,22 @@ __libnvme_public int libnvmf_context_set_hostnqn(struct libnvmf_context *fctx,
 	return 0;
 }
 
+__libnvme_public int libnvmf_context_set_connection_from_tid(
+		struct libnvmf_context *fctx, const struct libnvmf_tid *tid)
+{
+	if (!fctx || !tid)
+		return -EINVAL;
+
+	fctx->ctrl_params.subsysnqn = tid->subsysnqn;
+	fctx->ctrl_params.transport = tid->transport;
+	fctx->ctrl_params.traddr = tid->traddr;
+	fctx->ctrl_params.trsvcid = tid->trsvcid;
+	fctx->ctrl_params.host_traddr = tid->host_traddr;
+	fctx->ctrl_params.host_iface = tid->host_iface;
+
+	return libnvmf_context_set_hostnqn(fctx, tid->hostnqn, tid->hostid);
+}
+
 __libnvme_public int libnvmf_context_set_crypto(struct libnvmf_context *fctx,
 		const char *hostkey, const char *ctrlkey,
 		const char *keyring, const char *tls_key,

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -29,6 +29,7 @@
  * operations.
  */
 struct libnvmf_context;
+struct libnvmf_tid;
 
 /**
  * libnvmf_generate_hostnqn() - Generate a machine specific host nqn
@@ -426,6 +427,20 @@ int libnvmf_context_set_connection(struct libnvmf_context *fctx,
  */
 int libnvmf_context_set_hostnqn(struct libnvmf_context *fctx,
 		const char *hostnqn, const char *hostid);
+
+/**
+ * libnvmf_context_set_connection_from_tid() - Set connection and identity
+ * from a TID
+ * @fctx: Fabrics context
+ * @tid:  Transport ID to copy from
+ *
+ * Equivalent to libnvmf_context_set_connection() followed by
+ * libnvmf_context_set_hostnqn(), reading every field from @tid.
+ *
+ * Return: 0 on success, -EINVAL if @fctx or @tid is NULL.
+ */
+int libnvmf_context_set_connection_from_tid(struct libnvmf_context *fctx,
+		const struct libnvmf_tid *tid);
 
 /**
  * libnvmf_context_set_crypto() - Set cryptographic parameters for context

--- a/libnvme/test/config-api.c
+++ b/libnvme/test/config-api.c
@@ -564,6 +564,67 @@ out:
 	return pass;
 }
 
+static bool test_set_connection_from_tid(struct libnvme_global_ctx *ctx)
+{
+	struct libnvmf_context *fctx;
+	struct libnvmf_tid *tid;
+	bool pass = true;
+
+	printf("test_set_connection_from_tid:\n");
+
+	tid = libnvmf_tid_from_fields("tcp", "10.0.0.9", "4420",
+			"nqn.2014-08.org.nvmexpress:subsys",
+			"10.0.0.1", "eth0",
+			"nqn.2014-08.org.nvmexpress:host",
+			"2cd2c43b-a90a-45c1-a8cd-86b33ab273b5");
+	assert(tid);
+
+	assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
+
+	if (libnvmf_context_set_connection_from_tid(fctx, tid)) {
+		printf(" - set failed [FAIL]\n");
+		pass = false;
+		goto out;
+	}
+
+	if (strcmp(libnvmf_context_get_transport(fctx), "tcp") ||
+	    strcmp(libnvmf_context_get_traddr(fctx), "10.0.0.9") ||
+	    strcmp(libnvmf_context_get_trsvcid(fctx), "4420") ||
+	    strcmp(libnvmf_context_get_subsysnqn(fctx),
+		   "nqn.2014-08.org.nvmexpress:subsys") ||
+	    strcmp(libnvmf_context_get_host_traddr(fctx), "10.0.0.1") ||
+	    strcmp(libnvmf_context_get_host_iface(fctx), "eth0")) {
+		printf(" - addressing fields [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - addressing fields applied [PASS]\n");
+	}
+
+	if (strcmp(libnvmf_context_get_hostnqn(fctx),
+		   "nqn.2014-08.org.nvmexpress:host") ||
+	    strcmp(libnvmf_context_get_hostid(fctx),
+		   "2cd2c43b-a90a-45c1-a8cd-86b33ab273b5")) {
+		printf(" - identity fields [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - identity fields applied [PASS]\n");
+	}
+
+out:
+	if (libnvmf_context_set_connection_from_tid(NULL, tid) != -EINVAL ||
+	    libnvmf_context_set_connection_from_tid(fctx, NULL) != -EINVAL) {
+		printf(" - NULL rejected [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - NULL rejected [PASS]\n");
+	}
+
+	libnvmf_context_free(fctx);
+	libnvmf_tid_free(tid);
+
+	return pass;
+}
+
 static bool test_edge_cases(struct libnvme_global_ctx *ctx,
 			    const struct fixture *fx)
 {
@@ -641,6 +702,7 @@ int main(void)
 	pass &= test_validate(ctx, &fx);
 	pass &= test_emit(ctx, &fx);
 	pass &= test_apply_params(ctx);
+	pass &= test_set_connection_from_tid(ctx);
 	pass &= test_edge_cases(ctx, &fx);
 
 	fixture_destroy(&fx);

--- a/libnvme/test/config-api.c
+++ b/libnvme/test/config-api.c
@@ -23,6 +23,7 @@
 
 #include <nvme/lib.h>
 #include <nvme/config.h>
+#include <nvme/fabrics.h>
 #include <nvme/nvme-types-fabrics.h>
 #include <nvme/tid.h>
 
@@ -469,6 +470,100 @@ static bool test_emit(struct libnvme_global_ctx *ctx, const struct fixture *fx)
 	return pass;
 }
 
+/* Built ad hoc, not from the fixture files, to cover every key class in
+ * one pass: ints, bools, an explicit reset, and the five crypto keys
+ * that share one setter.
+ */
+static bool test_apply_params(struct libnvme_global_ctx *ctx)
+{
+	struct libnvmf_context *fctx;
+	struct libnvmf_params *params;
+	bool pass = true;
+
+	printf("test_apply_params:\n");
+
+	params = libnvmf_params_new();
+	assert(params);
+	/* Hex, matching check_int()'s own base-0 parsing (config-ini.c). */
+	assert(!libnvmf_params_set(params, "nr-io-queues", "0x10"));
+	assert(!libnvmf_params_set(params, "keep-alive-tmo", "30"));
+	assert(!libnvmf_params_set(params, "tls", "true"));
+	assert(!libnvmf_params_set(params, "hdr-digest", "false"));
+	/* Explicit resets: must be skipped, not applied as "0". */
+	assert(!libnvmf_params_set(params, "tos", ""));
+	assert(!libnvmf_params_set(params, "ctrl-loss-tmo", ""));
+	/* The five crypto keys: one shared setter, must not clobber. */
+	assert(!libnvmf_params_set(params, "keyring", "my-keyring"));
+	assert(!libnvmf_params_set(params, "tls-key", "deadbeef"));
+	assert(!libnvmf_params_set(params, "tls-key-identity",
+				    "NVMe1R02 my-id"));
+	assert(!libnvmf_params_set(params, "dhchap-secret", "DHHC-1:00:host:"));
+	assert(!libnvmf_params_set(params, "dhchap-ctrl-secret",
+				    "DHHC-1:00:ctrl:"));
+
+	assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
+
+	if (libnvmf_context_apply_params(fctx, params)) {
+		printf(" - apply failed [FAIL]\n");
+		pass = false;
+		goto out;
+	}
+
+	if (libnvmf_context_get_nr_io_queues(fctx) != 0x10 ||
+	    libnvmf_context_get_keep_alive_tmo(fctx) != 30) {
+		printf(" - int fields (hex + decimal) [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - int fields applied (hex + decimal) [PASS]\n");
+	}
+
+	if (!libnvmf_context_get_tls(fctx) ||
+	    libnvmf_context_get_hdr_digest(fctx)) {
+		printf(" - bool fields [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - bool fields applied [PASS]\n");
+	}
+
+	/* A fresh context starts at tos=-1, ctrl-loss-tmo=600 (see
+	 * libnvmf_default_config()); a reset must leave both untouched,
+	 * not overwrite them with 0.
+	 */
+	if (libnvmf_context_get_tos(fctx) != -1 ||
+	    libnvmf_context_get_ctrl_loss_tmo(fctx) != NVMF_DEF_CTRL_LOSS_TMO) {
+		printf(" - reset skipped, library default kept [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - reset skipped, library default kept [PASS]\n");
+	}
+
+	if (strcmp(libnvmf_context_get_keyring(fctx), "my-keyring") ||
+	    strcmp(libnvmf_context_get_tls_key(fctx), "deadbeef") ||
+	    strcmp(libnvmf_context_get_tls_key_identity(fctx),
+		   "NVMe1R02 my-id") ||
+	    strcmp(libnvmf_context_get_hostkey(fctx), "DHHC-1:00:host:") ||
+	    strcmp(libnvmf_context_get_ctrlkey(fctx), "DHHC-1:00:ctrl:")) {
+		printf(" - crypto fields (shared setter, no clobber) [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - crypto fields (shared setter, no clobber) [PASS]\n");
+	}
+
+out:
+	if (libnvmf_context_apply_params(NULL, params) != -EINVAL ||
+	    libnvmf_context_apply_params(fctx, NULL) != -EINVAL) {
+		printf(" - NULL rejected [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - NULL rejected [PASS]\n");
+	}
+
+	libnvmf_context_free(fctx);
+	libnvmf_params_free(params);
+
+	return pass;
+}
+
 static bool test_edge_cases(struct libnvme_global_ctx *ctx,
 			    const struct fixture *fx)
 {
@@ -545,6 +640,7 @@ int main(void)
 	pass &= test_resolve_discovered(ctx, &fx);
 	pass &= test_validate(ctx, &fx);
 	pass &= test_emit(ctx, &fx);
+	pass &= test_apply_params(ctx);
 	pass &= test_edge_cases(ctx, &fx);
 
 	fixture_destroy(&fx);

--- a/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
@@ -2,6 +2,8 @@
 Description=Connect NVMe-oF subsystems automatically during boot
 ConditionPathExists=|@SYSCONFDIR@/nvme/config.json
 ConditionPathExists=|@SYSCONFDIR@/nvme/discovery.conf
+ConditionPathExists=|@SYSCONFDIR@/nvme/nvme-fabrics.conf
+ConditionDirectoryNotEmpty=|@SYSCONFDIR@/nvme/nvme-fabrics.conf.d
 Wants=modprobe@nvme_fabrics.service
 After=modprobe@nvme_fabrics.service
 After=network-online.target

--- a/util/cleanup.h
+++ b/util/cleanup.h
@@ -63,6 +63,12 @@ static inline void cleanup_nvmf_context(struct libnvmf_context **fctx)
 	libnvmf_context_free(*fctx);
 }
 #define __cleanup_nvmf_context __cleanup(cleanup_nvmf_context)
+
+static inline void cleanup_nvmf_tid(struct libnvmf_tid **tid)
+{
+	libnvmf_tid_free(*tid);
+}
+#define __cleanup_nvmf_tid __cleanup(cleanup_nvmf_tid)
 #endif
 
 static inline DEFINE_CLEANUP_FUNC(cleanup_file, FILE *, fclose)


### PR DESCRIPTION
## Summary

- Add `libnvmf_context_apply_params()`, a table-driven helper that applies a resolved parameter set (from INI) to a connect context (fctx).
- Switch `connect-all`/`discover`/`connect -J` to read the INI configuration directly and iterate connections in the CLI itself, instead of going through libnvme's JSON config loops. Hostname resolution and hostnqn/hostid selection are policy decisions and now live in the CLI. The CLI enforces the exclusion list on every auto-connected entry.
- Old style config (config.json, discovery.conf) automatically converted to INI on first invocation.
- Retire the `/run/nvme` volatile-config reader and the discovery.conf line-parser hooks: nothing reads the former, and the INI config replaces the latter's only caller.

First slice of moving nvme-cli off the legacy JSON config path onto the INI config from #3566/#3587/#3590/#3591. Self-contained: `-O`/`--dump-config`, `nvme config`'s `-M`/`-R`/`-U`, and the now-unused JSON loops in libnvme are untouched here, addressed in follow-up PRs.

## Test plan

- [x] `meson test -C .build` — 86/86 passing
- [x] `make checkpatch` — 0 errors
- [x] Each commit builds standalone
- [x] Manual: `nvme connect -J <ini-file>`, `nvme discover`, `nvme connect-all` against scratch INI configs (default path, custom `-J`, legacy-JSON auto-convert), under valgrind — no leaks
