### PR TITLE
exclusion: fix uninitialized argument in libnvmf_exclusion_read()

### DIFF
--- a/libnvme/src/nvme/exclusion.c
+++ b/libnvme/src/nvme/exclusion.c
@@ -917,7 +917,7 @@ __libnvme_public int libnvmf_exclusion_read(struct libnvme_global_ctx *ctx,
 {
 	char pathbuf[PATH_MAX];
 	const char *path;
-	size_t len;
+	size_t len = 0;
 	int ret;
 
 	if (!ctx)


### PR DESCRIPTION
The clang static analyzer warns that len, declared without an initial value in libnvmf_exclusion_read(), may be passed uninitialized to content_hash().  In practice this cannot happen: every non-zero return from slurp() causes libnvmf_exclusion_read() to return early before reaching content_hash(), so *len is always written on any path that reaches it.

Regardless, initializing variables to a sane default before passing them to a function that writes through them is good defensive practice preventing stale or indeterminate values from being observable if control flow ever changes. Initialize len to 0 to suppress the warning and follow this practice.