### PR TITLE
shared: add a small static utility library

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -552,6 +552,7 @@ substs.set('LIBNVME_SO_VERSION', libnvme_so_major)
 doc_tgts = []
 
 subdir('ccan')      # declares: ccan_dep
+subdir('shared')    # declares: shared_dep
 subdir('libnvme')   # declares: libnvme_dep
 
 if want_nvme

--- a/shared/array-util.c
+++ b/shared/array-util.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "array-util.h"
+
+int ptrarray_append(struct ptrarray *a, void *item)
+{
+	if (a->len == a->cap) {
+		size_t newcap = a->cap ? a->cap * 2 : 8;
+		void **newitems = realloc(a->items, newcap * sizeof(*newitems));
+
+		if (!newitems)
+			return -ENOMEM;
+		a->items = newitems;
+		a->cap = newcap;
+	}
+	a->items[a->len++] = item;
+	return 0;
+}
+
+void ptrarray_free(struct ptrarray *a)
+{
+	free(a->items);
+	a->items = NULL;
+	a->len = 0;
+	a->cap = 0;
+}

--- a/shared/array-util.h
+++ b/shared/array-util.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stddef.h>
+
+/*
+ * A growable array of untyped pointers, doubling capacity (starting at 8)
+ * as items are appended. Neither owns nor frees the pointed-to items --
+ * only the backing array itself (see ptrarray_free()).
+ */
+struct ptrarray {
+	void **items;
+	size_t len;
+	size_t cap;
+};
+
+/*
+ * Append item to a, growing the backing array as needed.
+ *
+ * To build a NULL-terminated array (e.g. to hand back to a caller that
+ * expects one), append every real item, then append NULL last -- that
+ * final call reserves the extra slot itself, same as any other append.
+ *
+ * Return: 0 on success, -ENOMEM on allocation failure.
+ */
+int ptrarray_append(struct ptrarray *a, void *item);
+
+/*
+ * Free the backing array only, leaving *a zeroed. Caller is responsible
+ * for freeing each item first if the array owns them.
+ */
+void ptrarray_free(struct ptrarray *a);

--- a/shared/fs-util.c
+++ b/shared/fs-util.c
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#if defined(_WIN32)
+#include <direct.h>
+#define mkdir(path, mode) ((void)(mode), _mkdir(path))
+#endif
+
+#include "fs-util.h"
+
+int mkdir_p(const char *path, mode_t mode)
+{
+	char buf[256];
+	char *p;
+	size_t len;
+
+	snprintf(buf, sizeof(buf), "%s", path);
+	len = strlen(buf);
+	if (len && buf[len - 1] == '/')
+		buf[len - 1] = '\0';
+
+	for (p = buf + 1; *p; p++) {
+		if (*p == '/') {
+			*p = '\0';
+			mkdir(buf, mode);
+			*p = '/';
+		}
+	}
+	return mkdir(buf, mode) == 0 || errno == EEXIST ? 0 : -errno;
+}

--- a/shared/fs-util.h
+++ b/shared/fs-util.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <sys/types.h>
+
+/*
+ * Create path and every missing parent directory, like "mkdir -p".
+ * Return: 0 on success (including if path already exists as a directory),
+ * -errno otherwise.
+ */
+int mkdir_p(const char *path, mode_t mode);

--- a/shared/meson.build
+++ b/shared/meson.build
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+# Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+#
+# Authors: Martin Belanger <martin.belanger@dell.com>
+#
+# Small utility library shared across nvme-cli, libnvme, nvme-discoverd, and
+# the Python bindings. The utilities are split by topic (one concern per file),
+# not lumped into a single header. Files with no real implementation (just
+# static inline functions/macros) are header-only.
+
+sources = [
+    'array-util.c',
+    'fs-util.c',
+    'parse-util.c',
+]
+
+libshared = static_library(
+    'shared',
+    sources,
+    install: false,
+    dependencies: [ccan_dep],
+)
+
+shared_dep = declare_dependency(
+    include_directories: '.',
+    link_with: libshared,
+)

