### PR TITLE
nbft: ensure transport buffer is null terminated in read_ssns() and r…

### DIFF
--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -258,7 +258,8 @@ static int read_ssns(struct libnvme_global_ctx *ctx,
 
 	ssns->index = le16_to_cpu(raw_ssns->index);
 	strncpy(ssns->transport, trtype_to_string(raw_ssns->trtype),
-		sizeof(ssns->transport));
+		sizeof(ssns->transport) - 1);
+	ssns->transport[sizeof(ssns->transport) - 1] = '\0';
 
 	/* transport specific flags */
 	ssns->trflags = le16_to_cpu(raw_ssns->trflags);
@@ -508,7 +509,8 @@ static int read_hfi(struct libnvme_global_ctx *ctx, struct libnbft_info *nbft,
 		struct nbft_hfi_info_tcp *raw_hfi_info_tcp;
 
 		strncpy(hfi->transport, trtype_to_string(raw_hfi->trtype),
-			sizeof(hfi->transport));
+			sizeof(hfi->transport) - 1);
+		hfi->transport[sizeof(hfi->transport) - 1] = '\0';
 
 		ret = get_heap_obj(ctx, raw_hfi, trinfo_obj,
 			0, (char **)&raw_hfi_info_tcp);


### PR DESCRIPTION
strncpy() does not guarantee null termination when the source string is exactly as long as or longer than the destination buffer. Both read_ssns() and read_hfi() copy the result of trtype_to_string() into a char transport[8] field using sizeof(transport) as the length, which leaves no room for a null terminator if the source fills all 8 bytes.

Reduce the strncpy length by 1 and explicitly set the final byte to '\0' in both call sites, ensuring the buffer is always null terminated regardless of the source string length.

Fixes: Coverity CID 557381 (Buffer not null terminated, High)