### PR TITLE
wdc: free dssd_specific_ver when smart_log_ver < 3

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -8131,6 +8131,8 @@ static void wdc_show_cloud_smart_log_json(struct ocp_cloud_smart_log *log)
 	if (smart_log_ver >= 3)
 		json_object_add_value_object(root, "dssd_specific_ver",
 				     dssd_specific_ver);
+	else
+		json_free_object(dssd_specific_ver);
 	json_object_add_value_uint(root, "pcie_correctable_error_count",
 				   le64_to_cpu(log->pcie_correctable_error_count));
 	json_object_add_value_uint(root, "incomplete_shutdowns",


### PR DESCRIPTION
In wdc_show_cloud_smart_log_json(), dssd_specific_ver is always allocated via json_create_object() regardless of smart_log_ver. However, it is only added to the root JSON object (and therefore owned and freed with it) when smart_log_ver >= 3.  When smart_log_ver < 3 the object is neither added nor freed, causing a resource leak on every such call.

Add an else branch to free dssd_specific_ver when the version check fails so the allocated object is always released.

Fixes: Coverity CID 557510 (Resource leak)