### PR TITLE
libnvme/tree: split lookup and create operations

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3079,13 +3079,9 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 	struct libnvme_host *h;
 	int ret, rr, i;
 
-	h = libnvme_lookup_host(ctx, fctx->hostnqn, fctx->hostid);
-	if (!h) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR,
-			"Failed to lookup host '%s'\n",
-			fctx->hostnqn ? fctx->hostnqn : "<unset>");
-		return -ENODEV;
-	}
+	ret = libnvme_get_host(ctx, fctx->hostnqn, fctx->hostid, &h);
+	if (ret)
+		return ret;
 
 	ret = setup_connection(fctx, h, false);
 	if (ret)
@@ -3124,14 +3120,9 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 				hostid = fctx->hostid;
 		}
 
-		h = libnvme_lookup_host(ctx, hostnqn, hostid);
-		if (!h) {
-			libnvme_msg(ctx, LIBNVME_LOG_ERR,
-				"Failed to lookup host '%s'\n",
-				hostnqn ? hostnqn : "<unset>");
-			ret = -ENODEV;
+		ret = libnvme_get_host(ctx, hostnqn, hostid, &h);
+		if (ret)
 			goto out_free;
-		}
 
 		/* Subsystem Namespace Descriptor List */
 		for (ss = entry->nbft->subsystem_ns_list; ss && *ss; ss++)
@@ -3313,13 +3304,9 @@ __libnvme_public int libnvmf_discovery(
 	struct libnvme_host *h;
 	int ret;
 
-	h = libnvme_lookup_host(ctx, fctx->hostnqn, fctx->hostid);
-	if (!h) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR,
-			"Failed to lookup host '%s'\n",
-			fctx->hostnqn ? fctx->hostnqn : "<unset>");
-		return -ENODEV;
-	}
+	ret = libnvme_get_host(ctx, fctx->hostnqn, fctx->hostid, &h);
+	if (ret)
+		return ret;
 
 	ret = setup_connection(fctx, h, true);
 	if (ret)
@@ -3420,13 +3407,9 @@ __libnvme_public int libnvmf_connect(
 			return devid_fd;
 	}
 
-	h = libnvme_lookup_host(ctx, fctx->hostnqn, fctx->hostid);
-	if (!h) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR,
-			"Failed to lookup host '%s'\n",
-			fctx->hostnqn ? fctx->hostnqn : "<unset>");
-		return -ENODEV;
-	}
+	err = libnvme_get_host(ctx, fctx->hostnqn, fctx->hostid, &h);
+	if (err)
+		return err;
 
 	err = setup_connection(fctx, h, false);
 	if (err)

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -483,6 +483,9 @@ int libnvme_create_ctrl(struct libnvme_global_ctx *ctx,
 		struct libnvme_ctrl **cp);
 void nvme_deconfigure_ctrl(struct libnvme_ctrl *c);
 
+int libnvme_create_host(struct libnvme_global_ctx *ctx,
+		const char *hostnqn, const char *hostid,
+		struct libnvme_host **host);
 struct libnvme_host *libnvme_lookup_host(struct libnvme_global_ctx *ctx,
 		const char *hostnqn, const char *hostid);
 struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -493,6 +493,12 @@ struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,
 struct libnvme_ctrl *libnvme_lookup_ctrl(struct libnvme_subsystem *s,
 		const struct libnvme_ctrl_params *params,
 		struct libnvme_ctrl *p);
+int libnvme_create_subsystem(struct libnvme_host *h,
+		const char *name, const char *subsysnqn,
+		struct libnvme_subsystem **s);
+int libnvme_subsystem_create_ctrl(libnvme_subsystem_t s,
+		const struct libnvme_ctrl_params *in,
+		libnvme_ctrl_t *p);
 bool traddr_is_hostname(struct libnvme_global_ctx *ctx,
 		const char *transport, const char *traddr);
 void libnvmf_default_config(struct libnvme_fabrics_config *cfg);

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -376,9 +376,13 @@ __libnvme_public int libnvme_init_ctrl(
 		return ENVME_CONNECT_LOOKUP_SUBSYS_NAME;
 	}
 
-	s = libnvme_lookup_subsystem(h, subsys_name, c->subsysnqn);
-	if (!s)
+	ret = libnvme_get_subsystem(h->ctx, h, subsys_name, c->subsysnqn, &s);
+	if (ret) {
+		libnvme_msg(h->ctx, LIBNVME_LOG_ERR,
+			 "Failed to lookup subsystem %s\n",
+			 subsys_name);
 		return -ENVME_CONNECT_LOOKUP_SUBSYS;
+	}
 
 	if (s->subsystype && !strcmp(s->subsystype, "discovery"))
 		c->discovery_ctrl = true;
