### PR TITLE
micron: Add tests for some micron plugin commands and fix errors found in testing

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -245,6 +245,7 @@ struct nvme_args nvme_args = {
 	.output_format = "normal",
 	.output_format_ver = 2,
 	.timeout = NVME_DEFAULT_IOCTL_TIMEOUT,
+	.supported_output_formats = DEFAULT_OUTPUT_FORMATS,
 };
 
 static void *mmap_registers(struct libnvme_transport_handle *hdl, bool writable);
@@ -584,10 +585,10 @@ static int open_fallback_chardev(struct libnvme_global_ctx *ctx,
 	return 0;
 }
 
-
 int validate_output_format(const char *format, nvme_print_flags_t *flags)
 {
 	nvme_print_flags_t f;
+	nvme_print_flags_t supported_formats = nvme_args.supported_output_formats;
 
 	if (!format)
 		return -EINVAL;
@@ -595,12 +596,12 @@ int validate_output_format(const char *format, nvme_print_flags_t *flags)
 	if (!strcmp(format, "normal"))
 		f = NORMAL;
 #ifdef CONFIG_JSONC
-	else if (!strcmp(format, "json"))
+	else if (!strcmp(format, "json") && (supported_formats & JSON))
 		f = JSON;
 #endif /* CONFIG_JSONC */
-	else if (!strcmp(format, "binary"))
+	else if (!strcmp(format, "binary") && (supported_formats & BINARY))
 		f = BINARY;
-	else if (!strcmp(format, "tabular"))
+	else if (!strcmp(format, "tabular") && (supported_formats & TABULAR))
 		f = TABULAR;
 	else
 		return -EINVAL;
@@ -10737,6 +10738,14 @@ static int show_topology_cmd(int argc, char **argv, struct command *acmd, struct
 	enum nvme_cli_topo_ranking rank;
 	int err;
 
+#ifdef CONFIG_JSONC
+	nvme_print_flags_t supported_formats = (NORMAL | JSON | TABULAR);
+	const char *supported_formats_desc = "Output format: normal|json|tabular";
+#else /* CONFIG_JSONC */
+	nvme_print_flags_t supported_formats = (NORMAL | TABULAR);
+	const char *supported_formats_desc = "Output format: normal|tabular";
+#endif /* CONFIG_JSONC */
+
 	struct config {
 		char	*ranking;
 	};
@@ -10745,7 +10754,7 @@ static int show_topology_cmd(int argc, char **argv, struct command *acmd, struct
 		.ranking	= "namespace",
 	};
 
-	NVME_ARGS(opts,
+	NVME_ARGS_OUTPUT_FORMATS(opts, supported_formats, supported_formats_desc,
 		  OPT_FMT("ranking",       'r', &cfg.ranking,       ranking));
 
 	err = parse_args(argc, argv, desc, opts);

--- a/nvme.h
+++ b/nvme.h
@@ -58,28 +58,31 @@ struct nvme_args {
 	bool no_retries;
 	bool no_ioctl_probing;
 	unsigned int output_format_ver;
+	nvme_print_flags_t supported_output_formats;
 	const char *set_options;
 };
 
 #ifdef CONFIG_JSONC
-#define DESC_OUTPUT_FORMAT "Output format: normal|json|binary|tabular"
+#define DEFAULT_OUTPUT_FORMATS (NORMAL | JSON | BINARY)
+#define DEFAULT_OUTPUT_FORMAT_DESC "Output format: normal|json|binary"
 #else /* CONFIG_JSONC */
-#define DESC_OUTPUT_FORMAT "Output format: normal|binary|tabular"
+#define DEFAULT_OUTPUT_FORMATS (NORMAL | BINARY)
+#define DEFAULT_OUTPUT_FORMAT_DESC "Output format: normal|binary"
 #endif /* CONFIG_JSONC */
 
 /*
  * the ordering of the arguments matters, as the argument parser uses the first
  * match, thus any command which defines -t shorthand will match first.
  */
-#define NVME_ARGS(n, ...)                                                              \
+#define NVME_ARGS_OUTPUT_FORMATS(n, of_mask, of_desc, ...)                             \
+	nvme_args.supported_output_formats = of_mask;                                  \
 	struct argconfig_commandline_options n[] = {                                   \
 		OPT_GROUP("Options"),                                                  \
 		##__VA_ARGS__,                                                         \
 		OPT_GROUP("Global options"),                                           \
 		OPT_INCR("verbose",      'v', &nvme_args.verbose,                      \
                          "Increase output verbosity"),                                 \
-		OPT_FMT("output-format", 'o', &nvme_args.output_format,                \
-                         DESC_OUTPUT_FORMAT),                                          \
+		OPT_FMT("output-format", 'o', &nvme_args.output_format, of_desc),      \
 		OPT_UINT("timeout",        0, &nvme_args.timeout,                      \
                          "timeout value, in milliseconds"),                            \
 		OPT_FLAG("dry-run",        0, &nvme_args.dry_run,                      \
@@ -96,6 +99,12 @@ struct nvme_args {
 			 "set a libnvme library option (key=value[,key=value,...]);"), \
 		OPT_END()                                                              \
 	}
+
+#define NVME_ARGS(n, ...)                   \
+	NVME_ARGS_OUTPUT_FORMATS(n,         \
+		DEFAULT_OUTPUT_FORMATS,     \
+		DEFAULT_OUTPUT_FORMAT_DESC, \
+		##__VA_ARGS__)
 
 static inline bool nvme_is_multipath(libnvme_subsystem_t s)
 {

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -648,6 +648,44 @@ exit_status:
 	return err;
 }
 
+static int micron_validate_output_format(const char *format,
+	nvme_print_flags_t supported_formats,
+	nvme_print_flags_t *output_format)
+{
+	nvme_print_flags_t f;
+	int err = validate_output_format(format, &f);
+
+	if (err)
+		return err;
+
+	/* NORMAL is 0, so it is always supported and handled separately */
+	if (f == NORMAL || (f & supported_formats)) {
+		*output_format = f;
+		return 0;
+	}
+
+	return -ENOTSUP;
+}
+
+static int micron_get_output_format(struct argconfig_commandline_options *opts,
+	const char *global_format, const char *local_format,
+	nvme_print_flags_t supported_formats, nvme_print_flags_t default_format,
+	nvme_print_flags_t *format)
+{
+	if (!format)
+		return -EINVAL;
+
+	if (global_format && argconfig_parse_seen(opts, "output-format"))
+		return micron_validate_output_format(global_format,
+			supported_formats, format);
+	else if (local_format && argconfig_parse_seen(opts, "format"))
+		return micron_validate_output_format(local_format,
+			supported_formats, format);
+
+	*format = default_format;
+	return 0;
+}
+
 /*
  * Plugin Commands
  */
@@ -891,7 +929,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	unsigned int tempSensors[SensorCount] = { 0 };
 	const char *desc = "Retrieve Micron temperature info for the given device ";
 	const char *fmt = "output format normal|json";
-	nvme_print_flags_t flags;
+	nvme_print_flags_t format = NORMAL;
 	struct format {
 		char *fmt;
 	};
@@ -912,14 +950,13 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 		return -1;
 	}
 
-	err = validate_output_format(nvme_args.output_format, &flags);
-	if (err) {
+	err = micron_get_output_format(opts, nvme_args.output_format, cfg.fmt,
+		JSON | NORMAL, NORMAL, &format);
+	if (err < 0) {
 		nvme_show_error("Invalid output format");
 		return err;
 	}
-
-	if (!strcmp(cfg.fmt, "json") || flags & JSON)
-		is_json = true;
+	is_json = format == JSON;
 
 	err = nvme_get_log_smart(hdl, NVME_NSID_ALL, &smart_log);
 	if (!err) {
@@ -1025,14 +1062,13 @@ struct {
 		offsetof(struct pcie_error_counters, receiver_error)},
 	};
 
-
 static int micron_pcie_stats(int argc, char **argv,
 				 struct command *command, struct plugin *plugin)
 {
 	int  i, err = 0;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
-	nvme_print_flags_t flags;
+	nvme_print_flags_t format = JSON;
 	struct libnvme_passthru_cmd admin_cmd = { 0 };
 	enum eDriveModel eModel = UNKNOWN_MODEL;
 	bool is_json = true;
@@ -1058,11 +1094,13 @@ static int micron_pcie_stats(int argc, char **argv,
 		return -1;
 	}
 
-	err = validate_output_format(nvme_args.output_format, &flags);
+	err = micron_get_output_format(opts, nvme_args.output_format, cfg.fmt,
+		JSON | NORMAL, JSON, &format);
 	if (err < 0) {
 		nvme_show_error("Invalid output format");
 		return err;
 	}
+	is_json = format == JSON;
 
 	/* pull log details based on the model name */
 	eModel = GetDriveModel(ctx, hdl);
@@ -1071,9 +1109,6 @@ static int micron_pcie_stats(int argc, char **argv,
 		err = -ENOTSUP;
 		goto out;
 	}
-
-	if (!strcmp(cfg.fmt, "normal") || flags & NORMAL)
-		is_json = false;
 
 	if (eModel == M5407) {
 		admin_cmd.opcode = 0xD6;

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -648,39 +648,17 @@ exit_status:
 	return err;
 }
 
-static int micron_validate_output_format(const char *format,
-	nvme_print_flags_t supported_formats,
-	nvme_print_flags_t *output_format)
-{
-	nvme_print_flags_t f;
-	int err = validate_output_format(format, &f);
-
-	if (err)
-		return err;
-
-	/* NORMAL is 0, so it is always supported and handled separately */
-	if (f == NORMAL || (f & supported_formats)) {
-		*output_format = f;
-		return 0;
-	}
-
-	return -ENOTSUP;
-}
-
 static int micron_get_output_format(struct argconfig_commandline_options *opts,
 	const char *global_format, const char *local_format,
-	nvme_print_flags_t supported_formats, nvme_print_flags_t default_format,
-	nvme_print_flags_t *format)
+	nvme_print_flags_t default_format, nvme_print_flags_t *format)
 {
 	if (!format)
 		return -EINVAL;
 
 	if (global_format && argconfig_parse_seen(opts, "output-format"))
-		return micron_validate_output_format(global_format,
-			supported_formats, format);
+		return validate_output_format(global_format, format);
 	else if (local_format && argconfig_parse_seen(opts, "format"))
-		return micron_validate_output_format(local_format,
-			supported_formats, format);
+		return validate_output_format(local_format, format);
 
 	*format = default_format;
 	return 0;
@@ -928,7 +906,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	unsigned int temperature = 0, i = 0;
 	unsigned int tempSensors[SensorCount] = { 0 };
 	const char *desc = "Retrieve Micron temperature info for the given device ";
-	const char *fmt = "output format normal|json";
+	const char *fmt = "Output format: normal|json";
 	nvme_print_flags_t format = NORMAL;
 	struct format {
 		char *fmt;
@@ -941,7 +919,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	struct json_object *logPages;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
-	NVME_ARGS(opts,
+	NVME_ARGS_OUTPUT_FORMATS(opts, (JSON | NORMAL), fmt,
 		OPT_FMT("format", 'f', &cfg.fmt, fmt));
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
@@ -951,7 +929,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	}
 
 	err = micron_get_output_format(opts, nvme_args.output_format, cfg.fmt,
-		JSON | NORMAL, NORMAL, &format);
+		NORMAL, &format);
 	if (err < 0) {
 		nvme_show_error("Invalid output format");
 		return err;
@@ -1077,7 +1055,7 @@ static int micron_pcie_stats(int argc, char **argv,
 		char *fmt;
 	};
 	const char *desc = "Retrieve PCIe event counters";
-	const char *fmt = "output format json|normal";
+	const char *fmt = "Output format: json|normal";
 	struct format cfg = {
 		.fmt = "json",
 	};
@@ -1085,7 +1063,7 @@ static int micron_pcie_stats(int argc, char **argv,
 	__u32 correctable_errors = 0;
 	__u32 uncorrectable_errors = 0;
 
-	NVME_ARGS(opts,
+	NVME_ARGS_OUTPUT_FORMATS(opts, (JSON | NORMAL), fmt,
 		OPT_FMT("format", 'f', &cfg.fmt, fmt));
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
@@ -1095,7 +1073,7 @@ static int micron_pcie_stats(int argc, char **argv,
 	}
 
 	err = micron_get_output_format(opts, nvme_args.output_format, cfg.fmt,
-		JSON | NORMAL, JSON, &format);
+		JSON, &format);
 	if (err < 0) {
 		nvme_show_error("Invalid output format");
 		return err;

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -886,7 +886,8 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 {
 
 	struct nvme_smart_log smart_log;
-	unsigned int temperature = 0, i = 0, err = 0;
+	int err = 0;
+	unsigned int temperature = 0, i = 0;
 	unsigned int tempSensors[SensorCount] = { 0 };
 	const char *desc = "Retrieve Micron temperature info for the given device ";
 	const char *fmt = "output format normal|json";
@@ -912,7 +913,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	}
 
 	err = validate_output_format(nvme_args.output_format, &flags);
-	if (err < 0) {
+	if (err) {
 		nvme_show_error("Invalid output format");
 		return err;
 	}
@@ -924,7 +925,7 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 	if (!err) {
 		temperature = ((smart_log.temperature[1] << 8) | smart_log.temperature[0]);
 		temperature = temperature ? temperature - 273 : 0;
-		for (i = 0; i < SensorCount && tempSensors[i]; i++) {
+		for (i = 0; i < SensorCount; i++) {
 			tempSensors[i] = le16_to_cpu(smart_log.temp_sensor[i]);
 			tempSensors[i] = tempSensors[i] ? tempSensors[i] - 273 : 0;
 		}
@@ -937,10 +938,12 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 			json_object_add_value_array(root, "Micron temperature information", logPages);
 			sprintf(tempstr, "%u C", temperature);
 			json_object_add_value_string(stats, "Current Composite Temperature", tempstr);
-			for (i = 0; i < SensorCount && tempSensors[i]; i++) {
+			for (i = 0; i < SensorCount; i++) {
 				char sensor_str[256] = { 0 };
 				char datastr[64] = { 0 };
 
+				if (!smart_log.temp_sensor[i])
+					continue;
 				sprintf(sensor_str, "Temperature Sensor #%d", (i + 1));
 				sprintf(datastr, "%u C", tempSensors[i]);
 				json_object_add_value_string(stats, sensor_str, datastr);
@@ -952,8 +955,11 @@ static int micron_temp_stats(int argc, char **argv, struct command *acmd,
 		} else {
 			printf("Micron temperature information:\n");
 			printf("%-10s : %u C\n", "Current Composite Temperature", temperature);
-			for (i = 0; i < SensorCount && tempSensors[i]; i++)
+			for (i = 0; i < SensorCount; i++) {
+				if (!smart_log.temp_sensor[i])
+					continue;
 				printf("%-10s%d : %u C\n", "Temperature Sensor #", i + 1, tempSensors[i]);
+			}
 		}
 	}
 	return err;

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -3616,6 +3616,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 	if (err)
 		return err;
 
+	err = -EINVAL;
 	/* if telemetry type is specified, check for data area */
 	if (strlen(cfg.type)) {
 		if (!strcmp(cfg.type, "controller")) {
@@ -3655,6 +3656,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == UNKNOWN_MODEL) {
 		nvme_show_error("Unsupported drive model for vs-internal-log collection");
+		err = -ENOTSUP;
 		goto out;
 	}
 

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -660,7 +660,7 @@ static int micron_parse_options(struct libnvme_global_ctx **ctx,
 	int err = parse_and_open(ctx, hdl, argc, argv, desc, opts);
 
 	if (err) {
-		nvme_show_err(err, "open");
+		nvme_show_err(err, "open failed");
 		return -1;
 	}
 
@@ -1175,7 +1175,7 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 		if (!err)
 			err = (int)result;
 		if (!err) {
-			nvme_show_verbose_result("Device correctable errors are cleared!");
+			nvme_show_verbose_result("Device correctable errors cleared!");
 			return 0;
 		}
 	} else if (model == M5407) {
@@ -1184,7 +1184,7 @@ static int micron_clear_pcie_correctable_errors(int argc, char **argv,
 		admin_cmd.cdw10 = 0;
 		err = libnvme_exec_admin_passthru(hdl, &admin_cmd);
 		if (!err) {
-			nvme_show_verbose_result("Device correctable error counters are cleared!");
+			nvme_show_verbose_result("Device correctable errors cleared!");
 			return 0;
 		}
 	}

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -1068,6 +1068,7 @@ static int micron_pcie_stats(int argc, char **argv,
 	eModel = GetDriveModel(ctx, hdl);
 	if (eModel == UNKNOWN_MODEL) {
 		nvme_show_error("Unsupported drive model for vs-pcie-stats command");
+		err = -ENOTSUP;
 		goto out;
 	}
 

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -5,12 +5,15 @@
  * Authors: Broc Going <bgoing@micron.com>
  */
 
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <spawn.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #include <libnvme.h>
 
@@ -19,74 +22,286 @@
 #include "micron-utils.h"
 #include "util/cleanup.h"
 
+extern char **environ;
+
+/*
+ * Validates that a string is a canonical PCI address in the
+ * "DDDD:BB:DD.F" form (domain:bus:device.function), e.g. "0000:03:00.0".
+ *
+ * Return: true if valid, false otherwise.
+ */
+static bool pcie_bdf_is_valid(const char *bdf)
+{
+	int i;
+
+	if (!bdf)
+		return false;
+
+	/* DDDD:BB:DD.F — exactly 12 characters */
+	if (strlen(bdf) != 12)
+		return false;
+
+	for (i = 0; i < 4; i++)
+		if (!isxdigit((unsigned char)bdf[i]))
+			return false;
+	if (bdf[4] != ':')
+		return false;
+	for (i = 5; i < 7; i++)
+		if (!isxdigit((unsigned char)bdf[i]))
+			return false;
+	if (bdf[7] != ':')
+		return false;
+	for (i = 8; i < 10; i++)
+		if (!isxdigit((unsigned char)bdf[i]))
+			return false;
+	if (bdf[10] != '.')
+		return false;
+	/* PCI function is a single digit 0-7 */
+	if (bdf[11] < '0' || bdf[11] > '7')
+		return false;
+
+	return true;
+}
+
+/*
+ * Retrieves the PCI BDF string (e.g. "0000:03:00.0") for the NVMe controller.
+ * Tries /sys/class/nvme/<ctrl>/address first (kernel >= 4.13), then falls back
+ * to resolving the /sys/class/nvme/<ctrl>/device symlink.
+ */
+static int get_pcie_bdf(struct libnvme_transport_handle *hdl,
+	char *bdf, size_t bdf_len)
+{
+	__cleanup_free char *ctrl_name = micron_get_ctrl_name(hdl);
+	char path[512];
+	char target[512];
+	ssize_t n;
+	int fd;
+	int err;
+	char *slash;
+
+	if (!ctrl_name)
+		return -EINVAL;
+
+	/*
+	 * If possible, use /sys/class/nvme/<ctrl>/address (kernel >= 4.13).
+	 * On failure, fall back to using the /device symlink.
+	 */
+	snprintf(path, sizeof(path), "/sys/class/nvme/%s/address", ctrl_name);
+	fd = open(path, O_RDONLY);
+	if (fd >= 0) {
+		n = read(fd, target, sizeof(target) - 1);
+		close(fd);
+		if (n > 0) {
+			size_t len;
+
+			target[n] = '\0';
+			len = strcspn(target, "\n");
+
+			if (len > 0 && len < bdf_len) {
+				snprintf(bdf, bdf_len, "%.*s", (int)len, target);
+				if (pcie_bdf_is_valid(bdf))
+					return 0;
+			}
+		}
+	}
+
+	/*
+	 * If unable to use the address file, use the last component of the
+	 * /sys/class/nvme/<ctrl>/device symlink.
+	 */
+	snprintf(path, sizeof(path), "/sys/class/nvme/%s/device", ctrl_name);
+	n = readlink(path, target, sizeof(target) - 1);
+	if (n < 0) {
+		err = -errno;
+		nvme_show_perror("%s", path);
+		return err;
+	}
+	target[n] = '\0';
+
+	slash = strrchr(target, '/');
+	if (!slash) {
+		nvme_show_error("Unexpected sysfs path: %s", target);
+		return -EINVAL;
+	}
+
+	slash++;
+	if (strlen(slash) >= bdf_len) {
+		nvme_show_error("PCI address too long: %s", slash);
+		return -EINVAL;
+	}
+
+	memcpy(bdf, slash, strlen(slash) + 1);
+	if (!pcie_bdf_is_valid(bdf)) {
+		nvme_show_error("Invalid PCI address: %s", bdf);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/*
+ * Waits for a spawned child, retrying across signal interruptions, and maps its
+ * termination to a return code.
+ *
+ * @pid: PID of the child to wait for.
+ *
+ * Return: 0 if the child exited with status 0, negative errno on a wait
+ * failure, or -EIO if the child did not exit cleanly with status 0.
+ */
+static int wait_for_child(pid_t pid)
+{
+	int status;
+
+	while (waitpid(pid, &status, 0) == -1) {
+		if (errno != EINTR)
+			return -errno;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		return -EIO;
+
+	return 0;
+}
+
+/*
+ * Reads all data from @fd into @out (NUL-terminated), keeping at most
+ * @out_len - 1 bytes and discarding any excess. Always reads to EOF so the
+ * writer never blocks on a full pipe, which would otherwise hang.
+ *
+ * @fd:      File descriptor to read from.
+ * @out:     Buffer to receive up to @out_len - 1 bytes (NUL-terminated).
+ * @out_len: Size of @out; must be at least 1.
+ *
+ * Return: 0 on success, negative errno on a read failure.
+ */
+static int read_to_eof(int fd, char *out, size_t out_len)
+{
+	size_t total = 0;
+	ssize_t n = 1; /* non-zero to ensure drain loop runs */
+	char discard[512];
+
+	out[0] = '\0';
+
+	/* Fill the output buffer with up to out_len - 1 bytes. */
+	while (total < out_len - 1) {
+		n = read(fd, out + total, out_len - 1 - total);
+
+		if (n == -1) {
+			if (errno == EINTR)
+				continue;
+			return -errno;
+		}
+		if (n == 0)
+			break;
+		total += (size_t)n;
+	}
+	out[total] = '\0';
+
+	/* Drain any remaining output so the writer never blocks on a full pipe. */
+	while (n > 0) {
+		n = read(fd, discard, sizeof(discard));
+		if (n == -1) {
+			if (errno == EINTR)
+				continue;
+			return -errno;
+		}
+		if (n == 0)
+			break;
+	}
+
+	return 0;
+}
+
+/*
+ * Runs a command (given as an argv vector) without a shell and captures its
+ * standard output into @out.
+ *
+ * @argv:    NULL-terminated argument vector; argv[0] is the program name.
+ * @out:     Buffer to receive up to @out_len - 1 bytes of stdout (NUL-terminated).
+ * @out_len: Size of @out; must be at least 1.
+ *
+ * Return: 0 on success, negative errno on failure.
+ */
+static int spawn_and_capture(char *const argv[], char *out, size_t out_len)
+{
+	posix_spawn_file_actions_t actions;
+	int pipefd[2];
+	pid_t pid;
+	int ret;
+	int err = 0;
+
+	if (!out || out_len == 0)
+		return -EINVAL;
+
+	out[0] = '\0';
+
+	if (pipe(pipefd) == -1)
+		return -errno;
+
+	err = posix_spawn_file_actions_init(&actions);
+	if (err) {
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return -err;
+	}
+
+	/* Child: redirect stdout to the pipe write end, close both raw fds. */
+	err = posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
+	if (!err)
+		err = posix_spawn_file_actions_addclose(&actions, pipefd[0]);
+	if (!err)
+		err = posix_spawn_file_actions_addclose(&actions, pipefd[1]);
+	if (err) {
+		posix_spawn_file_actions_destroy(&actions);
+		close(pipefd[0]);
+		close(pipefd[1]);
+		return -err;
+	}
+
+	err = posix_spawnp(&pid, argv[0], &actions, NULL, argv, environ);
+	posix_spawn_file_actions_destroy(&actions);
+	close(pipefd[1]);
+	if (err) {
+		close(pipefd[0]);
+		return -err;
+	}
+
+	/* Parent: read the child's output, always draining to EOF. */
+	err = read_to_eof(pipefd[0], out, out_len);
+	close(pipefd[0]);
+
+	ret = wait_for_child(pid);
+	return err ? err : ret;
+}
 
 int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 	__u32 *correctable_errors, __u32 *uncorrectable_errors)
 {
-	int bus = 0, domain = 0, device = 0, function = 0;
-	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
-	char buf[8] = { 0 };
-	char *businfo = NULL;
-	__cleanup_free char *devicename = NULL;
-	ssize_t sLinkSize = 0;
-	FILE *fp;
-	char *res;
+	char bdf[64], buf[16] = { 0 };
+	int ret;
 
-	devicename = micron_get_ns_name(hdl);
-	if (!devicename || !strstr(devicename, "nvme")) {
-		nvme_show_error("Invalid device specified!");
-		return -EINVAL;
+	ret = get_pcie_bdf(hdl, bdf, sizeof(bdf));
+	if (ret) {
+		nvme_show_error("Failed to get PCI address");
+		return ret;
 	}
-	snprintf(strTempFile, sizeof(strTempFile), "/sys/block/%s/device", devicename);
-	sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
-	if (sLinkSize < 0) {
-		nvme_show_error("Failed to read device");
-		return -errno;
-	}
-	strTempFile2[sLinkSize] = '\0';
-	if (strstr(strTempFile2, "../../nvme")) {
-		snprintf(strTempFile, sizeof(strTempFile), "/sys/block/%s/device/device", devicename);
-		sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
-		if (sLinkSize < 0) {
-			nvme_show_error("Failed to read device");
-			return -errno;
-		}
-		strTempFile2[sLinkSize] = '\0';
-	}
-	businfo = strrchr(strTempFile2, '/');
-	if (!businfo || sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
-		domain = bus = device = function = 0;
-	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+10.L", bus, device,
-		function);
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
-		nvme_show_error("Failed to retrieve error count");
-		return -EIO;
-	}
-	res = fgets(buf, sizeof(buf), fp);
-	if (!res) {
-		nvme_show_error("Failed to retrieve error count");
-		pclose(fp);
-		return -EIO;
-	}
-	pclose(fp);
-	*correctable_errors = (__u32)strtol(buf, NULL, 16);
 
-	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+0x4.L", bus, device,
-		function);
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
+	ret = spawn_and_capture(
+		(char *const []){"setpci", "-s", bdf, "ECAP_AER+0x10.L", NULL},
+		buf, sizeof(buf));
+	if (ret) {
 		nvme_show_error("Failed to retrieve error count");
-		return -EIO;
+		return ret;
 	}
-	res = fgets(buf, sizeof(buf), fp);
-	if (!res) {
+	*correctable_errors = (__u32)strtoul(buf, NULL, 16);
+
+	ret = spawn_and_capture(
+		(char *const []){"setpci", "-s", bdf, "ECAP_AER+0x4.L", NULL},
+		buf, sizeof(buf));
+	if (ret) {
 		nvme_show_error("Failed to retrieve error count");
-		pclose(fp);
-		return -EIO;
+		return ret;
 	}
-	pclose(fp);
-	*uncorrectable_errors = (__u32)strtol(buf, NULL, 16);
+	*uncorrectable_errors = (__u32)strtoul(buf, NULL, 16);
 
 	return 0;
 }
@@ -94,82 +309,43 @@ int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 int micron_clear_pcie_aer_correctable_errors(
 	struct libnvme_transport_handle *hdl)
 {
-	int err, bus = 0, domain = 0, device = 0, function = 0;
-	char strTempFile[1024], strTempFile2[1024], cmdbuf[1024];
-	char *businfo = NULL;
-	__cleanup_free char *devicename = NULL;
-	ssize_t sLinkSize = 0;
-	char correctable[8] = { 0 };
-	FILE *fp;
-	char *res;
+	char bdf[64], correctable[16] = { 0 };
+	int ret;
 
-	devicename = micron_get_ns_name(hdl);
-	if (!devicename || !strstr(devicename, "nvme")) {
-		nvme_show_error("Invalid device specified!");
-		return -EINVAL;
+	ret = get_pcie_bdf(hdl, bdf, sizeof(bdf));
+	if (ret) {
+		nvme_show_error("Failed to get PCI address");
+		return ret;
 	}
-	err = snprintf(strTempFile, sizeof(strTempFile),
-				   "/sys/block/%s/device", devicename);
-	if (err < 0)
-		return err;
 
-	sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
-	if (sLinkSize < 0) {
-		nvme_show_error("Failed to read device");
-		return -errno;
-	}
-	strTempFile2[sLinkSize] = '\0';
-	if (strstr(strTempFile2, "../../nvme")) {
-		err = snprintf(strTempFile, sizeof(strTempFile),
-					   "/sys/block/%s/device/device", devicename);
-		if (err < 0)
-			return err;
-		sLinkSize = readlink(strTempFile, strTempFile2, sizeof(strTempFile2) - 1);
-		if (sLinkSize < 0) {
-			nvme_show_error("Failed to read device");
-			return -errno;
-		}
-		strTempFile2[sLinkSize] = '\0';
-	}
-	businfo = strrchr(strTempFile2, '/');
-	if (!businfo || sscanf(businfo, "/%x:%x:%x.%x", &domain, &bus, &device, &function) != 4)
-		domain = bus = device = function = 0;
-	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+0x10.L=0xffffffff", bus,
-			device, function);
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
+	/* Writing all 1s clears the errors. */
+	ret = spawn_and_capture(
+		(char *const []){"setpci", "-s", bdf,
+			"ECAP_AER+0x10.L=0xffffffff", NULL},
+		correctable, sizeof(correctable));
+	if (ret) {
 		nvme_show_error("Failed to clear error count");
-		return -1;
+		return ret;
 	}
-	pclose(fp);
 
-	snprintf(cmdbuf, sizeof(cmdbuf), "setpci -s %x:%x.%x ECAP_AER+0x10.L", bus, device,
-			function);
-	fp = popen(cmdbuf, "r");
-	if (!fp) {
+	ret = spawn_and_capture(
+		(char *const []){"setpci", "-s", bdf, "ECAP_AER+0x10.L", NULL},
+		correctable, sizeof(correctable));
+	if (ret) {
 		nvme_show_error("Failed to retrieve error count");
-		return -1;
+		return ret;
 	}
-	res = fgets(correctable, sizeof(correctable), fp);
-	if (!res) {
-		nvme_show_error("Failed to retrieve error count");
-		pclose(fp);
-		return -1;
-	}
-	pclose(fp);
 	nvme_show_verbose_result("Device correctable errors cleared!");
 	nvme_show_result("Device correctable errors detected: %s", correctable);
 	return 0;
 }
-
-extern char **environ;
 
 int micron_run_spawn(char *const argv[], const char *outfile, bool append)
 {
 	posix_spawn_file_actions_t actions;
 	posix_spawn_file_actions_t *actionsp = NULL;
 	pid_t pid;
-	int status, ret;
+	int ret;
 	int oflags = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
 
 	if (outfile) {
@@ -196,13 +372,8 @@ int micron_run_spawn(char *const argv[], const char *outfile, bool append)
 
 	if (ret)
 		return -ret;
-	while (waitpid(pid, &status, 0) == -1) {
-		if (errno != EINTR)
-			return -errno;
-	}
-	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
-		return -EIO;
-	return 0;
+
+	return wait_for_child(pid);
 
 out_destroy:
 	posix_spawn_file_actions_destroy(actionsp);

--- a/tests/plugins/micron/meson.build
+++ b/tests/plugins/micron/meson.build
@@ -3,6 +3,7 @@
 # Micron plugin tests
 
 micron_tests = [
+    'micron_clear_pcie_correctable_errors_test.py',
     'micron_vs_drive_info_test.py',
     'micron_vs_internal_log_test.py',
     'micron_vs_pcie_stats_test.py',

--- a/tests/plugins/micron/meson.build
+++ b/tests/plugins/micron/meson.build
@@ -5,6 +5,7 @@
 micron_tests = [
     'micron_vs_drive_info_test.py',
     'micron_vs_internal_log_test.py',
+    'micron_vs_temperature_stats_test.py',
 ]
 
 python_module = import('python')

--- a/tests/plugins/micron/meson.build
+++ b/tests/plugins/micron/meson.build
@@ -5,6 +5,7 @@
 micron_tests = [
     'micron_vs_drive_info_test.py',
     'micron_vs_internal_log_test.py',
+    'micron_vs_pcie_stats_test.py',
     'micron_vs_temperature_stats_test.py',
 ]
 

--- a/tests/plugins/micron/meson.build
+++ b/tests/plugins/micron/meson.build
@@ -4,6 +4,7 @@
 
 micron_tests = [
     'micron_vs_drive_info_test.py',
+    'micron_vs_internal_log_test.py',
 ]
 
 python_module = import('python')

--- a/tests/plugins/micron/micron_clear_pcie_correctable_errors_test.py
+++ b/tests/plugins/micron/micron_clear_pcie_correctable_errors_test.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Tests for the micron clear-pcie-correctable-errors command.
+
+The clear-pcie-correctable-errors command resets the PCIe correctable
+error status and has two model-dependent success paths:
+
+  NVMe command path:
+    Clears the correctable error status by issuing an NVMe command on
+    drives that support it -- either an NVMe set-features command or a
+    vendor-specific admin passthru command, depending on the model.
+    This path does not read back or report a correctable-error value.
+
+  AER/sysfs fallback path:
+    Writes 0xffffffff to the correctable error status register (via the
+    Linux AER sysfs interface) to clear all error bits, then reads the
+    register back and prints the value to stdout.  On Windows, PCIe
+    register writes are unsupported and drives without a dedicated clear
+    command fail with -ENOTSUP.
+
+Which path runs depends on the drive model present in the test
+environment, so the tests probe for support and assert only the
+behaviour common to whichever path is exercised.
+
+Tests in this module verify:
+  * Successful exit for controller and namespace device paths.
+  * The verbose success message on stderr across every path, and the
+    AER/sysfs read-back value on stdout.
+  * A read-back correctable error count of zero after an AER clear.
+  * Idempotency: clearing an already-cleared register still succeeds.
+  * Error detection for a non-existent device (parse_and_open failure).
+  * Graceful skipping when the platform does not support the command.
+"""
+
+import re
+
+from tests.plugins.micron.micron_test import TestMicron
+
+_WINDOWS_AER_UNSUPPORTED_MSG = "register writes not supported on the current platform"
+_AER_STDOUT_MARKER = "Device correctable errors detected:"
+_VERBOSE_CLEARED_MSG = "Device correctable errors cleared!"
+
+
+class TestMicronClearPcieCorrectableErrors(TestMicron):
+    """Test suite for the micron clear-pcie-correctable-errors plugin command."""
+
+    def _run_clear(self, device=None, args=""):
+        """Run clear-pcie-correctable-errors and return the CompletedProcess result."""
+        return self.run_plugin_cmd(
+            "clear-pcie-correctable-errors", device=device, args=args
+        )
+
+    def _is_clear_supported(self):
+        """Return True if clear-pcie-correctable-errors is supported on this platform.
+
+        On Windows, PCIE register writes are not supported, so drives without a
+        dedicated command to clear the errors will fail with -ENOTSUP and the
+        message "register writes not supported on the current platform".
+
+        On Linux the AER sysfs path is always supported, so no probe is needed.
+        """
+        if not self.is_windows():
+            return True
+        result = self._run_clear()
+        return not (
+            result.returncode != 0 and _WINDOWS_AER_UNSUPPORTED_MSG in result.stderr
+        )
+
+    def _skip_if_clear_unavailable(self):
+        """Skip the calling test if the clear command cannot succeed on this platform."""
+        if not self._is_clear_supported():
+            self.skipTest(
+                "clear-pcie-correctable-errors is not supported on this platform "
+                f"(stderr: {_WINDOWS_AER_UNSUPPORTED_MSG!r})"
+            )
+
+    def test_bad_device_returns_error(self):
+        """clear-pcie-correctable-errors fails with a message when the device does not exist.
+
+        Exercises the parse_and_open failure branch.
+        """
+        result = self._run_clear(device="/dev/nvme-nonexistent-test-device")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit code for a non-existent device",
+        )
+        self.assertTrue(
+            "open failed" in result.stderr,
+            f"Expected 'open failed' in stderr, "
+            f"got: {result.stderr!r}",
+        )
+
+    def test_command_exits_zero_on_success(self):
+        """clear-pcie-correctable-errors exits 0 when the drive is reachable.
+
+        Covers all hardware success paths. Which one is exercised depends on
+        the drive model present in the test environment.
+        """
+        self._skip_if_clear_unavailable()
+        result = self.run_plugin_cmd_check("clear-pcie-correctable-errors")
+
+        self.assertEqual(
+            result.returncode, 0,
+            f"Expected exit code 0, got {result.returncode}; "
+            f"stderr={result.stderr!r}",
+        )
+
+    def test_verbose_output_reports_cleared(self):
+        """With --verbose, every code path reports success on stderr.
+
+        All paths print the same verbose message to stderr.
+        The AER/sysfs fallback path additionally prints the read-back
+        correctable value to stdout.
+        """
+        self._skip_if_clear_unavailable()
+        result = self.run_plugin_cmd_check(
+            "clear-pcie-correctable-errors", args="--verbose"
+        )
+        stdout = result.stdout
+        stderr = result.stderr
+
+        # The verbose success message is emitted on every path.
+        self.assertIn(
+            _VERBOSE_CLEARED_MSG, stderr,
+            f"Expected verbose message {_VERBOSE_CLEARED_MSG!r} in stderr, "
+            f"got: {stderr!r}",
+        )
+
+        if _AER_STDOUT_MARKER in stdout:
+            # AER/sysfs fallback path: read-back value is printed to stdout.
+            self.assertRegex(
+                stdout,
+                rf"{re.escape(_AER_STDOUT_MARKER)}\s+[0-9a-fA-F]+",
+                f"Expected '{_AER_STDOUT_MARKER} <hex>', got: {stdout!r}",
+            )
+        else:
+            # NVMe command path: nothing is written to stdout.
+            self.assertEqual(
+                stdout, "",
+                f"Expected no stdout on the NVMe command path, got: {stdout!r}",
+            )
+
+    def test_aer_path_reported_value_is_zero_after_clear(self):
+        """After a clear, the read-back correctable error count is zero.
+
+        The AER clear writes 0xffffffff to the correctable error status
+        register, which clears all error bits.  Reading back
+        the register immediately after should return 0x00000000.
+
+        This test is skipped when the drive uses the NVMe command path
+        (set-features or passthru) because that path does not read back and
+        report a correctable-error value; success on those models is validated
+        by test_verbose_output_reports_cleared instead.
+        """
+        self._skip_if_clear_unavailable()
+        result = self.run_plugin_cmd_check("clear-pcie-correctable-errors")
+        stdout = result.stdout
+
+        if _AER_STDOUT_MARKER not in stdout:
+            self.skipTest(
+                "Drive uses the NVMe command path with no read-back value; "
+                "post-clear value assertion applies only to the AER/sysfs path"
+            )
+
+        m = re.search(rf"{re.escape(_AER_STDOUT_MARKER)}\s+([0-9a-fA-F]+)", stdout)
+        self.assertIsNotNone(
+            m,
+            f"Could not parse correctable error value from output: {stdout!r}",
+        )
+        reported = int(m.group(1), 16)
+        self.assertEqual(
+            reported, 0,
+            f"Expected correctable error count to be 0x0 after clear, "
+            f"got 0x{m.group(1)}",
+        )
+
+    def test_command_is_idempotent(self):
+        """clear-pcie-correctable-errors can be called twice and both invocations succeed.
+
+        Clearing an already-cleared register must not cause an error.  Both
+        success paths (the NVMe command path and AER/sysfs) should behave
+        idempotently.
+        """
+        self._skip_if_clear_unavailable()
+        result1 = self.run_plugin_cmd_check("clear-pcie-correctable-errors")
+        result2 = self.run_plugin_cmd_check("clear-pcie-correctable-errors")
+
+        self.assertEqual(
+            result1.returncode, 0,
+            f"First invocation failed: rc={result1.returncode}, "
+            f"stderr={result1.stderr!r}",
+        )
+        self.assertEqual(
+            result2.returncode, 0,
+            f"Second invocation failed: rc={result2.returncode}, "
+            f"stderr={result2.stderr!r}",
+        )
+
+    def test_namespace_device_succeeds(self):
+        """clear-pcie-correctable-errors exits 0 when given a namespace path.
+
+        micron_parse_options resolves the namespace device to its parent
+        controller, so the clear operation should succeed regardless of whether
+        a controller or namespace path is passed.
+        """
+        if self.is_windows():
+            ns_probe = self._run_clear(device=self.ns1)
+            if (
+                ns_probe.returncode != 0
+                and _WINDOWS_AER_UNSUPPORTED_MSG in ns_probe.stderr
+            ):
+                self.skipTest(
+                    "clear-pcie-correctable-errors is not supported on this platform "
+                    f"(stderr: {_WINDOWS_AER_UNSUPPORTED_MSG!r})"
+                )
+            self.assertEqual(
+                ns_probe.returncode, 0,
+                f"Expected exit code 0 for namespace device, "
+                f"got {ns_probe.returncode}; stderr={ns_probe.stderr!r}",
+            )
+        else:
+            result = self.run_plugin_cmd_check(
+                "clear-pcie-correctable-errors", device=self.ns1
+            )
+            self.assertEqual(
+                result.returncode, 0,
+                f"Expected exit code 0 for namespace device, "
+                f"got {result.returncode}; stderr={result.stderr!r}",
+            )

--- a/tests/plugins/micron/micron_vs_drive_info_test.py
+++ b/tests/plugins/micron/micron_vs_drive_info_test.py
@@ -2,14 +2,372 @@
 #
 # Copyright (c) 2026 Micron Technology, Inc.
 #
-"""Test for Micron vs-drive-info plugin command."""
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Tests for the micron vs-drive-info command.
+
+The vs-drive-info command reports drive hardware information -- hardware
+version, FTL unit size, boot-spec version, and drive-ownership status.
+Which fields appear and how they are formatted depends on the drive model
+and its customer ID, so several fields are optional and present only on
+certain drives.  Output is human-readable text by default or JSON when
+--format=json is passed.
+
+Tests in this module verify:
+  * Error handling for a non-existent device and an invalid --format value.
+  * Text output by default and with --format=normal, and that --format=json
+    switches the output to JSON.
+  * Valid JSON shape: a one-element "Micron Drive HW Information" array
+    holding a single info object.
+  * The always-present "Drive Hardware Version" field, and the format of the
+    optional FTL size, boot-spec, and ownership-status fields when present.
+  * Consistency of the reported fields and values between JSON and text.
+  * Equivalent results for the controller and namespace device paths.
+"""
+
+import json
+import re
 
 from tests.plugins.micron.micron_test import TestMicron
 
+_MICRON_HW_INFORMATION_KEY = "Micron Drive HW Information"
+_UNSUPPORTED_MSG = "Unsupported drive for vs-drive-info cmd"
 
-class TestMicronDriveInfo(TestMicron):
-    """Verify that the micron vs-drive-info command executes successfully."""
+# Field labels shared by the JSON (keys) and text ("Label: value") branches.
+_DRIVE_HW_VERSION = "Drive Hardware Version"
+_FTL_UNIT_SIZE = "FTL_unit_size"
+_BOOT_SPEC_VERSION = "Boot Spec.Version"
+_OWNERSHIP_STATUS = "Drive Ownership Status"
 
-    def test_vs_drive_info(self):
-        """Run micron vs-drive-info and verify it returns success."""
-        self.run_plugin_cmd_check("vs-drive-info")
+_ALL_LABELS = [
+    _DRIVE_HW_VERSION,
+    _FTL_UNIT_SIZE,
+    _BOOT_SPEC_VERSION,
+    _OWNERSHIP_STATUS,
+]
+
+_OWNERSHIP_VALUES = {"N/A", "UNSET", "SET", "BLOCKED"}
+
+
+class TestMicronVsDriveInfo(TestMicron):
+    """Test suite for the micron vs-drive-info plugin command."""
+
+    # Cached result of the drive info availability probe.
+    # None means "not yet probed".
+    _drive_info_available = None
+
+    def _run_drive_info(self, device=None, args=""):
+        """Run vs-drive-info and return the CompletedProcess result."""
+        return self.run_plugin_cmd("vs-drive-info", device=device, args=args)
+
+    def _is_drive_info_available(self):
+        """Return True if drive info is available for the current drive. """
+
+        cls = type(self)
+        if cls._drive_info_available is None:
+            result = self._run_drive_info()
+            cls._drive_info_available = not (
+                result.returncode != 0 and _UNSUPPORTED_MSG in result.stderr
+            )
+        return cls._drive_info_available
+
+    def _skip_if_unavailable(self):
+        """Skip the calling test if the drive model is unsupported here."""
+        if not self._is_drive_info_available():
+            self.skipTest(
+                f"vs-drive-info reports an unsupported drive on this platform "
+                f"(stderr: {_UNSUPPORTED_MSG!r})"
+            )
+
+    def _drive_info_json(self, args="--format=json"):
+        """Run vs-drive-info in JSON mode and return the parsed top-level dict.
+
+        Skips the test if the drive is unsupported on this platform.
+        """
+        self._skip_if_unavailable()
+        result = self.run_plugin_cmd_check("vs-drive-info", args=args)
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(f"stdout is not valid JSON: {exc}\nstdout={result.stdout!r}")
+
+    def _drive_info_object(self, args="--format=json"):
+        """Return the single info object from the JSON array."""
+        data = self._drive_info_json(args=args)
+        self.assertIn(
+            _MICRON_HW_INFORMATION_KEY, data,
+            f"Expected top-level '{_MICRON_HW_INFORMATION_KEY}' key, "
+            f"got: {list(data.keys())}",
+        )
+        array = data[_MICRON_HW_INFORMATION_KEY]
+        self.assertIsInstance(
+            array, list, f"'{_MICRON_HW_INFORMATION_KEY}' value must be a list"
+        )
+        self.assertEqual(
+            len(array), 1,
+            f"Expected exactly one info object, got {len(array)}",
+        )
+        return array[0]
+
+    def _text_labels_present(self, stdout):
+        """Return the set of known labels that appear as 'Label:' in text output."""
+        present = set()
+        for label in _ALL_LABELS:
+            if re.search(r"^" + re.escape(label) + r"\s*:", stdout, re.MULTILINE):
+                present.add(label)
+        return present
+
+    def test_bad_device_returns_error(self):
+        """vs-drive-info fails with 'open failed' when the device does not exist.
+
+        Exercises the parse_and_open failure branch.  Only the constant
+        "open failed" prefix is asserted because the OS strerror text appended
+        to it differs between Windows and Linux.
+        """
+        result = self._run_drive_info(device="/dev/nvme-nonexistent-test-device")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit code for a non-existent device",
+        )
+        self.assertIn(
+            "open failed", result.stderr,
+            f"Expected 'open failed' in stderr, got: {result.stderr!r}",
+        )
+
+    def test_invalid_format_returns_error(self):
+        """vs-drive-info fails for an unrecognised -f/--format value.
+
+        Uses the command-local --format flag, which only accepts "normal" or
+        "json".
+        """
+        result = self._run_drive_info(args="--format=notaformat")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit code for an invalid --format value",
+        )
+        self.assertIn(
+            "Invalid output format", result.stderr,
+            f"Expected 'Invalid output format' in stderr, got: {result.stderr!r}",
+        )
+
+    def test_default_output_is_text(self):
+        """vs-drive-info produces human-readable text by default.
+
+        With no format flag the output is text, always includes the
+        "Drive Hardware Version:" line, and must not parse as JSON.
+        """
+        self._skip_if_unavailable()
+        result = self.run_plugin_cmd_check("vs-drive-info")
+
+        self.assertRegex(
+            result.stdout, r"Drive Hardware Version\s*:\s*\d+\.\d+",
+            f"Expected 'Drive Hardware Version: <N.M>' in text output, "
+            f"got: {result.stdout!r}",
+        )
+        with self.assertRaises((json.JSONDecodeError, ValueError),
+                               msg="Default output must not be JSON"):
+            json.loads(result.stdout)
+
+    def test_explicit_normal_format_is_text(self):
+        """vs-drive-info produces text output when --format=normal is passed."""
+        self._skip_if_unavailable()
+        result = self.run_plugin_cmd_check("vs-drive-info", args="--format=normal")
+
+        self.assertRegex(
+            result.stdout, r"Drive Hardware Version\s*:\s*\d+\.\d+",
+            f"Expected 'Drive Hardware Version: <N.M>' with --format=normal, "
+            f"got: {result.stdout!r}",
+        )
+
+    def test_format_json_produces_valid_json(self):
+        """vs-drive-info produces valid JSON when --format=json is passed."""
+        obj = self._drive_info_object(args="--format=json")
+        self.assertIsInstance(obj, dict)
+
+    def test_short_f_json_produces_valid_json(self):
+        """vs-drive-info produces valid JSON when the short -f json flag is passed."""
+        obj = self._drive_info_object(args="-f json")
+        self.assertIsInstance(obj, dict)
+
+    def test_json_top_level_is_single_element_array(self):
+        """vs-drive-info wraps the info object in a one-element JSON array.
+
+        The "Micron Drive HW Information" array holds exactly one object.
+        """
+        data = self._drive_info_json()
+        array = data[_MICRON_HW_INFORMATION_KEY]
+
+        self.assertIsInstance(array, list,
+                              f"'{_MICRON_HW_INFORMATION_KEY}' must be a JSON array")
+        self.assertEqual(len(array), 1,
+                         f"Expected exactly one element, got {len(array)}")
+
+    def test_json_always_has_drive_hardware_version(self):
+        """vs-drive-info JSON output always contains 'Drive Hardware Version'.
+
+        This field is emitted unconditionally as "<N>.<M>".
+        """
+        obj = self._drive_info_object()
+
+        self.assertIn(
+            _DRIVE_HW_VERSION, obj,
+            f"Expected '{_DRIVE_HW_VERSION}' key, got: {list(obj.keys())}",
+        )
+        self.assertRegex(
+            obj[_DRIVE_HW_VERSION], r"^\d+\.\d+$",
+            f"Expected '<N>.<M>' HW version, got: {obj[_DRIVE_HW_VERSION]!r}",
+        )
+
+    def test_text_always_has_drive_hardware_version(self):
+        """vs-drive-info text output always contains a 'Drive Hardware Version:' line."""
+        self._skip_if_unavailable()
+        result = self.run_plugin_cmd_check("vs-drive-info")
+
+        self.assertRegex(
+            result.stdout, r"Drive Hardware Version\s*:\s*\d+\.\d+",
+            f"Expected 'Drive Hardware Version: <N.M>' line, got: {result.stdout!r}",
+        )
+
+    def test_json_has_no_unexpected_fields(self):
+        """vs-drive-info JSON object contains only the documented fields.
+
+        Any key outside the known label set indicates a regression where a
+        new field was added without updating this test.
+        """
+        obj = self._drive_info_object()
+
+        extra = set(obj.keys()) - set(_ALL_LABELS)
+        self.assertFalse(
+            extra,
+            f"Unexpected extra keys in drive-info JSON object: {extra}",
+        )
+
+    def test_ftl_unit_size_format_if_present(self):
+        """When present, 'FTL_unit_size' is formatted as '<N> B' or '<N> KB'.
+
+        The units are model-dependent, and the field is emitted only when the
+        FTL unit size is non-zero, so absence is acceptable.
+        """
+        obj = self._drive_info_object()
+        if _FTL_UNIT_SIZE not in obj:
+            self.skipTest("FTL_unit_size not reported by this drive (ftl_unit_size == 0)")
+
+        self.assertRegex(
+            obj[_FTL_UNIT_SIZE], r"^\d+ (B|KB)$",
+            f"Expected FTL size as '<N> B' or '<N> KB', got: {obj[_FTL_UNIT_SIZE]!r}",
+        )
+
+    def test_boot_spec_version_present_in_both_or_neither(self):
+        """'Boot Spec.Version' is emitted (or omitted) consistently in JSON and text.
+
+        The field appears only on drives that report a boot-spec version; when
+        present its value must be a non-empty string.
+        """
+        obj = self._drive_info_object()
+        result_text = self.run_plugin_cmd_check("vs-drive-info")
+        text_has = _BOOT_SPEC_VERSION in self._text_labels_present(result_text.stdout)
+        json_has = _BOOT_SPEC_VERSION in obj
+
+        self.assertEqual(
+            json_has, text_has,
+            f"'{_BOOT_SPEC_VERSION}' presence differs between JSON ({json_has}) "
+            f"and text ({text_has})",
+        )
+        if json_has:
+            self.assertTrue(
+                obj[_BOOT_SPEC_VERSION].strip(),
+                f"'{_BOOT_SPEC_VERSION}' JSON value must be non-empty, "
+                f"got: {obj[_BOOT_SPEC_VERSION]!r}",
+            )
+
+    def test_ownership_status_value_if_present(self):
+        """When present, 'Drive Ownership Status' is one of the four known states.
+
+        This field is emitted only on certain drives; its value is one of
+        N/A / UNSET / SET / BLOCKED.
+        """
+        obj = self._drive_info_object()
+        if _OWNERSHIP_STATUS not in obj:
+            self.skipTest("Drive Ownership Status not reported by this drive")
+
+        self.assertIn(
+            obj[_OWNERSHIP_STATUS], _OWNERSHIP_VALUES,
+            f"Expected ownership status in {_OWNERSHIP_VALUES}, "
+            f"got: {obj[_OWNERSHIP_STATUS]!r}",
+        )
+
+    def test_json_and_text_report_same_fields(self):
+        """JSON keys and text 'Label:' lines expose the same set of fields.
+
+        Both output formats are driven by the same data, so the set of emitted
+        fields must match regardless of format.
+        """
+        obj = self._drive_info_object()
+        json_labels = set(obj.keys())
+
+        result_text = self.run_plugin_cmd_check("vs-drive-info")
+        text_labels = self._text_labels_present(result_text.stdout)
+
+        self.assertEqual(
+            json_labels, text_labels,
+            f"JSON and text output expose different fields:\n"
+            f"  JSON: {sorted(json_labels)}\n"
+            f"  text: {sorted(text_labels)}",
+        )
+
+    def test_hardware_version_matches_between_json_and_text(self):
+        """The HW version value is identical in JSON and text output."""
+        obj = self._drive_info_object()
+        json_version = obj[_DRIVE_HW_VERSION]
+
+        result_text = self.run_plugin_cmd_check("vs-drive-info")
+        m = re.search(r"Drive Hardware Version\s*:\s*(\d+\.\d+)", result_text.stdout)
+        self.assertIsNotNone(
+            m,
+            f"Could not parse HW version from text output: {result_text.stdout!r}",
+        )
+
+        self.assertEqual(
+            json_version, m.group(1),
+            f"HW version differs between JSON ({json_version!r}) and "
+            f"text ({m.group(1)!r})",
+        )
+
+    def test_namespace_device_produces_same_fields_as_ctrl(self):
+        """vs-drive-info yields the same JSON fields for the namespace path.
+
+        A namespace path resolves to its parent controller, so the reported
+        field set must match that of the controller path.
+        """
+        # Probe availability against the namespace path specifically.
+        ns_probe = self.run_plugin_cmd("vs-drive-info", device=self.ns1)
+        if ns_probe.returncode != 0 and _UNSUPPORTED_MSG in ns_probe.stderr:
+            self.skipTest(
+                f"vs-drive-info reports an unsupported drive on this platform "
+                f"(stderr: {_UNSUPPORTED_MSG!r})"
+            )
+
+        result_ctrl = self.run_plugin_cmd_check(
+            "vs-drive-info", device=self.ctrl, args="--format=json"
+        )
+        result_ns = self.run_plugin_cmd_check(
+            "vs-drive-info", device=self.ns1, args="--format=json"
+        )
+
+        try:
+            data_ctrl = json.loads(result_ctrl.stdout)
+            data_ns = json.loads(result_ns.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(f"Output is not valid JSON: {exc}")
+
+        keys_ctrl = set(data_ctrl[_MICRON_HW_INFORMATION_KEY][0].keys())
+        keys_ns = set(data_ns[_MICRON_HW_INFORMATION_KEY][0].keys())
+
+        self.assertEqual(
+            keys_ctrl, keys_ns,
+            f"Controller and namespace paths produced different field sets:\n"
+            f"  ctrl ({self.ctrl}): {sorted(keys_ctrl)}\n"
+            f"  ns1  ({self.ns1}):  {sorted(keys_ns)}",
+        )

--- a/tests/plugins/micron/micron_vs_internal_log_test.py
+++ b/tests/plugins/micron/micron_vs_internal_log_test.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Tests for the micron vs-internal-log command.
+
+The vs-internal-log command has two operating modes:
+
+  Debug package mode (default):
+    Collects model-specific NVMe log pages and OS diagnostics into a
+    compressed archive (.zip, .tgz, or .tar.gz).  A temporary working
+    directory named after the drive serial number is created in the
+    current working directory and then removed once the archive is built.
+
+  Telemetry mode (--type=host|controller):
+    Extracts a single binary telemetry log file.  Requires both --type
+    and --data_area (1-4).
+
+Tests in this module verify:
+  * Archive generation for each supported format (.zip, .tgz, .tar.gz).
+  * Temporary directory cleanup after successful collection.
+  * Error detection in stdout/stderr for every known failure path.
+  * Argument validation: missing package, unsafe paths, telemetry
+    mis-use, and out-of-range data_area.
+"""
+
+import os
+
+from tests.plugins.micron.micron_test import TestMicron
+
+
+class TestMicronVsInternalLog(TestMicron):
+    """Test suite for the micron vs-internal-log plugin command."""
+
+    # ------------------------------------------------------------------
+    # Setup / teardown
+    # ------------------------------------------------------------------
+
+    def setUp(self):
+        super().setUp()
+        # Paths of archive files created by tests; removed in tearDown.
+        self._archive_files = []
+
+    def tearDown(self):
+        for path in self._archive_files:
+            if os.path.exists(path):
+                os.remove(path)
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _archive_path(self, filename):
+        """Return a path inside the test log directory.
+
+        The path is registered for automatic deletion in tearDown so that
+        large archive files do not accumulate between test runs.
+        """
+        path = os.path.join(self.test_log_dir, filename)
+        self._archive_files.append(path)
+        return path
+
+    def _subdirs(self, path):
+        """Return the set of subdirectory names in path."""
+        return {n for n in os.listdir(path) if os.path.isdir(os.path.join(path, n))}
+
+    def _run_log(self, args=""):
+        """Run micron vs-internal-log against the default controller."""
+        return self.run_plugin_cmd("vs-internal-log", args=args)
+
+    def _test_archive_format(self, extension):
+        """Shared body for the archive-format tests.
+
+        Verifies:
+          - Command exits with code 0.
+          - The archive file is created and is non-empty.
+          - No "Failed to create log data package" message appears in stderr.
+          - No temporary working directories remain in the current directory
+            after the command returns.
+        """
+        output_path = self._archive_path(f"internal_log{extension}")
+        cwd = os.getcwd()
+        dirs_before = self._subdirs(cwd)
+
+        result = self._run_log(args=f"--package={output_path}")
+
+        self.assertEqual(
+            result.returncode, 0,
+            f"vs-internal-log '{extension}' failed: "
+            f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}",
+        )
+
+        # Archive must exist and contain data.
+        self.assertTrue(
+            os.path.isfile(output_path),
+            f"Archive was not created: {output_path}",
+        )
+        self.assertGreater(
+            os.path.getsize(output_path), 0,
+            f"Archive is empty: {output_path}",
+        )
+
+        # No packaging failure message should appear in stderr.
+        self.assertNotIn(
+            "Failed to create log data package", result.stderr,
+            f"Archive creation error for '{extension}': {result.stderr}",
+        )
+
+        # All temporary working directories must have been removed.
+        dirs_after = self._subdirs(cwd)
+        leaked = dirs_after - dirs_before
+        self.assertFalse(
+            leaked,
+            f"Temporary directories were not cleaned up after '{extension}' "
+            f"collection: {leaked}",
+        )
+
+    # ------------------------------------------------------------------
+    # Archive format tests
+    # ------------------------------------------------------------------
+
+    def test_zip_package(self):
+        """vs-internal-log creates a .zip archive and removes temporary directories."""
+        self._test_archive_format(".zip")
+
+    def test_tgz_package(self):
+        """vs-internal-log creates a .tgz archive and removes temporary directories."""
+        self._test_archive_format(".tgz")
+
+    def test_tar_gz_package(self):
+        """vs-internal-log creates a .tar.gz archive and removes temporary directories."""
+        self._test_archive_format(".tar.gz")
+
+    # ------------------------------------------------------------------
+    # Missing / invalid --package argument
+    # ------------------------------------------------------------------
+
+    def test_no_package_argument(self):
+        """vs-internal-log fails with a descriptive message when --package is omitted.
+
+        Covers both the debug-package and telemetry code paths: each branch
+        emits a mode-specific example path in the error message.
+        """
+        cases = [
+            ("debug-package mode", "",                        "logfile.zip"),
+            ("telemetry mode",     "--type=host --data_area=1", "logfile.bin"),
+        ]
+        for label, args, hint in cases:
+            with self.subTest(mode=label):
+                result = self._run_log(args=args)
+
+                self.assertNotEqual(
+                    result.returncode, 0,
+                    f"Expected non-zero exit when --package is omitted ({label})",
+                )
+                self.assertIn(
+                    "Log data file must be specified", result.stderr,
+                    f"Expected usage hint about missing package in stderr ({label}), "
+                    f"got: {result.stderr!r}",
+                )
+                self.assertIn(
+                    hint, result.stderr,
+                    f"Expected mode-specific hint '{hint}' in stderr ({label}), "
+                    f"got: {result.stderr!r}",
+                )
+
+    def test_unsafe_package_path_leading_dash(self):
+        """vs-internal-log rejects a --package path that starts with '-'.
+
+        A path starting with '-' could be mis-interpreted as a flag by the
+        tar or zip tool that archives the output.  is_safe_path() rejects
+        it before any I/O is attempted.
+        """
+        result = self._run_log(args="--package=-output.zip")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit for --package path starting with '-'",
+        )
+        self.assertIn(
+            "Invalid package path", result.stderr,
+            f"Expected unsafe-path message in stderr, got: {result.stderr!r}",
+        )
+
+    def test_unsafe_package_path_special_chars(self):
+        """vs-internal-log rejects a --package path containing unsafe characters.
+
+        The glob character '*' is in the rejected-character table of
+        is_safe_path().  It is safe to embed in a double-quoted shell argument
+        in both POSIX shells (bash suppresses glob expansion inside double
+        quotes) and cmd.exe (where '*' is not a shell metachar in argument
+        strings).
+        """
+        result = self._run_log(args='--package="file*name.zip"')
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit for --package path containing '*'",
+        )
+        self.assertIn(
+            "Invalid package path", result.stderr,
+            f"Expected unsafe-path message in stderr, got: {result.stderr!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # Telemetry mode argument validation
+    # ------------------------------------------------------------------
+
+    def test_telemetry_invalid_type(self):
+        """vs-internal-log rejects an unrecognised value for --type.
+
+        Only "host" and "controller" are valid telemetry types.
+        """
+        output_path = self._archive_path("telemetry_invalid.bin")
+        result = self._run_log(
+            args=f"--type=invalid --data_area=1 --package={output_path}"
+        )
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit for unrecognised --type value",
+        )
+        self.assertIn(
+            "host or controller", result.stderr,
+            f"Expected message naming valid telemetry types, "
+            f"got stderr={result.stderr!r}",
+        )
+
+    def test_telemetry_missing_data_area(self):
+        """vs-internal-log requires --data_area."""
+        output_path = self._archive_path("telemetry_host.bin")
+        result = self._run_log(args=f"--type=host --package={output_path}")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit when --data_area is omitted",
+        )
+        self.assertIn(
+            "data area", result.stderr.lower(),
+            f"Expected message about missing data area, got stderr={result.stderr!r}",
+        )
+
+    def test_telemetry_data_area_out_of_range(self):
+        """vs-internal-log rejects --data_area values outside the 1-4 range.
+
+        The implementation checks cfg.data_area <= 0 || cfg.data_area > 4.
+        Both bounds are exercised: 0 (lower) and 5 (upper).
+        """
+        output_path = self._archive_path("telemetry_oor.bin")
+        for value in (0, 5):
+            with self.subTest(data_area=value):
+                result = self._run_log(
+                    args=f"--type=host --data_area={value} --package={output_path}"
+                )
+
+                self.assertNotEqual(
+                    result.returncode, 0,
+                    f"Expected non-zero exit for --data_area={value} (valid range is 1-4)",
+                )
+                self.assertIn(
+                    "data area", result.stderr.lower(),
+                    f"Expected message about data area range, got stderr={result.stderr!r}",
+                )
+
+    # ------------------------------------------------------------------
+    # Telemetry mode happy paths
+    # ------------------------------------------------------------------
+
+    def test_telemetry_success(self):
+        """vs-internal-log extracts a telemetry log to a binary file."""
+        output_path = self._archive_path("telemetry_ctrl_da1.bin")
+        result = self._run_log(
+            args=f"--type=controller --data_area=1 --package={output_path}"
+        )
+
+        self.assertEqual(
+            result.returncode, 0,
+            f"vs-internal-log --type=controller --data_area=1 failed: "
+            f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}",
+        )
+        self.assertTrue(
+            os.path.isfile(output_path),
+            f"Telemetry log file was not created: {output_path}",
+        )
+        size = os.path.getsize(output_path)
+        self.assertGreater(size, 0, "Telemetry log file is empty")
+        self.assertEqual(
+            size % 512, 0,
+            f"Telemetry log file size {size} is not a multiple of 512 bytes",
+        )
+
+    def test_data_area_without_type(self):
+        """vs-internal-log rejects --data_area when --type is not specified.
+
+        --data_area is only meaningful in telemetry mode; the implementation
+        prints an explicit error when it appears without --type.
+        """
+        output_path = self._archive_path("data_area_notype.zip")
+        result = self._run_log(
+            args=f"--data_area=1 --package={output_path}"
+        )
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit for --data_area without --type",
+        )
+        self.assertIn(
+            "data area option is valid only for telemetry", result.stderr,
+            f"Expected telemetry-only message, got stderr={result.stderr!r}",
+        )

--- a/tests/plugins/micron/micron_vs_pcie_stats_test.py
+++ b/tests/plugins/micron/micron_vs_pcie_stats_test.py
@@ -6,84 +6,30 @@
 #
 """Tests for the micron vs-pcie-stats command.
 
-The command retrieves PCIe error statistics and prints them in JSON or text
-format.  The full code-path map is:
+The vs-pcie-stats command retrieves PCIe error statistics and prints them in
+either JSON (the default) or plain-text format.  The statistics are gathered
+in a model-dependent way: some drives report per-field error counters, while
+others expose the AER error-status bits read from the PCIe registers.  On
+Windows, drives that rely on register reads are unsupported, so the command
+fails with -ENOTSUP; the tests probe for this at runtime and skip gracefully.
 
-  1.  parse_and_open fails
-        → rc=-1, "Device not found" in stderr
-
-  2.  validate_output_format fails
-        → rc<0, "Invalid output format" in stderr
-
-  3.  GetDriveModel returns UNKNOWN_MODEL
-        → "Unsupported drive model for vs-pcie-stats command" in stderr,
-          err=-ENOTSUP, goto out (returns a non-zero error)
-
-  4.  eModel == M5407: libnvme_exec_admin_passthru succeeds
-        → counters=true, goto print_stats with counter values from hardware
-
-  5.  eModel == M5407: libnvme_exec_admin_passthru fails
-        → falls through to micron_get_pcie_aer_errors
-
-  6.  micron_get_pcie_aer_errors fails
-        → goto out with error
-
-  6a. On Windows, micron_get_pcie_aer_errors always returns -ENOTSUP with
-      "register reads not supported on the current platform" in stderr.
-      For non-M5407 drives (which don't take the 0xD6 passthru path), this
-      means the command exits with an error and print_stats is never reached.
-      M5407 drives are unaffected because they reach print_stats via the
-      passthru path before micron_get_pcie_aer_errors is called.
-
-  7.  print_stats, is_json=true (default cfg.fmt="json")
-        → JSON output with top-level "PCIE Stats" array containing one
-          object with all 16 named error fields
-
-  8.  print_stats, is_json=true, --format=json explicit
-        → same JSON output as path 7
-
-  9.  print_stats, is_json=true, --output-format=json
-        → same JSON output as path 7
-
-  10. print_stats, is_json=false (--format=normal or --output-format=normal),
-      counters=true (M5407 passthru succeeded)
-        → per-field text with %hu format
-
-  11. print_stats, is_json=false, counters=false, eModel==M5407 or M5410
-        → per-field text with bit values (AER registers)
-
-  12. print_stats, is_json=false, counters=false, other models
-        → "PCIE Stats:" header line, hex correctable/uncorrectable counts
-
-Testable paths on real hardware:  1, 2, 7, 8, 9, 10-or-11-or-12
-  (which of 10/11/12 is exercised depends on the drive model present)
-
-On Windows with a non-M5407 drive: only paths 1 and 2 are reachable;
-paths 7-12 are all skipped because micron_get_pcie_aer_errors returns
--ENOTSUP before print_stats can be reached.  The tests detect this at
-runtime via _pcie_stats_available() and skip gracefully.
-
-Untestable paths:
-  - Path 3 (UNKNOWN_MODEL): live test hardware is always a supported Micron
-    drive; there is no way to inject an unknown device ID.
-  - Path 6 (micron_get_pcie_aer_errors error on Linux): requires sysfs to
-    be unavailable; not injectable in a live hardware test.
-  - Distinguishing paths 10 vs 11 on M5407 hardware: which branch the
-    0xD6 admin passthru takes (success → counters=true vs failure →
-    AER read) depends on firmware; both yield the same named-field text
-    output layout so the difference is transparent to the test.
+Tests in this module verify:
+  * Error detection for a non-existent device and an invalid output format.
+  * JSON output: the top-level "PCIE Stats" single-element array and its
+    full set of named correctable and uncorrectable error fields.
+  * Text output for whichever model-specific branch the drive exercises.
+  * Consistency between the JSON and text representations, and between the
+    controller and namespace device paths.
 """
 
 import json
+import re
 
 from tests.plugins.micron.micron_test import TestMicron
 
 _WINDOWS_AER_UNSUPPORTED_MSG = "register reads not supported on the current platform"
 
-
-# ---------------------------------------------------------------------------
-# Expected field names (same order as the C arrays)
-# ---------------------------------------------------------------------------
+# Expected PCIe error field names, in the order the command emits them.
 
 CORRECTABLE_FIELDS = [
     "Unsupported Request Error Status (URES)",
@@ -113,23 +59,16 @@ ALL_FIELDS = CORRECTABLE_FIELDS + UNCORRECTABLE_FIELDS
 class TestMicronVsPcieStats(TestMicron):
     """Test suite for the micron vs-pcie-stats plugin command."""
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
     def _run_pcie_stats(self, device=None, args=""):
         """Run vs-pcie-stats and return the CompletedProcess result."""
         return self.run_plugin_cmd("vs-pcie-stats", device=device, args=args)
 
     def _pcie_stats_available(self):
-        """Return True if vs-pcie-stats can reach the print_stats branch.
+        """Return True if vs-pcie-stats can produce statistics on this platform.
 
-        On Windows, micron_get_pcie_aer_errors() always returns -ENOTSUP for
-        non-M5407 drives, printing "register reads not supported on the current
-        platform" and exiting before print_stats is reached.  M5407 drives are
-        unaffected because they take the 0xD6 passthru path first.
-
-        On Linux, the AER path always succeeds on supported hardware, so no
+        On Windows, drives that rely on PCIe register reads are unsupported and
+        the command fails with -ENOTSUP and a "register reads not supported"
+        message.  On other platforms the command is always supported, so no
         probe is needed.
         """
         if not self.is_windows():
@@ -140,7 +79,7 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def _skip_if_pcie_stats_unavailable(self):
-        """Skip the calling test if print_stats is unreachable on this platform."""
+        """Skip the calling test if vs-pcie-stats is unsupported on this platform."""
         if not self._pcie_stats_available():
             self.skipTest(
                 "vs-pcie-stats is not supported on this platform "
@@ -153,6 +92,10 @@ class TestMicronVsPcieStats(TestMicron):
         Skips the test if PCIe stats are unavailable on this platform.
         """
         self._skip_if_pcie_stats_unavailable()
+        if "json" not in args:
+            # Explicitly specify JSON output. Don't rely on default behavior.
+            # Allow the caller to use a different json format flag if desired.
+            args += " --output-format=json"
         result = self.run_plugin_cmd_check("vs-pcie-stats", args=args)
         try:
             return json.loads(result.stdout)
@@ -174,15 +117,8 @@ class TestMicronVsPcieStats(TestMicron):
                          f"Expected exactly one stats object, got {len(array)}")
         return array[0]
 
-    # ------------------------------------------------------------------
-    # Error paths (paths 1 & 2)
-    # ------------------------------------------------------------------
-
     def test_bad_device_returns_error(self):
-        """vs-pcie-stats fails with a message when the device does not exist.
-
-        Exercises the parse_and_open failure branch (path 1).
-        """
+        """vs-pcie-stats fails with a message when the device does not exist."""
         result = self._run_pcie_stats(device="/dev/nvme-nonexistent-test-device")
 
         self.assertNotEqual(
@@ -195,10 +131,7 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def test_invalid_output_format_returns_error(self):
-        """vs-pcie-stats fails with a message for an unrecognised --output-format.
-
-        Exercises the validate_output_format failure branch (path 2).
-        """
+        """vs-pcie-stats fails with a message for an unrecognised --output-format."""
         result = self._run_pcie_stats(args="--output-format=notaformat")
 
         self.assertNotEqual(
@@ -210,16 +143,8 @@ class TestMicronVsPcieStats(TestMicron):
             f"Expected 'Invalid output format' in stderr, got: {result.stderr!r}",
         )
 
-    # ------------------------------------------------------------------
-    # JSON output (paths 7, 8, 9)
-    # ------------------------------------------------------------------
-
     def test_default_output_is_json(self):
-        """vs-pcie-stats produces JSON output by default.
-
-        The default cfg.fmt is "json", so is_json starts true and is never
-        cleared by the normal/NORMAL check (path 7).
-        """
+        """vs-pcie-stats produces JSON output by default."""
         self._skip_if_pcie_stats_unavailable()
         result = self.run_plugin_cmd_check("vs-pcie-stats")
 
@@ -238,10 +163,7 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def test_explicit_format_json_produces_valid_json(self):
-        """vs-pcie-stats produces valid JSON when --format=json is passed.
-
-        Exercises is_json=true via cfg.fmt == "json" (path 8).
-        """
+        """vs-pcie-stats produces valid JSON when --format=json is passed."""
         self._skip_if_pcie_stats_unavailable()
         result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=json")
 
@@ -260,11 +182,7 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def test_output_format_json_produces_valid_json(self):
-        """vs-pcie-stats produces valid JSON when --output-format=json is passed.
-
-        Exercises is_json=true via flags & JSON (path 9).  The flags path is
-        independent from the cfg.fmt path; both must result in JSON output.
-        """
+        """vs-pcie-stats produces valid JSON when --output-format=json is passed."""
         self._skip_if_pcie_stats_unavailable()
         result = self.run_plugin_cmd_check(
             "vs-pcie-stats", args="--output-format=json"
@@ -285,11 +203,7 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def test_json_pcie_stats_is_single_element_array(self):
-        """vs-pcie-stats JSON output wraps the stats object in a one-element array.
-
-        The implementation calls json_object_add_value_array(), appends a
-        single stats object, then json_print_object().  Verify the shape.
-        """
+        """vs-pcie-stats JSON output wraps the stats object in a one-element array."""
         data = self._run_pcie_stats_json()
         array = data["PCIE Stats"]
 
@@ -300,12 +214,7 @@ class TestMicronVsPcieStats(TestMicron):
                          f"got {len(array)}")
 
     def test_json_output_contains_all_correctable_error_fields(self):
-        """vs-pcie-stats JSON output contains all 10 correctable error fields.
-
-        Each entry in pcie_correctable_errors[] is emitted via
-        json_object_add_value_int(stats, field.err, val).  All 10 fields
-        must appear as keys in the stats object.
-        """
+        """vs-pcie-stats JSON output contains all 10 correctable error fields."""
         stats = self._pcie_stats_object()
 
         for field in CORRECTABLE_FIELDS:
@@ -316,11 +225,7 @@ class TestMicronVsPcieStats(TestMicron):
             )
 
     def test_json_output_contains_all_uncorrectable_error_fields(self):
-        """vs-pcie-stats JSON output contains all 6 uncorrectable error fields.
-
-        Each entry in pcie_uncorrectable_errors[] is emitted similarly.
-        All 6 fields must appear as keys in the stats object.
-        """
+        """vs-pcie-stats JSON output contains all 6 uncorrectable error fields."""
         stats = self._pcie_stats_object()
 
         for field in UNCORRECTABLE_FIELDS:
@@ -333,9 +238,8 @@ class TestMicronVsPcieStats(TestMicron):
     def test_json_error_values_are_non_negative_integers(self):
         """vs-pcie-stats JSON error values are non-negative integers.
 
-        Each value is either a __u16 counter (0–65535) from the M5407
-        passthru counters path or a single bit (0 or 1) from the AER path.
-        Both representations must be non-negative integers.
+        Each value is either a per-field counter or a single AER status bit,
+        depending on the drive model; both are non-negative integers.
         """
         stats = self._pcie_stats_object()
 
@@ -353,9 +257,7 @@ class TestMicronVsPcieStats(TestMicron):
     def test_json_has_exactly_16_error_fields(self):
         """vs-pcie-stats JSON stats object contains exactly 16 error fields.
 
-        10 correctable + 6 uncorrectable = 16 total.  Extra keys would
-        indicate a regression where new fields were added without updating
-        the test.
+        10 correctable + 6 uncorrectable, with no extra or missing keys.
         """
         stats = self._pcie_stats_object()
 
@@ -372,12 +274,7 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def test_format_json_and_output_format_json_produce_identical_fields(self):
-        """Both JSON flag paths yield the same set of field keys.
-
-        --format=json sets cfg.fmt and goes through the strcmp path.
-        --output-format=json sets flags & JSON and goes through the flags path.
-        The resulting field sets must be identical.
-        """
+        """--format=json and --output-format=json yield the same set of field keys."""
         stats_fmt = self._pcie_stats_object(args="--format=json")
         stats_ofmt = self._pcie_stats_object(args="--output-format=json")
 
@@ -388,16 +285,8 @@ class TestMicronVsPcieStats(TestMicron):
             f"  --output-format=json: {sorted(stats_ofmt.keys())}",
         )
 
-    # ------------------------------------------------------------------
-    # Text output (paths 10, 11, 12)
-    # ------------------------------------------------------------------
-
     def test_format_normal_flag_succeeds(self):
-        """vs-pcie-stats exits 0 and produces non-empty output with --format=normal.
-
-        Sets is_json=false via cfg.fmt == "normal" (shared entry point for
-        paths 10, 11, and 12).
-        """
+        """vs-pcie-stats produces non-empty output with --format=normal."""
         self._skip_if_pcie_stats_unavailable()
         result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=normal")
 
@@ -407,10 +296,7 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def test_output_format_normal_flag_succeeds(self):
-        """vs-pcie-stats exits 0 and produces non-empty output with --output-format=normal.
-
-        Sets is_json=false via flags & NORMAL (the global nvme-cli flag path).
-        """
+        """vs-pcie-stats produces non-empty output with --output-format=normal."""
         self._skip_if_pcie_stats_unavailable()
         result = self.run_plugin_cmd_check(
             "vs-pcie-stats", args="--output-format=normal"
@@ -422,122 +308,88 @@ class TestMicronVsPcieStats(TestMicron):
         )
 
     def test_normal_output_is_not_json(self):
-        """vs-pcie-stats text output is not valid JSON when --format=normal is used.
+        """vs-pcie-stats text output is not valid JSON for the normal format.
 
-        The text branches (paths 10, 11, 12) all produce plain printf() output,
-        never a JSON document.  Parsing must fail.
+        Checked for both the plugin's --format flag and the global nvme-cli
+        --output-format flag.
         """
         self._skip_if_pcie_stats_unavailable()
-        result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=normal")
 
-        try:
-            json.loads(result.stdout)
-            self.fail(
-                f"--format=normal output parsed as JSON unexpectedly; "
-                f"stdout={result.stdout!r}"
-            )
-        except (json.JSONDecodeError, ValueError):
-            pass  # expected: text output is not JSON
+        for flag in ("--format=normal", "--output-format=normal"):
+            with self.subTest(flag=flag):
+                result = self.run_plugin_cmd_check("vs-pcie-stats", args=flag)
+
+                try:
+                    json.loads(result.stdout)
+                    self.fail(
+                        f"{flag} output parsed as JSON unexpectedly; "
+                        f"stdout={result.stdout!r}"
+                    )
+                except (json.JSONDecodeError, ValueError):
+                    pass  # expected: text output is not JSON
 
     def test_normal_format_text_content(self):
         """vs-pcie-stats text output contains the expected fields for this hardware.
 
-        The text branch taken depends on the drive model:
-
-          M5407 (passthru counters=true, path 10) or
-          M5407/M5410 (AER bit-values, path 11):
-            16 named-field lines in "Field : value" format.
-
-          Other models (path 12):
-            A "PCIE Stats:" header followed by two hex-value lines for
-            correctable and uncorrectable error counts.
-
-        The test detects which branch was taken by looking for "PCIE Stats:"
-        (present only in path 12) and asserts the appropriate content.
+        The text layout depends on the drive model: some drives print 16
+        named-field lines ("Field : value"), while others print a "PCIE Stats:"
+        header followed by hex correctable/uncorrectable error counts.  The test
+        detects which layout was produced and asserts the matching content, for
+        both the plugin's --format flag and the global --output-format flag.
         """
         self._skip_if_pcie_stats_unavailable()
-        result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=normal")
-        stdout = result.stdout
 
-        if "PCIE Stats:" in stdout:
-            # Path 12: generic text branch for non-M5407/M5410 models.
-            self.assertIn(
-                "Device correctable errors detected:", stdout,
-                f"Expected correctable error line in 'PCIE Stats:' branch, "
-                f"got: {stdout!r}",
-            )
-            self.assertIn(
-                "Device uncorrectable errors detected:", stdout,
-                f"Expected uncorrectable error line in 'PCIE Stats:' branch, "
-                f"got: {stdout!r}",
-            )
-            # The hex values must match 0x<digits>.
-            import re
-            self.assertRegex(
-                stdout,
-                r"Device correctable errors detected:\s+0x[0-9a-fA-F]+",
-                f"Expected hex value after correctable error label, got: {stdout!r}",
-            )
-            self.assertRegex(
-                stdout,
-                r"Device uncorrectable errors detected:\s+0x[0-9a-fA-F]+",
-                f"Expected hex value after uncorrectable error label, got: {stdout!r}",
-            )
-        else:
-            # Paths 10/11: named-field text branch for M5407/M5410 models.
-            for field in ALL_FIELDS:
-                self.assertIn(
-                    field, stdout,
-                    f"Expected named field '{field}' in M5407/M5410 text output, "
-                    f"got: {stdout!r}",
-                )
-            # Each line must match "Field : integer".
-            import re
-            for field in ALL_FIELDS:
-                self.assertRegex(
-                    stdout,
-                    re.escape(field) + r"\s*:\s*\d+",
-                    f"Expected '{field} : <integer>' in text output, got: {stdout!r}",
-                )
+        for flag in ("--format=normal", "--output-format=normal"):
+            with self.subTest(flag=flag):
+                result = self.run_plugin_cmd_check("vs-pcie-stats", args=flag)
+                stdout = result.stdout
 
-    def test_output_format_normal_text_content(self):
-        """vs-pcie-stats --output-format=normal produces the same content as --format=normal.
-
-        The two flags converge on the same is_json=false branch.  Verify
-        that the output structure matches expectations using the same
-        branch-detection logic.
-        """
-        self._skip_if_pcie_stats_unavailable()
-        result = self.run_plugin_cmd_check(
-            "vs-pcie-stats", args="--output-format=normal"
-        )
-        stdout = result.stdout
-
-        if "PCIE Stats:" in stdout:
-            self.assertIn("Device correctable errors detected:", stdout)
-            self.assertIn("Device uncorrectable errors detected:", stdout)
-        else:
-            for field in ALL_FIELDS:
-                self.assertIn(
-                    field, stdout,
-                    f"Expected named field '{field}' in --output-format=normal output",
-                )
-
-    # ------------------------------------------------------------------
-    # Cross-format consistency
-    # ------------------------------------------------------------------
+                if "PCIE Stats:" in stdout:
+                    # Header-plus-hex-counts layout.
+                    self.assertIn(
+                        "Device correctable errors detected:", stdout,
+                        f"Expected correctable error line in 'PCIE Stats:' branch, "
+                        f"got: {stdout!r}",
+                    )
+                    self.assertIn(
+                        "Device uncorrectable errors detected:", stdout,
+                        f"Expected uncorrectable error line in 'PCIE Stats:' branch, "
+                        f"got: {stdout!r}",
+                    )
+                    # The hex values must match 0x<digits>.
+                    self.assertRegex(
+                        stdout,
+                        r"Device correctable errors detected:\s+0x[0-9a-fA-F]+",
+                        f"Expected hex value after correctable error label, got: {stdout!r}",
+                    )
+                    self.assertRegex(
+                        stdout,
+                        r"Device uncorrectable errors detected:\s+0x[0-9a-fA-F]+",
+                        f"Expected hex value after uncorrectable error label, got: {stdout!r}",
+                    )
+                else:
+                    # Named-field layout.
+                    for field in ALL_FIELDS:
+                        self.assertIn(
+                            field, stdout,
+                            f"Expected named field '{field}' in text output, "
+                            f"got: {stdout!r}",
+                        )
+                    # Each line must match "Field : integer".
+                    for field in ALL_FIELDS:
+                        self.assertRegex(
+                            stdout,
+                            re.escape(field) + r"\s*:\s*\d+",
+                            f"Expected '{field} : <integer>' in text output, got: {stdout!r}",
+                        )
 
     def test_json_and_normal_report_same_error_count_parity(self):
         """JSON and text output agree on whether any errors are non-zero.
 
-        The JSON path sums all field values; the text path prints the same
-        underlying data.  If JSON shows all zeros, the text output must not
-        report any non-zero values (and vice versa), ensuring both paths read
-        the same hardware registers.
-
-        This test only applies to the named-field text branch (paths 10/11);
-        it is skipped when the drive uses the generic "PCIE Stats:" branch
-        because that branch exposes a different level of aggregation.
+        Both representations read the same underlying data, so if one reports
+        all zeros the other must too.  Applies only to the named-field text
+        layout; it is skipped for the generic "PCIE Stats:" layout, which
+        exposes a different level of aggregation.
         """
         stats = self._pcie_stats_object()
         json_any_nonzero = any(stats[f] != 0 for f in ALL_FIELDS)
@@ -550,7 +402,6 @@ class TestMicronVsPcieStats(TestMicron):
                 "Drive uses generic text branch; cross-format parity check skipped"
             )
 
-        import re
         text_values = []
         for field in ALL_FIELDS:
             m = re.search(re.escape(field) + r"\s*:\s*(\d+)", stdout)
@@ -569,18 +420,13 @@ class TestMicronVsPcieStats(TestMicron):
             f"  Text stdout: {stdout!r}",
         )
 
-    # ------------------------------------------------------------------
-    # Namespace device path
-    # ------------------------------------------------------------------
-
     def test_namespace_device_produces_same_output_as_ctrl(self):
         """vs-pcie-stats produces identical JSON when given a namespace path.
 
-        Both controller and namespace paths must resolve to the same controller
-        and therefore produce the same set of PCIe error field keys.
+        Both controller and namespace paths resolve to the same controller and
+        therefore produce the same set of PCIe error field keys.
         """
-        # Probe availability using the namespace path specifically, since
-        # micron_get_pcie_aer_errors is the function under test here.
+        # Probe availability using the namespace path specifically.
         if self.is_windows():
             ns_probe = self.run_plugin_cmd("vs-pcie-stats", device=self.ns1)
             if ns_probe.returncode != 0 and _WINDOWS_AER_UNSUPPORTED_MSG in ns_probe.stderr:

--- a/tests/plugins/micron/micron_vs_pcie_stats_test.py
+++ b/tests/plugins/micron/micron_vs_pcie_stats_test.py
@@ -1,0 +1,609 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Tests for the micron vs-pcie-stats command.
+
+The command retrieves PCIe error statistics and prints them in JSON or text
+format.  The full code-path map is:
+
+  1.  parse_and_open fails
+        → rc=-1, "Device not found" in stderr
+
+  2.  validate_output_format fails
+        → rc<0, "Invalid output format" in stderr
+
+  3.  GetDriveModel returns UNKNOWN_MODEL
+        → "Unsupported drive model for vs-pcie-stats command" in stderr,
+          err=-ENOTSUP, goto out (returns a non-zero error)
+
+  4.  eModel == M5407: libnvme_exec_admin_passthru succeeds
+        → counters=true, goto print_stats with counter values from hardware
+
+  5.  eModel == M5407: libnvme_exec_admin_passthru fails
+        → falls through to micron_get_pcie_aer_errors
+
+  6.  micron_get_pcie_aer_errors fails
+        → goto out with error
+
+  6a. On Windows, micron_get_pcie_aer_errors always returns -ENOTSUP with
+      "register reads not supported on the current platform" in stderr.
+      For non-M5407 drives (which don't take the 0xD6 passthru path), this
+      means the command exits with an error and print_stats is never reached.
+      M5407 drives are unaffected because they reach print_stats via the
+      passthru path before micron_get_pcie_aer_errors is called.
+
+  7.  print_stats, is_json=true (default cfg.fmt="json")
+        → JSON output with top-level "PCIE Stats" array containing one
+          object with all 16 named error fields
+
+  8.  print_stats, is_json=true, --format=json explicit
+        → same JSON output as path 7
+
+  9.  print_stats, is_json=true, --output-format=json
+        → same JSON output as path 7
+
+  10. print_stats, is_json=false (--format=normal or --output-format=normal),
+      counters=true (M5407 passthru succeeded)
+        → per-field text with %hu format
+
+  11. print_stats, is_json=false, counters=false, eModel==M5407 or M5410
+        → per-field text with bit values (AER registers)
+
+  12. print_stats, is_json=false, counters=false, other models
+        → "PCIE Stats:" header line, hex correctable/uncorrectable counts
+
+Testable paths on real hardware:  1, 2, 7, 8, 9, 10-or-11-or-12
+  (which of 10/11/12 is exercised depends on the drive model present)
+
+On Windows with a non-M5407 drive: only paths 1 and 2 are reachable;
+paths 7-12 are all skipped because micron_get_pcie_aer_errors returns
+-ENOTSUP before print_stats can be reached.  The tests detect this at
+runtime via _pcie_stats_available() and skip gracefully.
+
+Untestable paths:
+  - Path 3 (UNKNOWN_MODEL): live test hardware is always a supported Micron
+    drive; there is no way to inject an unknown device ID.
+  - Path 6 (micron_get_pcie_aer_errors error on Linux): requires sysfs to
+    be unavailable; not injectable in a live hardware test.
+  - Distinguishing paths 10 vs 11 on M5407 hardware: which branch the
+    0xD6 admin passthru takes (success → counters=true vs failure →
+    AER read) depends on firmware; both yield the same named-field text
+    output layout so the difference is transparent to the test.
+"""
+
+import json
+
+from tests.plugins.micron.micron_test import TestMicron
+
+_WINDOWS_AER_UNSUPPORTED_MSG = "register reads not supported on the current platform"
+
+
+# ---------------------------------------------------------------------------
+# Expected field names (same order as the C arrays)
+# ---------------------------------------------------------------------------
+
+CORRECTABLE_FIELDS = [
+    "Unsupported Request Error Status (URES)",
+    "ECRC Error Status (ECRCES)",
+    "Malformed TLP Status (MTS)",
+    "Receiver Overflow Status (ROS)",
+    "Unexpected Completion Status (UCS)",
+    "Completer Abort Status (CAS)",
+    "Completion Timeout Status (CTS)",
+    "Flow Control Protocol Error Status (FCPES)",
+    "Poisoned TLP Status (PTS)",
+    "Data Link Protocol Error Status (DLPES)",
+]
+
+UNCORRECTABLE_FIELDS = [
+    "Advisory Non-Fatal Error Status (ANFES)",
+    "Replay Timer Timeout Status (RTS)",
+    "REPLAY_NUM Rollover Status (RRS)",
+    "Bad DLLP Status (BDS)",
+    "Bad TLP Status (BTS)",
+    "Receiver Error Status (RES)",
+]
+
+ALL_FIELDS = CORRECTABLE_FIELDS + UNCORRECTABLE_FIELDS
+
+
+class TestMicronVsPcieStats(TestMicron):
+    """Test suite for the micron vs-pcie-stats plugin command."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run_pcie_stats(self, device=None, args=""):
+        """Run vs-pcie-stats and return the CompletedProcess result."""
+        return self.run_plugin_cmd("vs-pcie-stats", device=device, args=args)
+
+    def _pcie_stats_available(self):
+        """Return True if vs-pcie-stats can reach the print_stats branch.
+
+        On Windows, micron_get_pcie_aer_errors() always returns -ENOTSUP for
+        non-M5407 drives, printing "register reads not supported on the current
+        platform" and exiting before print_stats is reached.  M5407 drives are
+        unaffected because they take the 0xD6 passthru path first.
+
+        On Linux, the AER path always succeeds on supported hardware, so no
+        probe is needed.
+        """
+        if not self.is_windows():
+            return True
+        result = self._run_pcie_stats()
+        return not (
+            result.returncode != 0 and _WINDOWS_AER_UNSUPPORTED_MSG in result.stderr
+        )
+
+    def _skip_if_pcie_stats_unavailable(self):
+        """Skip the calling test if print_stats is unreachable on this platform."""
+        if not self._pcie_stats_available():
+            self.skipTest(
+                "vs-pcie-stats is not supported on this platform "
+                f"(stderr: {_WINDOWS_AER_UNSUPPORTED_MSG!r})"
+            )
+
+    def _run_pcie_stats_json(self, args=""):
+        """Run vs-pcie-stats in JSON mode and return the parsed top-level dict.
+
+        Skips the test if PCIe stats are unavailable on this platform.
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check("vs-pcie-stats", args=args)
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"stdout is not valid JSON: {exc}\nstdout={result.stdout!r}"
+            )
+
+    def _pcie_stats_object(self, args=""):
+        """Return the first stats object from the 'PCIE Stats' JSON array."""
+        data = self._run_pcie_stats_json(args=args)
+        self.assertIn(
+            "PCIE Stats", data,
+            f"Expected top-level 'PCIE Stats' key, got: {list(data.keys())}",
+        )
+        array = data["PCIE Stats"]
+        self.assertIsInstance(array, list, "'PCIE Stats' value must be a list")
+        self.assertEqual(len(array), 1,
+                         f"Expected exactly one stats object, got {len(array)}")
+        return array[0]
+
+    # ------------------------------------------------------------------
+    # Error paths (paths 1 & 2)
+    # ------------------------------------------------------------------
+
+    def test_bad_device_returns_error(self):
+        """vs-pcie-stats fails with a message when the device does not exist.
+
+        Exercises the parse_and_open failure branch (path 1).
+        """
+        result = self._run_pcie_stats(device="/dev/nvme-nonexistent-test-device")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit code for a non-existent device",
+        )
+        self.assertIn(
+            "Device not found", result.stderr,
+            f"Expected 'Device not found' in stderr, got: {result.stderr!r}",
+        )
+
+    def test_invalid_output_format_returns_error(self):
+        """vs-pcie-stats fails with a message for an unrecognised --output-format.
+
+        Exercises the validate_output_format failure branch (path 2).
+        """
+        result = self._run_pcie_stats(args="--output-format=notaformat")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit code for an invalid --output-format value",
+        )
+        self.assertIn(
+            "Invalid output format", result.stderr,
+            f"Expected 'Invalid output format' in stderr, got: {result.stderr!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # JSON output (paths 7, 8, 9)
+    # ------------------------------------------------------------------
+
+    def test_default_output_is_json(self):
+        """vs-pcie-stats produces JSON output by default.
+
+        The default cfg.fmt is "json", so is_json starts true and is never
+        cleared by the normal/NORMAL check (path 7).
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check("vs-pcie-stats")
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"Default output is not valid JSON: {exc}\n"
+                f"stdout={result.stdout!r}"
+            )
+
+        self.assertIn(
+            "PCIE Stats", data,
+            f"Expected 'PCIE Stats' key in default JSON output, "
+            f"got keys: {list(data.keys())}",
+        )
+
+    def test_explicit_format_json_produces_valid_json(self):
+        """vs-pcie-stats produces valid JSON when --format=json is passed.
+
+        Exercises is_json=true via cfg.fmt == "json" (path 8).
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=json")
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"stdout is not valid JSON (--format=json): {exc}\n"
+                f"stdout={result.stdout!r}"
+            )
+
+        self.assertIn(
+            "PCIE Stats", data,
+            f"Expected 'PCIE Stats' key with --format=json, "
+            f"got keys: {list(data.keys())}",
+        )
+
+    def test_output_format_json_produces_valid_json(self):
+        """vs-pcie-stats produces valid JSON when --output-format=json is passed.
+
+        Exercises is_json=true via flags & JSON (path 9).  The flags path is
+        independent from the cfg.fmt path; both must result in JSON output.
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check(
+            "vs-pcie-stats", args="--output-format=json"
+        )
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"stdout is not valid JSON (--output-format=json): {exc}\n"
+                f"stdout={result.stdout!r}"
+            )
+
+        self.assertIn(
+            "PCIE Stats", data,
+            f"Expected 'PCIE Stats' key with --output-format=json, "
+            f"got keys: {list(data.keys())}",
+        )
+
+    def test_json_pcie_stats_is_single_element_array(self):
+        """vs-pcie-stats JSON output wraps the stats object in a one-element array.
+
+        The implementation calls json_object_add_value_array(), appends a
+        single stats object, then json_print_object().  Verify the shape.
+        """
+        data = self._run_pcie_stats_json()
+        array = data["PCIE Stats"]
+
+        self.assertIsInstance(array, list,
+                              "'PCIE Stats' must be a JSON array")
+        self.assertEqual(len(array), 1,
+                         f"Expected exactly one element in 'PCIE Stats' array, "
+                         f"got {len(array)}")
+
+    def test_json_output_contains_all_correctable_error_fields(self):
+        """vs-pcie-stats JSON output contains all 10 correctable error fields.
+
+        Each entry in pcie_correctable_errors[] is emitted via
+        json_object_add_value_int(stats, field.err, val).  All 10 fields
+        must appear as keys in the stats object.
+        """
+        stats = self._pcie_stats_object()
+
+        for field in CORRECTABLE_FIELDS:
+            self.assertIn(
+                field, stats,
+                f"Expected correctable error field '{field}' in JSON stats, "
+                f"got keys: {list(stats.keys())}",
+            )
+
+    def test_json_output_contains_all_uncorrectable_error_fields(self):
+        """vs-pcie-stats JSON output contains all 6 uncorrectable error fields.
+
+        Each entry in pcie_uncorrectable_errors[] is emitted similarly.
+        All 6 fields must appear as keys in the stats object.
+        """
+        stats = self._pcie_stats_object()
+
+        for field in UNCORRECTABLE_FIELDS:
+            self.assertIn(
+                field, stats,
+                f"Expected uncorrectable error field '{field}' in JSON stats, "
+                f"got keys: {list(stats.keys())}",
+            )
+
+    def test_json_error_values_are_non_negative_integers(self):
+        """vs-pcie-stats JSON error values are non-negative integers.
+
+        Each value is either a __u16 counter (0–65535) from the M5407
+        passthru counters path or a single bit (0 or 1) from the AER path.
+        Both representations must be non-negative integers.
+        """
+        stats = self._pcie_stats_object()
+
+        for field in ALL_FIELDS:
+            val = stats[field]
+            self.assertIsInstance(
+                val, int,
+                f"Expected integer value for '{field}', got {type(val).__name__}: {val!r}",
+            )
+            self.assertGreaterEqual(
+                val, 0,
+                f"Expected non-negative value for '{field}', got {val}",
+            )
+
+    def test_json_has_exactly_16_error_fields(self):
+        """vs-pcie-stats JSON stats object contains exactly 16 error fields.
+
+        10 correctable + 6 uncorrectable = 16 total.  Extra keys would
+        indicate a regression where new fields were added without updating
+        the test.
+        """
+        stats = self._pcie_stats_object()
+
+        extra = set(stats.keys()) - set(ALL_FIELDS)
+        self.assertFalse(
+            extra,
+            f"Unexpected extra keys in JSON stats object: {extra}",
+        )
+
+        missing = set(ALL_FIELDS) - set(stats.keys())
+        self.assertFalse(
+            missing,
+            f"Missing keys in JSON stats object: {missing}",
+        )
+
+    def test_format_json_and_output_format_json_produce_identical_fields(self):
+        """Both JSON flag paths yield the same set of field keys.
+
+        --format=json sets cfg.fmt and goes through the strcmp path.
+        --output-format=json sets flags & JSON and goes through the flags path.
+        The resulting field sets must be identical.
+        """
+        stats_fmt = self._pcie_stats_object(args="--format=json")
+        stats_ofmt = self._pcie_stats_object(args="--output-format=json")
+
+        self.assertEqual(
+            set(stats_fmt.keys()), set(stats_ofmt.keys()),
+            f"--format=json and --output-format=json produced different field sets:\n"
+            f"  --format=json:        {sorted(stats_fmt.keys())}\n"
+            f"  --output-format=json: {sorted(stats_ofmt.keys())}",
+        )
+
+    # ------------------------------------------------------------------
+    # Text output (paths 10, 11, 12)
+    # ------------------------------------------------------------------
+
+    def test_format_normal_flag_succeeds(self):
+        """vs-pcie-stats exits 0 and produces non-empty output with --format=normal.
+
+        Sets is_json=false via cfg.fmt == "normal" (shared entry point for
+        paths 10, 11, and 12).
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=normal")
+
+        self.assertTrue(
+            result.stdout.strip(),
+            "Expected non-empty stdout with --format=normal, got empty output",
+        )
+
+    def test_output_format_normal_flag_succeeds(self):
+        """vs-pcie-stats exits 0 and produces non-empty output with --output-format=normal.
+
+        Sets is_json=false via flags & NORMAL (the global nvme-cli flag path).
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check(
+            "vs-pcie-stats", args="--output-format=normal"
+        )
+
+        self.assertTrue(
+            result.stdout.strip(),
+            "Expected non-empty stdout with --output-format=normal, got empty output",
+        )
+
+    def test_normal_output_is_not_json(self):
+        """vs-pcie-stats text output is not valid JSON when --format=normal is used.
+
+        The text branches (paths 10, 11, 12) all produce plain printf() output,
+        never a JSON document.  Parsing must fail.
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=normal")
+
+        try:
+            json.loads(result.stdout)
+            self.fail(
+                f"--format=normal output parsed as JSON unexpectedly; "
+                f"stdout={result.stdout!r}"
+            )
+        except (json.JSONDecodeError, ValueError):
+            pass  # expected: text output is not JSON
+
+    def test_normal_format_text_content(self):
+        """vs-pcie-stats text output contains the expected fields for this hardware.
+
+        The text branch taken depends on the drive model:
+
+          M5407 (passthru counters=true, path 10) or
+          M5407/M5410 (AER bit-values, path 11):
+            16 named-field lines in "Field : value" format.
+
+          Other models (path 12):
+            A "PCIE Stats:" header followed by two hex-value lines for
+            correctable and uncorrectable error counts.
+
+        The test detects which branch was taken by looking for "PCIE Stats:"
+        (present only in path 12) and asserts the appropriate content.
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=normal")
+        stdout = result.stdout
+
+        if "PCIE Stats:" in stdout:
+            # Path 12: generic text branch for non-M5407/M5410 models.
+            self.assertIn(
+                "Device correctable errors detected:", stdout,
+                f"Expected correctable error line in 'PCIE Stats:' branch, "
+                f"got: {stdout!r}",
+            )
+            self.assertIn(
+                "Device uncorrectable errors detected:", stdout,
+                f"Expected uncorrectable error line in 'PCIE Stats:' branch, "
+                f"got: {stdout!r}",
+            )
+            # The hex values must match 0x<digits>.
+            import re
+            self.assertRegex(
+                stdout,
+                r"Device correctable errors detected:\s+0x[0-9a-fA-F]+",
+                f"Expected hex value after correctable error label, got: {stdout!r}",
+            )
+            self.assertRegex(
+                stdout,
+                r"Device uncorrectable errors detected:\s+0x[0-9a-fA-F]+",
+                f"Expected hex value after uncorrectable error label, got: {stdout!r}",
+            )
+        else:
+            # Paths 10/11: named-field text branch for M5407/M5410 models.
+            for field in ALL_FIELDS:
+                self.assertIn(
+                    field, stdout,
+                    f"Expected named field '{field}' in M5407/M5410 text output, "
+                    f"got: {stdout!r}",
+                )
+            # Each line must match "Field : integer".
+            import re
+            for field in ALL_FIELDS:
+                self.assertRegex(
+                    stdout,
+                    re.escape(field) + r"\s*:\s*\d+",
+                    f"Expected '{field} : <integer>' in text output, got: {stdout!r}",
+                )
+
+    def test_output_format_normal_text_content(self):
+        """vs-pcie-stats --output-format=normal produces the same content as --format=normal.
+
+        The two flags converge on the same is_json=false branch.  Verify
+        that the output structure matches expectations using the same
+        branch-detection logic.
+        """
+        self._skip_if_pcie_stats_unavailable()
+        result = self.run_plugin_cmd_check(
+            "vs-pcie-stats", args="--output-format=normal"
+        )
+        stdout = result.stdout
+
+        if "PCIE Stats:" in stdout:
+            self.assertIn("Device correctable errors detected:", stdout)
+            self.assertIn("Device uncorrectable errors detected:", stdout)
+        else:
+            for field in ALL_FIELDS:
+                self.assertIn(
+                    field, stdout,
+                    f"Expected named field '{field}' in --output-format=normal output",
+                )
+
+    # ------------------------------------------------------------------
+    # Cross-format consistency
+    # ------------------------------------------------------------------
+
+    def test_json_and_normal_report_same_error_count_parity(self):
+        """JSON and text output agree on whether any errors are non-zero.
+
+        The JSON path sums all field values; the text path prints the same
+        underlying data.  If JSON shows all zeros, the text output must not
+        report any non-zero values (and vice versa), ensuring both paths read
+        the same hardware registers.
+
+        This test only applies to the named-field text branch (paths 10/11);
+        it is skipped when the drive uses the generic "PCIE Stats:" branch
+        because that branch exposes a different level of aggregation.
+        """
+        stats = self._pcie_stats_object()
+        json_any_nonzero = any(stats[f] != 0 for f in ALL_FIELDS)
+
+        result = self.run_plugin_cmd_check("vs-pcie-stats", args="--format=normal")
+        stdout = result.stdout
+
+        if "PCIE Stats:" in stdout:
+            self.skipTest(
+                "Drive uses generic text branch; cross-format parity check skipped"
+            )
+
+        import re
+        text_values = []
+        for field in ALL_FIELDS:
+            m = re.search(re.escape(field) + r"\s*:\s*(\d+)", stdout)
+            self.assertIsNotNone(m,
+                f"Could not parse '{field}' value from text output: {stdout!r}")
+            text_values.append(int(m.group(1)))
+
+        text_any_nonzero = any(v != 0 for v in text_values)
+
+        self.assertEqual(
+            json_any_nonzero, text_any_nonzero,
+            f"JSON and text output disagree on whether errors are present:\n"
+            f"  JSON non-zero: {json_any_nonzero}\n"
+            f"  Text non-zero: {text_any_nonzero}\n"
+            f"  JSON stats: {stats}\n"
+            f"  Text stdout: {stdout!r}",
+        )
+
+    # ------------------------------------------------------------------
+    # Namespace device path
+    # ------------------------------------------------------------------
+
+    def test_namespace_device_produces_same_output_as_ctrl(self):
+        """vs-pcie-stats produces identical JSON when given a namespace path.
+
+        Both controller and namespace paths must resolve to the same controller
+        and therefore produce the same set of PCIe error field keys.
+        """
+        # Probe availability using the namespace path specifically, since
+        # micron_get_pcie_aer_errors is the function under test here.
+        if self.is_windows():
+            ns_probe = self.run_plugin_cmd("vs-pcie-stats", device=self.ns1)
+            if ns_probe.returncode != 0 and _WINDOWS_AER_UNSUPPORTED_MSG in ns_probe.stderr:
+                self.skipTest(
+                    "vs-pcie-stats is not supported on this platform "
+                    f"(stderr: {_WINDOWS_AER_UNSUPPORTED_MSG!r})"
+                )
+
+        result_ctrl = self.run_plugin_cmd_check("vs-pcie-stats", device=self.ctrl)
+        result_ns = self.run_plugin_cmd_check("vs-pcie-stats", device=self.ns1)
+
+        try:
+            data_ctrl = json.loads(result_ctrl.stdout)
+            data_ns = json.loads(result_ns.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(f"Output is not valid JSON: {exc}")
+
+        stats_ctrl = data_ctrl["PCIE Stats"][0]
+        stats_ns = data_ns["PCIE Stats"][0]
+
+        self.assertEqual(
+            set(stats_ctrl.keys()), set(stats_ns.keys()),
+            f"Controller and namespace device paths produced different field sets:\n"
+            f"  ctrl ({self.ctrl}): {sorted(stats_ctrl.keys())}\n"
+            f"  ns1  ({self.ns1}):  {sorted(stats_ns.keys())}",
+        )

--- a/tests/plugins/micron/micron_vs_temperature_stats_test.py
+++ b/tests/plugins/micron/micron_vs_temperature_stats_test.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+#   Author: Broc Going <broc.going@micron.com>
+#
+"""Tests for the micron vs-temperature-stats command.
+
+The vs-temperature-stats command reads the NVMe SMART log page and prints
+the current composite temperature along with any active per-sensor
+temperatures.  Output is human-readable text by default, or JSON when a
+JSON format flag is supplied.
+
+Temperature sensors are reported sparsely: only sensors with a non-zero
+reading appear, so gaps between sensor indices are possible.
+
+Tests in this module verify:
+  * Text output (default and explicit normal format flags).
+  * JSON output for both the --format=json and --output-format=json flags,
+    including that temperatures are formatted with a Celsius suffix.
+  * One sensor entry per active sensor and none for inactive sensors, in
+    both text and JSON output.
+  * Error detection for a non-existent device and an invalid output format.
+"""
+
+import json
+
+from tests.plugins.micron.micron_test import TestMicron
+
+
+class TestMicronVsTemperatureStats(TestMicron):
+    """Test suite for the micron vs-temperature-stats plugin command."""
+
+    def _run_temp(self, device=None, args=""):
+        """Run vs-temperature-stats and return the CompletedProcess result."""
+        return self.run_plugin_cmd("vs-temperature-stats", device=device, args=args)
+
+    def _active_sensor_indices(self):
+        """Return the 1-based indices of active temperature sensors from nvme smart-log.
+
+        Sensors are reported sparsely, so the returned indices may have gaps.
+        """
+        result = self.run_cmd(
+            f"{self.nvme_bin} smart-log {self.ctrl} --output-format=json"
+        )
+        self.assertEqual(result.returncode, 0,
+                         f"nvme smart-log failed: {result.stderr}")
+        data = json.loads(result.stdout)
+        return [i for i in range(1, 9) if f"temperature_sensor_{i}" in data]
+
+    def test_bad_device_returns_error(self):
+        """vs-temperature-stats fails with a message when the device does not exist."""
+        result = self._run_temp(device="/dev/nvme-nonexistent-test-device")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit code for a non-existent device",
+        )
+        self.assertIn(
+            "Device not found", result.stderr,
+            f"Expected 'Device not found' in stderr, got: {result.stderr!r}",
+        )
+
+    def test_invalid_output_format_returns_error(self):
+        """vs-temperature-stats fails with a message for an unrecognised --output-format."""
+        result = self._run_temp(args="--output-format=notaformat")
+
+        self.assertNotEqual(
+            result.returncode, 0,
+            "Expected non-zero exit code for an invalid --output-format value",
+        )
+        self.assertIn(
+            "Invalid output format", result.stderr,
+            f"Expected 'Invalid output format' in stderr, got: {result.stderr!r}",
+        )
+
+    def test_default_output_is_text(self):
+        """vs-temperature-stats produces human-readable text output by default."""
+        result = self.run_plugin_cmd_check("vs-temperature-stats")
+
+        self.assertIn(
+            "Micron temperature information", result.stdout,
+            f"Expected header line in stdout, got: {result.stdout!r}",
+        )
+        self.assertIn(
+            "Current Composite Temperature", result.stdout,
+            f"Expected composite temperature label in stdout, got: {result.stdout!r}",
+        )
+
+    def test_explicit_normal_format_flag(self):
+        """vs-temperature-stats produces text output when --format=normal is passed."""
+        result = self.run_plugin_cmd_check("vs-temperature-stats", args="--format=normal")
+
+        self.assertIn(
+            "Micron temperature information", result.stdout,
+            f"Expected header line in stdout, got: {result.stdout!r}",
+        )
+        self.assertIn(
+            "Current Composite Temperature", result.stdout,
+            f"Expected composite temperature label in stdout, got: {result.stdout!r}",
+        )
+
+    def test_output_format_normal_flag(self):
+        """vs-temperature-stats produces text output when --output-format=normal is passed."""
+        result = self.run_plugin_cmd_check(
+            "vs-temperature-stats", args="--output-format=normal"
+        )
+
+        self.assertIn(
+            "Micron temperature information", result.stdout,
+            f"Expected header line in stdout, got: {result.stdout!r}",
+        )
+        self.assertIn(
+            "Current Composite Temperature", result.stdout,
+            f"Expected composite temperature label in stdout, got: {result.stdout!r}",
+        )
+
+    def test_json_format_flag_produces_valid_json(self):
+        """vs-temperature-stats produces valid JSON when --format=json is passed."""
+        result = self.run_plugin_cmd_check("vs-temperature-stats", args="--format=json")
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"stdout is not valid JSON (--format=json): {exc}\n"
+                f"stdout={result.stdout!r}"
+            )
+
+        self.assertIn(
+            "Micron temperature information", data,
+            f"Expected top-level key 'Micron temperature information' in JSON, "
+            f"got keys: {list(data.keys())}",
+        )
+        log_pages = data["Micron temperature information"]
+        self.assertIsInstance(log_pages, list, "Expected 'Micron temperature information' to be a list")
+        self.assertGreater(len(log_pages), 0, "Expected at least one stats object in the JSON array")
+
+        stats = log_pages[0]
+        self.assertIn(
+            "Current Composite Temperature", stats,
+            f"Expected 'Current Composite Temperature' in stats object, got keys: {list(stats.keys())}",
+        )
+
+    def test_output_format_json_flag_produces_valid_json(self):
+        """vs-temperature-stats produces valid JSON when --output-format=json is passed."""
+        result = self.run_plugin_cmd_check(
+            "vs-temperature-stats", args="--output-format=json"
+        )
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"stdout is not valid JSON (--output-format=json): {exc}\n"
+                f"stdout={result.stdout!r}"
+            )
+
+        self.assertIn(
+            "Micron temperature information", data,
+            f"Expected top-level key 'Micron temperature information' in JSON, "
+            f"got keys: {list(data.keys())}",
+        )
+        log_pages = data["Micron temperature information"]
+        self.assertIsInstance(log_pages, list)
+        self.assertGreater(len(log_pages), 0)
+
+        stats = log_pages[0]
+        self.assertIn(
+            "Current Composite Temperature", stats,
+            f"Expected 'Current Composite Temperature' in stats object, got keys: {list(stats.keys())}",
+        )
+
+    def test_json_temperature_value_has_celsius_suffix(self):
+        """vs-temperature-stats JSON output formats temperatures as '<N> C'."""
+        result = self.run_plugin_cmd_check("vs-temperature-stats", args="--format=json")
+        data = json.loads(result.stdout)
+        temp_str = data["Micron temperature information"][0]["Current Composite Temperature"]
+
+        self.assertRegex(
+            temp_str, r"^\d+ C$",
+            f"Expected temperature formatted as '<N> C', got: {temp_str!r}",
+        )
+
+    def test_text_temperature_value_has_celsius_suffix(self):
+        """vs-temperature-stats text output formats temperatures as '<N> C'."""
+        result = self.run_plugin_cmd_check("vs-temperature-stats")
+
+        self.assertRegex(
+            result.stdout, r"Current Composite Temperature\s*:\s*\d+ C",
+            f"Expected 'Current Composite Temperature : <N> C' in stdout, "
+            f"got: {result.stdout!r}",
+        )
+
+    def test_json_sensor_entries_match_smart_log_count(self):
+        """vs-temperature-stats JSON output contains exactly one entry per active sensor.
+
+        Cross-checks the reported sensors against nvme smart-log: a
+        "Temperature Sensor #N" key must appear for each active sensor and for
+        no inactive one.
+        """
+        active = self._active_sensor_indices()
+
+        result = self.run_plugin_cmd_check("vs-temperature-stats", args="--format=json")
+        data = json.loads(result.stdout)
+        stats = data["Micron temperature information"][0]
+
+        for i in active:
+            key = f"Temperature Sensor #{i}"
+            self.assertIn(
+                key, stats,
+                f"Expected '{key}' in vs-temperature-stats JSON output, "
+                f"got keys: {list(stats.keys())}",
+            )
+            self.assertRegex(
+                stats[key], r"^\d+ C$",
+                f"Expected '{key}' formatted as '<N> C', got: {stats[key]!r}",
+            )
+
+        # No inactive sensor should appear.
+        for i in range(1, 9):
+            if i in active:
+                continue
+            self.assertNotIn(
+                f"Temperature Sensor #{i}", stats,
+                f"Unexpected sensor key for inactive sensor #{i} in JSON output: "
+                f"{list(stats.keys())}",
+            )
+
+    def test_text_sensor_entries_match_smart_log_count(self):
+        """vs-temperature-stats text output contains exactly one line per active sensor.
+
+        Cross-checks the reported sensors against nvme smart-log: a
+        "Temperature Sensor #N" line must appear for each active sensor and for
+        no inactive one.
+        """
+        active = self._active_sensor_indices()
+
+        result = self.run_plugin_cmd_check("vs-temperature-stats")
+
+        for i in active:
+            self.assertRegex(
+                result.stdout, rf"Temperature Sensor #{i}\s*:\s*\d+ C",
+                f"Expected 'Temperature Sensor #{i} : <N> C' in stdout, "
+                f"got: {result.stdout!r}",
+            )
+
+        # No inactive sensor should appear.
+        for i in range(1, 9):
+            if i in active:
+                continue
+            self.assertNotRegex(
+                result.stdout, rf"Temperature Sensor #{i}\s*:",
+                f"Unexpected sensor line for inactive sensor #{i} in stdout: "
+                f"{result.stdout!r}",
+            )


### PR DESCRIPTION
Adds tests for the following micron plugin commands:
- vs-internal-log
- vs-temperature-stats
- vs-pcie-stats
- clear-pcie-correctable-errors
- vs-drive-info

Also fixes micron plugin issues uncovered during testing:
- Fixes return value issues.
- Refactors PCI BDF discovery to fix issues and to simplify and standardize.
- Refactors BDF reading to spawn processes instead of using popen for security.
- Improves error messaging for accuracy and consistency.