### PR TITLE
netapp-nvme: fix uninitialized pointer in netapp_smdevices()

### DIFF
--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -906,7 +906,7 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Display information about E-Series volumes.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	struct dirent **devices;
+	struct dirent **devices = NULL;
 	int num, i, ret, fmt;
 	struct smdevice_info *smdevices;
 	char path[264];


### PR DESCRIPTION
The netapp_smdevices() function declares the devices pointer used to receive the scandir() output, but does not initialize it before passing its address to scandir().

If execution reaches the scandir() call with devices holding an indeterminate stack value, the behavior is undefined.

Initialize devices to NULL so it holds a defined value before scandir() writes to it through the pointer.