### PR TITLE
libnvme/tree: free hnqn/hid in error path

### DIFF
--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -485,8 +485,11 @@ int libnvme_create_host(struct libnvme_global_ctx *ctx,
 	}
 
 	h = calloc(1, sizeof(*h));
-	if (!h)
+	if (!h) {
+		free(hnqn);
+		free(hid);
 		return -ENOMEM;
+	}
 
 	h->hostnqn = hnqn;
 	h->hostid = hid;


### PR DESCRIPTION
133b16ddb938 ("libnvme/tree: only do a lookup in libnvme_lookup_host") forgot to free allocated resources when entering the error path.

Reported-by: Martin Belanger <martin.belanger@dell.com>

Fixes: #3610 