### PR TITLE
innogrit: fix resource leak in innogrit_vsc_getcdump()

### DIFF
--- a/plugins/innogrit/innogrit-nvme.c
+++ b/plugins/innogrit/innogrit-nvme.c
@@ -279,8 +279,11 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *acmd,
 		memset(data, 0, 4096);
 		ret = nvme_get_nsid_log(hdl, NVME_NSID_ALL,true, 0x07,
 					data, 4096);
-		if (ret != 0)
+		if (ret != 0) {
+			if (fp != NULL)
+				fclose(fp);
 			return ret;
+		}
 
 		ipackcount = 1;
 		memcpy(&itotal, &data[4092], 4);
@@ -294,6 +297,8 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *acmd,
 
 	if (itotal == 0) {
 		printf("no cdump data\n");
+		if (fp != NULL)
+			fclose(fp);
 		return 0;
 	}
 
@@ -318,8 +323,10 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *acmd,
 				ret = nvme_get_nsid_log(hdl, NVME_NSID_ALL, true,
 							0x07, data, 4096);
 			}
-			if (ret != 0)
+			if (ret != 0) {
+				fclose(fp);
 				return ret;
+			}
 
 			fwrite(data, 1, 4096, fp);
 			printf("\rWait for dump data %d%%" XCLEAN_LINE,
@@ -347,8 +354,10 @@ static int innogrit_vsc_getcdump(int argc, char **argv, struct command *acmd,
 				ret = nvme_get_nsid_log(hdl, NVME_NSID_ALL, true,
 							0x07, data, 4096);
 			}
-			if (ret != 0)
+			if (ret != 0) {
+				fclose(fp);
 				return ret;
+			}
 
 			itotal = cdumpinfo.cdumppack[ipackindex].ilenth;
 			memset(fwvera, 0, sizeof(fwvera));


### PR DESCRIPTION
Four early-return paths in innogrit_vsc_getcdump() exit the function after fp has been opened via fopen() without calling fclose(fp):

1. The nvme_get_nsid_log() error return inside the busevsc==false block can be reached after fp was opened in the busevsc==true path (ipackcount > 0 branch).  Add braces to the bare if and close fp when non-NULL before returning.

2. The itotal==0 early exit is reached after both fopen() paths have run.  Close fp when non-NULL before returning 0.

3. The per-chunk vsc read error return inside the for-loop is reached only after the main fopen(), so fp is always open.  Close it unconditionally before returning.

4. The inter-pack vsc read error return inside the while-loop second block is likewise reached only after fopen(), so fp is always open.  Close it unconditionally before returning.

The existing fclose(fp) at the normal function exit is unchanged.

Fixes: Coverity CID 557347 (Resource leak)