### PR TITLE
libnvme/fabrics: handle connect separately from discover

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -455,7 +455,9 @@ static void consume_conn(const struct libnvmf_config_conn *conn,
 				MAX_DISC_RETRIES);
 		libnvmf_context_set_default_keep_alive_timeout(fctx,
 				NVMF_DEF_DISC_TMO);
-		err = libnvmf_discover(st->ctx, fctx, st->connect, st->force);
+		libnvmf_context_set_connect(fctx, st->connect);
+		libnvmf_context_set_force(fctx, st->force);
+		err = libnvmf_discover(st->ctx, fctx);
 	} else {
 		err = libnvmf_connect(st->ctx, fctx);
 	}
@@ -867,12 +869,14 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 	if (ret)
 		return ret;
 
+	libnvmf_context_set_connect(fctx, connect);
+	libnvmf_context_set_force(fctx, force);
+
 	if (epcsd)
 		libnvmf_context_set_epcsd(fctx, LIBNVMF_TRISTATE_TRUE);
 
 	if (no_epcsd)
 		libnvmf_context_set_epcsd(fctx, LIBNVMF_TRISTATE_FALSE);
-
 
 	if (persistent)
 		libnvmf_context_set_persistent(fctx, LIBNVMF_TRISTATE_TRUE);
