### PR TITLE
Print `address` instead of `traddr`

### DIFF
--- a/config-convert.c
+++ b/config-convert.c
@@ -590,15 +590,9 @@ int nvme_config_convert(const char *desc, int argc, char **argv)
 
 	nvme_show_init();
 
-	log_level = map_log_level(verbose ? 1 : 0, false);
-
 	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-				 libnvme_strerror(-ret));
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	emitter = libnvmf_config_emit_new(ctx);
 	if (!emitter)

--- a/config-convert.c
+++ b/config-convert.c
@@ -565,7 +565,6 @@ int nvme_config_convert(const char *desc, int argc, char **argv)
 	char *output_file = NULL;
 	const char *target;
 	const char *json_path;
-	bool verbose = false;
 	bool force = false;
 	bool converted_json = false, converted_disc = false;
 	bool json_already_done = false, disc_already_done = false;
@@ -580,15 +579,12 @@ int nvme_config_convert(const char *desc, int argc, char **argv)
 			   "write result here (default: nvme-fabrics.conf)"),
 		OPT_FLAG("force", 0, &force,
 			 "overwrite an existing target"),
-		OPT_FLAG("verbose", 'v', &verbose, "increase output verbosity"),
 		OPT_END()
 	};
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
-
-	nvme_show_init();
 
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)

--- a/fabrics.c
+++ b/fabrics.c
@@ -67,7 +67,6 @@
 /* Name of file to output log pages in their raw format */
 static char *raw;
 static bool persistent;
-static bool quiet;
 
 static const char *nvmf_tport		= "transport type";
 static const char *nvmf_traddr		= "transport address";
