### PR TITLE
nvme-models: fix stream EOF state errors in __nvme_product_name and pull_class_info

### DIFF
--- a/nvme-models.c
+++ b/nvme-models.c
@@ -342,9 +342,12 @@ static char *__nvme_product_name(int id)
 						device,
 						sub_device,
 						sub_vendor);
+			clearerr(file);
 		}
-		if (is_class_info(readbuf))
+		if (is_class_info(readbuf)) {
 			pull_class_info(readbuf, file, class);
+			clearerr(file);
+		}
 	}
 	fclose(file);
 


### PR DESCRIPTION
parse_vendor_device() and pull_class_info() share the same FILE
pointer as the outer fgets loop in __nvme_product_name(). Either 
function can consume the file to EOF, leaving the stream's EOF 
indicator set before the outer loop re-evaluates its fgets condition on 
the back-edge, and before pull_class_info() reads from the same stream. 

Add clearerr() at the end of the outer loop body to reset the EOF indicator 
after each iteration, ensuring the stream is in a defined state before the next
fgets call and before any delegate reads.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>