@@ -437,9 +441,9 @@ __libnvme_public int libnvme_scan_ctrl(
 		return ret;
 	}
 
-	s = libnvme_lookup_subsystem(h, subsysname, subsysnqn);
-	if (!s)
-		return -ENOMEM;
+	ret = libnvme_get_subsystem(h->ctx, h, subsysname, subsysnqn, &s);
+	if (ret)
+		return ret;
 
 	ret = libnvme_ctrl_alloc(ctx, s, path, name, &c);
 	if (ret)

--- a/libnvme/src/nvme/tree-win.c
+++ b/libnvme/src/nvme/tree-win.c
@@ -175,12 +175,13 @@ free_transport:
 	return ret;
 }
 
-static libnvme_subsystem_t libnvme_lookup_subsystem_windows(libnvme_host_t h,
+static libnvme_subsystem_t libnvme_get_subsystem_windows(libnvme_host_t h,
 		const struct ctrl_map_entry *ctrl_entry)
 {
 	libnvme_subsystem_t s;
 	char *subsysnqn;
 	char *subsysname;
+	int ret;
 
 	subsysnqn = libnvme_ctrl_map_entry_get_subnqn(ctrl_entry);
 	if (!subsysnqn)
@@ -192,10 +193,10 @@ static libnvme_subsystem_t libnvme_lookup_subsystem_windows(libnvme_host_t h,
 		return NULL;
 	}
 
-	s = libnvme_lookup_subsystem(h, subsysname, subsysnqn);
+	ret = libnvme_get_subsystem(h->ctx, h, subsysname, subsysnqn, &s);
 	free(subsysnqn);
 	free(subsysname);
-	if (!s)
+	if (ret)
 		return NULL;
 
 	/* Populate subsystem info from first controller */
@@ -231,7 +232,7 @@ __libnvme_public int libnvme_scan_ctrl(struct libnvme_global_ctx *ctx,
 	if (ret)
 		return ret;
 
-	s = libnvme_lookup_subsystem_windows(h, ctrl_entry);
+	s = libnvme_get_subsystem_windows(h, ctrl_entry);
 	if (!s)
 		return -ENOMEM;
 

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -521,8 +521,6 @@ __libnvme_public int libnvme_get_host(
 	if (!h)
 		return -ENOMEM;
 
-	libnvme_host_set_hostsymname(h, NULL);
-
 	*host = h;
 	return 0;
 }

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -364,20 +364,21 @@ __libnvme_public void libnvme_free_subsystem(libnvme_subsystem_t s)
 	__nvme_free_subsystem(s);
 }
 
-struct libnvme_subsystem *libnvme_create_subsystem(struct libnvme_host *h,
-		const char *name, const char *subsysnqn)
+int libnvme_create_subsystem(struct libnvme_host *h,
+		const char *name, const char *subsysnqn,
+		struct libnvme_subsystem **ps)
 {
 	struct libnvme_subsystem *s;
 
 	s = calloc(1, sizeof(*s));
 	if (!s)
-		return NULL;
+		return -ENOMEM;
 
 	s->h = h;
 	s->subsysnqn = xstrdup(subsysnqn);
 	if (!s->subsysnqn) {
 		free(s);
-		return NULL;
+		return -ENOMEM;
 	}
 
 	if (name)
@@ -386,7 +387,10 @@ struct libnvme_subsystem *libnvme_create_subsystem(struct libnvme_host *h,
 	list_head_init(&s->namespaces);
 	list_node_init(&s->entry);
 	list_add_tail(&h->subsystems, &s->entry);
-	return s;
+
+	*ps = s;
+
+	return 0;
 }
 
 struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,
@@ -403,7 +407,8 @@ struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,
 			continue;
 		return s;
 	}
-	return libnvme_create_subsystem(h, name, subsysnqn);
+
+	return NULL;
 }
 
 __libnvme_public int libnvme_get_subsystem(struct libnvme_global_ctx *ctx,
@@ -411,11 +416,17 @@ __libnvme_public int libnvme_get_subsystem(struct libnvme_global_ctx *ctx,
 		const char *subsysnqn, struct libnvme_subsystem **subsys)
 {
 	struct libnvme_subsystem *s;
+	int err;
 
 	s = libnvme_lookup_subsystem(h, name, subsysnqn);
-	if (!s)
-		return -ENOMEM;
+	if (s)
+		goto found;
 
+	err = libnvme_create_subsystem(h, name, subsysnqn, &s);
+	if (err)
+		return err;
+
+found:
 	*subsys = s;
 
 	return 0;
@@ -621,9 +632,9 @@ static int libnvme_scan_subsystem(struct libnvme_global_ctx *ctx,
 		ret = libnvme_get_host(ctx, ctx->hostnqn, ctx->hostid, &h);
 		if (ret)
 			return ret;
-		s = libnvme_create_subsystem(h, name, subsysnqn);
-		if (!s)
-			return -ENOMEM;
+		ret = libnvme_create_subsystem(h, name, subsysnqn, &s);
+		if (ret)
+			return ret;
 		if (nvme_subsystem_scan_namespaces(ctx, s))
 			return -EINVAL;
 	} else if (strcmp(s->subsysnqn, subsysnqn)) {

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1444,10 +1444,7 @@ libnvme_ctrl_t libnvme_lookup_ctrl(libnvme_subsystem_t s,
 			     const struct libnvme_ctrl_params *in,
 			     libnvme_ctrl_t p)
 {
-	struct libnvme_global_ctx *ctx;
 	struct libnvme_ctrl_params search;
-	struct libnvme_ctrl *c;
-	int ret;
 
 	if (!s || !in->transport)
 		return NULL;
@@ -1459,21 +1456,42 @@ libnvme_ctrl_t libnvme_lookup_ctrl(libnvme_subsystem_t s,
 	search = *in;
 	libnvme_fabrics_config_copy(&search.cfg, &in->cfg);
 	search.subsysnqn = NULL;
-	c = libnvme_ctrl_find(s, &search, p);
-	if (c)
-		return c;
+
+	return libnvme_ctrl_find(s, &search, p);
+}
+
+int libnvme_subsystem_create_ctrl(libnvme_subsystem_t s,
+		const struct libnvme_ctrl_params *in,
+		libnvme_ctrl_t *pc)
+{
+	struct libnvme_global_ctx *ctx;
+	struct libnvme_ctrl_params params;
+	struct libnvme_ctrl *c;
+	int ret;
+
+	if (!s)
+		return -EINVAL;
+
+	if (in->subsysnqn && strcmp(in->subsysnqn, s->subsysnqn))
+		return -EINVAL;
 
 	ctx = s->h ? s->h->ctx : NULL;
-	search.subsysnqn = s->subsysnqn;
-	libnvmf_default_config(&search.cfg);
-	ret = libnvme_create_ctrl(ctx, &search, &c);
+
+	params = *in;
+	libnvme_fabrics_config_copy(&params.cfg, &in->cfg);
+	params.subsysnqn = s->subsysnqn;
+	libnvmf_default_config(&params.cfg);
+
+	ret = libnvme_create_ctrl(ctx, &params, &c);
 	if (ret)
-		return NULL;
+		return ret;
 
 	c->s = s;
 	list_add_tail(&s->ctrls, &c->entry);
 
-	return c;
+	*pc = c;
+
+	return 0;
 }
 
 int libnvme_ctrl_scan_paths(struct libnvme_global_ctx *ctx,
@@ -1553,15 +1571,16 @@ int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,
 	if (ret)
 		return ret;
 
+	struct libnvme_ctrl_params params = {
+		.transport = transport,
+		.traddr = traddr,
+		.host_traddr = host_traddr,
+		.host_iface = host_iface,
+		.trsvcid = trsvcid,
+	};
+
 	p = NULL;
 	do {
-		struct libnvme_ctrl_params params = {
-			.transport = transport,
-			.traddr = traddr,
-			.host_traddr = host_traddr,
-			.host_iface = host_iface,
-			.trsvcid = trsvcid,
-		};
 		c = libnvme_lookup_ctrl(s, &params, p);
 		if (c) {
 			if (!c->name)
@@ -1576,12 +1595,20 @@ int libnvme_ctrl_alloc(struct libnvme_global_ctx *ctx, libnvme_subsystem_t s,
 			p = c;
 		}
 	} while (c);
+
 	if (!c)
 		c = p;
-	if (!c && !p) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR, "failed to lookup ctrl\n");
-		return -ENODEV;
+
+	if (!c) {
+		ret = libnvme_subsystem_create_ctrl(s, &params, &c);
+		if (ret) {
+			libnvme_msg(ctx, LIBNVME_LOG_ERR,
+				"failed to created ctrl: %s\n",
+				libnvme_strerror(-ret));
+			return ret;
+		}
 	}
+
 	FREE_CTRL_ATTR(c->address);
 	c->address = xstrdup(addr);
 	if (s->subsystype && !strcmp(s->subsystype, "discovery"))

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -452,21 +452,34 @@ __libnvme_public void libnvme_free_host(struct libnvme_host *h)
 	__libnvme_free_host(h);
 }
 
-static int libnvme_create_host(struct libnvme_global_ctx *ctx,
+int libnvme_create_host(struct libnvme_global_ctx *ctx,
 		const char *hostnqn, const char *hostid,
 		struct libnvme_host **host)
 {
 	struct libnvme_host *h;
+	char *hnqn, *hid;
+
+	if (!hostnqn)
+		return -EINVAL;
+
+	hnqn = strdup(hostnqn);
+	if (hostid)
+		hid = strdup(hostid);
+	else
+		hid = libnvme_hostid_from_hostnqn(hostnqn);
+
+	if (!hid) {
+		free(hnqn);
+		return -EINVAL;
+	}
 
 	h = calloc(1, sizeof(*h));
 	if (!h)
 		return -ENOMEM;
 
-	h->hostnqn = strdup(hostnqn);
-	if (hostid)
-		h->hostid = strdup(hostid);
-	else
-		h->hostid = libnvme_hostid_from_hostnqn(hostnqn);
+	h->hostnqn = hnqn;
+	h->hostid = hid;
+
 	list_head_init(&h->subsystems);
 	list_node_init(&h->entry);
 	h->ctx = ctx;
@@ -495,10 +508,7 @@ struct libnvme_host *libnvme_lookup_host(struct libnvme_global_ctx *ctx,
 		return h;
 	}
 
-	if (libnvme_create_host(ctx, hostnqn, hostid, &h))
-		return NULL;
-
-	return h;
+	return NULL;
 }
 
 __libnvme_public int libnvme_get_host(
@@ -506,6 +516,7 @@ __libnvme_public int libnvme_get_host(
 		const char *hostid, libnvme_host_t *host)
 {
 	struct libnvme_host *h;
+	int err;
 
 	/*
 	 * No sysfs identity (e.g. PCIe) and no ctx default: use a fixed
@@ -518,9 +529,18 @@ __libnvme_public int libnvme_get_host(
 		hostid = NVME_DEFAULT_HOSTID;
 
 	h = libnvme_lookup_host(ctx, hostnqn, hostid);
-	if (!h)
-		return -ENOMEM;
+	if (h)
+		goto found;
 
+	err = libnvme_create_host(ctx, hostnqn, hostid, &h);
+	if (err) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR,
+			"Failed to create host '%s'\n",
+			hostnqn ? hostnqn : "<unset>");
+		return err;
+	}
+
+found:
 	*host = h;
 	return 0;
 }

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -364,7 +364,7 @@ __libnvme_public void libnvme_free_subsystem(libnvme_subsystem_t s)
 	__nvme_free_subsystem(s);
 }
 
-struct libnvme_subsystem *nvme_alloc_subsystem(struct libnvme_host *h,
+struct libnvme_subsystem *libnvme_create_subsystem(struct libnvme_host *h,
 		const char *name, const char *subsysnqn)
 {
 	struct libnvme_subsystem *s;
@@ -403,7 +403,7 @@ struct libnvme_subsystem *libnvme_lookup_subsystem(struct libnvme_host *h,
 			continue;
 		return s;
 	}
-	return nvme_alloc_subsystem(h, name, subsysnqn);
+	return libnvme_create_subsystem(h, name, subsysnqn);
 }
 
 __libnvme_public int libnvme_get_subsystem(struct libnvme_global_ctx *ctx,
@@ -601,7 +601,7 @@ static int libnvme_scan_subsystem(struct libnvme_global_ctx *ctx,
 		ret = libnvme_get_host(ctx, ctx->hostnqn, ctx->hostid, &h);
 		if (ret)
 			return ret;
-		s = nvme_alloc_subsystem(h, name, subsysnqn);
+		s = libnvme_create_subsystem(h, name, subsysnqn);
 		if (!s)
 			return -ENOMEM;
 		if (nvme_subsystem_scan_namespaces(ctx, s))

--- a/libnvme/test/tree-fabrics.c
+++ b/libnvme/test/tree-fabrics.c
@@ -139,7 +139,7 @@ static struct libnvme_global_ctx *create_tree(void)
 	libnvme_global_ctx_set_hostnqn(ctx, DEFAULT_HOSTNQN);
 	libnvme_global_ctx_set_hostid(ctx, DEFAULT_HOSTID);
 
-	libnvme_get_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h);
+	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 
 	printf("  ctrls created:\n");
@@ -313,7 +313,7 @@ static bool test_src_addr(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_DEBUG, false, false);
 
-	libnvme_get_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h);
+	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 
 	libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
@@ -492,7 +492,7 @@ static bool ctrl_match(const char *tag,
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	libnvme_get_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h);
+	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 
 	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
@@ -511,7 +511,7 @@ static bool ctrl_match(const char *tag,
 	found_ctrl = libnvmf_ctrl_find(s, &candidate->f);
 
 	candidate_ctrl = libnvme_lookup_ctrl(s,
-				&candidate->f.ctrl_params, NULL);
+		&candidate->f.ctrl_params, NULL);
 
 	if (should_match) {
 		if (candidate_ctrl != reference_ctrl) {
@@ -1526,7 +1526,7 @@ static bool test_well_known_nqn(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	libnvme_get_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h);
+	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 
 	/* Subsystem 1: discovery subsystem with a discovery ctrl */
@@ -1753,7 +1753,7 @@ static bool test_lookup_ctrl_pagination(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	libnvme_get_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h);
+	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
 				      DEFAULT_SUBSYSNQN, &s));

--- a/libnvme/test/tree-fabrics.c
+++ b/libnvme/test/tree-fabrics.c
@@ -149,7 +149,9 @@ static struct libnvme_global_ctx *create_tree(void)
 		assert(!libnvme_get_subsystem(ctx, h, d->subsysname,
 			d->f.ctrl_params.subsysnqn, &d->s));
 		assert(d->s);
-		d->c = libnvme_lookup_ctrl(d->s, &d->f.ctrl_params, NULL);
+
+		assert(!libnvme_subsystem_create_ctrl(d->s,
+			&d->f.ctrl_params, &d->c));
 		assert(d->c);
 		d->ctrl_id = i;
 
@@ -187,6 +189,7 @@ static bool tcp_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 	f.ctrl_params.host_traddr = NULL;
 	f.ctrl_params.host_iface = NULL;
 	c = libnvme_lookup_ctrl(s, &f.ctrl_params, NULL);
+	assert(c);
 	printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid, "", "");
 	show_ctrl(c);
 	pass &= match_ctrl(d, c);
@@ -321,7 +324,7 @@ static bool test_src_addr(void)
 			      DEFAULT_SUBSYSNQN, &s));
 	assert(s);
 
-	c = libnvme_lookup_ctrl(s, &fctx.ctrl_params, NULL);
+	assert(!libnvme_subsystem_create_ctrl(s, &fctx.ctrl_params, &c));
 	assert(c);
 
 	c->address = NULL;
@@ -500,8 +503,8 @@ static bool ctrl_match(const char *tag,
 		rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN, &s));
 	assert(s);
 
-	reference_ctrl = libnvme_lookup_ctrl(s,
-				&reference->f.ctrl_params, NULL);
+	assert(!libnvme_subsystem_create_ctrl(s, &reference->f.ctrl_params,
+		&reference_ctrl));
 	assert(reference_ctrl);
 	reference_ctrl->name = "nvme1";  /* fake the device name */
 	if (reference->address)
@@ -1310,15 +1313,15 @@ static bool ctrl_config_match(const char *tag,
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	libnvme_get_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h);
+	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 
 	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
 		 rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN, &s));
 	assert(s);
 