@@ -217,7 +216,7 @@ static void hook_already_connected(struct libnvmf_context *fctx,
 {
 	struct hook_fabrics_data *hfd = user_data;
 
-	if (quiet)
+	if (nvme_args.quiet)
 		return;
 
 	if (hfd->idempotent) {
@@ -774,7 +773,6 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 		  OPT_STRING("device",     'd', "DEV", &device,       "use existing discovery controller device"),
 		  OPT_FILE("raw",          'r', &raw,                 "save raw output to file"),
 		  OPT_FLAG("persistent",   'p', &persistent,          "persistent discovery connection"),
-		  OPT_FLAG("quiet",          0, &quiet,               "suppress already connected errors"),
 		  OPT_STRING("config",     'J', "FILE", &config_file, nvmf_config_file),
 		  OPT_FLAG("force",          0, &force,               "Force persistent discovery controller creation"),
 		  OPT_FLAG("nbft",           0, &nbft,                "Only look at NBFT tables"),
@@ -799,15 +797,12 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	if (!strcmp(config_file, "none"))
 		config_file = NULL;
 
-	log_level = map_log_level(nvme_args.verbose, quiet);
-
-	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(-ret));
+	ret = nvme_create_global_ctx_hostnqn(&ctx,
+		fa.hostnqn, fa.hostid, &hnqn, &hid);
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
+	fa.hostnqn = hnqn;
+	fa.hostid = hid;
 
 	/*
 	 * --nbft defaults the owner to "nbft" so legacy boot scripts that
@@ -842,15 +837,6 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 	ret = nvmf_resolve_addr(fa.transport, &fa.traddr);
 	if (ret)
 		return ret;
-
-	ret = libnvmf_host_get_ids(ctx, fa.hostnqn, fa.hostid, &hnqn, &hid);
-	if (ret) {
-		nvme_show_error("failed to determine hostnqn/hostid: %s",
-			libnvme_strerror(-ret));
-		return ret;
-	}
-	fa.hostnqn = hnqn;
-	fa.hostid = hid;
 
 	struct hook_fabrics_data dld = {
 		.flags = flags,
@@ -1022,15 +1008,12 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 		return ret;
 
 do_connect:
-	log_level = map_log_level(nvme_args.verbose, quiet);
-
-	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(-ret));
+	ret = nvme_create_global_ctx_hostnqn(&ctx,
+		fa.hostnqn, fa.hostid, &hnqn, &hid);
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
+	fa.hostnqn = hnqn;
+	fa.hostid = hid;
 
 	if (owner) {
 		ret = libnvme_set_owner(ctx, owner);
@@ -1052,15 +1035,6 @@ do_connect:
 	if (config_file)
 		return fabrics_connect_config(ctx, config_file, fa.hostnqn,
 			fa.hostid, flags);
-
-	ret = libnvmf_host_get_ids(ctx, fa.hostnqn, fa.hostid, &hnqn, &hid);
-	if (ret) {
-		nvme_show_error("failed to determine hostnqn/hostid: %s",
-			libnvme_strerror(-ret));
-		return ret;
-	}
-	fa.hostnqn = hnqn;
-	fa.hostid = hid;
 
 	struct hook_fabrics_data hfd = {
 		.flags = flags,
@@ -1187,15 +1161,9 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 		return -EINVAL;
 	}
 
-	log_level = map_log_level(nvme_args.verbose, false);
-
 	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(-ret));
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
@@ -1343,15 +1311,9 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 		}
 	}
 
-	log_level = map_log_level(nvme_args.verbose, false);
-
 	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(-ret));
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);
@@ -1405,15 +1367,9 @@ int fabrics_config_validate(const char *desc, int argc, char **argv)
 
 	nvme_show_init();
 
-	log_level = map_log_level(verbose ? 1 : 0, false);
-
 	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(-ret));
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	if (access(config_file, F_OK)) {
 		nvme_show_error("%s: no such file", config_file);
@@ -1453,15 +1409,9 @@ int fabrics_config_show(const char *desc, int argc, char **argv)
 		return ret;
 	}
 
-	log_level = map_log_level(nvme_args.verbose, false);
-
 	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(-ret));
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	ret = libnvmf_config_read(ctx, config_file, &cfg);
 	if (ret) {
@@ -1546,15 +1496,9 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 		return -EINVAL;
 	}
 
-	log_level = map_log_level(nvme_args.verbose, false);
-
 	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create topology root: %s",
-			libnvme_strerror(-ret));
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	libnvme_skip_namespaces(ctx);
 	ret = libnvme_scan_topology(ctx, NULL, NULL);

--- a/fabrics.c
+++ b/fabrics.c
@@ -782,7 +782,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 
 	nvmf_default_args(&fa);
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -963,7 +963,7 @@ int fabrics_connect(const char *desc, int argc, char **argv)
 
 	nvmf_default_args(&fa);
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -1146,7 +1146,7 @@ int fabrics_disconnect(const char *desc, int argc, char **argv)
 		OPT_STRING("device",     'd', "DEV",  &cfg.device,  device),
 		OPT_FLAG("exclude", 'x', &cfg.exclude, exclude_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -1279,7 +1279,7 @@ int fabrics_disconnect_all(const char *desc, int argc, char **argv)
 		OPT_STRING("owner", 0, "NAME", &cfg.owner, owner_help),
 		OPT_FLAG("force", 0, &cfg.force, force_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -1352,20 +1352,16 @@ int fabrics_config_validate(const char *desc, int argc, char **argv)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	char *config_file = PATH_NVMF_INI;
-	bool verbose = false;
 	int ret;
 
 	OPT_ARGS(opts) = {
 		OPT_STRING("config", 'J', "FILE", &config_file, nvmf_config_file_ro),
-		OPT_FLAG("verbose", 'v', &verbose, "increase output verbosity"),
 		OPT_END()
 	};
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
-
-	nvme_show_init();
 
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)
@@ -1397,11 +1393,9 @@ int fabrics_config_show(const char *desc, int argc, char **argv)
 		OPT_STRING("config", 'J', "FILE", &config_file,
 			   nvmf_config_file_ro));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
-
-	nvme_show_init();
 
 	ret = validate_output_format(nvme_args.output_format, &flags);
 	if (ret < 0) {
@@ -1470,7 +1464,7 @@ int fabrics_dim(const char *desc, int argc, char **argv)
 		OPT_STRING("device", 'd', "DEV",  &cfg.device, "Comma-separated list of DC nvme device handle."),
 		OPT_STRING("task",   't', "TASK", &cfg.tas,    "[register|deregister]"));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2677,7 +2677,7 @@ static unsigned int json_print_nvme_subsystem_multipath(libnvme_subsystem_t s, j
 		path_attrs = json_create_object();
 		obj_add_str(path_attrs, "Name", libnvme_ctrl_get_name(c));
 		obj_add_str(path_attrs, "Transport", libnvme_ctrl_get_transport(c));
-		obj_add_str(path_attrs, "Address", libnvme_ctrl_get_traddr(c));
+		obj_add_str(path_attrs, "Address", libnvme_ctrl_get_address(c));
 		obj_add_ctrl_address_details(path_attrs, "AddressDetails", c);
 		obj_add_str(path_attrs, "State", libnvme_ctrl_get_state(c));
 		obj_add_str(path_attrs, "ANAState", libnvme_path_get_ana_state(p));
@@ -2699,7 +2699,7 @@ static void json_print_nvme_subsystem_ctrls(libnvme_subsystem_t s,
 		path_attrs = json_create_object();
 		obj_add_str(path_attrs, "Name", libnvme_ctrl_get_name(c));
 		obj_add_str(path_attrs, "Transport", libnvme_ctrl_get_transport(c));
-		obj_add_str(path_attrs, "Address", libnvme_ctrl_get_traddr(c));
+		obj_add_str(path_attrs, "Address", libnvme_ctrl_get_address(c));
 		obj_add_ctrl_address_details(path_attrs, "AddressDetails", c);
 		obj_add_str(path_attrs, "State", libnvme_ctrl_get_state(c));
 		array_add_obj(paths, path_attrs);
@@ -4612,7 +4612,7 @@ static void json_print_detail_list_multipath(libnvme_subsystem_t s,
 			obj_add_str(jpath, "ModelNumber", libnvme_ctrl_get_model(c));
 			obj_add_str(jpath, "Firmware", libnvme_ctrl_get_firmware(c));
 			obj_add_str(jpath, "Transport", libnvme_ctrl_get_transport(c));
-			obj_add_str(jpath, "Address", libnvme_ctrl_get_traddr(c));
+			obj_add_str(jpath, "Address", libnvme_ctrl_get_address(c));
 			obj_add_ctrl_address_details(jpath, "AddressDetails", c);
 			obj_add_str(jpath, "Slot", slot ? slot : "");
 
@@ -4642,7 +4642,7 @@ static void json_print_detail_list(libnvme_subsystem_t s, struct json_object *js
 		obj_add_str(jctrl, "ModelNumber", libnvme_ctrl_get_model(c));
 		obj_add_str(jctrl, "Firmware", libnvme_ctrl_get_firmware(c));
 		obj_add_str(jctrl, "Transport", libnvme_ctrl_get_transport(c));
-		obj_add_str(jctrl, "Address", libnvme_ctrl_get_traddr(c));
+		obj_add_str(jctrl, "Address", libnvme_ctrl_get_address(c));
 		obj_add_ctrl_address_details(jctrl, "AddressDetails", c);
 		obj_add_str(jctrl, "Slot", slot ? slot : "");
 
@@ -4749,7 +4749,7 @@ static void json_detail_list(struct libnvme_global_ctx *ctx)
 				obj_add_str(jctrl, "ModelNumber", libnvme_ctrl_get_model(c));
 				obj_add_str(jctrl, "Firmware", libnvme_ctrl_get_firmware(c));
 				obj_add_str(jctrl, "Transport", libnvme_ctrl_get_transport(c));
-				obj_add_str(jctrl, "Address", libnvme_ctrl_get_traddr(c));
+				obj_add_str(jctrl, "Address", libnvme_ctrl_get_address(c));
 				obj_add_ctrl_address_details(jctrl, "AddressDetails", c);
 				obj_add_str(jctrl, "Slot", libnvme_ctrl_get_phy_slot(c));
 
@@ -4926,7 +4926,7 @@ static unsigned int json_subsystem_topology_multipath(libnvme_subsystem_t s,
 			ctrl_attrs = json_create_object();
 			obj_add_str(ctrl_attrs, "Name", libnvme_ctrl_get_name(c));
 			obj_add_str(ctrl_attrs, "Transport", libnvme_ctrl_get_transport(c));
-			obj_add_str(ctrl_attrs, "Address", libnvme_ctrl_get_traddr(c));
+			obj_add_str(ctrl_attrs, "Address", libnvme_ctrl_get_address(c));
 			obj_add_ctrl_address_details(ctrl_attrs, "AddressDetails", c);
 			obj_add_str(ctrl_attrs, "State", libnvme_ctrl_get_state(c));
 			array_add_obj(ctrls, ctrl_attrs);
@@ -4965,7 +4965,7 @@ static void json_print_nvme_subsystem_topology(libnvme_subsystem_t s,
 			obj_add_str(ctrl_attrs, "Transport",
 						     libnvme_ctrl_get_transport(c));
 			obj_add_str(ctrl_attrs, "Address",
-						     libnvme_ctrl_get_traddr(c));
+						     libnvme_ctrl_get_address(c));
 			obj_add_ctrl_address_details(ctrl_attrs, "AddressDetails", c);
 			obj_add_str(ctrl_attrs, "State",
 						     libnvme_ctrl_get_state(c));

--- a/nvme-print-stdout-top.c
+++ b/nvme-print-stdout-top.c
@@ -1474,10 +1474,8 @@ void stdout_top(int refresh_interval)
 	int err;
 
 	err = nvme_create_global_ctx(&ctx);
-	if (err) {
-		nvme_show_error("Failed to create global context");
+	if (err)
 		return;
-	}
 
 	if (libnvme_scan_topology(ctx, NULL, NULL)) {
 		nvme_show_error("Failed to scan topology");

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5875,7 +5875,7 @@ static bool stdout_detailed_ctrl(const char *name, void *arg)
 		       libnvme_ctrl_get_model(c),
 		       libnvme_ctrl_get_firmware(c),
 		       tr,
-		       libnvme_ctrl_get_traddr(c),
+		       libnvme_ctrl_get_address(c),
 		       slot ? slot : "",
 		       libnvme_subsystem_get_name(libnvme_ctrl_get_subsystem(c)));
 	}
@@ -6080,7 +6080,7 @@ static void stdout_tabular_subsystem_topology_multipath(libnvme_subsystem_t s)
 						    iopolicy_info,
 						    libnvme_ctrl_get_name(c),
 						    libnvme_ctrl_get_transport(c),
-						    libnvme_ctrl_get_traddr(c),
+						    libnvme_ctrl_get_address(c),
 						    libnvme_ctrl_get_state(c));
 			if (ret < 0)
 				goto free_tbl;
@@ -6106,7 +6106,7 @@ static void stdout_tabular_subsystem_topology_multipath(libnvme_subsystem_t s)
 					"--", /* Nodes/Qdepth */
 					libnvme_ctrl_get_name(c),
 					libnvme_ctrl_get_transport(c),
-					libnvme_ctrl_get_traddr(c),
+					libnvme_ctrl_get_address(c),
 					libnvme_ctrl_get_state(c));
 			if (ret < 0)
 				goto free_tbl;
@@ -6140,7 +6140,7 @@ static void stdout_subsystem_topology_multipath(libnvme_subsystem_t s,
 				printf("  +- %s %s %s %s %s\n",
 				       libnvme_ctrl_get_name(c),
 				       libnvme_ctrl_get_transport(c),
-				       libnvme_ctrl_get_traddr(c),
+				       libnvme_ctrl_get_address(c),
 				       libnvme_ctrl_get_state(c),
 				       libnvme_path_get_ana_state(p));
 			}
@@ -6151,7 +6151,7 @@ static void stdout_subsystem_topology_multipath(libnvme_subsystem_t s,
 			printf(" +- %s %s %s\n",
 			       libnvme_ctrl_get_name(c),
 			       libnvme_ctrl_get_transport(c),
-			       libnvme_ctrl_get_traddr(c));
+			       libnvme_ctrl_get_address(c));
 			printf(" \\\n");
 
 			libnvme_subsystem_for_each_ns(s, n) {
@@ -6187,7 +6187,7 @@ static void stdout_subsystem_topology_multipath(libnvme_subsystem_t s,
 						libnvme_path_get_numa_nodes(p),
 						libnvme_ctrl_get_name(c),
 						libnvme_ctrl_get_transport(c),
-						libnvme_ctrl_get_traddr(c),
+						libnvme_ctrl_get_address(c),
 						libnvme_ctrl_get_state(c));
 
 				} else if (!strcmp(iopolicy, "queue-depth")) {
@@ -6201,7 +6201,7 @@ static void stdout_subsystem_topology_multipath(libnvme_subsystem_t s,
 						libnvme_path_get_queue_depth(p),
 						libnvme_ctrl_get_name(c),
 						libnvme_ctrl_get_transport(c),
-						libnvme_ctrl_get_traddr(c),
+						libnvme_ctrl_get_address(c),
 						libnvme_ctrl_get_state(c));
 
 				} else { /* round-robin */
@@ -6214,7 +6214,7 @@ static void stdout_subsystem_topology_multipath(libnvme_subsystem_t s,
 						libnvme_path_get_ana_state(p),
 						libnvme_ctrl_get_name(c),
 						libnvme_ctrl_get_transport(c),
-						libnvme_ctrl_get_traddr(c),
+						libnvme_ctrl_get_address(c),
 						libnvme_ctrl_get_state(c));
 				}
 			}
