### PR TITLE
Add support to read/convert `persistent/epcsd`to config

### DIFF
--- a/Documentation/nvme-config-create.txt
+++ b/Documentation/nvme-config-create.txt
@@ -10,6 +10,8 @@ SYNOPSIS
 [verse]
 'nvme' [<global-options>] 'config create'
 			[--discovery]
+			[--persistent ]
+			[--no-persistent ]
 			[--host-symname=<name>]
 			[--output=<file>]
 			[<fabrics-options>]
@@ -38,6 +40,18 @@ OPTIONS
 --discovery::
 	Create a discovery controller entry instead of an I/O controller
 	entry. Without this, --nqn is required.
+
+--persistent::
+	Keep the discovery controller connected to receive Asynchronous
+	Event Notifications instead of disconnecting after the discovery
+	log page fetch. Requires --discovery. Mutually exclusive with
+	--no-persistent.
+
+--no-persistent::
+	Explicitly record that this discovery controller is not
+	persistent, overriding any default that would otherwise apply
+	(e.g. one derived from the discovery log page). Requires
+	--discovery. Mutually exclusive with --persistent.
 
 --host-symname=<name>::
 	Name this host persona. Puts it in its own configuration drop-in.

--- a/Documentation/nvme-config-create.txt
+++ b/Documentation/nvme-config-create.txt
@@ -12,6 +12,8 @@ SYNOPSIS
 			[--discovery]
 			[--persistent ]
 			[--no-persistent ]
+			[--epcsd ]
+			[--no-epcsd ]
 			[--host-symname=<name>]
 			[--output=<file>]
 			[<fabrics-options>]
@@ -52,6 +54,16 @@ OPTIONS
 	persistent, overriding any default that would otherwise apply
 	(e.g. one derived from the discovery log page). Requires
 	--discovery. Mutually exclusive with --persistent.
+
+--epcsd::
+	Mark this discovery controller as supporting Explicit Persistent
+	Connection Support for Discovery (EPCSD). Requires --discovery.
+	Mutually exclusive with --no-epcsd.
+
+--no-epcsd::
+	Explicitly record that this discovery controller does not support
+	EPCSD, overriding any default that would otherwise apply. Requires
+	--discovery. Mutually exclusive with --epcsd.
 
 --host-symname=<name>::
 	Name this host persona. Puts it in its own configuration drop-in.

--- a/config-convert.c
+++ b/config-convert.c
@@ -137,6 +137,16 @@ static void apply_dhchap_default(struct libnvmf_params *params,
 	}
 }
 
