### PR TITLE
libnvme: fix SIGSEGV in __libnvme_transport_handle_open_mi

### DIFF
--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -91,6 +91,10 @@ int __libnvme_transport_handle_open_mi(struct libnvme_transport_handle *hdl, con
 	if (!ep)
 		return -EINVAL;
 
+	hdl->ep = ep;
+	hdl->id = ctrl_id;
+	list_add_tail(&ep->controllers, &hdl->ep_entry);
+
 	return 0;
 }
 


### PR DESCRIPTION
When opening an MI connection over MCTP via __libnvme_transport_handle_open_mi, the returned endpoint pointer 'ep' was not saved into the transport handle 'hdl->ep', and the handle was not added to the endpoint's controllers list.

This led to a SIGSEGV later when attempting to submit commands using the handle, as hdl->ep remained NULL.

Fix this by correctly assigning hdl->ep, hdl->id, and adding the handle to the controllers list.