### PR TITLE
libnvme: write registry entry on an already-connected controller

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1441,6 +1441,22 @@ static int __nvmf_supported_options(struct libnvme_global_ctx *ctx)
 	return 0;
 }
 
+/* Parse the kernel instance number out of a ctrl's name ("nvme3" -> 3). */
+static int ctrl_instance(libnvme_ctrl_t c)
+{
+	int instance = -1;
+	const char *name;
+
+	if (!c)
+		return instance;
+
+	name = libnvme_ctrl_get_name(c);
+	if (name)
+		sscanf(name, "nvme%d", &instance);
+
+	return instance;
+}
+
 /*
  * Best-effort registry update after a successful connect: record ownership
  * when an owner is set, otherwise clear any stale entry for a recycled
@@ -3427,7 +3443,11 @@ __libnvme_public int libnvmf_connect(
 	c = lookup_ctrl(h, fctx);
 	if (c && libnvme_ctrl_get_name(c) &&
 	    !fctx->ctrl_params.cfg.duplicate_connect) {
+		int instance = ctrl_instance(c);
+
 		write_devid_file(fctx, devid_fd, c);
+		if (instance >= 0)
+			registry_update_on_connect(ctx, instance);
 		fctx->hooks.already_connected(fctx, h,
 			libnvme_ctrl_get_subsysnqn(c),
 			libnvme_ctrl_get_transport(c),
@@ -3468,8 +3488,14 @@ __libnvme_public int libnvmf_connect(
 		 * the winner -- rescan to find it.
 		 */
 		if (err == -ENVME_CONNECT_ALREADY &&
-		    libnvme_scan_topology(ctx, NULL, NULL) == 0)
-			write_devid_file(fctx, devid_fd, lookup_ctrl(h, fctx));
+		    libnvme_scan_topology(ctx, NULL, NULL) == 0) {
+			libnvme_ctrl_t winner = lookup_ctrl(h, fctx);
+			int instance = ctrl_instance(winner);
+
+			write_devid_file(fctx, devid_fd, winner);
+			if (instance >= 0)
+				registry_update_on_connect(ctx, instance);
+		}
 
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "could not add new controller: %s\n",
 			libnvme_strerror(-err));


### PR DESCRIPTION
## Summary
- Bug fix: `libnvmf_connect()` only wrote the ownership registry entry on a fresh connect. Its two "already connected" exit paths -- a tree-level dup match, and a kernel-race rescan -- skipped it, so `nvme connect --owner X --idempotent` against an already-connected controller left the registry stale. The registry must be authoritative "regardless of who made the initial connection" (RFC's own spec for this feature), and nvme-discoverd's `--idempotent`-based adoption of pre-existing connections (NBFT, FC boot) depends on it.
- Added a small `ctrl_instance()` helper (parses `"nvme3"` -> `3` from a ctrl's name, matching the existing `sscanf(..., "nvme%d", ...)` pattern in `scan-linux.c`) and reused the existing `registry_update_on_connect()` in both paths, unconditionally -- so the registry reflects the current invocation's `--owner` regardless of which path resolved the connection. No CLI-side change needed: `libnvme_set_owner()` already runs before `libnvmf_connect()` regardless of `--idempotent`.

## Test plan
- [x] `meson compile` clean: default, `-Dwerror=true`, `-Dfabrics=disabled`
- [x] `meson test`: 81/83 (2 expected-fail unchanged)
- [x] `make checkpatch-diff`: 0 errors, 0 warnings
- [x] `update-accessors`: no drift (no public API surface changed)
- [ ] Not live-tested -- exercising either already-connected exit path needs a real NVMe-oF connection
