### PR TITLE
libnvme: return libnvmf_tid_from_fields() as int, not a pointer

### DIFF
--- a/discoverd/src/tid.c
+++ b/discoverd/src/tid.c
@@ -19,11 +19,14 @@ struct libnvmf_tid *tid_new(const char *transport, const char *traddr,
 			    const char *host_traddr, const char *host_iface,
 			    const char *hostnqn, bool is_dc)
 {
+	struct libnvmf_tid *t;
+
 	if (!trsvcid || trsvcid[0] == '\0')
 		trsvcid = libnvmf_get_default_trsvcid(transport, is_dc);
 
-	return libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
-				       host_traddr, host_iface, hostnqn, NULL);
+	libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
+				host_traddr, host_iface, hostnqn, NULL, &t);
+	return t;
 }
 
 /*

--- a/fabrics.c
+++ b/fabrics.c
@@ -395,14 +395,12 @@ static int build_conn_tid(const struct libnvmf_config_conn *conn,
 	if (!hostid)
 		hostid = default_hostid;
 
-	*tid = libnvmf_tid_from_fields(transport, traddr,
+	return libnvmf_tid_from_fields(transport, traddr,
 			libnvmf_config_conn_get_trsvcid(conn),
 			libnvmf_config_conn_get_subsysnqn(conn),
 			libnvmf_config_conn_get_host_traddr(conn),
 			libnvmf_config_conn_get_host_iface(conn),
-			hostnqn, hostid);
-
-	return *tid ? 0 : -EINVAL;
+			hostnqn, hostid, tid);
 }
 
 /* libnvmf_config_conn_for_each() callback: settle addressing/identity,
@@ -1057,10 +1055,10 @@ do_connect:
 	if (nvme_args.verbose) {
 		struct libnvmf_tid *tid;
 
-		tid = libnvmf_tid_from_fields(fa.transport, fa.traddr,
-					      fa.trsvcid, fa.subsysnqn,
-					      fa.host_traddr, fa.host_iface,
-					      fa.hostnqn, fa.hostid);
+		libnvmf_tid_from_fields(fa.transport, fa.traddr,
+					fa.trsvcid, fa.subsysnqn,
+					fa.host_traddr, fa.host_iface,
+					fa.hostnqn, fa.hostid, &tid);
 		if (tid && libnvmf_exclusion_match(ctx, tid))
 			nvme_show_error(
 				"Note: %s is on the exclusion list; connecting anyway\n",

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -940,11 +940,16 @@ PyObject *exclusion_match(struct libnvme_global_ctx *ctx,
 {
 	struct libnvmf_tid *tid;
 	bool matched;
+	int ret;
 
-	tid = libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
-				      host_traddr, host_iface, hostnqn, hostid);
-	if (!tid)
-		return PyErr_NoMemory();
+	ret = libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
+				      host_traddr, host_iface, hostnqn, hostid,
+				      &tid);
+	if (ret) {
+		PyErr_Format(PyExc_OSError, "exclusion_match failed: %s",
+			     strerror(-ret));
+		return NULL;
+	}
 	matched = libnvmf_exclusion_match(ctx, tid);
 	libnvmf_tid_free(tid);
 	return PyBool_FromLong(matched);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1167,6 +1167,7 @@ static int nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx, libnvme_ctrl_t c)
 	struct libnvmf_tid *tid;
 	const char *canon;
 	char *dup;
+	int rc;
 
 	if (traddr_is_hostname(ctx, c->transport, c->traddr)) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,
@@ -1182,10 +1183,10 @@ static int nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx, libnvme_ctrl_t c)
 		return -ENVME_CONNECT_TRADDR;
 	}
 
-	tid = libnvmf_tid_from_fields(c->transport, c->traddr, c->trsvcid,
-			NULL, c->host_traddr, c->host_iface, NULL, NULL);
-	if (!tid)
-		return -ENOMEM;
+	rc = libnvmf_tid_from_fields(c->transport, c->traddr, c->trsvcid,
+			NULL, c->host_traddr, c->host_iface, NULL, NULL, &tid);
+	if (rc)
+		return rc;
 
 	canon = libnvmf_tid_get_traddr(tid);
 	if (canon) {
@@ -1707,9 +1708,8 @@ static bool nvmf_excluded(struct libnvme_global_ctx *ctx,
 	struct libnvmf_tid *tid;
 	bool excluded;
 
-	tid = libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
-				      host_traddr, host_iface, hostnqn,
-				      hostid);
+	libnvmf_tid_from_fields(transport, traddr, trsvcid, subsysnqn,
+				host_traddr, host_iface, hostnqn, hostid, &tid);
 	if (!tid)
 		return false; /* fail-safe: never block on allocation failure */
 
