### PR TITLE
libnvme: fix comments that still describe removed JSON config support

### DIFF
--- a/libnvme/src/nvme/crypto.c
+++ b/libnvme/src/nvme/crypto.c
@@ -1298,9 +1298,10 @@ int __libnvmf_import_keys_from_config(libnvme_host_t h, libnvme_ctrl_t c,
 		kr_id = c->cfg.keyring_id;
 
 	/*
-	 * Fallback to the default keyring. Note this will also add the
-	 * keyring to connect command line and to the JSON config output.
-	 * That means we are explicitly selecting the keyring.
+	 * Fallback to the default keyring. This makes the keyring
+	 * explicit on the ctrl rather than left unset, which matters
+	 * to anything downstream that inspects this connection's
+	 * parameters.
 	 */
 	if (!kr_id) {
 		ret = libnvmf_lookup_keyring(h->ctx, ".nvme", &kr_id);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -350,7 +350,7 @@ __libnvme_public int libnvmf_host_get_ids(struct libnvme_global_ctx *ctx,
 	if (hostnqn_arg)
 		hnqn = strdup(hostnqn_arg);
 
-	/* JSON config: assume the first entry is the default host */
+	/* first host already resolved in ctx->hosts, if any */
 	h = libnvme_first_host(ctx);
 	if (h) {
 		if (!hid)
@@ -1561,7 +1561,7 @@ __libnvme_public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
 	if (libnvme_ctrl_get_name(c) && !c->cfg.duplicate_connect)
 		return -ENVME_CONNECT_ALREADY;
 
-	/* apply configuration from config file (JSON) */
+	/* carry over config from an existing ctrl on the same subsystem */
 	s = libnvme_lookup_subsystem(h, NULL, libnvme_ctrl_get_subsysnqn(c));
 	if (s) {
 		libnvme_ctrl_t fc;

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -98,19 +98,21 @@ char *libnvmf_read_hostid(struct libnvme_global_ctx *ctx);
  *
  * The order is:
  *
- *  - Start with information from DMI or device-tree
- *  - Override hostnqn and hostid from /etc/nvme files
- *  - Override hostnqn or hostid with values from JSON
- *    configuration file. The first host entry in the file is
- *    considered the default host.
- *  - Override hostnqn or hostid with values from the command line
- *    (@hostnqn_arg, @hostid_arg).
+ *  - Start with hostnqn/hostid given on the command line
+ *    (@hostnqn_arg, @hostid_arg), if any
+ *  - Otherwise, use the first host already resolved in @ctx's host
+ *    list, if any
+ *  - Otherwise, use @ctx's own hostnqn/hostid default, or
+ *    /etc/nvme/hostnqn and /etc/nvme/hostid if @ctx has none
+ *  - Otherwise, if hostnqn is known but hostid is not, and hostnqn
+ *    has a "uuid:" component, derive hostid from it
+ *  - As a last resort, derive a still-missing hostid from DMI or
+ *    device-tree information (or generate a random one), then build
+ *    a hostnqn from that hostid if one is still missing
  *
- *  If the IDs are still NULL after the lookup algorithm, the function
- *  will generate random IDs.
- *
- *  The function also verifies that hostnqn and hostid matches. The Linux
- *  NVMe implementation expects a 1:1 matching between the IDs.
+ *  The function also checks that hostnqn and hostid match, logging a
+ *  debug warning if not. The Linux NVMe implementation expects a 1:1
+ *  matching between the IDs.
  *
  *  Return: 0 on success (@hostnqn and @hostid contain valid strings
  *  which the caller needs to free), or negative error code otherwise.


### PR DESCRIPTION
json-c was dropped from libnvme entirely during the INI migration, but several comments/kdoc still described host/keyring/ctrl-merge logic in terms of a JSON config file that is no longer read. Update them to describe what the code actually does now.

libnvmf_host_get_ids()'s kdoc also had two further inaccuracies unrelated to JSON: the tiers were listed weakest-first instead of in actual lookup order, hostid-from-hostnqn derivation only works when the hostnqn has a "uuid:" component (undocumented), and "verifies" overstated a mismatch check that only logs a debug warning.

No behavior change.