### PR TITLE
nbft: fix resource leak of ssns->hfis in read_ssns()

### DIFF
--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -345,6 +345,7 @@ static int read_ssns(struct libnvme_global_ctx *ctx,
 	return 0;
 
 fail:
+	free(ssns->hfis);
 	free(ssns);
 	return ret;
 }


### PR DESCRIPTION
ssns->hfis is allocated via calloc() but is not freed at the fail: label. Any goto fail that fires after ssns->hfis is allocated (e.g. when the primary HFI is not found, or when the subsys NQN heap object lookup fails) leaks ssns->hfis.

ssns is allocated with calloc() so ssns->hfis is NULL-initialized, making free(ssns->hfis) safe on all earlier goto fail paths where hfis was never allocated.

Fixes: Coverity CID 557464 (Resource leak)