### PR TITLE
WIP: nvme-discoverd: initial daemon implementation

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -282,6 +282,11 @@ adoc_sources_man5 = [
     'nvme-fabrics.conf',
 ]
 
+# Daemon references (man section 8), installed separately from man1/man5.
+adoc_sources_man8 = [
+    'nvme-discoverd',
+]
+
 adoc_includes = [
     'cmd-plugins.txt',
     'cmds-main.txt',
@@ -292,6 +297,7 @@ adoc_includes = [
 if want_docs != 'false'
     mandir = join_paths(prefixdir, get_option('mandir'), 'man1')
     man5dir = join_paths(prefixdir, get_option('mandir'), 'man5')
+    man8dir = join_paths(prefixdir, get_option('mandir'), 'man8')
     htmldir = join_paths(prefixdir, get_option('htmldir'), 'nvme')
 
     asciidoctor = find_program('asciidoc', required: want_docs_build)
@@ -308,6 +314,7 @@ if want_docs != 'false'
                 man_sets = [
                     {'sources': adoc_sources, 'section': '1', 'dir': mandir},
                     {'sources': adoc_sources_man5, 'section': '5', 'dir': man5dir},
+                    {'sources': adoc_sources_man8, 'section': '8', 'dir': man8dir},
                 ]
                 foreach man_set : man_sets
                     section = man_set['section']
@@ -353,7 +360,7 @@ if want_docs != 'false'
 
         # html
         if want_docs == 'all' or want_docs == 'html'
-            foreach adoc : adoc_sources + adoc_sources_man5
+            foreach adoc : adoc_sources + adoc_sources_man5 + adoc_sources_man8
                 input = adoc + '.txt'
                 subst = configure_file(
                     input: adoc + '.txt',
@@ -381,6 +388,7 @@ if want_docs != 'false'
         man_sets = [
             {'sources': adoc_sources, 'section': '1', 'dir': mandir},
             {'sources': adoc_sources_man5, 'section': '5', 'dir': man5dir},
+            {'sources': adoc_sources_man8, 'section': '8', 'dir': man8dir},
         ]
         foreach man_set : man_sets
             section = man_set['section']

--- a/Documentation/nvme-discoverd.txt
+++ b/Documentation/nvme-discoverd.txt
@@ -1,0 +1,132 @@
+nvme-discoverd(8)
+=================
+
+NAME
+----
+nvme-discoverd - NVMe-oF discovery and connectivity daemon
+
+SYNOPSIS
+--------
+[verse]
+'nvme-discoverd' [--config=<FILE>] [--nvme-path=<PATH>] [--debug] [--help]
+
+DESCRIPTION
+-----------
+nvme-discoverd is a persistent daemon that connects the host's desired
+NVMe-oF controllers and keeps them connected. It reads three sources to
+build its set of desired connections: the NBFT ACPI table (boot-time
+controllers), the shared NVMe-oF fabrics configuration
+(nvme-fabrics.conf(5)), and the Discovery Log Pages of any Discovery
+Controllers it connects to (including FC targets found via FC
+kickstart). It never disconnects a live controller in response to a
+discovery change; the only disconnects it causes are a side effect of
+stopping its own systemd units, at shutdown or on request.
+
+Every connection attempt is delegated to 'nvme connect', which runs
+inside a systemd transient unit instead of writing directly to
+/dev/nvme-fabrics. As a result, a stuck connect attempt never blocks
+the daemon's event loop. Each unit is named after a hash of the
+controller's transport identity.
+
+Failed connections retry with exponential backoff. Discovery
+Controllers from NBFT or the fabrics config represent explicit intent,
+so they always retry forever. A Discovery Controller found only
+through a referral or FC kickstart is different: it gives up after 72
+hours of unbroken failure and is dropped from tracking.
+
+Before connecting or reconnecting anything, nvme-discoverd checks the
+system-wide exclusion list. It also registers ownership of every
+controller it connects (--owner discoverd, or --owner nbft for an
+NBFT-sourced controller) in the NVMe-oF ownership registry. See
+nvme-registry-list(1) and nvme-exclusion-add(1).
+
+nvme-discoverd is still experimental. It is meant to replace the
+older udev-rule/systemd-unit autoconnect mechanism (built when the
+'nvmf-autoconnect' meson option is enabled). For now, nvme-discoverd
+can run alongside the legacy udev rules -- the goal is to eventually
+eliminate them completely. Switching a host over is a deliberate
+administrator choice ('systemctl enable --now nvme-discoverd',
+alongside disabling the legacy units), not something either
+mechanism decides automatically.
+
+OPTIONS
+-------
+-c <FILE>::
+--config=<FILE>::
+	Path to the daemon's own configuration file. Default:
+	@SYSCONFDIR@/nvme/discoverd.conf; see CONFIGURATION below. A
+	missing file is not an error -- every knob keeps its default.
+
+--nvme-path=<PATH>::
+	Absolute or relative path to the 'nvme' binary that transient
+	connection units exec. Default: @SBINDIR@/nvme. Mainly useful for
+	running nvme-discoverd against a locally built 'nvme' instead of
+	the installed one.
+
+-d::
+--debug::
+	Enable debug-level logging for both nvme-discoverd and the
+	libnvme calls it makes, overriding the configured debug-level.
+
+-h::
+--help::
+	Print usage and exit.
+
+CONFIGURATION
+-------------
+nvme-discoverd.conf holds only the daemon's own knobs, in a single
+'[Global]' section:
+
+	[Global]
+	nbft = true
+	debug-level = info
+	fc-kickstart-interval-minutes = 0
+
+'nbft' (boolean, default true) controls whether NBFT-listed controllers
+are adopted and reconnected. 'debug-level' (err, warn, info, or debug;
+default info) sets the log threshold; '--debug' on the command line
+overrides it. 'fc-kickstart-interval-minutes' (default 0, disabled)
+re-probes the FC fabric on a timer. This is independent of the
+kickstart nvme-discoverd already issues at startup and on every FC
+controller drop -- use it to detect FC equipment replacement sooner
+than the next connection event.
+
+The connections nvme-discoverd manages come entirely from the shared
+fabrics configuration, not from this file: which Discovery Controllers
+and subsystems to connect, host identity, per-connection parameters.
+See nvme-fabrics.conf(5).
+
+SIGNALS
+-------
+SIGHUP;;
+	Reload both discoverd.conf and the shared fabrics configuration.
+	Newly desired connections are started; nothing already connected
+	is ever disconnected by a reload. If the fabrics configuration
+	fails to reload (e.g. a syntax error), the previous one is kept
+	and the failure is logged.
+
+SIGTERM, SIGINT;;
+	Shut down gracefully.
+
+FILES
+-----
+@SYSCONFDIR@/nvme/discoverd.conf::
+	The daemon's own configuration; see CONFIGURATION.
+
+@SYSCONFDIR@/nvme/nvme-fabrics.conf, @SYSCONFDIR@/nvme/nvme-fabrics.conf.d/*.conf::
+	The connections nvme-discoverd manages; see nvme-fabrics.conf(5).
+
+@RUNDIR@/nvme/discoverd/::
+	Runtime state linking each connected controller to the systemd
+	transient unit that owns it. Does not survive a reboot.
+
+SEE ALSO
+--------
+nvme-fabrics.conf(5)
+nvme-connect(1)
+nvme-registry-list(1)
+nvme-exclusion-add(1)
+
+NVME
+----
+Part of the nvme-user suite

--- a/discoverd/README.md
+++ b/discoverd/README.md
@@ -1,0 +1,46 @@
+# nvme-discoverd
+
+A persistent daemon that connects the host's desired NVMe-oF controllers and keeps them connected. It tracks three sources: NBFT boot controllers, everything listed in the shared fabrics configuration, and whatever those Discovery Controllers' Discovery Log Pages (and FC kickstart) turn up along the way.
+
+> The code is the source of truth. This document summarizes behavior and intent; see `nvme-discoverd(8)` for the full CLI/config reference and `src/*.h` for module-level contracts.
+
+## Why it exists
+
+The host's alternative today is a udev-rule-triggered swarm of systemd units (`70-nvmf-autoconnect.rules`, `nvmf-connect@.service`, and friends — still built when the `nvmf-autoconnect` meson option is enabled). That mechanism has no retry. If a connect attempt fails because the target is momentarily unreachable, nothing reconnects it until the next fabric event fires — and that event may never come. nvme-discoverd is a real daemon with its own retry loop, so a transient failure recovers on its own.
+
+**nvme-discoverd is meant to replace the legacy autoconnect mechanism, not coexist with it long-term.** It is still a technology preview: the `nvme-discoverd` meson option defaults to `disabled`, and must be explicitly enabled to build. The legacy autoconnect units remain enabled by default and continue to ship unchanged. Both are built and installed side by side today only because it takes real-world testing to establish that nvme-discoverd is solid enough to take over — until then, switching a host from one to the other is a deliberate `systemctl` operation for the administrator, not something either mechanism decides for itself. Once nvme-discoverd is proven out, the `nvme-discoverd`/`nvmf-autoconnect` meson option defaults are expected to flip.
+
+## Design
+
+- **Single-threaded.** One `sd_event` loop, no threads. Every connect goes through a systemd transient unit running `nvme connect`, never a direct `/dev/nvme-fabrics` write. That ioctl blocks in D state until the kernel completes or times out the connection, and nvme-discoverd cannot afford to block its event loop waiting for it.
+- **Connect-only.** nvme-discoverd never disconnects a live controller because of a discovery change. That's TP8010 fabric-zoning territory, out of scope here. The only disconnects it causes are its own transient units' `ExecStop=`, at shutdown or on request.
+- **Retry with backoff and a give-up horizon.** A failed (re)connect retries with exponential backoff, capped at 5 minutes. NBFT and fabrics-config controllers represent explicit intent, so they always retry forever. A Discovery Controller found only through a referral or FC kickstart is different: it gives up after 72 hours of unbroken failure and is dropped from tracking.
+- **Cooperative, not exclusive.** Before connecting or reconnecting anything, nvme-discoverd checks the system-wide exclusion list and registers ownership in the ownership registry (`--owner discoverd`, or `--owner nbft` for an NBFT-sourced controller). See `libnvme/design/REGISTRY.md` and `EXCLUSIONS.md`.
+
+## Source layout
+
+| File | Role |
+|---|---|
+| `main.c` | Startup, signal handling, the desired-connection orchestration, retry/give-up |
+| `tid.c` | Transport-identity helpers: unit-name hashing, TID equality |
+| `inventory.c` | The desired-connection set: NBFT, fabrics-config, and per-DC Discovery Log Page tracking |
+| `units.c` | Transient systemd units over D-Bus (`StartTransient`/`Restart`/`Stop`/`ResetFailed`) |
+| `events.c` | udev monitoring: device add/remove/change, sysfs TID parsing |
+| `dlp.c` | Discovery Log Page fetch and parsing |
+| `fc.c` | FC kickstart |
+| `config.c` | The daemon's own three knobs (`discoverd.conf`) — not the connections it manages, see below |
+| `state.c` | Runtime state under `$RUNDIR/nvme/discoverd/`, linking a kernel device to the unit that owns it |
+| `log.c` | Journal logging wrapper |
+
+## Configuration
+
+nvme-discoverd reads two independent files:
+
+- **`discoverd.conf`** — the daemon's own knobs (`nbft`, `debug-level`, `fc-kickstart-interval-minutes`). Entirely optional; a missing file or key just keeps its default.
+- **The shared NVMe-oF fabrics configuration** (`nvme-fabrics.conf(5)`) — which Discovery Controllers and subsystems to connect, host identity, per-connection parameters. This is the same file `nvme connect-all`, `nvme discover`, and `nvme-stas` read. nvme-discoverd has no private connection format of its own.
+
+Both are reloaded on `SIGHUP`. Nothing already connected is ever disconnected by a reload.
+
+## Out of scope (for now)
+
+mDNS/DNS-SD discovery (TP8009), TP8010 fabric zoning, and disconnecting anything nvme-discoverd didn't itself decide to stop. These are nvme-stas's territory today; revisiting them is a future release, not this one.

--- a/discoverd/etc/nvme/discoverd.conf.in
+++ b/discoverd/etc/nvme/discoverd.conf.in
@@ -1,0 +1,25 @@
+# nvme-discoverd configuration
+# @SYSCONFDIR@/nvme/discoverd.conf
+#
+# The daemon's own knobs. The connections it manages come from the shared
+# NVMe-oF fabrics configuration (nvme-fabrics.conf(5)), not from here.
+# This file is entirely optional -- every knob below has the shown default,
+# so a missing file (or a missing key) is not an error.
+#
+# Boolean values: yes/no, true/false, 1/0, on/off (case-insensitive).
+
+[Global]
+
+# Adopt and connect controllers listed in the NBFT ACPI table.
+#nbft = true
+
+# Log verbosity for discoverd and the libnvme calls it makes: err, warn,
+# info, or debug (case-insensitive). A command-line --debug overrides this
+# and forces debug.
+#debug-level = info
+
+# FC kickstart interval in minutes.
+# 0 = kickstart only at startup and on every FC controller drop.
+# N (N >= 1) = additionally re-issue kickstart every N minutes, e.g. to
+# detect FC equipment replacement sooner.
+#fc-kickstart-interval-minutes = 0

--- a/discoverd/meson.build
+++ b/discoverd/meson.build
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+# Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+#
+# Authors: Martin Belanger <martin.belanger@dell.com>
+#
+
+discoverd_sources = files(
+    'src/config.c',
+    'src/dlp.c',
+    'src/events.c',
+    'src/fc.c',
+    'src/inventory.c',
+    'src/log.c',
+    'src/main.c',
+    'src/state.c',
+    'src/tid.c',
+    'src/units.c',
+)
+
+discoverd_inc = include_directories('src')
+
+# Absolute path to the nvme binary that the transient units exec (units.c).
+nvme_bin_path = sbindir / 'nvme'
+
+executable(
+    'nvme-discoverd',
+    discoverd_sources,
+    include_directories: discoverd_inc,
+    c_args: [
+        '-DNVME_PATH="@0@"'.format(nvme_bin_path),
+    ],
+    dependencies: [
+        ccan_dep,
+        libnvme_dep,
+        libsystemd_dep,
+        shared_dep,
+    ],
+    install: true,
+    install_dir: sbindir,
+)
+
+configure_file(
+    input: 'systemd/nvme-discoverd.service.in',
+    output: 'nvme-discoverd.service',
+    configuration: substs,
+    install: true,
+    install_dir: systemddir,
+)
+
+# Unlike nvme-fabrics.conf (re-read on every connect/connect-all/discover,
+# and holding host-specific connections an admin customizes), discoverd.conf
+# is read once at daemon startup and holds only generic daemon knobs, so it
+# installs directly as the live file rather than a .sample a user must copy.
+configure_file(
+    input: 'etc/nvme/discoverd.conf.in',
+    output: 'discoverd.conf',
+    configuration: substs,
+    install: true,
+    install_dir: sysconfdir / 'nvme',
+)

--- a/discoverd/src/config.c
+++ b/discoverd/src/config.c
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include <ccan/array_size/array_size.h>
+#include <ccan/str/str.h>
+#include <parse-util.h>
+#include <string-util.h>
+
+#include "config.h"
+#include "log.h"
+
+static void config_set_defaults(struct discoverd_config *cfg)
+{
+	cfg->nbft = true;
+	cfg->debug_level = DISC_LOG_INFO;
+	cfg->fc_kickstart_interval_minutes = 0;
+}
+
+static int parse_debug_level(const char *val, int *out)
+{
+	static const char * const names[] = {
+		[DISC_LOG_ERR]   = "err",
+		[DISC_LOG_WARN]  = "warn",
+		[DISC_LOG_INFO]  = "info",
+		[DISC_LOG_DEBUG] = "debug",
+	};
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(names); i++) {
+		if (!strcasecmp(val, names[i])) {
+			*out = (int)i;
+			return 0;
+		}
+	}
+	return -EINVAL;
+}
+
+static int parse_uint(const char *val, unsigned int *out)
+{
+	char *end;
+	unsigned long v;
+
+	if (val[0] == '-')
+		return -EINVAL;
+
+	v = strtoul(val, &end, 10);
+	if (end == val || *end != '\0' || v > UINT_MAX)
+		return -EINVAL;
+	*out = (unsigned int)v;
+	return 0;
+}
+
+/* Apply one "key = value" line from [Global]; @lineno is for diagnostics. */
+static void apply_global_key(struct discoverd_config *cfg, const char *key,
+			     const char *val, const char *conf_path, int lineno)
+{
+	int r = 0;
+
+	if (streq(key, "nbft"))
+		r = shr_parse_bool(val, &cfg->nbft);
+	else if (streq(key, "debug-level"))
+		r = parse_debug_level(val, &cfg->debug_level);
+	else if (streq(key, "fc-kickstart-interval-minutes"))
+		r = parse_uint(val, &cfg->fc_kickstart_interval_minutes);
+	else
+		disc_warn("%s:%d: unknown key '%s', ignored", conf_path,
+			  lineno, key);
+
+	if (r < 0)
+		disc_warn("%s:%d: invalid value for '%s', ignored", conf_path,
+			  lineno, key);
+}
+
+struct discoverd_config *config_load(const char *conf_path)
+{
+	struct discoverd_config *cfg;
+	FILE *f;
+	char line[256];
+	char section[64] = "";
+	int lineno = 0;
+
+	cfg = calloc(1, sizeof(*cfg));
+	if (!cfg)
+		return NULL;
+	config_set_defaults(cfg);
+
+	if (!conf_path)
+		conf_path = DISCOVERD_CONF_PATH;
+
+	f = fopen(conf_path, "r");
+	if (!f) {
+		/* A missing config file is not an error — defaults apply. */
+		if (errno != ENOENT)
+			disc_warn("%s: %s, using defaults", conf_path,
+				 strerror(errno));
+		return cfg;
+	}
+
+	while (fgets(line, sizeof(line), f)) {
+		char *s = shr_trim(line);
+		char *eq, *key, *val;
+		size_t len;
+
+		lineno++;
+		if (*s == '\0' || *s == '#' || *s == ';')
+			continue;
+
+		len = strlen(s);
+		if (s[0] == '[' && s[len - 1] == ']') {
+			s[len - 1] = '\0';
+			snprintf(section, sizeof(section), "%s",
+				shr_trim(s + 1));
+			continue;
+		}
+
+		eq = strchr(s, '=');
+		if (!eq) {
+			disc_warn("%s:%d: malformed line, ignored", conf_path,
+				  lineno);
+			continue;
+		}
+		*eq = '\0';
+		key = shr_trim(s);
+		val = shr_trim(eq + 1);
+		if (*key == '\0' || *val == '\0') {
+			disc_warn("%s:%d: malformed line, ignored", conf_path,
+				  lineno);
+			continue;
+		}
+
+		if (streq(section, "Global"))
+			apply_global_key(cfg, key, val, conf_path, lineno);
+		else
+			disc_warn("%s:%d: key outside [Global], ignored",
+				  conf_path, lineno);
+	}
+
+	fclose(f);
+	return cfg;
+}
+
+void config_free(struct discoverd_config *cfg)
+{
+	free(cfg);
+}

--- a/discoverd/src/config.h
+++ b/discoverd/src/config.h
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+
+/*
+ * discoverd.conf carries the daemon's own knobs only — the connections it
+ * manages come from the shared fabrics config (libnvmf_config_read()), not
+ * from here. Just a single [Global] section:
+ *
+ *   [Global]
+ *   nbft = true
+ *   debug-level = info
+ *   fc-kickstart-interval-minutes = 0
+ */
+struct discoverd_config {
+	bool nbft; // adopt/connect NBFT-listed controllers; default true
+
+	/*
+	 * Log threshold for discoverd and its in-process libnvme context, as
+	 * a DISC_LOG_* value (see log.h); default DISC_LOG_INFO. A
+	 * command-line --debug overrides this.
+	 */
+	int debug_level;
+
+	/*
+	 * FC kickstart interval in minutes. 0 = disabled (default), i.e.
+	 * kickstart only runs at startup and on FC controller drop; N >= 1 =
+	 * additionally re-issue every N minutes.
+	 */
+	unsigned int fc_kickstart_interval_minutes;
+};
+
+/*
+ * Load discoverd's own configuration. @conf_path is discoverd.conf's path
+ * (DISCOVERD_CONF_PATH if NULL). A missing file is not an error — every
+ * knob keeps its default; a malformed line is logged and skipped.
+ * Returns a newly allocated config (never NULL except on allocation
+ * failure). Caller frees with config_free().
+ */
+struct discoverd_config *config_load(const char *conf_path);
+
+void config_free(struct discoverd_config *cfg);
+
+/*
+ * Default discoverd.conf location, using the build-provided SYSCONFDIR
+ * prefix. The --config command line option overrides it.
+ */
+#define DISCOVERD_CONF_PATH SYSCONFDIR "/nvme/discoverd.conf"

--- a/discoverd/src/ctx.h
+++ b/discoverd/src/ctx.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+
+#include <systemd/sd-bus.h>
+#include <systemd/sd-event.h>
+
+/* Forward declarations — full headers included by each .c file as needed. */
+struct libnvme_global_ctx;
+struct libnvmf_config;
+struct discoverd_config;
+struct inventory;
+struct unit_mgr;
+struct events_ctx;
+
+/*
+ * Top-level discoverd application context. Created once at startup and
+ * freed at shutdown. Every subsystem receives a pointer to this struct
+ * rather than individual parameters, so adding new resources never
+ * requires changing function signatures across the codebase.
+ */
+struct discoverd_ctx {
+	struct libnvme_global_ctx *nvme_ctx;     // libnvme logging/scanning
+	const char                *conf_path;    // discoverd.conf path in use
+	struct discoverd_config   *cfg;          // parsed discoverd.conf
+	struct libnvmf_config     *fabrics_cfg;  // resolved fabrics config
+	struct inventory          *inventory;    // NBFT + config + DLP cache
+	sd_event                  *event;        // sd_event main loop
+	sd_bus                    *bus;          // D-Bus connection to systemd
+	struct unit_mgr           *umgr;         // transient unit manager
+	struct events_ctx         *evts;         // udev event monitor
+	bool                       force_debug;  // --debug forces DEBUG
+};

--- a/discoverd/src/dlp.c
+++ b/discoverd/src/dlp.c
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <endian.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <nvme/fabrics.h>
+#include <nvme/lib.h>
+#include <nvme/nvme-types-fabrics.h>
+#include <nvme/tree.h>
+
+#include "dlp.h"
+#include "log.h"
+#include "tid.h"
+
+/*
+ * Build a TID for one DLPE. Host-side parameters (host_traddr, host_iface,
+ * hostnqn) are inherited from the DC's TID since the IOC is reached via the
+ * same physical interface as the DC.
+ */
+static struct libnvmf_tid *tid_from_dlpe(const struct nvmf_disc_log_entry *e,
+					 const struct libnvmf_tid *dc_tid)
+{
+	const char *transport;
+
+	transport = libnvmf_trtype_str(e->trtype);
+	if (!transport)
+		return NULL;
+
+	return tid_new(transport,
+		       e->traddr,
+		       e->trsvcid[0] ? e->trsvcid : NULL,
+		       e->subnqn,
+		       dc_tid ? libnvmf_tid_get_host_traddr(dc_tid) : NULL,
+		       dc_tid ? libnvmf_tid_get_host_iface(dc_tid) : NULL,
+		       dc_tid ? libnvmf_tid_get_hostnqn(dc_tid) : NULL,
+		       e->subtype == NVME_NQN_DISC);
+}
+
+int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
+	      const struct libnvmf_tid *dc_tid,
+	      void (*ioc_callback)(const struct libnvmf_tid *t,
+				   void *user_data),
+	      void (*dc_callback)(const struct libnvmf_tid *t,
+				 void *user_data),
+	      void *user_data)
+{
+	libnvme_ctrl_t ctrl = NULL;
+	struct nvmf_discovery_log *log = NULL;
+	uint64_t numrec;
+	uint64_t i;
+	int ret;
+
+	ret = libnvme_scan_ctrl(ctx->nvme_ctx, devname, &ctrl);
+	if (ret < 0) {
+		disc_warn("%s | %s - scan_ctrl failed: %s",
+			  libnvmf_tid_str(dc_tid), devname, strerror(-ret));
+		goto out;
+	}
+
+	ret = libnvmf_get_discovery_log(ctrl, NULL, &log);
+	if (ret < 0) {
+		disc_warn("%s | %s - get_discovery_log failed: %s",
+			  libnvmf_tid_str(dc_tid), devname, strerror(-ret));
+		goto out;
+	}
+
+	numrec = le64toh((__u64)log->numrec);
+
+	for (i = 0; i < numrec; i++) {
+		const struct nvmf_disc_log_entry *e = &log->entries[i];
+		uint16_t eflags = le16toh((__u16)e->eflags);
+		struct libnvmf_tid *t;
+
+		if (eflags & NVMF_DISC_EFLAGS_DUPRETINFO)
+			continue;
+
+		t = tid_from_dlpe(e, dc_tid);
+		if (!t)
+			continue;
+
+		switch (e->subtype) {
+		case NVME_NQN_NVME:
+			if (ioc_callback)
+				ioc_callback(t, user_data);
+			break;
+		case NVME_NQN_DISC:
+			if (dc_callback)
+				dc_callback(t, user_data);
+			break;
+		default:
+			break;
+		}
+
+		tid_free(t);
+	}
+
+	ret = 0;
+out:
+	free(log);
+	libnvme_free_ctrl(ctrl); // detach from the global-ctx tree; NULL-safe
+	return ret;
+}

--- a/discoverd/src/dlp.h
+++ b/discoverd/src/dlp.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include "ctx.h"
+#include "tid.h"
+
+/*
+ * Fetch the Discovery Log Page from a connected DC and parse all entries.
+ *
+ * For each DLPE:
+ *   subtype == NVME_NQN_NVME (I/O controller): ioc_callback is called.
+ *   subtype == NVME_NQN_DISC (referral DC):    dc_callback is called.
+ *   DUPRETINFO flag set: entry is skipped.
+ *
+ * devname: kernel device name, e.g. "nvme0".
+ * dc_tid: TID of the DC (used as the cache key in the caller).
+ *
+ * Returns 0 on success, negative errno on failure.
+ */
+int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
+	      const struct libnvmf_tid *dc_tid,
+	      void (*ioc_callback)(const struct libnvmf_tid *t,
+				   void *user_data),
+	      void (*dc_callback)(const struct libnvmf_tid *t,
+				 void *user_data),
+	      void *user_data);

--- a/discoverd/src/events.c
+++ b/discoverd/src/events.c
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <systemd/sd-device.h>
+#include <systemd/sd-event.h>
+
+#include "events.h"
+#include "log.h"
+#include "tid.h"
+
+/* Sysfs soak delay: kernel sysfs attributes settle ~1 s after the add uevent. */
+#define SOAK_DELAY_USEC (UINT64_C(1000000))
+
+/* NVMe AEN for "Discovery Log Page Changed" (NVMe Base Spec §5.2.4.2). */
+#define NVME_AEN_DLP_CHANGED "0x70f002"
+
+struct soak_entry {
+	struct soak_entry *next;
+	char *syspath;
+	char *devname;
+	sd_event_source *timer;
+	struct events_ctx *ctx;
+};
+
+struct events_ctx {
+	sd_event *event;
+	struct events_callbacks callbacks;
+	void *user_data;
+	sd_device_monitor *nvme_monitor;
+	sd_device_monitor *fc_monitor;
+	struct soak_entry *soaking;
+};
+
+/*
+ * Extract a named field from a comma-separated "key=value,..." string such
+ * as the address sysattr: "traddr=192.0.2.1,trsvcid=4420,src_addr=10.0.0.1".
+ * Returns an allocated string on success, NULL if not found.
+ */
+static char *extract_addr_field(const char *address, const char *key)
+{
+	char search[64];
+	const char *p, *end;
+	size_t len;
+
+	if (!address || !key)
+		return NULL;
+
+	snprintf(search, sizeof(search), "%s=", key);
+	p = strstr(address, search);
+	if (!p)
+		return NULL;
+
+	p += strlen(search);
+	end = strchr(p, ',');
+	len = end ? (size_t)(end - p) : strlen(p);
+	if (!len)
+		return NULL;
+
+	return strndup(p, len);
+}
+
+/*
+ * Build a TID from sysfs attributes of an nvme device.
+ * Returns NULL on error (e.g. required attributes missing).
+ */
+struct libnvmf_tid *tid_from_sysfs(sd_device *dev, bool *is_dc)
+{
+	const char *transport = NULL, *address = NULL;
+	const char *subsysnqn = NULL, *hostnqn = NULL;
+	const char *host_iface = NULL, *cntrltype = NULL;
+	char *traddr = NULL, *trsvcid = NULL, *host_traddr = NULL;
+	struct libnvmf_tid *t = NULL;
+
+	if (is_dc)
+		*is_dc = false;
+
+	sd_device_get_sysattr_value(dev, "transport", &transport);
+	sd_device_get_sysattr_value(dev, "address", &address);
+	sd_device_get_sysattr_value(dev, "subsysnqn", &subsysnqn);
+	sd_device_get_sysattr_value(dev, "hostnqn", &hostnqn);
+	sd_device_get_sysattr_value(dev, "host_iface", &host_iface);
+	sd_device_get_sysattr_value(dev, "cntrltype", &cntrltype);
+
+	if (!transport || !address || !subsysnqn)
+		return NULL;
+
+	traddr = extract_addr_field(address, "traddr");
+	trsvcid = extract_addr_field(address, "trsvcid");
+
+	// host_traddr may appear as "src_addr" in some kernel versions; try both
+	host_traddr = extract_addr_field(address, "host_traddr");
+	if (!host_traddr)
+		host_traddr = extract_addr_field(address, "src_addr");
+
+	if (traddr) {
+		bool dc = shr_streq0(cntrltype, "discovery");
+
+		t = tid_new(transport, traddr, trsvcid, subsysnqn,
+			    host_traddr, host_iface, hostnqn, dc);
+		if (is_dc)
+			*is_dc = dc;
+	}
+
+	free(traddr);
+	free(trsvcid);
+	free(host_traddr);
+	return t;
+}
+
+static void soak_entry_free(struct soak_entry *e)
+{
+	if (!e)
+		return;
+	sd_event_source_unref(e->timer);
+	free(e->syspath);
+	free(e->devname);
+	free(e);
+}
+
+static void soak_unlink(struct events_ctx *ctx, struct soak_entry *entry)
+{
+	struct soak_entry **ep;
+
+	for (ep = &ctx->soaking; *ep; ep = &(*ep)->next) {
+		if (*ep == entry) {
+			*ep = entry->next;
+			return;
+		}
+	}
+}
+
+static int soak_timeout(sd_event_source *src __attribute__((unused)),
+			  uint64_t usec __attribute__((unused)),
+			  void *user_data)
+{
+	struct soak_entry *e = user_data;
+	struct events_ctx *ctx = e->ctx;
+	sd_device *dev = NULL;
+	const char *cntrltype = NULL;
+	struct libnvmf_tid *t;
+
+	if (sd_device_new_from_syspath(&dev, e->syspath) < 0) {
+		// Device disappeared during soak — treat as removal.
+		if (ctx->callbacks.nvme_remove)
+			ctx->callbacks.nvme_remove(e->devname, ctx->user_data);
+		goto out;
+	}
+
+	sd_device_get_sysattr_value(dev, "cntrltype", &cntrltype);
+
+	if (shr_streq0(cntrltype, "discovery")) {
+		t = tid_from_sysfs(dev, NULL);
+		if (t) {
+			if (ctx->callbacks.dc_add)
+				ctx->callbacks.dc_add(e->devname, t,
+						   ctx->user_data);
+			tid_free(t);
+		}
+	} else if (shr_streq0(cntrltype, "io")) {
+		if (ctx->callbacks.ioc_add)
+			ctx->callbacks.ioc_add(e->devname, ctx->user_data);
+	}
+
+	sd_device_unref(dev);
+out:
+	soak_unlink(ctx, e);
+	soak_entry_free(e);
+	return 0;
+}
+
+static int schedule_soak(struct events_ctx *ctx, sd_device *dev,
+			  const char *devname)
+{
+	struct soak_entry *e;
+	const char *syspath = NULL;
+	uint64_t now;
+	int r;
+
+	sd_device_get_syspath(dev, &syspath);
+	if (!syspath)
+		return -EINVAL;
+
+	e = calloc(1, sizeof(*e));
+	if (!e)
+		return -ENOMEM;
+
+	e->syspath = strdup(syspath);
+	e->devname = strdup(devname);
+	e->ctx = ctx;
+	if (!e->syspath || !e->devname) {
+		soak_entry_free(e);
+		return -ENOMEM;
+	}
+
+	r = sd_event_now(ctx->event, CLOCK_BOOTTIME, &now);
+	if (r < 0) {
+		soak_entry_free(e);
+		return r;
+	}
+
+	r = sd_event_add_time(ctx->event, &e->timer, CLOCK_BOOTTIME,
+			      now + SOAK_DELAY_USEC, 0,
+			      soak_timeout, e);
+	if (r < 0) {
+		soak_entry_free(e);
+		return r;
+	}
+
+	e->next = ctx->soaking;
+	ctx->soaking = e;
+	return 0;
+}
+
+static int nvme_monitor_handler(sd_device_monitor *monitor __attribute__((unused)),
+				sd_device *dev, void *user_data)
+{
+	struct events_ctx *ctx = user_data;
+	sd_device_action_t action;
+	const char *devname = NULL, *cntrltype = NULL;
+	const char *nvme_event = NULL, *nvme_aen = NULL;
+
+	if (sd_device_get_action(dev, &action) < 0)
+		return 0;
+	if (sd_device_get_sysname(dev, &devname) < 0)
+		return 0;
+
+	switch (action) {
+	case SD_DEVICE_ADD:
+		// Schedule a soak timer; the soak callback reads cntrltype
+		// and calls the appropriate add handler.
+		schedule_soak(ctx, dev, devname);
+		break;
+
+	case SD_DEVICE_REMOVE:
+		if (ctx->callbacks.nvme_remove)
+			ctx->callbacks.nvme_remove(devname, ctx->user_data);
+		break;
+
+	case SD_DEVICE_CHANGE:
+		/*
+		 * Two relevant CHANGE events:
+		 *   NVME_AEN=="0x70f002"      — DLP changed AEN
+		 *   NVME_EVENT=="rediscover"  — ctrl reconnected after loss
+		 * Both are handled the same way: re-fetch the DLP.
+		 */
+		sd_device_get_property_value(dev, "NVME_AEN", &nvme_aen);
+		sd_device_get_property_value(dev, "NVME_EVENT", &nvme_event);
+		sd_device_get_sysattr_value(dev, "cntrltype", &cntrltype);
+
+		if (shr_streq0(nvme_aen, NVME_AEN_DLP_CHANGED) ||
+		    (shr_streq0(nvme_event, "rediscover") &&
+		     shr_streq0(cntrltype, "discovery"))) {
+			if (ctx->callbacks.dc_changed)
+				ctx->callbacks.dc_changed(devname,
+							  ctx->user_data);
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+static int fc_monitor_handler(sd_device_monitor *monitor __attribute__((unused)),
+			       sd_device *dev, void *user_data)
+{
+	struct events_ctx *ctx = user_data;
+	const char *fc_event = NULL;
+	const char *traddr = NULL, *host_traddr = NULL;
+	struct libnvmf_tid *t;
+
+	sd_device_get_property_value(dev, "FC_EVENT", &fc_event);
+	if (!shr_streq0(fc_event, "nvmediscovery"))
+		return 0;
+
+	/*
+	 * Properties set by the kernel FC nvme-discovery uevent
+	 * (nvme_fc_signal_discovery_scan(), drivers/nvme/host/fc.c).
+	 * Note the "NVMEFC_" prefix, not "NVME_" - and the kernel never
+	 * sends TRSVCID or NQN for this event: FC has no port concept,
+	 * and the target is identified by address only, not by NQN.
+	 */
+	sd_device_get_property_value(dev, "NVMEFC_TRADDR", &traddr);
+	sd_device_get_property_value(dev, "NVMEFC_HOST_TRADDR", &host_traddr);
+
+	if (!traddr)
+		return 0;
+
+	/*
+	 * The kernel only fires this uevent for a remote port that
+	 * advertised FC_PORT_ROLE_NVME_DISCOVERY, so every instance of
+	 * this event is, by the kernel's own gating, a DC - there is no
+	 * NQN to check, and no well-known port to default either way.
+	 */
+	t = tid_new("fc", traddr, NULL,
+		    "nqn.2014-08.org.nvmexpress.discovery",
+		    host_traddr, NULL, NULL, true);
+	if (!t)
+		return 0;
+
+	if (ctx->callbacks.fc_discovery)
+		ctx->callbacks.fc_discovery(t, ctx->user_data);
+
+	tid_free(t);
+	return 0;
+}
+
+struct events_ctx *events_start(sd_event *event,
+				const struct events_callbacks *callbacks,
+				void *user_data)
+{
+	struct events_ctx *ctx;
+	int r;
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx)
+		return NULL;
+
+	ctx->event = event;
+	ctx->callbacks = *callbacks;
+	ctx->user_data = user_data;
+
+	// nvme subsystem monitor
+	r = sd_device_monitor_new(&ctx->nvme_monitor);
+	if (r < 0)
+		goto err;
+	r = sd_device_monitor_filter_add_match_subsystem_devtype(
+		ctx->nvme_monitor, "nvme", NULL);
+	if (r < 0)
+		goto err;
+	r = sd_device_monitor_attach_event(ctx->nvme_monitor, event);
+	if (r < 0)
+		goto err;
+	r = sd_device_monitor_start(ctx->nvme_monitor,
+				    nvme_monitor_handler, ctx);
+	if (r < 0)
+		goto err;
+
+	// FC subsystem monitor
+	r = sd_device_monitor_new(&ctx->fc_monitor);
+	if (r < 0)
+		goto err;
+	r = sd_device_monitor_filter_add_match_subsystem_devtype(
+		ctx->fc_monitor, "fc", NULL);
+	if (r < 0)
+		goto err;
+	r = sd_device_monitor_attach_event(ctx->fc_monitor, event);
+	if (r < 0)
+		goto err;
+	r = sd_device_monitor_start(ctx->fc_monitor,
+				    fc_monitor_handler, ctx);
+	if (r < 0)
+		goto err;
+
+	return ctx;
+err:
+	disc_err("%s: %s", __func__, strerror(-r));
+	events_stop(ctx);
+	return NULL;
+}
+
+void events_stop(struct events_ctx *ctx)
+{
+	struct soak_entry *e, *next;
+
+	if (!ctx)
+		return;
+
+	for (e = ctx->soaking; e; e = next) {
+		next = e->next;
+		soak_entry_free(e);
+	}
+
+	sd_device_monitor_unref(ctx->nvme_monitor);
+	sd_device_monitor_unref(ctx->fc_monitor);
+	free(ctx);
+}

--- a/discoverd/src/events.h
+++ b/discoverd/src/events.h
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <systemd/sd-device.h>
+#include <systemd/sd-event.h>
+
+#include "tid.h"
+
+/*
+ * Callbacks from the events layer to the main orchestrator.
+ * All callbacks are called from the event loop thread.
+ */
+struct events_callbacks {
+	/*
+	 * nvmeX device appeared with cntrltype=="discovery".
+	 * Called after the ~1 s sysfs soak. t contains the TID read from
+	 * sysfs; caller must not free t (it is freed by the events layer
+	 * after the callback returns).
+	 */
+	void (*dc_add)(const char *devname, const struct libnvmf_tid *t,
+		       void *user_data);
+
+	/*
+	 * DC sent NVME_AEN=="0x70f002" (DLP changed) or was rediscovered
+	 * after a ctrl-loss (NVME_EVENT=="rediscover"). Caller should
+	 * re-fetch the DLP for the named device.
+	 */
+	void (*dc_changed)(const char *devname, void *user_data);
+
+	/*
+	 * nvmeX device appeared with cntrltype=="io".
+	 * The state directory is already created by ExecStartPost= inside
+	 * the transient unit; this callback just confirms the connection.
+	 */
+	void (*ioc_add)(const char *devname, void *user_data);
+
+	/*
+	 * nvmeX device was removed by the kernel.
+	 * Caller is responsible for state cleanup and reconnect decisions.
+	 */
+	void (*nvme_remove)(const char *devname, void *user_data);
+
+	/*
+	 * FC kickstart produced a discovery event (FC_EVENT=="nvmediscovery").
+	 * t contains the TID built from the uevent properties; caller must
+	 * not free t.
+	 */
+	void (*fc_discovery)(const struct libnvmf_tid *t, void *user_data);
+};
+
+struct events_ctx;
+
+/*
+ * Start monitoring udev events. The bus must already be attached to the
+ * event loop by the caller. Returns an opaque context on success; the
+ * caller must call events_stop() when done.
+ */
+struct events_ctx *events_start(sd_event *event,
+				const struct events_callbacks *callbacks,
+				void *user_data);
+
+void events_stop(struct events_ctx *ctx);
+
+/*
+ * Build a TID from an nvme controller's sysfs attributes (transport,
+ * address, subsysnqn, ...). If @is_dc is non-NULL, *is_dc is set true when
+ * the controller's cntrltype is "discovery". Returns an allocated TID, or
+ * NULL if the mandatory attributes are missing. Shared by the event
+ * monitor and the startup audit.
+ */
+struct libnvmf_tid *tid_from_sysfs(sd_device *dev, bool *is_dc);

--- a/discoverd/src/fc.c
+++ b/discoverd/src/fc.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "fc.h"
+#include "log.h"
+
+#define FC_NVME_DISCOVERY_PATH \
+	"/sys/class/fc/fc_udev_device/nvme_discovery"
+
+int fc_kickstart(void)
+{
+	int fd, ret;
+
+	fd = open(FC_NVME_DISCOVERY_PATH, O_WRONLY | O_CLOEXEC);
+	if (fd < 0) {
+		if (errno == ENOENT)
+			return 0; // no FC HBA present — not an error
+		disc_err("%s: open(%s): %s", __func__,
+			 FC_NVME_DISCOVERY_PATH, strerror(errno));
+		return -errno;
+	}
+
+	ret = write(fd, "add", 3);
+	if (ret < 0) {
+		disc_err("%s: write: %s", __func__, strerror(errno));
+		close(fd);
+		return -errno;
+	}
+
+	close(fd);
+	return 0;
+}

--- a/discoverd/src/fc.h
+++ b/discoverd/src/fc.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+/*
+ * Trigger FC-NVMe discovery by writing "add" to the FC HBA's nvme_discovery
+ * sysfs node. The HBA firmware probes all reachable targets and fires
+ * FC_EVENT=="nvmediscovery" uevents; events.c delivers these to the
+ * fc_discovery callback.
+ *
+ * Idempotent: writing "add" while a probe is already in progress is
+ * harmless.
+ *
+ * Returns 0 on success, negative errno if the sysfs node cannot be written.
+ */
+int fc_kickstart(void);

--- a/discoverd/src/inventory.c
+++ b/discoverd/src/inventory.c
@@ -1,0 +1,607 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef NVME_HAVE_NETDB
+#include <netdb.h>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#endif
+
+#include <ccan/list/list.h>
+
+#include <array-util.h>
+#include <nvme/fabrics.h>
+#include <nvme/lib.h>
+#include <nvme/nbft.h>
+
+#include "inventory.h"
+#include "log.h"
+
+/* Simple growable TID array, backed by struct shr_ptrarray. */
+SHR_PTRARRAY_DEFINE(tid_list, struct libnvmf_tid);
+
+/* Per-DC DLP cache entry. */
+struct dlp_entry {
+	struct list_node entry;
+	struct libnvmf_tid *dc_tid; // key
+	struct tid_list iocs;       // value: IOC TIDs from last DLP fetch
+};
+
+/*
+ * Pairs a statically-configured TID with the libnvmf_config_conn it came
+ * from, so connect-time code can fetch that connection's own resolved
+ * params instead of falling back to libnvmf_config_resolve_discovered().
+ * conn is borrowed — valid only while the fabrics_cfg passed to
+ * inventory_load_config() stays alive.
+ */
+struct cfg_conn_entry {
+	struct list_node entry;
+	struct libnvmf_tid *tid;
+	const struct libnvmf_config_conn *conn;
+};
+
+struct inventory {
+	struct tid_list nbft_dcs;
+	struct tid_list nbft_iocs;
+	struct tid_list cfg_dcs;
+	struct tid_list cfg_iocs;
+	struct list_head dlp_cache;
+	struct list_head cfg_conns;
+};
+
+/* Free every TID in l, then the backing array, leaving l empty. */
+static void tlist_free_items(struct tid_list *l)
+{
+	size_t i;
+
+	for (i = 0; i < l->len; i++)
+		tid_free(l->items[i]);
+	tid_list_free(l);
+}
+
+/*
+ * The four flat TID sets (nbft_dcs/nbft_iocs/cfg_dcs/cfg_iocs) have no key —
+ * membership is a linear scan (tlist_contains()). dlp_cache is a map keyed
+ * by DC TID, each entry holding that DC's last-fetched IOC set; lookups
+ * (inventory_update_dlp(), inventory_remove_dlp(), inventory_is_desired())
+ * walk it with tid_same(), not a hash or tree — fine given how few DCs are
+ * tracked at once.
+ */
+struct inventory *inventory_new(void)
+{
+	struct inventory *inv = calloc(1, sizeof(*inv));
+
+	if (!inv)
+		return NULL;
+	list_head_init(&inv->dlp_cache);
+	list_head_init(&inv->cfg_conns);
+	return inv;
+}
+
+/*
+ * Free an inventory and everything in it: the four flat TID sets and
+ * every per-DC dlp_entry (and that entry's own IOC set) in dlp_cache.
+ */
+void inventory_free(struct inventory *inv)
+{
+	struct dlp_entry *e, *next;
+	struct cfg_conn_entry *ce, *cnext;
+
+	if (!inv)
+		return;
+	tlist_free_items(&inv->nbft_dcs);
+	tlist_free_items(&inv->nbft_iocs);
+	tlist_free_items(&inv->cfg_dcs);
+	tlist_free_items(&inv->cfg_iocs);
+	list_for_each_safe(&inv->dlp_cache, e, next, entry) {
+		tid_free(e->dc_tid);
+		tlist_free_items(&e->iocs);
+		free(e);
+	}
+	list_for_each_safe(&inv->cfg_conns, ce, cnext, entry) {
+		tid_free(ce->tid);
+		free(ce);
+	}
+	free(inv);
+}
+
+/*
+ * Replace the IOC set learned from dc_tid's Discovery Log Page. Called
+ * each time a DC's DLP is (re-)fetched, so this is a clean per-DC
+ * replacement, not an incremental merge - any IOC that dropped out of
+ * the new DLP simply disappears from the DLP cache for this DC.
+ */
+void inventory_update_dlp(struct inventory *inv,
+			  const struct libnvmf_tid *dc_tid,
+			  struct libnvmf_tid **ioc_tids)
+{
+	struct dlp_entry *e = NULL, *it;
+	size_t i;
+
+	/* Find the existing per-DC entry, if any. */
+	list_for_each(&inv->dlp_cache, it, entry) {
+		if (tid_same(it->dc_tid, dc_tid)) {
+			e = it;
+			break;
+		}
+	}
+
+	if (!e) {
+		/*
+		 * First DLP ever seen for this DC: allocate an entry and
+		 * link it in, keyed by a private copy of dc_tid.
+		 */
+		e = calloc(1, sizeof(*e));
+		if (!e)
+			return;
+		e->dc_tid = libnvmf_tid_dup(dc_tid);
+		if (!e->dc_tid) {
+			free(e);
+			return;
+		}
+		list_add(&inv->dlp_cache, &e->entry);
+	} else {
+		/*
+		 * DLP refresh for a DC we already track: drop the
+		 * previous IOC set before repopulating it below.
+		 */
+		tlist_free_items(&e->iocs);
+	}
+
+	/*
+	 * Take ownership of ioc_tids: each TID moves into e->iocs, and
+	 * the now-empty array itself is freed (per inventory.h contract).
+	 */
+	if (ioc_tids) {
+		for (i = 0; ioc_tids[i]; i++)
+			tid_list_append(&e->iocs, ioc_tids[i]);
+		free(ioc_tids);
+	}
+}
+
+/*
+ * Drop the per-DC dlp_entry for dc_tid entirely (e.g. the DC was
+ * removed from config on SIGHUP, or disconnected for good) - unlike
+ * inventory_update_dlp(), which replaces an entry's IOC set in place,
+ * this removes the entry itself, key and all, from dlp_cache.
+ * A no-op if dc_tid has no entry.
+ */
+void inventory_remove_dlp(struct inventory *inv,
+			  const struct libnvmf_tid *dc_tid)
+{
+	struct dlp_entry *e;
+
+	list_for_each(&inv->dlp_cache, e, entry) {
+		if (tid_same(e->dc_tid, dc_tid)) {
+			list_del_init(&e->entry);
+			tid_free(e->dc_tid);
+			tlist_free_items(&e->iocs);
+			free(e);
+			return;
+		}
+	}
+}
+
+/*
+ * Linear membership test: is t the same (per tid_same()) as any item
+ * already in l?
+ */
+static bool tlist_contains(const struct tid_list *l,
+			    const struct libnvmf_tid *t)
+{
+	size_t i;
+
+	for (i = 0; i < l->len; i++) {
+		if (tid_same(l->items[i], t))
+			return true;
+	}
+	return false;
+}
+
+/*
+ * Is t something discoverd should be (re)connecting? True if t is in
+ * any of the four flat sets, or if t is itself a tracked DC (a key in
+ * dlp_cache), or if t is in any tracked DC's IOC set. This is the
+ * union of every controller source discoverd knows about - NBFT,
+ * config, and everything learned via DLP - and is the gate used
+ * before reconnecting a dropped controller.
+ */
+bool inventory_is_desired(const struct inventory *inv,
+			  const struct libnvmf_tid *t)
+{
+	struct dlp_entry *e;
+
+	if (tlist_contains(&inv->nbft_dcs, t) ||
+	    tlist_contains(&inv->nbft_iocs, t) ||
+	    tlist_contains(&inv->cfg_dcs, t) ||
+	    tlist_contains(&inv->cfg_iocs, t))
+		return true;
+
+	list_for_each(&inv->dlp_cache, e, entry) {
+		if (tid_same(e->dc_tid, t))
+			return true;
+		if (tlist_contains(&e->iocs, t))
+			return true;
+	}
+	return false;
+}
+
+/*
+ * Is t firmware-sourced (present in nbft_dcs or nbft_iocs)? Used to
+ * decide whether a reconnect should use --owner nbft instead of
+ * --owner discoverd, preserving the NBFT ownership invariant.
+ */
+bool inventory_is_nbft(const struct inventory *inv, const struct libnvmf_tid *t)
+{
+	return tlist_contains(&inv->nbft_dcs, t) ||
+	       tlist_contains(&inv->nbft_iocs, t);
+}
+
+/*
+ * Build the NULL-terminated, deduplicated list of every DC that
+ * should be connected at startup: nbft_dcs union cfg_dcs. Does not
+ * include DCs only known via dlp_cache (those are reconnected via
+ * unit RestartUnit, not from this startup list). Caller owns the
+ * returned array and every TID in it.
+ */
+struct libnvmf_tid **inventory_desired_dcs(const struct inventory *inv)
+{
+	struct tid_list combined = { 0 };
+	struct libnvmf_tid **arr;
+	size_t i;
+
+	/* Merge nbft_dcs + cfg_dcs (deduplicated). */
+	for (i = 0; i < inv->nbft_dcs.len; i++) {
+		struct libnvmf_tid *t = libnvmf_tid_dup(inv->nbft_dcs.items[i]);
+
+		if (t)
+			tid_list_append(&combined, t);
+	}
+	for (i = 0; i < inv->cfg_dcs.len; i++) {
+		if (!tlist_contains(&combined, inv->cfg_dcs.items[i])) {
+			struct libnvmf_tid *t =
+				libnvmf_tid_dup(inv->cfg_dcs.items[i]);
+
+			if (t)
+				tid_list_append(&combined, t);
+		}
+	}
+
+	arr = malloc((combined.len + 1) * sizeof(*arr));
+	if (!arr) {
+		tlist_free_items(&combined);
+		return NULL;
+	}
+	for (i = 0; i < combined.len; i++)
+		arr[i] = combined.items[i];
+	arr[combined.len] = NULL;
+	free(combined.items);
+	return arr;
+}
+
+/*
+ * Extract the host address from an NVMe URI of the form
+ * "nvme+transport://host:port/..." or "nvme+transport://host/...".
+ * Returns an allocated string or NULL.
+ */
+static char *uri_host(const char *uri)
+{
+	const char *p, *end;
+
+	if (!uri)
+		return NULL;
+	p = strstr(uri, "://");
+	if (!p)
+		return NULL;
+	p += 3;
+	end = strpbrk(p, ":/");
+	return end ? strndup(p, (size_t)(end - p)) : strdup(p);
+}
+
+static char *uri_port(const char *uri)
+{
+	const char *p, *end;
+
+	if (!uri)
+		return NULL;
+	p = strstr(uri, "://");
+	if (!p)
+		return NULL;
+	p += 3;
+	p = strchr(p, ':');
+	if (!p)
+		return NULL;
+	p++;
+	end = strchr(p, '/');
+	return end ? strndup(p, (size_t)(end - p)) : strdup(p);
+}
+
+/*
+ * Boot Spec 1.5.7 / Figure 20: <PROTOCOL> (the "+<trtype>" part of the
+ * scheme) is mandatory in an NVMe-oF URI. Returns NULL if uri is NULL or
+ * the "+<trtype>" segment is missing — callers must treat a present-but-
+ * malformed URI as invalid, not default the transport.
+ */
+static char *uri_transport(const char *uri)
+{
+	const char *plus, *end;
+
+	if (!uri)
+		return NULL;
+	plus = strchr(uri, '+');
+	if (!plus)
+		return NULL;
+	plus++;
+	end = strstr(plus, "://");
+	return end ? strndup(plus, (size_t)(end - plus)) : strdup(plus);
+}
+
+#define NBFT_SYSFS_PATH "/sys/firmware/acpi/tables"
+
+static void load_one_nbft(struct inventory *inv, struct libnbft_info *nbft)
+{
+	int i;
+
+	if (nbft->discovery_list) {
+		for (i = 0; nbft->discovery_list[i]; i++) {
+			struct libnbft_discovery *d = nbft->discovery_list[i];
+			struct libnvmf_tid *t;
+			char *traddr, *trsvcid, *transport;
+			const char *host_traddr = NULL;
+
+			if (!d->hfi || !d->nqn)
+				continue;
+
+			// Reject a malformed or incomplete URI.
+			transport = uri_transport(d->uri);
+			if (!transport)
+				continue;
+
+			traddr = uri_host(d->uri);
+			if (!traddr) {
+				free(transport);
+				continue;
+			}
+
+			trsvcid = uri_port(d->uri); // optional: NULL ok
+			host_traddr = d->hfi->tcp_info.ipaddr;
+
+			t = tid_new(transport, traddr, trsvcid, d->nqn,
+				    host_traddr, NULL, NULL, true);
+			free(traddr);
+			free(trsvcid);
+			free(transport);
+			if (t)
+				tid_list_append(&inv->nbft_dcs, t);
+		}
+	}
+
+	if (nbft->subsystem_ns_list) {
+		for (i = 0; nbft->subsystem_ns_list[i]; i++) {
+			struct libnbft_subsystem_ns *ns =
+				nbft->subsystem_ns_list[i];
+			struct libnvmf_tid *t;
+			const char *host_traddr = NULL;
+
+			if (ns->hfis && ns->hfis[0])
+				host_traddr = ns->hfis[0]->tcp_info.ipaddr;
+
+			t = tid_new(ns->transport, ns->traddr,
+				    ns->trsvcid, ns->subsys_nqn,
+				    host_traddr, NULL, NULL, false);
+			if (t)
+				tid_list_append(&inv->nbft_iocs, t);
+		}
+	}
+}
+
+int inventory_load_nbft(struct inventory *inv,
+			struct libnvme_global_ctx *nvme_ctx)
+{
+	char *nbft_path = NBFT_SYSFS_PATH;
+	struct nbft_file_entry *head = NULL;
+	struct nbft_file_entry *e;
+	int ret;
+
+	ret = libnvmf_nbft_read_files(nvme_ctx, nbft_path, &head);
+	if (ret)
+		return 0; // no NBFT is not an error
+
+	for (e = head; e; e = e->next)
+		load_one_nbft(inv, e->nbft);
+
+	libnvmf_nbft_free(nvme_ctx, head);
+	return 0;
+}
+
+/*
+ * Resolve traddr to a numeric address if it names a tcp/rdma hostname.
+ * libnvmf_config_conn_get_traddr() never returns a hostname for FC (no
+ * hostname concept there), and an already-numeric address is returned
+ * unchanged. Deliberately blocking and sequential, one getaddrinfo() call
+ * at a time, no worker thread: config load runs once at startup and, more
+ * rarely, on SIGHUP — a rare, small path, not the daemon's steady-state
+ * event loop, so a blocking resolve here is acceptable.
+ * Returns an allocated numeric-address string, or NULL if traddr is not
+ * numeric and cannot be resolved.
+ */
+static char *resolve_traddr(const char *transport, const char *traddr)
+{
+	if (libnvmf_traddr_is_numeric(traddr))
+		return strdup(traddr);
+
+#ifdef NVME_HAVE_NETDB
+	struct addrinfo hints = { .ai_family = AF_UNSPEC };
+	struct addrinfo *host_info = NULL;
+	char addrstr[NVMF_TRADDR_SIZE];
+	const char *p = NULL;
+	char *resolved = NULL;
+	int ret;
+
+	if (strcmp(transport, "tcp") && strcmp(transport, "rdma"))
+		return NULL;
+
+	ret = getaddrinfo(traddr, NULL, &hints, &host_info);
+	if (ret) {
+		disc_warn("failed to resolve host '%s': %s",
+			  traddr, gai_strerror(ret));
+		return NULL;
+	}
+
+	switch (host_info->ai_family) {
+	case AF_INET:
+		p = inet_ntop(AF_INET,
+			&((struct sockaddr_in *)host_info->ai_addr)->sin_addr,
+			addrstr, sizeof(addrstr));
+		break;
+	case AF_INET6:
+		p = inet_ntop(AF_INET6,
+			&((struct sockaddr_in6 *)host_info->ai_addr)->sin6_addr,
+			addrstr, sizeof(addrstr));
+		break;
+	default:
+		break;
+	}
+	if (p)
+		resolved = strdup(addrstr);
+
+	freeaddrinfo(host_info);
+	return resolved;
+#else
+	disc_warn("cannot resolve host '%s': hostname resolution not available "
+		  "in this build", traddr);
+	return NULL;
+#endif
+}
+
+static void load_config_conn_callback(const struct libnvmf_config_conn *conn,
+				   void *user_data)
+{
+	struct inventory *inv = user_data;
+	const char *transport = libnvmf_config_conn_get_transport(conn);
+	const char *raw_traddr = libnvmf_config_conn_get_traddr(conn);
+	bool is_dc = libnvmf_config_conn_is_dc(conn);
+	char *traddr;
+	struct libnvmf_tid *t, *t2;
+	struct cfg_conn_entry *ce;
+
+	traddr = resolve_traddr(transport, raw_traddr);
+	if (!traddr) {
+		disc_warn("%s - failed to resolve, skipping", raw_traddr);
+		return;
+	}
+
+	t = tid_new(transport, traddr,
+		   libnvmf_config_conn_get_trsvcid(conn),
+		   libnvmf_config_conn_get_subsysnqn(conn),
+		   libnvmf_config_conn_get_host_traddr(conn),
+		   libnvmf_config_conn_get_host_iface(conn),
+		   libnvmf_config_conn_get_hostnqn(conn), is_dc);
+	free(traddr);
+	if (!t)
+		return;
+
+	// t2 feeds the plain membership set; t is kept (paired with conn)
+	// for inventory_config_conn_for() lookups — each list owns its copy.
+	t2 = libnvmf_tid_dup(t);
+	if (!t2 ||
+	    tid_list_append(is_dc ? &inv->cfg_dcs : &inv->cfg_iocs, t2) < 0) {
+		tid_free(t2);
+		tid_free(t);
+		return;
+	}
+
+	ce = calloc(1, sizeof(*ce));
+	if (!ce) {
+		tid_free(t);
+		return;
+	}
+	ce->tid = t;
+	ce->conn = conn;
+	list_add(&inv->cfg_conns, &ce->entry);
+}
+
+void inventory_load_config(struct inventory *inv,
+		       const struct libnvmf_config *fabrics_cfg)
+{
+	struct cfg_conn_entry *ce, *next;
+
+	tlist_free_items(&inv->cfg_dcs);
+	tlist_free_items(&inv->cfg_iocs);
+	list_for_each_safe(&inv->cfg_conns, ce, next, entry) {
+		tid_free(ce->tid);
+		free(ce);
+	}
+	list_head_init(&inv->cfg_conns);
+
+	if (fabrics_cfg)
+		libnvmf_config_conn_for_each(fabrics_cfg,
+					     load_config_conn_callback, inv);
+
+	disc_dbg("loaded %zu DC(s), %zu IOC(s) from the fabrics config",
+		 inv->cfg_dcs.len, inv->cfg_iocs.len);
+}
+
+const struct libnvmf_config_conn *inventory_config_conn_for(
+		const struct inventory *inv, const struct libnvmf_tid *t)
+{
+	struct cfg_conn_entry *ce;
+
+	list_for_each(&inv->cfg_conns, ce, entry) {
+		if (tid_same(ce->tid, t))
+			return ce->conn;
+	}
+	return NULL;
+}
+
+/*
+ * Same as inventory_desired_dcs(), but for IOCs: the NULL-terminated,
+ * deduplicated union of nbft_iocs and cfg_iocs. DLP-sourced IOCs are
+ * excluded for the same reason DLP-sourced DCs are excluded from
+ * inventory_desired_dcs() - they come back via unit restart, not a
+ * startup list.
+ */
+struct libnvmf_tid **inventory_desired_iocs(const struct inventory *inv)
+{
+	struct tid_list combined = { 0 };
+	struct libnvmf_tid **arr;
+	size_t i;
+
+	for (i = 0; i < inv->nbft_iocs.len; i++) {
+		struct libnvmf_tid *t =
+			libnvmf_tid_dup(inv->nbft_iocs.items[i]);
+
+		if (t)
+			tid_list_append(&combined, t);
+	}
+	for (i = 0; i < inv->cfg_iocs.len; i++) {
+		if (!tlist_contains(&combined, inv->cfg_iocs.items[i])) {
+			struct libnvmf_tid *t =
+				libnvmf_tid_dup(inv->cfg_iocs.items[i]);
+
+			if (t)
+				tid_list_append(&combined, t);
+		}
+	}
+
+	arr = malloc((combined.len + 1) * sizeof(*arr));
+	if (!arr) {
+		tlist_free_items(&combined);
+		return NULL;
+	}
+	for (i = 0; i < combined.len; i++)
+		arr[i] = combined.items[i];
+	arr[combined.len] = NULL;
+	free(combined.items);
+	return arr;
+}

--- a/discoverd/src/inventory.h
+++ b/discoverd/src/inventory.h
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+
+#include <nvme/config.h>
+
+#include "tid.h"
+
+struct libnvme_global_ctx;
+struct inventory;
+
+/* Allocate an empty inventory. */
+struct inventory *inventory_new(void);
+void inventory_free(struct inventory *inv);
+
+/*
+ * Populate the NBFT DC/IOC sets from the firmware NBFT ACPI table. Call
+ * once at startup; the NBFT itself does not change at runtime, so unlike
+ * inventory_load_config() this never needs a rebuild. A missing/absent
+ * NBFT is not an error.
+ * Returns 0 on success, negative errno on failure.
+ */
+int inventory_load_nbft(struct inventory *inv,
+			struct libnvme_global_ctx *nvme_ctx);
+
+/*
+ * Rebuild the config DC/IOC sets from the resolved fabrics configuration
+ * (libnvmf_config_read()). Call at startup and again on every SIGHUP —
+ * this always fully replaces the previous sets, never merges. A hostname
+ * traddr is resolved here, blocking, one connection at a time — this is a
+ * rare, small, startup/SIGHUP-only path, not the daemon's steady-state
+ * event loop, so no worker thread is warranted. A connection whose traddr
+ * cannot be resolved is skipped and logged.
+ * @fabrics_cfg may be NULL (equivalent to an empty configuration).
+ */
+void inventory_load_config(struct inventory *inv,
+			   const struct libnvmf_config *fabrics_cfg);
+
+/*
+ * The libnvmf_config_conn that produced @t via inventory_load_config(), or
+ * NULL if @t is not a statically configured connection (i.e. it was
+ * learned via NBFT, a Discovery Log Page, or FC kickstart). Used to
+ * choose between libnvmf_config_conn_get_params() and
+ * libnvmf_config_resolve_discovered() when resolving the connect
+ * parameters for @t.
+ */
+const struct libnvmf_config_conn *inventory_config_conn_for(
+		const struct inventory *inv, const struct libnvmf_tid *t);
+
+/*
+ * Update the per-DC entry in the DLP cache when a DC's log page is
+ * refreshed. ioc_tids is a NULL-terminated array of TIDs from the new
+ * DLP. The cache takes ownership of each TID in the array; the array
+ * itself is freed by this function.
+ */
+void inventory_update_dlp(struct inventory *inv,
+			  const struct libnvmf_tid *dc_tid,
+			  struct libnvmf_tid **ioc_tids);
+
+/* Remove the DLP cache entry for dc_tid (e.g. when DC disconnects). */
+void inventory_remove_dlp(struct inventory *inv,
+			  const struct libnvmf_tid *dc_tid);
+
+/*
+ * Query: is tid in the desired connection set?
+ * Returns true if tid appears in the NBFT set, the config set, or any
+ * per-DC entry in the DLP cache.
+ */
+bool inventory_is_desired(const struct inventory *inv,
+			  const struct libnvmf_tid *t);
+
+/*
+ * Query: is tid in the NBFT set?
+ * Used to determine whether to use --owner nbft.
+ */
+bool inventory_is_nbft(const struct inventory *inv,
+		       const struct libnvmf_tid *t);
+
+/*
+ * Iterate over all DC TIDs that should be connected at startup.
+ * (NBFT DCs + config DCs.)
+ * Returns a NULL-terminated array; caller must free each element and the array.
+ */
+struct libnvmf_tid **inventory_desired_dcs(const struct inventory *inv);
+
+/*
+ * Iterate over all IOC TIDs that should be connected at startup.
+ * (NBFT IOCs + config IOCs.)
+ */
+struct libnvmf_tid **inventory_desired_iocs(const struct inventory *inv);

--- a/discoverd/src/log.c
+++ b/discoverd/src/log.c
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <stdarg.h>
+#include <syslog.h>
+#include <systemd/sd-journal.h>
+
+#include "log.h"
+
+static int log_level = DISC_DEFAULT_LOGLEVEL;
+
+/* Map discoverd levels to syslog priorities for the journal. */
+static const int prio_map[] = {
+	[DISC_LOG_ERR]   = LOG_ERR,
+	[DISC_LOG_WARN]  = LOG_WARNING,
+	[DISC_LOG_INFO]  = LOG_INFO,
+	[DISC_LOG_DEBUG] = LOG_DEBUG,
+};
+
+void log_set_level(int level)
+{
+	log_level = level;
+}
+
+void log_msg(int level, const char *fmt, ...)
+{
+	va_list ap;
+
+	if (level > log_level)
+		return;
+	if (level < DISC_LOG_ERR || level > DISC_LOG_DEBUG)
+		level = DISC_LOG_ERR;
+
+	va_start(ap, fmt);
+	sd_journal_printv(prio_map[level], fmt, ap);
+	va_end(ap);
+}

--- a/discoverd/src/log.h
+++ b/discoverd/src/log.h
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+/*
+ * Logging wrapper.
+ *
+ * Levels mirror libnvme's (ERR/WARN/INFO/DEBUG): a message is emitted when
+ * its level is <= the configured threshold, so DEBUG turns everything on.
+ * All output currently goes to the systemd journal; routing lives behind
+ * this wrapper so a future change of logging backend touches only log.c.
+ */
+enum disc_log_level {
+	DISC_LOG_ERR   = 0,
+	DISC_LOG_WARN  = 1,
+	DISC_LOG_INFO  = 2,
+	DISC_LOG_DEBUG = 3,
+};
+
+#define DISC_DEFAULT_LOGLEVEL DISC_LOG_INFO
+
+/* Set the current threshold (e.g. from discoverd.conf's debug-level knob). */
+void log_set_level(int level);
+
+/*
+ * Emit one message at @level if it passes the threshold. Use the disc_*
+ * helpers below rather than calling this directly.
+ */
+void log_msg(int level, const char *fmt, ...)
+	__attribute__((format(printf, 2, 3)));
+
+/*
+ * INFO and higher print the message as-is (per convention, lead with the
+ * TID: "<tid> | <dev> - msg" — see libnvmf_tid_str()). DEBUG additionally
+ * prepends the calling function name for call tracing ("<func>() - msg");
+ * __func__ keeps it from drifting out of sync.
+ */
+#define disc_err(fmt, ...)  log_msg(DISC_LOG_ERR,   fmt, ##__VA_ARGS__)
+#define disc_warn(fmt, ...) log_msg(DISC_LOG_WARN,  fmt, ##__VA_ARGS__)
+#define disc_info(fmt, ...) log_msg(DISC_LOG_INFO,  fmt, ##__VA_ARGS__)
+#define disc_dbg(fmt, ...)  log_msg(DISC_LOG_DEBUG, "%s() - " fmt, __func__, ##__VA_ARGS__)

--- a/discoverd/src/main.c
+++ b/discoverd/src/main.c
@@ -1,0 +1,1086 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <getopt.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include <systemd/sd-bus.h>
+#include <systemd/sd-daemon.h>
+#include <systemd/sd-device.h>
+#include <systemd/sd-event.h>
+
+#include <ccan/list/list.h>
+
+#include <array-util.h>
+#include <nvme/config.h>
+#include <nvme/exclusion.h>
+#include <nvme/lib.h>
+#include <nvme/registry.h>
+
+#include "inventory.h"
+#include "config.h"
+#include "ctx.h"
+#include "dlp.h"
+#include "events.h"
+#include "fc.h"
+#include "log.h"
+#include "state.h"
+#include "tid.h"
+#include "units.h"
+
+// Exponential backoff for failed (re)connect attempts: 1s, 2s, 4s, ... capped
+// at 5 min. A dynamically-discovered DC (not NBFT- or config-sourced — a
+// referral or FC-kickstart find) additionally gives up after 72h of
+// unbroken failure and is dropped from tracking, since nothing but its own
+// retries vouches for it any more. Static and NBFT-sourced DCs represent
+// deliberate admin/firmware intent and always retry forever.
+#define RETRY_INITIAL_DELAY_SEC 1
+#define RETRY_MAX_DELAY_SEC     300
+#define DC_GIVEUP_USEC          (UINT64_C(72) * 3600 * UINT64_C(1000000))
+
+struct active_ctrl {
+	struct list_node entry;
+	char *unit_name;    // "nvme-discoverd-<12hex>.service"
+	char *devname;      // "nvmeX"; NULL until confirmed in sysfs
+	struct libnvmf_tid *tid;
+	bool is_dc;
+	unsigned int attempts;   // consecutive failed (re)connect attempts
+	uint64_t giveup_at_usec; // 0 = no deadline armed (ctrl_arm_giveup)
+	sd_event_source *retry_timer; // NULL when no retry pending
+};
+
+static LIST_HEAD(g_ctrls);
+static struct discoverd_ctx ctx;
+
+static struct active_ctrl *ctrl_find_by_unit(const char *unit_name)
+{
+	struct active_ctrl *e;
+
+	list_for_each(&g_ctrls, e, entry) {
+		if (streq(e->unit_name, unit_name))
+			return e;
+	}
+	return NULL;
+}
+
+static struct active_ctrl *ctrl_find_by_devname(const char *devname)
+{
+	struct active_ctrl *e;
+
+	list_for_each(&g_ctrls, e, entry) {
+		if (shr_streq0(e->devname, devname))
+			return e;
+	}
+	return NULL;
+}
+
+static void ctrl_free(struct active_ctrl *e)
+{
+	if (!e)
+		return;
+	sd_event_source_unref(e->retry_timer);
+	tid_free(e->tid);
+	free(e->unit_name);
+	free(e->devname);
+	free(e);
+}
+
+static int ctrl_add(const char *unit_name, const struct libnvmf_tid *t,
+		    bool is_dc)
+{
+	struct active_ctrl *e;
+
+	if (ctrl_find_by_unit(unit_name))
+		return 0; // already tracked
+
+	e = calloc(1, sizeof(*e));
+	if (!e)
+		return -ENOMEM;
+
+	e->unit_name = strdup(unit_name);
+	e->tid = libnvmf_tid_dup(t);
+	e->is_dc = is_dc;
+	if (!e->unit_name || !e->tid) {
+		ctrl_free(e);
+		return -ENOMEM;
+	}
+
+	list_add(&g_ctrls, &e->entry);
+	return 0;
+}
+
+static void ctrl_remove(struct active_ctrl *entry)
+{
+	list_del_init(&entry->entry);
+	ctrl_free(entry);
+}
+
+static char *find_devname_for_tid(const struct libnvmf_tid *t);
+
+/*
+ * Exclusion + registry-owner check — called before every connect decision.
+ *
+ * Exclusion applies to NBFT-sourced controllers too: the exclusion list is
+ * the host administrator's explicit, root-only instruction, and is the
+ * supported way to take a boot path out of service for testing or
+ * maintenance. owner=nbft still protects a boot-path controller from every
+ * *other* orchestrator via the registry — it just does not override the
+ * local admin's own exclusion entry.
+ *
+ * The registry check skips a controller another orchestrator (e.g.
+ * nvme-stas) already owns. "discoverd" and "nbft" are discoverd's own
+ * registry owner strings (see unit_start_dc()/unit_start_ioc() in units.c),
+ * so a controller discoverd itself owns is never skipped here.
+ *
+ * @known_devname is the live (or just-removed) device name for @t, when
+ * the caller already has it in hand (on_nvme_remove(), startup_audit()'s
+ * sysfs walk); NULL otherwise, in which case this function resolves it
+ * itself via a live sysfs scan (find_devname_for_tid()). Either way the
+ * registry is checked directly by device name, never through libnvme's
+ * in-process topology tree: that tree is only populated by a caller that
+ * has just run libnvme_scan_topology() (true for the CLI's one-shot
+ * fabrics commands, never true for this long-running daemon), so a
+ * tree-based match would silently report "no owner" for every
+ * already-connected controller discoverd didn't itself just scan.
+ */
+static bool should_connect(const struct libnvmf_tid *t,
+			   const char *known_devname)
+{
+	char *owner = NULL;
+	char *resolved_devname = NULL;
+	const char *devname = known_devname;
+	int r;
+
+	if (libnvmf_exclusion_match(ctx.nvme_ctx, t)) {
+		disc_info("%s - excluded, skipping", libnvmf_tid_str(t));
+		return false;
+	}
+
+	if (!devname) {
+		resolved_devname = find_devname_for_tid(t);
+		devname = resolved_devname;
+	}
+
+	if (devname) {
+		r = libnvmf_registry_retrieve(ctx.nvme_ctx, devname, "owner",
+					      &owner);
+		if (r == -ENOENT)
+			r = 0;
+	} else {
+		r = 0; // nothing currently connected matching t
+	}
+	free(resolved_devname);
+
+	if (r < 0) {
+		disc_warn("%s - failed to check registry owner: %s",
+			  libnvmf_tid_str(t), strerror(-r));
+		return false;
+	}
+	if (owner && strcmp(owner, "discoverd") && strcmp(owner, "nbft")) {
+		disc_info("%s - owned by '%s', skipping",
+			  libnvmf_tid_str(t), owner);
+		free(owner);
+		return false;
+	}
+
+	free(owner);
+	return true;
+}
+
+/*
+ * Resolved connect parameters for @t: a statically configured connection's
+ * own params, or — for anything discoverd found on its own (NBFT, DLP, FC
+ * kickstart) — the discovered-controller defaults for the scope @via_dc
+ * was learned through (NULL if @t has no configured parent DC either).
+ * See libnvmf_config_resolve_discovered() in <nvme/config.h>.
+ */
+static const struct libnvmf_params *params_for(
+		const struct libnvmf_tid *t, bool is_dc,
+		const struct libnvmf_config_conn *via_dc)
+{
+	const struct libnvmf_config_conn *conn =
+		inventory_config_conn_for(ctx.inventory, t);
+
+	if (conn)
+		return libnvmf_config_conn_get_params(conn);
+	if (!ctx.fabrics_cfg)
+		return NULL;
+	return libnvmf_config_resolve_discovered(ctx.fabrics_cfg, via_dc,
+						 is_dc);
+}
+
+/*
+ * Start a transient unit for @t (as a DC or an IOC) and track it — unless a
+ * unit for this TID is already tracked, in which case we skip to avoid
+ * issuing a duplicate StartTransient (e.g. startup_audit and
+ * connect_desired both reaching the same controller, or the same IOC
+ * appearing behind two DCs). The caller is responsible for the
+ * should_connect() decision. @via_dc is the parent DC's config connection,
+ * if @t was learned via that DC's Discovery Log Page; NULL otherwise.
+ */
+static void start_ctrl(const struct libnvmf_tid *t, bool is_dc, bool is_nbft,
+		       const struct libnvmf_config_conn *via_dc)
+{
+	char *unit_name = tid_unit_name(t);
+	const struct libnvmf_params *params;
+	int r;
+
+	if (!unit_name)
+		return;
+	if (ctrl_find_by_unit(unit_name)) {
+		free(unit_name); // already tracked — no duplicate connect
+		return;
+	}
+
+	params = params_for(t, is_dc, via_dc);
+
+	r = is_dc ? unit_start_dc(ctx.umgr, t, params, is_nbft)
+		  : unit_start_ioc(ctx.umgr, t, params, is_nbft);
+	if (r >= 0) {
+		ctrl_add(unit_name, t, is_dc);
+		disc_dbg("%s: requested %s unit", libnvmf_tid_str(t),
+			 is_dc ? "DC" : "IOC");
+	} else {
+		disc_warn("%s - failed to start %s unit: %s",
+			  libnvmf_tid_str(t), is_dc ? "DC" : "IOC",
+			  strerror(-r));
+	}
+	free(unit_name);
+}
+
+SHR_PTRARRAY_DEFINE(ioc_list, struct libnvmf_tid);
+
+struct dlp_fetch_ctx {
+	const struct libnvmf_config_conn *via_dc; // dc_tid's own conn, if any
+	struct ioc_list iocs;
+};
+
+static void dlp_ioc_callback(const struct libnvmf_tid *t, void *user_data)
+{
+	struct dlp_fetch_ctx *fctx = user_data;
+	bool is_nbft = inventory_is_nbft(ctx.inventory, t);
+	struct libnvmf_tid *dup;
+
+	// Accumulate IOC TIDs for inventory_update_dlp().
+	dup = libnvmf_tid_dup(t);
+	if (!dup || ioc_list_append(&fctx->iocs, dup) < 0) {
+		tid_free(dup);
+		return;
+	}
+
+	if (should_connect(t, NULL))
+		start_ctrl(t, false, is_nbft, fctx->via_dc);
+}
+
+static void dlp_dc_callback(const struct libnvmf_tid *t, void *user_data)
+{
+	struct dlp_fetch_ctx *fctx = user_data;
+	bool is_nbft = inventory_is_nbft(ctx.inventory, t);
+
+	if (should_connect(t, NULL))
+		start_ctrl(t, true, is_nbft, fctx->via_dc);
+}
+
+static void fetch_and_process_dlp(const char *devname,
+				  const struct libnvmf_tid *dc_tid)
+{
+	struct dlp_fetch_ctx fctx = {
+		.via_dc = inventory_config_conn_for(ctx.inventory, dc_tid),
+	};
+
+	dlp_fetch(&ctx, devname, dc_tid, dlp_ioc_callback, dlp_dc_callback,
+		  &fctx);
+
+	if (fctx.iocs.len) {
+		if (ioc_list_append(&fctx.iocs, NULL) == 0) {
+			inventory_update_dlp(ctx.inventory, dc_tid,
+					     fctx.iocs.items);
+		} else {
+			size_t i;
+
+			for (i = 0; i < fctx.iocs.len; i++)
+				tid_free(fctx.iocs.items[i]);
+			ioc_list_free(&fctx.iocs);
+		}
+	}
+}
+
+/*
+ * Arm a dynamically-discovered DC's give-up deadline the first time it is
+ * seen failing to (re)connect. Static/NBFT-sourced DCs and IOCs never get
+ * one and retry forever.
+ */
+static void ctrl_arm_giveup(struct active_ctrl *e)
+{
+	uint64_t now;
+
+	if (e->giveup_at_usec || !e->is_dc)
+		return;
+	if (inventory_is_nbft(ctx.inventory, e->tid) ||
+	    inventory_config_conn_for(ctx.inventory, e->tid))
+		return;
+	if (sd_event_now(ctx.event, CLOCK_BOOTTIME, &now) >= 0)
+		e->giveup_at_usec = now + DC_GIVEUP_USEC;
+}
+
+static uint64_t backoff_delay_usec(unsigned int attempts)
+{
+	uint64_t sec = RETRY_INITIAL_DELAY_SEC;
+	unsigned int i;
+
+	for (i = 0; i < attempts && sec < RETRY_MAX_DELAY_SEC; i++)
+		sec *= 2;
+	if (sec > RETRY_MAX_DELAY_SEC)
+		sec = RETRY_MAX_DELAY_SEC;
+	return sec * UINT64_C(1000000);
+}
+
+static int retry_timeout(sd_event_source *src, uint64_t usec, void *user_data);
+
+static int schedule_retry(struct active_ctrl *e)
+{
+	uint64_t now, delay;
+	int r;
+
+	if (e->retry_timer)
+		return 0; // already scheduled
+
+	ctrl_arm_giveup(e);
+
+	r = sd_event_now(ctx.event, CLOCK_BOOTTIME, &now);
+	if (r < 0)
+		return r;
+
+	delay = backoff_delay_usec(e->attempts);
+	e->attempts++;
+
+	return sd_event_add_time(ctx.event, &e->retry_timer, CLOCK_BOOTTIME,
+				 now + delay, 0, retry_timeout, e);
+}
+
+/*
+ * Restart @e's unit (parameters are baked in). Falls back to a fresh
+ * StartTransient — using the top-level discovered-controller scope, not
+ * @e's original parent DC's scope, a deliberate simplification since
+ * active_ctrl does not track that borrowed config_conn across a possible
+ * SIGHUP config reload — if the unit was garbage-collected.
+ */
+static int restart_or_start(struct active_ctrl *e)
+{
+	int r = unit_restart(ctx.umgr, e->unit_name);
+
+	if (r < 0) {
+		const struct libnvmf_params *params =
+			params_for(e->tid, e->is_dc, NULL);
+		bool is_nbft = inventory_is_nbft(ctx.inventory, e->tid);
+
+		if (e->is_dc)
+			r = unit_start_dc(ctx.umgr, e->tid, params, is_nbft);
+		else
+			r = unit_start_ioc(ctx.umgr, e->tid, params, is_nbft);
+	}
+	return r;
+}
+
+static int retry_timeout(sd_event_source *src,
+			 uint64_t usec __attribute__((unused)),
+			 void *user_data)
+{
+	struct active_ctrl *e = user_data;
+	uint64_t now;
+	int r;
+
+	sd_event_source_unref(src);
+	e->retry_timer = NULL;
+
+	if (!inventory_is_desired(ctx.inventory, e->tid)) {
+		disc_info("%s - no longer desired, not retrying",
+			  libnvmf_tid_str(e->tid));
+		ctrl_remove(e);
+		return 0;
+	}
+
+	if (e->giveup_at_usec &&
+	    sd_event_now(ctx.event, CLOCK_BOOTTIME, &now) >= 0 &&
+	    now >= e->giveup_at_usec) {
+		disc_warn("%s - giving up after repeated failures",
+			  libnvmf_tid_str(e->tid));
+		if (e->is_dc)
+			inventory_remove_dlp(ctx.inventory, e->tid);
+		ctrl_remove(e);
+		return 0;
+	}
+
+	r = restart_or_start(e);
+	if (r < 0) {
+		disc_err("%s - retry failed: %s",
+			 libnvmf_tid_str(e->tid), strerror(-r));
+		schedule_retry(e);
+	}
+	return 0;
+}
+
+// Periodic FC kickstart (opt-in via fc-kickstart-interval-minutes).
+static int fc_kickstart_timeout(sd_event_source *src,
+				uint64_t usec __attribute__((unused)),
+				void *user_data __attribute__((unused)))
+{
+	uint64_t now;
+
+	fc_kickstart();
+
+	if (sd_event_now(ctx.event, CLOCK_BOOTTIME, &now) >= 0) {
+		uint64_t interval =
+			(uint64_t)ctx.cfg->fc_kickstart_interval_minutes *
+			60 * UINT64_C(1000000);
+
+		sd_event_source_set_time(src, now + interval);
+		sd_event_source_set_enabled(src, SD_EVENT_ONESHOT);
+	}
+	return 0;
+}
+
+static void on_job_done(const char *unit_name, bool success,
+			void *user_data __attribute__((unused)))
+{
+	struct active_ctrl *e;
+
+	e = ctrl_find_by_unit(unit_name);
+	if (!e) {
+		if (!success)
+			disc_warn("unit %s failed (untracked)", unit_name);
+		return;
+	}
+
+	if (success) {
+		e->attempts = 0;
+		e->giveup_at_usec = 0;
+		return;
+	}
+
+	disc_warn("%s - connection unit failed", libnvmf_tid_str(e->tid));
+	if (schedule_retry(e) < 0)
+		disc_err("%s - failed to schedule retry",
+			 libnvmf_tid_str(e->tid));
+}
+
+static void on_dc_add(const char *devname, const struct libnvmf_tid *t,
+		      void *user_data __attribute__((unused)))
+{
+	struct active_ctrl *e;
+	char *unit_name;
+
+	// Link devname to the in-memory entry via state file.
+	unit_name = state_read_unit(devname);
+	if (unit_name) {
+		e = ctrl_find_by_unit(unit_name);
+		if (e && !e->devname)
+			e->devname = strdup(devname);
+		free(unit_name);
+	}
+
+	fetch_and_process_dlp(devname, t);
+}
+
+static void on_dc_changed(const char *devname,
+			  void *user_data __attribute__((unused)))
+{
+	struct active_ctrl *e;
+
+	e = ctrl_find_by_devname(devname);
+	if (!e || !e->tid) {
+		disc_warn("%s - dc_changed for untracked device", devname);
+		return;
+	}
+
+	disc_dbg("%s | %s: discovery log changed, re-fetching",
+		 libnvmf_tid_str(e->tid), devname);
+	fetch_and_process_dlp(devname, e->tid);
+}
+
+static void on_ioc_add(const char *devname,
+		       void *user_data __attribute__((unused)))
+{
+	struct active_ctrl *e;
+	char *unit_name;
+
+	unit_name = state_read_unit(devname);
+	if (!unit_name)
+		return;
+
+	e = ctrl_find_by_unit(unit_name);
+	if (e && !e->devname)
+		e->devname = strdup(devname);
+	free(unit_name);
+}
+
+static void on_nvme_remove(const char *devname,
+			   void *user_data __attribute__((unused)))
+{
+	struct active_ctrl *e;
+	bool is_fc;
+
+	e = ctrl_find_by_devname(devname);
+	state_remove_ctrl(devname);
+	if (!e)
+		return; // might be a controller we didn't start — ignore
+
+	state_remove_devid(e->unit_name); // ExecStopPost usually beat us to it
+
+	free(e->devname);
+	e->devname = NULL;
+
+	/*
+	 * Both checks must pass before reconnecting: a matching exclusion
+	 * entry wins even over a still-desired controller — it is the
+	 * administrator's explicit override.
+	 */
+	if (!should_connect(e->tid, devname)) {
+		unit_stop(ctx.umgr, e->unit_name);
+		ctrl_remove(e);
+		return;
+	}
+
+	if (!inventory_is_desired(ctx.inventory, e->tid)) {
+		disc_info("%s | %s - removed, not desired, dropping",
+			  libnvmf_tid_str(e->tid), devname);
+		ctrl_remove(e);
+		return;
+	}
+
+	disc_info("%s | %s - removed but still desired, reconnecting",
+		  libnvmf_tid_str(e->tid), devname);
+
+	is_fc = shr_streq0(libnvmf_tid_get_transport(e->tid), "fc");
+
+	if (is_fc) {
+		// FC: stop old unit, re-issue kickstart.
+		unit_stop(ctx.umgr, e->unit_name);
+		ctrl_remove(e);
+		fc_kickstart();
+	} else if (restart_or_start(e) < 0) {
+		if (schedule_retry(e) < 0)
+			disc_err("%s - failed to schedule retry",
+				 libnvmf_tid_str(e->tid));
+	}
+}
+
+static void on_fc_discovery(const struct libnvmf_tid *t,
+			    void *user_data __attribute__((unused)))
+{
+	bool is_nbft = inventory_is_nbft(ctx.inventory, t);
+
+	/*
+	 * fc_monitor_handler() is the only producer of fc_discovery
+	 * callbacks, and the kernel only fires that uevent for an FC
+	 * remote port advertising FC_PORT_ROLE_NVME_DISCOVERY - so t is
+	 * always a DC here, never an IOC. Connect as a DC; we fetch its
+	 * DLP (and discover any IOCs behind it) once the device appears.
+	 */
+	if (should_connect(t, NULL))
+		start_ctrl(t, true, is_nbft, NULL);
+}
+
+static struct libnvmf_tid *sysfs_read_tid(const char *devname, bool *is_dc)
+{
+	sd_device *dev = NULL;
+	char syspath[256];
+	struct libnvmf_tid *t;
+
+	if (is_dc)
+		*is_dc = false;
+
+	snprintf(syspath, sizeof(syspath), "/sys/class/nvme/%s", devname);
+	if (sd_device_new_from_syspath(&dev, syspath) < 0)
+		return NULL;
+
+	t = tid_from_sysfs(dev, is_dc);
+	sd_device_unref(dev);
+	return t;
+}
+
+/*
+ * Find the device name (e.g. "nvme3") of a currently-connected controller
+ * matching t, by walking sysfs directly -- the same approach
+ * sysfs_read_tid()'s callers already use, not libnvme's topology tree (see
+ * should_connect()'s comment for why that tree can't be relied on here).
+ * Returns NULL if nothing currently connected matches t. Caller frees the
+ * result.
+ */
+static char *find_devname_for_tid(const struct libnvmf_tid *t)
+{
+	DIR *d = opendir("/sys/class/nvme");
+	struct dirent *ent;
+	char *match = NULL;
+
+	if (!d)
+		return NULL;
+
+	while (!match && (ent = readdir(d))) {
+		struct libnvmf_tid *dt;
+		bool is_dc;
+
+		if (ent->d_name[0] == '.')
+			continue;
+		dt = sysfs_read_tid(ent->d_name, &is_dc);
+		if (!dt)
+			continue;
+		if (tid_same(dt, t))
+			match = strdup(ent->d_name);
+		tid_free(dt);
+	}
+	closedir(d);
+	return match;
+}
+
+static bool nvme_dev_exists(const char *devname)
+{
+	char path[256];
+	struct stat st;
+
+	snprintf(path, sizeof(path), "/sys/class/nvme/%s", devname);
+	return stat(path, &st) == 0;
+}
+
+static void startup_audit(void)
+{
+	char **devids;
+	int i;
+
+	// Phase 1: handle controllers with state files.
+	devids = state_list_ctrls();
+	if (devids) {
+		for (i = 0; devids[i]; i++) {
+			const char *devid = devids[i];
+			char *unit_name = state_read_unit(devid);
+
+			if (!unit_name) {
+				free(devids[i]);
+				continue;
+			}
+
+			if (nvme_dev_exists(devid)) {
+				// Device alive: read its TID, track it.
+				bool is_dc = false;
+				struct libnvmf_tid *t =
+					sysfs_read_tid(devid, &is_dc);
+
+				if (t) {
+					struct active_ctrl *e;
+
+					ctrl_add(unit_name, t, is_dc);
+					e = ctrl_find_by_unit(unit_name);
+					if (e)
+						e->devname = strdup(devid);
+
+					/*
+					 * An adopted DC produces no device-add
+					 * event, so warm its DLP here.
+					 * Otherwise its DLP-sourced IOCs never
+					 * enter the desired set and would not
+					 * be reconnected if they drop after a
+					 * warm restart.
+					 */
+					if (is_dc)
+						fetch_and_process_dlp(devid, t);
+
+					tid_free(t);
+				}
+			} else {
+				/*
+				 * Device gone while we were down. Reconnect
+				 * unless another orchestrator has since taken
+				 * ownership (an intentional handoff while we
+				 * were down) -- there is no TID available
+				 * here to also run the exclusion check
+				 * against, since state files don't store
+				 * transport parameters, only the registry
+				 * lookup by device name is possible.
+				 */
+				char *owner = NULL;
+				int r = libnvmf_registry_retrieve(
+						ctx.nvme_ctx, devid, "owner",
+						&owner);
+
+				if (r == -ENOENT)
+					r = 0;
+				if (r < 0) {
+					disc_warn("%s - failed to check registry owner: %s",
+						  devid, strerror(-r));
+				} else if (owner &&
+					   strcmp(owner, "discoverd") &&
+					   strcmp(owner, "nbft")) {
+					disc_info("%s - owned by '%s', not reconnecting",
+						  devid, owner);
+				} else {
+					unit_restart(ctx.umgr, unit_name);
+				}
+				free(owner);
+			}
+
+			free(unit_name);
+			free(devids[i]);
+		}
+		free(devids);
+	}
+
+	// Phase 2: find pre-existing connections without state files.
+	{
+		DIR *d = opendir("/sys/class/nvme");
+		struct dirent *ent;
+
+		if (!d)
+			return;
+
+		while ((ent = readdir(d))) {
+			const char *devname = ent->d_name;
+			char *existing_unit;
+			struct libnvmf_tid *t;
+			bool is_nbft, is_dc;
+
+			if (devname[0] == '.')
+				continue;
+			existing_unit = state_read_unit(devname);
+			if (existing_unit) {
+				free(existing_unit);
+				continue;
+			}
+
+			t = sysfs_read_tid(devname, &is_dc);
+			if (!t)
+				continue;
+
+			if (!inventory_is_desired(ctx.inventory, t)) {
+				disc_info("%s | %s - not desired, skipping",
+					  libnvmf_tid_str(t), devname);
+				tid_free(t);
+				continue;
+			}
+
+			is_nbft = inventory_is_nbft(ctx.inventory, t);
+			if (should_connect(t, devname))
+				start_ctrl(t, is_dc, is_nbft, NULL);
+			tid_free(t);
+		}
+		closedir(d);
+	}
+}
+
+static void connect_desired(void)
+{
+	struct libnvmf_tid **dcs, **iocs;
+	int i;
+
+	dcs = inventory_desired_dcs(ctx.inventory);
+	if (dcs) {
+		for (i = 0; dcs[i]; i++) {
+			bool is_nbft = inventory_is_nbft(ctx.inventory, dcs[i]);
+
+			if (should_connect(dcs[i], NULL))
+				start_ctrl(dcs[i], true, is_nbft, NULL);
+			tid_free(dcs[i]);
+		}
+		free(dcs);
+	}
+
+	iocs = inventory_desired_iocs(ctx.inventory);
+	if (iocs) {
+		for (i = 0; iocs[i]; i++) {
+			bool is_nbft =
+				inventory_is_nbft(ctx.inventory, iocs[i]);
+
+			if (should_connect(iocs[i], NULL))
+				start_ctrl(iocs[i], false, is_nbft, NULL);
+			tid_free(iocs[i]);
+		}
+		free(iocs);
+	}
+}
+
+/*
+ * Apply the effective log level to both discoverd and its in-process libnvme
+ * context. A command-line --debug (ctx.force_debug) forces DEBUG and
+ * overrides the config; otherwise the configured debug-level (default INFO)
+ * is used. Called at startup after config_load() and again after a SIGHUP
+ * reload, since the libnvme context outlives any single config.
+ */
+static void apply_log_level(void)
+{
+	int level = ctx.force_debug ? DISC_LOG_DEBUG : ctx.cfg->debug_level;
+
+	log_set_level(level);
+	libnvme_set_logging_level(ctx.nvme_ctx, level, false, false);
+}
+
+static int sighup_handler(sd_event_source *src __attribute__((unused)),
+			  const struct signalfd_siginfo *si __attribute__((unused)),
+			  void *user_data __attribute__((unused)))
+{
+	struct discoverd_config *new_cfg;
+	struct libnvmf_config *new_fabrics_cfg;
+
+	sd_notify(0, "RELOADING=1\n"
+		     "STATUS=Reloading configuration...");
+
+	new_cfg = config_load(ctx.conf_path);
+	if (!new_cfg) {
+		disc_err("failed to reload config");
+		sd_notify(0, "READY=1");
+		return 0;
+	}
+	config_free(ctx.cfg);
+	ctx.cfg = new_cfg;
+	apply_log_level();
+
+	if (libnvmf_config_read(ctx.nvme_ctx, NULL, &new_fabrics_cfg) == 0) {
+		libnvmf_config_free(ctx.fabrics_cfg);
+		ctx.fabrics_cfg = new_fabrics_cfg;
+	} else {
+		disc_err("failed to reload fabrics config, keeping last-good");
+	}
+	inventory_load_config(ctx.inventory, ctx.fabrics_cfg);
+
+	// Connect any newly added desired controllers (no disconnects).
+	connect_desired();
+
+	sd_notify(0, "READY=1");
+	return 0;
+}
+
+// Graceful shutdown: leave the event loop so main()'s cleanup runs.
+static int sigterm_handler(sd_event_source *src __attribute__((unused)),
+			   const struct signalfd_siginfo *si __attribute__((unused)),
+			   void *user_data __attribute__((unused)))
+{
+	sd_event_exit(ctx.event, 0);
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct events_callbacks callbacks = {
+		.dc_add       = on_dc_add,
+		.dc_changed   = on_dc_changed,
+		.ioc_add      = on_ioc_add,
+		.nvme_remove  = on_nvme_remove,
+		.fc_discovery = on_fc_discovery,
+	};
+	static const struct option long_opts[] = {
+		{ "config",    required_argument, NULL, 'c' },
+		{ "nvme-path", required_argument, NULL, 'N' },
+		{ "debug",     no_argument,       NULL, 'd' },
+		{ "help",      no_argument,       NULL, 'h' },
+		{ NULL, 0, NULL, 0 },
+	};
+	const char *nvme_path = NULL, *config_path = NULL;
+	char *nvme_path_abs = NULL, *config_path_abs = NULL;
+	bool debug = false;
+	sigset_t mask;
+	int r, c;
+
+	while ((c = getopt_long(argc, argv, "c:dh", long_opts, NULL)) != -1) {
+		switch (c) {
+		case 'c':
+			config_path = optarg;
+			break;
+		case 'N':
+			nvme_path = optarg;
+			break;
+		case 'd':
+			debug = true;
+			break;
+		case 'h':
+			printf("Usage: %s [OPTIONS]\n"
+			       "\n"
+			       "All options are optional; specify one only to override its default.\n"
+			       "  --config FILE, -c FILE  discoverd configuration file\n"
+			       "                          (default: " DISCOVERD_CONF_PATH ")\n"
+			       "  --nvme-path PATH        nvme binary the connection units exec\n"
+			       "                          (default: <sbindir>/nvme)\n"
+			       "  --debug, -d             enable debug logging (journal + libnvme)\n"
+			       "  --help, -h              show this help and exit\n",
+			       argv[0]);
+			return 0;
+		default:
+			fprintf(stderr, "Try '%s --help'.\n", argv[0]);
+			return 1;
+		}
+	}
+
+	if (debug)
+		log_set_level(DISC_LOG_DEBUG);
+	ctx.force_debug = debug;
+
+	/*
+	 * The nvme path is baked into each transient unit's ExecStart=, which
+	 * systemd requires to be absolute. Canonicalize it (resolving a
+	 * relative path against the current directory) so the daemon can be
+	 * launched as, e.g., --nvme-path ./.build/nvme. realpath() also
+	 * confirms the binary exists, failing fast on a typo.
+	 */
+	if (nvme_path) {
+		nvme_path_abs = realpath(nvme_path, NULL);
+		if (!nvme_path_abs) {
+			fprintf(stderr, "--nvme-path: cannot resolve '%s': %s\n",
+				nvme_path, strerror(errno));
+			return 1;
+		}
+	}
+
+	if (config_path) {
+		config_path_abs = realpath(config_path, NULL);
+		if (!config_path_abs) {
+			fprintf(stderr, "--config: cannot resolve '%s': %s\n",
+				config_path, strerror(errno));
+			return 1;
+		}
+	}
+	ctx.conf_path = config_path_abs ? config_path_abs : DISCOVERD_CONF_PATH;
+
+	r = sd_event_default(&ctx.event);
+	if (r < 0) {
+		disc_err("sd_event_default: %s", strerror(-r));
+		return 1;
+	}
+
+	r = sd_bus_open_system(&ctx.bus);
+	if (r < 0) {
+		disc_err("sd_bus_open_system: %s", strerror(-r));
+		return 1;
+	}
+
+	r = sd_bus_attach_event(ctx.bus, ctx.event, SD_EVENT_PRIORITY_NORMAL);
+	if (r < 0) {
+		disc_err("sd_bus_attach_event: %s", strerror(-r));
+		return 1;
+	}
+
+	r = state_init();
+	if (r < 0) {
+		disc_err("state_init: %s", strerror(-r));
+		return 1;
+	}
+
+	ctx.nvme_ctx = libnvme_create_global_ctx();
+	if (!ctx.nvme_ctx) {
+		disc_err("libnvme_create_global_ctx: failed");
+		return 1;
+	}
+	libnvme_set_logging_level(ctx.nvme_ctx,
+				  debug ? LIBNVME_LOG_DEBUG : LIBNVME_LOG_ERR,
+				  false, false);
+
+	ctx.cfg = config_load(ctx.conf_path);
+	if (!ctx.cfg) {
+		disc_err("config_load: failed");
+		return 1;
+	}
+	apply_log_level();
+
+	r = libnvmf_config_read(ctx.nvme_ctx, NULL, &ctx.fabrics_cfg);
+	if (r < 0) {
+		disc_err("libnvmf_config_read: %s", strerror(-r));
+		return 1;
+	}
+
+	ctx.inventory = inventory_new();
+	if (!ctx.inventory)
+		return 1;
+
+	if (ctx.cfg->nbft)
+		inventory_load_nbft(ctx.inventory, ctx.nvme_ctx);
+	inventory_load_config(ctx.inventory, ctx.fabrics_cfg);
+
+	ctx.umgr = unit_mgr_new(ctx.bus, ctx.event, on_job_done, NULL,
+				nvme_path_abs);
+	if (!ctx.umgr)
+		return 1;
+
+	ctx.evts = events_start(ctx.event, &callbacks, NULL);
+	if (!ctx.evts)
+		return 1;
+
+	// Block these from normal delivery; handle them via sd_event.
+	sigemptyset(&mask);
+	sigaddset(&mask, SIGHUP);
+	sigaddset(&mask, SIGTERM);
+	sigaddset(&mask, SIGINT);
+	sigprocmask(SIG_BLOCK, &mask, NULL);
+
+	r = sd_event_add_signal(ctx.event, NULL, SIGHUP, sighup_handler, NULL);
+	if (r < 0) {
+		disc_err("sd_event_add_signal(SIGHUP): %s", strerror(-r));
+		return 1;
+	}
+
+	// SIGTERM (systemctl stop) and SIGINT (Ctrl-C) → graceful shutdown.
+	r = sd_event_add_signal(ctx.event, NULL, SIGTERM, sigterm_handler, NULL);
+	if (r < 0) {
+		disc_err("sd_event_add_signal(SIGTERM): %s", strerror(-r));
+		return 1;
+	}
+	r = sd_event_add_signal(ctx.event, NULL, SIGINT, sigterm_handler, NULL);
+	if (r < 0) {
+		disc_err("sd_event_add_signal(SIGINT): %s", strerror(-r));
+		return 1;
+	}
+
+	// Startup: adopt existing connections, then connect the desired set.
+	startup_audit();
+	connect_desired();
+
+	/*
+	 * One-shot startup FC kickstart: mimics nvmefc-boot-connections.service
+	 * (which discoverd replaces). Always issued — fc_kickstart() is a
+	 * no-op (returns 0 on ENOENT) when no FC HBA is present, so it is
+	 * harmless on non-FC hosts. Independent of the periodic-kickstart
+	 * knob below.
+	 */
+	fc_kickstart();
+
+	// Periodic FC kickstart: opt-in (default 0 = disabled).
+	if (ctx.cfg->fc_kickstart_interval_minutes > 0) {
+		uint64_t now, interval;
+
+		interval = (uint64_t)ctx.cfg->fc_kickstart_interval_minutes *
+			   60 * UINT64_C(1000000);
+		r = sd_event_now(ctx.event, CLOCK_BOOTTIME, &now);
+		if (r >= 0)
+			r = sd_event_add_time(ctx.event, NULL, CLOCK_BOOTTIME,
+					      now + interval, 0,
+					      fc_kickstart_timeout, NULL);
+		if (r < 0)
+			disc_err("failed to arm FC kickstart timer: %s",
+				 strerror(-r));
+	}
+
+	sd_notify(0, "READY=1");
+
+	r = sd_event_loop(ctx.event);
+	if (r < 0)
+		disc_err("sd_event_loop: %s", strerror(-r));
+
+	events_stop(ctx.evts);
+	unit_mgr_free(ctx.umgr);
+	free(nvme_path_abs);
+	free(config_path_abs);
+	inventory_free(ctx.inventory);
+	config_free(ctx.cfg);
+	libnvmf_config_free(ctx.fabrics_cfg);
+	libnvme_free_global_ctx(ctx.nvme_ctx);
+	sd_bus_unref(ctx.bus);
+	sd_event_unref(ctx.event);
+
+	return r < 0 ? 1 : 0;
+}

--- a/discoverd/src/state.c
+++ b/discoverd/src/state.c
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array-util.h>
+#include <fs-util.h>
+
+#include "state.h"
+
+/*
+ * Manages discoverd's runtime state files under RUNDIR/nvme/discoverd/ (see
+ * the layout comment in state.h) - the on-disk link between a kernel device
+ * name (nvmeX), the systemd transient unit that owns it, and the .devid
+ * file nvme connect writes back so ExecStop= can find the device to
+ * disconnect. No TID/transport data is stored here; that is read from
+ * sysfs or re-derived from the unit itself.
+ */
+
+int state_init(void)
+{
+	int ret;
+
+	ret = shr_mkdir_p(STATE_UNITS_DIR, 0755);
+	if (ret)
+		return ret;
+
+	return shr_mkdir_p(STATE_CTRLS_DIR, 0755);
+}
+
+char *state_read_unit(const char *devid)
+{
+	char path[512];
+	char buf[256];
+	FILE *f;
+	char *ret;
+
+	snprintf(path, sizeof(path), STATE_CTRLS_DIR "/%s/unit", devid);
+	f = fopen(path, "r");
+	if (!f)
+		return NULL;
+
+	if (!fgets(buf, sizeof(buf), f)) {
+		fclose(f);
+		return NULL;
+	}
+	fclose(f);
+
+	ret = strdup(buf);
+	if (ret) {
+		char *nl = strchr(ret, '\n');
+
+		if (nl)
+			*nl = '\0';
+	}
+	return ret;
+}
+
+void state_remove_ctrl(const char *devid)
+{
+	char path[512];
+
+	snprintf(path, sizeof(path), STATE_CTRLS_DIR "/%s/unit", devid);
+	unlink(path);
+	snprintf(path, sizeof(path), STATE_CTRLS_DIR "/%s", devid);
+	rmdir(path);
+}
+
+void state_remove_devid(const char *unit_name)
+{
+	char base[256];
+	char path[512];
+	char *dot;
+
+	/* The .devid file is named after %N (unit name without .service). */
+	snprintf(base, sizeof(base), "%s", unit_name);
+	dot = strrchr(base, '.');
+	if (dot && !strcmp(dot, ".service"))
+		*dot = '\0';
+
+	snprintf(path, sizeof(path), STATE_UNITS_DIR "/%s.devid", base);
+	unlink(path);
+}
+
+/*
+ * List every devid (e.g. "nvme3") that currently has a state directory
+ * under STATE_CTRLS_DIR - i.e. every controller discoverd believes it
+ * owns a transient unit for, regardless of whether the kernel device
+ * still exists right now. Used by the startup audit to reconcile that
+ * belief against what is actually present in sysfs: a devid that no
+ * longer exists means the device dropped while discoverd was down and
+ * needs reconnecting; a devid that does exist is simply adopted.
+ *
+ * Returns a NULL-terminated array of strdup'd devid strings (caller
+ * frees each entry and the array itself), an empty (non-NULL,
+ * single NULL-terminator) array if the directory exists but is empty,
+ * or NULL if STATE_CTRLS_DIR itself could not be opened or on
+ * allocation failure.
+ */
+SHR_PTRARRAY_DEFINE(str_list, char);
+
+char **state_list_ctrls(void)
+{
+	DIR *d;
+	struct dirent *ent;
+	struct str_list a = { 0 };
+	bool ok = true;
+	size_t i;
+
+	d = opendir(STATE_CTRLS_DIR);
+	if (!d)
+		return NULL;
+
+	while ((ent = readdir(d))) {
+		char *name;
+
+		if (ent->d_name[0] == '.')
+			continue;
+		name = strdup(ent->d_name);
+		if (!name || str_list_append(&a, name) < 0) {
+			free(name);
+			ok = false;
+			break;
+		}
+	}
+	closedir(d);
+
+	if (ok && str_list_append(&a, NULL) < 0)
+		ok = false;
+
+	if (ok)
+		return a.items;
+
+	for (i = 0; i < a.len; i++)
+		free(a.items[i]);
+	str_list_free(&a);
+	return NULL;
+}

--- a/discoverd/src/state.h
+++ b/discoverd/src/state.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+/*
+ * State file management.
+ *
+ * Layout:
+ *   RUNDIR/nvme/discoverd/
+ *     units/<unit-name>.devid      — kernel device name written by nvme connect
+ *     controllers/<devid>/unit     — transient unit name for this controller
+ */
+
+#define STATE_RUN_DIR    RUNDIR "/nvme/discoverd"
+#define STATE_UNITS_DIR  STATE_RUN_DIR "/units"
+#define STATE_CTRLS_DIR  STATE_RUN_DIR "/controllers"
+
+/* Ensure the runtime directories exist. Call once at startup. */
+int state_init(void);
+
+/*
+ * Read the unit name from a controller's state directory.
+ * Returns an allocated string or NULL. Caller must free.
+ */
+char *state_read_unit(const char *devid);
+
+/*
+ * Remove a controller's state directory. Called by discoverd when the
+ * device is removed and the unit was cleaned up by ExecStopPost= (as
+ * belt-and-suspenders in case ExecStopPost= did not run).
+ */
+void state_remove_ctrl(const char *devid);
+
+/*
+ * Remove a unit's .devid file (units/<%N>.devid). The ".service" suffix
+ * is stripped from @unit_name to match the systemd %N specifier used to
+ * name it. Called from the KOBJ_REMOVE handler — ExecStopPost= normally
+ * removes it, but the kernel-removal path tears the controller down
+ * directly.
+ */
+void state_remove_devid(const char *unit_name);
+
+/*
+ * Enumerate all device IDs that have a state directory.
+ * Returns a NULL-terminated array of strings; caller must free each and
+ * the array itself. Returns NULL on error.
+ */
+char **state_list_ctrls(void);

--- a/discoverd/src/tid.c
+++ b/discoverd/src/tid.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <nvme/fabrics.h>
+
+#include "tid.h"
+
+struct libnvmf_tid *tid_new(const char *transport, const char *traddr,
+			    const char *trsvcid, const char *subsysnqn,
+			    const char *host_traddr, const char *host_iface,
+			    const char *hostnqn, bool is_dc)
+{
+	if (!trsvcid || trsvcid[0] == '\0')
+		trsvcid = libnvmf_get_default_trsvcid(transport, is_dc);
+
+	return libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
+				       host_traddr, host_iface, hostnqn, NULL);
+}
+
+/*
+ * FNV-1a 64-bit over a byte range. libnvme has its own internal copy
+ * (libnvmf_fnv1a_64() in util-fabrics.c) but it is not part of the public
+ * API, so discoverd carries this short, dependency-free copy of the same
+ * well-known algorithm rather than reaching into libnvme's private headers.
+ */
+static uint64_t fnv1a_64(const void *buf, size_t len)
+{
+	const unsigned char *p = buf;
+	uint64_t hash = 14695981039346656037ULL;
+	size_t i;
+
+	for (i = 0; i < len; i++) {
+		hash ^= p[i];
+		hash *= 1099511628211ULL;
+	}
+	return hash;
+}
+
+char *tid_unit_name(const struct libnvmf_tid *t)
+{
+	const char *canon = libnvmf_tid_get_canonical(t);
+	uint64_t hash;
+	char *name;
+
+	if (!canon)
+		return NULL;
+
+	/* Truncate to 48 bits (12 hex chars) — see tid.h. */
+	hash = fnv1a_64(canon, strlen(canon)) & 0xffffffffffffULL;
+
+	if (asprintf(&name, "nvme-discoverd-%012" PRIx64 ".service", hash) < 0)
+		return NULL;
+	return name;
+}

--- a/discoverd/src/tid.h
+++ b/discoverd/src/tid.h
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+
+#include <nvme/accessors-fabrics.h>
+#include <nvme/tid.h>
+
+#include <string-util.h>
+
+/*
+ * tid_new() - allocate a TID from individual field strings.
+ *
+ * Thin wrapper around libnvmf_tid_from_fields() that fills in trsvcid when
+ * the caller does not have one: if trsvcid is NULL or empty, it is set via
+ * libnvmf_get_default_trsvcid(transport, is_dc) - the caller must say
+ * whether this TID is a DC or an IOC, since the well-known port differs by
+ * role for at least NVMe/TCP (8009 vs 4420).
+ *
+ * Returns NULL if traddr/host_traddr is not numeric on an IP transport, or
+ * on allocation failure (same as libnvmf_tid_from_fields()).
+ */
+struct libnvmf_tid *tid_new(const char *transport, const char *traddr,
+			    const char *trsvcid, const char *subsysnqn,
+			    const char *host_traddr, const char *host_iface,
+			    const char *hostnqn, bool is_dc);
+
+/* tid_free() - release a TID (delegates to libnvmf_tid_free). */
+static inline void tid_free(struct libnvmf_tid *t)
+{
+	libnvmf_tid_free(t);
+}
+
+/*
+ * tid_same() - are two TIDs the same connection?
+ *
+ * Byte-comparison of libnvmf_tid_get_canonical(). Correct here because every
+ * TID discoverd compares is discoverd-built (sanitized/canonicalized by the
+ * same constructors), so canonical-string equality is byte-reproducible for
+ * this single producer. Do not reach for a sysfs connection-identity
+ * matcher instead - that answers "is this live kernel connection the same",
+ * a different question; this compares candidate TIDs from one producer
+ * (NBFT, config, or a Discovery Log Page).
+ */
+static inline bool tid_same(const struct libnvmf_tid *a,
+			    const struct libnvmf_tid *b)
+{
+	return shr_streq0(libnvmf_tid_get_canonical(a),
+			 libnvmf_tid_get_canonical(b));
+}
+
+/*
+ * tid_unit_name() - systemd unit name for a TID.
+ * Returns "nvme-discoverd-<12 hex chars>.service", the FNV-1a-64 hash of
+ * libnvmf_tid_get_canonical() truncated to 48 bits. Caller must free the
+ * returned string.
+ */
+char *tid_unit_name(const struct libnvmf_tid *t);

--- a/discoverd/src/units.c
+++ b/discoverd/src/units.c
@@ -1,0 +1,750 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <systemd/sd-bus.h>
+
+#include <ccan/array_size/array_size.h>
+#include <ccan/list/list.h>
+
+#include "log.h"
+#include "state.h"
+#include "units.h"
+
+/*
+ * NVME_PATH is the absolute path to the nvme binary the transient units exec.
+ * The build system supplies it from <sbindir>/nvme (see discoverd/meson.build)
+ * rather than hardcoding it here.  It is the default; the --nvme-path command
+ * line option overrides it (e.g. to run the daemon from a build tree), plumbed
+ * through unit_mgr->nvme_path.
+ */
+#ifndef NVME_PATH
+#error "NVME_PATH must be defined by the build system (<sbindir>/nvme)"
+#endif
+
+#define SH_PATH         "/bin/sh"
+
+/*
+ * systemd does NOT expand specifiers (%t, %N, %n) in a transient unit's Exec
+ * arguments passed over the D-Bus StartTransientUnit API — that expansion only
+ * happens when parsing a unit *file*.  So discoverd substitutes the real values
+ * itself when building each unit: the runtime directory (/run, via the STATE_*
+ * paths in state.h) and the unit name.  The per-unit devid file is
+ * STATE_UNITS_DIR/<unit-name-without-.service>.devid; the connect writes the
+ * kernel device name into it and the ExecStartPost/ExecStop/ExecStopPost shell
+ * commands (built in build_start_transient) read it back.
+ */
+static int unit_devid_path(char *buf, size_t len, const char *unit_name)
+{
+	static const char suffix[] = ".service";
+	size_t slen = sizeof(suffix) - 1;
+	size_t n = strlen(unit_name);
+
+	if (n > slen && !strcmp(unit_name + n - slen, suffix))
+		n -= slen;
+
+	return snprintf(buf, len, STATE_UNITS_DIR "/%.*s.devid",
+			(int)n, unit_name);
+}
+
+/* Tracked pending systemd job. */
+struct pending_job {
+	struct list_node entry;
+	char *job_path;
+	char *unit_name;
+};
+
+struct unit_mgr {
+	sd_bus *bus;
+	sd_event *event;
+	unit_job_callback callback;
+	void *user_data;
+	struct list_head jobs;
+	sd_bus_slot *job_removed_slot;
+	/* nvme binary the transient units exec; borrowed (lives for argv's life). */
+	const char *nvme_path;
+};
+
+/*
+ * These functions append a single (name, sv) struct to an already-open
+ * container of type a(sv).
+ */
+
+static int append_string_prop(sd_bus_message *m, const char *name,
+			       const char *val)
+{
+	int r;
+
+	r = sd_bus_message_open_container(m, 'r', "sv");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 's', name);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'v', "s");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 's', val);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_close_container(m);
+	if (r < 0)
+		return r;
+	return sd_bus_message_close_container(m);
+}
+
+static int append_bool_prop(sd_bus_message *m, const char *name, bool val)
+{
+	int bv = val ? 1 : 0;
+	int r;
+
+	r = sd_bus_message_open_container(m, 'r', "sv");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 's', name);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'v', "b");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 'b', &bv);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_close_container(m);
+	if (r < 0)
+		return r;
+	return sd_bus_message_close_container(m);
+}
+
+static int append_uint64_prop(sd_bus_message *m, const char *name,
+			       uint64_t val)
+{
+	int r;
+
+	r = sd_bus_message_open_container(m, 'r', "sv");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 's', name);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'v', "t");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 't', &val);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_close_container(m);
+	if (r < 0)
+		return r;
+	return sd_bus_message_close_container(m);
+}
+
+/* Append a string-array property: (name, a(s)). */
+static int append_strv_prop(sd_bus_message *m, const char *name,
+			     const char *const *strv)
+{
+	int r;
+
+	r = sd_bus_message_open_container(m, 'r', "sv");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 's', name);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'v', "as");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'a', "s");
+	if (r < 0)
+		return r;
+	for (; *strv; strv++) {
+		r = sd_bus_message_append_basic(m, 's', *strv);
+		if (r < 0)
+			return r;
+	}
+	r = sd_bus_message_close_container(m);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_close_container(m);
+	if (r < 0)
+		return r;
+	return sd_bus_message_close_container(m);
+}
+
+/*
+ * Append an exec property (ExecStart, ExecStop, etc.) with a single entry.
+ * argv[0] must be the executable path; argv is NULL-terminated.
+ * ignore=true means non-zero exit is acceptable (the `-` prefix).
+ */
+static int append_exec_prop(sd_bus_message *m, const char *name,
+			     const char **argv, bool ignore)
+{
+	int bv = ignore ? 1 : 0;
+	int r;
+
+	r = sd_bus_message_open_container(m, 'r', "sv");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 's', name);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'v', "a(sasb)");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'a', "(sasb)");
+	if (r < 0)
+		return r;
+
+	r = sd_bus_message_open_container(m, 'r', "sasb");
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 's', argv[0]);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_open_container(m, 'a', "s");
+	if (r < 0)
+		return r;
+	for (const char **a = argv; *a; a++) {
+		r = sd_bus_message_append_basic(m, 's', *a);
+		if (r < 0)
+			return r;
+	}
+	r = sd_bus_message_close_container(m); // as
+	if (r < 0)
+		return r;
+	r = sd_bus_message_append_basic(m, 'b', &bv);
+	if (r < 0)
+		return r;
+	r = sd_bus_message_close_container(m); // r sasb
+	if (r < 0)
+		return r;
+
+	r = sd_bus_message_close_container(m); // a(sasb)
+	if (r < 0)
+		return r;
+	r = sd_bus_message_close_container(m); // v
+	if (r < 0)
+		return r;
+	return sd_bus_message_close_container(m); // r sv
+}
+
+/* Append a shell-command exec property with ignore=true. */
+static int append_shell_exec_prop(sd_bus_message *m, const char *name,
+				   const char *cmd)
+{
+	const char *argv[] = { SH_PATH, "-c", cmd, NULL };
+
+	return append_exec_prop(m, name, argv, true);
+}
+
+static int track_job(struct unit_mgr *mgr, const char *job_path,
+		     const char *unit_name)
+{
+	struct pending_job *j;
+
+	j = calloc(1, sizeof(*j));
+	if (!j)
+		return -ENOMEM;
+	j->job_path = strdup(job_path);
+	j->unit_name = strdup(unit_name);
+	if (!j->job_path || !j->unit_name) {
+		free(j->job_path);
+		free(j->unit_name);
+		free(j);
+		return -ENOMEM;
+	}
+	list_add(&mgr->jobs, &j->entry);
+	return 0;
+}
+
+static int job_removed_handler(sd_bus_message *m, void *user_data,
+				sd_bus_error *ret_err __attribute__((unused)))
+{
+	struct unit_mgr *mgr = user_data;
+	struct pending_job *e;
+	uint32_t id;
+	const char *job_path, *unit_name, *result;
+	int r;
+
+	r = sd_bus_message_read(m, "uoss", &id, &job_path, &unit_name, &result);
+	if (r < 0)
+		return 0;
+
+	list_for_each(&mgr->jobs, e, entry) {
+		if (!streq(e->job_path, job_path))
+			continue;
+
+		list_del_init(&e->entry);
+		if (mgr->callback)
+			mgr->callback(e->unit_name,
+				   streq(result, "done"),
+				   mgr->user_data);
+		free(e->job_path);
+		free(e->unit_name);
+		free(e);
+		return 0;
+	}
+	return 0;
+}
+
+struct unit_mgr *unit_mgr_new(sd_bus *bus, sd_event *event,
+			       unit_job_callback callback, void *user_data,
+			       const char *nvme_path)
+{
+	struct unit_mgr *mgr;
+	int r;
+
+	mgr = calloc(1, sizeof(*mgr));
+	if (!mgr)
+		return NULL;
+
+	mgr->bus = bus;
+	mgr->event = event;
+	mgr->callback = callback;
+	mgr->user_data = user_data;
+	mgr->nvme_path = (nvme_path && *nvme_path) ? nvme_path : NVME_PATH;
+	list_head_init(&mgr->jobs);
+
+	/*
+	 * Subscribe to JobRemoved before any units are created.  The bus must
+	 * already be attached to the event loop (sd_bus_attach_event) by the
+	 * caller so that the signal is dispatched through the event loop.
+	 */
+	r = sd_bus_match_signal(bus, &mgr->job_removed_slot,
+				SYSTEMD_BUS_NAME, SYSTEMD_OBJ_PATH,
+				SYSTEMD_MGR_IFACE, "JobRemoved",
+				job_removed_handler, mgr);
+	if (r < 0) {
+		disc_err("sd_bus_match_signal(JobRemoved): %s", strerror(-r));
+		free(mgr);
+		return NULL;
+	}
+
+	return mgr;
+}
+
+void unit_mgr_free(struct unit_mgr *mgr)
+{
+	struct pending_job *e, *next;
+
+	if (!mgr)
+		return;
+	sd_bus_slot_unref(mgr->job_removed_slot);
+	list_for_each_safe(&mgr->jobs, e, next, entry) {
+		free(e->job_path);
+		free(e->unit_name);
+		free(e);
+	}
+	free(mgr);
+}
+
+/*
+ * Internal: call StartTransientUnit and track the returned job.
+ *
+ * Caller has built the message up through the properties array and must
+ * close the properties array container and the aux array before calling.
+ * We call sd_bus_call() synchronously — StartTransientUnit only enqueues a
+ * systemd job; the actual nvme-connect subprocess is managed by systemd and
+ * reports back via JobRemoved.
+ */
+static int do_start_transient(struct unit_mgr *mgr, sd_bus_message *msg,
+			       const char *unit_name)
+{
+	sd_bus_error err = SD_BUS_ERROR_NULL;
+	sd_bus_message *reply = NULL;
+	const char *job_path;
+	int r;
+
+	r = sd_bus_call(mgr->bus, msg, 0, &err, &reply);
+	if (r < 0) {
+		disc_err("StartTransientUnit(%s): %s",
+			 unit_name, err.message ?: strerror(-r));
+		sd_bus_error_free(&err);
+		return r;
+	}
+
+	r = sd_bus_message_read(reply, "o", &job_path);
+	if (r < 0)
+		goto out;
+
+	r = track_job(mgr, job_path, unit_name);
+out:
+	sd_bus_message_unref(reply);
+	return r;
+}
+
+/*
+ * Build a StartTransientUnit message for an nvme connect unit.
+ *
+ * connect_argv is a NULL-terminated argv starting at the nvme binary path.
+ * desc is the Description= value.
+ * is_fc determines whether After=network.target is added.
+ */
+static int build_start_transient(struct unit_mgr *mgr, const char *unit_name,
+				  const char *devid_path, const char *desc,
+				  bool is_fc, const char **connect_argv,
+				  sd_bus_message **out)
+{
+	sd_bus_message *m = NULL;
+	int r;
+
+	r = sd_bus_message_new_method_call(mgr->bus, &m,
+					   SYSTEMD_BUS_NAME,
+					   SYSTEMD_OBJ_PATH,
+					   SYSTEMD_MGR_IFACE,
+					   "StartTransientUnit");
+	if (r < 0)
+		return r;
+
+	/* Name and mode. */
+	r = sd_bus_message_append(m, "ss", unit_name, "replace");
+	if (r < 0)
+		goto err;
+
+	/* Open the properties array a(sv). */
+	r = sd_bus_message_open_container(m, 'a', "(sv)");
+	if (r < 0)
+		goto err;
+
+	r = append_string_prop(m, "Type", "oneshot");
+	if (r < 0)
+		goto err;
+	r = append_bool_prop(m, "RemainAfterExit", true);
+	if (r < 0)
+		goto err;
+	r = append_string_prop(m, "Description", desc);
+	if (r < 0)
+		goto err;
+	r = append_string_prop(m, "CollectMode", "inactive-or-failed");
+	if (r < 0)
+		goto err;
+	r = append_uint64_prop(m, "TimeoutStopUSec",
+			       DISCONNECT_TIMEOUT_SEC * UINT64_C(1000000));
+	if (r < 0)
+		goto err;
+
+	/* Ordering: Before=nvme-discoverd.service always. */
+	{
+		static const char *const before[] = { "nvme-discoverd.service", NULL };
+
+		r = append_strv_prop(m, "Before", before);
+		if (r < 0)
+			goto err;
+	}
+
+	/* After=network.target for TCP/RDMA (omit for FC). */
+	if (!is_fc) {
+		static const char *const after[] = { "network.target", NULL };
+
+		r = append_strv_prop(m, "After", after);
+		if (r < 0)
+			goto err;
+	}
+
+	r = append_exec_prop(m, "ExecStart", connect_argv, false);
+	if (r < 0)
+		goto err;
+
+	/*
+	 * Build the post/stop shell commands with the real devid path, state
+	 * directory and unit name substituted (systemd does not expand %t/%N/%n
+	 * here — see unit_devid_path()).  The nvme path in ExecStop is
+	 * double-quoted to tolerate spaces.
+	 */
+	{
+		char exec_start_post[512];
+		char exec_stop[PATH_MAX + 512];
+		char exec_stop_post[512];
+		int n1, n2, n3;
+
+		n1 = snprintf(exec_start_post, sizeof(exec_start_post),
+			      "DEV=$(cat %s 2>/dev/null) && "
+			      "mkdir -p %s/$DEV && "
+			      "echo %s > %s/$DEV/unit",
+			      devid_path, STATE_CTRLS_DIR,
+			      unit_name, STATE_CTRLS_DIR);
+
+		n2 = snprintf(exec_stop, sizeof(exec_stop),
+			      "DEV=$(cat %s 2>/dev/null); "
+			      "[ -n \"$DEV\" ] && "
+			      "[ \"$(cat %s/$DEV/unit 2>/dev/null)\" = \"%s\" ] && "
+			      "\"%s\" disconnect -d $DEV",
+			      devid_path, STATE_CTRLS_DIR, unit_name,
+			      mgr->nvme_path);
+
+		n3 = snprintf(exec_stop_post, sizeof(exec_stop_post),
+			      "DEV=$(cat %s 2>/dev/null); "
+			      "rm -f %s; "
+			      "[ -n \"$DEV\" ] && "
+			      "[ \"$(cat %s/$DEV/unit 2>/dev/null)\" = \"%s\" ] && "
+			      "rm -rf %s/$DEV",
+			      devid_path, devid_path, STATE_CTRLS_DIR,
+			      unit_name, STATE_CTRLS_DIR);
+
+		if (n1 < 0 || n1 >= (int)sizeof(exec_start_post) ||
+		    n2 < 0 || n2 >= (int)sizeof(exec_stop) ||
+		    n3 < 0 || n3 >= (int)sizeof(exec_stop_post)) {
+			r = -ENAMETOOLONG;
+			goto err;
+		}
+
+		r = append_shell_exec_prop(m, "ExecStartPost", exec_start_post);
+		if (r < 0)
+			goto err;
+		r = append_shell_exec_prop(m, "ExecStop", exec_stop);
+		if (r < 0)
+			goto err;
+		r = append_shell_exec_prop(m, "ExecStopPost", exec_stop_post);
+		if (r < 0)
+			goto err;
+	}
+
+	r = sd_bus_message_close_container(m); // a(sv)
+	if (r < 0)
+		goto err;
+
+	/* Empty auxiliary units array. */
+	r = sd_bus_message_open_container(m, 'a', "(sa(sv))");
+	if (r < 0)
+		goto err;
+	r = sd_bus_message_close_container(m);
+	if (r < 0)
+		goto err;
+
+	*out = m;
+	return 0;
+err:
+	sd_bus_message_unref(m);
+	return r;
+}
+
+/*
+ * Build the nvme-connect argv into s->argv[] and return it.
+ * @params: resolved connect parameters to emit (kato, ctrl-loss-tmo, tls, …).
+ * is_nbft: use --owner=nbft; otherwise --owner=discoverd.
+ * Strings are formatted into the provided scratch buffers (in the struct);
+ * the TID fields and params share the extra[] pool.
+ */
+#define MAX_EXTRA_ARGS 40
+struct connect_scratch {
+	char owner[32];
+	char devid_arg[160];
+	char extra[MAX_EXTRA_ARGS][320]; // TID fields + resolved params
+	int n_extra;
+	const char *argv[8 + MAX_EXTRA_ARGS];
+};
+
+/*
+ * libnvmf_connect_args_emit() callback: copy one formatted option into the
+ * extra[] pool.
+ */
+struct emit_ctx {
+	struct connect_scratch *s;
+	int *argc;
+};
+
+static void emit_arg(const char *arg, void *user_data)
+{
+	struct emit_ctx *e = user_data;
+	struct connect_scratch *s = e->s;
+
+	if (s->n_extra >= MAX_EXTRA_ARGS ||
+	    *e->argc >= (int)ARRAY_SIZE(s->argv) - 4)
+		return; // leave room for --idempotent, owner, devid-file, NULL
+	snprintf(s->extra[s->n_extra], sizeof(s->extra[0]), "%s", arg);
+	s->argv[(*e->argc)++] = s->extra[s->n_extra++];
+}
+
+static int build_connect_argv(const char *nvme_bin, const char *devid_path,
+			       const struct libnvmf_tid *t,
+			       const struct libnvmf_params *params,
+			       bool is_nbft, struct connect_scratch *s)
+{
+	struct emit_ctx ec;
+	int i = 0;
+	int r;
+
+	s->argv[i++] = nvme_bin;
+	s->argv[i++] = "connect";
+
+	/*
+	 * libnvmf_connect_args_emit() renders the TID's addressing/identity
+	 * fields and the resolved parameters as "nvme connect" options, in
+	 * that order; discoverd only appends the connect-manager-private
+	 * options below (--idempotent, --owner, --devid-file).
+	 */
+	ec.s = s;
+	ec.argc = &i;
+	r = libnvmf_connect_args_emit(t, params, emit_arg, &ec);
+	if (r < 0)
+		return r;
+
+	s->argv[i++] = "--idempotent";
+	snprintf(s->owner, sizeof(s->owner), "--owner=%s",
+		 is_nbft ? "nbft" : "discoverd");
+	s->argv[i++] = s->owner;
+	snprintf(s->devid_arg, sizeof(s->devid_arg), "--devid-file=%s",
+		 devid_path);
+	s->argv[i++] = s->devid_arg;
+	s->argv[i] = NULL;
+
+	return 0;
+}
+
+int unit_start_dc(struct unit_mgr *mgr, const struct libnvmf_tid *t,
+		  const struct libnvmf_params *params, bool is_nbft)
+{
+	struct connect_scratch scratch = { };
+	char desc[320];
+	char devid_path[128];
+	char *unit_name;
+	sd_bus_message *m = NULL;
+	const char *subsysnqn = libnvmf_tid_get_subsysnqn(t);
+	const char *transport = libnvmf_tid_get_transport(t);
+	const char *traddr = libnvmf_tid_get_traddr(t);
+	const char *trsvcid = libnvmf_tid_get_trsvcid(t);
+	bool is_fc;
+	int r;
+
+	unit_name = tid_unit_name(t);
+	if (!unit_name)
+		return -ENOMEM;
+
+	unit_devid_path(devid_path, sizeof(devid_path), unit_name);
+
+	r = build_connect_argv(mgr->nvme_path, devid_path, t, params, is_nbft,
+			       &scratch);
+	if (r < 0)
+		goto out;
+
+	snprintf(desc, sizeof(desc),
+		 "NVMe Discovery Controller %s @ %s:%s",
+		 subsysnqn, traddr, trsvcid ? trsvcid : "none");
+
+	is_fc = shr_streq0(transport, "fc");
+
+	r = build_start_transient(mgr, unit_name, devid_path, desc, is_fc,
+				   scratch.argv, &m);
+	if (r < 0)
+		goto out;
+
+	r = do_start_transient(mgr, m, unit_name);
+	sd_bus_message_unref(m);
+out:
+	free(unit_name);
+	return r;
+}
+
+int unit_start_ioc(struct unit_mgr *mgr, const struct libnvmf_tid *t,
+		   const struct libnvmf_params *params, bool is_nbft)
+{
+	struct connect_scratch scratch = { };
+	char desc[320];
+	char devid_path[128];
+	char *unit_name;
+	sd_bus_message *m = NULL;
+	const char *subsysnqn = libnvmf_tid_get_subsysnqn(t);
+	const char *transport = libnvmf_tid_get_transport(t);
+	const char *traddr = libnvmf_tid_get_traddr(t);
+	const char *trsvcid = libnvmf_tid_get_trsvcid(t);
+	bool is_fc;
+	int r;
+
+	unit_name = tid_unit_name(t);
+	if (!unit_name)
+		return -ENOMEM;
+
+	unit_devid_path(devid_path, sizeof(devid_path), unit_name);
+
+	r = build_connect_argv(mgr->nvme_path, devid_path, t, params, is_nbft,
+			       &scratch);
+	if (r < 0)
+		goto out;
+
+	snprintf(desc, sizeof(desc),
+		 "NVMe I/O Controller %s @ %s:%s",
+		 subsysnqn, traddr, trsvcid ? trsvcid : "none");
+
+	is_fc = shr_streq0(transport, "fc");
+
+	r = build_start_transient(mgr, unit_name, devid_path, desc, is_fc,
+				   scratch.argv, &m);
+	if (r < 0)
+		goto out;
+
+	r = do_start_transient(mgr, m, unit_name);
+	sd_bus_message_unref(m);
+out:
+	free(unit_name);
+	return r;
+}
+
+int unit_restart(struct unit_mgr *mgr, const char *unit_name)
+{
+	sd_bus_error err = SD_BUS_ERROR_NULL;
+	sd_bus_message *reply = NULL;
+	const char *job_path;
+	int r;
+
+	r = sd_bus_call_method(mgr->bus,
+			       SYSTEMD_BUS_NAME, SYSTEMD_OBJ_PATH,
+			       SYSTEMD_MGR_IFACE, "RestartUnit",
+			       &err, &reply, "ss", unit_name, "replace");
+	if (r < 0) {
+		disc_err("RestartUnit(%s): %s",
+			 unit_name, err.message ?: strerror(-r));
+		sd_bus_error_free(&err);
+		return r;
+	}
+
+	r = sd_bus_message_read(reply, "o", &job_path);
+	if (r >= 0)
+		track_job(mgr, job_path, unit_name);
+
+	sd_bus_message_unref(reply);
+	return r < 0 ? r : 0;
+}
+
+int unit_stop(struct unit_mgr *mgr, const char *unit_name)
+{
+	sd_bus_error err = SD_BUS_ERROR_NULL;
+	int r;
+
+	r = sd_bus_call_method(mgr->bus,
+			       SYSTEMD_BUS_NAME, SYSTEMD_OBJ_PATH,
+			       SYSTEMD_MGR_IFACE, "StopUnit",
+			       &err, NULL, "ss", unit_name, "replace");
+	if (r < 0) {
+		disc_err("StopUnit(%s): %s",
+			 unit_name, err.message ?: strerror(-r));
+		sd_bus_error_free(&err);
+	}
+	return r;
+}
+
+int unit_reset_failed(struct unit_mgr *mgr, const char *unit_name)
+{
+	sd_bus_error err = SD_BUS_ERROR_NULL;
+	int r;
+
+	r = sd_bus_call_method(mgr->bus,
+			       SYSTEMD_BUS_NAME, SYSTEMD_OBJ_PATH,
+			       SYSTEMD_MGR_IFACE, "ResetFailedUnit",
+			       &err, NULL, "s", unit_name);
+	if (r < 0) {
+		disc_err("ResetFailedUnit(%s): %s",
+			 unit_name, err.message ?: strerror(-r));
+		sd_bus_error_free(&err);
+	}
+	return r;
+}

