### PR TITLE
nvme: add JSON output to config show

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1379,108 +1379,17 @@ int fabrics_config_validate(const char *desc, int argc, char **argv)
 	return ret;
 }
 
-/*
- * libnvmf_connect_args_emit() callback for "nvme config-show": print each
- * formatted "--option=value" straight to stdout as part of the running
- * "nvme connect" line.
- */
-static void print_conn_arg(const char *arg, void *user_data)
-{
-	printf(" %s", arg);
-}
-
-static void print_conn_field(const char *name, const char *value)
-{
-	if (value)
-		printf(" --%s=%s", name, value);
-}
-
-/*
- * libnvmf_config_conn_for_each() callback for "nvme config-show": render
- * one resolved connection as its equivalent "nvme connect" command line.
- *
- * Identity is deliberately left unresolved here (unlike build_conn_tid()'s
- * connect-time callers): a persona with no hostnqn/hostid falls back to the
- * system default at connect time, not parse time, so showing the concrete
- * value here would suggest a fixed identity the config doesn't actually pin.
- *
- * Addressing is not resolved either, and no TID is built for a hostname:
- * "show" must never touch the network, and a hostname traddr is legitimate
- * INI content a TID (numeric-only) can't represent. The canonicalized TID
- * rendering is used when the address is already numeric; a raw hostname
- * falls back to printing the field as configured.
- */
-static void show_conn(const struct libnvmf_config_conn *conn, void *user_data)
-{
-	bool is_dc = libnvmf_config_conn_is_dc(conn);
-	const char *hostnqn = libnvmf_config_conn_get_hostnqn(conn);
-	const char *hostid = libnvmf_config_conn_get_hostid(conn);
-	const struct libnvmf_params *params =
-		libnvmf_config_conn_get_params(conn);
-	__cleanup_nvmf_tid struct libnvmf_tid *tid = NULL;
-
-	printf("# %s: %s\n", libnvmf_config_conn_get_source(conn),
-		is_dc ? "Discovery Controller" : "I/O Controller");
-
-	tid = libnvmf_tid_from_fields(
-			libnvmf_config_conn_get_transport(conn),
-			libnvmf_config_conn_get_traddr(conn),
-			libnvmf_config_conn_get_trsvcid(conn),
-			libnvmf_config_conn_get_subsysnqn(conn),
-			libnvmf_config_conn_get_host_traddr(conn),
-			libnvmf_config_conn_get_host_iface(conn),
-			hostnqn, hostid);
-
-	/*
-	 * A DC entry is consumed via libnvmf_discovery() (log in, fetch the
-	 * discovery log, connect everything returned) -- "nvme connect-all"
-	 * is its real equivalent, not a bare "nvme connect" (which would
-	 * only open the admin queue, matching just the niche "connect -J"
-	 * mode instead of the primary discover/connect-all consumption
-	 * path this command documents).
-	 */
-	printf("nvme %s", is_dc ? "connect-all" : "connect");
-	if (tid) {
-		libnvmf_connect_args_emit(tid, params, print_conn_arg, NULL);
-	} else {
-		const char *transport = libnvmf_config_conn_get_transport(conn);
-		const char *traddr = libnvmf_config_conn_get_traddr(conn);
-		const char *trsvcid = libnvmf_config_conn_get_trsvcid(conn);
-		const char *subsysnqn = libnvmf_config_conn_get_subsysnqn(conn);
-		const char *host_traddr =
-			libnvmf_config_conn_get_host_traddr(conn);
-		const char *host_iface =
-			libnvmf_config_conn_get_host_iface(conn);
-
-		print_conn_field("transport", transport);
-		print_conn_field("traddr", traddr);
-		print_conn_field("trsvcid", trsvcid);
-		print_conn_field("nqn", subsysnqn);
-		print_conn_field("host-traddr", host_traddr);
-		print_conn_field("host-iface", host_iface);
-		print_conn_field("hostnqn", hostnqn);
-		print_conn_field("hostid", hostid);
-		libnvmf_connect_args_emit(NULL, params, print_conn_arg, NULL);
-	}
-	printf("\n");
-	if (!hostnqn || !hostid)
-		printf("    (hostnqn/hostid: system default)\n");
-	printf("\n");
-}
-
 int fabrics_config_show(const char *desc, int argc, char **argv)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvmf_config *cfg;
 	char *config_file = PATH_NVMF_INI;
-	bool verbose = false;
+	nvme_print_flags_t flags;
 	int ret;
 
