### PR TITLE
sfx-nvme: fix resource leak in sfx_status()

### DIFF
--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1593,6 +1593,7 @@ static int sfx_status(int argc, char **argv, struct command *acmd, struct plugin
 		if (!err)
 			err = ioctl(fd, BLKGETSIZE64, &capacity);
 		capacity_valid = (!err);
+		close(fd);
 	}
 
 	if (capacity_valid && sector_size == 512)


### PR DESCRIPTION
The sfx_status() function opens a file descriptor for the block device path to retrieve the sector size and capacity via ioctl. The descriptor is never closed after the ioctls complete, and fd is silently overwritten on the next open() call.

This results in a file descriptor leak on every invocation of sfx_status() when the device has a readable block node.

Close fd after the ioctls to prevent the leak.