### PR TITLE
fabrics: load fabrics module after parsing args

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -756,11 +756,11 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 
 	nvmf_default_args(&fa);
 
-	load_nvme_fabrics_module();
-
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	load_nvme_fabrics_module();
 
 	ret = validate_output_format(nvme_args.output_format, &flags);
 	if (ret < 0) {
@@ -937,11 +937,11 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 
 	nvmf_default_args(&fa);
 
-	load_nvme_fabrics_module();
-
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
 		return ret;
+
+	load_nvme_fabrics_module();
 
 	ret = validate_output_format(nvme_args.output_format, &flags);
 	if (ret < 0) {


### PR DESCRIPTION
Defer load_nvme_fabrics_module() until after argconfig_parse() in fabrics_discovery() and fabrics_connect().

This is necessary for the new dump-command-metadata command.