@@ -6282,7 +6282,7 @@ static void stdout_tabular_subsystem_topology(libnvme_subsystem_t s)
 					"--",	/* NSID */
 					libnvme_ctrl_get_name(c),
 					libnvme_ctrl_get_transport(c),
-					libnvme_ctrl_get_traddr(c),
+					libnvme_ctrl_get_address(c),
 					libnvme_ctrl_get_state(c));
 			if (ret < 0)
 				goto free_tbl;
@@ -6298,7 +6298,7 @@ static void stdout_tabular_subsystem_topology(libnvme_subsystem_t s)
 						(const char *)nsid,
 						libnvme_ctrl_get_name(c),
 						libnvme_ctrl_get_transport(c),
-						libnvme_ctrl_get_traddr(c),
+						libnvme_ctrl_get_address(c),
 						libnvme_ctrl_get_state(c));
 				if (ret < 0)
 					goto free_tbl;
@@ -6324,7 +6324,7 @@ static void stdout_subsystem_topology(libnvme_subsystem_t s,
 				printf("  +- %s %s %s %s\n",
 				       libnvme_ctrl_get_name(c),
 				       libnvme_ctrl_get_transport(c),
-				       libnvme_ctrl_get_traddr(c),
+				       libnvme_ctrl_get_address(c),
 				       libnvme_ctrl_get_state(c));
 			}
 		}
