### PR TITLE
shared/shr-assert: replace assert with shr_assert

### DIFF
--- a/libnvme/examples/mi-mctp.c
+++ b/libnvme/examples/mi-mctp.c
@@ -10,7 +10,7 @@
  * mi-mctp: open a MI connection over MCTP, and query controller info
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <ctype.h>
 #include <err.h>
 #include <stddef.h>
@@ -168,7 +168,7 @@ static int do_controllers(libnvme_mi_ep_t ep)
 static const char *__copy_id_str(const void *field, size_t size,
 				 char *buf, size_t buf_size)
 {
-	assert(size < buf_size);
+	shr_assert(size < buf_size);
 	strncpy(buf, field, size);
 	buf[size] = '\0';
 	return buf;

--- a/libnvme/test/config-api.c
+++ b/libnvme/test/config-api.c
@@ -9,7 +9,7 @@
  * exported by the version script.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -34,8 +34,8 @@ static void write_file(const char *dir, const char *name, const char *text)
 
 	snprintf(path, sizeof(path), "%s/%s", dir, name);
 	fp = fopen(path, "w");
-	assert(fp);
-	assert(fputs(text, fp) >= 0);
+	shr_assert(fp);
+	shr_assert(fputs(text, fp) >= 0);
 	fclose(fp);
 }
 