-	reference_ctrl = libnvme_lookup_ctrl(s,
-				&reference->f.ctrl_params, NULL);
+	assert(!libnvme_subsystem_create_ctrl(s,
+		&reference->f.ctrl_params, &reference_ctrl));
 	assert(reference_ctrl);
 	reference_ctrl->name = "nvme1";  /* fake the device name */
 	if (reference->address)
@@ -1531,7 +1534,8 @@ static bool test_well_known_nqn(void)
 	/* Subsystem 1: discovery subsystem with a discovery ctrl */
 	assert(!libnvme_create_subsystem(h, "disc",
 		NVME_DISC_SUBSYS_NAME, &s_disc));
-	disc_ctrl = libnvme_lookup_ctrl(s_disc, &fctx.ctrl_params, NULL);
+	assert(!libnvme_subsystem_create_ctrl(s_disc, &fctx.ctrl_params,
+		&disc_ctrl));
 	assert(disc_ctrl);
 	disc_ctrl->name = "nvme1";
 	libnvme_ctrl_set_discovery_ctrl(disc_ctrl, true);
@@ -1547,7 +1551,8 @@ static bool test_well_known_nqn(void)
 	/* Subsystem 2: regular subsystem; discovery_ctrl defaults to false */
 	assert(!libnvme_create_subsystem(h, "regular", DEFAULT_SUBSYSNQN,
 		&s_regular));
