### PR TITLE
solidigm-telemetry: fix UB sign-extension shift in telemetry_log_get_value

### DIFF
--- a/plugins/solidigm/solidigm-telemetry/data-area.c
+++ b/plugins/solidigm/solidigm-telemetry/data-area.c
@@ -86,8 +86,8 @@ static bool telemetry_log_get_value(const struct telemetry_log *tl,
 	if (size_bit < 64)
 		val &= (1ULL << size_bit) - 1;
 	if (is_signed) {
-		if (val >> (size_bit - 1))
-			val |= (0ULL - 1) << size_bit;
+		if (size_bit < 64 && val >> (size_bit - 1))
+			val |= ~((1ULL << size_bit) - 1);
 		*val_obj = json_object_new_int64(val);
 	} else {
 		*val_obj = json_object_new_uint64(val);


### PR DESCRIPTION
When size_bit equals 64 the expression (0ULL - 1) << size_bit shifts a
64-bit value by its full width, which is undefined behaviour in C.  Guard
the sign-extension with size_bit < 64 and use ~((1ULL << size_bit) - 1)
to build the mask safely.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>