### PR TITLE
fabrics: check registry owner before connect-all/discover

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -42,6 +42,8 @@
 #include <sys/socket.h>
 #endif
 
+#include <ccan/str/str.h>
+
 #include <libnvme.h>
 
 #ifdef NVME_HAVE_LIBKMOD
@@ -716,6 +718,43 @@ static int fabrics_discovery_config(struct libnvme_global_ctx *ctx,
 
 #define NBFT_SYSFS_PATH		"/sys/firmware/acpi/tables"
 
+/*
+ * A controller's ownership extends to everything done through it, so the
+ * caller's operation may not proceed unless the invoking owner matches
+ * (mirrors disconnect_all_match()'s registry check). No ownerless
+ * exemption -- a mismatched or missing --owner is skipped the same way;
+ * the escape hatch is passing the owner's own identity.
+ *
+ * --force skips the check entirely: it means the caller will never reuse
+ * an existing controller, so there is nothing to check ownership against.
+ *
+ * Returns 0 to proceed, 1 to skip, or a negative errno on a registry
+ * read failure.
+ */
+static int check_ctrl_owner(struct libnvme_global_ctx *ctx,
+			     struct libnvmf_context *fctx,
+			     const char *owner, bool force)
+{
+	__cleanup_free char *reg_owner = NULL;
+	int ret;
+
+	if (force)
+		return 0;
+
+	ret = libnvmf_get_owner_from_fctx(ctx, fctx, &reg_owner);
+	if (ret)
+		return ret;
+	if (!reg_owner)   /* no owner in registry */
+		return 0;
+
+	if (owner && streq(reg_owner, owner))
+		return 0;
+
+	nvme_show_error("owned by '%s'; skipping -- owner handles discovery",
+			 reg_owner);
+	return 1;
+}
+
 int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 {
 	__cleanup_free char *hnqn = NULL;
@@ -840,6 +879,17 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 			&dld, &fctx);
 		if (ret)
 			return ret;
+
+		ret = check_ctrl_owner(ctx, fctx,
+				owner ? owner : (nbft ? "nbft" : NULL), force);
+		if (ret < 0) {
+			nvme_show_error("failed to check owner: %s",
+					libnvme_strerror(-ret));
+			return ret;
+		}
+		if (ret)
+			return 0;
+
 		ret = libnvmf_discovery(ctx, fctx, connect, force);
 	}
 