+static void apply_dc_persistent(struct libnvmf_params *params,
+		struct json_object *port_obj)
+{
+	struct json_object *val = json_object_object_get(port_obj, "persistent");
+
+	if (val)
+		libnvmf_params_set(params, "persistent",
+				    json_object_get_boolean(val) ? "true" : "false");
+}
+
 static int convert_port(struct libnvmf_config_emitter *emitter,
 		const char *hostnqn, const char *hostid,
 		const char *hostsymname, const char *host_dhchap_key,
@@ -152,6 +162,8 @@ static int convert_port(struct libnvmf_config_emitter *emitter,
 
 	apply_port_params(params, port_obj);
 	apply_dhchap_default(params, port_obj, host_dhchap_key);
+	if (is_dc)
+		apply_dc_persistent(params, port_obj);
 
 	ret = libnvmf_config_emit_add(emitter, is_dc,
 			json_get_string(port_obj, "transport"),
@@ -303,7 +315,7 @@ int nvme_config_convert_json(struct libnvmf_config_emitter *emitter,
 #endif /* CONFIG_JSONC */
 
 int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
-		const struct nvmf_args *fa)
+		const struct nvmf_args *fa, enum libnvmf_tristate persistent)
 {
 	struct libnvmf_params *params;
 	int ret;
@@ -313,6 +325,9 @@ int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
 		return -ENOMEM;
 
 	nvmf_args_to_params(params, fa);
+	if (persistent != LIBNVMF_TRISTATE_UNSET)
+		libnvmf_params_set(params, "persistent",
+			persistent == LIBNVMF_TRISTATE_TRUE ? "true" : "false");
 
 	ret = libnvmf_config_emit_add(emitter, true, fa->transport, fa->traddr,
 			fa->trsvcid, fa->subsysnqn, fa->host_traddr,

--- a/config-convert.c
+++ b/config-convert.c
@@ -315,7 +315,8 @@ int nvme_config_convert_json(struct libnvmf_config_emitter *emitter,
 #endif /* CONFIG_JSONC */
 
 int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
-		const struct nvmf_args *fa, enum libnvmf_tristate persistent)
+		const struct nvmf_args *fa, enum libnvmf_tristate persistent,
+		enum libnvmf_tristate epcsd)
 {
 	struct libnvmf_params *params;
 	int ret;
@@ -328,6 +329,9 @@ int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
 	if (persistent != LIBNVMF_TRISTATE_UNSET)
 		libnvmf_params_set(params, "persistent",
 			persistent == LIBNVMF_TRISTATE_TRUE ? "true" : "false");
+	if (epcsd != LIBNVMF_TRISTATE_UNSET)
+		libnvmf_params_set(params, "epcsd",
+			epcsd == LIBNVMF_TRISTATE_TRUE ? "true" : "false");
 
 	ret = libnvmf_config_emit_add(emitter, true, fa->transport, fa->traddr,
 			fa->trsvcid, fa->subsysnqn, fa->host_traddr,

--- a/config-convert.h
+++ b/config-convert.h
@@ -30,7 +30,8 @@ int nvme_config_convert_discovery(struct libnvmf_config_emitter *emitter,
  * entries are logged and skipped. Only -ENOMEM is treated as a fatal error.
  */
 int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
-		const struct nvmf_args *fa, enum libnvmf_tristate persistent);
+		const struct nvmf_args *fa, enum libnvmf_tristate persistent,
+		enum libnvmf_tristate epcsd);
 
 /*
  * Auto-convert on first use, called by connect-all/discover/connect

--- a/config-convert.h
+++ b/config-convert.h
@@ -30,7 +30,7 @@ int nvme_config_convert_discovery(struct libnvmf_config_emitter *emitter,
  * entries are logged and skipped. Only -ENOMEM is treated as a fatal error.
  */
 int nvme_config_convert_discovery_args(struct libnvmf_config_emitter *emitter,
-		const struct nvmf_args *fa);
+		const struct nvmf_args *fa, enum libnvmf_tristate persistent);
 
 /*
  * Auto-convert on first use, called by connect-all/discover/connect

--- a/config-create.c
+++ b/config-create.c
@@ -172,6 +172,13 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 		"own configuration drop-in";
 	const char *desc_output = "add the entry to this INI configuration "
 		"file (default: " PATH_NVMF_INI ")";
+	const char *desc_persistent = "keep the discovery controller "
+		"connected to receive Asynchronous Event Notifications "
+		"instead of disconnecting after the discovery log page "
+		"fetch; requires --discovery";
+	const char *desc_no_persistent = "explicitly record that this "
+		"discovery controller is not persistent, overriding any "
+		"default that would otherwise apply; requires --discovery";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvmf_config_emitter *emitter = NULL;
@@ -180,6 +187,8 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 	char *output_file = NULL;
 	char *hostsymname = NULL;
 	bool discovery = false;
+	bool persistent = false;
+	bool no_persistent = false;
 	bool duplicate = false;
 	bool replaced = false;
 	const char *target;
@@ -187,6 +196,8 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 
 	NVMF_ARGS(opts, fa,
 		OPT_FLAG("discovery", 0, &discovery, desc_discovery),
+		OPT_FLAG("persistent", 0, &persistent, desc_persistent),
+		OPT_FLAG("no-persistent", 0, &no_persistent, desc_no_persistent),
 		OPT_STRING("host-symname", 0, "STR", &hostsymname, desc_symname),
 		OPT_STRING("output", 0, "FILE", &output_file, desc_output));
 
@@ -195,6 +206,16 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 	err = parse_args(argc, argv, desc, opts);
 	if (err)
 		return err;
+
+	if (persistent && no_persistent) {
+		nvme_show_error("--persistent and --no-persistent are mutually exclusive");
+		return -EINVAL;
+	}
+
+	if ((persistent || no_persistent) && !discovery) {
+		nvme_show_error("--persistent/--no-persistent requires --discovery");
+		return -EINVAL;
+	}
 
 	err = nvme_create_global_ctx(&ctx);
 	if (err)
@@ -212,6 +233,10 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 		goto out;
 	}
 	nvmf_args_to_params(params, &fa);
+	if (persistent)
+		libnvmf_params_set(params, "persistent", "true");
+	else if (no_persistent)
+		libnvmf_params_set(params, "persistent", "false");
 
 	err = reload_existing(emitter, ctx, target, discovery, &fa, params,
 			&duplicate, &replaced);

--- a/config-create.c
+++ b/config-create.c
@@ -179,6 +179,12 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 	const char *desc_no_persistent = "explicitly record that this "
 		"discovery controller is not persistent, overriding any "
 		"default that would otherwise apply; requires --discovery";
+	const char *desc_epcsd = "mark this discovery controller as "
+		"supporting Explicit Persistent Connection Support for "
+		"Discovery (EPCSD); requires --discovery";
+	const char *desc_no_epcsd = "explicitly record that this discovery "
+		"controller does not support EPCSD, overriding any default "
+		"that would otherwise apply; requires --discovery";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	struct libnvmf_config_emitter *emitter = NULL;
@@ -189,6 +195,8 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 	bool discovery = false;
 	bool persistent = false;
 	bool no_persistent = false;
+	bool epcsd = false;
+	bool no_epcsd = false;
 	bool duplicate = false;
 	bool replaced = false;
 	const char *target;
@@ -198,6 +206,8 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 		OPT_FLAG("discovery", 0, &discovery, desc_discovery),
 		OPT_FLAG("persistent", 0, &persistent, desc_persistent),
 		OPT_FLAG("no-persistent", 0, &no_persistent, desc_no_persistent),
+		OPT_FLAG("epcsd", 0, &epcsd, desc_epcsd),
+		OPT_FLAG("no-epcsd", 0, &no_epcsd, desc_no_epcsd),
 		OPT_STRING("host-symname", 0, "STR", &hostsymname, desc_symname),
 		OPT_STRING("output", 0, "FILE", &output_file, desc_output));
 
@@ -212,8 +222,18 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 		return -EINVAL;
 	}
 
+	if (epcsd && no_epcsd) {
+		nvme_show_error("--epcsd and --no-epcsd are mutually exclusive");
+		return -EINVAL;
+	}
+
 	if ((persistent || no_persistent) && !discovery) {
 		nvme_show_error("--persistent/--no-persistent requires --discovery");
+		return -EINVAL;
+	}
+
+	if ((epcsd || no_epcsd) && !discovery) {
+		nvme_show_error("--epcsd/--no-epcsd requires --discovery");
 		return -EINVAL;
 	}
 
@@ -237,6 +257,10 @@ int nvme_config_create(const char *desc, int argc, char **argv)
 		libnvmf_params_set(params, "persistent", "true");
 	else if (no_persistent)
 		libnvmf_params_set(params, "persistent", "false");
+	if (epcsd)
+		libnvmf_params_set(params, "epcsd", "true");
+	else if (no_epcsd)
+		libnvmf_params_set(params, "epcsd", "false");
 
 	err = reload_existing(emitter, ctx, target, discovery, &fa, params,
 			&duplicate, &replaced);

--- a/fabrics.c
+++ b/fabrics.c
@@ -489,14 +489,18 @@ int nvmf_convert_discovery_line(struct libnvmf_config_emitter *emitter,
 	char *argv[MAX_DISC_ARGS] = { "discovery.conf" };
 	char *ptr, *p = line;
 	int argc = 1;
-	bool persistent = false, force = false;
-	bool no_persistent = false;
+	bool persistent = false, force = false, epcsd = false;
+	bool no_persistent = false, no_epcsd = false;
 
 	NVMF_ARGS(opts, fa,
 		  OPT_FLAG("persistent", 'p', &persistent,
 			   "persistent discovery connection"),
 		  OPT_FLAG("no-persistent", 0, &no_persistent,
 			   "explicitly not a persistent discovery connection"),
+		  OPT_FLAG("epcsd",        0, &epcsd,
+			   "Explicit Persistent Connection Support for Discovery"),
+		  OPT_FLAG("no-epcsd",     0, &no_epcsd,
+			   "explicitly does not support Explicit Persistent Connection Support for Discovery"),
 		  OPT_FLAG("force",        0, &force,
 			   "Force persistent discovery controller creation"));
 
@@ -519,7 +523,9 @@ int nvmf_convert_discovery_line(struct libnvmf_config_emitter *emitter,
 
 	return nvme_config_convert_discovery_args(emitter, &fa,
 		persistent ? LIBNVMF_TRISTATE_TRUE :
-			no_persistent ? LIBNVMF_TRISTATE_FALSE : LIBNVMF_TRISTATE_UNSET);
+			no_persistent ? LIBNVMF_TRISTATE_FALSE : LIBNVMF_TRISTATE_UNSET,
+		epcsd ? LIBNVMF_TRISTATE_TRUE :
+			no_epcsd ? LIBNVMF_TRISTATE_FALSE : LIBNVMF_TRISTATE_UNSET);
 }
 
 static int setup_common_context(struct libnvmf_context *fctx,

--- a/fabrics.c
+++ b/fabrics.c
@@ -489,12 +489,15 @@ int nvmf_convert_discovery_line(struct libnvmf_config_emitter *emitter,
 	char *argv[MAX_DISC_ARGS] = { "discovery.conf" };
 	char *ptr, *p = line;
 	int argc = 1;
-	bool line_persistent = false, line_force = false;
+	bool persistent = false, force = false;
+	bool no_persistent = false;
 
 	NVMF_ARGS(opts, fa,
-		  OPT_FLAG("persistent", 'p', &line_persistent,
+		  OPT_FLAG("persistent", 'p', &persistent,
 			   "persistent discovery connection"),
-		  OPT_FLAG("force",        0, &line_force,
+		  OPT_FLAG("no-persistent", 0, &no_persistent,
+			   "explicitly not a persistent discovery connection"),
+		  OPT_FLAG("force",        0, &force,
 			   "Force persistent discovery controller creation"));
 
 	if (line[0] == '#' || line[0] == '\n' || line[0] == '\0')
@@ -514,7 +517,9 @@ int nvmf_convert_discovery_line(struct libnvmf_config_emitter *emitter,
 	if (!fa.transport && !fa.traddr)
 		return 0;
 
-	return nvme_config_convert_discovery_args(emitter, &fa);
+	return nvme_config_convert_discovery_args(emitter, &fa,
+		persistent ? LIBNVMF_TRISTATE_TRUE :
+			no_persistent ? LIBNVMF_TRISTATE_FALSE : LIBNVMF_TRISTATE_UNSET);
 }
 
 static int setup_common_context(struct libnvmf_context *fctx,
@@ -560,7 +565,8 @@ static int create_common_context(struct libnvme_global_ctx *ctx,
 	if (err)
 		goto err;
 
-	libnvmf_context_set_persistent(fctx, persistent);
+	libnvmf_context_set_persistent(fctx, persistent ?
+			LIBNVMF_TRISTATE_TRUE : LIBNVMF_TRISTATE_UNSET);
 
 	*fctxp = fctx;
 

--- a/libnvme/libnvme3/accessors.i
+++ b/libnvme/libnvme3/accessors.i
@@ -188,10 +188,6 @@ Subsystem.__setattr__ = _nvme_guarded_setattr
 
 /* struct libnvme_host */
 %rename(Host) libnvme_host;
-%rename(libnvme_host_pdc_enabled_set) libnvme_host_set_pdc_enabled;
-%{
-	#define libnvme_host_pdc_enabled_set libnvme_host_set_pdc_enabled
-%}
 struct libnvme_host {
 	%immutable hostnqn;
 	const char * hostnqn;

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -197,7 +197,8 @@ static int set_fctx_host_params(struct libnvme_global_ctx *ctx,
 
 	val = PyDict_GetItemString(dict, "persistent");
 	if (val)
-		fctx->persistent = (bool)PyObject_IsTrue(val);
+		fctx->persistent = PyObject_IsTrue(val) ?
+			LIBNVMF_TRISTATE_TRUE : LIBNVMF_TRISTATE_FALSE;
 
 	for (p = tbl; p->key; p++)
 		*p->val = dict_get_str(dict, p->key);

--- a/libnvme/src/accessors-fabrics.ld
+++ b/libnvme/src/accessors-fabrics.ld
@@ -20,6 +20,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_devid_file;
 		libnvmf_context_get_disable_sqflow;
 		libnvmf_context_get_duplicate_connect;
+		libnvmf_context_get_epcsd;
 		libnvmf_context_get_fast_io_fail_tmo;
 		libnvmf_context_get_hdr_digest;
 		libnvmf_context_get_hostid;
@@ -53,6 +54,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_set_data_digest;
 		libnvmf_context_set_disable_sqflow;
 		libnvmf_context_set_duplicate_connect;
+		libnvmf_context_set_epcsd;
 		libnvmf_context_set_fast_io_fail_tmo;
 		libnvmf_context_set_hdr_digest;
 		libnvmf_context_set_keep_alive_tmo;

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -62,9 +62,7 @@ LIBNVME_3 {
 		libnvme_get_uuid_list;
 		libnvme_get_version;
 		libnvme_host_get_global_ctx;
-		libnvme_host_is_pdc_enabled;
 		libnvme_host_release_fds;
-		libnvme_host_set_pdc_enabled;
 		libnvme_init_ctrl;
 		libnvme_namespace_first_path;
 		libnvme_namespace_next_path;

--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -327,12 +327,12 @@ __shr_public const char *libnvmf_context_get_device(
 
 __shr_public void libnvmf_context_set_persistent(
 		struct libnvmf_context *p,
-		bool persistent)
+		enum libnvmf_tristate persistent)
 {
 	p->persistent = persistent;
 }
 
-__shr_public bool libnvmf_context_get_persistent(
+__shr_public enum libnvmf_tristate libnvmf_context_get_persistent(
 		const struct libnvmf_context *p)
 {
 	return p->persistent;

--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -338,6 +338,19 @@ __shr_public enum libnvmf_tristate libnvmf_context_get_persistent(
 	return p->persistent;
 }
 
+__shr_public void libnvmf_context_set_epcsd(
+		struct libnvmf_context *p,
+		enum libnvmf_tristate epcsd)
+{
+	p->epcsd = epcsd;
+}
+
+__shr_public enum libnvmf_tristate libnvmf_context_get_epcsd(
+		const struct libnvmf_context *p)
+{
+	return p->epcsd;
+}
+
 __shr_public const char *libnvmf_context_get_devid_file(
 		const struct libnvmf_context *p)
 {

--- a/libnvme/src/nvme/accessors-fabrics.h
+++ b/libnvme/src/nvme/accessors-fabrics.h
@@ -427,7 +427,9 @@ const char *libnvmf_context_get_device(const struct libnvmf_context *p);
  * @p: The &struct libnvmf_context instance to update.
  * @persistent: Value to assign to the persistent field.
  */
-void libnvmf_context_set_persistent(struct libnvmf_context *p, bool persistent);
+void libnvmf_context_set_persistent(
+		struct libnvmf_context *p,
+		enum libnvmf_tristate persistent);
 
 /**
  * libnvmf_context_get_persistent() - Get persistent.
@@ -435,7 +437,8 @@ void libnvmf_context_set_persistent(struct libnvmf_context *p, bool persistent);
  *
  * Return: The value of the persistent field.
  */
-bool libnvmf_context_get_persistent(const struct libnvmf_context *p);
+enum libnvmf_tristate libnvmf_context_get_persistent(
+		const struct libnvmf_context *p);
 
 /**
  * libnvmf_context_get_devid_file() - Get devid_file.

--- a/libnvme/src/nvme/accessors-fabrics.h
+++ b/libnvme/src/nvme/accessors-fabrics.h
@@ -441,6 +441,24 @@ enum libnvmf_tristate libnvmf_context_get_persistent(
 		const struct libnvmf_context *p);
 
 /**
+ * libnvmf_context_set_epcsd() - Set epcsd.
+ * @p: The &struct libnvmf_context instance to update.
+ * @epcsd: Value to assign to the epcsd field.
+ */
+void libnvmf_context_set_epcsd(
+		struct libnvmf_context *p,
+		enum libnvmf_tristate epcsd);
+
+/**
+ * libnvmf_context_get_epcsd() - Get epcsd.
+ * @p: The &struct libnvmf_context instance to query.
+ *
+ * Return: The value of the epcsd field.
+ */
+enum libnvmf_tristate libnvmf_context_get_epcsd(
+		const struct libnvmf_context *p);
+
+/**
  * libnvmf_context_get_devid_file() - Get devid_file.
  * @p: The &struct libnvmf_context instance to query.
  *

--- a/libnvme/src/nvme/config-ini.c
+++ b/libnvme/src/nvme/config-ini.c
@@ -47,6 +47,7 @@ static const struct libnvmf_key keys[] = {
 
 	/* discovery controller  */
 	{ "persistent",			LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_DC_TUNABLE },
+	{ "epcsd",			LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_DC_TUNABLE },
 
 	/* security -- bound to (hostnqn, subsysnqn); never per-path */
 	{ "tls",			LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_SECURITY },

--- a/libnvme/src/nvme/config-ini.c
+++ b/libnvme/src/nvme/config-ini.c
@@ -45,6 +45,9 @@ static const struct libnvmf_key keys[] = {
 	{ "hdr-digest",			LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_TUNABLE },
 	{ "data-digest",		LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_TUNABLE },
 
+	/* discovery controller  */
+	{ "persistent",			LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_DC_TUNABLE },
+
 	/* security -- bound to (hostnqn, subsysnqn); never per-path */
 	{ "tls",			LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_SECURITY },
 	{ "concat",			LIBNVMF_KEY_BOOL,	LIBNVMF_KEY_SECURITY },
@@ -201,7 +204,8 @@ __shr_public int libnvmf_params_set(struct libnvmf_params *p,
 	 */
 	k = libnvmf_key_lookup(key);
 	if (!k || (k->class != LIBNVMF_KEY_TUNABLE &&
-		   k->class != LIBNVMF_KEY_SECURITY))
+		   k->class != LIBNVMF_KEY_SECURITY &&
+		   k->class != LIBNVMF_KEY_DC_TUNABLE))
 		return -EINVAL;
 	if (libnvmf_key_check_value(k, value))
 		return -EINVAL;
@@ -521,6 +525,14 @@ static int add_path(struct conf_parse *pc, char *value, unsigned int line)
 			goto fail;
 		}
 		switch (k->class) {
+		case LIBNVMF_KEY_DC_TUNABLE:
+			if (pc->sect != SECT_DC) {
+				conf_err(pc, line,
+					 "%s is only valid for a discovery controller",
+					 key);
+				goto fail;
+			}
+			fallthrough;
 		case LIBNVMF_KEY_TUNABLE:
 			if (libnvmf_key_check_value(k, val)) {
 				conf_err(pc, line, "invalid %s value \"%s\"",
@@ -711,6 +723,17 @@ static int conf_kv(struct conf_parse *pc, const char *key, char *value,
 			return set_identity(pc, &pc->f->hostid, value);
 		}
 		return set_identity(pc, &pc->f->hostsymname, value);
+	case LIBNVMF_KEY_DC_TUNABLE:
+		if (pc->sect != SECT_DC && pc->sect != SECT_DC_DEFAULTS)
+			break;
+		if (libnvmf_key_check_value(k, value)) {
+			conf_err(pc, line, "invalid %s value \"%s\"", key,
+				 value);
+			return -EINVAL;
+		}
+		dest = (pc->sect == SECT_DC_DEFAULTS) ? pc->f->dc_defaults :
+							 pc->ep->params;
+		return libnvmf_params_set(dest, key, value);
 	case LIBNVMF_KEY_TUNABLE:
 	case LIBNVMF_KEY_SECURITY:
 		if (libnvmf_key_check_value(k, value)) {

--- a/libnvme/src/nvme/config-ini.h
+++ b/libnvme/src/nvme/config-ini.h
@@ -58,6 +58,7 @@ enum libnvmf_key_class {
 	LIBNVMF_KEY_IDENTITY,	/* [Host] only: hostnqn, hostid, hostsymname */
 	LIBNVMF_KEY_NQN,	/* endpoint sections only: nqn */
 	LIBNVMF_KEY_CONTROLLER,	/* endpoint sections only: ctrl (repeatable) */
+	LIBNVMF_KEY_DC_TUNABLE,	/* discovery controller sections/paths only */
 };
 
 struct libnvmf_key {

--- a/libnvme/src/nvme/config.c
+++ b/libnvme/src/nvme/config.c
@@ -310,6 +310,10 @@ static void apply_param(const char *key, const char *value, void *user_data)
 	} else if (!strcmp(key, "concat")) {
 		if (!shr_parse_bool(value, &bval))
 			cfg->concat = bval;
+	} else if (!strcmp(key, "persistent")) {
+		if (!shr_parse_bool(value, &bval))
+			fctx->persistent = bval ? LIBNVMF_TRISTATE_TRUE :
+						  LIBNVMF_TRISTATE_FALSE;
 	}
 	/* Identity/addressing and crypto keys never reach here -- only
 	 * tunable keys are handled in this loop. Crypto keys are read

--- a/libnvme/src/nvme/config.c
+++ b/libnvme/src/nvme/config.c
@@ -314,6 +314,10 @@ static void apply_param(const char *key, const char *value, void *user_data)
 		if (!shr_parse_bool(value, &bval))
 			fctx->persistent = bval ? LIBNVMF_TRISTATE_TRUE :
 						  LIBNVMF_TRISTATE_FALSE;
+	} else if (!strcmp(key, "epcsd")) {
+		if (!shr_parse_bool(value, &bval))
+			fctx->epcsd = bval ? LIBNVMF_TRISTATE_TRUE :
+					     LIBNVMF_TRISTATE_FALSE;
 	}
 	/* Identity/addressing and crypto keys never reach here -- only
 	 * tunable keys are handled in this loop. Crypto keys are read

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2545,11 +2545,12 @@ static int set_discovery_kato(struct libnvmf_context *fctx)
 	int tmo = fctx->ctrl_params.cfg.keep_alive_tmo;
 
 	/* Set kato to NVMF_DEF_DISC_TMO for persistent controllers */
-	if (fctx->persistent && !fctx->ctrl_params.cfg.keep_alive_tmo)
+	if (fctx->persistent == LIBNVMF_TRISTATE_TRUE &&
+	    !fctx->ctrl_params.cfg.keep_alive_tmo)
 		fctx->ctrl_params.cfg.keep_alive_tmo =
 			fctx->default_keep_alive_timeout;
 	/* Set kato to zero for non-persistent controllers */
-	else if (!fctx->persistent &&
+	else if (fctx->persistent != LIBNVMF_TRISTATE_TRUE &&
 		 (fctx->ctrl_params.cfg.keep_alive_tmo > 0))
 		fctx->ctrl_params.cfg.keep_alive_tmo = 0;
 
@@ -2655,7 +2656,7 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 			 * Are we supposed to keep the discovery
 			 * controller around?
 			 */
-			disconnect = !nfctx.persistent;
+			disconnect = nfctx.persistent != LIBNVMF_TRISTATE_TRUE;
 
 			if (strcmp(e->subnqn, NVME_DISC_SUBSYS_NAME)) {
 				/*
@@ -3424,14 +3425,14 @@ __shr_public int libnvmf_discovery(
 
 				libnvme_free_ctrl(c);
 				c = NULL;
-				fctx->persistent = false;
+				fctx->persistent = LIBNVMF_TRISTATE_FALSE;
 			} else {
 				/*
 				 * If the controller device is found it must
 				 * be persistent, and shouldn't be disconnected
 				 * on exit.
 				 */
-				fctx->persistent = true;
+				fctx->persistent = LIBNVMF_TRISTATE_TRUE;
 				/*
 				 * When --host-traddr/--host-iface are not specified on the
 				 * command line, use the discovery controller's (c) host-
@@ -3456,15 +3457,16 @@ __shr_public int libnvmf_discovery(
 			 */
 			libnvme_msg(ctx, LIBNVME_LOG_ERR,
 				"ctrl device %s not found%s\n", fctx->device,
-				fctx->persistent ? ", ignoring --persistent" : "");
-			fctx->persistent = false;
+				fctx->persistent == LIBNVMF_TRISTATE_TRUE ?
+					", ignoring --persistent" : "");
+			fctx->persistent = LIBNVMF_TRISTATE_FALSE;
 		}
 	}
 
 	if (!c && !force) {
 		c = lookup_ctrl(h, fctx);
 		if (c) {
-			fctx->persistent = true;
+			fctx->persistent = LIBNVMF_TRISTATE_TRUE;
 			if (!libnvme_ctrl_get_transport_handle(c)) {
 				ret = libnvme_open(ctx, c->name, &c->hdl);
 				if (ret) {
@@ -3488,7 +3490,7 @@ __shr_public int libnvmf_discovery(
 	}
 
 	ret = _nvmf_discovery(ctx, fctx, connect, c);
-	if (!fctx->persistent)
+	if (fctx->persistent != LIBNVMF_TRISTATE_TRUE)
 		libnvmf_disconnect_ctrl(c);
 	libnvme_free_ctrl(c);
 
@@ -3553,7 +3555,7 @@ __shr_public int libnvmf_connect(
 	 * this as a persistent connection and specify a KATO.
 	 */
 	if (!strcmp(fctx->ctrl_params.subsysnqn, NVME_DISC_SUBSYS_NAME)) {
-		fctx->persistent = true;
+		fctx->persistent = LIBNVMF_TRISTATE_TRUE;
 
 		set_discovery_kato(fctx);
 	}

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2717,14 +2717,6 @@ __shr_public const char *libnvmf_get_default_trsvcid(const char *transport,
 	return NULL;
 }
 
-static bool is_persistent_discovery_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
-{
-	if (libnvme_host_is_pdc_enabled(h, DEFAULT_PDC_ENABLED))
-		return libnvme_ctrl_get_unique_discovery_ctrl(c);
-
-	return false;
-}
-
 static int libnvme_add_ctrl(struct libnvmf_context *fctx,
 		struct libnvme_host *h, struct libnvme_ctrl *c)
 {
@@ -3496,7 +3488,7 @@ __shr_public int libnvmf_discovery(
 	}
 
 	ret = _nvmf_discovery(ctx, fctx, connect, c);
-	if (!(fctx->persistent || is_persistent_discovery_ctrl(h, c)))
+	if (!fctx->persistent)
 		libnvmf_disconnect_ctrl(c);
 	libnvme_free_ctrl(c);
 

--- a/libnvme/src/nvme/nvme-types-fabrics.h
+++ b/libnvme/src/nvme/nvme-types-fabrics.h
@@ -106,6 +106,27 @@ enum nvmf_disc_eflags {
 };
 
 /**
+ * enum libnvmf_tristate - Optional boolean discovery controller override.
+ * @LIBNVMF_TRISTATE_UNSET:  Not explicitly configured by the user. The
+ *			     effective value should be derived from another
+ *			     source, e.g. the discovery log page entry flags
+ *			     (see &enum nvmf_disc_eflags).
+ * @LIBNVMF_TRISTATE_TRUE:   Explicitly enabled by the user.
+ * @LIBNVMF_TRISTATE_FALSE:  Explicitly disabled by the user, overriding any
+ *			     value that would otherwise be derived elsewhere.
+ *
+ * This is a libnvme-defined helper type, not an NVMe-oF wire type. It is
+ * used by discovery-controller-level configuration knobs (e.g. persistent,
+ * epcsd) that must distinguish "the user did not say" from an explicit
+ * false, so a default derived at runtime is not silently overridden.
+ */
+enum libnvmf_tristate {
+	LIBNVMF_TRISTATE_UNSET	= 0,
+	LIBNVMF_TRISTATE_TRUE	= 1,
+	LIBNVMF_TRISTATE_FALSE	= 2,
+};
+
+/**
  * union nvmf_tsas - Transport Specific Address Subtype
  * @common:  Common transport specific attributes
  * @rdma:    RDMA transport specific attribute settings

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -49,7 +49,7 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 
 	/* common fabrics configuration */
 	const char *device;
-	bool persistent;
+	enum libnvmf_tristate persistent;
 	const char *devid_file; // !access:write=custom
 
 	/* host configuration */

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -50,6 +50,7 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 	/* common fabrics configuration */
 	const char *device;
 	enum libnvmf_tristate persistent;
+	enum libnvmf_tristate epcsd;
 	const char *devid_file; // !access:write=custom
 
 	/* host configuration */

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -390,13 +390,6 @@ struct libnvme_host {  // !generate-accessors:read=generated,write=none !generat
 	char *hostid;
 	char *dhchap_host_key;		// !access:write=generated
 	char *hostsymname;		// !access:write=generated
-
-	/* pdc_enabled and pdc_enabled_valid work together. pdc_enabled_valid,
-	 * when true, indicates that pdc_enabled has been explicitly defined.
-	 * pdc_enabled_valid is internal meta-data for pdc_enabled.
-	 */
-	bool pdc_enabled;		// !access:read=none,write=custom
-	bool pdc_enabled_valid;		// !access:read=none
 };
 
 struct libnvme_fabric_options { // !generate-accessors

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -193,21 +193,6 @@ __shr_public struct libnvme_global_ctx *libnvme_host_get_global_ctx(
 	return h->ctx;
 }
 
-__shr_public void libnvme_host_set_pdc_enabled(
-		libnvme_host_t h, bool enabled)
-{
-	h->pdc_enabled_valid = true;
-	h->pdc_enabled = enabled;
-}
-
-__shr_public bool libnvme_host_is_pdc_enabled(
-		libnvme_host_t h, bool fallback)
-{
-	if (h->pdc_enabled_valid)
-		return h->pdc_enabled;
-	return fallback;
-}
-
 __shr_public libnvme_subsystem_t libnvme_first_subsystem(libnvme_host_t h)
 {
 	return list_top(&h->subsystems, struct libnvme_subsystem, entry);

--- a/libnvme/src/nvme/tree.h
+++ b/libnvme/src/nvme/tree.h
@@ -77,28 +77,6 @@ libnvme_host_t libnvme_next_host(struct libnvme_global_ctx *ctx,
 struct libnvme_global_ctx *libnvme_host_get_global_ctx(libnvme_host_t h);
 
 /**
- * libnvme_host_set_pdc_enabled() - Set Persistent Discovery Controller flag
- * @h:		Host for which the falg should be set
- * @enabled:	The bool to set the enabled flag
- *
- * When libnvme_host_set_pdc_enabled() is not used to set the PDC flag,
- * libnvme_host_is_pdc_enabled() will return the default value which was
- * passed into the function and not the undefined flag value.
- */
-void libnvme_host_set_pdc_enabled(libnvme_host_t h, bool enabled);
-
-/**
- * libnvme_host_is_pdc_enabled() - Is Persistenct Discovery Controller enabled
- * @h: 		Host which to check if PDC is enabled
- * @fallback:	The fallback default value of the flag when
- * 		@libnvme_host_set_pdc_enabled has not be used
- * 		to set the flag.
- *
- * Return: true if PDC is enabled for @h, else false
- */
-bool libnvme_host_is_pdc_enabled(libnvme_host_t h, bool fallback);
-
-/**
  * libnvme_get_host() - Returns a host object
  * @ctx:	struct libnvme_global_ctx object
  * @hostnqn:	Host NQN (optional)

--- a/libnvme/test/config-api.c
+++ b/libnvme/test/config-api.c
@@ -493,6 +493,7 @@ static bool test_apply_params(struct libnvme_global_ctx *ctx)
 	assert(!libnvmf_params_set(params, "tls", "true"));
 	assert(!libnvmf_params_set(params, "hdr-digest", "false"));
 	assert(!libnvmf_params_set(params, "persistent", "true"));
+	assert(!libnvmf_params_set(params, "epcsd", "true"));
 	/* Explicit resets: must be skipped, not applied as "0". */
 	assert(!libnvmf_params_set(params, "tos", ""));
 	assert(!libnvmf_params_set(params, "ctrl-loss-tmo", ""));
@@ -523,7 +524,8 @@ static bool test_apply_params(struct libnvme_global_ctx *ctx)
 
 	if (!libnvmf_context_get_tls(fctx) ||
 	    libnvmf_context_get_hdr_digest(fctx) ||
-	    !libnvmf_context_get_persistent(fctx)) {
+	    libnvmf_context_get_persistent(fctx) != LIBNVMF_TRISTATE_TRUE ||
+	    libnvmf_context_get_epcsd(fctx) != LIBNVMF_TRISTATE_TRUE) {
 		printf(" - bool fields [FAIL]\n");
 		pass = false;
 	} else {
@@ -561,6 +563,48 @@ out:
 		pass = false;
 	} else {
 		printf(" - NULL rejected [PASS]\n");
+	}
+
+	libnvmf_context_free(fctx);
+	libnvmf_params_free(params);
+	return pass;
+}
+
+/*
+ * persistent/epcsd must distinguish "not configured" (UNSET, the library
+ * default derived elsewhere, e.g. from the discovery log page) from an
+ * explicit "false" -- a plain bool cannot represent that third state.
+ */
+static bool test_persistent_epcsd_tristate(struct libnvme_global_ctx *ctx)
+{
+	struct libnvmf_context *fctx;
+	struct libnvmf_params *params;
+	bool pass = true;
+
+	printf("test_persistent_epcsd_tristate:\n");
+
+	assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
+
+	if (libnvmf_context_get_persistent(fctx) != LIBNVMF_TRISTATE_UNSET ||
+	    libnvmf_context_get_epcsd(fctx) != LIBNVMF_TRISTATE_UNSET) {
+		printf(" - fresh context defaults to unset [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - fresh context defaults to unset [PASS]\n");
+	}
+
+	params = libnvmf_params_new();
+	assert(params);
+	assert(!libnvmf_params_set(params, "persistent", "false"));
+	assert(!libnvmf_params_set(params, "epcsd", "false"));
+	assert(!libnvmf_context_apply_params(fctx, params));
+
+	if (libnvmf_context_get_persistent(fctx) != LIBNVMF_TRISTATE_FALSE ||
+	    libnvmf_context_get_epcsd(fctx) != LIBNVMF_TRISTATE_FALSE) {
+		printf(" - explicit \"false\" recorded distinctly from unset [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - explicit \"false\" recorded distinctly from unset [PASS]\n");
 	}
 
 	libnvmf_context_free(fctx);
@@ -790,6 +834,7 @@ int main(void)
 	pass &= test_emit(ctx, &fx);
 	pass &= test_hostnqn_precedence(ctx, &fx);
 	pass &= test_apply_params(ctx);
+	pass &= test_persistent_epcsd_tristate(ctx);
 	pass &= test_set_connection_from_tid(ctx);
 	pass &= test_edge_cases(ctx, &fx);
 

--- a/libnvme/test/config-api.c
+++ b/libnvme/test/config-api.c
@@ -492,6 +492,7 @@ static bool test_apply_params(struct libnvme_global_ctx *ctx)
 	assert(!libnvmf_params_set(params, "keep-alive-tmo", "30"));
 	assert(!libnvmf_params_set(params, "tls", "true"));
 	assert(!libnvmf_params_set(params, "hdr-digest", "false"));
+	assert(!libnvmf_params_set(params, "persistent", "true"));
 	/* Explicit resets: must be skipped, not applied as "0". */
 	assert(!libnvmf_params_set(params, "tos", ""));
 	assert(!libnvmf_params_set(params, "ctrl-loss-tmo", ""));
@@ -521,7 +522,8 @@ static bool test_apply_params(struct libnvme_global_ctx *ctx)
 	}
 
 	if (!libnvmf_context_get_tls(fctx) ||
-	    libnvmf_context_get_hdr_digest(fctx)) {
+	    libnvmf_context_get_hdr_digest(fctx) ||
+	    !libnvmf_context_get_persistent(fctx)) {
 		printf(" - bool fields [FAIL]\n");
 		pass = false;
 	} else {

--- a/libnvme/test/config-ini.c
+++ b/libnvme/test/config-ini.c
@@ -139,6 +139,7 @@ static bool test_key_table(void)
 	} expect[] = {
 		{ "ctrl-loss-tmo",	LIBNVMF_KEY_TUNABLE },
 		{ "hdr-digest",		LIBNVMF_KEY_TUNABLE },
+		{ "persistent",		LIBNVMF_KEY_DC_TUNABLE },
 		{ "tls-key",		LIBNVMF_KEY_SECURITY },
 		{ "dhchap-secret",	LIBNVMF_KEY_SECURITY },
 		{ "hostnqn",		LIBNVMF_KEY_IDENTITY },
@@ -282,6 +283,7 @@ static bool test_parse_model(struct libnvme_global_ctx *ctx)
 		"dhchap-secret = DHHC-1:00:abc\n"
 		"\n"
 		"[Discovery Controller]\n"
+		"persistent = true\n"
 		"controller = transport=tcp;traddr=10.0.0.5;trsvcid=8009\n"
 		"\n"
 		"[Subsystem]\n"
@@ -337,6 +339,14 @@ static bool test_parse_model(struct libnvme_global_ctx *ctx)
 		pass = false;
 	} else {
 		printf(" - one DC (default NQN) + one [Subsystem] [PASS]\n");
+	}
+
+	if (!dc || !dc->params ||
+	    strcmp(libnvmf_params_get(dc->params, "persistent"), "true")) {
+		printf(" - [Discovery Controller] persistent [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - persistent recorded on the DC endpoint [PASS]\n");
 	}
 
 	if (!ss || !ss->params ||
@@ -445,6 +455,13 @@ static bool test_parse_errors(struct libnvme_global_ctx *ctx)
 		{ "malformed hostid",
 		  "[Host]\nhostnqn = nqn.2014-08.org.nvmexpress:h\n"
 		  "hostid = not-a-uuid\n" },
+		{ "persistent in [I/O Controller Defaults]",
+		  "[I/O Controller Defaults]\npersistent = true\n" },
+		{ "persistent in [Subsystem]",
+		  "[Subsystem]\nnqn = nqn.2014-08.org.nvmexpress:test\npersistent = true\n" },
+		{ "persistent as a [Subsystem] per-path override",
+		  "[Subsystem]\nnqn = nqn.2014-08.org.nvmexpress:test\n"
+		  "controller = transport=tcp;traddr=1.2.3.4;persistent=true\n" },
 	};
 	bool pass = true;
 	size_t i;

--- a/libnvme/test/config-ini.c
+++ b/libnvme/test/config-ini.c
@@ -140,6 +140,7 @@ static bool test_key_table(void)
 		{ "ctrl-loss-tmo",	LIBNVMF_KEY_TUNABLE },
 		{ "hdr-digest",		LIBNVMF_KEY_TUNABLE },
 		{ "persistent",		LIBNVMF_KEY_DC_TUNABLE },
+		{ "epcsd",		LIBNVMF_KEY_DC_TUNABLE },
 		{ "tls-key",		LIBNVMF_KEY_SECURITY },
 		{ "dhchap-secret",	LIBNVMF_KEY_SECURITY },
 		{ "hostnqn",		LIBNVMF_KEY_IDENTITY },
@@ -284,6 +285,7 @@ static bool test_parse_model(struct libnvme_global_ctx *ctx)
 		"\n"
 		"[Discovery Controller]\n"
 		"persistent = true\n"
+		"epcsd = true\n"
 		"controller = transport=tcp;traddr=10.0.0.5;trsvcid=8009\n"
 		"\n"
 		"[Subsystem]\n"
@@ -347,6 +349,14 @@ static bool test_parse_model(struct libnvme_global_ctx *ctx)
 		pass = false;
 	} else {
 		printf(" - persistent recorded on the DC endpoint [PASS]\n");
+	}
+
+	if (!dc || !dc->params ||
+	    strcmp(libnvmf_params_get(dc->params, "epcsd"), "true")) {
+		printf(" - [Discovery Controller] epcsd [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - epcsd recorded on the DC endpoint [PASS]\n");
 	}
 
 	if (!ss || !ss->params ||
@@ -462,6 +472,13 @@ static bool test_parse_errors(struct libnvme_global_ctx *ctx)
 		{ "persistent as a [Subsystem] per-path override",
 		  "[Subsystem]\nnqn = nqn.2014-08.org.nvmexpress:test\n"
 		  "controller = transport=tcp;traddr=1.2.3.4;persistent=true\n" },
+		{ "epcsd in [I/O Controller Defaults]",
+		  "[I/O Controller Defaults]\nepcsd = true\n" },
+		{ "epcsd in [Subsystem]",
+		  "[Subsystem]\nnqn = nqn.2014-08.org.nvmexpress:test\nepcsd = true\n" },
+		{ "epcsd as a [Subsystem] per-path override",
+		  "[Subsystem]\nnqn = nqn.2014-08.org.nvmexpress:test\n"
+		  "controller = transport=tcp;traddr=1.2.3.4;epcsd=true\n" },
 	};
 	bool pass = true;
 	size_t i;

--- a/meson.build
+++ b/meson.build
@@ -176,8 +176,6 @@ conf.set('CONFIG_JSONC', json_c_dep.found(), description: 'Is json-c available?'
 conf.set('NVME_VERSION', '"@0@"'.format(meson.project_version()))
 conf.set('LIBNVME_VERSION', '"@0@"'.format(meson.project_version()))
 
-conf.set10('DEFAULT_PDC_ENABLED', get_option('pdc-enabled'))
-
 # local (cross-compilable) implementations of ccan configure steps
 conf.set10(
     'NVME_HAVE_BUILTIN_TYPES_COMPATIBLE_P',
@@ -868,6 +866,5 @@ summary(wanted_dict, section: 'Features to build', bool_yn: true)
 
 conf_dict = {
     'git version':      conf.get('GIT_VERSION'),
-    'pdc enabled':      get_option('pdc-enabled'),
 }
 summary(conf_dict, section: 'Configuration', bool_yn: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,12 +108,6 @@ option(
   description : 'build tests'
 )
 option(
-  'pdc-enabled',
-  type: 'boolean',
-  value : false,
-  description : 'set default Persistent Discovery Controllers behavior'
-)
-option(
   'rundir',
   type : 'string',
   value : '/run',

--- a/tests/nvme_config_convert_test.py
+++ b/tests/nvme_config_convert_test.py
@@ -203,6 +203,83 @@ class ConfigConvertCLITest(TestNVMeBase):
         self.assertIn('dhchap-secret = DHHC-1:00:port-specific-key:', content)
         self.assertNotIn('DHHC-1:00:host-default-key:', content)
 
+    def test_discovery_persistent_true_is_mapped(self):
+        self._write_json({
+            'hosts': [{
+                'subsystems': [{
+                    'nqn': 'nqn.2014-08.org.nvmexpress.discovery',
+                    'ports': [{
+                        'transport': 'tcp',
+                        'traddr': '10.0.0.11',
+                        'discovery': True,
+                        'persistent': True,
+                    }],
+                }],
+            }],
+        })
+        self._convert()
+        content = self._read_output()
+        self.assertIn('[Discovery Controller]', content)
+        self.assertIn('persistent = true', content)
+
+    def test_discovery_persistent_false_is_mapped_distinctly(self):
+        self._write_json({
+            'hosts': [{
+                'subsystems': [{
+                    'nqn': 'nqn.2014-08.org.nvmexpress.discovery',
+                    'ports': [{
+                        'transport': 'tcp',
+                        'traddr': '10.0.0.12',
+                        'discovery': True,
+                        'persistent': False,
+                    }],
+                }],
+            }],
+        })
+        self._convert()
+        content = self._read_output()
+        self.assertIn('[Discovery Controller]', content)
+        self.assertIn('persistent = false', content)
+
+    def test_discovery_without_persistent_key_omits_it(self):
+        self._write_json({
+            'hosts': [{
+                'subsystems': [{
+                    'nqn': 'nqn.2014-08.org.nvmexpress.discovery',
+                    'ports': [{
+                        'transport': 'tcp',
+                        'traddr': '10.0.0.13',
+                        'discovery': True,
+                    }],
+                }],
+            }],
+        })
+        self._convert()
+        content = self._read_output()
+        self.assertIn('[Discovery Controller]', content)
+        self.assertNotIn('persistent', content)
+
+    def test_io_controller_persistent_key_is_ignored(self):
+        # "persistent" is only meaningful (and only valid ini syntax) on a
+        # discovery connection; on an I/O controller port it must not be
+        # forwarded, or the emitted ini would fail to parse back.
+        self._write_json({
+            'hosts': [{
+                'subsystems': [{
+                    'nqn': 'nqn.2024-01.com.example:data.vol9',
+                    'ports': [{
+                        'transport': 'tcp',
+                        'traddr': '10.0.0.14',
+                        'persistent': True,
+                    }],
+                }],
+            }],
+        })
+        self._convert()
+        content = self._read_output()
+        self.assertIn('[Subsystem]', content)
+        self.assertNotIn('persistent', content)
+
     # ------------------------------------------------------------------ #
     # errors                                                              #
     # ------------------------------------------------------------------ #

--- a/tests/nvme_config_create_test.py
+++ b/tests/nvme_config_create_test.py
@@ -116,6 +116,78 @@ class ConfigCreateCLITest(TestNVMeBase):
         content = self._read_output()
         self.assertIn('hostsymname = lab-host-01', content)
 
+    def test_discovery_persistent_flag_is_stored(self):
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0x2:pn-0x2', '--discovery',
+                     '--persistent')
+        content = self._read_output()
+        self.assertIn('[Discovery Controller]', content)
+        self.assertIn('persistent = true', content)
+
+    def test_persistent_flag_updates_existing_entry(self):
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0x3:pn-0x3',
+                     '--host-traddr=nn-0x4:pn-0x4', '--discovery')
+        content = self._read_output()
+        self.assertNotIn('persistent', content)
+
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0x3:pn-0x3',
+                     '--host-traddr=nn-0x4:pn-0x4', '--discovery',
+                     '--persistent')
+        content = self._read_output()
+        self.assertEqual(content.count('[Discovery Controller]'), 1,
+                         f'expected exactly one entry, got content:\n{content}')
+        self.assertIn('persistent = true', content)
+
+    def test_discovery_no_persistent_flag_is_stored(self):
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0x8:pn-0x8', '--discovery',
+                     '--no-persistent')
+        content = self._read_output()
+        self.assertIn('[Discovery Controller]', content)
+        self.assertIn('persistent = false', content)
+
+    def test_no_persistent_updates_existing_true_entry(self):
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0xa:pn-0xa', '--discovery',
+                     '--persistent')
+        content = self._read_output()
+        self.assertIn('persistent = true', content)
+
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0xa:pn-0xa', '--discovery',
+                     '--no-persistent')
+        content = self._read_output()
+        self.assertEqual(content.count('[Discovery Controller]'), 1,
+                         f'expected exactly one entry, got content:\n{content}')
+        self.assertIn('persistent = false', content)
+        self.assertNotIn('persistent = true', content)
+
+    def test_discovery_no_persistent_flag_is_stored(self):
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0x8:pn-0x8', '--discovery',
+                     '--no-persistent')
+        content = self._read_output()
+        self.assertIn('[Discovery Controller]', content)
+        self.assertIn('persistent = false', content)
+
+    def test_no_persistent_updates_existing_true_entry(self):
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0xa:pn-0xa', '--discovery',
+                     '--persistent')
+        content = self._read_output()
+        self.assertIn('persistent = true', content)
+
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0xa:pn-0xa', '--discovery',
+                     '--no-persistent')
+        content = self._read_output()
+        self.assertEqual(content.count('[Discovery Controller]'), 1,
+                         f'expected exactly one entry, got content:\n{content}')
+        self.assertIn('persistent = false', content)
+        self.assertNotIn('persistent = true', content)
+
     def test_second_create_preserves_first_entry(self):
         self._create('--transport', 'fc',
                      '--traddr=nn-0x1:pn-0x1', '--discovery')
@@ -156,6 +228,23 @@ class ConfigCreateCLITest(TestNVMeBase):
                               expect_fail=True)
         self.assertFalse(os.path.exists(self.output_ini))
 
+    def test_persistent_without_discovery_errors(self):
+        self._create('--transport', 'tcp', '--traddr=192.168.1.41',
+                     '--nqn=nqn.2024-01.com.example:data.vol4',
+                     '--persistent', expect_fail=True)
+        self.assertFalse(os.path.exists(self.output_ini))
+
+    def test_no_persistent_without_discovery_errors(self):
+        self._create('--transport', 'tcp', '--traddr=192.168.1.43',
+                     '--nqn=nqn.2024-01.com.example:data.vol6',
+                     '--no-persistent', expect_fail=True)
+        self.assertFalse(os.path.exists(self.output_ini))
+
+    def test_persistent_and_no_persistent_mutually_exclusive(self):
+        self._create('--transport', 'fc', '--traddr=nn-0xb:pn-0xb',
+                     '--discovery', '--persistent', '--no-persistent',
+                     expect_fail=True)
+        self.assertFalse(os.path.exists(self.output_ini))
 
 if __name__ == '__main__':
     # Remove the binary path from argv so unittest.main() doesn't see it.

--- a/tests/nvme_config_create_test.py
+++ b/tests/nvme_config_create_test.py
@@ -172,6 +172,14 @@ class ConfigCreateCLITest(TestNVMeBase):
         self.assertIn('[Discovery Controller]', content)
         self.assertIn('persistent = false', content)
 
+    def test_discovery_no_epcsd_flag_is_stored(self):
+        self._create('--transport', 'fc',
+                     '--traddr=nn-0x9:pn-0x9', '--discovery',
+                     '--no-epcsd')
+        content = self._read_output()
+        self.assertIn('[Discovery Controller]', content)
+        self.assertIn('epcsd = false', content)
+
     def test_no_persistent_updates_existing_true_entry(self):
         self._create('--transport', 'fc',
                      '--traddr=nn-0xa:pn-0xa', '--discovery',
@@ -234,10 +242,22 @@ class ConfigCreateCLITest(TestNVMeBase):
                      '--persistent', expect_fail=True)
         self.assertFalse(os.path.exists(self.output_ini))
 
+    def test_epcsd_without_discovery_errors(self):
+        self._create('--transport', 'tcp', '--traddr=192.168.1.42',
+                     '--nqn=nqn.2024-01.com.example:data.vol5',
+                     '--epcsd', expect_fail=True)
+        self.assertFalse(os.path.exists(self.output_ini))
+
     def test_no_persistent_without_discovery_errors(self):
         self._create('--transport', 'tcp', '--traddr=192.168.1.43',
                      '--nqn=nqn.2024-01.com.example:data.vol6',
                      '--no-persistent', expect_fail=True)
+        self.assertFalse(os.path.exists(self.output_ini))
+
+    def test_no_epcsd_without_discovery_errors(self):
+        self._create('--transport', 'tcp', '--traddr=192.168.1.44',
+                     '--nqn=nqn.2024-01.com.example:data.vol7',
+                     '--no-epcsd', expect_fail=True)
         self.assertFalse(os.path.exists(self.output_ini))
 
     def test_persistent_and_no_persistent_mutually_exclusive(self):
@@ -245,6 +265,13 @@ class ConfigCreateCLITest(TestNVMeBase):
                      '--discovery', '--persistent', '--no-persistent',
                      expect_fail=True)
         self.assertFalse(os.path.exists(self.output_ini))
+
+    def test_epcsd_and_no_epcsd_mutually_exclusive(self):
+        self._create('--transport', 'fc', '--traddr=nn-0xc:pn-0xc',
+                     '--discovery', '--epcsd', '--no-epcsd',
+                     expect_fail=True)
+        self.assertFalse(os.path.exists(self.output_ini))
+
 
 if __name__ == '__main__':
     # Remove the binary path from argv so unittest.main() doesn't see it.


### PR DESCRIPTION
The new config system doesn't know about PDC. Add support for `persistent` in the discovery sections.
While at it, also add a command which creates configs from the command line. 

Related to #3112 

This PR does not implement the PDC/EPCSD logic, it only adds the config related bits.