### PR TITLE
netapp: fix resource leak on alloc failure in netapp_ontapdevices()

### DIFF
--- a/libnvme/src/nvme/private-tree.h
+++ b/libnvme/src/nvme/private-tree.h
@@ -10,20 +10,6 @@
 #include "cleanup.h"
 #include <nvme/tree.h>
 
-struct dirents {
-	struct dirent **ents;
-	int num;
-};
-
-static inline void cleanup_dirents(struct dirents *ents)
-{
-	while (ents->num > 0)
-		free(ents->ents[--ents->num]);
-	free(ents->ents);
-}
-
-#define __cleanup_dirents __cleanup(cleanup_dirents)
-
 #define FREE_CTRL_ATTR(a) \
 	do { free(a); (a) = NULL; } while (0)
 

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -1006,8 +1006,8 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 {
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	const char *desc = "Display information about ONTAP devices.";
-	struct dirent **devices;
-	int num, i, ret, fmt;
+	__cleanup_dirents struct dirents devs = {};
+	int i, ret, fmt;
 	struct ontapdevice_info *ontapdevices;
 	char path[264];
 	char *devname = NULL;
@@ -1051,21 +1051,21 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 		}
 	}
 
-	num = scandir(dev_path, &devices, netapp_nvme_filter, alphasort);
-	if (num <= 0) {
+	devs.num = scandir(dev_path, &devs.ents, netapp_nvme_filter, alphasort);
+	if (devs.num <= 0) {
 		nvme_show_error("No ontapdevices detected");
-		return num;
+		return devs.num;
 	}
 
-	ontapdevices = calloc(num, sizeof(*ontapdevices));
+	ontapdevices = calloc(devs.num, sizeof(*ontapdevices));
 	if (!ontapdevices) {
 		nvme_show_error("Unable to allocate memory for devices");
 		return -ENOMEM;
 	}
 
-	for (i = 0; i < num; i++) {
+	for (i = 0; i < devs.num; i++) {
 		snprintf(path, sizeof(path), "%s%s", dev_path,
-				devices[i]->d_name);
+				devs.ents[i]->d_name);
 		ret = libnvme_open(ctx, path, &hdl);
 		if (ret) {
 			nvme_show_error("Unable to open %s: %s", path,
@@ -1094,9 +1094,6 @@ static int netapp_ontapdevices(int argc, char **argv, struct command *acmd,
 	} else
 		nvme_show_error("No ontapdevices detected");
 
-	for (i = 0; i < num; i++)
-		free(devices[i]);
-	free(devices);
 	free(ontapdevices);
 	return 0;
 }

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -906,8 +906,8 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 {
 	const char *desc = "Display information about E-Series volumes.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	struct dirent **devices;
-	int num, i, ret, fmt;
+	__cleanup_dirents struct dirents devs = {};
+	int i, ret, fmt;
 	struct smdevice_info *smdevices;
 	char path[264];
 	char *devname = NULL;
@@ -931,10 +931,10 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 		return -EINVAL;
 	}
 
-	num = scandir(dev_path, &devices, netapp_nvme_filter, alphasort);
-	if (num <= 0) {
+	devs.num = scandir(dev_path, &devs.ents, netapp_nvme_filter, alphasort);
+	if (devs.num <= 0) {
 		nvme_show_error("No smdevices detected");
-		return num;
+		return devs.num;
 	}
 
 	if (optind < argc)
@@ -957,15 +957,15 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 		}
 	}
 
-	smdevices = calloc(num, sizeof(*smdevices));
+	smdevices = calloc(devs.num, sizeof(*smdevices));
 	if (!smdevices) {
 		nvme_show_error("Unable to allocate memory for devices");
 		return -ENOMEM;
 	}
 
-	for (i = 0; i < num; i++) {
+	for (i = 0; i < devs.num; i++) {
 		snprintf(path, sizeof(path), "%s%s", dev_path,
-			devices[i]->d_name);
+			devs.ents[i]->d_name);
 		ret = libnvme_open(ctx, path, &hdl);
 		if (ret) {
 			nvme_show_error("Unable to open %s: %s", path,
@@ -993,9 +993,6 @@ static int netapp_smdevices(int argc, char **argv, struct command *acmd,
 	} else
 		nvme_show_error("No smdevices detected");
 
-	for (i = 0; i < num; i++)
-		free(devices[i]);
-	free(devices);
 	free(smdevices);
 	return 0;
 }

--- a/shared/cleanup.h
+++ b/shared/cleanup.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <dirent.h>
 #include <stdlib.h>
 
 #define __cleanup(fn) __attribute__((cleanup(fn)))
@@ -26,3 +27,17 @@ static inline void shr_freep(void *p)
 	free(*(void **)p);
 }
 #define __cleanup_free __cleanup(shr_freep)
+
+struct dirents {
+	struct dirent **ents;
+	int num;
+};
+
+static inline void cleanup_dirents(struct dirents *ents)
+{
+	while (ents->num > 0)
+		free(ents->ents[--ents->num]);
+	free(ents->ents);
+}
+
+#define __cleanup_dirents __cleanup(cleanup_dirents)


### PR DESCRIPTION
The netapp_ontapdevices() function calls scandir() to build a list of NVMe device entries. After scandir() succeeds, @ontapdevices is allocated with calloc(). If the calloc() fails, the function returns -ENOMEM without freeing the @devices array returned by scandir().

This results in a memory leak each time the allocation failure path is taken.

Free each @devices entry and then @devices itself before returning -ENOMEM to prevent the leak.