### PR TITLE
nvme: fix a crash in config-validate/config-show/config-convert under -o json

### DIFF
--- a/config-convert.c
+++ b/config-convert.c
@@ -587,6 +587,8 @@ int nvme_config_convert(const char *desc, int argc, char **argv)
 	if (ret)
 		return ret;
 
+	nvme_show_init();
+
 	log_level = map_log_level(verbose ? 1 : 0, false);
 
 	ret = nvme_create_global_ctx(&ctx);

--- a/fabrics.c
+++ b/fabrics.c
@@ -1362,6 +1362,8 @@ int fabrics_config_validate(const char *desc, int argc, char **argv)
 	if (ret)
 		return ret;
 
+	nvme_show_init();
+
 	log_level = map_log_level(verbose ? 1 : 0, false);
 
 	ret = nvme_create_global_ctx(&ctx);
@@ -1492,6 +1494,8 @@ int fabrics_config_show(const char *desc, int argc, char **argv)
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	nvme_show_init();
 
 	log_level = map_log_level(verbose ? 1 : 0, false);
 


### PR DESCRIPTION
## Summary

Fixes a crash reported as #3611: `nvme --output-format json config validate` (or `config-show`/`config-convert`) aborts with a json-c assertion failure.

Root cause turned out to be unrelated to `OPT_ARGS`/`NVME_ARGS` or the global option parser -- none of the three functions call `nvme_show_init()` before parsing options, unlike every device command (which gets it for free via the shared `parse_args()` helper). Without it, `json_r` is never created, so `nvme_show_result()`/`nvme_show_error()` crash trying to build JSON output once a global `--output-format json` is in effect.

Adding the missing call turns out to do more than stop the crash: `config-validate` and `config-convert` already report through `nvme_show_result()`/`nvme_show_error()`, so they now produce correct JSON automatically (`{"result": "..."}` / `{"error": "..."}`). `config-show` still ignores `-o json` and prints its usual literal command-line text unchanged -- its output is built with raw `printf`, not the `print_ops` path, so giving it real JSON output is a separate, bigger design question (what a rendered shell command line should even look like as JSON) that this fix doesn't attempt.

## Test plan

- [x] `meson compile -C .build` / `meson test -C .build` clean (86/88, 2 expected fail unchanged)
- [x] `-Dwerror=true` build clean
- [x] Reproduced the exact crash from #3611 (`nvme --output-format json config validate`) and confirmed it no longer crashes
- [x] `config-validate`/`config-convert` verified to produce well-formed JSON under `-o json` (both success and error paths)
- [x] `config-show` verified to still behave correctly (no crash, no garbled output) under `-o json`, just unchanged plain-text output
- [x] checkpatch clean (0 errors, 0 warnings)
