### PR TITLE
plugins: invoke the arg parser for the remaining commands

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -2578,16 +2578,34 @@ static int micron_drive_info(int argc, char **argv, struct command *acmd,
 static int micron_cloud_ssd_plugin_version(int argc, char **argv,
 					   struct command *command, struct plugin *plugin)
 {
-	printf("nvme-cli Micron cloud SSD plugin version: %s.%s\n",
-		   __version_major, __version_minor);
+	const char *desc = "Prints the Micron cloud SSD plugin version.";
+	int err;
+
+	NVME_ARGS(opts);
+
+	err = parse_args(argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	nvme_show_result("nvme-cli Micron cloud SSD plugin version: %s.%s",
+			 __version_major, __version_minor);
 	return 0;
 }
 
 static int micron_plugin_version(int argc, char **argv, struct command *acmd,
 				 struct plugin *plugin)
 {
-	printf("nvme-cli Micron plugin version: %s.%s.%s\n",
-		   __version_major, __version_minor, __version_patch);
+	const char *desc = "Prints the Micron plugin version.";
+	int err;
+
+	NVME_ARGS(opts);
+
+	err = parse_args(argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	nvme_show_result("nvme-cli Micron plugin version: %s.%s.%s",
+			 __version_major, __version_minor, __version_patch);
 	return 0;
 }
 

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1849,9 +1849,18 @@ out:
 /*SEAGATE-PLUGIN Version */
 static int seagate_plugin_version(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
-	printf("Seagate-Plugin version : %d.%d\n",
-		   SEAGATE_PLUGIN_VERSION_MAJOR,
-		   SEAGATE_PLUGIN_VERSION_MINOR);
+	const char *desc = "Prints the Seagate plugin version.";
+	int err;
+
+	NVME_ARGS(opts);
+
+	err = parse_args(argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	nvme_show_result("Seagate-Plugin version : %d.%d",
+			 SEAGATE_PLUGIN_VERSION_MAJOR,
+			 SEAGATE_PLUGIN_VERSION_MINOR);
 	return 0;
 }
 /*EOF SEAGATE-PLUGIN Version */
@@ -1859,9 +1868,18 @@ static int seagate_plugin_version(int argc, char **argv, struct command *acmd, s
 /*OCP SEAGATE-PLUGIN Version */
 static int stx_ocp_plugin_version(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
-	printf("Seagate-OCP-Plugin version : %d.%d\n",
-		SEAGATE_OCP_PLUGIN_VERSION_MAJOR,
-		SEAGATE_OCP_PLUGIN_VERSION_MINOR);
+	const char *desc = "Prints the Seagate OCP plugin version.";
+	int err;
+
+	NVME_ARGS(opts);
+
+	err = parse_args(argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	nvme_show_result("Seagate-OCP-Plugin version : %d.%d",
+			 SEAGATE_OCP_PLUGIN_VERSION_MAJOR,
+			 SEAGATE_OCP_PLUGIN_VERSION_MINOR);
 	return 0;
 }
 /*EOF OCP SEAGATE-PLUGIN Version */

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -92,6 +92,7 @@ static int print_zns_list(struct libnvme_global_ctx *ctx, struct table *t)
 static int list(int argc, char **argv, struct command *acmd,
 		struct plugin *plugin)
 {
+	const char *desc = "Retrieve basic information for all ZNS namespaces.";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	int err;
 	struct table_column columns[] = {
@@ -104,7 +105,13 @@ static int list(int argc, char **argv, struct command *acmd,
 		{ "Format", LEFT, 16 },
 		{ "FW Rev", LEFT, 8 },
 	};
-	struct table *t = table_init_with_columns(columns, ARRAY_SIZE(columns));
+	struct table *t;
+
+	NVME_ARGS_OUTPUT_FORMATS(opts, NORMAL, "Output format: normal");
+
+	err = parse_args(argc, argv, desc, opts);
+	if (err)
+		return err;
 
 	err = nvme_create_global_ctx(&ctx);
 	if (err)
@@ -114,6 +121,12 @@ static int list(int argc, char **argv, struct command *acmd,
 	if (err) {
 		nvme_show_error("Failed to scan nvme subsystems");
 		return err;
+	}
+
+	t = table_init_with_columns(columns, ARRAY_SIZE(columns));
+	if (!t) {
+		nvme_show_error("Failed to allocate table");
+		return -ENOMEM;
 	}
 
 	err = print_zns_list(ctx, t);


### PR DESCRIPTION
zns list and the micron/seagate plugin-version commands returned without calling the arg parser, so they silently ignored the global options (--output-format, --verbose, etc.) and offered no --help.

Wire each of them through parse_args() so the global options are accepted and --help works. Output is unchanged.