--- a/libnvme/design/REGISTRY.md
+++ b/libnvme/design/REGISTRY.md
@@ -120,6 +120,10 @@ In every case, controllers the kernel manages directly (PCIe and other memory-ba
 
 By contrast, `nvme disconnect <device>` targets one named controller and always disconnects it — the caller's intent is unambiguous, so no guardrail applies.
 
+## `connect-all` / `discover --device` behavior
+
+The exclusion list governs connections that don't exist yet; the registry governs ones that already do. Enumerating a discovery controller's log page is an operation on a live controller, so `nvme connect-all --device <dev>` and `nvme discover --device <dev>` check that controller's registry owner before proceeding: an unregistered or matching-owner DC proceeds, but a DC owned by someone else is skipped with a log line, regardless of whether `--owner` was given — there is no ownerless exemption, since the DC's ownership extends to everything discovered through it.
+
 ## Inspecting the registry
 
 ```sh

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -72,6 +72,8 @@ LIBNVMF_3 {
 		libnvmf_generate_tls_key_identity_compat;
 		libnvmf_get_default_trsvcid;
 		libnvmf_get_discovery_log;
+		libnvmf_get_owner_from_fctx;
+		libnvmf_get_owner_from_tid;
 		libnvmf_host_get_ids;
 		libnvmf_import_tls_key;
 		libnvmf_import_tls_key_versioned;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2450,6 +2450,81 @@ static libnvme_ctrl_t lookup_ctrl(libnvme_host_t h, struct libnvmf_context *fctx
 	return NULL;
 }
 
+__libnvme_public int libnvmf_get_owner_from_tid(struct libnvme_global_ctx *ctx,
+		const struct libnvmf_tid *tid, char **owner)
+{
+	struct libnvme_ctrl_params params = { 0 };
+	libnvme_subsystem_t s;
+	libnvme_host_t h;
+	libnvme_ctrl_t c = NULL;
+	int ret;
+
+	if (!ctx || !tid || !owner)
+		return -EINVAL;
+
+	*owner = NULL;
+
+	h = libnvme_lookup_host(ctx, libnvmf_tid_get_hostnqn(tid),
+				 libnvmf_tid_get_hostid(tid));
+	if (!h)
+		return 0;
+
+	params.transport = libnvmf_tid_get_transport(tid);
+	params.traddr = libnvmf_tid_get_traddr(tid);
+	params.trsvcid = libnvmf_tid_get_trsvcid(tid);
+	params.subsysnqn = libnvmf_tid_get_subsysnqn(tid);
+	params.host_traddr = libnvmf_tid_get_host_traddr(tid);
+	params.host_iface = libnvmf_tid_get_host_iface(tid);
+
+	libnvme_for_each_subsystem(h, s) {
+		c = libnvme_ctrl_find(s, &params, NULL);
+		if (c)
+			break;
+	}
+	if (!c)
+		return 0;
+
+	ret = libnvmf_registry_retrieve(ctx, libnvme_ctrl_get_name(c),
+					"owner", owner);
+	return (ret == -ENOENT) ? 0 : ret;
+}
+
+__libnvme_public int libnvmf_get_owner_from_fctx(struct libnvme_global_ctx *ctx,
+		struct libnvmf_context *fctx, char **owner)
+{
+	struct libnvmf_tid *tid;
+	const char *name;
+	int ret;
+
+	if (!ctx || !fctx || !owner)
+		return -EINVAL;
+
+	*owner = NULL;
+
+	name = libnvmf_context_get_device(fctx);
+	if (name) {
+		ret = libnvmf_registry_retrieve(ctx, name, "owner", owner);
+		return (ret == -ENOENT) ? 0 : ret;
+	}
+
+	tid = libnvmf_tid_from_fields(
+			libnvmf_context_get_transport(fctx),
+			libnvmf_context_get_traddr(fctx),
+			libnvmf_context_get_trsvcid(fctx),
+			libnvmf_context_get_subsysnqn(fctx),
+			libnvmf_context_get_host_traddr(fctx),
+			libnvmf_context_get_host_iface(fctx),
+			libnvmf_context_get_hostnqn(fctx),
+			libnvmf_context_get_hostid(fctx));
+	if (!tid)
+		return -ENOMEM;
+
+	ret = libnvmf_get_owner_from_tid(ctx, tid, owner);
+	libnvmf_tid_free(tid);
+
+	return ret;
+}
+
 static int setup_connection(struct libnvmf_context *fctx, struct libnvme_host *h,
 		bool discovery)
 {

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -536,6 +536,47 @@ int libnvmf_context_set_reconnect_policy(struct libnvmf_context *fctx,
 		int ctrl_loss_tmo, int reconnect_delay, int fast_io_fail_tmo);
 
 /**
+ * libnvmf_get_owner_from_tid() - Get the registry owner of a transport ID
+ *
+ * @ctx: Global context
+ * @tid: Transport ID identifying the connection to check
+ * @owner: Returned owner, NULL if no matching controller exists or it is
+ *         unowned
+ *
+ * Resolves the controller, if any, matching @tid and reports its registry
+ * owner. Does not connect, disconnect, or otherwise modify controller
+ * state.
+ *
+ * When a matching owned controller exists, @owner is set to a newly
+ * allocated string that the caller must free(). Otherwise, @owner is set
+ * to NULL. A negative errno return indicates the lookup failed; it is
+ * never used to report that no owner exists.
+ *
+ * Return: 0 on success (check @owner), negative errno on failure.
+ */
+int libnvmf_get_owner_from_tid(struct libnvme_global_ctx *ctx,
+		const struct libnvmf_tid *tid, char **owner);
+
+/**
+ * libnvmf_get_owner_from_fctx() - Get the registry owner of a fabrics context
+ *
+ * @ctx: Global context
+ * @fctx: Fabrics context describing the connection to check
+ * @owner: Returned owner, NULL if no matching controller exists or it is
+ *         unowned
+ *
+ * Convenience wrapper around libnvmf_get_owner_from_tid() for callers that
+ * already have a libnvmf_context rather than a bare TID. If @fctx names an
+ * explicit device, its registry entry is checked directly. Otherwise, a
+ * controller is resolved from @fctx's connection parameters. The @owner
+ * contract is identical to libnvmf_get_owner_from_tid().
+ *
+ * Return: 0 on success (check @owner), negative errno on failure.
+ */
+int libnvmf_get_owner_from_fctx(struct libnvme_global_ctx *ctx,
+		struct libnvmf_context *fctx, char **owner);
+
+/**
  * libnvmf_discovery() - Perform fabrics discovery
  * @ctx: Global context
  * @fctx: Fabrics context


### PR DESCRIPTION
## Summary
- Bug fix: `connect-all`/`discover` enumerated a discovery controller's log page regardless of who owns it, letting `70-nvmf-autoconnect.rules`' udev-triggered fan-out act on a device some other orchestrator already manages. `disconnect-all` already checks registry ownership before acting (`disconnect_all_match()`); this aligns `connect-all` with that existing behavior.
- Covers both the `--device=nvmeX` path and a bare `--transport`/`--traddr` invocation that resolves to an existing controller through `libnvmf_discovery()`'s own fallback matcher (transport/traddr/subsysnqn/host identity, including kernel-reported `src_addr` for TCP when `host-traddr`/`host-iface` aren't given) -- the latter needed a new public libnvme function, `libnvmf_lookup_ctrl()`, exposing that same matcher so the CLI can preview which controller (if any) a connection request resolves to before deciding whether to proceed.
- `REGISTRY.md` gets a new "`connect-all`/`discover --device` behavior" section documenting it.

## Test plan
- [x] `meson compile` clean: default, `-Dwerror=true`, `-Dfabrics=disabled`
- [x] `meson test`: 81/83 (2 expected-fail unchanged)
- [x] `make checkpatch-diff`: 0 errors (2 pre-accepted long string-literal warnings)
- [x] Manual verification with a scratch registry (`--set-options test-base-dir=`): owned device skipped with no `--owner`, proceeds with matching `--owner`, unregistered device proceeds
- [ ] The "no `--device`, matches an existing ctrl" branch is code-reviewed but not live-tested -- needs a real NVMe-oF connection