@@ -85,12 +85,12 @@ struct fixture {
 static void fixture_create(struct fixture *fx)
 {
 	snprintf(fx->dir, sizeof(fx->dir), "/tmp/nvme-config-api-XXXXXX");
-	assert(mkdtemp(fx->dir));
+	shr_assert(mkdtemp(fx->dir));
 	snprintf(fx->main_path, sizeof(fx->main_path), "%s/nvme-fabrics.conf",
 		 fx->dir);
 	snprintf(fx->dropin_dir, sizeof(fx->dropin_dir),
 		 "%s/nvme-fabrics.conf.d", fx->dir);
-	assert(mkdir(fx->dropin_dir, 0755) == 0);
+	shr_assert(mkdir(fx->dropin_dir, 0755) == 0);
 	write_file(fx->dir, "nvme-fabrics.conf", main_text);
 	write_file(fx->dropin_dir, "10-prod.conf", prod_text);
 }
@@ -112,7 +112,7 @@ static void collect(const struct libnvmf_config_conn *conn, void *user_data)
 {
 	struct conn_list *list = user_data;
 
-	assert(list->n < 8);
+	shr_assert(list->n < 8);
 	list->conn[list->n++] = conn;
 }
 
@@ -232,9 +232,9 @@ static bool test_resolve_discovered(struct libnvme_global_ctx *ctx,
 
 	printf("test_resolve_discovered:\n");
 
-	assert(!libnvmf_config_read(ctx, fx->main_path, &config));
+	shr_assert(!libnvmf_config_read(ctx, fx->main_path, &config));
 	libnvmf_config_conn_for_each(config, collect, &list);
-	assert(list.n == 3 && libnvmf_config_conn_is_dc(list.conn[0]));
+	shr_assert(list.n == 3 && libnvmf_config_conn_is_dc(list.conn[0]));
 
 	/* A DLP IOC discovered via the configured DC: that DC's file scope. */
 	params = libnvmf_config_resolve_discovered(config, list.conn[0], false);
@@ -335,7 +335,7 @@ static void collect_arg(const char *arg, void *user_data)
 {
 	struct arg_list *list = user_data;
 
-	assert(list->n < 16);
+	shr_assert(list->n < 16);
 	snprintf(list->args[list->n++], sizeof(list->args[0]), "%s", arg);
 }
 
@@ -405,15 +405,15 @@ static bool test_emit(struct libnvme_global_ctx *ctx, const struct fixture *fx)
 
 	printf("test_emit:\n");
 
-	assert(!libnvmf_config_read(ctx, fx->main_path, &config));
+	shr_assert(!libnvmf_config_read(ctx, fx->main_path, &config));
 	libnvmf_config_conn_for_each(config, collect, &conns);
-	assert(conns.n == 3);
+	shr_assert(conns.n == 3);
 	mv = conns.conn[1];
 	pv = conns.conn[2];
 
 	mv_tid = build_tid(mv);
 	pv_tid = build_tid(pv);
-	assert(mv_tid && pv_tid);
+	shr_assert(mv_tid && pv_tid);
 
 	/* TID fields in fixed order, then params; true bool = bare flag. */
 	if (libnvmf_connect_args_emit(mv_tid,
@@ -486,27 +486,27 @@ static bool test_apply_params(struct libnvme_global_ctx *ctx)
 	printf("test_apply_params:\n");
 
 	params = libnvmf_params_new();
-	assert(params);
+	shr_assert(params);
 	/* Hex, matching check_int()'s own base-0 parsing (config-ini.c). */
-	assert(!libnvmf_params_set(params, "nr-io-queues", "0x10"));
-	assert(!libnvmf_params_set(params, "keep-alive-tmo", "30"));
-	assert(!libnvmf_params_set(params, "tls", "true"));
-	assert(!libnvmf_params_set(params, "hdr-digest", "false"));
-	assert(!libnvmf_params_set(params, "persistent", "true"));
-	assert(!libnvmf_params_set(params, "epcsd", "true"));
+	shr_assert(!libnvmf_params_set(params, "nr-io-queues", "0x10"));
+	shr_assert(!libnvmf_params_set(params, "keep-alive-tmo", "30"));
+	shr_assert(!libnvmf_params_set(params, "tls", "true"));
+	shr_assert(!libnvmf_params_set(params, "hdr-digest", "false"));
+	shr_assert(!libnvmf_params_set(params, "persistent", "true"));
+	shr_assert(!libnvmf_params_set(params, "epcsd", "true"));
 	/* Explicit resets: must be skipped, not applied as "0". */
-	assert(!libnvmf_params_set(params, "tos", ""));
-	assert(!libnvmf_params_set(params, "ctrl-loss-tmo", ""));
+	shr_assert(!libnvmf_params_set(params, "tos", ""));
+	shr_assert(!libnvmf_params_set(params, "ctrl-loss-tmo", ""));
 	/* The five crypto keys: one shared setter, must not clobber. */
-	assert(!libnvmf_params_set(params, "keyring", "my-keyring"));
-	assert(!libnvmf_params_set(params, "tls-key", "deadbeef"));
-	assert(!libnvmf_params_set(params, "tls-key-identity",
+	shr_assert(!libnvmf_params_set(params, "keyring", "my-keyring"));
+	shr_assert(!libnvmf_params_set(params, "tls-key", "deadbeef"));
+	shr_assert(!libnvmf_params_set(params, "tls-key-identity",
 				    "NVMe1R02 my-id"));
-	assert(!libnvmf_params_set(params, "dhchap-secret", "DHHC-1:00:host:"));
-	assert(!libnvmf_params_set(params, "dhchap-ctrl-secret",
+	shr_assert(!libnvmf_params_set(params, "dhchap-secret", "DHHC-1:00:host:"));
+	shr_assert(!libnvmf_params_set(params, "dhchap-ctrl-secret",
 				    "DHHC-1:00:ctrl:"));
 
-	assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
+	shr_assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
 
 	if (libnvmf_context_apply_params(fctx, params)) {
 		printf(" - apply failed [FAIL]\n");
@@ -583,7 +583,7 @@ static bool test_persistent_epcsd_tristate(struct libnvme_global_ctx *ctx)
 
 	printf("test_persistent_epcsd_tristate:\n");
 
-	assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
+	shr_assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
 
 	if (libnvmf_context_get_persistent(fctx) != LIBNVMF_TRISTATE_UNSET ||
 	    libnvmf_context_get_epcsd(fctx) != LIBNVMF_TRISTATE_UNSET) {
@@ -594,10 +594,10 @@ static bool test_persistent_epcsd_tristate(struct libnvme_global_ctx *ctx)
 	}
 
 	params = libnvmf_params_new();
-	assert(params);
-	assert(!libnvmf_params_set(params, "persistent", "false"));
-	assert(!libnvmf_params_set(params, "epcsd", "false"));
-	assert(!libnvmf_context_apply_params(fctx, params));
+	shr_assert(params);
+	shr_assert(!libnvmf_params_set(params, "persistent", "false"));
+	shr_assert(!libnvmf_params_set(params, "epcsd", "false"));
+	shr_assert(!libnvmf_context_apply_params(fctx, params));
 
 	if (libnvmf_context_get_persistent(fctx) != LIBNVMF_TRISTATE_FALSE ||
 	    libnvmf_context_get_epcsd(fctx) != LIBNVMF_TRISTATE_FALSE) {
@@ -637,19 +637,19 @@ static bool test_hostnqn_precedence(struct libnvme_global_ctx *ctx,
 
 	printf("test_hostnqn_precedence:\n");
 
-	assert(!libnvmf_config_read(ctx, fx->main_path, &config));
+	shr_assert(!libnvmf_config_read(ctx, fx->main_path, &config));
 	libnvmf_config_conn_for_each(config, collect, &conns);
-	assert(conns.n == 3);
+	shr_assert(conns.n == 3);
 	mv = conns.conn[1];
 	pv = conns.conn[2];
 
 	hostnqn = libnvmf_config_conn_get_hostnqn(mv);
-	assert(!hostnqn);
+	shr_assert(!hostnqn);
 	hostnqn = default_hostnqn;
 	hostid = libnvmf_config_conn_get_hostid(mv);
-	assert(!hostid);
+	shr_assert(!hostid);
 	hostid = default_hostid;
-	assert(!libnvmf_tid_from_fields(
+	shr_assert(!libnvmf_tid_from_fields(
 			libnvmf_config_conn_get_transport(mv),
 			libnvmf_config_conn_get_traddr(mv),
 			libnvmf_config_conn_get_trsvcid(mv),
@@ -667,10 +667,10 @@ static bool test_hostnqn_precedence(struct libnvme_global_ctx *ctx,
 	}
 
 	hostnqn = libnvmf_config_conn_get_hostnqn(pv);
-	assert(hostnqn);
+	shr_assert(hostnqn);
 	hostid = libnvmf_config_conn_get_hostid(pv);
-	assert(hostid);
-	assert(!libnvmf_tid_from_fields(
+	shr_assert(hostid);
+	shr_assert(!libnvmf_tid_from_fields(
 			libnvmf_config_conn_get_transport(pv),
 			libnvmf_config_conn_get_traddr(pv),
 			libnvmf_config_conn_get_trsvcid(pv),
@@ -704,13 +704,13 @@ static bool test_set_connection_from_tid(struct libnvme_global_ctx *ctx)
 
 	printf("test_set_connection_from_tid:\n");
 
-	assert(!libnvmf_tid_from_fields("tcp", "10.0.0.9", "4420",
+	shr_assert(!libnvmf_tid_from_fields("tcp", "10.0.0.9", "4420",
 			"nqn.2014-08.org.nvmexpress:subsys",
 			"10.0.0.1", "eth0",
 			"nqn.2014-08.org.nvmexpress:host",
 			"2cd2c43b-a90a-45c1-a8cd-86b33ab273b5", &tid));
 
-	assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
+	shr_assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));
 
 	if (libnvmf_context_set_connection_from_tid(fctx, tid)) {
 		printf(" - set failed [FAIL]\n");
@@ -825,7 +825,7 @@ int main(void)
 	bool pass = true;
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 	fixture_create(&fx);
 
 	pass &= test_read(ctx, &fx);

--- a/libnvme/test/config-emit.c
+++ b/libnvme/test/config-emit.c
@@ -10,7 +10,7 @@
  * emitter symbols are exported.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -37,7 +37,7 @@ struct fixture {
 static void fixture_create(struct fixture *fx)
 {
 	snprintf(fx->dir, sizeof(fx->dir), "/tmp/nvme-config-emit-XXXXXX");
-	assert(mkdtemp(fx->dir));
+	shr_assert(mkdtemp(fx->dir));
 	snprintf(fx->main_path, sizeof(fx->main_path), "%s/nvme-fabrics.conf",
 		 fx->dir);
 	snprintf(fx->dropin_dir, sizeof(fx->dropin_dir),
@@ -81,7 +81,7 @@ static void collect(const struct libnvmf_config_conn *conn, void *user_data)
 {
 	struct conn_list *list = user_data;
 
-	assert(list->n < 8);
+	shr_assert(list->n < 8);
 	list->conn[list->n++] = conn;
 }
 
@@ -96,8 +96,8 @@ static int add(struct libnvmf_config_emitter *e, bool is_dc,
 
 	if (pkey) {
 		params = libnvmf_params_new();
-		assert(params);
-		assert(libnvmf_params_set(params, pkey, pval) == 0);
+		shr_assert(params);
+		shr_assert(libnvmf_params_set(params, pkey, pval) == 0);
 	}
 	ret = libnvmf_config_emit_add(e, is_dc, "tcp", traddr, "4420", nqn,
 				      NULL, NULL, hostnqn, hostid, params,
@@ -119,16 +119,16 @@ static bool test_roundtrip(struct libnvme_global_ctx *ctx, struct fixture *fx)
 	printf("test_roundtrip:\n");
 
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
+	shr_assert(e);
 
 	/* Default persona: a DC and an I/O controller in the main file. */
-	assert(add(e, true, "10.0.0.5", NULL, NULL, NULL, NULL,
+	shr_assert(add(e, true, "10.0.0.5", NULL, NULL, NULL, NULL,
 		   NULL, NULL) == 0);
-	assert(add(e, false, "10.0.0.9",
+	shr_assert(add(e, false, "10.0.0.9",
 		   "nqn.2014-08.org.nvmexpress:main-vol", NULL, NULL, NULL,
 		   "ctrl-loss-tmo", "600") == 0);
 	/* A named persona: goes to its own drop-in. */
-	assert(add(e, false, "10.0.0.7",
+	shr_assert(add(e, false, "10.0.0.7",
 		   "nqn.2014-08.org.nvmexpress:prod-vol",
 		   "nqn.2014-08.org.nvmexpress:prod-host",
 		   g_hostid, "prod", "tls", "true") == 0);
@@ -225,7 +225,7 @@ static bool test_hostname_traddr_verbatim(struct libnvme_global_ctx *ctx,
 	printf("test_hostname_traddr_verbatim:\n");
 
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
+	shr_assert(e);
 
 	if (libnvmf_config_emit_add(e, false, "tcp", "nas.example.com", "4420",
 				    "nqn.2014-08.org.nvmexpress:main-vol",
@@ -243,7 +243,7 @@ static bool test_hostname_traddr_verbatim(struct libnvme_global_ctx *ctx,
 	libnvmf_config_emit_free(e);
 	printf(" - hostname traddr accepted and installed [PASS]\n");
 
-	assert(libnvmf_config_read(ctx, fx->main_path, &config) == 0);
+	shr_assert(libnvmf_config_read(ctx, fx->main_path, &config) == 0);
 	libnvmf_config_conn_for_each(config, collect, &list);
 	if (list.n != 1 ||
 	    strcmp(libnvmf_config_conn_get_traddr(list.conn[0]),
@@ -278,8 +278,8 @@ static bool test_creates_missing_directory(struct libnvme_global_ctx *ctx,
 		 nested_dir);
 
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
-	assert(add(e, true, "10.0.0.5", NULL, NULL, NULL, NULL,
+	shr_assert(e);
+	shr_assert(add(e, true, "10.0.0.5", NULL, NULL, NULL, NULL,
 		   NULL, NULL) == 0);
 
 	if (libnvmf_config_emit_install(e, nested_main, false)) {
@@ -318,12 +318,12 @@ static bool test_refuse_existing(struct libnvme_global_ctx *ctx,
 
 	/* An empty main file alone is enough to occupy the target. */
 	f = fopen(fx->main_path, "w");
-	assert(f);
-	assert(fclose(f) == 0);
+	shr_assert(f);
+	shr_assert(fclose(f) == 0);
 
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
-	assert(add(e, false, "10.0.0.9", "nqn.vol", NULL, NULL, NULL,
+	shr_assert(e);
+	shr_assert(add(e, false, "10.0.0.9", "nqn.vol", NULL, NULL, NULL,
 		   NULL, NULL) == 0);
 	ret = libnvmf_config_emit_install(e, fx->main_path, false);
 	libnvmf_config_emit_free(e);
@@ -337,15 +337,15 @@ static bool test_refuse_existing(struct libnvme_global_ctx *ctx,
 	fixture_wipe(fx);
 
 	/* A lone .conf drop-in also counts as an existing configuration. */
-	assert(mkdir(fx->dropin_dir, 0755) == 0);
+	shr_assert(mkdir(fx->dropin_dir, 0755) == 0);
 	snprintf(path, sizeof(path), "%s/10-x.conf", fx->dropin_dir);
 	f = fopen(path, "w");
-	assert(f);
-	assert(fclose(f) == 0);
+	shr_assert(f);
+	shr_assert(fclose(f) == 0);
 
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
-	assert(add(e, false, "10.0.0.9", "nqn.vol", NULL, NULL, NULL,
+	shr_assert(e);
+	shr_assert(add(e, false, "10.0.0.9", "nqn.vol", NULL, NULL, NULL,
 		   NULL, NULL) == 0);
 	ret = libnvmf_config_emit_install(e, fx->main_path, false);
 	libnvmf_config_emit_free(e);
@@ -373,12 +373,12 @@ static bool test_force_overwrite(struct libnvme_global_ctx *ctx,
 
 	/* A stale configuration occupies the target. */
 	f = fopen(fx->main_path, "w");
-	assert(f);
-	assert(fclose(f) == 0);
+	shr_assert(f);
+	shr_assert(fclose(f) == 0);
 
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
-	assert(add(e, false, "10.0.0.9",
+	shr_assert(e);
+	shr_assert(add(e, false, "10.0.0.9",
 		   "nqn.2014-08.org.nvmexpress:force-vol", NULL, NULL, NULL,
 		   NULL, NULL) == 0);
 
@@ -427,11 +427,11 @@ static bool test_all_dropins(struct libnvme_global_ctx *ctx, struct fixture *fx)
 
 	/* No default persona: every connection is a named persona. */
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
-	assert(add(e, false, "10.0.0.9", "nqn.2014-08.org.nvmexpress:a",
+	shr_assert(e);
+	shr_assert(add(e, false, "10.0.0.9", "nqn.2014-08.org.nvmexpress:a",
 		   "nqn.2014-08.org.nvmexpress:host-a", NULL, "a",
 		   NULL, NULL) == 0);
-	assert(add(e, false, "10.0.0.10", "nqn.2014-08.org.nvmexpress:b",
+	shr_assert(add(e, false, "10.0.0.10", "nqn.2014-08.org.nvmexpress:b",
 		   "nqn.2014-08.org.nvmexpress:host-b", NULL, "b",
 		   NULL, NULL) == 0);
 
@@ -449,7 +449,7 @@ static bool test_all_dropins(struct libnvme_global_ctx *ctx, struct fixture *fx)
 	}
 	printf(" - empty anchor main file written [PASS]\n");
 
-	assert(libnvmf_config_read(ctx, fx->main_path, &config) == 0);
+	shr_assert(libnvmf_config_read(ctx, fx->main_path, &config) == 0);
 	libnvmf_config_conn_for_each(config, collect, &list);
 	if (list.n != 2) {
 		printf(" - expected 2 connections, got %zu [FAIL]\n", list.n);
@@ -470,7 +470,7 @@ static bool test_add_validation(struct libnvme_global_ctx *ctx)
 	printf("test_add_validation:\n");
 
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
+	shr_assert(e);
 
 	/* An I/O controller with no subsysnqn is rejected. */
 	if (libnvmf_config_emit_add(e, false, "tcp", "10.0.0.9", "4420",
@@ -493,7 +493,7 @@ static bool test_add_validation(struct libnvme_global_ctx *ctx)
 	}
 
 	/* Conflicting hostsymname for the same persona is rejected. */
-	assert(add(e, false, "10.0.0.9", "nqn.a", "nqn.host", g_hostid, "one",
+	shr_assert(add(e, false, "10.0.0.9", "nqn.a", "nqn.host", g_hostid, "one",
 		   NULL, NULL) == 0);
 	if (add(e, false, "10.0.0.10", "nqn.b", "nqn.host", g_hostid, "two",
 		NULL, NULL) != -EINVAL) {
@@ -506,7 +506,7 @@ static bool test_add_validation(struct libnvme_global_ctx *ctx)
 
 	/* A hostid without a hostnqn cannot become a valid drop-in. */
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
+	shr_assert(e);
 	if (add(e, false, "10.0.0.9", "nqn.v", NULL, g_hostid, NULL,
 		NULL, NULL) != -EINVAL) {
 		printf(" - hostid without hostnqn accepted [FAIL]\n");
@@ -518,8 +518,8 @@ static bool test_add_validation(struct libnvme_global_ctx *ctx)
 
 	/* One hostnqn must not appear with two different hostids. */
 	e = libnvmf_config_emit_new(ctx);
-	assert(e);
-	assert(add(e, false, "10.0.0.9", "nqn.a", "nqn.host", g_hostid, NULL,
+	shr_assert(e);
+	shr_assert(add(e, false, "10.0.0.9", "nqn.a", "nqn.host", g_hostid, NULL,
 		   NULL, NULL) == 0);
 	if (add(e, false, "10.0.0.10", "nqn.b", "nqn.host",
 		"00000000-0000-0000-0000-000000000002", NULL, NULL, NULL)
@@ -540,7 +540,7 @@ static bool test_params_set_validation(void)
 	bool pass = true;
 
 	printf("test_params_set_validation:\n");
-	assert(p);
+	shr_assert(p);
 
 	if (libnvmf_params_set(p, "ctrl-loss-tmo", "600") ||
 	    libnvmf_params_set(p, "tls", "true") ||
@@ -581,7 +581,7 @@ int main(void)
 	bool pass = true;
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 	fixture_create(&fx);
 
 	pass &= test_roundtrip(ctx, &fx);

--- a/libnvme/test/config-ini.c
+++ b/libnvme/test/config-ini.c
@@ -9,7 +9,7 @@
  * validators.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -32,7 +32,7 @@ static bool test_params_tristate(void)
 	bool pass = true;
 
 	printf("test_params_tristate:\n");
-	assert(p);
+	shr_assert(p);
 
 	/* Absent key -> unset (NULL). */
 	if (libnvmf_params_get(p, "ctrl-loss-tmo")) {
@@ -43,9 +43,9 @@ static bool test_params_tristate(void)
 	}
 
 	/* Set, overwrite, reset. */
-	assert(libnvmf_params_set(p, "ctrl-loss-tmo", "600") == 0);
-	assert(libnvmf_params_set(p, "keep-alive-tmo", "30") == 0);
-	assert(libnvmf_params_set(p, "ctrl-loss-tmo", "1800") == 0);
+	shr_assert(libnvmf_params_set(p, "ctrl-loss-tmo", "600") == 0);
+	shr_assert(libnvmf_params_set(p, "keep-alive-tmo", "30") == 0);
+	shr_assert(libnvmf_params_set(p, "ctrl-loss-tmo", "1800") == 0);
 	if (strcmp(libnvmf_params_get(p, "ctrl-loss-tmo"), "1800")) {
 		printf(" - set + overwrite [FAIL]\n");
 		pass = false;
@@ -53,7 +53,7 @@ static bool test_params_tristate(void)
 		printf(" - set + overwrite (last wins) [PASS]\n");
 	}
 
-	assert(libnvmf_params_set(p, "keep-alive-tmo", "") == 0);
+	shr_assert(libnvmf_params_set(p, "keep-alive-tmo", "") == 0);
 	if (strcmp(libnvmf_params_get(p, "keep-alive-tmo"), "")) {
 		printf(" - reset reads as \"\" [FAIL]\n");
 		pass = false;
@@ -86,15 +86,15 @@ static bool test_params_merge(void)
 	bool pass = true;
 
 	printf("test_params_merge:\n");
-	assert(base && over);
+	shr_assert(base && over);
 
 	/* base: the outer cascade level; over: the more-specific one. */
-	assert(libnvmf_params_set(base, "ctrl-loss-tmo", "600") == 0);
-	assert(libnvmf_params_set(base, "tls", "true") == 0);
-	assert(libnvmf_params_set(over, "ctrl-loss-tmo", "1800") == 0);
-	assert(libnvmf_params_set(over, "keep-alive-tmo", "") == 0);
+	shr_assert(libnvmf_params_set(base, "ctrl-loss-tmo", "600") == 0);
+	shr_assert(libnvmf_params_set(base, "tls", "true") == 0);
+	shr_assert(libnvmf_params_set(over, "ctrl-loss-tmo", "1800") == 0);
+	shr_assert(libnvmf_params_set(over, "keep-alive-tmo", "") == 0);
 
-	assert(libnvmf_params_merge(base, over) == 0);
+	shr_assert(libnvmf_params_merge(base, over) == 0);
 	if (strcmp(libnvmf_params_get(base, "ctrl-loss-tmo"), "1800") ||
 	    strcmp(libnvmf_params_get(base, "tls"), "true") ||
 	    strcmp(libnvmf_params_get(base, "keep-alive-tmo"), "")) {
@@ -115,8 +115,8 @@ static bool test_params_merge(void)
 
 	/* dup produces an equal, independent bag. */
 	copy = libnvmf_params_dup(base);
-	assert(copy);
-	assert(libnvmf_params_set(copy, "tls", "false") == 0);
+	shr_assert(copy);
+	shr_assert(libnvmf_params_set(copy, "tls", "false") == 0);
 	if (strcmp(libnvmf_params_get(base, "tls"), "true") ||
 	    strcmp(libnvmf_params_get(copy, "tls"), "false")) {
 		printf(" - dup independence [FAIL]\n");
@@ -196,7 +196,7 @@ static bool test_value_check(void)
 	size_t n;
 
 	printf("test_value_check:\n");
-	assert(i && b && s);
+	shr_assert(i && b && s);
 
 	/* Integers: decimals including -1; garbage rejected. */
 	if (libnvmf_key_check_value(i, "600") || libnvmf_key_check_value(i, "-1") ||
@@ -257,8 +257,8 @@ static struct libnvmf_conf_file *parse_text(struct libnvme_global_ctx *ctx,
 	int fd;
 
 	fd = mkstemp(path);
-	assert(fd >= 0);
-	assert(write(fd, text, len) == (ssize_t)len);
+	shr_assert(fd >= 0);
+	shr_assert(write(fd, text, len) == (ssize_t)len);
 	close(fd);
 	*err = libnvmf_conf_file_parse(ctx, path, &f);
 	unlink(path);
@@ -560,8 +560,8 @@ static void write_file(const char *dir, const char *name, const char *text)
 
 	snprintf(path, sizeof(path), "%s/%s", dir, name);
 	fp = fopen(path, "w");
-	assert(fp);
-	assert(fputs(text, fp) >= 0);
+	shr_assert(fp);
+	shr_assert(fputs(text, fp) >= 0);
 	fclose(fp);
 }
 
@@ -570,7 +570,7 @@ static void rm_tree(const char *dir)
 	char cmd[600];
 
 	snprintf(cmd, sizeof(cmd), "rm -rf %s", dir);
-	assert(system(cmd) == 0);
+	shr_assert(system(cmd) == 0);
 }
 
 static bool test_resolve_empty(struct libnvme_global_ctx *ctx)
@@ -582,7 +582,7 @@ static bool test_resolve_empty(struct libnvme_global_ctx *ctx)
 	int err;
 
 	printf("test_resolve_empty:\n");
-	assert(mkdtemp(dir));
+	shr_assert(mkdtemp(dir));
 	snprintf(main_path, sizeof(main_path), "%s/nvme-fabrics.conf", dir);
 
 	/* Nothing on disk: an empty configuration, not an error. */
@@ -614,7 +614,7 @@ static bool test_resolve_hostname(struct libnvme_global_ctx *ctx)
 	int err;
 
 	printf("test_resolve_hostname:\n");
-	assert(mkdtemp(dir));
+	shr_assert(mkdtemp(dir));
 	snprintf(main_path, sizeof(main_path), "%s/nvme-fabrics.conf", dir);
 	write_file(dir, "nvme-fabrics.conf",
 		   "[Subsystem]\nnqn = nqn.2014-08.org.nvmexpress:vol1\n"
@@ -680,11 +680,11 @@ static bool test_resolve_cascade(struct libnvme_global_ctx *ctx)
 	int err;
 
 	printf("test_resolve_cascade:\n");
-	assert(mkdtemp(dir));
+	shr_assert(mkdtemp(dir));
 	snprintf(main_path, sizeof(main_path), "%s/nvme-fabrics.conf", dir);
 	snprintf(dropin_dir, sizeof(dropin_dir), "%s/nvme-fabrics.conf.d",
 		 dir);
-	assert(mkdir(dropin_dir, 0755) == 0);
+	shr_assert(mkdir(dropin_dir, 0755) == 0);
 	write_file(dir, "nvme-fabrics.conf", main_text);
 	write_file(dropin_dir, "10-prod.conf", prod_text);
 
@@ -796,11 +796,11 @@ static bool resolve_expect_fail(struct libnvme_global_ctx *ctx,
 	struct libnvmf_config *conf;
 	int err = 0;
 
-	assert(mkdtemp(dir));
+	shr_assert(mkdtemp(dir));
 	snprintf(main_path, sizeof(main_path), "%s/nvme-fabrics.conf", dir);
 	snprintf(dropin_dir, sizeof(dropin_dir), "%s/nvme-fabrics.conf.d",
 		 dir);
-	assert(mkdir(dropin_dir, 0755) == 0);
+	shr_assert(mkdir(dropin_dir, 0755) == 0);
 	write_file(dropin_dir, "10-a.conf", dropin1);
 	if (dropin2)
 		write_file(dropin_dir, "20-b.conf", dropin2);
@@ -843,11 +843,11 @@ static bool test_resolve_personas(struct libnvme_global_ctx *ctx)
 		printf(" - relational Tier 1 rules rejected [PASS]\n");
 
 	/* A hostnqn reused between the top-level file and a drop-in. */
-	assert(mkdtemp(dir));
+	shr_assert(mkdtemp(dir));
 	snprintf(main_path, sizeof(main_path), "%s/nvme-fabrics.conf", dir);
 	snprintf(dropin_dir, sizeof(dropin_dir), "%s/nvme-fabrics.conf.d",
 		 dir);
-	assert(mkdir(dropin_dir, 0755) == 0);
+	shr_assert(mkdir(dropin_dir, 0755) == 0);
 	write_file(dir, "nvme-fabrics.conf", "[Host]\nhostnqn = nqn.2014-08.org.nvmexpress:a\n");
 	write_file(dropin_dir, "10-a.conf", "[Host]\nhostnqn = nqn.2014-08.org.nvmexpress:a\n");
 	err = libnvmf_config_load(ctx, main_path, &conf);
@@ -863,11 +863,11 @@ static bool test_resolve_personas(struct libnvme_global_ctx *ctx)
 
 	/* A drop-in with no [Host] is the default persona: legal. */
 	strcpy(dir, "/tmp/nvme-conf-XXXXXX");
-	assert(mkdtemp(dir));
+	shr_assert(mkdtemp(dir));
 	snprintf(main_path, sizeof(main_path), "%s/nvme-fabrics.conf", dir);
 	snprintf(dropin_dir, sizeof(dropin_dir), "%s/nvme-fabrics.conf.d",
 		 dir);
-	assert(mkdir(dropin_dir, 0755) == 0);
+	shr_assert(mkdir(dropin_dir, 0755) == 0);
 	write_file(dropin_dir, "10-a.conf",
 		   "[Subsystem]\nnqn = nqn.2014-08.org.nvmexpress:x\n"
 		   "controller = transport=tcp;traddr=192.0.2.9\n");
@@ -894,7 +894,7 @@ int main(void)
 	bool pass = true;
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	pass &= test_params_tristate();
 	pass &= test_params_merge();

--- a/libnvme/test/exclusion.c
+++ b/libnvme/test/exclusion.c
@@ -9,7 +9,7 @@
  * optimistic-concurrency (version token / -ESTALE) save protocol.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -29,8 +29,8 @@ static void setup_tmpdir(struct libnvme_global_ctx *ctx)
 {
 	/* libnvme confines the test base dir to /tmp, so it lives there. */
 	snprintf(tmpdir, sizeof(tmpdir), "/tmp/nvme-exclusion-test-XXXXXX");
-	assert(mkdtemp(tmpdir) != NULL);
-	assert(libnvme_set_test_base_dir(ctx, tmpdir) == 0);
+	shr_assert(mkdtemp(tmpdir) != NULL);
+	shr_assert(libnvme_set_test_base_dir(ctx, tmpdir) == 0);
 }
 
 static void cleanup_tmpdir(struct libnvme_global_ctx *ctx)
@@ -153,7 +153,7 @@ static bool test_stale_rejected(struct libnvme_global_ctx *ctx)
 	printf("test_stale_rejected:\n");
 
 	ret = libnvmf_exclusion_read(ctx, "list", &text, &ver);
-	assert(ret == 0);
+	shr_assert(ret == 0);
 
 	/* First write changes the file; @ver is now stale. */
 	ret = libnvmf_exclusion_write(ctx, "list",
@@ -189,7 +189,7 @@ static bool test_invalid_entry_rejected(struct libnvme_global_ctx *ctx)
 	printf("test_invalid_entry_rejected:\n");
 
 	ret = libnvmf_exclusion_read(ctx, "list", &text, &ver);
-	assert(ret == 0);
+	shr_assert(ret == 0);
 
 	ret = libnvmf_exclusion_write(ctx, "list",
 				      "[exclusions]\nexclusion = boguskey=x\n", ver);
@@ -416,7 +416,7 @@ static bool test_section_semantics(struct libnvme_global_ctx *ctx)
 	/* A hand-made file without the header: entries are ignored... */
 	snprintf(path, sizeof(path), "%s/exclusions.conf.d/hand.conf", tmpdir);
 	f = fopen(path, "w");
-	assert(f);
+	shr_assert(f);
 	fputs("exclusion = transport=fc\n", f);
 	fclose(f);
 	if (entry_count(ctx, "hand") != 0) {

--- a/libnvme/test/mi-mctp.c
+++ b/libnvme/test/mi-mctp.c
@@ -5,7 +5,7 @@
  */
 
 #undef NDEBUG
-#include <assert.h>
+#include <shr-assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -101,7 +101,7 @@ static void test_set_tx_mic(struct test_peer *peer)
 	__u32 crc = 0xffffffff;
 	__le32 crc_le;
 
-	assert(peer->tx_buf_len + sizeof(crc_le) <= MAX_BUFSIZ);
+	shr_assert(peer->tx_buf_len + sizeof(crc_le) <= MAX_BUFSIZ);
 
 	crc = libnvme_mi_crc32_update(crc, peer->tx_buf, peer->tx_buf_len);
 	crc_le = cpu_to_le32(~crc);
@@ -127,7 +127,7 @@ ssize_t __wrap_sendmsg(int sd, const struct msghdr *hdr, int flags)
 {
 	size_t i, pos;
 
-	assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX]);
+	shr_assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 	test_peer.rx_buf[0] = NVME_MI_MSGTYPE_NVME;
 
@@ -135,7 +135,7 @@ ssize_t __wrap_sendmsg(int sd, const struct msghdr *hdr, int flags)
 	for (i = 0, pos = 1; i < hdr->msg_iovlen; i++) {
 		struct iovec *iov = &hdr->msg_iov[i];
 
-		assert(pos + iov->iov_len < MAX_BUFSIZ - 1);
+		shr_assert(pos + iov->iov_len < MAX_BUFSIZ - 1);
 		memcpy(test_peer.rx_buf + pos, iov->iov_base, iov->iov_len);
 		pos += iov->iov_len;
 	}
@@ -151,7 +151,7 @@ ssize_t __wrap_recvmsg(int sd, struct msghdr *hdr, int flags)
 {
 	size_t i, pos, len;
 
-	assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX] ||
+	shr_assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX] ||
 		   sd == test_peer.sd[TEST_PEER_SD_AEMS_IDX]);
 
 	//Check for purge case
@@ -207,14 +207,14 @@ struct mctp_ioc_tag_ctl;
 #ifdef SIOCMCTPALLOCTAG
 int test_ioctl_tag(int sd, unsigned long req, struct mctp_ioc_tag_ctl *ctl)
 {
-	assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX]);
+	shr_assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 	switch (req) {
 	case SIOCMCTPALLOCTAG:
 		ctl->tag = 1 | MCTP_TAG_PREALLOC | MCTP_TAG_OWNER;
 		break;
 	case SIOCMCTPDROPTAG:
-		assert(ctl->tag == (1 | MCTP_TAG_PREALLOC | MCTP_TAG_OWNER));
+		shr_assert(ctl->tag == (1 | MCTP_TAG_PREALLOC | MCTP_TAG_OWNER));
 		break;
 	};
 
@@ -223,7 +223,7 @@ int test_ioctl_tag(int sd, unsigned long req, struct mctp_ioc_tag_ctl *ctl)
 #else
 int test_ioctl_tag(int sd, unsigned long req, struct mctp_ioc_tag_ctl *ctl)
 {
-	assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX]);
+	shr_assert(sd == test_peer.sd[TEST_PEER_SD_COMMANDS_IDX]);
 	return 0;
 }
 #endif
@@ -246,7 +246,7 @@ static void test_rx_err(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->rx_rc = -1;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 static int tx_none(struct test_peer *peer, void *buf, size_t len, int sd)
@@ -263,7 +263,7 @@ static void test_tx_none(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->tx_fn = tx_none;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 static void test_tx_err(libnvme_mi_ep_t ep, struct test_peer *peer)
@@ -274,7 +274,7 @@ static void test_tx_err(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->tx_rc = -1;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 static void test_tx_short(libnvme_mi_ep_t ep, struct test_peer *peer)
@@ -285,7 +285,7 @@ static void test_tx_short(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->tx_buf_len = 11;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 static int poll_fn_err(struct test_peer *peer, struct pollfd *fds,
@@ -302,7 +302,7 @@ static void test_poll_err(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->poll_fn = poll_fn_err;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 static void test_read_mi_data(libnvme_mi_ep_t ep, struct test_peer *peer)
@@ -314,7 +314,7 @@ static void test_read_mi_data(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->tx_buf_len = 8 + 32;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 static void test_mi_resp_err(libnvme_mi_ep_t ep, struct test_peer *peer)
@@ -327,7 +327,7 @@ static void test_mi_resp_err(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->tx_buf_len = 8;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0x2);
+	shr_assert(rc == 0x2);
 }
 
 static void setup_unaligned_ctrl_list_resp(struct test_peer *peer)
@@ -361,11 +361,11 @@ static void test_mi_resp_unaligned(libnvme_mi_ep_t ep, struct test_peer *peer)
 	memset(&list, 0, sizeof(list));
 
 	rc = libnvme_mi_mi_read_mi_data_ctrl_list(ep, 0, &list);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 
-	assert(le16_to_cpu(list.num) == 2);
-	assert(le16_to_cpu(list.identifier[0]) == 1);
-	assert(le16_to_cpu(list.identifier[1]) == 2);
+	shr_assert(le16_to_cpu(list.num) == 2);
+	shr_assert(le16_to_cpu(list.identifier[0]) == 1);
+	shr_assert(le16_to_cpu(list.identifier[1]) == 2);
 }
 
 /* Will call through the xfer/submit API expecting an unaligned list,
@@ -405,12 +405,12 @@ static void test_mi_resp_unaligned_expected(libnvme_mi_ep_t ep,
 	resp.data_len = peer->tx_buf_len;
 
 	rc = libnvme_mi_submit(ep, &req, &resp);
-	assert(rc == 0);
-	assert(resp.data_len == 6); /* 2-byte length, 2*2 byte controller IDs */
+	shr_assert(rc == 0);
+	shr_assert(resp.data_len == 6); /* 2-byte length, 2*2 byte controller IDs */
 
-	assert(le16_to_cpu(list.num) == 2);
-	assert(le16_to_cpu(list.identifier[0]) == 1);
-	assert(le16_to_cpu(list.identifier[1]) == 2);
+	shr_assert(le16_to_cpu(list.num) == 2);
+	shr_assert(le16_to_cpu(list.identifier[0]) == 1);
+	shr_assert(le16_to_cpu(list.identifier[1]) == 2);
 }
 
 static void test_admin_resp_err(libnvme_mi_ep_t ep, struct test_peer *peer)
@@ -421,7 +421,7 @@ static void test_admin_resp_err(libnvme_mi_ep_t ep, struct test_peer *peer)
 	int rc;
 
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
-	assert(hdl);
+	shr_assert(hdl);
 
 	/* Simple error response, will be shorter than the expected Admin
 	 * command response header. */
@@ -430,8 +430,8 @@ static void test_admin_resp_err(libnvme_mi_ep_t ep, struct test_peer *peer)
 
 	nvme_init_identify_ctrl(&cmd, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
-	assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
+	shr_assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
+	shr_assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
 }
 
 /* test: all 4-byte aligned response sizes - should be decoded into the
@@ -449,7 +449,7 @@ static void test_admin_resp_sizes(libnvme_mi_ep_t ep, struct test_peer *peer)
 	int rc;
 
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
-	assert(hdl);
+	shr_assert(hdl);
 
 	peer->tx_buf[4] = 0x02; /* internal error */
 
@@ -457,8 +457,8 @@ static void test_admin_resp_sizes(libnvme_mi_ep_t ep, struct test_peer *peer)
 		peer->tx_buf_len = i;
 		nvme_init_identify_ctrl(&cmd, &id);
 		rc = libnvme_exec_admin_passthru(hdl, &cmd);
-		assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
-		assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
+		shr_assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
+		shr_assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
 	}
 
 	libnvme_close(hdl);
@@ -468,7 +468,7 @@ static void test_admin_resp_sizes(libnvme_mi_ep_t ep, struct test_peer *peer)
 static int poll_fn_timeout_value(struct test_peer *peer, struct pollfd *fds,
 				 nfds_t nfds, int timeout)
 {
-	assert(timeout == 3141);
+	shr_assert(timeout == 3141);
 	return 1;
 }
 
@@ -484,7 +484,7 @@ static void test_poll_timeout_value(libnvme_mi_ep_t ep, struct test_peer *peer)
 	libnvme_mi_ep_set_timeout(ep, 3141);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 /* test: poll timeout expiry */
@@ -502,8 +502,8 @@ static void test_poll_timeout(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->poll_fn = poll_fn_timeout;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
-	assert(errno == ETIMEDOUT);
+	shr_assert(rc != 0);
+	shr_assert(errno == ETIMEDOUT);
 }
 
 /* test: send a More Processing Required response, then the actual response */
@@ -517,7 +517,7 @@ static int tx_mpr(struct test_peer *peer, void *buf, size_t len, int sd)
 {
 	struct mpr_tx_info *tx_info = peer->tx_data;
 
-	assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
+	shr_assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 	memset(peer->tx_buf, 0, sizeof(peer->tx_buf));
 	peer->tx_buf[0] = NVME_MI_MSGTYPE_NVME;
@@ -536,7 +536,7 @@ static int tx_mpr(struct test_peer *peer, void *buf, size_t len, int sd)
 		peer->tx_buf_len = tx_info->final_len;
 		break;
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	test_set_tx_mic(peer);
@@ -560,7 +560,7 @@ static void test_mpr_mi(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->tx_data = &tx_info;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 static void test_mpr_admin(libnvme_mi_ep_t ep, struct test_peer *peer)
@@ -582,7 +582,7 @@ static void test_mpr_admin(libnvme_mi_ep_t ep, struct test_peer *peer)
 
 	nvme_init_identify_ctrl(&cmd, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 
 	libnvme_close(hdl);
 }
@@ -609,7 +609,7 @@ static void test_mpr_admin_quirked(libnvme_mi_ep_t ep, struct test_peer *peer)
 
 	nvme_init_identify_ctrl(&cmd, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 
 	libnvme_close(hdl);
 }
@@ -629,10 +629,10 @@ static int poll_fn_mpr_poll(struct test_peer *peer, struct pollfd *fds,
 	switch (info->poll_no) {
 	case 1:
 	case 2:
-		assert(timeout == info->timeouts[info->poll_no - 1]);
+		shr_assert(timeout == info->timeouts[info->poll_no - 1]);
 		break;
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	info->poll_no++;
@@ -645,7 +645,7 @@ static int tx_fn_mpr_poll(struct test_peer *peer, void *buf, size_t len, int sd)
 	struct mpr_poll_info *poll_info = peer->poll_data;
 	unsigned int mprt;
 
-	assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
+	shr_assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 	memset(peer->tx_buf, 0, sizeof(peer->tx_buf));
 	peer->tx_buf[0] = NVME_MI_MSGTYPE_NVME;
@@ -664,7 +664,7 @@ static int tx_fn_mpr_poll(struct test_peer *peer, void *buf, size_t len, int sd)
 		peer->tx_buf_len = tx_info->final_len;
 		break;
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	test_set_tx_mic(peer);
@@ -699,7 +699,7 @@ static void test_mpr_timeouts(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->poll_data = &poll_info;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 /* test: MPR value is limited to the max mpr */
@@ -728,7 +728,7 @@ static void test_mpr_timeout_clamp(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->poll_data = &poll_info;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 /* test: MPR value of zero doesn't result in poll with zero timeout */
@@ -757,7 +757,7 @@ static void test_mpr_mprt_zero(libnvme_mi_ep_t ep, struct test_peer *peer)
 	peer->poll_data = &poll_info;
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 enum aem_enable_state {
@@ -891,9 +891,9 @@ static void check_aem_sync_message(struct libnvme_mi_aem_enabled_map *expected_m
 	struct nvme_mi_aem_supported_list *list =
 		(struct nvme_mi_aem_supported_list *)(req+1);
 
-	assert(req->opcode == nvme_mi_mi_opcode_configuration_set);
-	assert((le32_to_cpu(req->cdw0) & 0xFF) == NVME_MI_CONFIG_AE);
-	assert(list->hdr.aeslver == 0);
+	shr_assert(req->opcode == nvme_mi_mi_opcode_configuration_set);
+	shr_assert((le32_to_cpu(req->cdw0) & 0xFF) == NVME_MI_CONFIG_AE);
+	shr_assert(list->hdr.aeslver == 0);
 
 	int count = 0;
 	//Count how many events we want to act are in the expected state
@@ -902,9 +902,9 @@ static void check_aem_sync_message(struct libnvme_mi_aem_enabled_map *expected_m
 			count++;
 	}
 
-	assert(list->hdr.numaes == count);
-	assert(list->hdr.aeslhl == sizeof(struct nvme_mi_aem_supported_list));
-	assert(list->hdr.aest == list->hdr.aeslhl +
+	shr_assert(list->hdr.numaes == count);
+	shr_assert(list->hdr.aeslhl == sizeof(struct nvme_mi_aem_supported_list));
+	shr_assert(list->hdr.aest == list->hdr.aeslhl +
 		count * sizeof(struct nvme_mi_aem_supported_item));
 
 	struct nvme_mi_aem_supported_item *item =
@@ -923,7 +923,7 @@ static void check_aem_sync_message(struct libnvme_mi_aem_enabled_map *expected_m
 					break;
 				}
 			}
-			assert(found);
+			shr_assert(found);
 		}
 	}
 }
@@ -943,7 +943,7 @@ static int aem_rcv_enable_fn(struct test_peer *peer, void *buf, size_t len, int 
 	switch (fn_data->state) {
 	case AEM_ES_GET_ENABLED:
 	{
-		assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
+		shr_assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 		//First, we want to return some data about what is already enabled
 		struct nvme_mi_aem_supported_list_header *list_hdr =
@@ -991,7 +991,7 @@ static int aem_rcv_enable_fn(struct test_peer *peer, void *buf, size_t len, int 
 	}
 	case AEM_ES_SET_TO_DISABLED:
 	{
-		assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
+		shr_assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 		struct libnvme_mi_aem_enabled_map expected = {false};
 		//The items in the ep_enabled_map should get disabled
@@ -1017,7 +1017,7 @@ static int aem_rcv_enable_fn(struct test_peer *peer, void *buf, size_t len, int 
 		break;
 	}
 	case AEM_ES_ENABLE_SET_ENABLED:
-		assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
+		shr_assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 		//We should verify the right things are enabled
 		//The items in the host enable map should get enabled
@@ -1031,7 +1031,7 @@ static int aem_rcv_enable_fn(struct test_peer *peer, void *buf, size_t len, int 
 		break;
 	case AEM_ES_PROCESS:
 		//This case is actually a TX without any request from the host
-		assert(sd == peer->sd[TEST_PEER_SD_AEMS_IDX]);
+		shr_assert(sd == peer->sd[TEST_PEER_SD_AEMS_IDX]);
 
 		//Prepare an OCC list response
 		populate_tx_occ_list(true, fn_data, &fn_data->aem_during_process_map);
@@ -1039,7 +1039,7 @@ static int aem_rcv_enable_fn(struct test_peer *peer, void *buf, size_t len, int 
 		fn_data->state = AEM_ES_ACK_RESPONSE;
 		break;
 	case AEM_ES_ACK_RESPONSE:
-		assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
+		shr_assert(sd == peer->sd[TEST_PEER_SD_COMMANDS_IDX]);
 
 		//Prepare an OCC list response
 		populate_tx_occ_list(false, fn_data, &fn_data->ack_events_map);
@@ -1047,7 +1047,7 @@ static int aem_rcv_enable_fn(struct test_peer *peer, void *buf, size_t len, int 
 		fn_data->state = AEM_ES_ACK_RECEIVED;
 		break;
 	default:
-		assert(false);//Not expected
+		shr_assert(false);//Not expected
 	}
 
 	return 0;
@@ -1080,38 +1080,38 @@ enum libnvme_mi_aem_handler_next_action aem_handler(libnvme_mi_ep_t ep, size_t n
 			map = &fn_data->ack_events_map;
 			break;
 		default:
-			assert(false);
+			shr_assert(false);
 		}
 
 		for (int i = 0; i < 256; i++)
 			if (map->enabled[i])
 				item_count++;
 
-		assert(num_events == item_count);
+		shr_assert(num_events == item_count);
 
 		for (int i = 0; i < num_events; i++) {
 			struct libnvme_mi_event *e = libnvme_mi_aem_get_next_event(ep);
 			uint8_t idx = e->aeoi;
 
-			assert(fn_data->events[idx]);
-			assert(fn_data->host_enabled_map.enabled[idx]);
-			assert(fn_data->events[idx]->aeocidi == e->aeocidi);
-			assert(fn_data->events[idx]->aessi == e->aessi);
-			assert(fn_data->events[idx]->spec_info_len ==
+			shr_assert(fn_data->events[idx]);
+			shr_assert(fn_data->host_enabled_map.enabled[idx]);
+			shr_assert(fn_data->events[idx]->aeocidi == e->aeocidi);
+			shr_assert(fn_data->events[idx]->aessi == e->aessi);
+			shr_assert(fn_data->events[idx]->spec_info_len ==
 				e->spec_info_len);
-			assert(memcmp(fn_data->events[idx]->spec_info,
+			shr_assert(memcmp(fn_data->events[idx]->spec_info,
 				e->spec_info, e->spec_info_len) == 0);
-			assert(fn_data->events[idx]->vend_spec_info_len ==
+			shr_assert(fn_data->events[idx]->vend_spec_info_len ==
 				e->vend_spec_info_len);
-			assert(memcmp(fn_data->events[idx]->vend_spec_info,
+			shr_assert(memcmp(fn_data->events[idx]->vend_spec_info,
 				e->vend_spec_info, e->vend_spec_info_len) == 0);
 		}
 
-		assert(libnvme_mi_aem_get_next_event(ep) == NULL);
+		shr_assert(libnvme_mi_aem_get_next_event(ep) == NULL);
 		break;
 	}
 	default:
-		assert(false);
+		shr_assert(false);
 	}
 
 	return NVME_MI_AEM_HNA_ACK;
@@ -1127,22 +1127,22 @@ static void aem_test_aem_api_helper(libnvme_mi_ep_t ep,
 	test_peer.tx_fn = aem_rcv_enable_fn;
 
 	//This should not work outside the handler
-	assert(libnvme_mi_aem_get_next_event(ep) == NULL);
+	shr_assert(libnvme_mi_aem_get_next_event(ep) == NULL);
 
 	rc = libnvme_mi_aem_enable(ep, config, test_peer.tx_data);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 
 	//This should not work outside the handler
-	assert(libnvme_mi_aem_get_next_event(ep) == NULL);
+	shr_assert(libnvme_mi_aem_get_next_event(ep) == NULL);
 
 	rc = libnvme_mi_aem_process(ep, test_peer.tx_data);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 
 	//One for initial enable, one for AEM.  No ACK events
-	assert(fn_data->callback_count == expected_event_count);
+	shr_assert(fn_data->callback_count == expected_event_count);
 
 	//This should not work outside the handler
-	assert(libnvme_mi_aem_get_next_event(ep) == NULL);
+	shr_assert(libnvme_mi_aem_get_next_event(ep) == NULL);
 }
 
 static void aem_test_aem_disable_helper(libnvme_mi_ep_t ep,
@@ -1152,7 +1152,7 @@ static void aem_test_aem_disable_helper(libnvme_mi_ep_t ep,
 		sizeof(fn_data->host_enabled_map));
 
 	fn_data->state = AEM_ES_GET_ENABLED;//This is the flow for disabling
-	assert(libnvme_mi_aem_disable(ep) == 0);
+	shr_assert(libnvme_mi_aem_disable(ep) == 0);
 }
 
 static void test_mi_aem_ep_based_failure_helper(libnvme_mi_ep_t ep,
@@ -1186,17 +1186,17 @@ static void test_mi_aem_ep_based_failure_helper(libnvme_mi_ep_t ep,
 	case AEM_FC_BAD_OCC_RSP_TOTAL_LEN_SYNC:
 	case AEM_FC_BAD_OCC_RSP_BUFFER_LEN_SYNC:
 		//These all should fail before processing
-		assert(libnvme_mi_aem_enable(ep, &config, &fn_data) == -EPROTO);
+		shr_assert(libnvme_mi_aem_enable(ep, &config, &fn_data) == -EPROTO);
 		break;
 	case AEM_FC_BAD_OCC_RSP_HDR_LEN_AEM:
 	case AEM_FC_BAD_OCC_RSP_TOTAL_LEN_AEM:
 	case AEM_FC_BAD_OCC_RSP_BUFFER_LEN_AEM:
 		//These should fail on the processing
-		assert(libnvme_mi_aem_enable(ep, &config, &fn_data) == 0);
-		assert(libnvme_mi_aem_process(ep, &fn_data) == -EPROTO);
+		shr_assert(libnvme_mi_aem_enable(ep, &config, &fn_data) == 0);
+		shr_assert(libnvme_mi_aem_process(ep, &fn_data) == -EPROTO);
 		break;
 	default:
-		assert(false);//Unexpected
+		shr_assert(false);//Unexpected
 	}
 }
 
@@ -1225,46 +1225,46 @@ static void test_mi_aem_enable_invalid_usage(libnvme_mi_ep_t ep, struct test_pee
 	config.aerd = 2;
 
 	//Call with invalid config due to nothing enabled
-	assert(libnvme_mi_aem_enable(ep, &config, NULL) == -1);
+	shr_assert(libnvme_mi_aem_enable(ep, &config, NULL) == -1);
 
 	config.aem_handler = NULL;
 	config.enabled_map.enabled[0] = true;
 
 	//Call with invalid config due to no callback
-	assert(libnvme_mi_aem_enable(ep, &config, NULL) == -1);
+	shr_assert(libnvme_mi_aem_enable(ep, &config, NULL) == -1);
 
 	//Call with invalid config due to being NULL
-	assert(libnvme_mi_aem_enable(ep, NULL, NULL) == -1);
+	shr_assert(libnvme_mi_aem_enable(ep, NULL, NULL) == -1);
 
 	config.aem_handler = aem_handler;
 	config.enabled_map.enabled[0] = true;
 
 	//Call with invalid endpoint
-	assert(libnvme_mi_aem_enable(NULL, &config, NULL) == -1);
+	shr_assert(libnvme_mi_aem_enable(NULL, &config, NULL) == -1);
 }
 
 /* test: Check aem process logic when API used improperly */
 static void test_mi_aem_process_invalid_usage(libnvme_mi_ep_t ep, struct test_peer *peer)
 {
 	//Without calling enable first
-	assert(libnvme_mi_aem_process(ep, NULL) == -1);
+	shr_assert(libnvme_mi_aem_process(ep, NULL) == -1);
 
 	//Call with invalid ep
-	assert(libnvme_mi_aem_process(NULL, NULL) == -1);
+	shr_assert(libnvme_mi_aem_process(NULL, NULL) == -1);
 }
 
 /* test: Check aem disable logic when API used improperly */
 static void test_mi_aem_disable_invalid_usage(libnvme_mi_ep_t ep, struct test_peer *peer)
 {
-	assert(libnvme_mi_aem_disable(NULL) == -1);
+	shr_assert(libnvme_mi_aem_disable(NULL) == -1);
 }
 
 static void test_mi_aem_get_enabled_invalid_usage(libnvme_mi_ep_t ep, struct test_peer *peer)
 {
 	struct libnvme_mi_aem_enabled_map map;
 
-	assert(libnvme_mi_aem_get_enabled(ep, NULL) == -1);
-	assert(libnvme_mi_aem_get_enabled(NULL, &map) == -1);
+	shr_assert(libnvme_mi_aem_get_enabled(ep, NULL) == -1);
+	shr_assert(libnvme_mi_aem_get_enabled(NULL, &map) == -1);
 }
 
 /* test: Check aem get enabled logic*/
@@ -1281,8 +1281,8 @@ static void test_mi_aem_get_enabled(libnvme_mi_ep_t ep, struct test_peer *peer)
 	fn_data.ep_enabled_map.enabled[51] = true;
 	fn_data.ep_enabled_map.enabled[255] = true;
 
-	assert(libnvme_mi_aem_get_enabled(ep, &map) == 0);
-	assert(memcmp(&fn_data.ep_enabled_map, &map, sizeof(map)) == 0);
+	shr_assert(libnvme_mi_aem_get_enabled(ep, &map) == 0);
+	shr_assert(memcmp(&fn_data.ep_enabled_map, &map, sizeof(map)) == 0);
 }
 
 
@@ -1464,11 +1464,11 @@ int main(void)
 	__libnvme_mi_mctp_set_ops(&ops);
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 	libnvme_set_logging_file(ctx, fd);
 
 	ep = libnvme_mi_open_mctp(ctx, 0, 0);
-	assert(ep);
+	shr_assert(ep);
 
 	for (i = 0; i < ARRAY_SIZE(tests); i++) {
 		reset_test_peer();

--- a/libnvme/test/mi.c
+++ b/libnvme/test/mi.c
@@ -5,7 +5,7 @@
  */
 
 #undef NDEBUG
-#include <assert.h>
+#include <shr-assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -42,7 +42,7 @@ static int test_transport_submit(struct libnvme_mi_ep *ep,
 {
 	struct test_transport_data *tpd = ep->transport_data;
 
-	assert(tpd->magic == test_transport_magic);
+	shr_assert(tpd->magic == test_transport_magic);
 
 	/* start from a minimal response: zeroed data, nmp to match request */
 	memset(resp->hdr, 0, resp->hdr_len);
@@ -60,7 +60,7 @@ static int test_transport_submit(struct libnvme_mi_ep *ep,
 static void test_transport_close(struct libnvme_mi_ep *ep)
 {
 	struct test_transport_data *tpd = ep->transport_data;
-	assert(tpd->magic == test_transport_magic);
+	shr_assert(tpd->magic == test_transport_magic);
 	free(tpd);
 }
 
@@ -69,7 +69,7 @@ static int test_transport_desc_ep(struct libnvme_mi_ep *ep,
 {
 	struct test_transport_data *tpd = ep->transport_data;
 
-	assert(tpd->magic == test_transport_magic);
+	shr_assert(tpd->magic == test_transport_magic);
 
 	if (!tpd->named)
 		return -1;
@@ -107,7 +107,7 @@ static void test_set_transport_callback(libnvme_mi_ep_t ep, test_submit_cb cb,
 					void *data)
 {
 	struct test_transport_data *tpd = ep->transport_data;
-	assert(tpd->magic == test_transport_magic);
+	shr_assert(tpd->magic == test_transport_magic);
 
 	tpd->submit_cb = cb;
 	tpd->submit_cb_data = data;
@@ -119,13 +119,13 @@ libnvme_mi_ep_t libnvme_mi_open_test(struct libnvme_global_ctx *ctx)
 	struct libnvme_mi_ep *ep;
 
 	ep = libnvme_mi_init_ep(ctx);
-	assert(ep);
+	shr_assert(ep);
 
 	/* preempt the quirk probe to avoid clutter */
 	ep->quirks_probed = true;
 
 	tpd = malloc(sizeof(*tpd));
-	assert(tpd);
+	shr_assert(tpd);
 
 	tpd->magic = test_transport_magic;
 	tpd->named = true;
@@ -156,15 +156,15 @@ static void test_endpoint_lifetime(libnvme_mi_ep_t ep)
 	libnvme_mi_ep_t ep2;
 
 	count = count_root_eps(ctx);
-	assert(count == 1);
+	shr_assert(count == 1);
 
 	ep2 = libnvme_mi_open_test(ctx);
 	count = count_root_eps(ctx);
-	assert(count == 2);
+	shr_assert(count == 2);
 
 	libnvme_mi_close(ep2);
 	count = count_root_eps(ctx);
-	assert(count == 1);
+	shr_assert(count == 1);
 }
 
 unsigned int count_ep_controllers(libnvme_mi_ep_t ep)
@@ -188,23 +188,23 @@ static void test_ctrl_lifetime(libnvme_mi_ep_t ep)
 	ep->controllers_scanned = true;
 
 	count = count_ep_controllers(ep);
-	assert(count == 0);
+	shr_assert(count == 0);
 
 	hdl1 = libnvme_mi_init_transport_handle(ep, 1);
 	count = count_ep_controllers(ep);
-	assert(count == 1);
+	shr_assert(count == 1);
 
 	hdl2 = libnvme_mi_init_transport_handle(ep, 2);
 	count = count_ep_controllers(ep);
-	assert(count == 2);
+	shr_assert(count == 2);
 
 	libnvme_close(hdl1);
 	count = count_ep_controllers(ep);
-	assert(count == 1);
+	shr_assert(count == 1);
 
 	libnvme_close(hdl2);
 	count = count_ep_controllers(ep);
-	assert(count == 0);
+	shr_assert(count == 0);
 }
 
 
@@ -216,23 +216,23 @@ static int test_read_mi_data_cb(struct libnvme_mi_ep *ep,
 {
 	__u8 ror, mt, *hdr, *buf;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_MI);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_MI);
 
 	/* do we have enough for a mi header? */
-	assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
 
 	/* inspect response as raw bytes */
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_mi_mi_opcode_mi_data_read);
+	shr_assert(hdr[4] == nvme_mi_mi_opcode_mi_data_read);
 
 	/* create basic response */
-	assert(resp->hdr_len >= sizeof(struct nvme_mi_mi_resp_hdr));
-	assert(resp->data_len >= 4);
+	shr_assert(resp->hdr_len >= sizeof(struct nvme_mi_mi_resp_hdr));
+	shr_assert(resp->data_len >= 4);
 
 	hdr = (__u8 *)resp->hdr;
 	hdr[4] = 0; /* status */
@@ -256,7 +256,7 @@ static void test_read_mi_data(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_read_mi_data_cb, NULL);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 /* test: failed transport */
@@ -275,7 +275,7 @@ static void test_transport_fail(libnvme_mi_ep_t ep)
 
 	test_set_transport_callback(ep, test_transport_fail_cb, NULL);
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 static void test_transport_describe(libnvme_mi_ep_t ep)
@@ -287,14 +287,14 @@ static void test_transport_describe(libnvme_mi_ep_t ep)
 
 	tpd->named = false;
 	str = libnvme_mi_endpoint_desc(ep);
-	assert(str);
-	assert(!strcmp(str, "test-mi endpoint"));
+	shr_assert(str);
+	shr_assert(!strcmp(str, "test-mi endpoint"));
 	free(str);
 
 	tpd->named = true;
 	str = libnvme_mi_endpoint_desc(ep);
-	assert(str);
-	assert(!strcmp(str, "test-mi: test endpoint 0x74657374"));
+	shr_assert(str);
+	shr_assert(!strcmp(str, "test-mi: test endpoint 0x74657374"));
 	free(str);
 }
 
@@ -315,7 +315,7 @@ static void test_invalid_crc(libnvme_mi_ep_t ep)
 
 	test_set_transport_callback(ep, test_invalid_crc_cb, NULL);
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc < 0);
+	shr_assert(rc < 0);
 }
 
 /* test: test that the controller list populates the endpoint's list of
@@ -327,24 +327,24 @@ static int test_scan_ctrl_list_cb(struct libnvme_mi_ep *ep,
 {
 	__u8 ror, mt, *hdr, *buf;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_MI);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_MI);
 
 	/* do we have enough for a mi header? */
-	assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
 
 	/* inspect response as raw bytes */
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_mi_mi_opcode_mi_data_read);
-	assert(hdr[11] == nvme_mi_dtyp_ctrl_list);
+	shr_assert(hdr[4] == nvme_mi_mi_opcode_mi_data_read);
+	shr_assert(hdr[11] == nvme_mi_dtyp_ctrl_list);
 
 	/* create basic response */
-	assert(resp->hdr_len >= sizeof(struct nvme_mi_mi_resp_hdr));
-	assert(resp->data_len >= 4);
+	shr_assert(resp->hdr_len >= sizeof(struct nvme_mi_mi_resp_hdr));
+	shr_assert(resp->data_len >= 4);
 
 	hdr = (__u8 *)resp->hdr;
 	hdr[4] = 0; /* status */
@@ -372,19 +372,19 @@ static void test_scan_ctrl_list(libnvme_mi_ep_t ep)
 	libnvme_mi_scan_ep(ep, false);
 
 	hdl = libnvme_mi_first_transport_handle(ep);
-	assert(hdl);
-	assert(hdl->id == 1);
+	shr_assert(hdl);
+	shr_assert(hdl->id == 1);
 
 	hdl = libnvme_mi_next_transport_handle(ep, hdl);
-	assert(hdl);
-	assert(hdl->id == 4);
+	shr_assert(hdl);
+	shr_assert(hdl->id == 4);
 
 	hdl = libnvme_mi_next_transport_handle(ep, hdl);
-	assert(hdl);
-	assert(hdl->id == 5);
+	shr_assert(hdl);
+	shr_assert(hdl->id == 5);
 
 	hdl = libnvme_mi_next_transport_handle(ep, hdl);
-	assert(hdl == NULL);
+	shr_assert(hdl == NULL);
 }
 
 /* test: simple NVMe admin request/response */
@@ -398,35 +398,35 @@ static int test_admin_id_cb(struct libnvme_mi_ep *ep,
 	__u16 ctrl_id;
 	__u8 flags;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_ADMIN);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_ADMIN);
 
 	/* do we have enough for a mi header? */
-	assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
 
 	/* inspect response as raw bytes */
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_admin_identify);
+	shr_assert(hdr[4] == nvme_admin_identify);
 	flags = hdr[5];
 
 	ctrl_id = hdr[7] << 8 | hdr[6];
-	assert(ctrl_id == 0x5); /* controller id */
+	shr_assert(ctrl_id == 0x5); /* controller id */
 
 	/* we requested a full id; if we've set the length flag,
 	 * ensure the length matches */
 	dlen = hdr[35] << 24 | hdr[34] << 16 | hdr[33] << 8 | hdr[32];
 	if (flags & 0x1) {
-		assert(dlen == sizeof(struct nvme_id_ctrl));
+		shr_assert(dlen == sizeof(struct nvme_id_ctrl));
 	}
-	assert(!(flags & 0x2));
+	shr_assert(!(flags & 0x2));
 
 	/* CNS value of 1 in cdw10 field */
 	cdw10 = hdr[47] << 24 | hdr[46] << 16 | hdr[45] << 8 | hdr[44];
-	assert(cdw10 == 0x1);
+	shr_assert(cdw10 == 0x1);
 
 	/* create valid (but somewhat empty) response */
 	hdr = (__u8 *)resp->hdr;
@@ -447,11 +447,11 @@ static void test_admin_id(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_admin_id_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_ctrl(&cmd, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 /* test: simple NVMe error response, error reported in the MI header */
@@ -462,22 +462,22 @@ static int test_admin_err_mi_resp_cb(struct libnvme_mi_ep *ep,
 {
 	__u8 ror, mt, *hdr;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_ADMIN);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_ADMIN);
 
 	/* do we have enough for a mi header? */
-	assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
 
 	/* inspect response as raw bytes */
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_admin_identify);
+	shr_assert(hdr[4] == nvme_admin_identify);
 
 	/* we need at least 8 bytes for error information */
-	assert(resp->hdr_len >= 8);
+	shr_assert(resp->hdr_len >= 8);
 
 	/* create error response */
 	hdr = (__u8 *)resp->hdr;
@@ -503,13 +503,13 @@ static void test_admin_err_mi_resp(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_admin_err_mi_resp_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_ctrl(&cmd, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc != 0);
-	assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
-	assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
+	shr_assert(rc != 0);
+	shr_assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_MI);
+	shr_assert(nvme_status_get_value(rc) == NVME_MI_RESP_INTERNAL_ERR);
 }
 
 /* test: NVMe Admin error, with the error reported in the Admin response */
@@ -520,22 +520,22 @@ static int test_admin_err_nvme_resp_cb(struct libnvme_mi_ep *ep,
 {
 	__u8 ror, mt, *hdr;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_ADMIN);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_ADMIN);
 
 	/* do we have enough for a mi header? */
-	assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
 
 	/* inspect response as raw bytes */
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_admin_identify);
+	shr_assert(hdr[4] == nvme_admin_identify);
 
 	/* we need at least 8 bytes for error information */
-	assert(resp->hdr_len >= sizeof(struct nvme_mi_admin_resp_hdr));
+	shr_assert(resp->hdr_len >= sizeof(struct nvme_mi_admin_resp_hdr));
 
 	/* create error response */
 	hdr = (__u8 *)resp->hdr;
@@ -567,13 +567,13 @@ static void test_admin_err_nvme_resp(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_admin_err_nvme_resp_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_ctrl(&cmd, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc != 0);
-	assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_NVME);
-	assert(nvme_status_get_value(rc) ==
+	shr_assert(rc != 0);
+	shr_assert(nvme_status_get_type(rc) == NVME_STATUS_TYPE_NVME);
+	shr_assert(nvme_status_get_value(rc) ==
 	       (NVME_SC_INTERNAL | (NVME_SCT_GENERIC << NVME_SCT_SHIFT)
 		| NVME_SC_DNR));
 }
@@ -585,7 +585,7 @@ static int test_rejected_command_cb(struct libnvme_mi_ep *ep,
 					 void *data)
 {
 	/* none of the tests should result in message transfer */
-	assert(0);
+	shr_assert(0);
 	return -1;
 }
 
@@ -603,42 +603,42 @@ static void test_admin_invalid_formats(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_rejected_command_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
-	assert(hdl);
+	shr_assert(hdl);
 
 	/* unaligned req size */
 	len = 0;
 	rc = libnvme_mi_admin_xfer(hdl, &req.hdr, 1, &resp, 0, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	/* unaligned resp size */
 	len = 1;
 	rc = libnvme_mi_admin_xfer(hdl, &req.hdr, 0, &resp, 0, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	/* unaligned resp offset */
 	len = 4;
 	rc = libnvme_mi_admin_xfer(hdl, &req.hdr, 0, &resp, 1, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	/* resp too large */
 	len = 4096 + 4;
 	rc = libnvme_mi_admin_xfer(hdl, &req.hdr, 0, &resp, 0, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	/* resp offset too large */
 	len = 4;
 	rc = libnvme_mi_admin_xfer(hdl, &req.hdr, 0, &resp, (off_t)1 << 32, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	/* resp offset with no len */
 	len = 0;
 	rc = libnvme_mi_admin_xfer(hdl, &req.hdr, 0, &resp, 4, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	/* req and resp payloads */
 	len = 4;
 	rc = libnvme_mi_admin_xfer(hdl, &req.hdr, 4, &resp, 0, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 static void test_mi_invalid_formats(libnvme_mi_ep_t ep)
@@ -655,12 +655,12 @@ static void test_mi_invalid_formats(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_rejected_command_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 1);
-	assert(hdl);
+	shr_assert(hdl);
 
 	/* resp too large */
 	len = 4096 + 4;
 	rc = libnvme_mi_mi_xfer(ep, &req.hdr, 0, &resp, &len);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 /* test: header length too small */
@@ -682,7 +682,7 @@ static void test_resp_hdr_small(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_resp_hdr_small_cb, NULL);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 /* test: respond with a request message */
@@ -704,7 +704,7 @@ static void test_resp_req(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_resp_req_cb, NULL);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 /* test: invalid MCTP type in response */
@@ -726,7 +726,7 @@ static void test_resp_invalid_type(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_resp_invalid_type_cb, NULL);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 }
 
 /* test: response with mis-matching command slot */
@@ -746,7 +746,7 @@ static int test_resp_csi_check_cb(struct libnvme_mi_ep *ep,
 	struct libnvme_mi_resp *resp,
 	void *data)
 {
-	assert((req->hdr->nmp & 1) == (ep->csi & 1));
+	shr_assert((req->hdr->nmp & 1) == (ep->csi & 1));
 	return 0;
 }
 
@@ -759,12 +759,12 @@ static void test_resp_csi_request(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_resp_csi_check_cb, NULL);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	libnvme_mi_set_csi(ep, 1);//Change CSI
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	libnvme_mi_set_csi(ep, 0);//Change CSI
 }
@@ -780,12 +780,12 @@ static void test_resp_csi_mismatch(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_resp_csi_invert_cb, NULL);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	libnvme_mi_set_csi(ep, 1);//Change CSI
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc != 0);
+	shr_assert(rc != 0);
 
 	libnvme_mi_set_csi(ep, 0);//Change CSI
 }
@@ -800,15 +800,15 @@ static int test_mi_config_get_mtu_cb(struct libnvme_mi_ep *ep,
 	struct nvme_mi_mi_resp_hdr *mi_resp;
 	uint8_t *buf;
 
-	assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
-	assert(req->data_len == 0);
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
+	shr_assert(req->data_len == 0);
 
 	/* validate req as raw bytes */
 	buf = (void *)req->hdr;
-	assert(buf[4] == nvme_mi_mi_opcode_configuration_get);
+	shr_assert(buf[4] == nvme_mi_mi_opcode_configuration_get);
 	/* dword 0: port and config id */
-	assert(buf[11] == 0x5);
-	assert(buf[8] == NVME_MI_CONFIG_MCTP_MTU);
+	shr_assert(buf[11] == 0x5);
+	shr_assert(buf[8] == NVME_MI_CONFIG_MCTP_MTU);
 
 	/* set MTU in response */
 	mi_resp = (void *)resp->hdr;
@@ -829,8 +829,8 @@ static void test_mi_config_get_mtu(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_mi_config_get_mtu_cb, NULL);
 
 	rc = libnvme_mi_mi_config_get_mctp_mtu(ep, 5, &mtu);
-	assert(rc == 0);
-	assert(mtu == 0x1234);
+	shr_assert(rc == 0);
+	shr_assert(mtu == 0x1234);
 }
 
 /* test: config set SMBus freq, both valid and invalid */
@@ -842,15 +842,15 @@ static int test_mi_config_set_freq_cb(struct libnvme_mi_ep *ep,
 	struct nvme_mi_mi_resp_hdr *mi_resp;
 	uint8_t *buf;
 
-	assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
-	assert(req->data_len == 0);
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
+	shr_assert(req->data_len == 0);
 
 	/* validate req as raw bytes */
 	buf = (void *)req->hdr;
-	assert(buf[4] == nvme_mi_mi_opcode_configuration_set);
+	shr_assert(buf[4] == nvme_mi_mi_opcode_configuration_set);
 	/* dword 0: port and config id */
-	assert(buf[11] == 0x5);
-	assert(buf[8] == NVME_MI_CONFIG_SMBUS_FREQ);
+	shr_assert(buf[11] == 0x5);
+	shr_assert(buf[8] == NVME_MI_CONFIG_SMBUS_FREQ);
 
 	mi_resp = (void *)resp->hdr;
 	resp->hdr_len = sizeof(*mi_resp);
@@ -880,7 +880,7 @@ static void test_mi_config_set_freq(libnvme_mi_ep_t ep)
 
 	rc = libnvme_mi_mi_config_set_smbus_freq(ep, 5,
 					      NVME_MI_CONFIG_SMBUS_FREQ_100kHz);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 static void test_mi_config_set_freq_invalid(libnvme_mi_ep_t ep)
@@ -891,7 +891,7 @@ static void test_mi_config_set_freq_invalid(libnvme_mi_ep_t ep)
 
 	rc = libnvme_mi_mi_config_set_smbus_freq(ep, 5,
 					      NVME_MI_CONFIG_SMBUS_FREQ_1MHz);
-	assert(rc == 4);
+	shr_assert(rc == 4);
 }
 
 /* Get Features callback, implementing Arbitration (which doesn't return
@@ -906,34 +906,34 @@ static int test_admin_get_features_cb(struct libnvme_mi_ep *ep,
 	__u16 ctrl_id;
 	int i;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_ADMIN);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_ADMIN);
 
 	/* do we have enough for a mi header? */
-	assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
 
 	/* inspect response as raw bytes */
 	rq_hdr = (__u8 *)req->hdr;
 
 	/* opcode */
-	assert(rq_hdr[4] == nvme_admin_get_features);
+	shr_assert(rq_hdr[4] == nvme_admin_get_features);
 
 	/* controller */
 	ctrl_id = rq_hdr[7] << 8 | rq_hdr[6];
-	assert(ctrl_id == 0x5); /* controller id */
+	shr_assert(ctrl_id == 0x5); /* controller id */
 
 	/* sel & fid from lower bytes of cdw10 */
 	fid = rq_hdr[44];
 	sel = rq_hdr[45] & 0x7;
 
 	/* reserved fields */
-	assert(!(rq_hdr[46] || rq_hdr[47] || rq_hdr[45] & 0xf8));
+	shr_assert(!(rq_hdr[46] || rq_hdr[47] || rq_hdr[45] & 0xf8));
 
-	assert(sel == 0x00);
+	shr_assert(sel == 0x00);
 
 	rs_hdr = (__u8 *)resp->hdr;
 	rs_hdr[4] = 0x00; /* status: success */
@@ -958,7 +958,7 @@ static int test_admin_get_features_cb(struct libnvme_mi_ep *ep,
 		break;
 
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	test_transport_resp_calc_mic(resp);
@@ -975,12 +975,12 @@ static void test_get_features(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_admin_get_features_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_get_features(&cmd, NVME_FEAT_FID_ARBITRATION, 0);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc == 0);
-	assert(cmd.result == 0x04030201);
+	shr_assert(rc == 0);
+	shr_assert(cmd.result == 0x04030201);
 }
 
 /* Set Features callback for timestamp */
@@ -994,38 +994,38 @@ static int test_admin_set_features_cb(struct libnvme_mi_ep *ep,
 	uint8_t ts[6];
 	int i;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_ADMIN);
-	assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
-	assert(req->data_len == 8);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_ADMIN);
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
+	shr_assert(req->data_len == 8);
 
 	rq_hdr = (__u8 *)req->hdr;
 	rq_data = req->data;
 
 	/* opcode */
-	assert(rq_hdr[4] == nvme_admin_set_features);
+	shr_assert(rq_hdr[4] == nvme_admin_set_features);
 
 	/* controller */
 	ctrl_id = rq_hdr[7] << 8 | rq_hdr[6];
-	assert(ctrl_id == 0x5); /* controller id */
+	shr_assert(ctrl_id == 0x5); /* controller id */
 
 	/* fid from lower bytes of cdw10, save from top bit */
 	fid = rq_hdr[44];
 	save = rq_hdr[47] & 0x80;
 
 	/* reserved fields */
-	assert(!(rq_hdr[45] || rq_hdr[46]));
+	shr_assert(!(rq_hdr[45] || rq_hdr[46]));
 
-	assert(fid == NVME_FEAT_FID_TIMESTAMP);
-	assert(save == 0x80);
+	shr_assert(fid == NVME_FEAT_FID_TIMESTAMP);
+	shr_assert(save == 0x80);
 
 	for (i = 0; i < sizeof(ts); i++)
 		ts[i] = i;
-	assert(!memcmp(ts, rq_data, sizeof(ts)));
+	shr_assert(!memcmp(ts, rq_data, sizeof(ts)));
 
 	rs_hdr = (__u8 *)resp->hdr;
 	rs_hdr[4] = 0x00;
@@ -1045,11 +1045,11 @@ static void test_set_features(libnvme_mi_ep_t ep)
 	test_set_transport_callback(ep, test_admin_set_features_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_set_features_timestamp(&cmd, true, 0x050403020100, &tstmp);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 enum ns_type {
@@ -1069,14 +1069,14 @@ static int test_admin_id_ns_list_cb(struct libnvme_mi_ep *ep,
 	__u16 cns;
 
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_admin_identify);
+	shr_assert(hdr[4] == nvme_admin_identify);
 
-	assert(req->data_len == 0);
+	shr_assert(req->data_len == 0);
 
 	cns = hdr[45] << 8 | hdr[44];
 
 	/* NSID */
-	assert(hdr[8] == 1 && !hdr[9] && !hdr[10] && !hdr[11]);
+	shr_assert(hdr[8] == 1 && !hdr[9] && !hdr[10] && !hdr[11]);
 
 	type = *(enum ns_type *)data;
 	resp->data_len = sizeof(*list);
@@ -1084,15 +1084,15 @@ static int test_admin_id_ns_list_cb(struct libnvme_mi_ep *ep,
 
 	switch (type) {
 	case NS_ALLOC:
-		assert(cns == NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST);
+		shr_assert(cns == NVME_IDENTIFY_CNS_ALLOCATED_NS_LIST);
 		offset = 2;
 		break;
 	case NS_ACTIVE:
-		assert(cns == NVME_IDENTIFY_CNS_NS_ACTIVE_LIST);
+		shr_assert(cns == NVME_IDENTIFY_CNS_NS_ACTIVE_LIST);
 		offset = 4;
 		break;
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	list->ns[0] = cpu_to_le32(offset);
@@ -1115,15 +1115,15 @@ static void test_admin_id_alloc_ns_list(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_id_ns_list_cb, &type);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_allocated_ns_list(&cmd, 1, &list);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
-	assert(le32_to_cpu(list.ns[0]) == 2);
-	assert(le32_to_cpu(list.ns[1]) == 3);
-	assert(le32_to_cpu(list.ns[2]) == 0);
+	shr_assert(le32_to_cpu(list.ns[0]) == 2);
+	shr_assert(le32_to_cpu(list.ns[1]) == 3);
+	shr_assert(le32_to_cpu(list.ns[2]) == 0);
 }
 
 static void test_admin_id_active_ns_list(struct libnvme_mi_ep *ep)
@@ -1138,15 +1138,15 @@ static void test_admin_id_active_ns_list(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_id_ns_list_cb, &type);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_active_ns_list(&cmd, 1, &list);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
-	assert(le32_to_cpu(list.ns[0]) == 4);
-	assert(le32_to_cpu(list.ns[1]) == 5);
-	assert(le32_to_cpu(list.ns[2]) == 0);
+	shr_assert(le32_to_cpu(list.ns[0]) == 4);
+	shr_assert(le32_to_cpu(list.ns[1]) == 5);
+	shr_assert(le32_to_cpu(list.ns[2]) == 0);
 }
 
 static int test_admin_id_ns_cb(struct libnvme_mi_ep *ep,
@@ -1160,15 +1160,15 @@ static int test_admin_id_ns_cb(struct libnvme_mi_ep *ep,
 	__u8 *hdr;
 
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_admin_identify);
+	shr_assert(hdr[4] == nvme_admin_identify);
 
-	assert(req->data_len == 0);
+	shr_assert(req->data_len == 0);
 
 	cns = hdr[45] << 8 | hdr[44];
 
 	/* NSID */
 	nsid = hdr[8];
-	assert(!hdr[9] && !hdr[10] && !hdr[11]);
+	shr_assert(!hdr[9] && !hdr[10] && !hdr[11]);
 
 	type = *(enum ns_type *)data;
 	resp->data_len = sizeof(*id);
@@ -1177,13 +1177,13 @@ static int test_admin_id_ns_cb(struct libnvme_mi_ep *ep,
 
 	switch (type) {
 	case NS_ALLOC:
-		assert(cns == NVME_IDENTIFY_CNS_ALLOCATED_NS);
+		shr_assert(cns == NVME_IDENTIFY_CNS_ALLOCATED_NS);
 		break;
 	case NS_ACTIVE:
-		assert(cns == NVME_IDENTIFY_CNS_NS);
+		shr_assert(cns == NVME_IDENTIFY_CNS_NS);
 		break;
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	test_transport_resp_calc_mic(resp);
@@ -1203,12 +1203,12 @@ static void test_admin_id_alloc_ns(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_id_ns_cb, &type);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_allocated_ns(&cmd, 1, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
-	assert(le64_to_cpu(id.nsze) == 1);
+	shr_assert(!rc);
+	shr_assert(le64_to_cpu(id.nsze) == 1);
 }
 
 static void test_admin_id_active_ns(struct libnvme_mi_ep *ep)
@@ -1223,12 +1223,12 @@ static void test_admin_id_active_ns(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_id_ns_cb, &type);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_ns(&cmd, 1, &id);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
-	assert(le64_to_cpu(id.nsze) == 1);
+	shr_assert(!rc);
+	shr_assert(le64_to_cpu(id.nsze) == 1);
 }
 
 static int test_admin_id_ns_ctrl_list_cb(struct libnvme_mi_ep *ep,
@@ -1241,18 +1241,18 @@ static int test_admin_id_ns_ctrl_list_cb(struct libnvme_mi_ep *ep,
 	__u8 *hdr;
 
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_admin_identify);
+	shr_assert(hdr[4] == nvme_admin_identify);
 
-	assert(req->data_len == 0);
+	shr_assert(req->data_len == 0);
 
 	cns = hdr[45] << 8 | hdr[44];
-	assert(cns == NVME_IDENTIFY_CNS_NS_CTRL_LIST);
+	shr_assert(cns == NVME_IDENTIFY_CNS_NS_CTRL_LIST);
 
 	nsid = hdr[11] << 24 | hdr[10] << 16 | hdr[9] << 8 | hdr[8];
-	assert(nsid == 0x01020304);
+	shr_assert(nsid == 0x01020304);
 
 	ctrlid = hdr[47] << 8 | hdr[46];
-	assert(ctrlid == 5);
+	shr_assert(ctrlid == 5);
 
 	resp->data_len = sizeof(struct nvme_ctrl_list);
 	test_transport_resp_calc_mic(resp);
@@ -1270,11 +1270,11 @@ static void test_admin_id_ns_ctrl_list(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_id_ns_ctrl_list_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_ns_ctrl_list(&cmd, 0x01020304, 5, &list);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 static int test_admin_id_secondary_ctrl_list_cb(struct libnvme_mi_ep *ep,
@@ -1286,15 +1286,15 @@ static int test_admin_id_secondary_ctrl_list_cb(struct libnvme_mi_ep *ep,
 	__u8 *hdr;
 
 	hdr = (__u8 *)req->hdr;
-	assert(hdr[4] == nvme_admin_identify);
+	shr_assert(hdr[4] == nvme_admin_identify);
 
-	assert(req->data_len == 0);
+	shr_assert(req->data_len == 0);
 
 	cns = hdr[45] << 8 | hdr[44];
-	assert(cns == NVME_IDENTIFY_CNS_SECONDARY_CTRL_LIST);
+	shr_assert(cns == NVME_IDENTIFY_CNS_SECONDARY_CTRL_LIST);
 
 	ctrlid = hdr[47] << 8 | hdr[46];
-	assert(ctrlid == 5);
+	shr_assert(ctrlid == 5);
 
 	resp->data_len = sizeof(struct nvme_secondary_ctrl_list);
 	test_transport_resp_calc_mic(resp);
@@ -1313,11 +1313,11 @@ static void test_admin_id_secondary_ctrl_list(struct libnvme_mi_ep *ep)
 				    NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_identify_secondary_ctrl_list(&cmd, 5, &list);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 static int test_admin_ns_mgmt_cb(struct libnvme_mi_ep *ep,
@@ -1330,7 +1330,7 @@ static int test_admin_ns_mgmt_cb(struct libnvme_mi_ep *ep,
 	__u32 nsid;
 
 	rq_hdr = (__u8 *)req->hdr;
-	assert(rq_hdr[4] == nvme_admin_ns_mgmt);
+	shr_assert(rq_hdr[4] == nvme_admin_ns_mgmt);
 
 	sel = rq_hdr[44];
 	csi = rq_hdr[45];
@@ -1340,12 +1340,12 @@ static int test_admin_ns_mgmt_cb(struct libnvme_mi_ep *ep,
 
 	switch (sel) {
 	case NVME_NS_MGMT_SEL_CREATE:
-		assert(req->data_len == sizeof(struct nvme_ns_mgmt_host_sw_specified));
+		shr_assert(req->data_len == sizeof(struct nvme_ns_mgmt_host_sw_specified));
 		create_data = req->data;
 
 		/* No NSID on created namespaces */
-		assert(nsid == 0);
-		assert(csi == 0);
+		shr_assert(nsid == 0);
+		shr_assert(csi == 0);
 
 		/* allow operations on nsze == 42, reject others */
 		if (le64_to_cpu(create_data->nsze) != 42) {
@@ -1361,13 +1361,13 @@ static int test_admin_ns_mgmt_cb(struct libnvme_mi_ep *ep,
 		break;
 
 	case NVME_NS_MGMT_SEL_DELETE:
-		assert(req->data_len == 0);
+		shr_assert(req->data_len == 0);
 		/* NSID required on delete */
-		assert(nsid == 0x05060708);
+		shr_assert(nsid == 0x05060708);
 		break;
 
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	test_transport_resp_calc_mic(resp);
@@ -1386,18 +1386,18 @@ static void test_admin_ns_mgmt_create(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_ns_mgmt_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_ns_mgmt_create(&cmd, NVME_CSI_NVM, &data);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 	ns = cmd.result;
-	assert(ns == 0x01020304);
+	shr_assert(ns == 0x01020304);
 
 	data.nsze = cpu_to_le64(42);
 	nvme_init_ns_mgmt_create(&cmd, NVME_CSI_NVM, &data);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(rc);
+	shr_assert(rc);
 }
 
 static void test_admin_ns_mgmt_delete(struct libnvme_mi_ep *ep)
@@ -1409,11 +1409,11 @@ static void test_admin_ns_mgmt_delete(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_ns_mgmt_cb, NULL);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_ns_mgmt_delete(&cmd, 0x05060708);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 struct attach_op {
@@ -1434,26 +1434,26 @@ static int test_admin_ns_attach_cb(struct libnvme_mi_ep *ep,
 	__u32 nsid;
 
 	rq_hdr = (__u8 *)req->hdr;
-	assert(rq_hdr[4] == nvme_admin_ns_attach);
+	shr_assert(rq_hdr[4] == nvme_admin_ns_attach);
 
 	sel = rq_hdr[44];
 	nsid = rq_hdr[11] << 24 | rq_hdr[10] << 16 | rq_hdr[9] << 8 | rq_hdr[8];
 
-	assert(req->data_len == sizeof(*op->list));
+	shr_assert(req->data_len == sizeof(*op->list));
 
-	assert(nsid == 0x02030405);
+	shr_assert(nsid == 0x02030405);
 	switch (op->op) {
 	case NS_ATTACH:
-		assert(sel == NVME_NS_ATTACH_SEL_CTRL_ATTACH);
+		shr_assert(sel == NVME_NS_ATTACH_SEL_CTRL_ATTACH);
 		break;
 	case NS_DETACH:
-		assert(sel == NVME_NS_ATTACH_SEL_CTRL_DEATTACH);
+		shr_assert(sel == NVME_NS_ATTACH_SEL_CTRL_DEATTACH);
 		break;
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
-	assert(!memcmp(req->data, op->list, sizeof(*op->list)));
+	shr_assert(!memcmp(req->data, op->list, sizeof(*op->list)));
 
 	test_transport_resp_calc_mic(resp);
 
@@ -1478,11 +1478,11 @@ static void test_admin_ns_attach(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_ns_attach_cb, &aop);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_ns_attach_ctrls(&cmd, 0x02030405, &list);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 static void test_admin_ns_detach(struct libnvme_mi_ep *ep)
@@ -1503,11 +1503,11 @@ static void test_admin_ns_detach(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_ns_attach_cb, &aop);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	nvme_init_ns_detach_ctrls(&cmd, 0x02030405, &list);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 struct fw_download_info {
@@ -1526,18 +1526,18 @@ static int test_admin_fw_download_cb(struct libnvme_mi_ep *ep,
 	__u8 *rq_hdr;
 
 	rq_hdr = (__u8 *)req->hdr;
-	assert(rq_hdr[4] == nvme_admin_fw_download);
+	shr_assert(rq_hdr[4] == nvme_admin_fw_download);
 
 	len = rq_hdr[47] << 24 | rq_hdr[46] << 16 | rq_hdr[45] << 8 | rq_hdr[44];
 	off = rq_hdr[51] << 24 | rq_hdr[50] << 16 | rq_hdr[49] << 8 | rq_hdr[48];
 
-	assert(off << 2 == info->offset);
-	assert(((len+1) << 2) == info->len);
+	shr_assert(off << 2 == info->offset);
+	shr_assert(((len+1) << 2) == info->len);
 
 	/* ensure that the request len matches too */
-	assert(req->data_len == info->len);
+	shr_assert(req->data_len == info->len);
 
-	assert(!memcmp(req->data, info->data, len));
+	shr_assert(!memcmp(req->data, info->data, len));
 
 	test_transport_resp_calc_mic(resp);
 
@@ -1562,49 +1562,49 @@ static void test_admin_fw_download(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_fw_download_cb, &info);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	/* invalid (zero) len */
 	info.len = 1;
 	info.offset = 0;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
-	assert(rc);
+	shr_assert(rc);
 
 	/* invalid (unaligned) len */
 	info.len = 1;
 	info.offset = 0;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
-	assert(rc);
+	shr_assert(rc);
 
 	/* invalid offset */
 	info.len = 4;
 	info.offset = 1;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
-	assert(rc);
+	shr_assert(rc);
 
 	/* smallest len */
 	info.len = 4;
 	info.offset = 0;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
-	assert(!rc);
+	shr_assert(!rc);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
 	/* largest len */
 	info.len = 4096;
 	info.offset = 0;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
-	assert(!rc);
+	shr_assert(!rc);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
 	/* offset value */
 	info.len = 4096;
 	info.offset = 4096;
 	rc = nvme_init_fw_download(&cmd, fw, info.len, info.offset);
-	assert(!rc);
+	shr_assert(!rc);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 struct fw_commit_info {
@@ -1623,15 +1623,15 @@ static int test_admin_fw_commit_cb(struct libnvme_mi_ep *ep,
 	__u8 *rq_hdr;
 
 	rq_hdr = (__u8 *)req->hdr;
-	assert(rq_hdr[4] == nvme_admin_fw_commit);
+	shr_assert(rq_hdr[4] == nvme_admin_fw_commit);
 
 	bpid = (rq_hdr[47] >> 7) & 0x1;
 	slot = rq_hdr[44] & 0x7;
 	action = (rq_hdr[44] >> 3) & 0x7;
 
-	assert(!!bpid == !!info->bpid);
-	assert(slot == info->slot);
-	assert(action == info->action);
+	shr_assert(!!bpid == !!info->bpid);
+	shr_assert(slot == info->slot);
+	shr_assert(action == info->action);
 
 	test_transport_resp_calc_mic(resp);
 
@@ -1650,7 +1650,7 @@ static void test_admin_fw_commit(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_fw_commit_cb, &info);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	/* all zeros */
 	info.bpid = 0;
@@ -1658,7 +1658,7 @@ static void test_admin_fw_commit(struct libnvme_mi_ep *ep)
 	info.action = 0;
 	nvme_init_fw_commit(&cmd, info.slot, info.action, info.bpid);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
 	/* all ones */
 	info.bpid = 1;
@@ -1666,7 +1666,7 @@ static void test_admin_fw_commit(struct libnvme_mi_ep *ep)
 	info.action = 0x7;
 	nvme_init_fw_commit(&cmd, info.slot, info.action, info.bpid);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
 	/* correct fields */
 	info.bpid = 1;
@@ -1674,7 +1674,7 @@ static void test_admin_fw_commit(struct libnvme_mi_ep *ep)
 	info.action = 3;
 	nvme_init_fw_commit(&cmd, info.slot, info.action, info.bpid);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 struct format_data {
@@ -1695,25 +1695,25 @@ static int test_admin_format_nvm_cb(struct libnvme_mi_ep *ep,
 	__u8 *rq_hdr;
 	__u32 nsid;
 
-	assert(req->data_len == 0);
+	shr_assert(req->data_len == 0);
 
 	rq_hdr = (__u8 *)req->hdr;
 
-	assert(rq_hdr[4] == nvme_admin_format_nvm);
+	shr_assert(rq_hdr[4] == nvme_admin_format_nvm);
 
 	nsid = (__u32)rq_hdr[11] << 24
 	     | rq_hdr[10] << 16
 	     | rq_hdr[9] << 8
 	     | rq_hdr[8];
-	assert(nsid == args->nsid);
+	shr_assert(nsid == args->nsid);
 
-	assert(((rq_hdr[44] >> 0) & 0xf) == (args->lbaf & 0xf));
-	assert(((rq_hdr[44] >> 4) & 0x1) == args->mset);
-	assert(((rq_hdr[44] >> 5) & 0x7) == args->pi);
+	shr_assert(((rq_hdr[44] >> 0) & 0xf) == (args->lbaf & 0xf));
+	shr_assert(((rq_hdr[44] >> 4) & 0x1) == args->mset);
+	shr_assert(((rq_hdr[44] >> 5) & 0x7) == args->pi);
 
-	assert(((rq_hdr[45] >> 0) & 0x1) == args->pil);
-	assert(((rq_hdr[45] >> 1) & 0x7) == args->ses);
-	assert(((rq_hdr[45] >> 4) & 0x3) == (args->lbaf >> 4));
+	shr_assert(((rq_hdr[45] >> 0) & 0x1) == args->pil);
+	shr_assert(((rq_hdr[45] >> 1) & 0x7) == args->ses);
+	shr_assert(((rq_hdr[45] >> 4) & 0x3) == (args->lbaf >> 4));
 
 	test_transport_resp_calc_mic(resp);
 
@@ -1728,7 +1728,7 @@ static void test_admin_format_nvm(struct libnvme_mi_ep *ep)
 	int rc;
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	test_set_transport_callback(ep, test_admin_format_nvm_cb, &args);
 
@@ -1744,7 +1744,7 @@ static void test_admin_format_nvm(struct libnvme_mi_ep *ep)
 	nvme_init_format_nvm(&cmd, args.nsid, args.lbaf, args.mset,
 			     args.pi, args.pil, args.ses);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
 	args.nsid = ~args.nsid;
 	args.ses = 0x7;
@@ -1756,7 +1756,7 @@ static void test_admin_format_nvm(struct libnvme_mi_ep *ep)
 	nvme_init_format_nvm(&cmd, args.nsid, args.lbaf, args.mset,
 			     args.pi, args.pil, args.ses);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 struct nvme_sanitize_nvm_args {
@@ -1778,22 +1778,22 @@ static int test_admin_sanitize_nvm_cb(struct libnvme_mi_ep *ep,
 	__u8 *rq_hdr;
 	__u32 ovrpat;
 
-	assert(req->data_len == 0);
+	shr_assert(req->data_len == 0);
 
 	rq_hdr = (__u8 *)req->hdr;
 
-	assert(rq_hdr[4] == nvme_admin_sanitize_nvm);
+	shr_assert(rq_hdr[4] == nvme_admin_sanitize_nvm);
 
-	assert(((rq_hdr[44] >> 0) & 0x7) == args->sanact);
-	assert(((rq_hdr[44] >> 3) & 0x1) == args->ause);
-	assert(((rq_hdr[44] >> 4) & 0xf) == args->owpass);
+	shr_assert(((rq_hdr[44] >> 0) & 0x7) == args->sanact);
+	shr_assert(((rq_hdr[44] >> 3) & 0x1) == args->ause);
+	shr_assert(((rq_hdr[44] >> 4) & 0xf) == args->owpass);
 
-	assert(((rq_hdr[45] >> 0) & 0x1) == args->oipbp);
-	assert(((rq_hdr[45] >> 1) & 0x1) == args->ndas);
+	shr_assert(((rq_hdr[45] >> 0) & 0x1) == args->oipbp);
+	shr_assert(((rq_hdr[45] >> 1) & 0x1) == args->ndas);
 
 	ovrpat = (__u32)rq_hdr[51] << 24 | rq_hdr[50] << 16 |
 		rq_hdr[49] << 8 | rq_hdr[48];
-	assert(ovrpat == args->ovrpat);
+	shr_assert(ovrpat == args->ovrpat);
 
 	test_transport_resp_calc_mic(resp);
 
@@ -1808,7 +1808,7 @@ static void test_admin_sanitize_nvm(struct libnvme_mi_ep *ep)
 	int rc;
 
 	hdl = libnvme_mi_init_transport_handle(ep, 5);
-	assert(hdl);
+	shr_assert(hdl);
 
 	test_set_transport_callback(ep, test_admin_sanitize_nvm_cb, &args);
 
@@ -1822,7 +1822,7 @@ static void test_admin_sanitize_nvm(struct libnvme_mi_ep *ep)
 	nvme_init_sanitize_nvm(&cmd, args.sanact, args.ause, args.owpass,
 		args.oipbp, args.ndas, args.emvs, args.ovrpat);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 
 	args.sanact = 0x0;
 	args.ause = 0x1;
@@ -1834,7 +1834,7 @@ static void test_admin_sanitize_nvm(struct libnvme_mi_ep *ep)
 	nvme_init_sanitize_nvm(&cmd, args.sanact, args.ause, args.owpass,
 		args.oipbp, args.ndas, args.emvs, args.ovrpat);
 	rc = libnvme_exec_admin_passthru(hdl, &cmd);
-	assert(!rc);
+	shr_assert(!rc);
 }
 
 /* test that we set the correct offset and size on get_log() calls that
@@ -1853,11 +1853,11 @@ static int test_admin_get_log_split_cb(struct libnvme_mi_ep *ep,
 	uint32_t len, off;
 	__u8 *rq_hdr;
 
-	assert(req->data_len == 0);
+	shr_assert(req->data_len == 0);
 
 	rq_hdr = (__u8 *)req->hdr;
 
-	assert(rq_hdr[4] == nvme_admin_get_log_page);
+	shr_assert(rq_hdr[4] == nvme_admin_get_log_page);
 
 	/* from the MI message's DOFST/DLEN fields */
 	off = rq_hdr[31] << 24 | rq_hdr[30] << 16 | rq_hdr[29] << 8 | rq_hdr[28];
@@ -1869,26 +1869,26 @@ static int test_admin_get_log_split_cb(struct libnvme_mi_ep *ep,
 	/* we should have a full-sized start and middle, and a short end */
 	switch (ldata->n) {
 	case 0:
-		assert(log_page_offset_lower == 0);
-		assert(len == 4096);
-		assert(off == 0);
+		shr_assert(log_page_offset_lower == 0);
+		shr_assert(len == 4096);
+		shr_assert(off == 0);
 		break;
 	case 1:
-		assert(log_page_offset_lower == 4096);
-		assert(len == 4096);
-		assert(off == 0);
+		shr_assert(log_page_offset_lower == 4096);
+		shr_assert(len == 4096);
+		shr_assert(off == 0);
 		break;
 	case 2:
-		assert(log_page_offset_lower == 8192);
-		assert(len == 4);
-		assert(off == 0);
+		shr_assert(log_page_offset_lower == 8192);
+		shr_assert(len == 4);
+		shr_assert(off == 0);
 		break;
 	default:
-		assert(0);
+		shr_assert(0);
 	}
 
 	/* ensure we've sized the expected response correctly */
-	assert(resp->data_len == len);
+	shr_assert(resp->data_len == len);
 	memset(resp->data, ldata->n & 0xff, len);
 
 	test_transport_resp_calc_mic(resp);
@@ -1914,10 +1914,10 @@ static void test_admin_get_log_split(struct libnvme_mi_ep *ep)
 	nvme_init_get_log(&cmd, NVME_NSID_ALL, NVME_LOG_LID_ERROR,
 		NVME_CSI_NVM, buf, sizeof(buf));
 	rc = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
-	assert(!rc);
+	shr_assert(!rc);
 
 	/* we should have sent three commands */
-	assert(ldata.n == 3);
+	shr_assert(ldata.n == 3);
 }
 
 static int test_endpoint_quirk_probe_cb_stage2(struct libnvme_mi_ep *ep,
@@ -1936,19 +1936,19 @@ static int test_endpoint_quirk_probe_cb_stage1(struct libnvme_mi_ep *ep,
 	struct nvme_mi_admin_req_hdr *admin_req;
 	__u8 ror, mt;
 
-	assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
+	shr_assert(req->hdr->type == NVME_MI_MSGTYPE_NVME);
 
 	ror = req->hdr->nmp >> 7;
 	mt = req->hdr->nmp >> 3 & 0x7;
-	assert(ror == NVME_MI_ROR_REQ);
-	assert(mt == NVME_MI_MT_ADMIN);
+	shr_assert(ror == NVME_MI_ROR_REQ);
+	shr_assert(mt == NVME_MI_MT_ADMIN);
 
-	assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_admin_req_hdr));
 
 	admin_req = (struct nvme_mi_admin_req_hdr *)req->hdr;
-	assert(admin_req->opcode == nvme_admin_identify);
-	assert(le32_to_cpu(admin_req->doff) == 0);
-	assert(le32_to_cpu(admin_req->dlen) == offsetof(struct nvme_id_ctrl, rab));
+	shr_assert(admin_req->opcode == nvme_admin_identify);
+	shr_assert(le32_to_cpu(admin_req->doff) == 0);
+	shr_assert(le32_to_cpu(admin_req->dlen) == offsetof(struct nvme_id_ctrl, rab));
 
 	test_set_transport_callback(ep, test_endpoint_quirk_probe_cb_stage2, data);
 
@@ -1966,7 +1966,7 @@ static void test_endpoint_quirk_probe(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_endpoint_quirk_probe_cb_stage1, NULL);
 
 	rc = libnvme_mi_mi_read_mi_data_subsys(ep, &ss_info);
-	assert(rc == 0);
+	shr_assert(rc == 0);
 }
 
 struct req_dlen_doff_data {
@@ -1992,13 +1992,13 @@ static int test_admin_dlen_doff_cb(struct libnvme_mi_ep *ep,
 	doff = hdr[39] << 24 | hdr[38] << 16 | hdr[37] << 8 | hdr[36];
 
 	if (args->direction == DATA_DIR_OUT) {
-		assert(dlen == args->req_len);
-		assert(dlen == req->data_len);
-		assert(doff == 0);
+		shr_assert(dlen == args->req_len);
+		shr_assert(dlen == req->data_len);
+		shr_assert(doff == 0);
 	} else {
-		assert(dlen == args->resp_len);
-		assert(dlen == resp->data_len);
-		assert(doff == args->exp_doff);
+		shr_assert(dlen == args->resp_len);
+		shr_assert(dlen == resp->data_len);
+		shr_assert(doff == args->exp_doff);
 	}
 
 	/* minimal valid response */
@@ -2029,12 +2029,12 @@ static void test_admin_dlen_doff_req(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_dlen_doff_cb, &data);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 0);
-	assert(hdl);
+	shr_assert(hdl);
 
 	rc = libnvme_mi_admin_xfer(hdl, &admin_req.hdr, sizeof(admin_req.data),
 				&admin_resp, 0, &resp_sz);
 
-	assert(!rc);
+	shr_assert(!rc);
 };
 
 /* Check dlen value on admin_xfer requests that return data in their response.
@@ -2058,12 +2058,12 @@ static void test_admin_dlen_doff_resp(struct libnvme_mi_ep *ep)
 	test_set_transport_callback(ep, test_admin_dlen_doff_cb, &data);
 
 	hdl = libnvme_mi_init_transport_handle(ep, 0);
-	assert(hdl);
+	shr_assert(hdl);
 
 	rc = libnvme_mi_admin_xfer(hdl, &admin_req, 0, &admin_resp.hdr, 0,
 				&resp_sz);
 
-	assert(!rc);
+	shr_assert(!rc);
 };
 
 #define DEFINE_TEST(name) { #name, test_ ## name }
@@ -2133,11 +2133,11 @@ int main(void)
 	fd = test_setup_log();
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 	libnvme_set_logging_file(ctx, fd);
 
 	ep = libnvme_mi_open_test(ctx);
-	assert(ep);
+	shr_assert(ep);
 
 	for (i = 0; i < ARRAY_SIZE(tests); i++) {
 		run_test(&tests[i], fd, ep);

--- a/libnvme/test/registry.c
+++ b/libnvme/test/registry.c
@@ -9,7 +9,7 @@
  * access from multiple processes.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <dirent.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -37,9 +37,9 @@ static void setup_tmpdir(struct libnvme_global_ctx *ctx)
 	 * test directory must live there (not under an arbitrary $TMPDIR).
 	 */
 	snprintf(tmpdir, sizeof(tmpdir), "/tmp/nvme-registry-test-XXXXXX");
-	assert(mkdtemp(tmpdir) != NULL);
+	shr_assert(mkdtemp(tmpdir) != NULL);
 	snprintf(regdir, sizeof(regdir), "%s/registry", tmpdir);
-	assert(libnvme_set_test_base_dir(ctx, tmpdir) == 0);
+	shr_assert(libnvme_set_test_base_dir(ctx, tmpdir) == 0);
 }
 
 static void cleanup_tmpdir(struct libnvme_global_ctx *ctx)
@@ -485,7 +485,7 @@ static bool test_parallel_writes(struct libnvme_global_ctx *ctx)
 
 	for (i = 0; i < NPROCS; i++) {
 		pids[i] = fork();
-		assert(pids[i] >= 0);
+		shr_assert(pids[i] >= 0);
 		if (pids[i] == 0) {
 			snprintf(owner, sizeof(owner), "child%d", i);
 			for (int j = 0; j < 200; j++)

--- a/libnvme/test/tree-fabrics.c
+++ b/libnvme/test/tree-fabrics.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2023 Daniel Wagner, SUSE LLC
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -132,27 +132,27 @@ static struct libnvme_global_ctx *create_tree(void)
 	libnvme_host_t h;
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_DEBUG, false, false);
 	libnvme_set_hostnqn(ctx, DEFAULT_HOSTNQN);
 	libnvme_set_hostid(ctx, DEFAULT_HOSTID);
 
-	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
-	assert(h);
+	shr_assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
+	shr_assert(h);
 
 	printf("  ctrls created:\n");
 	for (int i = 0; i < ARRAY_SIZE(test_data); i++) {
 		struct test_data *d = &test_data[i];
 
-		assert(!libnvme_get_subsystem(ctx, h, d->subsysname,
+		shr_assert(!libnvme_get_subsystem(ctx, h, d->subsysname,
 			d->f.ctrl_params.subsysnqn, &d->s));
-		assert(d->s);
+		shr_assert(d->s);
 
-		assert(!libnvme_subsystem_create_ctrl(d->s,
+		shr_assert(!libnvme_subsystem_create_ctrl(d->s,
 			&d->f.ctrl_params, &d->c));
-		assert(d->c);
+		shr_assert(d->c);
 		d->ctrl_id = i;
 
 		printf("    ");
@@ -189,7 +189,7 @@ static bool tcp_ctrl_lookup(libnvme_subsystem_t s, struct test_data *d)
 	f.ctrl_params.host_traddr = NULL;
 	f.ctrl_params.host_iface = NULL;
 	c = libnvme_lookup_ctrl(s, &f.ctrl_params, NULL);
-	assert(c);
+	shr_assert(c);
 	printf("%10s %12s %10s -> ", f.ctrl_params.trsvcid, "", "");
 	show_ctrl(c);
 	pass &= match_ctrl(d, c);
@@ -254,9 +254,9 @@ static bool ctrl_lookups(struct libnvme_global_ctx *ctx)
 	bool pass = true;
 
 	h = libnvme_first_host(ctx);
-	assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
+	shr_assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
 			      DEFAULT_SUBSYSNQN, &s));
-	assert(s);
+	shr_assert(s);
 
 	printf("  lookup controller:\n");
 	for (int i = 0; i < ARRAY_SIZE(test_data); i++) {
@@ -312,20 +312,20 @@ static bool test_src_addr(void)
 	printf("\ntest_src_addr:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_DEBUG, false, false);
 
-	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
-	assert(h);
+	shr_assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
+	shr_assert(h);
 
-	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+	shr_assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
 			      DEFAULT_SUBSYSNQN, &s));
-	assert(s);
+	shr_assert(s);
 
-	assert(!libnvme_subsystem_create_ctrl(s, &fctx.ctrl_params, &c));
-	assert(c);
+	shr_assert(!libnvme_subsystem_create_ctrl(s, &fctx.ctrl_params, &c));
+	shr_assert(c);
 
 	c->address = NULL;
 	printf(" - Test c->address = NULL                                                       : src_addr = NULL             ");
@@ -491,21 +491,21 @@ static bool ctrl_match(const char *tag,
 	const struct libnvme_ctrl_params *rp = &reference->f.ctrl_params;
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
-	assert(h);
+	shr_assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
+	shr_assert(h);
 
-	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+	shr_assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
 		rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN, &s));
-	assert(s);
+	shr_assert(s);
 
-	assert(!libnvme_subsystem_create_ctrl(s, &reference->f.ctrl_params,
+	shr_assert(!libnvme_subsystem_create_ctrl(s, &reference->f.ctrl_params,
 		&reference_ctrl));
-	assert(reference_ctrl);
+	shr_assert(reference_ctrl);
 	reference_ctrl->name = "nvme1";  /* fake the device name */
 	if (reference->address)
 		reference_ctrl->address = (char *)reference->address;
@@ -1308,21 +1308,21 @@ static bool ctrl_config_match(const char *tag,
 	libnvme_subsystem_t s;
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
-	assert(h);
+	shr_assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
+	shr_assert(h);
 
-	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+	shr_assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
 		 rp->subsysnqn ? rp->subsysnqn : DEFAULT_SUBSYSNQN, &s));
-	assert(s);
+	shr_assert(s);
 
-	assert(!libnvme_subsystem_create_ctrl(s,
+	shr_assert(!libnvme_subsystem_create_ctrl(s,
 		&reference->f.ctrl_params, &reference_ctrl));
-	assert(reference_ctrl);
+	shr_assert(reference_ctrl);
 	reference_ctrl->name = "nvme1";  /* fake the device name */
 	if (reference->address)
 		reference_ctrl->address = (char *)reference->address;
@@ -1523,20 +1523,20 @@ static bool test_well_known_nqn(void)
 	printf("\ntest_well_known_nqn:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
-	assert(h);
+	shr_assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
+	shr_assert(h);
 
 	/* Subsystem 1: discovery subsystem with a discovery ctrl */
-	assert(!libnvme_create_subsystem(h, "disc",
+	shr_assert(!libnvme_create_subsystem(h, "disc",
 		NVME_DISC_SUBSYS_NAME, &s_disc));
-	assert(!libnvme_subsystem_create_ctrl(s_disc, &fctx.ctrl_params,
+	shr_assert(!libnvme_subsystem_create_ctrl(s_disc, &fctx.ctrl_params,
 		&disc_ctrl));
-	assert(disc_ctrl);
+	shr_assert(disc_ctrl);
 	disc_ctrl->name = "nvme1";
 	libnvme_ctrl_set_discovery_ctrl(disc_ctrl, true);
 
@@ -1549,11 +1549,11 @@ static bool test_well_known_nqn(void)
 	}
 
 	/* Subsystem 2: regular subsystem; discovery_ctrl defaults to false */
-	assert(!libnvme_create_subsystem(h, "regular", DEFAULT_SUBSYSNQN,
+	shr_assert(!libnvme_create_subsystem(h, "regular", DEFAULT_SUBSYSNQN,
 		&s_regular));
-	assert(!libnvme_subsystem_create_ctrl(s_regular, &fctx.ctrl_params,
+	shr_assert(!libnvme_subsystem_create_ctrl(s_regular, &fctx.ctrl_params,
 		&regular_ctrl));
-	assert(regular_ctrl);
+	shr_assert(regular_ctrl);
 	regular_ctrl->name = "nvme2";
 
 	found = libnvmf_ctrl_find(s_regular, &fctx_wknqn);
@@ -1752,22 +1752,22 @@ static bool test_lookup_ctrl_pagination(void)
 	printf("\ntest_lookup_ctrl_pagination:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_INFO, false, false);
 
-	assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
-	assert(h);
-	assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
+	shr_assert(!libnvme_create_host(ctx, DEFAULT_HOSTNQN, DEFAULT_HOSTID, &h));
+	shr_assert(h);
+	shr_assert(!libnvme_create_subsystem(h, DEFAULT_SUBSYSNAME,
 		DEFAULT_SUBSYSNQN, &s));
-	assert(s);
+	shr_assert(s);
 
 	/* Build list: [ctrl_a, ctrl_b] */
-	assert(!libnvme_subsystem_create_ctrl(s, &fctx_a.ctrl_params, &ctrl_a));
-	assert(ctrl_a);
-	assert(!libnvme_subsystem_create_ctrl(s, &fctx_b.ctrl_params, &ctrl_b));
-	assert(ctrl_b);
+	shr_assert(!libnvme_subsystem_create_ctrl(s, &fctx_a.ctrl_params, &ctrl_a));
+	shr_assert(ctrl_a);
+	shr_assert(!libnvme_subsystem_create_ctrl(s, &fctx_b.ctrl_params, &ctrl_b));
+	shr_assert(ctrl_b);
 
 	/* p=NULL: search starts from head, finds ctrl_a */
 	found = libnvmf_ctrl_find(s, &fctx_a);

--- a/libnvme/test/tree.c
+++ b/libnvme/test/tree.c
@@ -8,7 +8,7 @@
  * host/subsystem creation, deduplication, iteration, and attribute getters.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,16 +42,16 @@ static bool test_host_dedup(void)
 	printf("test_host_dedup:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h1));
-	assert(h1);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h1));
+	shr_assert(h1);
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h2));
-	assert(h2);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h2));
+	shr_assert(h2);
 
 	if (h1 != h2) {
 		printf(" - same hostnqn+hostid must return same pointer [FAIL]\n");
@@ -60,8 +60,8 @@ static bool test_host_dedup(void)
 		printf(" - same hostnqn+hostid returns same pointer [PASS]\n");
 	}
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_2, HOSTID_2, &h3));
-	assert(h3);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_2, HOSTID_2, &h3));
+	shr_assert(h3);
 
 	if (h1 == h3) {
 		printf(" - different hostnqn+hostid must return different pointer [FAIL]\n");
@@ -88,13 +88,13 @@ static bool test_hostid_from_hostnqn(void)
 	printf("test_hostid_from_hostnqn:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
 	libnvme_create_host(ctx, HOSTNQN_1, NULL, &h);
-	assert(h);
+	shr_assert(h);
 
 	hostid = libnvme_host_get_hostid(h);
 	if (!hostid || strcmp(hostid, HOSTID_1)) {
@@ -122,13 +122,13 @@ static bool test_host_attrs(void)
 	printf("test_host_attrs:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
-	assert(h);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
+	shr_assert(h);
 
 	if (!libnvme_host_get_hostnqn(h) ||
 	    strcmp(libnvme_host_get_hostnqn(h), HOSTNQN_1)) {
@@ -164,17 +164,17 @@ static bool test_host_iteration(void)
 	printf("test_host_iteration:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
-	assert(h);
-	assert(!libnvme_get_host(ctx, HOSTNQN_2, HOSTID_2, &h));
-	assert(h);
-	assert(!libnvme_get_host(ctx, HOSTNQN_3, HOSTID_3, &h));
-	assert(h);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
+	shr_assert(h);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_2, HOSTID_2, &h));
+	shr_assert(h);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_3, HOSTID_3, &h));
+	shr_assert(h);
 
 	libnvme_for_each_host(ctx, h)
 		count++;
@@ -205,19 +205,19 @@ static bool test_subsystem_dedup(void)
 	printf("test_subsystem_dedup:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
-	assert(h);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
+	shr_assert(h);
 
-	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s1));
-	assert(s1);
+	shr_assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s1));
+	shr_assert(s1);
 
-	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s2));
-	assert(s2);
+	shr_assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s2));
+	shr_assert(s2);
 
 	if (s1 != s2) {
 		printf(" - same name+subsysnqn must return same pointer [FAIL]\n");
@@ -226,8 +226,8 @@ static bool test_subsystem_dedup(void)
 		printf(" - same name+subsysnqn returns same pointer [PASS]\n");
 	}
 
-	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_2, SUBSYSNQN_2, &s3));
-	assert(s3);
+	shr_assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_2, SUBSYSNQN_2, &s3));
+	shr_assert(s3);
 
 	if (s1 == s3) {
 		printf(" - different name+subsysnqn must return different pointer [FAIL]\n");
@@ -254,16 +254,16 @@ static bool test_subsystem_attrs(void)
 	printf("test_subsystem_attrs:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
-	assert(h);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
+	shr_assert(h);
 
-	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s));
-	assert(s);
+	shr_assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s));
+	shr_assert(s);
 
 	if (!libnvme_subsystem_get_name(s) ||
 	    strcmp(libnvme_subsystem_get_name(s), SUBSYSNAME_1)) {
@@ -300,16 +300,16 @@ static bool test_subsystem_iteration(void)
 	printf("test_subsystem_iteration:\n");
 
 	ctx = libnvme_create_global_ctx();
-	assert(ctx);
+	shr_assert(ctx);
 
 	libnvme_set_logging_file(ctx, stdout);
 	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
 
-	assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
-	assert(h);
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
+	shr_assert(h);
 
-	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s));
-	assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_2, SUBSYSNQN_2, &s));
+	shr_assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s));
+	shr_assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_2, SUBSYSNQN_2, &s));
 
 	libnvme_for_each_subsystem(h, s)
 		count++;

--- a/libnvme/test/uriparser.c
+++ b/libnvme/test/uriparser.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2024 Tomas Bzatek <tbzatek@redhat.com>
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -160,50 +160,50 @@ static void test_uriparser(void)
 		int j;
 
 		printf(" '%s'...", d->uri);
-		assert(!libnvmf_uri_parse(d->uri, &parsed_data));
+		shr_assert(!libnvmf_uri_parse(d->uri, &parsed_data));
 
-		assert(strcmp(d->scheme,
+		shr_assert(strcmp(d->scheme,
 		      libnvmf_uri_get_scheme(parsed_data)) == 0);
 
 		str = libnvmf_uri_get_protocol(parsed_data);
 		if (d->proto) {
-			assert(str != NULL);
-			assert(strcmp(d->proto, str) == 0);
+			shr_assert(str != NULL);
+			shr_assert(strcmp(d->proto, str) == 0);
 		} else {
-			assert(d->proto == str);
+			shr_assert(d->proto == str);
 		}
 
-		assert(strcmp(d->host,
+		shr_assert(strcmp(d->host,
 		      libnvmf_uri_get_host(parsed_data)) == 0);
 
-		assert(d->port == libnvmf_uri_get_port(parsed_data));
+		shr_assert(d->port == libnvmf_uri_get_port(parsed_data));
 
 		segments = libnvmf_uri_get_path_segments(parsed_data);
 		if (!segments) {
-			assert(d->path[0] == NULL);
+			shr_assert(d->path[0] == NULL);
 		} else {
 			for (j = 0; segments && segments[j]; j++) {
-				assert(d->path[j] != NULL);
-				assert(strcmp(d->path[j], segments[j]) == 0);
+				shr_assert(d->path[j] != NULL);
+				shr_assert(strcmp(d->path[j], segments[j]) == 0);
 			}
 			/* trailing NULL element */
-			assert(d->path[j] == segments[j]);
+			shr_assert(d->path[j] == segments[j]);
 		}
 
 		str = libnvmf_uri_get_query(parsed_data);
 		if (d->query) {
-			assert(str != NULL);
-			assert(strcmp(d->query, str) == 0);
+			shr_assert(str != NULL);
+			shr_assert(strcmp(d->query, str) == 0);
 		} else {
-			assert(d->query == str);
+			shr_assert(d->query == str);
 			}
 
 		str = libnvmf_uri_get_fragment(parsed_data);
 		if (d->frag) {
-			assert(str != NULL);
-			assert(strcmp(d->frag, str) == 0);
+			shr_assert(str != NULL);
+			shr_assert(strcmp(d->frag, str) == 0);
 		} else {
-			assert(d->frag == str);
+			shr_assert(d->frag == str);
 		}
 
 		libnvmf_uri_free(parsed_data);
@@ -218,8 +218,8 @@ static void test_uriparser_bad(void)
 		struct libnvmf_uri *parsed_data = NULL;
 
 		printf(" '%s'...", test_data_bad[i]);
-		assert(libnvmf_uri_parse(test_data_bad[i], &parsed_data));
-		assert(parsed_data == NULL);
+		shr_assert(libnvmf_uri_parse(test_data_bad[i], &parsed_data));
+		shr_assert(parsed_data == NULL);
 		printf("   OK\n");
 	}
 }

--- a/shared/meson.build
+++ b/shared/meson.build
@@ -17,6 +17,7 @@ sources = [
     'fs-util.c',
     'ini.c',
     'parse-util.c',
+    'shr-assert.c',
 ]
 
 if host_system == 'windows'

--- a/shared/shr-assert.c
+++ b/shared/shr-assert.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "shr-assert.h"
+
+void shr_assert_fail(const char *file, int line, const char *cond)
+{
+	fflush(NULL);
+	fprintf(stderr, "%s:%d: assertion failed: %s\n", file, line, cond);
+	fflush(NULL);
+	exit(EXIT_FAILURE);
+}

--- a/shared/shr-assert.h
+++ b/shared/shr-assert.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+#pragma once
+
+void shr_assert_fail(const char *file, int line, const char *cond) __attribute__((noreturn));
+
+#define shr_assert(cond) \
+	((void)((cond) || (shr_assert_fail(__FILE__, __LINE__, #cond), 0)))

--- a/shared/test/meson.build
+++ b/shared/test/meson.build
@@ -115,3 +115,16 @@ if host_system != 'windows'
 
     test('shared - net-util', test_net_util)
 endif
+
+if host_system != 'windows'
+    test_shr_assert = executable(
+        'test-shr-assert',
+        ['test-shr-assert.c'],
+        dependencies: [
+            config_dep,
+            shared_dep,
+        ],
+    )
+
+    test('shared - shr-assert', test_shr_assert)
+endif

--- a/shared/test/test-ini.c
+++ b/shared/test/test-ini.c
@@ -9,7 +9,7 @@
  * reporting, exact line numbers, and the parse-abort contract.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -40,7 +40,7 @@ static int record(enum shr_ini_event event, const char *section,
 {
 	struct ev *e = &got[ngot++];
 
-	assert(ngot <= MAX_EVENTS);
+	shr_assert(ngot <= MAX_EVENTS);
 	e->event = event;
 	e->section_null = !section;
 	if (section)
@@ -219,8 +219,8 @@ static bool test_file(void)
 	printf("test_file:\n");
 
 	fd = mkstemp(path);
-	assert(fd >= 0);
-	assert(write(fd, "# file\n[f]\nkey = val\n", 21) == 21);
+	shr_assert(fd >= 0);
+	shr_assert(write(fd, "# file\n[f]\nkey = val\n", 21) == 21);
 	close(fd);
 
 	ngot = 0;

--- a/shared/test/test-shr-assert.c
+++ b/shared/test/test-shr-assert.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <shr-assert.h>
+
+static bool check_bool(const char *name, bool got, bool want)
+{
+	if (got == want) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got %d, want %d [FAIL]\n", name, got, want);
+	return false;
+}
+
+/*
+ * shr_assert() must be a no-op when the condition holds: no output, no
+ * termination.
+ */
+static bool test_pass_is_silent(void)
+{
+	printf("test_pass_is_silent:\n");
+
+	shr_assert(1 == 1);
+
+	return check_bool("condition true", true, true);
+}
+
+/*
+ * Run a child that prints unterminated (buffered) output, then fails a
+ * shr_assert(). Capture everything the child writes to stdout/stderr and
+ * how it exits, to verify:
+ *  - the buffered output written before the failure was not lost, i.e.
+ *    fflush(NULL) actually flushes stdio buffers before exiting - the
+ *    exact case plain assert()/abort() gets wrong.
+ *  - the diagnostic names this file and the failing condition text.
+ *  - the process exits normally instead of being killed by a signal
+ *    (contrasts with assert()'s SIGABRT via abort()).
+ */
+static bool test_fail_flushes_and_reports(void)
+{
+	char buf[4096] = { 0 };
+	int pipefd[2];
+	ssize_t total = 0, n;
+	pid_t pid;
+	int status;
+	bool pass = true;
+
+	printf("test_fail_flushes_and_reports:\n");
+
+	if (pipe(pipefd)) {
+		printf(" - pipe() failed [FAIL]\n");
+		return false;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		printf(" - fork() failed [FAIL]\n");
+		return false;
+	}
+
+	if (pid == 0) {
+		close(pipefd[0]);
+		dup2(pipefd[1], STDOUT_FILENO);
+		dup2(pipefd[1], STDERR_FILENO);
+		close(pipefd[1]);
+
+		/* Unterminated: only survives if something flushes it. */
+		printf("marker-before-failure");
+		shr_assert(1 == 2);
+		_exit(EXIT_SUCCESS); /* unreachable */
+	}
+
+	close(pipefd[1]);
+	while (total < (ssize_t)sizeof(buf) - 1 &&
+	       (n = read(pipefd[0], buf + total, sizeof(buf) - 1 - total)) > 0)
+		total += n;
+	close(pipefd[0]);
+	buf[total] = '\0';
+
+	waitpid(pid, &status, 0);
+
+	pass &= check_bool("child exited (not signaled)", WIFEXITED(status), true);
+	if (WIFEXITED(status))
+		pass &= check_bool("child exit status nonzero", WEXITSTATUS(status) != 0, true);
+
+	pass &= check_bool("buffered output before failure survived",
+			   strstr(buf, "marker-before-failure") != NULL, true);
+	pass &= check_bool("diagnostic names this file",
+			   strstr(buf, "test-shr-assert.c") != NULL, true);
+	pass &= check_bool("diagnostic names failing condition",
+			   strstr(buf, "1 == 2") != NULL, true);
+
+	if (!pass)
+		printf(" - captured output:\n%s\n", buf);
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_pass_is_silent();
+	pass &= test_fail_flushes_and_reports();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/unit/test-global-config.c
+++ b/unit/test-global-config.c
@@ -12,7 +12,7 @@
  * unknown keys, malformed values, and a missing file.
  */
 
-#include <assert.h>
+#include <shr-assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -35,10 +35,10 @@ static char *write_temp(const char *content)
 	char *path = strdup("/tmp/nvme-cli-conf-test-XXXXXX");
 	int fd;
 
-	assert(path);
+	shr_assert(path);
 	fd = mkstemp(path);
-	assert(fd >= 0);
-	assert(write(fd, content, strlen(content)) == (ssize_t)strlen(content));
+	shr_assert(fd >= 0);
+	shr_assert(write(fd, content, strlen(content)) == (ssize_t)strlen(content));
 	close(fd);
 
 	return path;


### PR DESCRIPTION
The test code uses assert to verify return values. Because assert aborts the process immediately, it does not flush stdout and stderr. Replace it with shr_assert, which ensures that all streams are flushed before exiting. While at it, also report the file and line number where a test fails.

Fixes: #3679