@@ -6334,7 +6334,7 @@ static void stdout_subsystem_topology(libnvme_subsystem_t s,
 			printf(" +- %s %s %s\n",
 			       libnvme_ctrl_get_name(c),
 			       libnvme_ctrl_get_transport(c),
-			       libnvme_ctrl_get_traddr(c));
+			       libnvme_ctrl_get_address(c));
 			printf(" \\\n");
 			libnvme_ctrl_for_each_ns(c, n) {
 				printf("  +- ns %d %s\n",
@@ -6355,7 +6355,7 @@ static void stdout_subsystem_topology(libnvme_subsystem_t s,
 				printf("  +- %s %s %s %s\n",
 						libnvme_ctrl_get_name(c),
 						libnvme_ctrl_get_transport(c),
-						libnvme_ctrl_get_traddr(c),
+						libnvme_ctrl_get_address(c),
 						libnvme_ctrl_get_state(c));
 			}
 		}

--- a/nvme.c
+++ b/nvme.c
@@ -364,7 +364,6 @@ static int parse_args(int argc, char *argv[], const char *desc,
 	if (ret)
 		return ret;
 
-	log_level = map_log_level(nvme_args.verbose, false);
 	nvme_show_init();
 
 	return 0;
@@ -443,17 +442,22 @@ static int nvme_apply_option(struct libnvme_global_ctx *ctx, const char *kv)
 	return ret;
 }
 
-int nvme_create_global_ctx(struct libnvme_global_ctx **pctx)
+static int __nvme_create_global_ctx(struct libnvme_global_ctx **pctx)
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free char *buf = NULL;
 	const char *opt;
+	int log_level;
 	char *p;
 	int err;
 
 	ctx = libnvme_create_global_ctx();
 	if (!ctx)
 		return -ENOMEM;
+
+	log_level = map_log_level(nvme_args.verbose, nvme_args.quiet);
+	libnvme_set_logging_file(ctx, stdout);
+	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	if (!nvme_args.set_options)
 		goto out;
@@ -478,6 +482,51 @@ out:
 	return 0;
 }
 
