### PR TITLE
nvme: add utils dump-command-metadata command

### DIFF
--- a/common.h
+++ b/common.h
@@ -28,6 +28,7 @@
  * Provide compatibility wrappers.
  */
 #if defined(_WIN32)
+#define DEV_NULL "NUL"
 #define mkdir(path, mode) _mkdir(path)
 
 #define fsync _commit
@@ -39,6 +40,8 @@ static inline int getpagesize(void)
 	GetSystemInfo(&si);
 	return si.dwPageSize;
 }
+#else
+#define DEV_NULL "/dev/null"
 #endif
 
 /*

--- a/meson.build
+++ b/meson.build
@@ -657,6 +657,7 @@ if want_nvme
     if host_system != 'windows'
         subdir('unit')
     endif
+    subdir('unit-py')
 
     if get_option('nvme-tests')
         subdir('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -180,7 +180,7 @@ option(
             'intel', 'lm', 'mangoboost', 'memblaze', 'micron', 'nbft',
             'netapp', 'nvidia', 'ocp', 'registry', 'sandisk', 'scaleflux',
             'seagate', 'sed', 'shannon', 'solidigm', 'ssstc', 'toshiba',
-            'transcend', 'virtium', 'wdc', 'ymtc', 'zns'],
+            'transcend', 'utils', 'virtium', 'wdc', 'ymtc', 'zns'],
   description : 'comma-separated list of plugins to build (all plugins are included if unset, [] = no plugins)'
 )
 option(

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -22,6 +22,7 @@ all_plugins = {
   'ssstc': ['plugins/ssstc/ssstc-nvme.c'],
   'toshiba': ['plugins/toshiba/toshiba-nvme.c'],
   'transcend': ['plugins/transcend/transcend-nvme.c'],
+  'utils': ['plugins/utils/utils.c', 'plugins/utils/command-metadata.c'],
   'virtium': ['plugins/virtium/virtium-nvme.c'],
   'ymtc': ['plugins/ymtc/ymtc-nvme.c'],
 }

--- a/plugins/utils/command-metadata-schema.json
+++ b/plugins/utils/command-metadata-schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/linux-nvme/nvme-cli/command-metadata-schema.json",
+  "title": "nvme-cli command metadata",
+  "description": "Schema for the JSON emitted by `nvme dump-command-metadata`, which describes every command and its accepted options for tooling such as shell-completion generators, documentation, and drift checks.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "name", "commands", "plugins"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "description": "Bumped on any breaking change to the output structure. Consumers should reject a major version they do not understand.",
+      "minimum": 1
+    },
+    "name": {
+      "type": "string",
+      "description": "Program name (\"nvme\")."
+    },
+    "version": {
+      "type": "string",
+      "description": "Program version string. Omitted if unknown."
+    },
+    "description": {
+      "type": "string",
+      "description": "Program description. Omitted if unset."
+    },
+    "commands": {
+      "type": "array",
+      "description": "Top-level (builtin) commands.",
+      "items": { "$ref": "#/$defs/command" }
+    },
+    "plugins": {
+      "type": "array",
+      "description": "Named plugins, each grouping its own commands.",
+      "items": { "$ref": "#/$defs/plugin" }
+    }
+  },
+  "$defs": {
+    "plugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "commands"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Plugin name, used as the first argument to dispatch its commands."
+        },
+        "description": {
+          "type": "string",
+          "description": "Plugin description. Omitted if unset."
+        },
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/command" }
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "options"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Command name as typed on the command line."
+        },
+        "alias": {
+          "type": "string",
+          "description": "Alternate name accepted for the command. Omitted if none."
+        },
+        "description": {
+          "type": "string",
+          "description": "Command description (the command-list one-liner). Omitted if unset."
+        },
+        "options": {
+          "type": "array",
+          "description": "Options the command accepts. Empty for commands that take no options.",
+          "items": { "$ref": "#/$defs/option" }
+        }
+      }
+    },
+    "option": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["long", "argument"],
+      "properties": {
+        "long": {
+          "type": "string",
+          "description": "Long option name, without the leading \"--\"."
+        },
+        "short": {
+          "type": "string",
+          "description": "Single-character short option name, without the leading \"-\". Omitted if none.",
+          "minLength": 1,
+          "maxLength": 1
+        },
+        "argument": {
+          "type": "string",
+          "description": "Whether the option consumes an argument.",
+          "enum": ["none", "required", "optional"]
+        },
+        "metavar": {
+          "type": "string",
+          "description": "Placeholder name for the option's value (e.g. \"NUM\", \"FMT\"). Present only for options that take a value."
+        },
+        "description": {
+          "type": "string",
+          "description": "Option help text. Omitted if unset."
+        },
+        "global": {
+          "type": "boolean",
+          "description": "True for the shared global options appended to every command (verbose, output-format, timeout, ...). Absent otherwise.",
+          "const": true
+        },
+        "hidden": {
+          "type": "boolean",
+          "description": "True for options accepted on the command line but suppressed from --help. Absent otherwise.",
+          "const": true
+        },
+        "values": {
+          "type": "array",
+          "description": "The set of values the parser enforces for this option, when it constrains them to a fixed set. Absent when the value is unconstrained.",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      }
+    }
+  }
+}

--- a/plugins/utils/command-metadata.c
+++ b/plugins/utils/command-metadata.c
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Command/option metadata dump for nvme-cli.
+ *
+ * Builds an in-memory model of every command and its options, then writes it to
+ * stdout as JSON for the `dump-command-metadata` subcommand. The JSON is a
+ * machine-readable description of the CLI surface, intended for tooling such as
+ * shell-completion generators, documentation, and drift checks.
+ *
+ * The model is captured by walking the live plugin/command tree and, for each
+ * command, intercepting the options array it builds on its stack via NVME_ARGS.
+ * Capture installs a hook in argconfig_parse() (see argconfig_set_parse_hook):
+ * when a command calls into the parser, the hook copies the options array into
+ * the model and returns a sentinel so the command unwinds before opening any
+ * device.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "command-metadata.h"
+#include "common.h"
+#include "nvme.h"
+#include "util/json.h"
+
+/*
+ * The whole command is JSON-only, so it is compiled out entirely without
+ * json-c support: the utils plugin does not register it and does not define
+ * its handler, so dump_command_metadata() is never referenced.
+ */
+#ifdef CONFIG_JSONC
+
+/*
+ * Returned by the capture hook so argconfig_parse() unwinds before the
+ * command's fn opens a device.
+ */
+#define METADATA_CAPTURE_SENTINEL (-ECANCELED)
+
+/*
+ * Version of the emitted JSON schema, bumped on any breaking change to the
+ * output structure (renamed/removed keys, changed value semantics). Additive
+ * changes that keep existing keys stable do not require a bump. Consumers
+ * should reject a major version they do not understand.
+ */
+#define COMMAND_METADATA_SCHEMA_VERSION 1
+
+/*
+ * The command currently being captured; set by capture_command()
+ * before it invokes the command fn, read by metadata_capture_hook().
+ */
+static struct command_metadata_command *command_metadata_cur_command;
+
+/*
+ * Capture OOM, reported out-of-band because the hook's return value is reserved
+ * for the parser-unwind sentinel; checked after each command fn returns.
+ */
+static int command_metadata_capture_error;
+
+/* ------------------------------------------------------------------ */
+/* Pass 1: capture                                                    */
+/* ------------------------------------------------------------------ */
+
+static char *xstrdup(const char *s)
+{
+	return s ? strdup(s) : NULL;
+}
+
+/*
+ * Deep-copy an opt_val table into *out. A NULL src is not an error: *out is set
+ * to NULL, the "no value table" sentinel consumers expect. Returns -ENOMEM on
+ * allocation failure so the caller can abort rather than silently drop values.
+ */
+static int copy_opt_val(const struct argconfig_opt_val *src, const struct argconfig_opt_val **out)
+{
+	struct argconfig_opt_val *dst;
+	size_t n = 0, i;
+
+	*out = NULL;
+	if (!src)
+		return 0;
+
+	for (; src[n].str; n++)
+		;
+
+	dst = calloc(n + 1, sizeof(*dst));
+	if (!dst)
+		return -ENOMEM;
+
+	for (i = 0; i < n; i++) {
+		dst[i] = src[i];
+		/* src[i].str is non-NULL for i < n, so NULL here means OOM. */
+		dst[i].str = strdup(src[i].str);
+		if (!dst[i].str)
+			return -ENOMEM;
+	}
+	dst[n].str = NULL;
+
+	*out = dst;
+	return 0;
+}
+
+/*
+ * Duplicate a possibly-NULL string: NULL src succeeds (copies to NULL); a
+ * non-NULL src that fails to duplicate returns -ENOMEM.
+ */
+static int dup_field(const char *src, const char **dst)
+{
+	*dst = xstrdup(src);
+	if (src && !*dst)
+		return -ENOMEM;
+	return 0;
+}
+
+/*
+ * Deep-copy an options array into *out (a heap array of *n_out entries).
+ * Returns -ENOMEM on failure; the partial allocation is left for process exit
+ * to reclaim, as the model is never explicitly freed.
+ */
+static int copy_options(const struct argconfig_commandline_options *opts,
+			struct command_metadata_option **out, size_t *n_out)
+{
+	const struct argconfig_commandline_options *s;
+	struct command_metadata_option *dst;
+	size_t n = 0, i;
+
+	*out = NULL;
+	*n_out = 0;
+
+	for (s = opts; s->option; s++)
+		n++;
+
+	if (!n)	/* calloc(0) may return NULL, indistinguishable from OOM */
+		return 0;
+
+	dst = calloc(n, sizeof(*dst));
+	if (!dst)
+		return -ENOMEM;
+
+	/*
+	 * Deep-copy: option/meta/help and the opt_val table are valid while the
+	 * parser runs but may point at command-local storage that is freed once
+	 * the command's fn returns, so duplicate rather than alias them.
+	 */
+	for (i = 0; i < n; i++) {
+		if (dup_field(opts[i].option, &dst[i].option) ||
+		    dup_field(opts[i].meta, &dst[i].meta) ||
+		    dup_field(opts[i].help, &dst[i].help) ||
+		    copy_opt_val(opts[i].opt_val, &dst[i].opt_val))
+			return -ENOMEM;
+		dst[i].short_option = opts[i].short_option;
+		dst[i].config_type = opts[i].config_type;
+		dst[i].argument_type = opts[i].argument_type;
+		dst[i].hidden = opts[i].hidden;
+	}
+
+	*out = dst;
+	*n_out = n;
+	return 0;
+}
+
+/*
+ * argconfig_parse() hook installed by build_model(): copies the current
+ * command's options into the model, then returns the sentinel so the parser
+ * unwinds before the command opens a device.
+ */
+static int metadata_capture_hook(int argc, char **argv, const char *program_desc,
+				 struct argconfig_commandline_options *options)
+{
+	(void)argc;
+	(void)argv;
+	(void)program_desc;
+
+	if (command_metadata_cur_command && !command_metadata_cur_command->captured) {
+		int err = copy_options(options,
+				&command_metadata_cur_command->options,
+				&command_metadata_cur_command->num_options);
+		if (err)
+			command_metadata_capture_error = err;
+		command_metadata_cur_command->captured = true;
+	}
+
+	return METADATA_CAPTURE_SENTINEL;
+}
+
+/* Returns 0 on success, or -ENOMEM if the capture hook failed to allocate. */
+static int capture_command(struct command_metadata_command *mc, struct command *cmd,
+			   struct plugin *plugin)
+{
+	/*
+	 * argv[1] is a placeholder device; the sentinel returns before it is
+	 * ever opened, so it need not (and must not) name a real device.
+	 */
+	char *argv[] = { cmd->name, (char *)"metadata-dump-dummy-device", NULL };
+
+	mc->name = cmd->name;
+	mc->alias = cmd->alias;
+	mc->help = cmd->help;
+	mc->captured = false;
+
+	/*
+	 * Don't invoke the dump command itself: it would re-enter
+	 * dump_command_metadata() and recurse forever. It has no
+	 * completable options, so leave its options array empty.
+	 */
+	if (!strcmp(cmd->name, "dump-command-metadata"))
+		return 0;
+
+	command_metadata_capture_error = 0;
+	command_metadata_cur_command = mc;
+	(void)cmd->fn(2, argv, cmd, plugin);
+	command_metadata_cur_command = NULL;
+
+	/*
+	 * If the hook never fired, the command returned before reaching the
+	 * parser (e.g. gen-hostnqn) and has no completable options; its options
+	 * array is simply left empty.
+	 */
+	return command_metadata_capture_error;
+}
+
+static size_t count_commands(struct command **commands)
+{
+	size_t n = 0;
+
+	while (commands && commands[n])
+		n++;
+
+	return n;
+}
+
+static size_t count_plugins(struct plugin *p)
+{
+	size_t n = 0;
+
+	for (; p; p = p->next)
+		n++;
+
+	return n;
+}
+
+static struct command_metadata_program *build_model(struct program *prog)
+{
+	struct command_metadata_program *model;
+	struct plugin *plugin;
+	int saved_stdout = -1, saved_stderr = -1, devnull;
+	int err = 0;
+	size_t pi;
+
+	model = calloc(1, sizeof(*model));
+	if (!model)
+		return NULL;
+
+	model->name = prog->name;
+	model->version = prog->version;
+	model->desc = prog->desc;
+	model->num_plugins = count_plugins(prog->extensions);
+	if (model->num_plugins) {
+		model->plugins = calloc(model->num_plugins, sizeof(*model->plugins));
+		if (!model->plugins) {
+			free(model);
+			return NULL;
+		}
+	}
+
+	/*
+	 * Suppress stdout/stderr while invoking command fns: some commands
+	 * may print before or during option capture, which would corrupt the
+	 * JSON output.
+	 */
+	fflush(stdout);
+	fflush(stderr);
+	devnull = open(DEV_NULL, O_WRONLY);
+	if (devnull >= 0) {
+		saved_stdout = dup(STDOUT_FILENO);
+		saved_stderr = dup(STDERR_FILENO);
+		if (saved_stdout >= 0)
+			dup2(devnull, STDOUT_FILENO);
+		if (saved_stderr >= 0)
+			dup2(devnull, STDERR_FILENO);
+	}
+
+	argconfig_set_parse_hook(metadata_capture_hook);
+
+	for (pi = 0, plugin = prog->extensions; plugin; plugin = plugin->next, pi++) {
+		struct command_metadata_plugin *mp = &model->plugins[pi];
+		size_t ci;
+
+		mp->name = plugin->name;
+		mp->desc = plugin->desc;
+		mp->num_commands = count_commands(plugin->commands);
+		if (!mp->num_commands)
+			continue;
+		mp->commands = calloc(mp->num_commands, sizeof(*mp->commands));
+		if (!mp->commands) {
+			mp->num_commands = 0;
+			err = -ENOMEM;
+			break;
+		}
+
+		for (ci = 0; ci < mp->num_commands; ci++) {
+			err = capture_command(&mp->commands[ci],
+					plugin->commands[ci], plugin);
+			if (err)
+				break;
+		}
+		if (err)
+			break;
+	}
+
+	argconfig_set_parse_hook(NULL);
+
+	fflush(stdout);
+	fflush(stderr);
+	if (saved_stdout >= 0) {
+		dup2(saved_stdout, STDOUT_FILENO);
+		close(saved_stdout);
+	}
+	if (saved_stderr >= 0) {
+		dup2(saved_stderr, STDERR_FILENO);
+		close(saved_stderr);
+	}
+	if (devnull >= 0)
+		close(devnull);
+
+	/*
+	 * An allocation failure while capturing would leave an incomplete model
+	 * that looks complete in the emitted JSON; fail the dump instead. The
+	 * partial model is left for process exit to reclaim (it is never freed
+	 * on the success path either).
+	 */
+	if (err)
+		return NULL;
+
+	return model;
+}
+
+/* ------------------------------------------------------------------ */
+/* Model helpers shared by emitters                                   */
+/* ------------------------------------------------------------------ */
+
+static bool opt_is_separator(const struct command_metadata_option *o)
+{
+	return o->config_type == CFG_GROUP_SEPARATOR;
+}
+
+static bool opt_is_global_separator(const struct command_metadata_option *o)
+{
+	return opt_is_separator(o) && o->help && !strcmp(o->help, "Global options");
+}
+
+/* "none" / "required" / "optional" — how the option consumes its argument. */
+static const char *opt_argument(const struct command_metadata_option *o)
+{
+	switch (o->argument_type) {
+	case optional_argument:
+		return "optional";
+	case no_argument:
+		return "none";
+	default:
+		return "required";
+	}
+}
+
+static bool opt_takes_value(const struct command_metadata_option *o)
+{
+	return o->argument_type != no_argument;
+}
+
+/*
+ * True for an option that should be emitted: a real, named, non-separator
+ * option. Hidden options are emitted too (tagged "hidden" in the output) so
+ * the dump describes the full set of accepted options; consumers that only
+ * want user-facing options (e.g. completion generators) filter on that tag.
+ */
+static bool opt_is_emittable(const struct command_metadata_option *o)
+{
+	return !opt_is_separator(o) && o->option && o->option[0];
+}
+
+/* ------------------------------------------------------------------ */
+/* Pass 2: JSON                                                       */
+/* ------------------------------------------------------------------ */
+
+/*
+ * The value set for an option, when the generator can derive it. Returns a
+ * json array of strings, or NULL if the option has no known value set. The
+ * caller owns the returned array.
+ *
+ * output-format is special-cased because its values are not represented via an
+ * opt_val table; keep the hard-coded list below in sync with
+ * validate_output_format() / DESC_OUTPUT_FORMAT. Since the whole command is
+ * compiled out without json-c, "json" is always a valid value here. Every
+ * other value set comes from the option's opt_val table, which is the set the
+ * parser actually enforces; options whose value is unconstrained (e.g. any
+ * OPT_UINT such as output-format-version) have no values array.
+ */
+static struct json_object *json_option_values(const struct command_metadata_option *o)
+{
+	const struct argconfig_opt_val *v;
+	struct json_object *vals;
+
+	if (!strcmp(o->option, "output-format")) {
+		vals = json_create_array();
+		json_array_add_value_string(vals, "normal");
+		json_array_add_value_string(vals, "json");
+		json_array_add_value_string(vals, "binary");
+		json_array_add_value_string(vals, "tabular");
+		return vals;
+	}
+	if (!o->opt_val)
+		return NULL;
+
+	vals = json_create_array();
+	for (v = o->opt_val; v->str; v++)
+		json_array_add_value_string(vals, v->str);
+	return vals;
+}
+
+/* Build one option as a json object and add it to the given array. */
+static void json_option(struct json_object *arr, const struct command_metadata_option *o,
+			bool global)
+{
+	struct json_object *jo, *vals;
+	char shortbuf[2] = { o->short_option, '\0' };
+
+	if (!opt_is_emittable(o))
+		return;
+
+	jo = json_create_object();
+	json_object_add_value_string(jo, "long", o->option);
+	if (o->short_option)
+		json_object_add_value_string(jo, "short", shortbuf);
+	json_object_add_value_string(jo, "argument", opt_argument(o));
+	if (o->meta && opt_takes_value(o))
+		json_object_add_value_string(jo, "metavar", o->meta);
+	if (o->help)
+		json_object_add_value_string(jo, "description", o->help);
+	if (global)
+		json_object_add_value_bool(jo, "global", true);
+	if (o->hidden)
+		json_object_add_value_bool(jo, "hidden", true);
+
+	vals = json_option_values(o);
+	if (vals)
+		json_object_add_value_array(jo, "values", vals);
+
+	json_array_add_value_object(arr, jo);
+}
+
+/* Build one command as a json object: name, alias, description, and options. */
+static struct json_object *json_command(const struct command_metadata_command *c)
+{
+	struct json_object *jc, *opts;
+	bool global = false;
+	size_t i;
+
+	jc = json_create_object();
+	json_object_add_value_string(jc, "name", c->name);
+	if (c->alias)
+		json_object_add_value_string(jc, "alias", c->alias);
+	if (c->help)
+		json_object_add_value_string(jc, "description", c->help);
+
+	opts = json_create_array();
+	for (i = 0; i < c->num_options; i++) {
+		/*
+		 * Options after the "Global options" separator are the shared
+		 * NVME_ARGS globals; flag them so generators can group them.
+		 */
+		if (opt_is_global_separator(&c->options[i])) {
+			global = true;
+			continue;
+		}
+		json_option(opts, &c->options[i], global);
+	}
+	json_object_add_value_array(jc, "options", opts);
+
+	return jc;
+}
+
+/* Build one named plugin as a json object: name, description, commands. */
+static struct json_object *json_plugin(const struct command_metadata_plugin *p)
+{
+	struct json_object *jp, *cmds;
+	size_t i;
+
+	jp = json_create_object();
+	assert(p->name);	/* builtin (NULL-name) is emitted inline by json_program() */
+	json_object_add_value_string(jp, "name", p->name);
+	if (p->desc)
+		json_object_add_value_string(jp, "description", p->desc);
+
+	cmds = json_create_array();
+	for (i = 0; i < p->num_commands; i++)
+		json_array_add_value_object(cmds, json_command(&p->commands[i]));
+	json_object_add_value_array(jp, "commands", cmds);
+
+	return jp;
+}
+
+static void json_program(const struct command_metadata_program *m)
+{
+	struct json_object *root, *builtin, *plugins;
+	size_t i;
+
+	root = json_create_object();
+	json_object_add_value_int(root, "schema_version",
+				  COMMAND_METADATA_SCHEMA_VERSION);
+	json_object_add_value_string(root, "name", m->name);
+	if (m->version)
+		json_object_add_value_string(root, "version", m->version);
+	if (m->desc)
+		json_object_add_value_string(root, "description", m->desc);
+
+	/*
+	 * Builtin (top-level) commands live in their own array; named plugins
+	 * go under "plugins" so generators can build the dispatch nesting.
+	 */
+	builtin = json_create_array();
+	plugins = json_create_array();
+	for (i = 0; i < m->num_plugins; i++) {
+		const struct command_metadata_plugin *p = &m->plugins[i];
+		size_t j;
+
+		if (!p->name) {
+			for (j = 0; j < p->num_commands; j++)
+				json_array_add_value_object(builtin,
+					json_command(&p->commands[j]));
+		} else {
+			json_array_add_value_object(plugins, json_plugin(p));
+		}
+	}
+	json_object_add_value_array(root, "commands", builtin);
+	json_object_add_value_array(root, "plugins", plugins);
+
+	json_print_object(root, NULL);
+	printf("\n");
+	json_free_object(root);
+}
+
+/* ------------------------------------------------------------------ */
+/* Entry point                                                        */
+/* ------------------------------------------------------------------ */
+
+int dump_command_metadata(struct program *prog)
+{
+	struct command_metadata_program *model;
+
+	model = build_model(prog);
+	if (!model)
+		return -ENOMEM;
+
+	json_program(model);
+
+	return 0;
+}
+
+#endif /* CONFIG_JSONC */