-	OPT_ARGS(opts) = {
-		OPT_STRING("config", 'J', "FILE", &config_file, nvmf_config_file_ro),
-		OPT_FLAG("verbose", 'v', &verbose, "increase output verbosity"),
-		OPT_END()
-	};
+	NVME_ARGS(opts,
+		OPT_STRING("config", 'J', "FILE", &config_file,
+			   nvmf_config_file_ro));
 
 	ret = argconfig_parse(argc, argv, desc, opts);
 	if (ret)
@@ -1488,7 +1397,13 @@ int fabrics_config_show(const char *desc, int argc, char **argv)
 
 	nvme_show_init();
 
-	log_level = map_log_level(verbose ? 1 : 0, false);
+	ret = validate_output_format(nvme_args.output_format, &flags);
+	if (ret < 0) {
+		nvme_show_error("Invalid output format");
+		return ret;
+	}
+
+	log_level = map_log_level(nvme_args.verbose, false);
 
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret) {
@@ -1505,7 +1420,7 @@ int fabrics_config_show(const char *desc, int argc, char **argv)
 		return ret;
 	}
 
-	libnvmf_config_conn_for_each(cfg, show_conn, NULL);
+	nvme_show_config_conn_list(cfg, flags);
 	libnvmf_config_free(cfg);
 
 	return 0;

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -34,6 +34,7 @@
 #define array_add_str json_array_add_value_string
 
 #define obj_add_array json_object_add_value_array
+#define obj_add_bool json_object_add_value_bool
 #define obj_add_int json_object_add_value_int
 #define obj_add_obj json_object_add_value_object
 #define obj_add_uint json_object_add_value_uint
@@ -5188,6 +5189,55 @@ static void json_discovery_log(struct nvmf_discovery_log *log, int numrec)
 static void json_discovery_log(struct nvmf_discovery_log *log, int numrec) {}
 #endif
 
