### PR TITLE
nbft-plugin: fix resource leak in show_nbft()

### DIFF
--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -700,7 +700,7 @@ int show_nbft(int argc, char **argv, struct command *acmd, struct plugin *plugin
 		else if (flags == JSON)
 			ret = json_show_nbfts(head, show_subsys,
 				show_hfi, show_discovery);
-		libnvmf_nbft_free(ctx, head);
 	}
+	libnvmf_nbft_free(ctx, head);
 	return ret;
 }


### PR DESCRIPTION
The show_nbft() function calls libnvmf_nbft_read_files() to build a linked list of NBFT file entries pointed to by head. The call to libnvmf_nbft_free() to release that list is guarded by the condition that ret is zero and head is non-NULL.

If libnvmf_nbft_read_files() partially populates head before returning an error, the already-allocated entries are never freed, resulting in a resource leak on the error path.

Move libnvmf_nbft_free() outside the conditional block so head is always freed. libnvmf_nbft_free() already handles a NULL head safely, so the unconditional call is correct in all cases.