+int nvme_create_global_ctx_hostnqn(struct libnvme_global_ctx **pctx,
+				       const char *hostnqn_arg,
+				       const char *hostid_arg,
+				       char **hostnqn, char **hostid)
+{
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_free char *hnqn = NULL;
+	__cleanup_free char *hid = NULL;
+	int err;
+
+	err = __nvme_create_global_ctx(&ctx);
+	if (err)
+		return err;
+
+	libnvme_set_ioctl_probing(ctx, !nvme_args.no_ioctl_probing);
+
+#ifdef CONFIG_FABRICS
+	err = libnvmf_host_get_ids(ctx, hostnqn_arg, hostid_arg, &hnqn, &hid);
+	if (err)
+		return err;
+
+	libnvme_set_hostnqn(ctx, hnqn);
+	libnvme_set_hostid(ctx, hid);
+#endif
+
+	if (hostnqn) {
+		*hostnqn = hnqn;
+		hnqn = NULL;
+	}
+	if (hostid) {
+		*hostid = hid;
+		hid = NULL;
+	}
+
+	*pctx = ctx;
+	ctx = NULL;
+
+	return 0;
+}
+
+int nvme_create_global_ctx(struct libnvme_global_ctx **pctx)
+{
+	return nvme_create_global_ctx_hostnqn(pctx, NULL, NULL, NULL, NULL);
+}
+
 int parse_and_open(struct libnvme_global_ctx **ctx,
 		   struct libnvme_transport_handle **hdl, int argc, char **argv,
 		   const char *desc, struct argconfig_commandline_options *opts)
@@ -493,11 +542,6 @@ int parse_and_open(struct libnvme_global_ctx **ctx,
 	ret = nvme_create_global_ctx(&ctx_new);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx_new, stdout);
