### PR TITLE
discoverd: rename discoverd.conf to nvme-discoverd.conf

### DIFF
--- a/Documentation/nvme-discoverd.txt
+++ b/Documentation/nvme-discoverd.txt
@@ -54,8 +54,8 @@ OPTIONS
 -c <FILE>::
 --config=<FILE>::
 	Path to the daemon's own configuration file. Default:
-	@SYSCONFDIR@/nvme/discoverd.conf; see CONFIGURATION below. A
-	missing file is not an error -- every knob keeps its default.
+	@SYSCONFDIR@/nvme/nvme-discoverd.conf; see CONFIGURATION below.
+	A missing file is not an error -- every knob keeps its default.
 
 --nvme-path=<PATH>::
 	Absolute or relative path to the 'nvme' binary that transient
@@ -99,7 +99,7 @@ See nvme-fabrics.conf(5).
 SIGNALS
 -------
 SIGHUP;;
-	Reload both discoverd.conf and the shared fabrics configuration.
+	Reload both nvme-discoverd.conf and the shared fabrics configuration.
 	Newly desired connections are started; nothing already connected
 	is ever disconnected by a reload. If the fabrics configuration
 	fails to reload (e.g. a syntax error), the previous one is kept
@@ -110,7 +110,7 @@ SIGTERM, SIGINT;;
 
 FILES
 -----
-@SYSCONFDIR@/nvme/discoverd.conf::
+@SYSCONFDIR@/nvme/nvme-discoverd.conf::
 	The daemon's own configuration; see CONFIGURATION.
 
 @SYSCONFDIR@/nvme/nvme-fabrics.conf, @SYSCONFDIR@/nvme/nvme-fabrics.conf.d/*.conf::

--- a/discoverd/README.md
+++ b/discoverd/README.md
@@ -28,7 +28,7 @@ The host's alternative today is a udev-rule-triggered swarm of systemd units (`7
 | `events.c` | udev monitoring: device add/remove/change, sysfs TID parsing |
 | `dlp.c` | Discovery Log Page fetch and parsing |
 | `fc.c` | FC kickstart |
-| `config.c` | The daemon's own three knobs (`discoverd.conf`) — not the connections it manages, see below |
+| `config.c` | The daemon's own three knobs (`nvme-discoverd.conf`) — not the connections it manages, see below |
 | `state.c` | Runtime state under `$RUNDIR/nvme/discoverd/`, linking a kernel device to the unit that owns it |
 | `log.c` | Journal logging wrapper |
 
@@ -36,7 +36,7 @@ The host's alternative today is a udev-rule-triggered swarm of systemd units (`7
 
 nvme-discoverd reads two independent files:
 
-- **`discoverd.conf`** — the daemon's own knobs (`nbft`, `debug-level`, `fc-kickstart-interval-minutes`). Entirely optional; a missing file or key just keeps its default.
+- **`nvme-discoverd.conf`** — the daemon's own knobs (`nbft`, `debug-level`, `fc-kickstart-interval-minutes`). Entirely optional; a missing file or key just keeps its default.
 - **The shared NVMe-oF fabrics configuration** (`nvme-fabrics.conf(5)`) — which Discovery Controllers and subsystems to connect, host identity, per-connection parameters. This is the same file `nvme connect-all`, `nvme discover`, and `nvme-stas` read. nvme-discoverd has no private connection format of its own.
 
 Both are reloaded on `SIGHUP`. Nothing already connected is ever disconnected by a reload.

--- a/discoverd/etc/nvme/nvme-discoverd.conf.in
+++ b/discoverd/etc/nvme/nvme-discoverd.conf.in
@@ -1,5 +1,5 @@
 # nvme-discoverd configuration
-# @SYSCONFDIR@/nvme/discoverd.conf
+# @SYSCONFDIR@/nvme/nvme-discoverd.conf
 #
 # The daemon's own knobs. The connections it manages come from the shared
 # NVMe-oF fabrics configuration (nvme-fabrics.conf(5)), not from here.

--- a/discoverd/meson.build
+++ b/discoverd/meson.build
@@ -50,12 +50,13 @@ configure_file(
 )
 
 # Unlike nvme-fabrics.conf (re-read on every connect/connect-all/discover,
-# and holding host-specific connections an admin customizes), discoverd.conf
-# is read once at daemon startup and holds only generic daemon knobs, so it
-# installs directly as the live file rather than a .sample a user must copy.
+# and holding host-specific connections an admin customizes), nvme-discoverd's
+# config file is read once at daemon startup and holds only generic daemon
+# knobs, so it installs directly as the live file rather than a .sample a
+# user must copy.
 configure_file(
-    input: 'etc/nvme/discoverd.conf.in',
-    output: 'discoverd.conf',
+    input: 'etc/nvme/nvme-discoverd.conf.in',
+    output: 'nvme-discoverd.conf',
     configuration: substs,
     install: true,
     install_dir: sysconfdir / 'nvme',

--- a/discoverd/src/config.h
+++ b/discoverd/src/config.h
@@ -10,9 +10,9 @@
 #include <stdbool.h>
 
 /*
- * discoverd.conf carries the daemon's own knobs only — the connections it
- * manages come from the shared fabrics config (libnvmf_config_read()), not
- * from here. Just a single [Global] section:
+ * nvme-discoverd's config file carries the daemon's own knobs only — the
+ * connections it manages come from the shared fabrics config
+ * (libnvmf_config_read()), not from here. Just a single [Global] section:
  *
  *   [Global]
  *   nbft = true
@@ -38,18 +38,18 @@ struct discoverd_config {
 };
 
 /*
- * Load discoverd's own configuration. @conf_path is discoverd.conf's path
+ * Load discoverd's own configuration. @conf_path is the config file's path
  * (DISCOVERD_CONF_PATH if NULL). A missing file is not an error — every
- * knob keeps its default; a malformed line is logged and skipped.
- * Returns a newly allocated config (never NULL except on allocation
- * failure). Caller frees with config_free().
+ * knob keeps its default; a malformed line is logged and skipped. Returns
+ * a newly allocated config (never NULL except on allocation failure).
+ * Caller frees with config_free().
  */
 struct discoverd_config *config_load(const char *conf_path);
 
 void config_free(struct discoverd_config *cfg);
 
 /*
- * Default discoverd.conf location, using the build-provided SYSCONFDIR
- * prefix. The --config command line option overrides it.
+ * Default nvme-discoverd's config file location, using the build-provided
+ * SYSCONFDIR prefix. The --config command line option overrides it.
  */
