### PR TITLE
libnvme: fix regressions from the implicit host-lookup removal

### DIFF
--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -175,10 +175,10 @@ typedef struct { const char *key; const char **val; } str_fields_t;
  */
 static int set_fctx_host_params(struct libnvme_global_ctx *ctx,
 				struct libnvmf_context *fctx,
+				const char *transport,
 				PyObject *dict)
 {
 	const char *hostnqn = NULL, *hostid = NULL;
-	char *hnqn = NULL, *hid = NULL;
 	const char *hostkey = NULL, *ctrlkey = NULL;
 	const char *keyring = NULL, *tls_key = NULL, *tls_key_identity = NULL;
 	int err;
@@ -202,16 +202,52 @@ static int set_fctx_host_params(struct libnvme_global_ctx *ctx,
 	for (p = tbl; p->key; p++)
 		*p->val = dict_get_str(dict, p->key);
 
-	err = libnvmf_host_get_ids(ctx, hostnqn, hostid, &hnqn, &hid);
-	if (err) {
-		raise_nvme(NvmeError, err);
+	/* Fall back to the ctx default only when the dict supplies neither
+	 * field. Never splice a dict-given hostnqn with a ctx-default
+	 * hostid (or vice versa) -- that pairing was never validated
+	 * together. This mirrors the Host() constructor's use of the ctx
+	 * default; neither does the full lookup-and-generate chain here:
+	 * unlike scan_topology(), constructing a fabrics context is exactly
+	 * the caller-facing policy decision libnvmf_host_get_ids() exists
+	 * to keep out of the library.
+	 */
+	if (!hostnqn && !hostid) {
+		hostnqn = ctx->hostnqn;
+		hostid = ctx->hostid;
+	}
+
+	/* PCIe (and apple-nvme) have no host identity concept -- a fabrics
+	 * transport is a policy decision the caller must have already made
+	 * by the time it constructs a Ctrl, not something to discover only
+	 * when connect()/discover() is later called on it.
+	 */
+	if (!hostnqn && libnvme_transport_is_fabric(transport)) {
+		PyErr_Format(PyExc_ValueError,
+			"transport '%s' requires a hostnqn (set it in the "
+			"dict, or as GlobalCtx.hostnqn)", transport);
 		return -1;
 	}
 
-	libnvmf_context_set_hostnqn(fctx, hnqn, hid);
+	if (hostnqn || hostid) {
+		bool hostid_missing = !hostid;
 
-	free(hnqn);
-	free(hid);
+		err = libnvmf_context_set_hostnqn(fctx, hostnqn, hostid);
+		if (err) {
+			/* The only way this specific combination fails is a
+			 * hostid that can't be derived from hostnqn (it's
+			 * only derivable from a uuid:-form hostnqn) -- say so,
+			 * instead of surfacing the bare errno from below.
+			 */
+			if (hostid_missing && hostnqn)
+				PyErr_Format(PyExc_ValueError,
+					"hostid not given and could not be "
+					"derived from hostnqn '%s' (expected "
+					"a uuid: suffix)", hostnqn);
+			else
+				raise_nvme(NvmeError, err);
+			return -1;
+		}
+	}
 
 	if (hostkey || ctrlkey || keyring || tls_key || tls_key_identity)
 		libnvmf_context_set_crypto(fctx, hostkey, ctrlkey, keyring,
@@ -251,7 +287,7 @@ static int set_fctx_from_dict(struct libnvme_global_ctx *ctx,
 				       dict_get_str(dict, "host_traddr"),
 				       dict_get_str(dict, "host_iface"));
 
-	if (set_fctx_host_params(ctx, fctx, dict))
+	if (set_fctx_host_params(ctx, fctx, transport, dict))
 		return -1;
 	set_fctx_fabrics_config(fctx, dict);
 

--- a/libnvme/libnvme3/tests/create-ctrl-obj.py
+++ b/libnvme/libnvme3/tests/create-ctrl-obj.py
@@ -6,6 +6,9 @@ from libnvme3 import nvme
 
 ctx = nvme.GlobalCtx()
 ctx.log_level('debug')
+(hostnqn, hostid) = nvme.host_get_ids(ctx)
+ctx.hostnqn = hostnqn
+ctx.hostid = hostid
 
 ctrl = nvme.Ctrl(ctx, {
     'subsysnqn': nvme.NVME_DISC_SUBSYS_NAME,

--- a/libnvme/libnvme3/tests/test-objects.py
+++ b/libnvme/libnvme3/tests/test-objects.py
@@ -125,6 +125,9 @@ class TestCtrl(unittest.TestCase):
 
     def setUp(self):
         self.ctx = nvme.GlobalCtx()
+        (hostnqn, hostid) = nvme.host_get_ids(self.ctx)
+        self.ctx.hostnqn = hostnqn
+        self.ctx.hostid = hostid
         self.subsysnqn = nvme.NVME_DISC_SUBSYS_NAME
 
     def tearDown(self):
@@ -288,6 +291,9 @@ class TestCtrlErrorHandling(unittest.TestCase):
 
     def setUp(self):
         self.ctx = nvme.GlobalCtx()
+        (hostnqn, hostid) = nvme.host_get_ids(self.ctx)
+        self.ctx.hostnqn = hostnqn
+        self.ctx.hostid = hostid
         self.ctrl = nvme.Ctrl(self.ctx, {
             'subsysnqn': nvme.NVME_DISC_SUBSYS_NAME,
             'transport': 'loop',

--- a/libnvme/libnvme3/tests/test-setattr.py
+++ b/libnvme/libnvme3/tests/test-setattr.py
@@ -12,6 +12,9 @@ class TestCtrlSetattr(unittest.TestCase):
 
     def setUp(self):
         self.ctx = nvme.GlobalCtx()
+        (hostnqn, hostid) = nvme.host_get_ids(self.ctx)
+        self.ctx.hostnqn = hostnqn
+        self.ctx.hostid = hostid
         self.ctrl = nvme.Ctrl(self.ctx, {
             'subsysnqn': nvme.NVME_DISC_SUBSYS_NAME,
             'transport': 'loop',
@@ -41,6 +44,9 @@ class TestCtrlDictValidation(unittest.TestCase):
 
     def setUp(self):
         self.ctx = nvme.GlobalCtx()
+        (hostnqn, hostid) = nvme.host_get_ids(self.ctx)
+        self.ctx.hostnqn = hostnqn
+        self.ctx.hostid = hostid
 
     def test_unknown_dict_key_raises(self):
         """An unknown key in the constructor dict must raise KeyError."""

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -178,6 +178,7 @@ LIBNVME_3 {
 		libnvme_transport_handle_set_submit_entry;
 		libnvme_transport_handle_set_submit_exit;
 		libnvme_transport_handle_set_timeout;
+		libnvme_transport_is_fabric;
 		libnvme_unlink_ctrl;
 		libnvme_update_block_size;
 		libnvme_uuid_from_string;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -306,6 +306,9 @@ static char *nvmf_read_file(const char *f, int len)
 
 __libnvme_public char *libnvmf_read_hostnqn(struct libnvme_global_ctx *ctx)
 {
+	if (!ctx)
+		return NULL;
+
 	if (ctx->hostnqn) {
 		if (!strcmp(ctx->hostnqn, ""))
 			return NULL;
@@ -317,6 +320,9 @@ __libnvme_public char *libnvmf_read_hostnqn(struct libnvme_global_ctx *ctx)
 
 __libnvme_public char *libnvmf_read_hostid(struct libnvme_global_ctx *ctx)
 {
+	if (!ctx)
+		return NULL;
+
 	if (ctx->hostid) {
 		if (!strcmp(ctx->hostid, ""))
 			return NULL;
@@ -334,6 +340,9 @@ __libnvme_public int libnvmf_host_get_ids(struct libnvme_global_ctx *ctx,
 	__cleanup_free char *hid = NULL;
 	__cleanup_free char *hnqn = NULL;
 	libnvme_host_t h;
+
+	if (!ctx)
+		return -EINVAL;
 
 	/* command line argumments */
 	if (hostid_arg)

--- a/libnvme/src/nvme/private-tree.h
+++ b/libnvme/src/nvme/private-tree.h
@@ -27,6 +27,13 @@ static inline void cleanup_dirents(struct dirents *ents)
 #define FREE_CTRL_ATTR(a) \
 	do { free(a); (a) = NULL; } while (0)
 
+/* Placeholder identity for a controller with none of its own (e.g.
+ * PCIe) -- fixed, not resolved/generated, so it's deterministic.
+ */
+#define NVME_DEFAULT_HOSTNQN \
+	"nqn.2014-08.org.nvmexpress:uuid:00000000-0000-0000-0000-000000000000"
+#define NVME_DEFAULT_HOSTID "00000000-0000-0000-0000-000000000000"
+
 char *libnvme_hostid_from_hostnqn(const char *hostnqn);
 
 int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -208,6 +208,16 @@ __libnvme_public int libnvme_get_host(
 {
 	struct libnvme_host *h;
 
+	/*
+	 * No sysfs identity (e.g. PCIe) and no ctx default: use a fixed
+	 * placeholder rather than resolving/generating one -- that's a
+	 * policy call for the caller, not us. Matches tree-win.c.
+	 */
+	if (!hostnqn)
+		hostnqn = NVME_DEFAULT_HOSTNQN;
+	if (!hostid)
+		hostid = NVME_DEFAULT_HOSTID;
+
 	h = libnvme_lookup_host(ctx, hostnqn, hostid);
 	if (!h)
 		return -ENOMEM;

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -202,32 +202,6 @@ __libnvme_public char *libnvme_get_path_attr(libnvme_path_t p, const char *attr)
 	return libnvme_get_attr(libnvme_path_get_sysfs_dir(p), attr);
 }
 
-__libnvme_public int libnvme_get_host(
-		struct libnvme_global_ctx *ctx, const char *hostnqn,
-		const char *hostid, libnvme_host_t *host)
-{
-	struct libnvme_host *h;
-
-	/*
-	 * No sysfs identity (e.g. PCIe) and no ctx default: use a fixed
-	 * placeholder rather than resolving/generating one -- that's a
-	 * policy call for the caller, not us. Matches tree-win.c.
-	 */
-	if (!hostnqn)
-		hostnqn = NVME_DEFAULT_HOSTNQN;
-	if (!hostid)
-		hostid = NVME_DEFAULT_HOSTID;
-
-	h = libnvme_lookup_host(ctx, hostnqn, hostid);
-	if (!h)
-		return -ENOMEM;
-
-	libnvme_host_set_hostsymname(h, NULL);
-
-	*host = h;
-	return 0;
-}
-
 __libnvme_public const char *libnvme_ctrl_get_state(libnvme_ctrl_t c)
 {
 	char *state = c->state;

--- a/libnvme/src/nvme/tree-win.c
+++ b/libnvme/src/nvme/tree-win.c
@@ -115,27 +115,6 @@ int libnvme_reconfigure_ctrl(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-__libnvme_public int libnvme_get_host(struct libnvme_global_ctx *ctx,
-		const char *hostnqn, const char *hostid, libnvme_host_t *host)
-{
-	struct libnvme_host *h;
-
-	/* Same fallback as tree-linux.c's libnvme_get_host(). */
-	if (!hostnqn)
-		hostnqn = NVME_DEFAULT_HOSTNQN;
-	if (!hostid)
-		hostid = NVME_DEFAULT_HOSTID;
-
-	h = libnvme_lookup_host(ctx, hostnqn, hostid);
-	if (!h)
-		return -ENOMEM;
-
-	libnvme_host_set_hostsymname(h, NULL);
-
-	*host = h;
-	return 0;
-}
-
 __libnvme_public const char *libnvme_ctrl_get_state(libnvme_ctrl_t c)
 {
 	char *state = c->state;

--- a/libnvme/src/nvme/tree-win.c
+++ b/libnvme/src/nvme/tree-win.c
@@ -118,28 +118,15 @@ int libnvme_reconfigure_ctrl(struct libnvme_global_ctx *ctx,
 __libnvme_public int libnvme_get_host(struct libnvme_global_ctx *ctx,
 		const char *hostnqn, const char *hostid, libnvme_host_t *host)
 {
-	__cleanup_free char *hnqn = NULL;
-	__cleanup_free char *hid = NULL;
 	struct libnvme_host *h;
 
-	/* Use provided values or generate defaults */
-	if (hostnqn)
-		hnqn = strdup(hostnqn);
-	else
-		hnqn = strdup("nqn.2014-08.org.nvmexpress:uuid:00000000-0000-0000-0000-000000000000");
+	/* Same fallback as tree-linux.c's libnvme_get_host(). */
+	if (!hostnqn)
+		hostnqn = NVME_DEFAULT_HOSTNQN;
+	if (!hostid)
+		hostid = NVME_DEFAULT_HOSTID;
 
-	if (!hnqn)
-		return -ENOMEM;
-
-	if (hostid)
-		hid = strdup(hostid);
-	else
-		hid = strdup("00000000-0000-0000-0000-000000000000");
-
-	if (!hid)
-		return -ENOMEM;
-
-	h = libnvme_lookup_host(ctx, hnqn, hid);
+	h = libnvme_lookup_host(ctx, hostnqn, hostid);
 	if (!h)
 		return -ENOMEM;
 

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1504,11 +1504,16 @@ int libnvme_ctrl_scan_namespaces(struct libnvme_global_ctx *ctx,
  * Fabrics = any transport that is not a known local one (pcie/apple-nvme).
  * Testing by exclusion means a newly added transport defaults to fabrics.
  */
+__libnvme_public bool libnvme_transport_is_fabric(const char *transport)
+{
+	return transport &&
+	       strcmp(transport, "pcie") &&
+	       strcmp(transport, "apple-nvme");
+}
+
 __libnvme_public bool libnvme_ctrl_is_transport_fabric(libnvme_ctrl_t c)
 {
-	return c && c->transport &&
-	       strcmp(c->transport, "pcie") &&
-	       strcmp(c->transport, "apple-nvme");
+	return c && libnvme_transport_is_fabric(c->transport);
 }
 
 int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -534,6 +534,32 @@ struct libnvme_host *libnvme_lookup_host(struct libnvme_global_ctx *ctx,
 	return h;
 }
 
+__libnvme_public int libnvme_get_host(
+		struct libnvme_global_ctx *ctx, const char *hostnqn,
+		const char *hostid, libnvme_host_t *host)
+{
+	struct libnvme_host *h;
+
+	/*
+	 * No sysfs identity (e.g. PCIe) and no ctx default: use a fixed
+	 * placeholder rather than resolving/generating one -- that's a
+	 * policy call for the caller, not us.
+	 */
+	if (!hostnqn)
+		hostnqn = NVME_DEFAULT_HOSTNQN;
+	if (!hostid)
+		hostid = NVME_DEFAULT_HOSTID;
+
+	h = libnvme_lookup_host(ctx, hostnqn, hostid);
+	if (!h)
+		return -ENOMEM;
+
+	libnvme_host_set_hostsymname(h, NULL);
+
+	*host = h;
+	return 0;
+}
+
 static int nvme_subsystem_scan_namespaces(struct libnvme_global_ctx *ctx,
 		libnvme_subsystem_t s)
 {

--- a/libnvme/src/nvme/tree.h
+++ b/libnvme/src/nvme/tree.h
@@ -794,6 +794,19 @@ char *libnvme_ctrl_get_src_addr(libnvme_ctrl_t c, char *src_addr,
 const char *libnvme_ctrl_get_state(libnvme_ctrl_t c);
 
 /**
+ * libnvme_transport_is_fabric() - True for a fabrics transport string
+ * @transport:	Transport name, e.g. "tcp", "pcie"
+ *
+ * A transport is either local (pcie, apple-nvme) or NVMe-over-Fabrics
+ * (tcp, rdma, fc, loop). Use this when only the transport string is
+ * available, e.g. before a controller exists to ask
+ * libnvme_ctrl_is_transport_fabric() instead.
+ *
+ * Return: true if @transport is a fabrics transport, false if local.
+ */
+bool libnvme_transport_is_fabric(const char *transport);
+
+/**
  * libnvme_ctrl_is_transport_fabric() - True for a fabrics transport
  * @c:	Controller instance
  *


### PR DESCRIPTION
Follow-up fixes for #3596. I was partway through reviewing it when it merged, and kept finding things — sorry these are only showing up now instead of as review comments.

## What broke

`25d6c95a7` ("libnvme/fabrics: do not look up hostnqn/hostid implicitly") correctly moved hostnqn/hostid resolution out of connect/discover and into the caller's hands, but three places didn't get updated to match the new contract, and one gap was worth closing while in there.

**PCIe controllers vanish from `nvme list`.** `libnvme_get_host()` lost its fallback entirely. A PCIe controller has no `hostnqn`/`hostid` sysfs attribute, so it now hits `libnvme_lookup_host(ctx, NULL, NULL)`, which returns `NULL` at its own `if (!hostnqn)` guard, and `scan_topology()` just logs the failure at DEBUG and silently drops the controller. Reproduced on real hardware: a drive that lists fine on `master` disappears entirely after this merge.

**Python bindings can crash the interpreter.** `libnvmf_read_hostnqn()`, `libnvmf_read_hostid()`, and `libnvmf_host_get_ids()` all dereference `ctx` unconditionally. They're public API now and reachable from Python, which can pass `None`. `None` maps to a NULL pointer, and all three segfault instead of raising.

**The Python binding reintroduces the exact thing the PR removes.** `set_fctx_host_params()` (nvme.i) called `libnvmf_host_get_ids()` unconditionally, so a `Ctrl(ctx, {...})` built from a dict with no `hostnqn`/`hostid` got one invented via the full fallback-and-generate chain — the same implicit lookup this PR takes out of the C side, just resurfacing one layer up in the SWIG glue.

## The fixes (2 commits)

1. **`libnvme: fix regressions from the implicit host-lookup removal`** — all three regressions above, plus one new check: a fabrics-transport `Ctrl` (tcp/rdma/fc/loop) with no resolvable hostnqn anywhere used to construct successfully and only fail later, confusingly, the first time `connect()`/`discover()` was called. It now rejects at construction instead, since the caller already knows which transport it asked for at that point. PCIe and apple-nvme are unaffected — neither has a host identity concept.

   For the PCIe fix specifically: rather than resolving a hostnqn/hostid for `libnvme_get_host()` (which would just relocate the same policy-in-the-library problem this PR is fixing), it falls back to a fixed placeholder. `tree-win.c` already did exactly this; the two platforms now share one `#define` instead of Linux resolving and Windows hardcoding a duplicate literal.

2. **`libnvme: consolidate libnvme_get_host() into tree.c`** — a separate commit, not a regression fix. Once both platforms fall back to the same placeholder, `tree-linux.c`'s and `tree-win.c`'s `libnvme_get_host()` are byte-identical, and neither has any platform-specific dependency left (`libnvme_lookup_host()` and `libnvme_host_set_hostsymname()` already live in shared code). Moved the one implementation into `tree.c`, dropped both copies.

## Testing

Full `meson test` suite passes (86/86). Manually verified `nvme list` on real hardware, side by side with a pre-merge build, to confirm the PCIe regression and the fix. Exercised the identity-resolution paths directly against the built Python module — every combination of dict-supplied / ctx-default / neither, for both a UUID-derivable and a non-derivable hostnqn, plus the `None`-ctx crash paths before and after.
