### PR TITLE
ibm: fix missing break in show_ibm_smart_log() case 0x00f5

### DIFF
--- a/plugins/ibm/ibm-nvme.c
+++ b/plugins/ibm/ibm-nvme.c
@@ -214,6 +214,7 @@ static void show_ibm_smart_log(struct nvme_ibm_additional_smart_log *smart, cons
 				le32_to_cpu(smart->device_pcie_received_errors.split_raw2.upper));
 			printf("PCIe Recd Transitions to Recoveries : %"PRIu32"\n",
 				le32_to_cpu(smart->device_pcie_received_errors.split_raw2.lower));
+			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
In show_ibm_smart_log(), the switch statement that dispatches on entry->attr is missing a break at the end of case 0x00f5. Without it, execution falls through into the default branch after printing the PCIe error counters, which is unintended behaviour.

Add the missing break to terminate case 0x00f5 cleanly so that only the default branch handles unrecognised attribute values.

Fixes: Coverity CID 557383 (Out-of-bounds read)