-	regular_ctrl = libnvme_lookup_ctrl(s_regular, &fctx.ctrl_params, NULL);
+	assert(!libnvme_subsystem_create_ctrl(s_regular, &fctx.ctrl_params,
+		&regular_ctrl));
 	assert(regular_ctrl);
 	regular_ctrl->name = "nvme2";
 
@@ -1718,7 +1723,7 @@ static bool test_ctrl_config_match_fc(void)
  *
  * With p set, __nvme_ctrl_find() starts searching from the controller
  * *after* p. This verifies that a controller appearing before p in the
- * list is skipped, causing a new controller to be created.
+ * list is skipped.
  *
  * @return true when all tests have passed. false otherwise.
  */
@@ -1727,7 +1732,7 @@ static bool test_lookup_ctrl_pagination(void)
 	struct libnvme_global_ctx *ctx;
 	libnvme_host_t h;
 	libnvme_subsystem_t s;
-	libnvme_ctrl_t ctrl_a, ctrl_b, found, ctrl_new, ctrl_found_again;
+	libnvme_ctrl_t ctrl_a, ctrl_b, found, ctrl_new;
 	bool pass = true;
 	struct libnvmf_context fctx_a = {
 		.ctrl_params = {
@@ -1759,9 +1764,9 @@ static bool test_lookup_ctrl_pagination(void)
 	assert(s);
 
 	/* Build list: [ctrl_a, ctrl_b] */
-	ctrl_a = libnvme_lookup_ctrl(s, &fctx_a.ctrl_params, NULL);
+	assert(!libnvme_subsystem_create_ctrl(s, &fctx_a.ctrl_params, &ctrl_a));
 	assert(ctrl_a);
-	ctrl_b = libnvme_lookup_ctrl(s, &fctx_b.ctrl_params, NULL);
+	assert(!libnvme_subsystem_create_ctrl(s, &fctx_b.ctrl_params, &ctrl_b));
 	assert(ctrl_b);
 
 	/* p=NULL: search starts from head, finds ctrl_a */
@@ -1774,25 +1779,13 @@ static bool test_lookup_ctrl_pagination(void)
 	}
 
 	/* p=ctrl_b: search starts after ctrl_b; ctrl_a is before ctrl_b so
-	 * it is skipped. No match found → a new ctrl is created.
+	 * it is skipped.
 	 */
 	ctrl_new = libnvme_lookup_ctrl(s, &fctx_a.ctrl_params, ctrl_b);
-	if (ctrl_new && ctrl_new != ctrl_a) {
-		printf(" - lookup_ctrl(p=ctrl_b) skips ctrl_a, creates new ctrl [PASS]\n");
+	if (!ctrl_new) {
+		printf(" - lookup_ctrl(p=ctrl_b) skips ctrl_a, returns NULL [PASS]\n");
 	} else {
-		printf(" - lookup_ctrl(p=ctrl_b) must skip ctrl_a and create new ctrl [FAIL]\n");
-		pass = false;
-	}
-
-	/* List is now [ctrl_a, ctrl_b, ctrl_new].
-	 * p=ctrl_a: search starts after ctrl_a → checks ctrl_b (no match),
-	 * then ctrl_new (match) → returns ctrl_new without creating.
-	 */
-	ctrl_found_again = libnvme_lookup_ctrl(s, &fctx_a.ctrl_params, ctrl_a);
-	if (ctrl_found_again == ctrl_new) {
-		printf(" - lookup_ctrl(p=ctrl_a) finds ctrl_new [PASS]\n");
-	} else {
-		printf(" - lookup_ctrl(p=ctrl_a) must find ctrl_new [FAIL]\n");
+		printf(" - lookup_ctrl(p=ctrl_b) must skip ctrl_a and must not find a ctrl [FAIL]\n");
 		pass = false;
 	}
 

--- a/libnvme/test/tree-fabrics.c
+++ b/libnvme/test/tree-fabrics.c
@@ -251,8 +251,9 @@ static bool ctrl_lookups(struct libnvme_global_ctx *ctx)
 	bool pass = true;
 
 	h = libnvme_first_host(ctx);
-	libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
-			      DEFAULT_SUBSYSNQN, &s);
+	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
+			      DEFAULT_SUBSYSNQN, &s));
+	assert(s);
 
 	printf("  lookup controller:\n");
 	for (int i = 0; i < ARRAY_SIZE(test_data); i++) {
@@ -316,8 +317,8 @@ static bool test_src_addr(void)
 	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 
-	libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
-			      DEFAULT_SUBSYSNQN, &s);
+	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+			      DEFAULT_SUBSYSNQN, &s));
 	assert(s);
 
 	c = libnvme_lookup_ctrl(s, &fctx.ctrl_params, NULL);
