### PR TITLE
nvme-rpmb: fix out-of-bounds allocation in read_rpmb_key()

### DIFF
--- a/nvme-rpmb.c
+++ b/nvme-rpmb.c
@@ -192,7 +192,7 @@ static unsigned char *read_rpmb_key(char *keystr, char *keyfile, unsigned int *k
 			if (err < 0)
 				return NULL;
 		}
-	} else if ((keybuf = (unsigned char *)malloc(strlen(keystr))) != NULL) {
+	} else if ((keybuf = (unsigned char *)malloc(strlen(keystr) + 1)) != NULL) {
 		*keysize = strlen(keystr);
 		memcpy(keybuf, keystr, *keysize);
 	}


### PR DESCRIPTION
malloc(strlen(keystr)) allocates one byte fewer than needed: strlen() returns the length of the string excluding the NUL terminator, so the buffer is too small by one byte.  Any code that later appends a NUL or treats the buffer as a C string would read or write past the end of the allocation.

Fix by allocating strlen(keystr) + 1 bytes so the buffer is large enough to hold the full string content.

Fixes: Coverity CID 254613 (Out-of-bounds access)