--- a/plugins/utils/command-metadata.h
+++ b/plugins/utils/command-metadata.h
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Command/option metadata dump: emits every command and its options as JSON.
+ * See command-metadata.c for details.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "plugin.h"
+#include "util/argconfig.h"
+
+/*
+ * A single command-line option, copied from struct argconfig_commandline_options.
+ * String fields and the opt_val table are deep-copied (and owned) because they
+ * may point at command-local storage that is freed once the command's fn
+ * returns; see command_metadata_copy_options().
+ */
+struct command_metadata_option {
+	const char *option;		/* long name; "" for a group separator */
+	char short_option;		/* 0 if none */
+	const char *meta;		/* metavar / value placeholder ("NUM"/"FMT"/...) or NULL */
+	enum argconfig_types config_type;
+	int argument_type;		/* no_/required_/optional_argument */
+	const char *help;
+	const struct argconfig_opt_val *opt_val; /* NULL or .str==NULL terminated */
+	bool hidden;			/* not shown in help/completion */
+};
+
+struct command_metadata_command {
+	const char *name;
+	const char *alias;		/* may be NULL */
+	const char *help;
+	struct command_metadata_option *options;	/* heap array */
+	size_t num_options;
+	bool captured;			/* hook fired -> options valid */
+};
+
+struct command_metadata_plugin {
+	const char *name;		/* NULL for the builtin plugin */
+	const char *desc;
+	struct command_metadata_command *commands;	/* heap array */
+	size_t num_commands;
+};
+
+struct command_metadata_program {
+	const char *name;
+	const char *version;
+	const char *desc;
+	struct command_metadata_plugin *plugins;	/* heap array, builtin first */
+	size_t num_plugins;
+};
+
+/*
+ * Entry point for the `nvme dump-command-metadata` subcommand. Builds the
+ * command/option model by walking the program's plugin/command tree and
+ * writes it to stdout as JSON, a machine-readable description of the CLI
+ * surface for tooling (completion generators, docs, drift checks). Returns 0
+ * on success, negative errno on failure.
+ */
+int dump_command_metadata(struct program *prog);

