### PR TITLE
scaleflux: clamp code_type before array access in nvme_parse_evtlog()

### DIFF
--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1162,6 +1162,10 @@ static int nvme_parse_evtlog(void *pevent_log_info, __u32 log_len, char *output)
 
 			code_level = (info->code & 0x100) >> 8;
 			code_type  = (info->code % 0x100);
+			if (code_level == sfx_evtlog_level_warning && code_type >= ARRAY_SIZE(sfx_evtlog_warning))
+				code_type = 0;
+			if (code_level == sfx_evtlog_level_error && code_type >= ARRAY_SIZE(sfx_evtlog_error))
+				code_type = 0;
 			if (code_level == sfx_evtlog_level_warning) {
 				snprintf(str_buffer + str_pos, 128,
 					 "  > error_str:          [WARNING][%s]\n\n",


### PR DESCRIPTION
code_type is derived from firmware data as (info->code % 0x100), giving a value in the range 0..255. It is then used directly as an index into sfx_evtlog_warning[4] or sfx_evtlog_error[14] with no bounds check, so any code_type value exceeding the array size causes an out-of-bounds read.

Clamp code_type to 0 ("RESERVED") when it would exceed the bounds of the relevant array before either array is indexed.

Fixes: Coverity CID 557357 (Out-of-bounds read, High)