### PR TITLE
virtium: remove erroneous (float) cast in vt_save_smart_to_vtview_log()

### DIFF
--- a/plugins/virtium/virtium-nvme.c
+++ b/plugins/virtium/virtium-nvme.c
@@ -989,8 +989,8 @@ static int vt_save_smart_to_vtview_log(int argc, char **argv,
 	if (ret)
 		return ret;
 
-	total_time = cfg.run_time_hrs * (float)HOUR_IN_SECONDS;
-	freq_time = cfg.log_record_frequency_hrs * (float)HOUR_IN_SECONDS;
+	total_time = cfg.run_time_hrs * HOUR_IN_SECONDS;
+	freq_time = cfg.log_record_frequency_hrs * HOUR_IN_SECONDS;
 
 	if (!freq_time)
 		freq_time = 1;


### PR DESCRIPTION
Multiplying a double by (float)HOUR_IN_SECONDS unnecessarily downcasts the integer constant to a lower-precision float before the multiplication, introducing a spurious type conversion. The result is then assigned to a long, which Coverity flags as an overflowed integer argument.

Remove the (float) cast so the multiplication is double * int, which is well-defined and loses no precision before the long assignment.

Fixes: Coverity CID 557484 (Overflowed integer argument)