--- a/discoverd/src/units.h
+++ b/discoverd/src/units.h
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <systemd/sd-bus.h>
+#include <systemd/sd-event.h>
+
+#include <nvme/config.h>
+
+#include "tid.h"
+
+/*
+ * Bound on how long systemd waits for ExecStop= (nvme disconnect) before it
+ * SIGTERMs the job.  This must exceed realistic disconnect time, not undershoot
+ * it: a healthy disconnect can take 30-40 s on large configs (~200 namespaces,
+ * 8 paths, 80 CPUs) and longer still beyond that, so too low a bound would kill
+ * a disconnect that is still making progress and leave the controller
+ * half-torn-down.  Generous default; this should become a discoverd.conf knob
+ * so large deployments can raise it further.
+ */
+#define DISCONNECT_TIMEOUT_SEC 300
+
+/* systemd D-Bus destination and path. */
+#define SYSTEMD_BUS_NAME  "org.freedesktop.systemd1"
+#define SYSTEMD_OBJ_PATH  "/org/freedesktop/systemd1"
+#define SYSTEMD_MGR_IFACE "org.freedesktop.systemd1.Manager"
+
+/* Result of a StartTransient / RestartUnit / StopUnit job. */
+typedef void (*unit_job_callback)(const char *unit_name,
+			       bool success, void *user_data);
+
+struct unit_mgr;
+
+/*
+ * Create a unit manager.  Attaches to the given sd_bus connection and
+ * sd_event loop.  unit_job_callback is called for every JobRemoved signal.
+ * nvme_path is the nvme binary the transient units exec; NULL or "" selects the
+ * build-time default (NVME_PATH).  The string is borrowed, not copied, so it
+ * must outlive the unit manager (e.g. a pointer into argv).
+ */
+struct unit_mgr *unit_mgr_new(sd_bus *bus, sd_event *event,
+			      unit_job_callback callback, void *user_data,
+			      const char *nvme_path);
+void unit_mgr_free(struct unit_mgr *mgr);
+
+/*
+ * Create a transient DC connection unit.  @params carries the resolved
+ * connect parameters to emit (may be NULL for none) — see
+ * libnvmf_connect_args_emit() in <nvme/config.h>.
+ * If is_nbft is true, uses --owner nbft; otherwise --owner discoverd.
+ */
+int unit_start_dc(struct unit_mgr *mgr, const struct libnvmf_tid *t,
+		  const struct libnvmf_params *params, bool is_nbft);
+
+/*
+ * Create a transient IOC connection unit.  @params carries the resolved
+ * connect parameters to emit (may be NULL for none).
+ */
+int unit_start_ioc(struct unit_mgr *mgr, const struct libnvmf_tid *t,
+		   const struct libnvmf_params *params, bool is_nbft);
+
+/* Restart an existing unit (reconnect with baked-in parameters). */
+int unit_restart(struct unit_mgr *mgr, const char *unit_name);
+
+/* Stop a unit (triggers ExecStop= disconnect). */
+int unit_stop(struct unit_mgr *mgr, const char *unit_name);
+
+/* Reset a failed unit so it can be started again. */
+int unit_reset_failed(struct unit_mgr *mgr, const char *unit_name);