--- a/shared/parse-util.c
+++ b/shared/parse-util.c
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <strings.h>
+
+#include <ccan/array_size/array_size.h>
+
+#include "parse-util.h"
+
+int parse_bool(const char *value, bool *out)
+{
+	static const char * const yes[] = {
+		"1", "yes", "y", "true", "t", "on"
+	};
+	static const char * const no[] = {
+		"0", "no", "n", "false", "f", "off"
+	};
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(yes); i++) {
+		if (!strcasecmp(value, yes[i])) {
+			*out = true;
+			return 0;
+		}
+	}
+	for (i = 0; i < ARRAY_SIZE(no); i++) {
+		if (!strcasecmp(value, no[i])) {
+			*out = false;
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}

--- a/shared/parse-util.h
+++ b/shared/parse-util.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+
+/*
+ * Parse a boolean string using the systemd parse_boolean() convention:
+ * 1/yes/y/true/t/on, 0/no/n/false/f/off (case-insensitive).
+ * Return: 0 on success (*out set), -EINVAL if value matches neither list.
+ */
+int parse_bool(const char *value, bool *out);

--- a/shared/string-util.h
+++ b/shared/string-util.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <ctype.h>
+#include <stdbool.h>
+#include <string.h>
+#include <strings.h>
+
+/*
+ * NULL-safe string equality: two NULLs are equal, one NULL and one
+ * non-NULL are never equal, otherwise this is strcmp() == 0.
+ */
+static inline bool streq0(const char *s1, const char *s2)
+{
+	if (s1 == s2)
+		return true;
+	if (!s1 || !s2)
+		return false;
+	return !strcmp(s1, s2);
+}
+
+/* Case-insensitive sibling of streq0(). */
+static inline bool streqcase0(const char *s1, const char *s2)
+{
+	if (s1 == s2)
+		return true;
+	if (!s1 || !s2)
+		return false;
+	return !strcasecmp(s1, s2);
+}
+
+/* Allocation-checking strdup() that returns NULL for a NULL input. */
+static inline char *xstrdup(const char *s)
+{
+	return s ? strdup(s) : NULL;
+}
+
+/*
+ * Trim leading and trailing whitespace from s in place and return a
+ * pointer to the first non-whitespace character. s itself is modified:
+ * the byte after the last non-whitespace character is overwritten with
+ * '\0'.
+ */
+static inline char *trim(char *s)
+{
+	char *end;
+
+	s += strspn(s, " \t\n\r\v\f");
+	end = s + strlen(s);
+	while (end > s && isspace((unsigned char)end[-1]))
+		end--;
+	*end = '\0';
+	return s;
+}


### PR DESCRIPTION
## Summary

Adds a small `shared/` static library for utility code with no natural home in any one of nvme-cli, libnvme, python-bindings, or nvme-discoverd -- string helpers, a growable pointer-array, a boolean parser, and `mkdir -p`. Modeled loosely on systemd's `src/basic/`: one topic per file, header-only where the whole thing is a static inline function, a `.c`/`.h` pair where it isn't. No umbrella header, matching the precedent already set by libnvme's own `nvme/cleanup.h`.

**This PR only adds the library. Nothing consumes it yet.** No existing file is touched other than one line in the root `meson.build` wiring up the new `subdir('shared')`. The intent is to get the framework itself reviewed and merged first, since it's a small, low-risk, purely additive diff; a follow-up PR will then port to the existing code base.

## What's included

- `shared/string-util.h` -- `streq0()`, `streqcase0()`, `xstrdup()`, `trim()` (static inline).
- `shared/parse-util.h`/`.c` -- `parse_bool()`, the systemd `parse_boolean()` convention (1/yes/y/true/t/on, 0/no/n/false/f/off).
- `shared/array-util.h`/`.c` -- `struct ptrarray` / `ptrarray_append()` / `ptrarray_free()`, a generic growable pointer array.
- `shared/fs-util.h`/`.c` -- `mkdir_p()`.
- `shared/meson.build` -- builds `libshared` (static), declares `shared_dep`.
- One line in the root `meson.build`: `subdir('shared')` alongside the existing `subdir('ccan')`.

## Test plan

- [x] `meson compile` clean (default options)
- [x] `meson test`: 81/83 (2 expected-fail, unchanged from master)
- [x] checkpatch: clean
- [x] Confirmed `libshared.a` builds standalone with nothing yet linking against `shared_dep`
