### PR TITLE
wdc: fix out-of-bounds access in wdc_show_cloud_smart_log_normal()

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -8008,7 +8008,7 @@ static void stringify_log_page_guid(__u8 *guid, char *buf)
 	char *ptr = buf;
 	int i;
 
-	memset(buf, 0, sizeof(char) * 19);
+	memset(buf, 0, sizeof(char) * (2 * 16 + 1));
 
 	ptr += sprintf(ptr, "0x");
 	for (i = 0; i < 16; i++)


### PR DESCRIPTION
stringify_log_page_guid() clears the caller-supplied buffer with memset(buf, 0, sizeof(char) * 19), but the subsequent sprintf() loop writes "0x" (2 bytes) followed by up to 16 * 2 = 32 hex digits plus an implicit NUL terminator — 35 bytes total when all 16 GUID bytes are >= 0x10.  Only 19 of those bytes are initialised, so the final 16 bytes written by sprintf() touch uninitialised stack memory in the caller (wdc_show_cloud_smart_log_normal()).

Increase the memset size to (2 * 16 + 1) so that all bytes written by the function are first zeroed, eliminating the out-of-bounds access.

Fixes: Coverity CID 557366 (Out-of-bounds access)