### PR TITLE
build: add python-jsonschema to Windows UCRT64 deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,6 +310,7 @@ jobs:
             mingw-w64-ucrt-x86_64-ninja
             mingw-w64-ucrt-x86_64-ccache
             mingw-w64-ucrt-x86_64-json-c
+            mingw-w64-ucrt-x86_64-python-jsonschema
 
       - name: Build nvme-cli
         shell: msys2 {0}

--- a/scripts/win-ucrt64-setup.sh
+++ b/scripts/win-ucrt64-setup.sh
@@ -41,4 +41,5 @@ pacman $PACMAN_CMD --noconfirm --needed \
     mingw-w64-ucrt-x86_64-meson \
     mingw-w64-ucrt-x86_64-ninja \
     mingw-w64-ucrt-x86_64-ccache \
-    mingw-w64-ucrt-x86_64-json-c
+    mingw-w64-ucrt-x86_64-json-c \
+    mingw-w64-ucrt-x86_64-python-jsonschema


### PR DESCRIPTION
Install mingw-w64-ucrt-x86_64-python-jsonschema in the Windows setup script and CI job so schema validation can run there.

This will be used by the tests for the new dump-command-metadata command.