### PR TITLE
util: add optional argconfig parse hook

### DIFF
--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -318,6 +318,13 @@ static bool argconfig_check_verbose(struct argconfig_commandline_options *s)
 	return false;
 }
 
+static argconfig_parse_hook_fn argconfig_parse_hook;
+
+void argconfig_set_parse_hook(argconfig_parse_hook_fn hook)
+{
+	argconfig_parse_hook = hook;
+}
+
 int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		    struct argconfig_commandline_options *options)
 {
@@ -327,6 +334,9 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 	struct argconfig_commandline_options *s;
 	int c, long_opt_index = 0, opt_index = 0, short_index = 0, options_count = 0;
 	int ret = 0;
+
+	if (argconfig_parse_hook)
+		return argconfig_parse_hook(argc, argv, program_desc, options);
 
 	errno = 0;
 	for (s = options; s->option; s++)

--- a/util/argconfig.h
+++ b/util/argconfig.h
@@ -180,6 +180,12 @@ int argconfig_parse(int argc, char *argv[], const char *program_desc,
 		    struct argconfig_commandline_options *options);
 int argconfig_parse_global(int argc, char *argv[],
 			   struct argconfig_commandline_options *options);
+
+typedef int (*argconfig_parse_hook_fn)(int argc, char *argv[],
+				       const char *program_desc,
+				       struct argconfig_commandline_options *options);
+void argconfig_set_parse_hook(argconfig_parse_hook_fn hook);
+
 int argconfig_parse_comma_sep_array(char *string, int *ret, unsigned int max_length);
 int argconfig_parse_comma_sep_array_short(char *string, unsigned short *ret,
 					  unsigned int max_length);


### PR DESCRIPTION
Add argconfig_set_parse_hook() to register a hook that, when set, replaces argconfig_parse() entirely and supplies its return value. NULL (the default) keeps normal parsing.

This will be used by the new dump-command-metadata command.