### PR TITLE
nvme: fabrics_config_validate: reject a missing config file

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1372,6 +1372,11 @@ int fabrics_config_validate(const char *desc, int argc, char **argv)
 	}
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
+	if (access(config_file, F_OK)) {
+		nvme_show_error("%s: no such file", config_file);
+		return -ENOENT;
+	}
+
 	ret = libnvmf_config_validate(ctx, config_file);
 	if (ret)
 		nvme_show_error("%s: invalid configuration", config_file);


### PR DESCRIPTION
libnvmf_config_validate() treats an absent file as a valid, empty configuration -- correct for connect-all/discover, where no config just means nothing to connect, not an error. "nvme config validate" inherited that behavior and reported "OK" for a file that does not exist at all, which is misleading: the whole point of the command is confirming the file itself is correct.

Check for the file explicitly before validating and report a clear error instead.