### PR TITLE
doc: add nvme-fabrics.conf(5) man page and sample file

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -273,6 +273,12 @@ adoc_sources = [
     'nvme-mangoboost-id-ctrl',
 ]
 
+# File-format references (man section 5), installed separately from the
+# man1 command pages above.
+adoc_sources_man5 = [
+    'nvme-fabrics.conf',
+]
+
 adoc_includes = [
     'cmd-plugins.txt',
     'cmds-main.txt',
@@ -282,6 +288,7 @@ adoc_includes = [
 
 if want_docs != 'false'
     mandir = join_paths(prefixdir, get_option('mandir'), 'man1')
+    man5dir = join_paths(prefixdir, get_option('mandir'), 'man5')
     htmldir = join_paths(prefixdir, get_option('htmldir'), 'nvme')
 
     asciidoctor = find_program('asciidoc', required: want_docs_build)
@@ -295,48 +302,55 @@ if want_docs != 'false'
         if want_docs == 'all' or want_docs == 'man'
             xmlto = find_program('xmlto', required: false)
             if xmlto.found()
-                foreach adoc : adoc_sources
-                    input = adoc + '.txt'
-                    subst = configure_file(
-                        input: adoc + '.txt',
-                        output: adoc + '.msubst',
-                        configuration: substs
-                    )
-                    xml = custom_target(
-                        adoc.underscorify() + '_xml',
-                        input: subst,
-                        output: '@BASENAME@.xml',
-                        command: [
-                            asciidoctor,
-                            '-f', files('asciidoc.conf'),
-                            '-b', 'docbook',
-                            '-d', 'manpage',
-                            '-o', '@OUTPUT@',
-                            '@INPUT@',
-                        ],
-                    )
-                    doc_tgts += custom_target(
-                        adoc.underscorify() + '_man',
-                        input: xml,
-                        output: '@BASENAME@.1',
-                        command: [
-                            xmlto,
-                            '-m', files('manpage-normal.xsl'),
-                            '-o', '@OUTDIR@',
-                            '--skip-validation',
-                            'man',
-                            '@INPUT@',
-                        ],
-                        install: true,
-                        install_dir: mandir,
-                    )
+                man_sets = [
+                    {'sources': adoc_sources, 'section': '1', 'dir': mandir},
+                    {'sources': adoc_sources_man5, 'section': '5', 'dir': man5dir},
+                ]
+                foreach man_set : man_sets
+                    section = man_set['section']
+                    foreach adoc : man_set['sources']
+                        input = adoc + '.txt'
+                        subst = configure_file(
+                            input: adoc + '.txt',
+                            output: adoc + '.m' + section + 'subst',
+                            configuration: substs
+                        )
+                        xml = custom_target(
+                            adoc.underscorify() + '_xml' + section,
+                            input: subst,
+                            output: '@BASENAME@.xml',
+                            command: [
+                                asciidoctor,
+                                '-f', files('asciidoc.conf'),
+                                '-b', 'docbook',
+                                '-d', 'manpage',
+                                '-o', '@OUTPUT@',
+                                '@INPUT@',
+                            ],
+                        )
+                        doc_tgts += custom_target(
+                            adoc.underscorify() + '_man' + section,
+                            input: xml,
+                            output: '@BASENAME@.' + section,
+                            command: [
+                                xmlto,
+                                '-m', files('manpage-normal.xsl'),
+                                '-o', '@OUTDIR@',
+                                '--skip-validation',
+                                'man',
+                                '@INPUT@',
+                            ],
+                            install: true,
+                            install_dir: man_set['dir'],
+                        )
+                    endforeach
                 endforeach
             endif
         endif
 
         # html
         if want_docs == 'all' or want_docs == 'html'
-            foreach adoc : adoc_sources
+            foreach adoc : adoc_sources + adoc_sources_man5
                 input = adoc + '.txt'
                 subst = configure_file(
                     input: adoc + '.txt',
@@ -361,15 +375,22 @@ if want_docs != 'false'
         endif
     else
         # asciidoctor not found, install pre compiled documetationx
-        foreach adoc : adoc_sources
-            if want_docs == 'all' or want_docs == 'man'
-                man = files(adoc + '.1')
-                install_data(man, install_dir: mandir)
-            endif
-            if want_docs == 'all' or want_docs == 'html'
-                html = files(adoc + '.html')
-                install_data(html, install_dir: htmldir)
-            endif
+        man_sets = [
+            {'sources': adoc_sources, 'section': '1', 'dir': mandir},
+            {'sources': adoc_sources_man5, 'section': '5', 'dir': man5dir},
+        ]
+        foreach man_set : man_sets
+            section = man_set['section']
+            foreach adoc : man_set['sources']
+                if want_docs == 'all' or want_docs == 'man'
+                    man = files(adoc + '.' + section)
+                    install_data(man, install_dir: man_set['dir'])
+                endif
+                if want_docs == 'all' or want_docs == 'html'
+                    html = files(adoc + '.html')
+                    install_data(html, install_dir: htmldir)
+                endif
+            endforeach
         endforeach
     endif
 endif

--- a/Documentation/nvme-fabrics.conf.txt
+++ b/Documentation/nvme-fabrics.conf.txt
@@ -1,0 +1,149 @@
+nvme-fabrics.conf(5)
+=====================
+
+NAME
+----
+nvme-fabrics.conf - NVMe-oF connection configuration file format
+
+SYNOPSIS
+--------
+[verse]
+'@SYSCONFDIR@/nvme/nvme-fabrics.conf'
+'@SYSCONFDIR@/nvme/nvme-fabrics.conf.d/*.conf'
+
+DESCRIPTION
+-----------
+An INI-format file describing which NVMe over Fabrics (NVMe-oF)
+controllers a host should connect to, and with what parameters. It is
+read by 'nvme connect-all', 'nvme discover' and 'nvme connect', by the
+nvme-discoverd daemon, and (through the Python bindings) by nvme-stas.
+
+A configuration is a main file plus an optional drop-in directory,
+the same 'foo.conf' + 'foo.conf.d/' pattern systemd uses. Both parts
+are read independently, and either may be absent; an absent
+configuration is not an error; it simply yields no connections.
+
+--config FILE (on 'connect-all'/'discover'/'connect') names the main
+file; its drop-in directory is always 'FILE.d/'. Omitting --config
+uses the default path above.
+
+SECTIONS
+--------
+Each section is one or more 'key = value' lines. An empty value
+('key =') resets the key to the kernel default, overriding whatever an
+outer scope set (see RESETTING A KEY below). Unknown keys are ignored.
+Boolean values accept '1'/'yes'/'y'/'true'/'t'/'on' and
+'0'/'no'/'n'/'false'/'f'/'off' (case-insensitive).
+
+'[Host]'::
+	Optional, at most one per file. The identity used by every
+	connection in that file: 'hostnqn', 'hostid', 'hostsymname',
+	plus any SECURITY key below. A file with no '[Host]' connects
+	as the system default identity ('@SYSCONFDIR@/nvme/hostnqn' /
+	'hostid'). A drop-in that defines '[Host]' must set 'hostnqn'
+	explicitly.
+
+'[Discovery Controller Defaults]', '[I/O Controller Defaults]'::
+	Optional, at most one of each per file. Default TUNABLE values
+	for connections of that class, drawn from below. A drop-in's
+	copy overlays the top-level file's, for that drop-in's own
+	connections only.
+
+'[Discovery Controller]'::
+	One Discovery Controller to connect to. Repeatable. 'nqn ='
+	defaults to the well-known discovery NQN if omitted.
+
+'[Subsystem]'::
+	One I/O subsystem to connect to, named by 'nqn ='. Repeatable.
+
+Both endpoint sections accept any TUNABLE or SECURITY key as a
+per-section override, plus one or more 'controller =' lines (below).
+
+CONTROLLER LINES
+-----------------
+Each 'controller =' line under a '[Discovery Controller]' or
+'[Subsystem]' section is one path to that endpoint; repeating the key
+expresses multipath (native NVMe multipath groups all paths sharing a
+subsysnqn). The value is a ';'-separated 'key=value' list:
+
+	controller = transport=tcp;traddr=10.0.0.9;trsvcid=4420;host-iface=eth0
+
+'transport' and 'traddr' are required; 'trsvcid', 'host-traddr' and
+'host-iface' are optional. Any TUNABLE key may also appear on the line
+as a per-path override -- SECURITY keys may not, since they are bound
+to the (host, subsystem) pair, not to a single path.
+
+KEYS
+----
+TUNABLE (type default, '[Host]', endpoint section, or 'controller =' line):
+
+	nr-io-queues, nr-write-queues, nr-poll-queues, queue-size,
+	keep-alive-tmo, reconnect-delay, ctrl-loss-tmo, fast-io-fail-tmo,
+	tos, duplicate-connect, disable-sqflow, hdr-digest, data-digest
+
+SECURITY ('[Host]' or endpoint section only, never a 'controller =' line):
+
+	tls, tls-key, tls-key-identity, keyring, concat, dhchap-secret,
+	dhchap-ctrl-secret
+
+IDENTITY ('[Host]' only):
+
+	hostnqn, hostid, hostsymname
+
+Every key here is the same name as its 'nvme connect' long option
+(hyphenated). See linknvme:nvme-connect[1] for what each one means.
+
+RESETTING A KEY
+----------------
+An empty assignment ('key =') resets that key to the kernel default,
+undoing whatever an outer scope (a '*Defaults' section or '[Host]')
+set. This differs from simply not writing the key, which instead
+inherits through the cascade below.
+
+PRECEDENCE
+----------
+A key resolves most-specific first:
+
+	controller = line > endpoint section > [Host] > type defaults > kernel default
+
+The type-defaults level is chosen by the connection's class: a
+Discovery Controller draws from '[Discovery Controller Defaults]', an
+I/O Controller from '[I/O Controller Defaults]'.
+
+EXAMPLE
+-------
+------------
+# @SYSCONFDIR@/nvme/nvme-fabrics.conf
+
+[Discovery Controller Defaults]
+keep-alive-tmo = 30
+
+[I/O Controller Defaults]
+keep-alive-tmo = 5
+
+[Host]
+hostsymname = lab-host-01
+
+[Discovery Controller]
+controller = transport=tcp;traddr=192.168.1.10;trsvcid=8009
+
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+controller = transport=tcp;traddr=192.168.1.21;trsvcid=4420
+------------
+
+See '@SYSCONFDIR@/nvme/nvme-fabrics.conf.sample' for a longer,
+commented example.
+
+SEE ALSO
+--------
+nvme-connect-all(1)
+nvme-discover(1)
+nvme-connect(1)
+nvme-config-convert(1)
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md
+
+NVME
+----
+Part of the nvme-user suite

--- a/etc/nvme-fabrics.conf.sample.in
+++ b/etc/nvme-fabrics.conf.sample.in
@@ -1,0 +1,46 @@
+# Example NVMe-oF connection configuration.
+#
+# This file is NOT read by nvme-cli -- it is a reference only. The real
+# configuration file is @SYSCONFDIR@/nvme/nvme-fabrics.conf (plus an
+# optional @SYSCONFDIR@/nvme/nvme-fabrics.conf.d/ drop-in directory).
+#
+# See nvme-fabrics.conf(5) for the full key reference and precedence
+# rules, and https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md
+# for the complete design rationale.
+
+# Type defaults: applied unless a more specific scope below overrides them.
+[Discovery Controller Defaults]
+keep-alive-tmo = 30                  # DC keep-alive default
+ctrl-loss-tmo  = 600
+
+[I/O Controller Defaults]
+keep-alive-tmo = 5                   # IOC keep-alive default (kernel default)
+ctrl-loss-tmo  = 600
+
+# Optional: state this host's identity explicitly. Omit this whole
+# section to fall back to @SYSCONFDIR@/nvme/hostnqn and hostid.
+[Host]
+hostsymname = lab-host-01
+
+# A Discovery Controller with an explicit NQN.
+[Discovery Controller]
+nqn        = nqn.2014-08.org.example:cdc.main
+controller = transport=tcp;traddr=192.168.1.10;trsvcid=8009
+
+# A Discovery Controller with no nqn = : defaults to the well-known
+# discovery NQN.
+[Discovery Controller]
+controller = transport=tcp;traddr=192.168.1.11;trsvcid=8009
+
+# A subsystem reachable over a single path.
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+
+# A subsystem reachable over two paths (multipath), overriding the
+# I/O Controller Defaults' ctrl-loss-tmo for this subsystem only.
+[Subsystem]
+nqn           = nqn.2024-01.com.example:data.vol2
+ctrl-loss-tmo = 1800
+controller    = transport=tcp;traddr=192.168.1.21;trsvcid=4420
+controller    = transport=tcp;traddr=192.168.1.22;trsvcid=4420

--- a/meson.build
+++ b/meson.build
@@ -664,6 +664,14 @@ if want_nvme
         configuration: substs,
     )
 
+    configure_file(
+        input: 'etc/nvme-fabrics.conf.sample.in',
+        output: 'nvme-fabrics.conf.sample',
+        configuration: substs,
+        install: true,
+        install_dir: join_paths(sysconfdir, 'nvme'),
+    )
+
     dracut_files = [
         '70-nvmf-autoconnect.conf',
     ]

--- a/nvme.spec.in
+++ b/nvme.spec.in
@@ -24,11 +24,13 @@ touch %{buildroot}@SYSCONFDIR@/nvme/hostid
 %defattr(-,root,root)
 @SBINDIR@/nvme
 @MANDIR@/man1/nvme*.1*
+@MANDIR@/man5/nvme*.5*
 @DATADIR@/bash-completion/completions/nvme
 @DATADIR@/zsh/site-functions/_nvme
 %dir @SYSCONFDIR@/nvme
 @SYSCONFDIR@/nvme/hostnqn
 @SYSCONFDIR@/nvme/hostid
+@SYSCONFDIR@/nvme/nvme-fabrics.conf.sample
 %ghost @SYSCONFDIR@/nvme/config.json
 %ghost @SYSCONFDIR@/nvme/discovery.conf
 @UDEVRULESDIR@/65-persistent-net-nbft.rules


### PR DESCRIPTION
## Summary

Adds a `nvme-fabrics.conf(5)` man page documenting the INI connection-configuration format (sections, keys, controller-line syntax, precedence), plus an example file at `/etc/nvme/nvme-fabrics.conf.sample`.

This restores -- at a path the config reader never touches -- what removing the old `discovery.conf` install stub took away: a way to see the expected file format without reading source or the network.

- `Documentation/nvme-fabrics.conf.txt` -- the man page source. Keeps to a quick-reference shape (every key listed, minimal prose per key) rather than CONFIG.md's design-rationale depth; pulls its key list and worked example from CONFIG.md directly.
- `Documentation/meson.build` -- only installs man1 pages today; adds a man5 install path.
- `etc/nvme-fabrics.conf.sample.in` -- installed as a plain `%files` entry (not `%ghost` -- static reference content, not runtime state). 

## Test plan

- [x] `meson compile -C .build` / `meson test -C .build` clean (86/88, 2 expected fail unchanged)
- [x] Man page actually built and rendered via `-Ddocs=man -Ddocs-build=true` (real asciidoc/xmlto toolchain) and checked with `man --local-file`; `-Ddocs=all` (html) also builds
- [x] Precompiled-fallback install path isolate-tested (man1 and man5 both land in the right `mandir`)
- [x] Refactored man1/man5 meson blocks verified to produce byte-identical output against the pre-refactor two-block version
- [x] checkpatch clean (0 errors, 0 warnings)