+#ifdef CONFIG_FABRICS
+static void json_add_param(const char *key, const char *value, void *user_data)
+{
+	obj_add_str(user_data, key, value);
+}
+
+/*
+ * libnvmf_config_conn_for_each() callback for "nvme config show -o json".
+ * Reports fields as configured, not canonicalized through a TID (which has
+ * no per-field accessors). hostnqn/hostid are null when a persona falls
+ * back to the system default, not the value it would resolve to.
+ */
+static void json_add_conn(const struct libnvmf_config_conn *c, void *user_data)
+{
+	struct json_object *entries = user_data;
+	struct json_object *entry = json_create_object();
+	struct json_object *params_obj = json_create_object();
+	const struct libnvmf_params *params = libnvmf_config_conn_get_params(c);
+
+	obj_add_str(entry, "source", libnvmf_config_conn_get_source(c));
+	obj_add_bool(entry, "is_dc", libnvmf_config_conn_is_dc(c));
+	obj_add_str(entry, "transport", libnvmf_config_conn_get_transport(c));
+	obj_add_str(entry, "traddr", libnvmf_config_conn_get_traddr(c));
+	obj_add_str(entry, "trsvcid", libnvmf_config_conn_get_trsvcid(c));
+	obj_add_str(entry, "nqn", libnvmf_config_conn_get_subsysnqn(c));
+	obj_add_str(entry, "host-traddr",
+		    libnvmf_config_conn_get_host_traddr(c));
+	obj_add_str(entry, "host-iface", libnvmf_config_conn_get_host_iface(c));
+	obj_add_str(entry, "hostnqn", libnvmf_config_conn_get_hostnqn(c));
+	obj_add_str(entry, "hostid", libnvmf_config_conn_get_hostid(c));
+
+	libnvmf_params_for_each(params, json_add_param, params_obj);
+	obj_add_obj(entry, "params", params_obj);
+
+	array_add_obj(entries, entry);
+}
+
+static void json_config_conn_list(struct libnvmf_config *config)
+{
+	struct json_object *r = json_r;
+	struct json_object *entries = json_create_array();
+
+	obj_add_array(r, "connections", entries);
+	libnvmf_config_conn_for_each(config, json_add_conn, entries);
+}
+#else
+static void json_config_conn_list(struct libnvmf_config *config) {}
+#endif
+
 static void json_connect_msg(libnvme_ctrl_t c)
 {
 	struct json_object *r = json_r;
@@ -5805,6 +5855,9 @@ static struct print_ops json_print_ops = {
 	.topology_ctrl			= json_simple_topology,
 	.topology_namespace		= json_simple_topology,
 	.topology_multipath		= json_simple_topology,
+
+	/* config show */
+	.config_conn_list		= json_config_conn_list,
 
 	/* status and error messages */
 	.connect_msg			= json_connect_msg,

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -26,6 +26,7 @@
 #include "util/suffix.h"
 #include "util/types.h"
 #include "util/table.h"
+#include "util/cleanup.h"
 #include "logging.h"
 #include "common.h"
 
@@ -6513,6 +6514,107 @@ static void stdout_discovery_log(struct nvmf_discovery_log *log, int numrec)
 static void stdout_discovery_log(struct nvmf_discovery_log *log, int numrec) {}
 #endif
 
+#ifdef CONFIG_FABRICS
+/*
+ * libnvmf_connect_args_emit() callback for "nvme config show": print each
+ * formatted "--option=value" straight to stdout as part of the running
+ * "nvme connect" line.
+ */
+static void stdout_print_conn_arg(const char *arg, void *user_data)
+{
+	printf(" %s", arg);
+}
+
+static void stdout_print_conn_field(const char *name, const char *value)
+{
+	if (value)
+		printf(" --%s=%s", name, value);
+}
+
+/*
+ * libnvmf_config_conn_for_each() callback for "nvme config show": render
+ * one resolved connection as its equivalent "nvme connect" command line.
+ *
+ * Identity is deliberately left unresolved here (unlike build_conn_tid()'s
+ * connect-time callers): a persona with no hostnqn/hostid falls back to the
+ * system default at connect time, not parse time, so showing the concrete
+ * value here would suggest a fixed identity the config doesn't actually pin.
+ *
+ * Addressing is not resolved either, and no TID is built for a hostname:
+ * "show" must never touch the network, and a hostname traddr is legitimate
+ * INI content a TID (numeric-only) can't represent. The canonicalized TID
+ * rendering is used when the address is already numeric; a raw hostname
+ * falls back to printing the field as configured.
+ */
+static void stdout_print_conn(const struct libnvmf_config_conn *conn,
+			       void *user_data)
+{
+	bool is_dc = libnvmf_config_conn_is_dc(conn);
+	const char *hostnqn = libnvmf_config_conn_get_hostnqn(conn);
+	const char *hostid = libnvmf_config_conn_get_hostid(conn);
+	const struct libnvmf_params *params =
+		libnvmf_config_conn_get_params(conn);
+	__cleanup_nvmf_tid struct libnvmf_tid *tid = NULL;
+
+	printf("# %s: %s\n", libnvmf_config_conn_get_source(conn),
+		is_dc ? "Discovery Controller" : "I/O Controller");
+
+	tid = libnvmf_tid_from_fields(
+			libnvmf_config_conn_get_transport(conn),
+			libnvmf_config_conn_get_traddr(conn),
+			libnvmf_config_conn_get_trsvcid(conn),
+			libnvmf_config_conn_get_subsysnqn(conn),
+			libnvmf_config_conn_get_host_traddr(conn),
+			libnvmf_config_conn_get_host_iface(conn),
+			hostnqn, hostid);
+
+	/*
+	 * A DC entry is consumed via libnvmf_discovery() (log in, fetch the
+	 * discovery log, connect everything returned) -- "nvme connect-all"
+	 * is its real equivalent, not a bare "nvme connect" (which would
+	 * only open the admin queue, matching just the niche "connect -J"
+	 * mode instead of the primary discover/connect-all consumption
+	 * path this command documents).
+	 */
+	printf("nvme %s", is_dc ? "connect-all" : "connect");
+	if (tid) {
+		libnvmf_connect_args_emit(tid, params, stdout_print_conn_arg,
+					   NULL);
+	} else {
+		const char *transport = libnvmf_config_conn_get_transport(conn);
+		const char *traddr = libnvmf_config_conn_get_traddr(conn);
+		const char *trsvcid = libnvmf_config_conn_get_trsvcid(conn);
+		const char *subsysnqn = libnvmf_config_conn_get_subsysnqn(conn);
+		const char *host_traddr =
+			libnvmf_config_conn_get_host_traddr(conn);
+		const char *host_iface =
+			libnvmf_config_conn_get_host_iface(conn);
+
+		stdout_print_conn_field("transport", transport);
+		stdout_print_conn_field("traddr", traddr);
+		stdout_print_conn_field("trsvcid", trsvcid);
+		stdout_print_conn_field("nqn", subsysnqn);
+		stdout_print_conn_field("host-traddr", host_traddr);
+		stdout_print_conn_field("host-iface", host_iface);
+		stdout_print_conn_field("hostnqn", hostnqn);
+		stdout_print_conn_field("hostid", hostid);
+		libnvmf_connect_args_emit(NULL, params, stdout_print_conn_arg,
+					   NULL);
+	}
+	printf("\n");
+	if (!hostnqn || !hostid)
+		printf("    (hostnqn/hostid: system default)\n");
+	printf("\n");
+}
+
+static void stdout_config_conn_list(struct libnvmf_config *config)
+{
+	libnvmf_config_conn_for_each(config, stdout_print_conn, NULL);
+}
+#else
+static void stdout_config_conn_list(struct libnvmf_config *config) {}
+#endif
+
 static void stdout_connect_msg(libnvme_ctrl_t c)
 {
 	printf("connecting to device: %s\n", libnvme_ctrl_get_name(c));
@@ -7107,6 +7209,9 @@ static struct print_ops stdout_print_ops = {
 	.topology_namespace		= stdout_topology_namespace,
 	.topology_multipath		= stdout_topology_multipath,
 	.topology_tabular		= stdout_topology_tabular,
+
+	/* config show */
+	.config_conn_list		= stdout_config_conn_list,
 
 	/* nvme top */
 #ifdef CONFIG_TOP

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1828,6 +1828,12 @@ void nvme_show_connect_msg(libnvme_ctrl_t c, nvme_print_flags_t flags)
 	nvme_print(connect_msg, flags, c);
 }
 
+void nvme_show_config_conn_list(struct libnvmf_config *config,
+				 nvme_print_flags_t flags)
+{
+	nvme_print(config_conn_list, flags, config);
+}
+
 void nvme_show_init(void)
 {
 	nvme_print_output_format(show_init);

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -36,6 +36,11 @@ struct nvme_error_log_filter {
 	__u8 opcode;
 };
 
+/* config.h is fabrics-only; forward-declare so this header stays valid in a
+ * -Dfabrics=disabled build.
+ */
+struct libnvmf_config;
+
 struct print_ops {
 	/* libnvme types.h print functions */
 	void (*ana_log)(struct nvme_ana_log *ana_log, const char *devname, size_t len);
@@ -128,6 +133,9 @@ struct print_ops {
 	void (*topology_namespace)(struct libnvme_global_ctx *ctx);
 	void (*topology_multipath)(struct libnvme_global_ctx *ctx);
 	void (*topology_tabular)(struct libnvme_global_ctx *ctx);
+
+	/* config show */
+	void (*config_conn_list)(struct libnvmf_config *config);
 
 	/* nvme top */
 	void (*top)(int refresh_interval);
@@ -333,6 +341,8 @@ void nvme_show_fdp_ruh_status(struct nvme_fdp_ruh_status *status, size_t len,
 void nvme_show_discovery_log(struct nvmf_discovery_log *log, uint64_t numrec,
 			     nvme_print_flags_t flags);
 void nvme_show_connect_msg(libnvme_ctrl_t c, nvme_print_flags_t flags);
+void nvme_show_config_conn_list(struct libnvmf_config *config,
+				 nvme_print_flags_t flags);
 
 const char *nvme_ana_state_to_string(enum nvme_ana_state state);
 const char *nvme_cmd_to_string(int admin, __u8 opcode);


### PR DESCRIPTION
## Summary
- Add `-o json` support to `nvme config show`. New `print_ops` member `config_conn_list`: the existing text renderer moved from `fabrics.c` into `nvme-print-stdout.c` (`stdout_config_conn_list()`), and a new JSON renderer was added in `nvme-print-json.c` (`json_config_conn_list()`), both `#ifdef CONFIG_FABRICS`-gated following the existing `discovery_log` pattern. `fabrics_config_show()` switches from a bare `OPT_ARGS` list to `NVME_ARGS` to gain `-o`/`--output-format` (it had none before).
- JSON reports each connection's fields as configured, not canonicalized through a TID -- an array of connection objects under `"connections"`, with a nested `"params"` object for per-connection tunables. `hostnqn`/`hostid` are `null` when a persona falls back to the system default, matching the text renderer's existing "don't show a fixed identity the config doesn't actually pin" rule.

## Test plan
- [x] `meson compile` clean, both default and `-Dfabrics=disabled`
- [x] `meson test`: 81/83 (2 expected-fail unchanged)
- [x] `make checkpatch-diff`: 0 errors, 0 warnings
- [x] Manual verification against real INI fixtures: text output unchanged, JSON output correct for both default-identity and pinned-identity configs, malformed-INI error path returns a valid JSON error object with no crash