@@ -495,9 +496,8 @@ static bool ctrl_match(const char *tag,
 	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
 
-	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
-		 rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN,
-		&s));
+	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+		rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN, &s));
 	assert(s);
 
 	reference_ctrl = libnvme_lookup_ctrl(s,
@@ -1313,9 +1313,8 @@ static bool ctrl_config_match(const char *tag,
 	libnvme_get_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h);
 	assert(h);
 
-	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
-		 rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN,
-		&s));
+	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+		 rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN, &s));
 	assert(s);
 
 	reference_ctrl = libnvme_lookup_ctrl(s,
@@ -1530,7 +1529,7 @@ static bool test_well_known_nqn(void)
 	assert(h);
 
 	/* Subsystem 1: discovery subsystem with a discovery ctrl */
-	assert(!libnvme_get_subsystem(ctx, h, "disc",
+	assert(!libnvme_create_subsystem(h, "disc",
 		NVME_DISC_SUBSYS_NAME, &s_disc));
 	disc_ctrl = libnvme_lookup_ctrl(s_disc, &fctx.ctrl_params, NULL);
 	assert(disc_ctrl);
@@ -1546,8 +1545,8 @@ static bool test_well_known_nqn(void)
 	}
 
 	/* Subsystem 2: regular subsystem; discovery_ctrl defaults to false */
-	assert(!libnvme_get_subsystem(ctx, h, "regular",
-		DEFAULT_SUBSYSNQN, &s_regular));
+	assert(!libnvme_create_subsystem(h, "regular", DEFAULT_SUBSYSNQN,
+		&s_regular));
 	regular_ctrl = libnvme_lookup_ctrl(s_regular, &fctx.ctrl_params, NULL);
 	assert(regular_ctrl);
 	regular_ctrl->name = "nvme2";
@@ -1755,8 +1754,8 @@ static bool test_lookup_ctrl_pagination(void)
 
 	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
 	assert(h);
-	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
-				      DEFAULT_SUBSYSNQN, &s));
+	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+		DEFAULT_SUBSYSNQN, &s));
 	assert(s);
 
 	/* Build list: [ctrl_a, ctrl_b] */