--- a/discoverd/systemd/nvme-discoverd.service.in
+++ b/discoverd/systemd/nvme-discoverd.service.in
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+[Unit]
+Description=NVMe-oF Discovery Daemon
+Documentation=man:nvme-discoverd(8)
+Before=remote-fs.target
+
+[Service]
+Type=notify-reload
+ExecStart=@SBINDIR@/nvme-discoverd
+Restart=on-failure
+RuntimeDirectory=nvme/discoverd nvme/discoverd/units nvme/discoverd/controllers
+RuntimeDirectoryPreserve=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ want_fabrics = get_option('fabrics').disabled() == false and host_system != 'win
 want_mi = get_option('mi').disabled() == false and host_system != 'windows'
 want_top = get_option('top').disabled() == false and host_system != 'windows'
 want_discoverd = get_option('nvme-discoverd').disabled() == false and want_fabrics and host_system != 'windows'
+want_nvmf_autoconnect = get_option('nvmf-autoconnect').disabled() == false
 want_json_c = get_option('json-c').disabled() == false
 want_libkmod = get_option('libkmod').disabled() == false and host_system != 'windows'
 want_tests = get_option('tests')
@@ -692,46 +693,52 @@ if want_nvme
         install_dir: join_paths(sysconfdir, 'nvme'),
     )
 
