### PR TITLE
shared: add more test coverage

### DIFF
--- a/shared/test/meson.build
+++ b/shared/test/meson.build
@@ -47,3 +47,71 @@ if host_system != 'windows'
 
     test('shared - ini', test_ini)
 endif
+
+test_parse_util = executable(
+    'test-parse-util',
+    ['test-parse-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
+
+test('shared - parse-util', test_parse_util)
+
+test_hash_util = executable(
+    'test-hash-util',
+    ['test-hash-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
+
+test('shared - hash-util', test_hash_util)
+
+test_string_util = executable(
+    'test-string-util',
+    ['test-string-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
+
+test('shared - string-util', test_string_util)
+
+test_io_util = executable(
+    'test-io-util',
+    ['test-io-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
+
+test('shared - io-util', test_io_util)
+
+test_fs_util = executable(
+    'test-fs-util',
+    ['test-fs-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
+
+test('shared - fs-util', test_fs_util)
+
+if host_system != 'windows'
+    test_net_util = executable(
+        'test-net-util',
+        ['test-net-util.c'],
+        dependencies: [
+            config_dep,
+            shared_dep,
+        ],
+    )
+
+    test('shared - net-util', test_net_util)
+endif

--- a/shared/test/test-fs-util.c
+++ b/shared/test/test-fs-util.c
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#include <direct.h>
+#define rmdir _rmdir
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+#include <fs-util.h>
+
+static bool check_str(const char *name, const char *got, const char *want)
+{
+	bool eq = (got == want) || (got && want && !strcmp(got, want));
+
+	if (eq) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got \"%s\", want \"%s\" [FAIL]\n",
+	       name, got ? got : "(null)", want ? want : "(null)");
+	return false;
+}
+
+static bool check_ret(const char *name, int got, int want)
+{
+	if (got == want) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got %d, want %d [FAIL]\n", name, got, want);
+	return false;
+}
+
+static bool check_bool(const char *name, bool got)
+{
+	printf(" - %s [%s]\n", name, got ? "PASS" : "FAIL");
+	return got;
+}
+
+static bool test_basename(void)
+{
+	bool pass = true;
+
+	printf("test_basename:\n");
+
+	pass &= check_str("regular path", shr_basename("/a/b/c"), "c");
+	pass &= check_str("no slash at all",
+			   shr_basename("noslash"), "noslash");
+	pass &= check_str("trailing slash → empty (unlike POSIX basename())",
+			   shr_basename("/trailing/"), "");
+	pass &= check_str("bare \"/\" → empty", shr_basename("/"), "");
+	pass &= check_str("empty input → empty", shr_basename(""), "");
+
+	return pass;
+}
+
+/* Prove the directory tree really exists by writing a file inside it. */
+static bool dir_is_writable(const char *dir)
+{
+	char path[512];
+	FILE *f;
+
+	snprintf(path, sizeof(path), "%s/marker", dir);
+	f = fopen(path, "w");
+	if (!f)
+		return false;
+	fclose(f);
+	remove(path);
+
+	return true;
+}
+
+static bool test_mkdir_p(void)
+{
+	static const char *base = "shr-test-mkdir-p-dir";
+	char deep[256];
+	bool pass = true;
+	int ret;
+
+	printf("test_mkdir_p:\n");
+
+	snprintf(deep, sizeof(deep), "%s/level1/level2", base);
+
+	ret = shr_mkdir_p(deep, 0755);
+	pass &= check_ret("creates every missing parent", ret, 0);
+	pass &= check_bool("the deepest directory is real and writable",
+			    dir_is_writable(deep));
+
+	ret = shr_mkdir_p(deep, 0755);
+	pass &= check_ret("re-running on an existing tree is a no-op success",
+			   ret, 0);
+
+	snprintf(deep, sizeof(deep), "%s/level1/level2/", base);
+	ret = shr_mkdir_p(deep, 0755);
+	pass &= check_ret("a trailing slash does not confuse it", ret, 0);
+
+	{
+		char toolong[PATH_MAX + 2];
+
+		memset(toolong, 'a', sizeof(toolong) - 1);
+		toolong[sizeof(toolong) - 1] = '\0';
+		ret = shr_mkdir_p(toolong, 0755);
+		pass &= check_ret("a path longer than PATH_MAX is rejected",
+				  ret, -ENAMETOOLONG);
+	}
+
+	/* Clean up what we created, deepest first. */
+	rmdir("shr-test-mkdir-p-dir/level1/level2");
+	rmdir("shr-test-mkdir-p-dir/level1");
+	rmdir("shr-test-mkdir-p-dir");
+
+	return pass;
+}
+
+#if !defined(_WIN32)
+static bool test_mkstemp(void)
+{
+	char template[] = "shr-test-mkstemp-XXXXXX";
+	bool pass = true;
+	int fd, flags;
+
+	printf("test_mkstemp:\n");
+
+	fd = shr_mkstemp(template);
+	pass &= check_bool("returns a valid fd", fd >= 0);
+	if (fd < 0)
+		return pass;
+
+	pass &= check_bool("template's X's got replaced",
+			    strcmp(template, "shr-test-mkstemp-XXXXXX") != 0);
+
+	flags = fcntl(fd, F_GETFD);
+	pass &= check_bool("O_CLOEXEC is set on the returned fd",
+			    flags >= 0 && (flags & FD_CLOEXEC));
+
+	close(fd);
+	unlink(template);
+
+	return pass;
+}
+#endif
+
+static bool test_fsync_dir(void)
+{
+	printf("test_fsync_dir:\n");
+
+	/* Neither call has a return value to check; passing means no crash. */
+	shr_fsync_dir(".");
+	shr_fsync_dir("/no/such/directory/at/all");
+
+	printf(" - fsync_dir on a real and a bogus path [PASS]\n");
+
+	return true;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_basename();
+	pass &= test_mkdir_p();
+#if !defined(_WIN32)
+	pass &= test_mkstemp();
+#endif
+	pass &= test_fsync_dir();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/shared/test/test-hash-util.c
+++ b/shared/test/test-hash-util.c
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <hash-util.h>
+
+static bool check(const char *name, uint64_t got, uint64_t want)
+{
+	if (got == want) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got 0x%016lX, want 0x%016lX [FAIL]\n",
+	       name, (unsigned long)got, (unsigned long)want);
+	return false;
+}
+
+static bool test_known_vectors(void)
+{
+	bool pass = true;
+
+	printf("test_known_vectors:\n");
+
+	/* Reference FNV-1a 64-bit values (fnv1a64 offset basis / test set). */
+	pass &= check("empty input", shr_fnv1a_64("", 0),
+		      0xcbf29ce484222325ULL);
+	pass &= check("\"a\"", shr_fnv1a_64("a", 1), 0xaf63dc4c8601ec8cULL);
+	pass &= check("\"foobar\"", shr_fnv1a_64("foobar", 6),
+		      0x85944171f73967e8ULL);
+	pass &= check("\"123456789\"", shr_fnv1a_64("123456789", 9),
+		      0x06d5573923c6cdfcULL);
+
+	return pass;
+}
+
+static bool test_deterministic(void)
+{
+	uint64_t h1, h2;
+	bool pass;
+
+	printf("test_deterministic:\n");
+
+	h1 = shr_fnv1a_64("same input", strlen("same input"));
+	h2 = shr_fnv1a_64("same input", strlen("same input"));
+
+	pass = check("two calls on identical input match", h1, h2);
+
+	return pass;
+}
+
+static bool test_different_inputs_differ(void)
+{
+	uint64_t h1, h2;
+	bool pass;
+
+	printf("test_different_inputs_differ:\n");
+
+	h1 = shr_fnv1a_64("input-a", 7);
+	h2 = shr_fnv1a_64("input-b", 7);
+
+	if (h1 != h2) {
+		printf(" - single-byte difference changes the hash [PASS]\n");
+		pass = true;
+	} else {
+		printf(" - single-byte difference changes the hash [FAIL]\n");
+		pass = false;
+	}
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_known_vectors();
+	pass &= test_deterministic();
+	pass &= test_different_inputs_differ();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/shared/test/test-io-util.c
+++ b/shared/test/test-io-util.c
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <io-util.h>
+
+static bool check_ret(const char *name, int got, int want)
+{
+	if (got == want) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got %d, want %d [FAIL]\n", name, got, want);
+	return false;
+}
+
+static bool check_bool(const char *name, bool got)
+{
+	printf(" - %s [%s]\n", name, got ? "PASS" : "FAIL");
+	return got;
+}
+
+static bool test_round_trip(void)
+{
+	static const char *path = "shr-test-io-util-file";
+	static const char *msg = "some bytes written through shr_write_all";
+	char readback[128] = { 0 };
+	bool pass = true;
+	int fd, ret;
+	ssize_t n;
+
+	printf("test_round_trip:\n");
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	pass &= check_bool("temp file opened for writing", fd >= 0);
+	if (fd < 0)
+		return pass;
+
+	ret = shr_write_all(fd, msg, strlen(msg));
+	pass &= check_ret("writes the whole buffer in one call", ret, 0);
+	close(fd);
+
+	fd = open(path, O_RDONLY);
+	pass &= check_bool("temp file reopened for reading", fd >= 0);
+	if (fd >= 0) {
+		n = read(fd, readback, sizeof(readback) - 1);
+		close(fd);
+		pass &= check_bool("readback matches what was written",
+				   n == (ssize_t)strlen(msg) &&
+				   !strcmp(readback, msg));
+	}
+
+	unlink(path);
+
+	return pass;
+}
+
+static bool test_zero_length(void)
+{
+	bool pass;
+
+	printf("test_zero_length:\n");
+
+	/* len == 0 must succeed without touching the fd at all. */
+	pass = check_ret("zero-length write on an invalid fd still succeeds",
+			  shr_write_all(-1, "x", 0), 0);
+
+	return pass;
+}
+
+static bool test_bad_fd(void)
+{
+	bool pass;
+
+	printf("test_bad_fd:\n");
+
+	pass = check_ret("a real write on an invalid fd reports -EBADF",
+			  shr_write_all(-1, "x", 1), -EBADF);
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_round_trip();
+	pass &= test_zero_length();
+	pass &= test_bad_fd();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/shared/test/test-net-util.c
+++ b/shared/test/test-net-util.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include <net-util.h>
+
+static bool check_bool(const char *name, bool got, bool want)
+{
+	if (got == want) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got %d, want %d [FAIL]\n", name, got, want);
+	return false;
+}
+
+static bool check_str(const char *name, const char *got, const char *want)
+{
+	bool eq = (got == want) || (got && want && !strcmp(got, want));
+
+	if (eq) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got \"%s\", want \"%s\" [FAIL]\n",
+	       name, got ? got : "(null)", want ? want : "(null)");
+	return false;
+}
+
+static bool test_ipaddrs_eq(void)
+{
+	/*
+	 * Two distinct buffers with identical content -- guards against the
+	 * compiler pooling two identical string literals into one address,
+	 * which would trigger the addr1 == addr2 pointer shortcut instead of
+	 * exercising the "hostnames are never numeric" rejection path below.
+	 */
+	char hostname1[] = "example.com";
+	char hostname2[] = "example.com";
+	bool pass = true;
+
+	printf("test_ipaddrs_eq:\n");
+
+	pass &= check_bool("NULL == NULL", shr_ipaddrs_eq(NULL, NULL), true);
+	pass &= check_bool("NULL != a real address",
+			    shr_ipaddrs_eq(NULL, "1.2.3.4"), false);
+	pass &= check_bool("identical IPv4 strings",
+			    shr_ipaddrs_eq("1.2.3.4", "1.2.3.4"), true);
+	pass &= check_bool("different IPv4 addresses",
+			    shr_ipaddrs_eq("1.2.3.4", "1.2.3.5"), false);
+	pass &= check_bool("compressed vs. expanded IPv6, same address",
+			    shr_ipaddrs_eq("2001:db8::1",
+					   "2001:0db8:0000:0000:0000:0000:0000:0001"),
+			    true);
+	pass &= check_bool("IPv4-mapped IPv6 matches its plain IPv4 form",
+			    shr_ipaddrs_eq("::ffff:192.168.1.1", "192.168.1.1"),
+			    true);
+	pass &= check_bool("a hostname is never treated as equal to anything",
+			    shr_ipaddrs_eq(hostname1, hostname2), false);
+
+	return pass;
+}
+
+/* Build a 3-entry synthetic interface list, no real NICs required. */
+struct fake_iface {
+	struct ifaddrs pub;
+	struct sockaddr_storage ss;
+};
+
+static void set_addr(struct fake_iface *f, const char *name,
+		     sa_family_t family, const char *addr)
+{
+	f->pub.ifa_name = (char *)name;
+	f->pub.ifa_addr = (struct sockaddr *)&f->ss;
+
+	if (family == AF_INET) {
+		struct sockaddr_in *s4 = (struct sockaddr_in *)&f->ss;
+
+		s4->sin_family = AF_INET;
+		inet_pton(AF_INET, addr, &s4->sin_addr);
+	} else {
+		struct sockaddr_in6 *s6 = (struct sockaddr_in6 *)&f->ss;
+
+		s6->sin6_family = AF_INET6;
+		inet_pton(AF_INET6, addr, &s6->sin6_addr);
+	}
+}
+
+static struct ifaddrs *build_fake_ifaddrs(struct fake_iface *nodes, int n)
+{
+	int i;
+
+	for (i = 0; i < n - 1; i++)
+		nodes[i].pub.ifa_next = &nodes[i + 1].pub;
+	nodes[n - 1].pub.ifa_next = NULL;
+
+	return &nodes[0].pub;
+}
+
+static bool test_iface_matching_addr(void)
+{
+	struct fake_iface nodes[3] = { 0 };
+	struct ifaddrs *list;
+	bool pass = true;
+
+	printf("test_iface_matching_addr:\n");
+
+	set_addr(&nodes[0], "eth0", AF_INET, "10.0.0.1");
+	set_addr(&nodes[1], "eth1", AF_INET6, "2001:db8::2");
+	set_addr(&nodes[2], "eth2", AF_INET, "10.0.0.3");
+	list = build_fake_ifaddrs(nodes, 3);
+
+	pass &= check_str("finds the IPv4 owner",
+			   shr_iface_matching_addr(list, "10.0.0.1"), "eth0");
+	pass &= check_str("finds the IPv6 owner",
+			   shr_iface_matching_addr(list, "2001:db8::2"),
+			   "eth1");
+	pass &= check_str("no owner for an address not in the list",
+			   shr_iface_matching_addr(list, "10.0.0.99"), NULL);
+	pass &= check_str("NULL list → NULL",
+			   shr_iface_matching_addr(NULL, "10.0.0.1"), NULL);
+
+	return pass;
+}
+
+static bool test_iface_primary_addr_matches(void)
+{
+	struct fake_iface nodes[3] = { 0 };
+	struct ifaddrs *list;
+	bool pass = true;
+
+	printf("test_iface_primary_addr_matches:\n");
+
+	/* eth0's primary IPv4, a secondary IPv4, then its primary IPv6. */
+	set_addr(&nodes[0], "eth0", AF_INET, "10.0.0.1");
+	set_addr(&nodes[1], "eth0", AF_INET, "10.0.0.99");
+	set_addr(&nodes[2], "eth0", AF_INET6, "2001:db8::5");
+	list = build_fake_ifaddrs(nodes, 3);
+
+	pass &= check_bool("matches the primary (first-listed) IPv4",
+			    shr_iface_primary_addr_matches(list, "eth0",
+							   "10.0.0.1"),
+			    true);
+	pass &= check_bool("the secondary IPv4 is not the primary",
+			    shr_iface_primary_addr_matches(list, "eth0",
+							   "10.0.0.99"),
+			    false);
+	pass &= check_bool("matches the primary IPv6",
+			    shr_iface_primary_addr_matches(list, "eth0",
+							   "2001:db8::5"),
+			    true);
+	pass &= check_bool("no such interface",
+			    shr_iface_primary_addr_matches(list, "eth9",
+							   "10.0.0.1"),
+			    false);
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_ipaddrs_eq();
+	pass &= test_iface_matching_addr();
+	pass &= test_iface_primary_addr_matches();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/shared/test/test-parse-util.c
+++ b/shared/test/test-parse-util.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <parse-util.h>
+
+static bool check_bool(const char *value, int want_ret, bool want_out)
+{
+	bool out = false;
+	int ret;
+
+	ret = shr_parse_bool(value, &out);
+	if (ret != want_ret || (!ret && out != want_out)) {
+		printf(" - \"%s\": got ret=%d out=%d, want ret=%d out=%d [FAIL]\n",
+		       value, ret, out, want_ret, want_out);
+		return false;
+	}
+
+	printf(" - \"%s\" [PASS]\n", value);
+	return true;
+}
+
+static bool test_accepted_spellings(void)
+{
+	bool pass = true;
+
+	printf("test_accepted_spellings:\n");
+
+	pass &= check_bool("1", 0, true);
+	pass &= check_bool("yes", 0, true);
+	pass &= check_bool("y", 0, true);
+	pass &= check_bool("true", 0, true);
+	pass &= check_bool("t", 0, true);
+	pass &= check_bool("on", 0, true);
+
+	pass &= check_bool("0", 0, false);
+	pass &= check_bool("no", 0, false);
+	pass &= check_bool("n", 0, false);
+	pass &= check_bool("false", 0, false);
+	pass &= check_bool("f", 0, false);
+	pass &= check_bool("off", 0, false);
+
+	return pass;
+}
+
+static bool test_case_insensitive(void)
+{
+	bool pass = true;
+
+	printf("test_case_insensitive:\n");
+
+	pass &= check_bool("YES", 0, true);
+	pass &= check_bool("True", 0, true);
+	pass &= check_bool("ON", 0, true);
+	pass &= check_bool("NO", 0, false);
+	pass &= check_bool("False", 0, false);
+	pass &= check_bool("OFF", 0, false);
+
+	return pass;
+}
+
+static bool test_rejected(void)
+{
+	bool pass = true;
+
+	printf("test_rejected:\n");
+
+	pass &= check_bool("maybe", -EINVAL, false);
+	pass &= check_bool("", -EINVAL, false);
+	pass &= check_bool("2", -EINVAL, false);
+	pass &= check_bool("yesplease", -EINVAL, false);
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_accepted_spellings();
+	pass &= test_case_insensitive();
+	pass &= test_rejected();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/shared/test/test-string-util.c
+++ b/shared/test/test-string-util.c
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <string-util.h>
+
+static bool check_str(const char *name, const char *got, const char *want)
+{
+	bool eq = (got == want) || (got && want && !strcmp(got, want));
+
+	if (eq) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got \"%s\", want \"%s\" [FAIL]\n",
+	       name, got ? got : "(null)", want ? want : "(null)");
+	return false;
+}
+
+static bool check_bool(const char *name, bool got, bool want)
+{
+	if (got == want) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got %d, want %d [FAIL]\n", name, got, want);
+	return false;
+}
+
+static bool test_streq0(void)
+{
+	bool pass = true;
+
+	printf("test_streq0:\n");
+
+	pass &= check_bool("NULL == NULL", shr_streq0(NULL, NULL), true);
+	pass &= check_bool("NULL != non-NULL",
+			    shr_streq0(NULL, "a"), false);
+	pass &= check_bool("non-NULL != NULL",
+			    shr_streq0("a", NULL), false);
+	pass &= check_bool("equal strings", shr_streq0("abc", "abc"), true);
+	pass &= check_bool("different strings",
+			    shr_streq0("abc", "abd"), false);
+	pass &= check_bool("case differs, not equal",
+			    shr_streq0("ABC", "abc"), false);
+
+	return pass;
+}
+
+static bool test_streqcase0(void)
+{
+	bool pass = true;
+
+	printf("test_streqcase0:\n");
+
+	pass &= check_bool("NULL == NULL", shr_streqcase0(NULL, NULL), true);
+	pass &= check_bool("NULL != non-NULL",
+			    shr_streqcase0(NULL, "a"), false);
+	pass &= check_bool("case differs, still equal",
+			    shr_streqcase0("ABC", "abc"), true);
+	pass &= check_bool("different strings",
+			    shr_streqcase0("abc", "abd"), false);
+
+	return pass;
+}
+
+static bool test_xstrdup(void)
+{
+	char input[] = "hello";
+	char *dup;
+	bool pass = true;
+
+	printf("test_xstrdup:\n");
+
+	pass &= check_str("NULL in → NULL out", shr_xstrdup(NULL), NULL);
+
+	dup = shr_xstrdup(input);
+	pass &= check_bool("returns a new allocation, not the input pointer",
+			    dup != NULL && dup != input, true);
+	pass &= check_str("copy has the same content", dup, "hello");
+	free(dup);
+
+	return pass;
+}
+
+static bool test_startswith(void)
+{
+	bool pass = true;
+
+	printf("test_startswith:\n");
+
+	pass &= check_str("matching prefix returns the remainder",
+			   shr_startswith("keyword", "key"), "word");
+	pass &= check_str("exact match returns the empty remainder",
+			   shr_startswith("key", "key"), "");
+	pass &= check_str("non-matching prefix returns NULL",
+			   shr_startswith("value", "key"), NULL);
+	pass &= check_str("empty prefix always matches, full string remains",
+			   shr_startswith("anything", ""), "anything");
+
+	return pass;
+}
+
+static bool test_trim(void)
+{
+	char buf1[] = "  hello world  ";
+	char buf2[] = "no-padding";
+	char buf3[] = "   ";
+	char buf4[] = "\t\n leading only";
+	char buf5[] = "trailing only \t\n";
+	bool pass = true;
+
+	printf("test_trim:\n");
+
+	pass &= check_str("both sides trimmed", shr_trim(buf1), "hello world");
+	pass &= check_str("no padding is a no-op",
+			   shr_trim(buf2), "no-padding");
+	pass &= check_str("all-whitespace trims to empty", shr_trim(buf3), "");
+	pass &= check_str("leading whitespace only",
+			   shr_trim(buf4), "leading only");
+	pass &= check_str("trailing whitespace only",
+			   shr_trim(buf5), "trailing only");
+
+	return pass;
+}
+
+static bool test_valid_name(void)
+{
+	bool pass = true;
+
+	printf("test_valid_name:\n");
+
+	pass &= check_bool("alnum + '_' + '-' accepted",
+			    shr_valid_name("Valid_Name-123"), true);
+	pass &= check_bool("NULL rejected", shr_valid_name(NULL), false);
+	pass &= check_bool("empty string rejected", shr_valid_name(""), false);
+	pass &= check_bool("space rejected", shr_valid_name("bad name"), false);
+	pass &= check_bool("'.' rejected", shr_valid_name("bad.name"), false);
+	pass &= check_bool("'/' rejected", shr_valid_name("bad/name"), false);
+
+	return pass;
+}
+
+static bool test_kv_strip(void)
+{
+	char buf1[] = "  key = value \x20\n";
+	char buf2[] = "key = value # a trailing comment";
+	char buf3[] = "# a whole-line comment\n";
+	char buf4[] = "\n";
+	char buf5[] = "key=value#nospacecomment";
+	bool pass = true;
+
+	printf("test_kv_strip:\n");
+
+	pass &= check_str("leading/trailing whitespace and newline stripped",
+			   shr_kv_strip(buf1), "key = value");
+	pass &= check_str("trailing comment (with its leading spaces) stripped",
+			   shr_kv_strip(buf2), "key = value");
+	pass &= check_str("whole-line comment strips to empty",
+			   shr_kv_strip(buf3), "");
+	pass &= check_str("blank line strips to empty", shr_kv_strip(buf4), "");
+	pass &= check_str("comment with no preceding space still stripped",
+			   shr_kv_strip(buf5), "key=value");
+
+	return pass;
+}
+
+static bool test_kv_keymatch(void)
+{
+	bool pass = true;
+
+	printf("test_kv_keymatch:\n");
+
+	pass &= check_str("'key = value' matches key, returns value",
+			   shr_kv_keymatch("key = value", "key"), "value");
+	pass &= check_str("'key=value' (no spaces) matches too",
+			   shr_kv_keymatch("key=value", "key"), "value");
+	pass &= check_str("wrong key does not match",
+			   shr_kv_keymatch("otherkey = value", "key"), NULL);
+	pass &= check_str("key as a prefix of a longer word does not match",
+			   shr_kv_keymatch("keyword = value", "key"), NULL);
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_streq0();
+	pass &= test_streqcase0();
+	pass &= test_xstrdup();
+	pass &= test_startswith();
+	pass &= test_trim();
+	pass &= test_valid_name();
+	pass &= test_kv_strip();
+	pass &= test_kv_keymatch();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}


### PR DESCRIPTION
Unit-test parse-util, hash-util, string-util, io-util, fs-util, and net-util. Internal helpers like these don't need public-API-style NULL hardening, so string-util's tests only exercise NULL where a function already documents handling it.