--- a/plugins/utils/utils.c
+++ b/plugins/utils/utils.c
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ */
+#include "command-metadata.h"
+#include "common.h"
+#include "nvme.h"
+
+#define CREATE_CMD
+#include "utils.h"
+
+#ifdef CONFIG_JSONC
+static int dump_command_metadata_cmd(int argc, char **argv, struct command *acmd,
+				     struct plugin *plugin)
+{
+	(void)argc;
+	(void)argv;
+	(void)acmd;
+
+	return dump_command_metadata(plugin->parent);
+}
+#endif /* CONFIG_JSONC */

--- a/plugins/utils/utils.h
+++ b/plugins/utils/utils.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (c) 2026 Micron Technology, Inc.
+ */
+#undef CMD_INC_FILE
+#define CMD_INC_FILE plugins/utils/utils
+
+#if !defined(UTILS_NVME) || defined(CMD_HEADER_MULTI_READ)
+#define UTILS_NVME
+
+#include "cmd.h"
+
+PLUGIN(NAME("utils", "General purpose utilities", NVME_VERSION),
+	COMMAND_LIST(
+#ifdef CONFIG_JSONC
+		ENTRY("dump-command-metadata", "Dump all commands and their options as JSON", dump_command_metadata_cmd)
+#endif
+	)
+);
+
+#endif
+
+#include "define_cmd.h"