-    dracut_files = [
-        '70-nvmf-autoconnect.conf',
-    ]
+    if want_nvmf_autoconnect
+        dracut_files = [
+            '70-nvmf-autoconnect.conf',
+        ]
 
-    foreach file : dracut_files
-        configure_file(
-            input: 'nvmf-autoconnect/dracut-conf/' + file + '.in',
-            output: file,
-            configuration: substs,
-            install: true,
-            install_dir: dracutrulesdir,
-        )
-    endforeach
+        foreach file : dracut_files
+            configure_file(
+                input: 'nvmf-autoconnect/dracut-conf/' + file + '.in',
+                output: file,
+                configuration: substs,
+                install: true,
+                install_dir: dracutrulesdir,
+            )
+        endforeach
 
-    systemd_files = [
-        'nvmefc-boot-connections.service',
-        'nvmf-autoconnect.service',
-        'nvmf-connect-nbft.service',
-        'nvmf-connect.target',
-        'nvmf-connect@.service',
-    ]
+        systemd_files = [
+            'nvmefc-boot-connections.service',
+            'nvmf-autoconnect.service',
+            'nvmf-connect-nbft.service',
+            'nvmf-connect.target',
+            'nvmf-connect@.service',
+        ]
 
-    foreach file : systemd_files
-        configure_file(
-            input: 'nvmf-autoconnect/systemd/' + file + '.in',
-            output: file,
-            configuration: substs,
-            install: true,
-            install_dir: systemddir,
-        )
-    endforeach
+        foreach file : systemd_files
+            configure_file(
+                input: 'nvmf-autoconnect/systemd/' + file + '.in',
+                output: file,
+                configuration: substs,
+                install: true,
+                install_dir: systemddir,
+            )
+        endforeach
+    endif
 
