### PR TITLE
nvme, libnvme: fix two config-conversion regressions found via #3607

### DIFF
--- a/config-convert.c
+++ b/config-convert.c
@@ -488,7 +488,8 @@ int nvme_config_convert_auto(struct libnvme_global_ctx *ctx,
 
 	*ini_path = NULL;
 
-	is_default = !strcmp(config_file, PATH_NVMF_INI);
+	is_default = !strcmp(config_file, PATH_NVMF_INI) ||
+		     !strcmp(config_file, PATH_NVMF_CONFIG);
 	if (is_default) {
 		json_path = PATH_NVMF_CONFIG;
 		*ini_path = strdup(PATH_NVMF_INI);

--- a/config-convert.h
+++ b/config-convert.h
@@ -40,9 +40,11 @@ int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
  * nothing converted. No-op if @config_file isn't a legacy ".json" or
  * the destination already exists.
  *
- * The default path (@config_file == PATH_NVMF_INI) converts config.json
- * and discovery.conf together; any other (an explicit "--config
- * x.json") converts only that file, leaving discovery.conf alone.
+ * The default path (@config_file == PATH_NVMF_INI, or an explicit
+ * "--config" pointing at the legacy default PATH_NVMF_CONFIG) converts
+ * config.json and discovery.conf together; any other explicit
+ * "--config x.json" converts only that file, leaving discovery.conf
+ * alone.
  *
  * Prints a notice to stderr on success; stdout stays silent.
  */

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3120,7 +3120,7 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 	struct libnvme_host *h;
 	int ret, rr, i;
 
-	h = libnvme_lookup_host(ctx, hostnqn, hostid);
+	h = libnvme_lookup_host(ctx, fctx->hostnqn, fctx->hostid);
 	if (!h) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,
 			"Failed to lookup host '%s'\n",


### PR DESCRIPTION
## Summary
- Fix `libnvmf_discovery_nbft()` logging a bogus "Failed to lookup host" error on every `connect-all`/`discover` invocation that doesn't pass `--no-nbft`, regardless of whether any NBFT tables exist. It looked up the host using local `hostnqn`/`hostid` variables that are only assigned later, per NBFT-table entry -- still `NULL` at the point of this first lookup.
- Fix `nvme_config_convert_auto()` naming an explicit `--config` pointing at the legacy default `config.json` path as `config.conf` instead of `nvme-fabrics.conf`, unlike a bare invocation converting the same file. Beyond the inconsistent naming, this orphaned the config: a later bare invocation found neither `nvme-fabrics.conf` nor `config.json` (renamed to `.converted`) and silently proceeded empty.

Both surfaced while following up on #3607.

## Test plan
- [x] `meson compile` clean
- [x] `meson test`: 86/88 (2 expected-fail unchanged)
- [x] `make checkpatch-diff`: 0 errors, 0 warnings
- [x] Live repro + fix verification for both bugs via `nvme connect-all --dry-run`