@@ -882,8 +886,12 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 
 	if (!device && !fa.transport && !fa.traddr) {
 		if (!nonbft) {
-			ret = libnvmf_discover_nbft(ctx, fctx, connect,
-				nbft_path);
+			if (!nbft_path) {
+				nvme_show_error("no nbft_path set");
+				return -EINVAL;
+			}
+			libnvmf_context_set_nbft_path(fctx, nbft_path);
+			ret = libnvmf_discover_nbft(ctx, fctx);
 		}
 		if (!nbft && config_file)
 			ret = fabrics_discovery_config(ctx, config_file,
@@ -899,7 +907,7 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 		if (ret)
 			return 0;
 
-		ret = libnvmf_discover(ctx, fctx, connect, force);
+		ret = libnvmf_discover(ctx, fctx);
 	}
 
 	return ret;

--- a/fabrics.c
+++ b/fabrics.c
@@ -235,14 +235,14 @@ static void hook_already_connected(struct libnvmf_context *fctx,
 }
 
 static void hook_discovery_log(struct libnvmf_context *fctx,
-		bool connect, struct nvmf_discovery_log *log,
+		struct nvmf_discovery_log *log,
 		uint64_t numrec, void *user_data)
 {
 	struct hook_fabrics_data *hfd = user_data;
 
 	if (hfd->raw)
 		save_discovery_log(hfd->raw, log);
-	else if (!connect)
+	else if (!libnvmf_context_get_connect(fctx))
 		nvme_show_discovery_log(log, numrec, hfd->flags);
 }
 

--- a/fabrics.c
+++ b/fabrics.c
@@ -46,6 +46,8 @@
 
 #include <libnvme.h>
 
+#include <io-util.h>
+
 #ifdef NVME_HAVE_LIBKMOD
 #include <libkmod.h>
 #endif
@@ -144,25 +146,45 @@ void nvmf_args_to_params(struct libnvmf_params *params,
 
 static void save_discovery_log(char *raw, struct nvmf_discovery_log *log)
 {
-	uint64_t numrec = le64_to_cpu(log->numrec);
+	__cleanup_free char *path = NULL;
+	static unsigned int save_count;
 	int fd, len, ret;
+	uint64_t numrec;
 
-	fd = open(raw, O_CREAT | O_RDWR | O_TRUNC, 0600);
+	if (save_count) {
+		if (asprintf(&path, "%s.%u", raw, save_count) < 0) {
+			nvme_show_error("failed to allocate path for %s", raw);
+			return;
+		}
+	} else {
+		path = strdup(raw);
+		if (!path) {
+			nvme_show_error("failed to allocate path for %s", raw);
+			return;
+		}
+	}
+
+	fd = open(path, O_CREAT | O_RDWR | O_TRUNC, 0600);
 	if (fd < 0) {
-		nvme_show_error("failed to open %s: %s", raw, libnvme_strerror(errno));
+		nvme_show_error("failed to open %s: %s",
+			path, libnvme_strerror(errno));
 		return;
 	}
 
-	len = sizeof(struct nvmf_discovery_log) + numrec * sizeof(struct nvmf_disc_log_entry);
+	numrec = le64_to_cpu(log->numrec);
+	len = sizeof(struct nvmf_discovery_log) +
+		numrec * sizeof(struct nvmf_disc_log_entry);
 
-	ret = write(fd, log, len);
+	ret = shr_write_all(fd, log, len);
 	if (ret < 0)
 		nvme_show_error("failed to write to %s: %s",
-			raw, libnvme_strerror(errno));
+			path, libnvme_strerror(-ret));
 	else
-		nvme_show_verbose_info("Discovery log is saved to %s", raw);
+		nvme_show_verbose_info("Discovery log is saved to %s", path);
 
 	close(fd);
+
+	save_count++;
 }
 
 static int setup_common_context(struct libnvmf_context *fctx,

--- a/libnvme/src/accessors-fabrics.ld
+++ b/libnvme/src/accessors-fabrics.ld
@@ -18,8 +18,8 @@
 LIBNVMF_ACCESSORS_3 {
 	global:
 		libnvmf_context_get_concat;
-		libnvmf_context_get_ctrlkey;
 		libnvmf_context_get_ctrl_loss_tmo;
+		libnvmf_context_get_ctrlkey;
 		libnvmf_context_get_data_digest;
 		libnvmf_context_get_default_keep_alive_timeout;
 		libnvmf_context_get_default_max_discovery_retries;
@@ -30,11 +30,11 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_epcsd;
 		libnvmf_context_get_fast_io_fail_tmo;
 		libnvmf_context_get_hdr_digest;
-		libnvmf_context_get_hostid;
 		libnvmf_context_get_host_iface;
+		libnvmf_context_get_host_traddr;
+		libnvmf_context_get_hostid;
 		libnvmf_context_get_hostkey;
 		libnvmf_context_get_hostnqn;
-		libnvmf_context_get_host_traddr;
 		libnvmf_context_get_keep_alive_tmo;
 		libnvmf_context_get_keyring;
 		libnvmf_context_get_keyring_id;
@@ -55,10 +55,10 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_transport;
 		libnvmf_context_get_trsvcid;
 		libnvmf_context_set_concat;
-		libnvmf_context_set_default_keep_alive_timeout;
-		libnvmf_context_set_default_max_discovery_retries;
 		libnvmf_context_set_ctrl_loss_tmo;
 		libnvmf_context_set_data_digest;
+		libnvmf_context_set_default_keep_alive_timeout;
+		libnvmf_context_set_default_max_discovery_retries;
 		libnvmf_context_set_disable_sqflow;
 		libnvmf_context_set_duplicate_connect;
 		libnvmf_context_set_epcsd;
@@ -85,9 +85,9 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_discovery_args_set_max_retries;
 		libnvmf_tid_free;
 		libnvmf_tid_get_host_iface;
-		libnvmf_tid_get_hostnqn;
-		libnvmf_tid_get_hostid;
 		libnvmf_tid_get_host_traddr;
+		libnvmf_tid_get_hostid;
+		libnvmf_tid_get_hostnqn;
 		libnvmf_tid_get_subsysnqn;
 		libnvmf_tid_get_traddr;
 		libnvmf_tid_get_transport;

--- a/libnvme/src/accessors-fabrics.ld
+++ b/libnvme/src/accessors-fabrics.ld
@@ -18,6 +18,7 @@
 LIBNVMF_ACCESSORS_3 {
 	global:
 		libnvmf_context_get_concat;
+		libnvmf_context_get_connect;
 		libnvmf_context_get_ctrl_loss_tmo;
 		libnvmf_context_get_ctrlkey;
 		libnvmf_context_get_data_digest;
@@ -29,6 +30,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_duplicate_connect;
 		libnvmf_context_get_epcsd;
 		libnvmf_context_get_fast_io_fail_tmo;
+		libnvmf_context_get_force;
 		libnvmf_context_get_hdr_digest;
 		libnvmf_context_get_host_iface;
 		libnvmf_context_get_host_traddr;
@@ -38,6 +40,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_keep_alive_tmo;
 		libnvmf_context_get_keyring;
 		libnvmf_context_get_keyring_id;
+		libnvmf_context_get_nbft_path;
 		libnvmf_context_get_nr_io_queues;
 		libnvmf_context_get_nr_poll_queues;
 		libnvmf_context_get_nr_write_queues;
@@ -55,6 +58,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_transport;
 		libnvmf_context_get_trsvcid;
 		libnvmf_context_set_concat;
+		libnvmf_context_set_connect;
 		libnvmf_context_set_ctrl_loss_tmo;
 		libnvmf_context_set_data_digest;
 		libnvmf_context_set_default_keep_alive_timeout;
@@ -63,9 +67,11 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_set_duplicate_connect;
 		libnvmf_context_set_epcsd;
 		libnvmf_context_set_fast_io_fail_tmo;
+		libnvmf_context_set_force;
 		libnvmf_context_set_hdr_digest;
 		libnvmf_context_set_keep_alive_tmo;
 		libnvmf_context_set_keyring_id;
+		libnvmf_context_set_nbft_path;
 		libnvmf_context_set_nr_io_queues;
 		libnvmf_context_set_nr_poll_queues;
 		libnvmf_context_set_nr_write_queues;

--- a/libnvme/src/nvme/accessors-fabrics.c
+++ b/libnvme/src/nvme/accessors-fabrics.c
@@ -357,6 +357,44 @@ __shr_public const char *libnvmf_context_get_devid_file(
 	return p->devid_file;
 }
 
+__shr_public void libnvmf_context_set_connect(
+		struct libnvmf_context *p,
+		bool connect)
+{
+	p->connect = connect;
+}
+
+__shr_public bool libnvmf_context_get_connect(const struct libnvmf_context *p)
+{
+	return p->connect;
+}
+
+__shr_public void libnvmf_context_set_force(
+		struct libnvmf_context *p,
+		bool force)
+{
+	p->force = force;
+}
+
+__shr_public bool libnvmf_context_get_force(const struct libnvmf_context *p)
+{
+	return p->force;
+}
+
+__shr_public void libnvmf_context_set_nbft_path(
+		struct libnvmf_context *p,
+		const char *nbft_path)
+{
+	free(p->nbft_path);
+	p->nbft_path = nbft_path ? strdup(nbft_path) : NULL;
+}
+
+__shr_public const char *libnvmf_context_get_nbft_path(
+		const struct libnvmf_context *p)
+{
+	return p->nbft_path;
+}
+
 __shr_public const char *libnvmf_context_get_hostnqn(
 		const struct libnvmf_context *p)
 {

--- a/libnvme/src/nvme/accessors-fabrics.h
+++ b/libnvme/src/nvme/accessors-fabrics.h
@@ -467,6 +467,53 @@ enum libnvmf_tristate libnvmf_context_get_epcsd(
 const char *libnvmf_context_get_devid_file(const struct libnvmf_context *p);
 
 /**
+ * libnvmf_context_set_connect() - Set connect.
+ * @p: The &struct libnvmf_context instance to update.
+ * @connect: Value to assign to the connect field.
+ */
+void libnvmf_context_set_connect(struct libnvmf_context *p, bool connect);
+
+/**
+ * libnvmf_context_get_connect() - Get connect.
+ * @p: The &struct libnvmf_context instance to query.
+ *
+ * Return: The value of the connect field.
+ */
+bool libnvmf_context_get_connect(const struct libnvmf_context *p);
+
+/**
+ * libnvmf_context_set_force() - Set force.
+ * @p: The &struct libnvmf_context instance to update.
+ * @force: Value to assign to the force field.
+ */
+void libnvmf_context_set_force(struct libnvmf_context *p, bool force);
+
+/**
+ * libnvmf_context_get_force() - Get force.
+ * @p: The &struct libnvmf_context instance to query.
+ *
+ * Return: The value of the force field.
+ */
+bool libnvmf_context_get_force(const struct libnvmf_context *p);
+
+/**
+ * libnvmf_context_set_nbft_path() - Set nbft_path.
+ * @p: The &struct libnvmf_context instance to update.
+ * @nbft_path: New string; a copy is stored. Pass NULL to clear.
+ */
+void libnvmf_context_set_nbft_path(
+		struct libnvmf_context *p,
+		const char *nbft_path);
+
+/**
+ * libnvmf_context_get_nbft_path() - Get nbft_path.
+ * @p: The &struct libnvmf_context instance to query.
+ *
+ * Return: The value of the nbft_path field, or NULL if not set.
+ */
+const char *libnvmf_context_get_nbft_path(const struct libnvmf_context *p);
+
+/**
  * libnvmf_context_get_hostnqn() - Get hostnqn.
  * @p: The &struct libnvmf_context instance to query.
  *

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -587,7 +587,6 @@ __shr_public void libnvmf_context_free(struct libnvmf_context *fctx)
 __shr_public int libnvmf_context_set_discovery_hooks(
 		struct libnvmf_context *fctx,
 		void (*discovery_log)(struct libnvmf_context *fctx,
-			bool connect,
 			struct nvmf_discovery_log *log,
 			uint64_t numrec, void *user_data))
 {
@@ -2590,7 +2589,6 @@ static void nvme_parse_tls_args(const char *keyring, const char *tls_key,
 	}
 }
 
-
 static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, bool connect,
 		struct libnvme_ctrl *c)
@@ -2629,7 +2627,7 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 	}
 
 	if (fctx->hooks.discovery_log)
-		fctx->hooks.discovery_log(fctx, connect, log, numrec,
+		fctx->hooks.discovery_log(fctx, log, numrec,
 			fctx->hooks.user_data);
 
 	if (!connect)

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2590,8 +2590,7 @@ static void nvme_parse_tls_args(const char *keyring, const char *tls_key,
 }
 
 static int _nvmf_discover(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, bool connect,
-		struct libnvme_ctrl *c)
+		struct libnvmf_context *fctx, struct libnvme_ctrl *c)
 {
 	__cleanup_free struct nvmf_discovery_log *log = NULL;
 	libnvme_subsystem_t s = libnvme_ctrl_get_subsystem(c);
@@ -2629,9 +2628,6 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 	if (fctx->hooks.discovery_log)
 		fctx->hooks.discovery_log(fctx, log, numrec,
 			fctx->hooks.user_data);
-
-	if (!connect)
-		return 0;
 
 	for (int i = 0; i < numrec; i++) {
 		struct nvmf_disc_log_entry *e = &log->entries[i];
@@ -2690,6 +2686,9 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 			set_discovery_kato(&nfctx);
 		} else {
 			/* NVME_NQN_NVME */
+
+			if (!fctx->connect)
+				continue;
 			disconnect = false;
 		}
 
@@ -2699,7 +2698,7 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 
 		if (child) {
 			if (discover)
-				_nvmf_discover(ctx, &nfctx, true, child);
+				_nvmf_discover(ctx, &nfctx, child);
 
 			if (disconnect) {
 				libnvmf_disconnect_ctrl(child);
@@ -3525,7 +3524,7 @@ __shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
 		}
 	}
 
-	ret = _nvmf_discover(ctx, fctx, fctx->connect, c);
+	ret = _nvmf_discover(ctx, fctx, c);
 	if (fctx->persistent != LIBNVMF_TRISTATE_TRUE)
 		libnvmf_disconnect_ctrl(c);
 	libnvme_free_ctrl(c);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -577,6 +577,7 @@ __shr_public void libnvmf_context_free(struct libnvmf_context *fctx)
 	if (!fctx)
 		return;
 
+	free(fctx->nbft_path);
 	free(fctx->hostnqn);
 	free(fctx->hostid);
 	free(fctx->tls_key);
@@ -3171,7 +3172,7 @@ static char *nbft_find_hfi_iface(struct libnbft_hfi *hfi)
 }
 
 __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, bool connect, char *nbft_path)
+		struct libnvmf_context *fctx)
 {
 	const char *hostnqn = NULL, *hostid = NULL, *host_traddr = NULL;
 	char uuid[NVME_UUID_LEN_STRING];
@@ -3182,6 +3183,9 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 	struct libnvme_host *h;
 	int ret, rr, i;
 
+	if (!fctx->nbft_path)
+		return -EINVAL;
+
 	ret = libnvme_get_host(ctx, fctx->hostnqn, fctx->hostid, &h);
 	if (ret)
 		return ret;
@@ -3190,11 +3194,11 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 	if (ret)
 		return ret;
 
-	if (!connect)
+	if (!fctx->connect)
 		/* TODO: print discovery-type info from NBFT tables */
 		return 0;
 
-	ret = libnvmf_nbft_read_files(ctx, nbft_path, &entry);
+	ret = libnvmf_nbft_read_files(ctx, fctx->nbft_path, &entry);
 	if (ret) {
 		if (ret != -ENOENT)
 			libnvme_msg(ctx, LIBNVME_LOG_ERR,
@@ -3426,9 +3430,8 @@ out_free:
 	return ret;
 }
 
-__shr_public int libnvmf_discover(
-		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
-		bool connect, bool force)
+__shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
+		struct libnvmf_context *fctx)
 {
 	struct libnvme_ctrl *c = NULL;
 	struct libnvme_host *h;
@@ -3442,7 +3445,7 @@ __shr_public int libnvmf_discover(
 	if (ret)
 		return ret;
 
-	if (fctx->device && !force) {
+	if (fctx->device && !fctx->force) {
 		ret = libnvme_scan_ctrl(ctx, fctx->device, &c);
 		if (!ret) {
 			/* Check if device matches command-line options */
@@ -3498,7 +3501,7 @@ __shr_public int libnvmf_discover(
 		}
 	}
 
-	if (!c && !force) {
+	if (!c && !fctx->force) {
 		c = lookup_ctrl(h, fctx);
 		if (c) {
 			fctx->persistent = LIBNVMF_TRISTATE_TRUE;
@@ -3524,7 +3527,7 @@ __shr_public int libnvmf_discover(
 		}
 	}
 
-	ret = _nvmf_discover(ctx, fctx, connect, c);
+	ret = _nvmf_discover(ctx, fctx, fctx->connect, c);
 	if (fctx->persistent != LIBNVMF_TRISTATE_TRUE)
 		libnvmf_disconnect_ctrl(c);
 	libnvme_free_ctrl(c);

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -386,7 +386,7 @@ void libnvmf_context_free(struct libnvmf_context *fctx);
  */
 int libnvmf_context_set_discovery_hooks(struct libnvmf_context *fctx,
 		void (*discovery_log)(struct libnvmf_context *fctx,
-			bool connect, struct nvmf_discovery_log *log,
+			struct nvmf_discovery_log *log,
 			uint64_t numrec, void *user_data));
 
 /**

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -582,29 +582,25 @@ int libnvmf_get_owner_from_fctx(struct libnvme_global_ctx *ctx,
  * libnvmf_discover() - Discover fabrics subsystems
  * @ctx: Global context
  * @fctx: Fabrics context
- * @connect: Whether to connect discovered subsystems
- * @force: Force discovery even if already connected
  *
  * Performs discovery for fabrics subsystems and optionally connects.
  *
  * Return: 0 on success, negative error code otherwise.
  */
 int libnvmf_discover(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, bool connect, bool force);
+		struct libnvmf_context *fctx);
 
 /**
  * libnvmf_discover_nbft() - Discover fabrics subsystems using NBFT
  * @ctx: Global context
  * @fctx: Fabrics context
- * @connect: Whether to connect discovered subsystems
- * @nbft_path: Path to NBFT file
  *
- * Performs discovery using the specified NBFT file.
+ * Performs discovery using the NBFT tables found at @fctx's nbft_path.
  *
  * Return: 0 on success, negative error code otherwise.
  */
 int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, bool connect, char *nbft_path);
+		struct libnvmf_context *fctx);
 
 /**
  * libnvmf_create_ctrl() - Allocate an unconnected NVMe controller

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -29,7 +29,6 @@ struct libnvmf_hooks {
 
 	/* discovery hooks */
 	void (*discovery_log)(struct libnvmf_context *fctx,
-			bool connect,
 			struct nvmf_discovery_log *log,
 			uint64_t numrec, void *user_data);
 

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -38,7 +38,7 @@ struct libnvmf_hooks {
 
 struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 	struct libnvme_global_ctx *ctx;
-	struct libnvmf_hooks hooks; // !access:read=none,write=none
+	struct libnvmf_hooks hooks;	// !access:read=none,write=none
 
 	/* NVMe controller parameters */
 	struct libnvme_ctrl_params ctrl_params; // !access:nested
@@ -51,18 +51,18 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 	const char *device;
 	enum libnvmf_tristate persistent;
 	enum libnvmf_tristate epcsd;
-	const char *devid_file; // !access:write=custom
+	const char *devid_file;		// !access:write=custom
 
 	/* host configuration */
-	char *hostnqn; // !access:write=custom
-	char *hostid;  // !access:write=custom
+	char *hostnqn;			// !access:write=custom
+	char *hostid;			// !access:write=custom
 
 	/* authentication and transport encryption configuration */
-	const char *hostkey;          // !access:write=custom
-	const char *ctrlkey;          // !access:write=custom
-	const char *keyring;          // !access:write=custom
-	char *tls_key;                // !access:write=custom
-	const char *tls_key_identity; // !access:write=custom
+	const char *hostkey;		// !access:write=custom
+	const char *ctrlkey;		// !access:write=custom
+	const char *keyring;		// !access:write=custom
+	char *tls_key;			// !access:write=custom
+	const char *tls_key_identity;	// !access:write=custom
 };
 
 /**

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -53,6 +53,11 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 	enum libnvmf_tristate epcsd;
 	const char *devid_file;		// !access:write=custom
 
+	/* discovery invocation options */
+	bool connect;			// !access
+	bool force;			// !access
+	char *nbft_path;		// !access
+
 	/* host configuration */
 	char *hostnqn;			// !access:write=custom
 	char *hostid;			// !access:write=custom


### PR DESCRIPTION
connect-all uses the discover APIs to connect to all I/O
controllers. The connect argument of _nvmf_discover is currently
used for both discovery and connection.

_nvmf_discover should always iterate over all discovery entries.
It implicitly assumes that child discovery controllers are connected
first. Therefore, _nvmf_discover does not need a connect
argument.

For the connect-all case, use the user's explicit request to connect
or not connect to all I/O controllers.

Supersede: #3720 