+    # These rules provision keys and tune vendor devices; kept regardless of
+    # which NVMe-oF autoconnect mechanism (if any) is in use.
     udev_files = [
         '65-persistent-net-nbft.rules',
-        '70-nvmf-autoconnect.rules',
         '70-nvmf-keys.rules',
         '71-nvmf-hpe.rules',
         '71-nvmf-netapp.rules',
         '71-nvmf-vastdata.rules',
     ]
+    if want_nvmf_autoconnect
+        udev_files += '70-nvmf-autoconnect.rules'
+    endif
 
     foreach file : udev_files
         configure_file(
@@ -743,20 +750,22 @@ if want_nvme
         )
     endforeach
 
-    nm_dispatcher_files = [
-        '80-nvmf-connect-nbft.sh'
-    ]
+    if want_nvmf_autoconnect
+        nm_dispatcher_files = [
+            '80-nvmf-connect-nbft.sh'
+        ]
 
-    foreach file : nm_dispatcher_files
-        configure_file(
-            input: 'nvmf-autoconnect/nm-dispatcher/' + file + '.in',
-            output: file,
-            configuration: substs,
-            install: true,
-            install_mode: 'rwxr-xr-x',
-            install_dir: nmdispatchdir
-        )
-    endforeach
+        foreach file : nm_dispatcher_files
+            configure_file(
+                input: 'nvmf-autoconnect/nm-dispatcher/' + file + '.in',
+                output: file,
+                configuration: substs,
+                install: true,
+                install_mode: 'rwxr-xr-x',
+                install_dir: nmdispatchdir
+            )
+        endforeach
+    endif
 
     install_data(
         'completions/bash-nvme-completion.sh',
@@ -846,6 +855,7 @@ wanted_dict = {
     'libnvme':          want_libnvme,
     'fabrics':          want_fabrics,
     'nvme-discoverd':   want_discoverd,
+    'nvmf-autoconnect': want_nvmf_autoconnect,
     'python bindings ': want_python,
     'build docs':       want_docs_build,
 }

--- a/meson.build
+++ b/meson.build
@@ -54,6 +54,7 @@ want_libnvme = get_option('libnvme').disabled() == false
 want_fabrics = get_option('fabrics').disabled() == false and host_system != 'windows'
 want_mi = get_option('mi').disabled() == false and host_system != 'windows'
 want_top = get_option('top').disabled() == false and host_system != 'windows'
+want_discoverd = get_option('nvme-discoverd').disabled() == false and want_fabrics and host_system != 'windows'
 want_json_c = get_option('json-c').disabled() == false
 want_libkmod = get_option('libkmod').disabled() == false and host_system != 'windows'
 want_tests = get_option('tests')
@@ -363,6 +364,16 @@ else
 endif
 conf.set('CONFIG_KEYUTILS', keyutils_dep.found(), description: 'Is libkeyutils available?')
 
+if not want_discoverd
+    libsystemd_dep = dependency('', required: false)
+else
+    # v253 for Type=notify-reload (nvme-discoverd.service).
+    libsystemd_dep = dependency('libsystemd', version: '>=253',
+                                 required: get_option('nvme-discoverd'))
+endif
+want_discoverd = want_discoverd and libsystemd_dep.found()
+conf.set('CONFIG_DISCOVERD', want_discoverd, description: 'Is nvme-discoverd enabled')
+
 if not want_mi or get_option('libdbus').disabled()
     libdbus_dep = dependency('', required: false)
 else
@@ -659,6 +670,10 @@ if want_nvme
     endif
     subdir('unit-py')
 
+    if want_discoverd
+        subdir('discoverd')
+    endif
+
     if get_option('nvme-tests')
         subdir('tests')
     endif
@@ -814,6 +829,7 @@ dep_dict = {
     'python3':          py3_dep.found(),
     'liburing':         liburing_dep.found(),
     'libkmod':          libkmod_dep.found(),
+    'libsystemd':       libsystemd_dep.found(),
 }
 if host_system == 'windows'
     dep_dict += {
@@ -829,6 +845,7 @@ wanted_dict = {
     'nvme':             want_nvme,
     'libnvme':          want_libnvme,
     'fabrics':          want_fabrics,
+    'nvme-discoverd':   want_discoverd,
     'python bindings ': want_python,
     'build docs':       want_docs_build,
 }

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,6 +24,12 @@ option(
   description : 'MI support'
 )
 option(
+  'nvme-discoverd',
+  type : 'feature',
+  value: 'disabled',
+  description : 'nvme-discoverd daemon (technology preview; requires fabrics and libsystemd >=253)'
+)
+option(
   'top',
   type : 'feature',
   value: 'enabled',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -30,6 +30,12 @@ option(
   description : 'nvme-discoverd daemon (technology preview; requires fabrics and libsystemd >=253)'
 )
 option(
+  'nvmf-autoconnect',
+  type : 'feature',
+  value: 'enabled',
+  description : 'legacy udev/systemd NVMe-oF autoconnect (independent of nvme-discoverd; both may be installed side by side)'
+)
+option(
   'top',
   type : 'feature',
   value: 'enabled',


### PR DESCRIPTION
## Summary

This is the initial implementation of nvme-discoverd, a small daemon that automatically connects NVMe-oF controllers discovered via NBFT, static config, or Discovery Log Pages, using systemd transient units (one per controller, no unit files written to disk). It's meant to eventually replace the `70-nvmf-autoconnect.rules`/`nvmf-connect@.service` mechanism.

**This is a work-in-progress submission, not ready for merge.** I'm opening it now so you can start looking at the overall shape and design while I finish the remaining items below.

## What's included

- `discoverd: add the daemon skeleton` — CLI options, config knobs, meson wiring.
- `discoverd: track controllers and manage connections as systemd units` — TID handling, in-memory cache, transient-unit management via D-Bus.
- `discoverd: react to events, fetch DLPs, and read the fabrics config (nvme-fabrics.conf)` — udev monitoring, Discovery Log Page fetch, FC kickstart, the shared `nvme-fabrics.conf` as the connection source, and the exclusion-list/registry-ownership checks before connecting.
- `meson: split discoverd and legacy autoconnect into independent options` — `-Dnvme-discoverd`/`-Dnvmf-autoconnect`, both enabled by default during this stabilization period.
- `discoverd: add the systemd service, config, and docs` — unit file, `discoverd.conf`, README, man page.
- `discoverd: use ccan for linked lists and string helpers` — shares the existing ccan static lib instead of hand-rolling lists/streq/ARRAY_SIZE.

## Known gaps before this is review-ready

- No automated tests yet.
- `nvme.spec.in` doesn't reference the new binary/service/config yet.
- Registry-ownership check is a courtesy check for intentional handoffs between orchestrators, not a race guard between two daemons managing the same controller.

## Test plan

- [x] `meson compile` clean: default, `-Dwerror=true`, `-Dfabrics=disabled`
- [x] `meson test`: 81/83 (2 expected-fail unchanged)
- [x] `make checkpatch-diff`: clean
- [x] Live-tested against real nvmet dummy targets: discovery, connect, exclusion, and registry-ownership all behave as expected
