### PR TITLE
keys: accept spec-valid DHHC-1 secrets, and fix the base64 decoder

### DIFF
--- a/plugins/keys/keys-plugin.c
+++ b/plugins/keys/keys-plugin.c
@@ -158,56 +158,49 @@ static int validate_kxchap_key(const char *key, int *hmac_out,
 {
 	uint32_t crc = shr_crc32(0L, NULL, 0);
 	uint32_t key_crc;
+	size_t len = strlen(key);
 	int decoded_len, hmac, err;
 
 	if (sscanf(key, "DHHC-1:%02x:%*s", &hmac) != 1) {
 		nvme_show_error("Invalid key header '%s'", key);
 		return -EINVAL;
 	}
-	switch (hmac) {
-	case 0:
-		break;
-	case 1:
-		if (strlen(key) != 59) {
-			nvme_show_error("Invalid key length for SHA(256)");
-			return -EINVAL;
-		}
-		break;
-	case 2:
-		if (strlen(key) != 83) {
-			nvme_show_error("Invalid key length for SHA(384)");
-			return -EINVAL;
-		}
-		break;
-	case 3:
-		if (strlen(key) != 103) {
-			nvme_show_error("Invalid key length for SHA(512)");
-			return -EINVAL;
-		}
-		break;
-	default:
+	if (hmac > 3) {
 		nvme_show_error("Invalid HMAC identifier %d", hmac);
 		return -EINVAL;
 	}
 
-	if (key[strlen(key) - 1] != ':') {
- 		nvme_show_error("Invalid key format (missing trailing ':')");
- 		return -EINVAL;
- 	}
+	/*
+	 * The hash identifier selects the function used to transform the
+	 * secret into a key; it does not constrain the length of the secret
+	 * itself, so apply the same length check whichever one is selected.
+	 * A 32, 48 or 64 byte secret plus a 4 byte CRC encodes to 48, 72 or
+	 * 92 base64 characters, giving a total of 59, 83 or 103.
+	 *
+	 * This does not pin the length of the secret - the same number of
+	 * base64 characters can carry three different byte counts - so the
+	 * decoded length is still checked below. What it does do is bound
+	 * the decode before it runs.
+	 */
+	if (len != 59 && len != 83 && len != 103) {
+		nvme_show_error("Invalid DHHC-1 string length %zu", len);
+		return -EINVAL;
+	}
 
-	err = shr_base64_decode(key + 10, strlen(key) - 11, decoded_key);
+	if (key[len - 1] != ':') {
+		nvme_show_error("Invalid key format (missing trailing ':')");
+		return -EINVAL;
+	}
+
+	err = shr_base64_decode(key + 10, len - 11, decoded_key);
 	if (err < 0) {
 		nvme_show_error("Base64 decoding failed, error %d", err);
 		return err;
 	}
 	decoded_len = err;
-	if (decoded_len < 32) {
-		nvme_show_error("Base64 decoding failed (%s, size %u)", key + 10, decoded_len);
-		return -EINVAL;
-	}
 	decoded_len -= 4;
 	if (decoded_len != 32 && decoded_len != 48 && decoded_len != 64) {
-		nvme_show_error("Invalid key length %d", decoded_len);
+		nvme_show_error("Invalid secret length %d", decoded_len);
 		return -EINVAL;
 	}
 	crc = shr_crc32(crc, decoded_key, decoded_len);

--- a/shared/base64.c
+++ b/shared/base64.c
@@ -57,29 +57,33 @@ int shr_base64_encode(const unsigned char *src, int srclen, char *dst)
 /**
  * shr_base64_decode() - base64-decode some bytes
  * @src: the base64-encoded string to decode
- * @len: number of bytes to decode
+ * @srclen: number of bytes to decode
  * @dst: (output) the decoded bytes.
  *
- * Decodes the base64-encoded bytes @src according to RFC 4648.
+ * Decodes the base64-encoded bytes @src according to RFC 4648,
+ * including the '=' padding: @srclen has to be a multiple of four, and
+ * a '=' anywhere other than in the trailing padding is rejected.
  *
  * Return: number of decoded bytes
  */
 int shr_base64_decode(const char *src, int srclen, unsigned char *dst)
 {
 	uint32_t ac = 0;
-	int i, bits = 0;
+	int i, bits = 0, pad = 0;
 	unsigned char *bp = dst;
+
+	if (srclen < 0 || srclen % 4)
+		return -EINVAL;
+
+	while (srclen > 0 && src[srclen - 1] == '=') {
+		if (++pad > 2)
+			return -EINVAL;
+		srclen--;
+	}
 
 	for (i = 0; i < srclen; i++) {
 		const char *p = strchr(base64_table, src[i]);
 
-		if (src[i] == '=') {
-			ac = (ac << 6);
-			bits += 6;
-			if (bits >= 8)
-				bits -= 8;
-			continue;
-		}
 		if (!p || !src[i])
 			return -EINVAL;
 		ac = (ac << 6) | (p - base64_table);
@@ -89,8 +93,8 @@ int shr_base64_decode(const char *src, int srclen, unsigned char *dst)
 			*bp++ = (unsigned char)(ac >> bits);
 		}
 	}
-	if (ac && ((1 << bits) - 1))
-		return -EAGAIN;
+	if (ac & ((1 << bits) - 1))
+		return -EINVAL;
 
 	return bp - dst;
 }

--- a/shared/test/test-base64.c
+++ b/shared/test/test-base64.c
@@ -86,6 +86,52 @@ static bool test_invalid_input_rejected(void)
 		printf(" - decode of non-base64 input rejected [PASS]\n");
 	}
 
+	if (shr_base64_decode("Zm9vYmFy", -4, decoded) >= 0) {
+		printf(" - decode of a negative length [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - decode of a negative length rejected [PASS]\n");
+	}
+
+	return pass;
+}
+
+/* Inputs that must be rejected. */
+static const char * const rejected[] = {
+	"Zm9v=YmFy",		/* '=' in the middle */
+	"Zm9v====YmFy",		/* ... keeping the group alignment */
+	"====Zm9vYmFy",		/* '=' at the front */
+	"Zm9vYmFy====",		/* more padding than a group can hold */
+	"====",
+	"Zg===",
+	"Zm9v==",		/* padding on a complete group */
+	"Zh==",			/* the trailing bits are not zero */
+	"Zm9vYmF=",
+	"Zm9vYg",		/* padding omitted */
+	"Zm9vYmE",
+	"AAAAAAA",		/* ... and the trailing bits are zero */
+	"Zm9vY",		/* a single leftover character */
+};
+
+static bool test_padding_rules(void)
+{
+	unsigned char decoded[64];
+	bool pass = true;
+	size_t i;
+
+	printf("test_padding:\n");
+
+	for (i = 0; i < ARRAY_SIZE(rejected); i++) {
+		if (shr_base64_decode(rejected[i], strlen(rejected[i]),
+				      decoded) >= 0) {
+			printf(" - decode(\"%s\") not rejected [FAIL]\n",
+			       rejected[i]);
+			pass = false;
+		}
+	}
+	if (pass)
+		printf(" - malformed padding rejected [PASS]\n");
+
 	return pass;
 }
 
@@ -95,6 +141,7 @@ int main(void)
 
 	pass &= test_known_vectors();
 	pass &= test_invalid_input_rejected();
+	pass &= test_padding_rules();
 
 	fflush(stdout);
 	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);


### PR DESCRIPTION
`nvme keys check-kxchap` and `nvme keys import` reject DHHC-1 secrets that the specification allows and that both `nvme connect` and the kernel accept, and they smash the stack on an over-long string with a hash id of 0.

Fixing that leans on `shr_base64_decode()`, which turns out to mishandle RFC 4648's padding, so the decoder goes first.

The commit messages carry the detail.