### PR TITLE
nvme: add dump-command-metadata command

### DIFF
--- a/plugins/utils/command-metadata.c
+++ b/plugins/utils/command-metadata.c
@@ -21,10 +21,14 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #include "command-metadata.h"
 #include "common.h"
@@ -63,6 +67,139 @@ static struct command_metadata_command *command_metadata_cur_command;
  * for the parser-unwind sentinel; checked after each command fn returns.
  */
 static int command_metadata_capture_error;
+
+/*
+ * capture_saved_stderr_fd holds a dup of stderr from before the NUL redirect,
+ * so crash messages still reach the user.
+ */
+static const char *capture_current_command;
+static int capture_saved_stderr_fd = -1;
+
+/*
+ * (void)write() does not suppress GCC's warn_unused_result under
+ * _FORTIFY_SOURCE; assigning to a discarded variable does.
+ */
+static void write_raw(int fd, const char *buf, size_t len)
+{
+	ssize_t ret = write(fd, buf, len);
+	(void)ret;
+}
+
+/* strlen() is not async-signal-safe; measure inline for the crash handler. */
+static void write_str(int fd, const char *s)
+{
+	size_t len = 0;
+
+	if (!s)
+		return;
+
+	while (s[len])
+		len++;
+
+	write_raw(fd, s, len);
+}
+
+static void write_uint(int fd, unsigned int n)
+{
+	char buf[10];	/* enough for any 32-bit unsigned int */
+	int i = sizeof(buf);
+
+	do {
+		buf[--i] = '0' + (n % 10);
+		n /= 10;
+	} while (n && i);
+
+	write_raw(fd, buf + i, sizeof(buf) - i);
+}
+
+static void capture_crash_handler(int sig)
+{
+	int fd = capture_saved_stderr_fd >= 0 ? capture_saved_stderr_fd : STDERR_FILENO;
+
+	write_str(fd, "dump-command-metadata: fatal: '");
+	write_str(fd, capture_current_command ? capture_current_command : "(unknown)");
+	write_str(fd, "' crashed during option capture (signal ");
+	write_uint(fd, sig);
+	write_str(fd, ")\n");
+
+	signal(sig, SIG_DFL);
+	raise(sig);
+}
+
+/*
+ * On Windows, OS-level exceptions (stack overflow, access violations) bypass
+ * the C signal() mechanism entirely and terminate the process silently.
+ * SetUnhandledExceptionFilter intercepts these so we can print the same
+ * diagnostic before dying.
+ */
+#ifdef _WIN32
+static void write_hex(int fd, unsigned int n)
+{
+	char buf[8];
+	int i = sizeof(buf);
+
+	do {
+		buf[--i] = "0123456789abcdef"[n & 0xf];
+		n >>= 4;
+	} while (n && i);
+
+	write_raw(fd, buf + i, sizeof(buf) - i);
+}
+
+static LONG WINAPI capture_exception_filter(EXCEPTION_POINTERS *ep)
+{
+	int fd = capture_saved_stderr_fd >= 0 ? capture_saved_stderr_fd : STDERR_FILENO;
+
+	write_str(fd, "dump-command-metadata: fatal: '");
+	write_str(fd, capture_current_command ? capture_current_command : "(unknown)");
+	write_str(fd, "' crashed during option capture (exception 0x");
+	write_hex(fd, ep->ExceptionRecord->ExceptionCode);
+	write_str(fd, ")\n");
+
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+static LPTOP_LEVEL_EXCEPTION_FILTER capture_prev_filter;
+#endif
+
+static void (*capture_prev_sigsegv)(int);
+static void (*capture_prev_sigabrt)(int);
+#ifdef SIGBUS
+static void (*capture_prev_sigbus)(int);
+#endif
+
+/* Normalize SIG_ERR to SIG_DFL so restoration is always a valid disposition. */
+static void (*set_crash_handler(int sig))(int)
+{
+	void (*prev)(int) = signal(sig, capture_crash_handler);
+
+	return prev == SIG_ERR ? SIG_DFL : prev;
+}
+
+static void install_crash_handlers(void)
+{
+	capture_prev_sigsegv = set_crash_handler(SIGSEGV);
+	capture_prev_sigabrt = set_crash_handler(SIGABRT);
+#ifdef SIGBUS
+	capture_prev_sigbus = set_crash_handler(SIGBUS);
+#endif
+#ifdef _WIN32
+	capture_prev_filter = SetUnhandledExceptionFilter(capture_exception_filter);
+#endif
+}
+
+static void remove_crash_handlers(void)
+{
+	signal(SIGSEGV, capture_prev_sigsegv);
+	signal(SIGABRT, capture_prev_sigabrt);
+#ifdef SIGBUS
+	signal(SIGBUS, capture_prev_sigbus);
+#endif
+#ifdef _WIN32
+	SetUnhandledExceptionFilter(capture_prev_filter);
+	capture_prev_filter = NULL;
+#endif
+}
 
 /* ------------------------------------------------------------------ */
 /* Pass 1: capture                                                    */
@@ -215,7 +352,9 @@ static int capture_command(struct command_metadata_command *mc, struct command *
 
 	command_metadata_capture_error = 0;
 	command_metadata_cur_command = mc;
+	capture_current_command = cmd->name;
 	(void)cmd->fn(2, argv, cmd, plugin);
+	capture_current_command = NULL;
 	command_metadata_cur_command = NULL;
 
 	/*
@@ -281,12 +420,14 @@ static struct command_metadata_program *build_model(struct program *prog)
 	if (devnull >= 0) {
 		saved_stdout = dup(STDOUT_FILENO);
 		saved_stderr = dup(STDERR_FILENO);
+		capture_saved_stderr_fd = saved_stderr;
 		if (saved_stdout >= 0)
 			dup2(devnull, STDOUT_FILENO);
 		if (saved_stderr >= 0)
 			dup2(devnull, STDERR_FILENO);
 	}
 
+	install_crash_handlers();
 	argconfig_set_parse_hook(metadata_capture_hook);
 
 	for (pi = 0, plugin = prog->extensions; plugin; plugin = plugin->next, pi++) {
@@ -316,6 +457,8 @@ static struct command_metadata_program *build_model(struct program *prog)
 	}
 
 	argconfig_set_parse_hook(NULL);
+	remove_crash_handlers();
+	capture_saved_stderr_fd = -1;
 
 	fflush(stdout);
 	fflush(stderr);

--- a/unit-py/test_command_metadata_schema.py
+++ b/unit-py/test_command_metadata_schema.py
@@ -63,8 +63,8 @@ def json_c_available():
 
 
 def dump_metadata():
-    """Run `nvme utils dump-command-metadata` and return parsed JSON, or None if
-    it produced no usable output."""
+    """Run `nvme utils dump-command-metadata` and return (parsed JSON, stderr).
+    Returns (None, stderr) if it produced no usable output."""
     proc = subprocess.run(
         [NVME_BIN, "utils", "dump-command-metadata"],
         stdout=subprocess.PIPE,
@@ -73,8 +73,8 @@ def dump_metadata():
     )
     text = proc.stdout.strip()
     if proc.returncode != 0 or not text:
-        return None
-    return json.loads(text)
+        return None, proc.stderr
+    return json.loads(text), proc.stderr
 
 
 def iter_commands(data):
@@ -128,10 +128,12 @@ class TestCommandMetadataSchema(unittest.TestCase):
     def setUpClass(cls):
         if not json_c_available():
             raise unittest.SkipTest("nvme built without json-c")
-        cls.data = dump_metadata()
+        cls.data, stderr = dump_metadata()
         if cls.data is None:
-            raise AssertionError(
-                "dump-command-metadata produced no output (built with json-c)")
+            msg = "dump-command-metadata produced no output (built with json-c)"
+            if stderr:
+                msg += "\nstderr: " + stderr.rstrip()
+            raise AssertionError(msg)
         with open(SCHEMA_PATH) as f:
             cls.schema = json.load(f)
 


### PR DESCRIPTION
Add `nvme dump-command-metadata`, which walks the live plugin/command tree and emits every command and its options as JSON describing the CLI surface. The command needs no device and is gated on CONFIG_JSONC.

This is the first step toward generating shell completion scripts: the JSON output is intended to be consumed by a generator that produces completions for bash, zsh, and PowerShell.

To capture options, dump-command-metadata invokes each command's fn, which calls argconfig_parse(). A hook there copies the command's options array and returns a sentinel so the command unwinds before opening a device, rather than actually running it.

Includes command-metadata-schema.json and a Python unit test (unit-py/) that validates the output against the schema and cross-checks it against --help and `nvme help`.