--- a/libnvme/test/tree.c
+++ b/libnvme/test/tree.c
@@ -191,7 +191,7 @@ static bool test_host_iteration(void)
 }
 
 /**
- * test_subsystem_dedup - libnvme_lookup_subsystem() must return the same
+ * test_subsystem_dedup - libnvme_get_subsystem() must return the same
  * pointer for the same name+subsysnqn, and a different pointer for different
  * ones.
  */
@@ -213,10 +213,10 @@ static bool test_subsystem_dedup(void)
 	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
 	assert(h);
 
-	s1 = libnvme_lookup_subsystem(h, SUBSYSNAME_1, SUBSYSNQN_1);
+	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s1));
 	assert(s1);
 
-	s2 = libnvme_lookup_subsystem(h, SUBSYSNAME_1, SUBSYSNQN_1);
+	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s2));
 	assert(s2);
 
 	if (s1 != s2) {
@@ -226,7 +226,7 @@ static bool test_subsystem_dedup(void)
 		printf(" - same name+subsysnqn returns same pointer [PASS]\n");
 	}
 
-	s3 = libnvme_lookup_subsystem(h, SUBSYSNAME_2, SUBSYSNQN_2);
+	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_2, SUBSYSNQN_2, &s3));
 	assert(s3);
 
 	if (s1 == s3) {
@@ -262,7 +262,7 @@ static bool test_subsystem_attrs(void)
 	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
 	assert(h);
 
-	s = libnvme_lookup_subsystem(h, SUBSYSNAME_1, SUBSYSNQN_1);
+	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s));
 	assert(s);
 
 	if (!libnvme_subsystem_get_name(s) ||
@@ -308,8 +308,8 @@ static bool test_subsystem_iteration(void)
 	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
 	assert(h);
 
-	libnvme_lookup_subsystem(h, SUBSYSNAME_1, SUBSYSNQN_1);
-	libnvme_lookup_subsystem(h, SUBSYSNAME_2, SUBSYSNQN_2);
+	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s));
+	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_2, SUBSYSNQN_2, &s));
 
 	libnvme_for_each_subsystem(h, s)
 		count++;