--- a/unit-py/meson.build
+++ b/unit-py/meson.build
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Python unit tests that need no NVMe hardware.  The C equivalents live in
+# unit/; the device/integration tests in tests/.
+
+py3 = find_program('python3', required: false)
+
+if py3.found()
+    # dump-command-metadata is compiled out without json-c, so its test only
+    # makes sense when json-c is available.  Tests added here that don't
+    # depend on json-c belong outside this inner guard.
+    if want_json_c
+        test(
+            'nvme-cli - command-metadata-schema',
+            py3,
+            args: [
+                files('test_command_metadata_schema.py'),
+                nvme_exe,
+                meson.project_source_root() / 'plugins' / 'utils' / 'command-metadata-schema.json',
+            ],
+            depends: nvme_exe,
+            timeout: 120,
+        )
+    endif
+endif

--- a/unit-py/test_command_metadata_schema.py
+++ b/unit-py/test_command_metadata_schema.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+"""Validate `nvme utils dump-command-metadata` output against its JSON schema.
+
+The command walks the live plugin/command tree and emits every command and its
+options as JSON (see command-metadata.c).  This test runs it and checks:
+
+  1. It conforms to command-metadata-schema.json (structural: required keys,
+     value enums such as an option's "argument" and "values" sets).
+  2. Known commands are present, and the emitted plugins match what
+     `nvme help` lists (the schema proves the shape is legal, not that any
+     particular command or plugin was actually emitted).
+  3. Every command's option set matches what `--help` prints for it -- an
+     independent code path over the same data, which catches the silent
+     failure where capture never fires and a command emits no options.
+
+The command needs no device, so this can run in every CI job.  It requires json-c
+in the nvme build (the command is compiled out otherwise); when the output is
+empty the test skips rather than fails.
+
+Usage: test_command_metadata_schema.py <nvme-binary> <schema.json>
+
+Exits 77 (meson "skip") when the jsonschema module is unavailable.
+"""
+import copy
+import json
+import re
+import subprocess
+import sys
+import unittest
+
+# Long option as printed in --help, e.g. "[  --output-format=<FMT>, -o <FMT> ]".
+HELP_LONG_OPT = re.compile(r"\[\s*--([A-Za-z0-9][A-Za-z0-9_-]*)")
+# Plugin as printed by `nvme help`, e.g. "  ocp             ...description".
+HELP_PLUGIN = re.compile(r"^\s{2}(\S+)\s{2,}", re.MULTILINE)
+
+try:
+    import jsonschema
+except ImportError:
+    print("jsonschema module not available; skipping")
+    sys.exit(77)
+
+if len(sys.argv) < 3:
+    print("usage: %s <nvme-binary> <schema-path>" % sys.argv[0])
+    sys.exit(77)
+
+NVME_BIN = sys.argv[1]
+SCHEMA_PATH = sys.argv[2]
+
+
+def json_c_available():
+    """True if nvme was built with json-c. Its absence is the one legitimate
+    reason to skip. Detected via --output-format help (lists 'json' only with
+    json-c), not the dump command itself -- else a moved/renamed command would
+    skip, not fail."""
+    proc = subprocess.run(
+        [NVME_BIN, "list", "--help"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True)
+    return "json" in proc.stdout + proc.stderr
+
+
+def dump_metadata():
+    """Run `nvme utils dump-command-metadata` and return parsed JSON, or None if
+    it produced no usable output."""
+    proc = subprocess.run(
+        [NVME_BIN, "utils", "dump-command-metadata"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    text = proc.stdout.strip()
+    if proc.returncode != 0 or not text:
+        return None
+    return json.loads(text)
+
+
+def iter_commands(data):
+    """Yield (command_path, command) for every builtin and plugin command.
+    command_path is the argv words that name the command: ["id-ctrl"] for a
+    builtin, ["ocp", "smart-add-log"] for a plugin command."""
+    for cmd in data["commands"]:
+        yield [cmd["name"]], cmd
+    for plugin in data["plugins"]:
+        for cmd in plugin["commands"]:
+            yield [plugin["name"], cmd["name"]], cmd
+
+
+def help_option_names(command_path):
+    """The set of long options `nvme <command_path> --help` prints, or None if
+    the command crashed (non-zero exit with no output), e.g. due to a stack
+    overflow on platforms with a small default stack size."""
+    proc = subprocess.run(
+        [NVME_BIN] + command_path + ["--help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    output = proc.stdout + proc.stderr
+    if proc.returncode != 0 and not output.strip():
+        return None
+    return set(HELP_LONG_OPT.findall(output))
+
+
+def help_plugin_names():
+    """The set of plugins `nvme help` lists as installed extensions -- an
+    independent source of truth for which plugins are compiled in, so the test
+    adapts to builds configured with a subset of plugins."""
+    proc = subprocess.run(
+        [NVME_BIN, "help"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        universal_newlines=True)
+    text = proc.stdout + proc.stderr
+    marker = "installed plugin extensions"
+    if marker not in text:
+        # No plugin-extension section (e.g. built with zero external
+        # plugins); scraping the whole help text would mis-read builtin
+        # commands as plugins.
+        return set()
+    after = text.split(marker, 1)[-1]
+    return set(HELP_PLUGIN.findall(after))
+
+
+class TestCommandMetadataSchema(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not json_c_available():
+            raise unittest.SkipTest("nvme built without json-c")
+        cls.data = dump_metadata()
+        if cls.data is None:
+            raise AssertionError(
+                "dump-command-metadata produced no output (built with json-c)")
+        with open(SCHEMA_PATH) as f:
+            cls.schema = json.load(f)
+
+    def test_conforms_to_schema(self):
+        """Output validates against command-metadata-schema.json."""
+        jsonschema.validate(self.data, self.schema)
+
+    def test_schema_rejects_malformed(self):
+        """The schema is strict: targeted corruptions of valid output fail.
+
+        Guards against a schema edit that silently loosens a constraint
+        (a dropped 'required' entry or additionalProperties) so malformed
+        output would pass unnoticed."""
+        cases = [
+            lambda d: d["commands"][0]["options"][0].pop("long"),
+            lambda d: d["commands"][0]["options"][0].update(argument="bogus"),
+            lambda d: d["commands"][0]["options"][0].update(surprise=1),
+        ]
+        for mutate in cases:
+            bad = copy.deepcopy(self.data)
+            mutate(bad)
+            with self.assertRaises(jsonschema.ValidationError):
+                jsonschema.validate(bad, self.schema)
+
+    def test_expected_commands_present(self):
+        """A few well-known builtin commands are emitted."""
+        names = {c["name"] for c in self.data["commands"]}
+        for expected in ("list", "id-ctrl", "id-ns", "smart-log"):
+            self.assertIn(expected, names)
+
+    def test_plugins_match_help(self):
+        """The emitted plugins equal what `nvme help` lists as installed.
+
+        `nvme help` enumerates plugins via an independent code path, so this
+        adapts to builds configured with a subset of plugins (unlike a
+        hardcoded list) while still catching a dump that drops or invents one.
+        Each emitted plugin must also carry at least one command."""
+        dumped = {p["name"]: p for p in self.data["plugins"]}
+        self.assertEqual(set(dumped), help_plugin_names())
+        for name, plugin in dumped.items():
+            self.assertTrue(plugin["commands"],
+                            msg="plugin '%s' emitted no commands" % name)
+
+    def test_options_match_help(self):
+        """Each command's visible options equal what --help prints.
+
+        --help is generated by an independent code path (argconfig_print_help)
+        over the same option array the dump walks, so agreement catches the
+        critical silent failure: capture never fires for a command and it emits
+        an empty option set that still validates against the schema.  Hidden
+        options are excluded since --help suppresses them by design."""
+        for command_path, cmd in iter_commands(self.data):
+            dumped = {o["long"] for o in cmd["options"] if not o.get("hidden")}
+            printed = help_option_names(command_path)
+            if printed is None:
+                # Command crashed before producing output (e.g. stack
+                # overflow); skip rather than fail -- the underlying bug
+                # is unrelated to the metadata dump.
+                continue
+            self.assertEqual(
+                dumped, printed,
+                msg="option mismatch for '%s'" % " ".join(command_path))
+
+    def test_stdout_is_pure_json(self):
+        """The dump writes only JSON to stdout, nothing to stderr, rc 0.
+
+        Some command fns print before parsing (e.g. gen-hostnqn); this guards
+        against such output leaking into the machine-readable stream."""
+        proc = subprocess.run(
+            [NVME_BIN, "utils", "dump-command-metadata"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stderr, "")
+        json.loads(proc.stdout)  # raises if stdout is not pure JSON
+
+    def test_output_is_deterministic(self):
+        """Two runs produce byte-identical output (needed for drift checks)."""
+        runs = [
+            subprocess.run(
+                [NVME_BIN, "utils", "dump-command-metadata"],
+                stdout=subprocess.PIPE, universal_newlines=True).stdout
+            for _ in range(2)
+        ]
+        self.assertEqual(runs[0], runs[1])
+
+    def test_schema_version(self):
+        """schema_version is the expected 1; a change must be conscious."""
+        self.assertEqual(self.data["schema_version"], 1)
+
+    def test_global_output_format_option(self):
+        """The shared output-format option carries its constrained value set."""
+        cmd = next(c for c in self.data["commands"] if c["name"] == "list")
+        opt = next(o for o in cmd["options"] if o["long"] == "output-format")
+        self.assertTrue(opt.get("global"))
+        self.assertEqual(opt["argument"], "required")
+        self.assertIn("json", opt["values"])
+
+
+if __name__ == "__main__":
+    # argv[1:3] are consumed above; hand unittest only its own args.
+    unittest.main(argv=[sys.argv[0]] + sys.argv[3:])


### PR DESCRIPTION
Add `nvme utils dump-command-metadata`, which walks the live plugin/command tree and emits every command and its options as JSON describing the CLI surface. The command needs no device and is gated on CONFIG_JSONC. It is intended to feed a generator that produces shell completion scripts.

Options are captured via an argconfig_parse() hook that copies each command's options array without running the command. Includes command-metadata-schema.json and a Python unit test that validates the output and cross-checks it against --help and `nvme help`.

Cherry pick from #3603 