### PR TITLE
lm-nvme: return errors from lm_migration_recv()

### DIFF
--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -509,7 +509,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *acmd, struct
 		}
 	}
 
-	return 0;
+	return err;
 }
 
 enum lm_controller_data_queue_feature_id {


### PR DESCRIPTION
lm_migration_recv() stores command and write failures in err but returns success unconditionally at the end of the function.

Return err so command execution and output write failures are reported to the caller.