### PR TITLE
doc: add man pages for config show and validate

### DIFF
--- a/Documentation/cmds-main.txt
+++ b/Documentation/cmds-main.txt
@@ -172,6 +172,12 @@ linknvme:nvme-disconnect-all[1]::
 linknvme:nvme-config-convert[1]::
 	Convert a legacy NVMe-oF configuration to the INI format
 
+linknvme:nvme-config-validate[1]::
+	Validate an NVMe-oF INI connection configuration file
+
+linknvme:nvme-config-show[1]::
+	Show the resolved NVMe-oF INI connection configuration
+
 linknvme:nvme-get-property[1]::
 	Reads and shows NVMe-over-Fabrics controller property
 

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -11,6 +11,8 @@ adoc_sources = [
     'nvme-cmdset-ind-id-ns',
     'nvme-compare',
     'nvme-config-convert',
+    'nvme-config-show',
+    'nvme-config-validate',
     'nvme-connect',
     'nvme-connect-all',
     'nvme-copy',

--- a/Documentation/nvme-config-convert.txt
+++ b/Documentation/nvme-config-convert.txt
@@ -85,6 +85,8 @@ the system, this command still converts it and renames it to
 
 SEE ALSO
 --------
+nvme-config-validate(1)
+nvme-config-show(1)
 nvme-connect-all(1)
 nvme-discover(1)
 https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md

--- a/Documentation/nvme-config-show.txt
+++ b/Documentation/nvme-config-show.txt
@@ -1,0 +1,80 @@
+nvme-config-show(1)
+====================
+
+NAME
+----
+nvme-config-show - Show the resolved NVMe-oF INI connection configuration
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'config show'
+			[--config=<file> | -J <file>]
+
+DESCRIPTION
+-----------
+Reads the NVMe-oF INI connection configuration file used by
+'nvme connect-all' and 'nvme discover', and prints every configured
+connection entry. The INI format is documented at
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md
+
+By default, the file at @SYSCONFDIR@/nvme/nvme-fabrics.conf is read. Use
+--config to show a file at a different path instead.
+
+In the default and 'tabular' output formats, each entry is rendered as the
+equivalent command line that would establish it: 'nvme connect-all' for a
+Discovery Controller entry, 'nvme connect' for an I/O Controller entry,
+preceded by a comment naming the entry's source (which file/section it came
+from). The 'json' output format instead reports each entry's fields
+individually (transport, address, NQN, host identity, and any extra
+connect parameters).
+
+This command never touches the network: addressing is shown exactly as
+configured, with no hostname resolution attempted. A persona with no
+'hostnqn'/'hostid' set is shown without those fields rather than the system
+default it would resolve to at connect time, since showing a concrete value
+here would suggest a fixed identity the configuration doesn't actually pin.
+
+OPTIONS
+-------
+-J <file>::
+--config=<file>::
+	Show this INI file instead of the default
+	@SYSCONFDIR@/nvme/nvme-fabrics.conf.
+
+include::global-options.txt[]
+
+EXAMPLES
+--------
+* Show the system's resolved configuration:
++
+------------
+# nvme config show
+------------
++
+------------
+# nvme0: Discovery Controller
+nvme connect-all --transport=tcp --traddr=192.168.1.10 --trsvcid=8009
+
+# nvme1: I/O Controller
+nvme connect --transport=tcp --traddr=192.168.1.10 --trsvcid=4420 \
+	--nqn=nqn.2014-08.org.nvmexpress:uuid:6a4f5e3e-...
+------------
+
+* Show a configuration file at a non-default path, as JSON:
++
+------------
+$ nvme config show --config /tmp/nvme-fabrics.conf -o json
+------------
+
+SEE ALSO
+--------
+nvme-config-validate(1)
+nvme-config-convert(1)
+nvme-connect-all(1)
+nvme-discover(1)
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md
+
+NVME
+----
+Part of the nvme-user suite

--- a/Documentation/nvme-config-validate.txt
+++ b/Documentation/nvme-config-validate.txt
@@ -1,0 +1,67 @@
+nvme-config-validate(1)
+========================
+
+NAME
+----
+nvme-config-validate - Validate an NVMe-oF INI connection configuration file
+
+SYNOPSIS
+--------
+[verse]
+'nvme' 'config validate'
+			[--config=<file> | -J <file>]
+			[--verbose | -v]
+
+DESCRIPTION
+-----------
+Parses and validates the NVMe-oF INI connection configuration file used by
+'nvme connect-all' and 'nvme discover'. The INI format is documented at
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md
+
+By default, the file at @SYSCONFDIR@/nvme/nvme-fabrics.conf is validated.
+Use --config to validate a file at a different path instead, for example
+before installing it as the system configuration.
+
+On success, '<file>: OK' is printed and the command exits with status 0.
+If the file is malformed, '<file>: invalid configuration' is printed
+along with diagnostic details, and the command exits with a non-zero
+status. A missing file is also reported as an error, not treated as an
+empty, valid configuration.
+
+OPTIONS
+-------
+-J <file>::
+--config=<file>::
+	Validate this INI file instead of the default
+	@SYSCONFDIR@/nvme/nvme-fabrics.conf.
+
+-v::
+--verbose::
+	Increase the level of detail in the output.
+
+EXAMPLES
+--------
+* Validate the system's configuration:
++
+------------
+# nvme config validate
+------------
+
+* Validate a configuration file before installing it as the system
+  configuration:
++
+------------
+$ nvme config validate --config /tmp/nvme-fabrics.conf
+------------
+
+SEE ALSO
+--------
+nvme-config-show(1)
+nvme-config-convert(1)
+nvme-connect-all(1)
+nvme-discover(1)
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md
+
+NVME
+----
+Part of the nvme-user suite


### PR DESCRIPTION
The `config` plugin's `show` and `validate` subcommands had no documentation; only `config convert` did. Cover them the same way, and cross-link all three from cmds-main.txt and each other's SEE ALSO.