--- a/libnvme/test/tree.c
+++ b/libnvme/test/tree.c
@@ -30,7 +30,7 @@
 #define SUBSYSNQN_2  "nqn.2022-01.com.example:subsys2"
 
 /**
- * test_host_dedup - libnvme_lookup_host() must return the same pointer for
+ * test_host_dedup - libnvme_get_host() must return the same pointer for
  * the same hostnqn+hostid, and a different pointer for different credentials.
  */
 static bool test_host_dedup(void)
@@ -47,10 +47,10 @@ static bool test_host_dedup(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	h1 = libnvme_lookup_host(ctx, HOSTNQN_1, HOSTID_1);
+	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h1));
 	assert(h1);
 
-	h2 = libnvme_lookup_host(ctx, HOSTNQN_1, HOSTID_1);
+	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h2));
 	assert(h2);
 
 	if (h1 != h2) {
@@ -60,7 +60,7 @@ static bool test_host_dedup(void)
 		printf(" - same hostnqn+hostid returns same pointer [PASS]\n");
 	}
 
-	h3 = libnvme_lookup_host(ctx, HOSTNQN_2, HOSTID_2);
+	assert(!libnvme_get_host(ctx, HOSTNQN_2, HOSTID_2, &h3));
 	assert(h3);
 
 	if (h1 == h3) {
@@ -75,7 +75,7 @@ static bool test_host_dedup(void)
 }
 
 /**
- * test_hostid_from_hostnqn - When hostid is NULL, libnvme_lookup_host()
+ * test_hostid_from_hostnqn - When hostid is NULL, libnvme_create_host()
  * must derive the hostid from the UUID embedded in the hostnqn.
  */
 static bool test_hostid_from_hostnqn(void)
