### PR TITLE
nvme-print: handle NULL phy slot pointer

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -4594,6 +4594,7 @@ static void json_print_detail_list_multipath(libnvme_subsystem_t s,
 		libnvme_namespace_for_each_path(n, p) {
 			libnvme_ctrl_t c;
 			struct json_object *jpath = json_create_object();
+			const char *slot;
 
 			obj_add_str(jpath, "Path", libnvme_path_get_name(p));
 			obj_add_str(jpath, "ANAState", libnvme_path_get_ana_state(p));
@@ -4604,6 +4605,7 @@ static void json_print_detail_list_multipath(libnvme_subsystem_t s,
 			 * controller  attributes.
 			 */
 			c = libnvme_path_get_ctrl(p);
+			slot = libnvme_ctrl_get_phy_slot(c);
 			obj_add_str(jpath, "Controller", libnvme_ctrl_get_name(c));
 			obj_add_str(jpath, "Cntlid", libnvme_ctrl_get_cntlid(c));
 			obj_add_str(jpath, "SerialNumber", libnvme_ctrl_get_serial(c));
@@ -4612,7 +4614,7 @@ static void json_print_detail_list_multipath(libnvme_subsystem_t s,
 			obj_add_str(jpath, "Transport", libnvme_ctrl_get_transport(c));
 			obj_add_str(jpath, "Address", libnvme_ctrl_get_traddr(c));
 			obj_add_ctrl_address_details(jpath, "AddressDetails", c);
-			obj_add_str(jpath, "Slot", libnvme_ctrl_get_phy_slot(c));
+			obj_add_str(jpath, "Slot", slot ? slot : "");
 
 			array_add_obj(jpaths, jpath);
 		}
@@ -4632,6 +4634,7 @@ static void json_print_detail_list(libnvme_subsystem_t s, struct json_object *js
 	libnvme_subsystem_for_each_ctrl(s, c) {
 		struct json_object *jctrl = json_create_object();
 		struct json_object *jnss = json_create_array();
+		const char *slot = libnvme_ctrl_get_phy_slot(c);
 
 		obj_add_str(jctrl, "Controller", libnvme_ctrl_get_name(c));
 		obj_add_str(jctrl, "Cntlid", libnvme_ctrl_get_cntlid(c));
@@ -4641,7 +4644,7 @@ static void json_print_detail_list(libnvme_subsystem_t s, struct json_object *js
 		obj_add_str(jctrl, "Transport", libnvme_ctrl_get_transport(c));
 		obj_add_str(jctrl, "Address", libnvme_ctrl_get_traddr(c));
 		obj_add_ctrl_address_details(jctrl, "AddressDetails", c);
-		obj_add_str(jctrl, "Slot", libnvme_ctrl_get_phy_slot(c));
+		obj_add_str(jctrl, "Slot", slot ? slot : "");
 
 		libnvme_ctrl_for_each_ns(c, n) {
 			struct json_object *jns = json_create_object();

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5859,12 +5859,14 @@ static bool stdout_detailed_ctrl(const char *name, void *arg)
 	{
 		const char *tr = libnvme_ctrl_get_transport(c);
 		__cleanup_free char *reg_owner = libnvme_ctrl_owner(c);
+		const char *slot = libnvme_ctrl_get_phy_slot(c);
 		const char *owner_str;
 
 		if (!libnvme_ctrl_is_transport_fabric(c))
 			owner_str = "kernel";
 		else
 			owner_str = reg_owner ? reg_owner : "-";
+
 		printf("%-16s %-12s %-6s %-20s %-40s %-8s %-6s %-14s %-6s %-12s ",
 		       libnvme_ctrl_get_name(c),
 		       owner_str,
@@ -5874,7 +5876,7 @@ static bool stdout_detailed_ctrl(const char *name, void *arg)
 		       libnvme_ctrl_get_firmware(c),
 		       tr,
 		       libnvme_ctrl_get_traddr(c),
-		       libnvme_ctrl_get_phy_slot(c),
+		       slot ? slot : "",
 		       libnvme_subsystem_get_name(libnvme_ctrl_get_subsystem(c)));
 	}
 


### PR DESCRIPTION
libnvme 1 returns an empty string when the PHY slot is not found, while libnvme 3 returns NULL instead. The getter is generated, and all generated getters follow the same convention.

Changing the generated getters to return an empty string instead of NULL is not possible because existing code depends on NULL. Since libnvme_ctrl_get_phy_slot is the only caller affected by this change, handle the NULL pointer here instead.

Fixes: #3622 