### PR TITLE
sfx-nvme: fix dead assignment in sfx_dump_evtlog()

### DIFF
--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1389,7 +1389,7 @@ static int sfx_dump_evtlog(int argc, char **argv, struct command *acmd, struct p
 
 	err = nvme_dump_evtlog(hdl, cfg.namespace_id, cfg.storage_medium, cfg.file, cfg.parse, cfg.output);
 
-	return 0;
+	return err;
 }
 
 static int filter_namespace(const struct dirent *d)


### PR DESCRIPTION
The sfx_dump_evtlog() function calls nvme_dump_evtlog() and stores the return value in err. However, the function unconditionally returns 0 instead of returning err, so the result of the call is never used. Any error returned by nvme_dump_evtlog() is silently discarded, causing the caller to always see success even when the operation failed.

Return err instead of 0 so that errors are correctly propagated to the caller.