@@ -93,7 +93,7 @@ static bool test_hostid_from_hostnqn(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	h = libnvme_lookup_host(ctx, HOSTNQN_1, NULL);
+	libnvme_create_host(ctx, HOSTNQN_1, NULL, &h);
 	assert(h);
 
 	hostid = libnvme_host_get_hostid(h);
@@ -127,7 +127,7 @@ static bool test_host_attrs(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	h = libnvme_lookup_host(ctx, HOSTNQN_1, HOSTID_1);
+	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
 	assert(h);
 
 	if (!libnvme_host_get_hostnqn(h) ||
@@ -169,9 +169,12 @@ static bool test_host_iteration(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	libnvme_lookup_host(ctx, HOSTNQN_1, HOSTID_1);
-	libnvme_lookup_host(ctx, HOSTNQN_2, HOSTID_2);
-	libnvme_lookup_host(ctx, HOSTNQN_3, HOSTID_3);
+	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
+	assert(h);
+	assert(!libnvme_get_host(ctx, HOSTNQN_2, HOSTID_2, &h));
+	assert(h);
+	assert(!libnvme_get_host(ctx, HOSTNQN_3, HOSTID_3, &h));
+	assert(h);
 
 	libnvme_for_each_host(ctx, h)
 		count++;
@@ -207,7 +210,7 @@ static bool test_subsystem_dedup(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	h = libnvme_lookup_host(ctx, HOSTNQN_1, HOSTID_1);
+	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
 	assert(h);
 
 	s1 = libnvme_lookup_subsystem(h, SUBSYSNAME_1, SUBSYSNQN_1);
@@ -256,7 +259,7 @@ static bool test_subsystem_attrs(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	h = libnvme_lookup_host(ctx, HOSTNQN_1, HOSTID_1);
+	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
 	assert(h);
 
 	s = libnvme_lookup_subsystem(h, SUBSYSNAME_1, SUBSYSNQN_1);
@@ -302,7 +305,7 @@ static bool test_subsystem_iteration(void)
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	h = libnvme_lookup_host(ctx, HOSTNQN_1, HOSTID_1);
+	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
 	assert(h);
 
 	libnvme_lookup_subsystem(h, SUBSYSNAME_1, SUBSYSNQN_1);


### PR DESCRIPTION
The host, subsystem, and controller lookup functions currently create an
object when no matching entry is found. This makes negative lookups
impossible and makes the code difficult to follow.

Split the functionality into separate lookup and create functions. Add
corresponding `get` helpers that preserve the previous lookup-or-create
behavior where needed. This streamlines the API and makes the semantics
of each function explicit.

While at it, change the function signatures to return error codes rather
than object pointers so that errors can be propagated correctly.

Fixes: #3597