-	libnvme_set_logging_level(ctx_new, log_level, false, false);
-
-	libnvme_set_ioctl_probing(ctx_new,
-		!nvme_args.no_ioctl_probing);
 
 	ret = get_transport_handle(ctx_new, argc, argv, O_RDONLY, &hdl_new);
 	if (ret) {
@@ -530,11 +574,6 @@ int open_exclusive(struct libnvme_global_ctx **ctx,
 	ret = nvme_create_global_ctx(&ctx_new);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx_new, stdout);
-	libnvme_set_logging_level(ctx_new, log_level, false, false);
-
-	libnvme_set_ioctl_probing(ctx_new,
-		!nvme_args.no_ioctl_probing);
 
 	ret = get_transport_handle(ctx_new, argc, argv, flags, &hdl_new);
 	if (ret) {
@@ -3648,8 +3687,6 @@ static int list_subsys(int argc, char **argv, struct command *acmd,
 			nvme_show_error("Failed to scan nvme subsystem");
 		return err;
 	}
-	libnvme_set_logging_file(ctx, stdout);
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	if (devname) {
 		int subsys_num;
@@ -3741,12 +3778,8 @@ static int list(int argc, char **argv, struct command *acmd, struct plugin *plug
 		flags |= VERBOSE;
 
 	err = nvme_create_global_ctx(&ctx);
-	if (err) {
-		nvme_show_error("Failed to create global context");
+	if (err)
 		return err;
-	}
-	libnvme_set_logging_file(ctx, stdout);
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	err = libnvme_scan_topology(ctx, NULL, NULL);
 	if (err < 0)
@@ -6904,15 +6937,12 @@ static int set_property(int argc, char **argv, struct command *acmd, struct plug
 
 static void show_relatives(const char *name, nvme_print_flags_t flags)
 {
-	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int err;
 
 	err = nvme_create_global_ctx(&ctx);
-	if (err) {
-		nvme_show_error("Failed to create global context");
+	if (err)
 		return;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	err = libnvme_scan_topology(ctx, NULL, NULL);
 	if (err < 0) {
@@ -10023,11 +10053,8 @@ static int gen_dhchap_key(int argc, char **argv, struct command *acmd, struct pl
 		return err;
 
 	err = nvme_create_global_ctx(&ctx);
-	if (err) {
-		nvme_show_error("Failed to create global context");
+	if (err)
 		return err;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	if (cfg.hmac > 3) {
 		nvme_show_error("Invalid HMAC identifier %u", cfg.hmac);
@@ -10338,11 +10365,8 @@ static int gen_tls_key(int argc, char **argv, struct command *acmd, struct plugi
 		key_len = 48;
 
 	err = nvme_create_global_ctx(&ctx);
-	if (err) {
-		nvme_show_error("Failed to create global context");
+	if (err)
 		return err;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	err = libnvmf_create_raw_secret(ctx, cfg.secret, key_len, &raw_secret);
 	if (err)
@@ -10782,11 +10806,8 @@ static int show_topology_cmd(int argc, char **argv, struct command *acmd, struct
 	}
 
 	err = nvme_create_global_ctx(&ctx);
-	if (err) {
-		nvme_show_error("Failed to create global context");
+	if (err)
 		return err;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	if (optind < argc)
 		devname = basename(argv[optind++]);

--- a/nvme.c
+++ b/nvme.c
@@ -355,8 +355,8 @@ void put_transport_handle(struct libnvme_transport_handle *hdl)
 	libnvme_close(hdl);
 }
 
-static int parse_args(int argc, char *argv[], const char *desc,
-		      struct argconfig_commandline_options *opts)
+int parse_args(int argc, char *argv[], const char *desc,
+	       struct argconfig_commandline_options *opts)
 {
 	int ret;
 

--- a/nvme.h
+++ b/nvme.h
@@ -181,6 +181,8 @@ int nvme_create_global_ctx_hostnqn(struct libnvme_global_ctx **ctx,
 
 int nvme_create_global_ctx(struct libnvme_global_ctx **ctx);
 
+int parse_args(int argc, char *argv[], const char *desc,
+	       struct argconfig_commandline_options *opts);
 int validate_output_format(const char *format, nvme_print_flags_t *flags);
 bool nvme_is_output_format_json(void);
 int __id_ctrl(int argc, char **argv, struct command *acmd,

--- a/nvme.h
+++ b/nvme.h
@@ -53,6 +53,7 @@ enum nvme_cli_topo_ranking {
 struct nvme_args {
 	char *output_format;
 	int verbose;
+	bool quiet;
 	__u32 timeout;
 	bool dry_run;
 	bool no_retries;
@@ -82,6 +83,8 @@ struct nvme_args {
 		OPT_GROUP("Global options"),                                           \
 		OPT_INCR("verbose",      'v', &nvme_args.verbose,                      \
                          "Increase output verbosity"),                                 \
+		OPT_FLAG("quiet",        0, &nvme_args.quiet,                          \
+                         "suppress output messages, overwrites verbose mode"),         \
 		OPT_FMT("output-format", 'o', &nvme_args.output_format, of_desc),      \
 		OPT_UINT("timeout",        0, &nvme_args.timeout,                      \
                          "timeout value, in milliseconds"),                            \
@@ -161,14 +164,21 @@ extern const char *namespace_id_desired;
 extern struct nvme_args nvme_args;
 
 /*
- * nvme_create_global_ctx() - Create a global context and apply --set-options
+ * nvme_create_global_ctx_hostnqn() - Create context and resolve host identity
+ * @ctx: output global context
+ * @hostnqn_arg: optional hostnqn override
+ * @hostid_arg: optional hostid override
+ * @hostnqn: optional output resolved hostnqn (caller owns/frees when provided)
+ * @hostid: optional output resolved hostid (caller owns/frees when provided)
  *
- * Wrapper around libnvme_create_global_ctx() that additionally applies any
- * key=value pairs passed via --set-options.  All code in nvme-cli that creates
- * a context should call this instead of libnvme_create_global_ctx() directly.
- *
+ * Creates a global context, applies --set-options, resolves hostnqn/hostid
+ * via libnvmf_host_get_ids(), and stores the resolved values in the context.
  * This function has to be called after @parse_args.
  */
+int nvme_create_global_ctx_hostnqn(struct libnvme_global_ctx **ctx,
+		const char *hostnqn_arg, const char *hostid_arg,
+		char **hostnqn, char **hostid);
+
 int nvme_create_global_ctx(struct libnvme_global_ctx **ctx);
 
 int validate_output_format(const char *format, nvme_print_flags_t *flags);

--- a/plugins/exclusion/exclusion-nvme.c
+++ b/plugins/exclusion/exclusion-nvme.c
@@ -55,7 +55,7 @@ static int excl_create(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts,
 		OPT_STRING("name", 'N', "NAME", &cfg.name, name_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -89,7 +89,7 @@ static int excl_delete(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts,
 		OPT_STRING("name", 'N', "NAME", &cfg.name, name_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -133,7 +133,7 @@ static int excl_list(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts,
 		OPT_STRING("name", 'N', "NAME", &cfg.name, name_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -175,7 +175,7 @@ static int excl_add(int argc, char **argv, struct command *acmd,
 		OPT_STRING("name",  'N', "NAME",  &cfg.name,  name_help),
 		OPT_STRING("entry", 'e', "ENTRY", &cfg.entry, entry_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -250,7 +250,7 @@ static int excl_remove(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts,
 		OPT_STRING("name", 'N', "NAME", &cfg.name, name_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -506,7 +506,7 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts,
 		OPT_STRING("name", 'N', "NAME", &cfg.name, name_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -334,8 +334,6 @@ static int huawei_list(int argc, char **argv, struct command *acmd,
 	if (ret)
 		return ret;
 
-	libnvme_set_logging_file(ctx, stdout);
-
 	n = scandir("/dev", &devices, filter_namespace, alphasort);
 	if (n <= 0)
 		return n;

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -322,7 +322,7 @@ static int huawei_list(int argc, char **argv, struct command *acmd,
 
 	NVME_ARGS(opts);
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -675,18 +675,13 @@ int show_nbft(int argc, char **argv, struct command *acmd, struct plugin *plugin
 	if (ret)
 		return ret;
 
-	log_level = map_log_level(nvme_args.verbose, false /* quiet */);
-
 	ret = validate_output_format(nvme_args.output_format, &flags);
 	if (ret < 0)
 		return ret;
 
 	ret = nvme_create_global_ctx(&ctx);
-	if (ret) {
-		nvme_show_error("Failed to create global context");
+	if (ret)
 		return ret;
-	}
-	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	if (!(show_subsys || show_hfi || show_discovery))
 		show_subsys = show_hfi = show_discovery = true;

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -671,7 +671,7 @@ int show_nbft(int argc, char **argv, struct command *acmd, struct plugin *plugin
 		OPT_FLAG("discovery", 'd', &show_discovery, "show NBFT discovery controllers"),
 		OPT_STRING("nbft-path", 0, "STR", &nbft_path, "user-defined path for NBFT tables"));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -923,8 +923,6 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx, stdout);
-
 
 	fmt = netapp_output_format(nvme_args.output_format);
 	if (fmt != NNORMAL && fmt != NCOLUMN && fmt != NJSON) {
@@ -1025,8 +1023,6 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx, stdout);
-
 
 	fmt = netapp_output_format(nvme_args.output_format);
 	if (fmt != NNORMAL && fmt != NCOLUMN && fmt != NJSON) {

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -916,7 +916,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 
 	NVME_ARGS(opts);
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret < 0)
 		return ret;
 
@@ -1016,7 +1016,7 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 
 	NVME_ARGS(opts);
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret < 0)
 		return ret;
 

--- a/plugins/registry/registry-nvme.c
+++ b/plugins/registry/registry-nvme.c
@@ -90,7 +90,7 @@ static int registry_list(int argc, char **argv, struct command *acmd,
 
 	NVME_ARGS(opts);
 
-	if (argconfig_parse(argc, argv, desc, opts))
+	if (parse_args(argc, argv, desc, opts))
 		return -EINVAL;
 
 	ret = nvme_create_global_ctx(&ctx);
@@ -119,7 +119,7 @@ static int registry_retrieve(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts,
 		OPT_STRING("attr", 'a', "ATTR", &cfg.attr, attr_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -172,7 +172,7 @@ static int registry_update(int argc, char **argv, struct command *acmd,
 		OPT_STRING("attr",  'a', "ATTR", &cfg.attr,  attr_help),
 		OPT_STRING("value", 'V', "VAL",  &cfg.value, value_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 
@@ -219,7 +219,7 @@ static int registry_delete(int argc, char **argv, struct command *acmd,
 	NVME_ARGS(opts,
 		OPT_STRING("attr", 'a', "ATTR", &cfg.attr, attr_help));
 
-	ret = argconfig_parse(argc, argv, desc, opts);
+	ret = parse_args(argc, argv, desc, opts);
 	if (ret)
 		return ret;
 

--- a/plugins/registry/registry-nvme.c
+++ b/plugins/registry/registry-nvme.c
@@ -96,7 +96,6 @@ static int registry_list(int argc, char **argv, struct command *acmd,
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx, stdout);
 
 	return libnvmf_registry_device_for_each(ctx, print_device, ctx);
 }
@@ -137,7 +136,6 @@ static int registry_retrieve(int argc, char **argv, struct command *acmd,
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx, stdout);
 
 	ret = libnvmf_registry_retrieve(ctx, device, cfg.attr, &value);
 	if (ret == -ENOENT) {
@@ -196,7 +194,6 @@ static int registry_update(int argc, char **argv, struct command *acmd,
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx, stdout);
 
 	ret = libnvmf_registry_update(ctx, device, cfg.attr, cfg.value);
 	if (ret)
@@ -246,7 +243,6 @@ static int registry_delete(int argc, char **argv, struct command *acmd,
 	ret = nvme_create_global_ctx(&ctx);
 	if (ret)
 		return ret;
-	libnvme_set_logging_file(ctx, stdout);
 
 	if (cfg.attr)
 		ret = libnvmf_registry_update(ctx, device, cfg.attr, NULL);

--- a/plugins/solidigm/solidigm-ocp-version.c
+++ b/plugins/solidigm/solidigm-ocp-version.c
@@ -14,7 +14,7 @@ int sldgm_ocp_version(int argc, char **argv, struct command *acmd, struct plugin
 
 	NVME_ARGS(opts);
 
-	int err = argconfig_parse(argc, argv, desc, opts);
+	int err = parse_args(argc, argv, desc, opts);
 
 	if (!err)
 		printf("1.0\n");

--- a/plugins/solidigm/solidigm-telemetry.c
+++ b/plugins/solidigm/solidigm-telemetry.c
@@ -98,7 +98,7 @@ int solidigm_get_telemetry_log(int argc, char **argv, struct command *acmd, stru
 		OPT_FILE("source-file",     's', &cfg.binary_file, sfile),
 		OPT_STR("jq-filter",        'q', &cfg.jq_filter, jqfilt));
 
-	int err = argconfig_parse(argc, argv, desc, opts);
+	int err = parse_args(argc, argv, desc, opts);
 
 	if (err) {
 		return err;

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -107,11 +107,8 @@ static int list(int argc, char **argv, struct command *acmd,
 	struct table *t = table_init_with_columns(columns, ARRAY_SIZE(columns));
 
 	err = nvme_create_global_ctx(&ctx);
-	if (err) {
-		nvme_show_error("Failed to create root object");
+	if (err)
 		return err;
-	}
-	libnvme_set_logging_file(ctx, stdout);
 
 	err = libnvme_scan_topology(ctx, NULL, NULL);
 	if (err) {


### PR DESCRIPTION
nvme-print: print address instead of traddr

Commit ac6c2b259fb5 ("libnvme: drop duplicate function
nvme_ctrl_get_address()") replaced `address` with `traddr`. However,
`address` contains the complete transport address information, for
example:

  traddr=192.168.30.30,trsvcid=4420,src_addr=192.168.30.209

Printing only `traddr` is a regression. Restore the previous behavior by
printing the full `address` instead.

Fixes: #3622 

