### PR TITLE
gitignore: ignore unit-py build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ compile_commands.json
 tests/**/__pycache__
 tests/nvmetests
 tests/**/*.pyc
+unit-py/**/__pycache__
+unit-py/**/*.pyc
 
 .build
 .build-ci


### PR DESCRIPTION
Ignore the __pycache__ and *.pyc files generated by the unit-py tests.

This will be used by the new dump-command-metadata command.