### PR TITLE
libnvme/fabrics: skip NBFT records with Security Profile Descriptors

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3235,6 +3235,14 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 					continue;
 				}
 
+				if ((*ss)->security) {
+					libnvme_msg(ctx, LIBNVME_LOG_ERR,
+						"SSNS %d has Security Profile Descriptor %d associated, security profile descriptors are currently unimplemented, skipping\n",
+						(*ss)->index,
+						(*ss)->security->index);
+					continue;
+				}
+
 				nfctx.ctrl_params.host_traddr = NULL;
 				if (!fctx->ctrl_params.host_traddr &&
 				    !strncmp((*ss)->transport, "tcp", 3))
@@ -3314,6 +3322,14 @@ __libnvme_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
 				}
 			if (linked)
 				continue;
+
+			if ((*dd)->security) {
+				libnvme_msg(ctx, LIBNVME_LOG_ERR,
+					"Discovery Descriptor %d has Security Profile Descriptor %d associated, security profile descriptors are currently unimplemented, skipping\n",
+					(*dd)->index,
+					(*dd)->security->index);
+				continue;
+			}
 
 			hfi = (*dd)->hfi;
 			if (!hfi) {

--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -301,10 +301,14 @@ static int read_ssns(struct libnvme_global_ctx *ctx,
 	if (raw_ssns->security_desc_index) {
 		ssns->security = security_from_index(nbft,
 			raw_ssns->security_desc_index);
-		if (!ssns->security)
-			libnvme_msg(ctx, LIBNVME_LOG_DEBUG,
-				 "file %s: namespace %d security controller not found\n",
-				 nbft->filename, ssns->index);
+		if (!ssns->security) {
+			libnvme_msg(ctx, LIBNVME_LOG_WARN,
+				 "file %s: namespace %d security descriptor %d not found, skipping entry\n",
+				 nbft->filename, ssns->index,
+				 raw_ssns->security_desc_index);
+			ret = -EINVAL;
+			goto fail;
+		}
 	}
 
 	/* HFI descriptors */
@@ -573,12 +577,17 @@ static int read_discovery(struct libnvme_global_ctx *ctx,
 		goto error;
 	}
 
-	discovery->security =
-		security_from_index(nbft, raw_discovery->sec_index);
-	if (raw_discovery->sec_index && !discovery->security)
-		libnvme_msg(ctx, LIBNVME_LOG_DEBUG,
-			 "file %s: discovery %d security descriptor not found\n",
-			 nbft->filename, discovery->index);
+	if (raw_discovery->sec_index) {
+		discovery->security =
+			security_from_index(nbft, raw_discovery->sec_index);
+		if (!discovery->security) {
+			libnvme_msg(ctx, LIBNVME_LOG_WARN,
+				 "file %s: discovery %d security descriptor %d not found, skipping entry\n",
+				 nbft->filename, discovery->index,
+				 raw_discovery->sec_index);
+			goto error;
+		}
+	}
 
 	*d = discovery;
 	r = 0;


### PR DESCRIPTION
Use of NBFT Security Profile Descriptors is currently unimplemented, print an error and skip SSNS records and Discovery Descriptors that have an associated Security Profile Descriptor to avoid connecting without the required security parameters.

At the current state the code will still make a connection attempt totally ignoring the security descriptor values. Although bypassing security like this is considered a target misconfiguration, user should be aware of what's going on. Thus deny such connections and skip them, incl. discovery. 

----

As discussed on previous Timberland SIG meetings, we intentionally want to avoid making use of Security Descriptors at the moment until we have other components ready and tested (dracut, tlshd, the secret retrieval mechanism/Redfish client). Also, we currently don't have access to any system with capable firmware, unable to develop nor test this solution. Lastly, this functionality is also missing from the reference edk2 implementation. Rather than shipping half-baked untested solution, disable the functionality for now.

Cc: @flaviens @mwilck @johnmeneghini @MichaelRabek @stuarthayes @cleech 