-#define DISCOVERD_CONF_PATH SYSCONFDIR "/nvme/discoverd.conf"
+#define DISCOVERD_CONF_PATH SYSCONFDIR "/nvme/nvme-discoverd.conf"

--- a/discoverd/src/ctx.h
+++ b/discoverd/src/ctx.h
@@ -28,8 +28,8 @@ struct events_ctx;
  */
 struct discoverd_ctx {
 	struct libnvme_global_ctx *nvme_ctx;     // libnvme logging/scanning
-	const char                *conf_path;    // discoverd.conf path in use
-	struct discoverd_config   *cfg;          // parsed discoverd.conf
+	const char                *conf_path;    // nvme-discoverd's conf path
+	struct discoverd_config   *cfg;          // parsed @conf_path
 	struct libnvmf_config     *fabrics_cfg;  // resolved fabrics config
 	struct inventory          *inventory;    // NBFT + config + DLP cache
 	sd_event                  *event;        // sd_event main loop

--- a/discoverd/src/log.h
+++ b/discoverd/src/log.h
@@ -24,7 +24,7 @@ enum disc_log_level {
 
 #define DISC_DEFAULT_LOGLEVEL DISC_LOG_INFO
 
-/* Set the current threshold (e.g. from discoverd.conf's debug-level knob). */
+/* Set the current threshold (e.g. from nvme-discoverd's config debug-level). */
 void log_set_level(int level);
 
 /*

--- a/discoverd/src/units.h
+++ b/discoverd/src/units.h
@@ -21,8 +21,8 @@
  * it: a healthy disconnect can take 30-40 s on large configs (~200 namespaces,
  * 8 paths, 80 CPUs) and longer still beyond that, so too low a bound would kill
  * a disconnect that is still making progress and leave the controller
- * half-torn-down.  Generous default; this should become a discoverd.conf knob
- * so large deployments can raise it further.
+ * half-torn-down.  Generous default; this should become an nvme-discoverd
+ * config knob so large deployments can raise it further.
  */
 #define DISCONNECT_TIMEOUT_SEC 300
 

--- a/libnvme/design/CONFIG.md
+++ b/libnvme/design/CONFIG.md
@@ -50,7 +50,7 @@ The drop-in directory name is derived mechanically from whatever file you point 
 - An **empty or absent main file** with a populated `.conf.d/` is fully valid: read the main file *if it exists*, then read `<file>.d/*.conf` *if that directory exists*. This is the layout for a host that wants only explicit, non-default personalities and no default config.
 - If **neither exists**, the configuration is empty (no connections) — a gentle no-op, not an error.
 
-> A consumer daemon may keep its *own* configuration file for daemon-specific behavior — for example nvme-discoverd's `discoverd.conf` carries its discovery-source toggles (`nbft`, `zeroconf`, …) and log level. Those keys are specific to that consumer and documented by it; they are **not** part of the shared connectivity format described here.
+> A consumer daemon may keep its *own* configuration file for daemon-specific behavior — for example nvme-discoverd's `nvme-discoverd.conf` carries its discovery-source toggles (`nbft`, `zeroconf`, …) and log level. Those keys are specific to that consumer and documented by it; they are **not** part of the shared connectivity format described here.
 
 ### Pointing at a configuration — `--config` and the `.d/` rule
 


### PR DESCRIPTION
discoverd.conf and the legacy discovery.conf sit in the same directory and are easy to confuse. Rename discoverd's own configuration file to nvme-discoverd.conf.