@@ -2507,7 +2507,7 @@ __libnvme_public int libnvmf_get_owner_from_fctx(struct libnvme_global_ctx *ctx,
 		return (ret == -ENOENT) ? 0 : ret;
 	}
 
-	tid = libnvmf_tid_from_fields(
+	ret = libnvmf_tid_from_fields(
 			libnvmf_context_get_transport(fctx),
 			libnvmf_context_get_traddr(fctx),
 			libnvmf_context_get_trsvcid(fctx),
@@ -2515,9 +2515,9 @@ __libnvme_public int libnvmf_get_owner_from_fctx(struct libnvme_global_ctx *ctx,
 			libnvmf_context_get_host_traddr(fctx),
 			libnvmf_context_get_host_iface(fctx),
 			libnvmf_context_get_hostnqn(fctx),
-			libnvmf_context_get_hostid(fctx));
-	if (!tid)
-		return -ENOMEM;
+			libnvmf_context_get_hostid(fctx), &tid);
+	if (ret)
+		return ret;
 
 	ret = libnvmf_get_owner_from_tid(ctx, tid, owner);
 	libnvmf_tid_free(tid);

--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -147,16 +147,22 @@ static int tid_sanitize_addr(struct libnvmf_tid *t)
 	return 0;
 }
 
-__libnvme_public struct libnvmf_tid *libnvmf_tid_from_fields(
+__libnvme_public int libnvmf_tid_from_fields(
 		const char *transport, const char *traddr,
 		const char *trsvcid, const char *subsysnqn,
 		const char *host_traddr, const char *host_iface,
-		const char *hostnqn, const char *hostid)
+		const char *hostnqn, const char *hostid,
+		struct libnvmf_tid **out)
 {
 	struct libnvmf_tid *t;
+	int rc;
+
+	if (!out)
+		return -EINVAL;
+	*out = NULL;
 
 	if (libnvmf_tid_new(&t) < 0)
-		return NULL;
+		return -ENOMEM;
 
 	t->transport   = shr_xstrdup(transport);
 	t->traddr      = shr_xstrdup(traddr);
@@ -167,12 +173,26 @@ __libnvme_public struct libnvmf_tid *libnvmf_tid_from_fields(
 	t->hostnqn     = shr_xstrdup(hostnqn);
 	t->hostid      = shr_xstrdup(hostid);
 
-	if (tid_sanitize_addr(t)) {
+	if ((transport && !t->transport) ||
+	    (traddr && !t->traddr) ||
+	    (trsvcid && !t->trsvcid) ||
+	    (subsysnqn && !t->subsysnqn) ||
+	    (host_traddr && !t->host_traddr) ||
+	    (host_iface && !t->host_iface) ||
+	    (hostnqn && !t->hostnqn) ||
+	    (hostid && !t->hostid)) {
 		libnvmf_tid_free(t);
-		return NULL;
+		return -ENOMEM;
 	}
 
-	return t;
+	rc = tid_sanitize_addr(t);
+	if (rc) {
+		libnvmf_tid_free(t);
+		return rc;
+	}
+
+	*out = t;
+	return 0;
 }
 
 /*
@@ -269,6 +289,18 @@ __libnvme_public struct libnvmf_tid *libnvmf_tid_dup(
 	t->host_iface  = shr_xstrdup(tid->host_iface);
 	t->hostnqn     = shr_xstrdup(tid->hostnqn);
 	t->hostid      = shr_xstrdup(tid->hostid);
+
+	if ((tid->transport && !t->transport) ||
+	    (tid->traddr && !t->traddr) ||
+	    (tid->trsvcid && !t->trsvcid) ||
+	    (tid->subsysnqn && !t->subsysnqn) ||
+	    (tid->host_traddr && !t->host_traddr) ||
+	    (tid->host_iface && !t->host_iface) ||
+	    (tid->hostnqn && !t->hostnqn) ||
+	    (tid->hostid && !t->hostid)) {
+		libnvmf_tid_free(t);
+		return NULL;
+	}
 
 	return t;
 }

--- a/libnvme/src/nvme/tid.h
+++ b/libnvme/src/nvme/tid.h
@@ -22,22 +22,21 @@ struct libnvme_global_ctx;
  * @host_iface:  Host interface name, or NULL.
  * @hostnqn:     Host NQN, or NULL.
  * @hostid:      Host Identifier, or NULL.
+ * @out:         The allocated TID on success; NULL on error.
  *
  * Convenience constructor.  NULL fields are stored as NULL.  For an IP
  * transport (tcp, rdma) a numeric traddr/host_traddr is canonicalized; a
  * hostname is rejected -- resolving it is the caller's job, not libnvme's.
  *
- * Return: Allocated TID, or NULL if traddr/host_traddr is not numeric on an
- * IP transport, or on allocation failure.
+ * Return: 0 on success (*@out is the allocated TID); -EINVAL if @out is
+ * NULL or traddr/host_traddr is not numeric on an IP transport; -ENOMEM on
+ * allocation failure.
  */
-struct libnvmf_tid *libnvmf_tid_from_fields(const char *transport,
-					    const char *traddr,
-					    const char *trsvcid,
-					    const char *subsysnqn,
-					    const char *host_traddr,
-					    const char *host_iface,
-					    const char *hostnqn,
-					    const char *hostid);
+int libnvmf_tid_from_fields(const char *transport, const char *traddr,
+			    const char *trsvcid, const char *subsysnqn,
+			    const char *host_traddr, const char *host_iface,
+			    const char *hostnqn, const char *hostid,
+			    struct libnvmf_tid **out);
 
 /**
  * libnvmf_tid_set_identity() - Set the subsystem and host identity together.

--- a/libnvme/test/config-api.c
+++ b/libnvme/test/config-api.c
@@ -361,7 +361,9 @@ static bool args_match(const struct arg_list *list,
  */
 static struct libnvmf_tid *build_tid(const struct libnvmf_config_conn *conn)
 {
-	return libnvmf_tid_from_fields(
+	struct libnvmf_tid *tid;
+
+	libnvmf_tid_from_fields(
 			libnvmf_config_conn_get_transport(conn),
 			libnvmf_config_conn_get_traddr(conn),
 			libnvmf_config_conn_get_trsvcid(conn),
@@ -369,7 +371,8 @@ static struct libnvmf_tid *build_tid(const struct libnvmf_config_conn *conn)
 			libnvmf_config_conn_get_host_traddr(conn),
 			libnvmf_config_conn_get_host_iface(conn),
 			libnvmf_config_conn_get_hostnqn(conn),
-			libnvmf_config_conn_get_hostid(conn));
+			libnvmf_config_conn_get_hostid(conn), &tid);
+	return tid;
 }
 
 static bool test_emit(struct libnvme_global_ctx *ctx, const struct fixture *fx)
@@ -600,15 +603,14 @@ static bool test_hostnqn_precedence(struct libnvme_global_ctx *ctx,
 	hostid = libnvmf_config_conn_get_hostid(mv);
 	assert(!hostid);
 	hostid = default_hostid;
-	mv_tid = libnvmf_tid_from_fields(
+	assert(!libnvmf_tid_from_fields(
 			libnvmf_config_conn_get_transport(mv),
 			libnvmf_config_conn_get_traddr(mv),
 			libnvmf_config_conn_get_trsvcid(mv),
 			libnvmf_config_conn_get_subsysnqn(mv),
 			libnvmf_config_conn_get_host_traddr(mv),
 			libnvmf_config_conn_get_host_iface(mv),
-			hostnqn, hostid);
-	assert(mv_tid);
+			hostnqn, hostid, &mv_tid));
 
 	if (strcmp(libnvmf_tid_get_hostnqn(mv_tid), default_hostnqn) ||
 	    strcmp(libnvmf_tid_get_hostid(mv_tid), default_hostid)) {
@@ -622,15 +624,14 @@ static bool test_hostnqn_precedence(struct libnvme_global_ctx *ctx,
 	assert(hostnqn);
 	hostid = libnvmf_config_conn_get_hostid(pv);
 	assert(hostid);
-	pv_tid = libnvmf_tid_from_fields(
+	assert(!libnvmf_tid_from_fields(
 			libnvmf_config_conn_get_transport(pv),
 			libnvmf_config_conn_get_traddr(pv),
 			libnvmf_config_conn_get_trsvcid(pv),
 			libnvmf_config_conn_get_subsysnqn(pv),
 			libnvmf_config_conn_get_host_traddr(pv),
 			libnvmf_config_conn_get_host_iface(pv),
-			hostnqn, hostid);
-	assert(pv_tid);
+			hostnqn, hostid, &pv_tid));
 
 	if (strcmp(libnvmf_tid_get_hostnqn(pv_tid),
 		   "nqn.2014-08.org.nvmexpress:prod-host") ||
@@ -657,12 +658,11 @@ static bool test_set_connection_from_tid(struct libnvme_global_ctx *ctx)
 
 	printf("test_set_connection_from_tid:\n");
 
-	tid = libnvmf_tid_from_fields("tcp", "10.0.0.9", "4420",
+	assert(!libnvmf_tid_from_fields("tcp", "10.0.0.9", "4420",
 			"nqn.2014-08.org.nvmexpress:subsys",
 			"10.0.0.1", "eth0",
 			"nqn.2014-08.org.nvmexpress:host",
-			"2cd2c43b-a90a-45c1-a8cd-86b33ab273b5");
-	assert(tid);
+			"2cd2c43b-a90a-45c1-a8cd-86b33ab273b5", &tid));
 
 	assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
 

--- a/libnvme/test/exclusion.c
+++ b/libnvme/test/exclusion.c
@@ -339,8 +339,8 @@ static bool test_match(struct libnvme_global_ctx *ctx)
 	 * A TID matching all of the entry's fields -- plus an extra trsvcid the
 	 * entry does not constrain -- is excluded (subset match).
 	 */
-	tid = libnvmf_tid_from_fields("tcp", "9.9.9.9", "4420", "nqn.a",
-				      NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "9.9.9.9", "4420", "nqn.a",
+				NULL, NULL, NULL, NULL, &tid);
 	if (libnvmf_exclusion_match(ctx, tid)) {
 		printf(" - subset match → excluded [PASS]\n");
 	} else {
@@ -350,8 +350,8 @@ static bool test_match(struct libnvme_global_ctx *ctx)
 	libnvmf_tid_free(tid);
 
 	/* A difference in one constrained field (subsysnqn) → not excluded. */
-	tid = libnvmf_tid_from_fields("tcp", "9.9.9.9", "4420", "nqn.other",
-				      NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "9.9.9.9", "4420", "nqn.other",
+				NULL, NULL, NULL, NULL, &tid);
 	if (!libnvmf_exclusion_match(ctx, tid)) {
 		printf(" - different subsysnqn → not excluded [PASS]\n");
 	} else {
@@ -477,8 +477,8 @@ static bool test_default_list(struct libnvme_global_ctx *ctx)
 		printf(" - add(NULL) -> 1 entry in the default list [PASS]\n");
 	}
 
-	tid = libnvmf_tid_from_fields("tcp", "7.7.7.7", "4420", "nqn.x",
-				      NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "7.7.7.7", "4420", "nqn.x",
+				NULL, NULL, NULL, NULL, &tid);
 	if (libnvmf_exclusion_match(ctx, tid)) {
 		printf(" - default-list entry matches [PASS]\n");
 	} else {

--- a/libnvme/test/test-tid.c
+++ b/libnvme/test/test-tid.c
@@ -423,8 +423,8 @@ static bool test_tid_set_identity(void)
 	printf("\ntest_tid_set_identity:\n");
 
 	/* Sets the triplet. */
-	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
-				    NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
+				NULL, NULL, NULL, NULL, &t);
 	p = t && libnvmf_tid_set_identity(t, "nqn.sub", "nqn.host",
 		"46ba5037-7ce5-41fa-9452-48477bf00080") == 0 &&
 	    streq(libnvmf_tid_get_subsysnqn(t), "nqn.sub") &&
@@ -443,8 +443,8 @@ static bool test_tid_set_identity(void)
 	libnvmf_tid_free(t);
 
 	/* hostid derived from a UUID-format hostnqn when none is given. */
-	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
-				    NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
+				NULL, NULL, NULL, NULL, &t);
 	p = t && libnvmf_tid_set_identity(t, "nqn.sub",
 		"nqn.2014-08.org.nvmexpress:uuid:46ba5037-7ce5-41fa-9452-48477bf00080",
 		NULL) == 0 &&
@@ -455,8 +455,8 @@ static bool test_tid_set_identity(void)
 	libnvmf_tid_free(t);
 
 	/* A hostid without any hostnqn is rejected. */
-	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
-				    NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", NULL,
+				NULL, NULL, NULL, NULL, &t);
 	p = t && libnvmf_tid_set_identity(t, "nqn.sub", NULL,
 		"46ba5037-7ce5-41fa-9452-48477bf00080") == -EINVAL;
 	CHECK(p, "hostid without hostnqn rejected");
@@ -575,40 +575,40 @@ static bool test_tid_sanitize(void)
 	printf("  (error messages on stderr below are expected)\n");
 
 	/* An expanded IPv6 traddr is canonicalized to its compressed form. */
-	t = libnvmf_tid_from_fields("tcp", "2001:db8:0:0:0:0:0:1", "4420",
-				    "nqn.t", NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "2001:db8:0:0:0:0:0:1", "4420",
+				"nqn.t", NULL, NULL, NULL, NULL, &t);
 	p = t && streq(libnvmf_tid_get_traddr(t), "2001:db8::1");
 	CHECK(p, "expanded IPv6 traddr → compressed");
 	pass &= p;
 	libnvmf_tid_free(t);
 
 	/* A numeric host_traddr is canonicalized too. */
-	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", "nqn.t",
-				    "2001:db8:0:0:0:0:0:2", NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", "nqn.t",
+				"2001:db8:0:0:0:0:0:2", NULL, NULL, NULL, &t);
 	p = t && streq(libnvmf_tid_get_host_traddr(t), "2001:db8::2");
 	CHECK(p, "host_traddr IPv6 canonicalized");
 	pass &= p;
 	libnvmf_tid_free(t);
 
 	/* An IPv6 scope suffix is kept verbatim after the canonical address. */
-	t = libnvmf_tid_from_fields("tcp", "fe80:0:0:0:0:0:0:1%eth0", "4420",
-				    "nqn.t", NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "fe80:0:0:0:0:0:0:1%eth0", "4420",
+				"nqn.t", NULL, NULL, NULL, NULL, &t);
 	p = t && streq(libnvmf_tid_get_traddr(t), "fe80::1%eth0");
 	CHECK(p, "IPv6 scope preserved: fe80::1%%eth0");
 	pass &= p;
 	libnvmf_tid_free(t);
 
 	/* A hostname traddr is rejected outright: construction fails. */
-	t = libnvmf_tid_from_fields("tcp", "dc.example.com", "8009", "nqn.t",
-				    NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "dc.example.com", "8009", "nqn.t",
+				NULL, NULL, NULL, NULL, &t);
 	p = (t == NULL);
 	CHECK(p, "hostname traddr rejected by from_fields()");
 	libnvmf_tid_free(t);
 	pass &= p;
 
 	/* A hostname host_traddr is rejected too. */
-	t = libnvmf_tid_from_fields("tcp", "1.2.3.4", "8009", "nqn.t",
-				    "dc.example.com", NULL, NULL, NULL);
+	libnvmf_tid_from_fields("tcp", "1.2.3.4", "8009", "nqn.t",
+				"dc.example.com", NULL, NULL, NULL, &t);
 	p = (t == NULL);
 	CHECK(p, "hostname host_traddr rejected by from_fields()");
 	libnvmf_tid_free(t);
@@ -622,32 +622,32 @@ static bool test_tid_sanitize(void)
 	pass &= p;
 
 	/* A well-formed FC WWN pair passes through unchanged. */
-	t = libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
-				    NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
+				NULL, NULL, NULL, NULL, &t);
 	p = t && streq(libnvmf_tid_get_traddr(t), "nn-0x1:pn-0x2");
 	CHECK(p, "fc traddr untouched");
 	pass &= p;
 	libnvmf_tid_free(t);
 
 	/* A malformed FC traddr is rejected, same as a bad tcp/rdma one. */
-	t = libnvmf_tid_from_fields("fc", "21:00:00:e0:8b:05:05:01", NULL,
-				    "nqn.t", NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("fc", "21:00:00:e0:8b:05:05:01", NULL,
+				"nqn.t", NULL, NULL, NULL, NULL, &t);
 	p = (t == NULL);
 	CHECK(p, "malformed fc traddr rejected");
 	pass &= p;
 	libnvmf_tid_free(t);
 
 	/* A malformed FC host_traddr is rejected too. */
-	t = libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
-				    "not-a-wwn", NULL, NULL, NULL);
+	libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
+				"not-a-wwn", NULL, NULL, NULL, &t);
 	p = (t == NULL);
 	CHECK(p, "malformed fc host_traddr rejected");
 	pass &= p;
 	libnvmf_tid_free(t);
 
 	/* loop has no addressing shape at all: truly untouched. */
-	t = libnvmf_tid_from_fields("loop", "anything goes", NULL, "nqn.t",
-				    NULL, NULL, NULL, NULL);
+	libnvmf_tid_from_fields("loop", "anything goes", NULL, "nqn.t",
+				NULL, NULL, NULL, NULL, &t);
 	p = t && streq(libnvmf_tid_get_traddr(t), "anything goes");
 	CHECK(p, "loop traddr untouched");
 	pass &= p;

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -6562,14 +6562,14 @@ static void stdout_print_conn(const struct libnvmf_config_conn *conn,
 	printf("# %s: %s\n", libnvmf_config_conn_get_source(conn),
 		is_dc ? "Discovery Controller" : "I/O Controller");
 
-	tid = libnvmf_tid_from_fields(
+	libnvmf_tid_from_fields(
 			libnvmf_config_conn_get_transport(conn),
 			libnvmf_config_conn_get_traddr(conn),
 			libnvmf_config_conn_get_trsvcid(conn),
 			libnvmf_config_conn_get_subsysnqn(conn),
 			libnvmf_config_conn_get_host_traddr(conn),
 			libnvmf_config_conn_get_host_iface(conn),
-			hostnqn, hostid);
+			hostnqn, hostid, &tid);
 
 	/*
 	 * A DC entry is consumed via libnvmf_discovery() (log in, fetch the


### PR DESCRIPTION
libnvmf_tid_from_fields() returned NULL on any failure, so a caller could not tell a validation error (-EINVAL, non-numeric traddr/host_traddr) from an allocation failure (-ENOMEM). Two internal callers actually got this wrong: fabrics.c's build_conn_tid() reported every failure as -EINVAL, and libnvme/src/nvme/fabrics.c's nvmf_sanitize_addrs() and the owner lookup in libnvmf_get_owner_from_fctx() reported every failure as -ENOMEM.

Convert to int with an out-param, matching libnvmf_config_read()'s existing convention, and update every call site. The SWIG binding now raises a real errno-based message instead of always PyErr_NoMemory().

Also check for a partial shr_xstrdup() failure across the struct's multi-field copy, which the pointer-returning version never checked.