### PR TITLE
fabrics: fix host_traddr hostname resolution + add FC WWN validation

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -321,17 +321,6 @@ static int nvmf_resolve_addr(const char *transport, const char **addr)
 #endif /* NVME_HAVE_NETDB */
 }
 
-static int nvmf_resolve_args(struct nvmf_args *fa)
-{
-	int ret;
-
-	ret = nvmf_resolve_addr(fa->transport, &fa->traddr);
-	if (ret)
-		return ret;
-
-	return nvmf_resolve_addr(fa->transport, &fa->host_traddr);
-}
-
 static int set_fabrics_options(struct libnvmf_context *fctx,
 		struct nvmf_args *fa)
 {
@@ -810,7 +799,8 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 			device += 5;
 	}
 
-	ret = nvmf_resolve_args(&fa);
+	/* Only traddr may be a hostname; host_traddr never is. */
+	ret = nvmf_resolve_addr(fa.transport, &fa.traddr);
 	if (ret)
 		return ret;
 
@@ -976,7 +966,8 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 		}
 	}
 
-	ret = nvmf_resolve_args(&fa);
+	/* Only traddr may be a hostname; host_traddr never is. */
+	ret = nvmf_resolve_addr(fa.transport, &fa.traddr);
 	if (ret)
 		return ret;
 

--- a/libnvme/src/nvme/config.h
+++ b/libnvme/src/nvme/config.h
@@ -171,7 +171,7 @@ const char *libnvmf_config_conn_get_subsysnqn(
  * address.
  * @conn: the resolved connection
  *
- * May be a hostname; see libnvmf_config_conn_get_transport().
+ * Never a hostname -- always one of the host's own local addresses.
  *
  * Return: borrowed string, or NULL when the path left it unset.
  */

--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -78,21 +78,52 @@ static int canon_ip(const char *in, char **out)
 }
 
 /*
- * Sanitize the addressing fields once the transport is known: canonicalize a
- * numeric traddr/host_traddr via canon_ip(); a hostname is rejected outright
- * -- resolving one is the caller's job, not libnvme's.  IP addressing
- * applies only to the IP transports; fc and loop are left untouched.
+ * A lightweight structural check for FC addressing: "nn-0x<hex>:pn-0x<hex>"
+ * (node name + port name, each up to a 64-bit WWN in hex) -- the same shape
+ * sanitize_discovery_log_entry() already normalizes discovery-log traddr
+ * into.  Not a deep WWN semantic check (OUI bits etc.), the same spirit as
+ * canon_ip() below for tcp/rdma: catch a malformed value, not police it.
+ */
+static bool fc_wwn_is_valid(const char *in)
+{
+	char nn[17], pn[17];
+	int len = 0;
+
+	if (sscanf(in, "nn-0x%16[0-9a-fA-F]:pn-0x%16[0-9a-fA-F]%n",
+		   nn, pn, &len) != 2)
+		return false;
+
+	return (size_t)len == strlen(in);
+}
+
+/*
+ * Sanitize the addressing fields once the transport is known.  IP
+ * transports: canonicalize a numeric traddr/host_traddr via canon_ip(); a
+ * hostname is rejected outright -- resolving one is the caller's job, not
+ * libnvme's.  FC: validate the "nn-0x:pn-0x" shape via fc_wwn_is_valid();
+ * left as-is on success, since it's already in canonical form once it
+ * matches. loop is left untouched.
  *
- * Return: 0 on success; -EINVAL if traddr or host_traddr is set but not
- * numeric; -ENOMEM on allocation failure.
+ * Return: 0 on success; -EINVAL if traddr or host_traddr is set but
+ * malformed for the transport; -ENOMEM on allocation failure.
  */
 static int tid_sanitize_addr(struct libnvmf_tid *t)
 {
 	char *canon;
 	int rc;
 
-	if (!t->transport ||
-	    (strcmp(t->transport, "tcp") && strcmp(t->transport, "rdma")))
+	if (!t->transport)
+		return 0;
+
+	if (!strcmp(t->transport, "fc")) {
+		if (t->traddr && !fc_wwn_is_valid(t->traddr))
+			return -EINVAL;
+		if (t->host_traddr && !fc_wwn_is_valid(t->host_traddr))
+			return -EINVAL;
+		return 0;
+	}
+
+	if (strcmp(t->transport, "tcp") && strcmp(t->transport, "rdma"))
 		return 0;
 
 	if (t->traddr) {

--- a/libnvme/test/test-tid.c
+++ b/libnvme/test/test-tid.c
@@ -621,11 +621,35 @@ static bool test_tid_sanitize(void)
 	libnvmf_tid_free(t);
 	pass &= p;
 
-	/* Non-IP transports are untouched: no canonicalize, no rejection. */
+	/* A well-formed FC WWN pair passes through unchanged. */
 	t = libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
 				    NULL, NULL, NULL, NULL);
 	p = t && streq(libnvmf_tid_get_traddr(t), "nn-0x1:pn-0x2");
 	CHECK(p, "fc traddr untouched");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* A malformed FC traddr is rejected, same as a bad tcp/rdma one. */
+	t = libnvmf_tid_from_fields("fc", "21:00:00:e0:8b:05:05:01", NULL,
+				    "nqn.t", NULL, NULL, NULL, NULL);
+	p = (t == NULL);
+	CHECK(p, "malformed fc traddr rejected");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* A malformed FC host_traddr is rejected too. */
+	t = libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
+				    "not-a-wwn", NULL, NULL, NULL);
+	p = (t == NULL);
+	CHECK(p, "malformed fc host_traddr rejected");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* loop has no addressing shape at all: truly untouched. */
+	t = libnvmf_tid_from_fields("loop", "anything goes", NULL, "nqn.t",
+				    NULL, NULL, NULL, NULL);
+	p = t && streq(libnvmf_tid_get_traddr(t), "anything goes");
+	CHECK(p, "loop traddr untouched");
 	pass &= p;
 	libnvmf_tid_free(t);
 


### PR DESCRIPTION
## Summary
- `nvmf_resolve_args()` resolved both `traddr` and `host_traddr` via DNS; `host_traddr` is always one of the host's own local addresses, never a remote hostname. Only `traddr` is resolved now. Fixed the matching kdoc on `libnvmf_config_conn_get_host_traddr()`, which had copy-pasted the "may be a hostname" wording from `get_traddr()`'s doc.
- `tid_sanitize_addr()` validated tcp/rdma addressing (`canon_ip()`) but left FC untouched -- any string was accepted as `traddr`/`host_traddr` for `transport=fc`. Added a lightweight structural check for the `nn-0x<hex>:pn-0x<hex>` WWN-pair shape, the same format `sanitize_discovery_log_entry()` already normalizes discovery-log traddr into.

## Test plan
- [x] `meson compile` clean
- [x] `meson test`: 86/88 (2 expected-fail unchanged)
- [x] `make checkpatch-diff`: 0 errors, 0 warnings
- [x] valgrind on `test-tid`: 0 errors, 0 leaks
- [x] Standalone check covering 10 FC-address edge cases (valid pair, wrong-case prefix, trailing garbage, short/empty hex, legacy colon-byte format, cross-transport) -- all as expected
