### PR TITLE
ocp: fix resource leak of description in parse_event_fifo

### DIFF
--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1098,7 +1098,8 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 
 	if (status != 0) {
 		nvme_show_error("Failed to get C9 String. status: %d", status);
-		return -1;
+		ret = -1;
+		goto free_desc;
 	}
 
 	char event_fifo_name[100] = {0};


### PR DESCRIPTION
When parse_ocp_telemetry_string_log() returns an error, the function exits early via return -1 without freeing the heap-allocated description buffer (malloc'd 41 bytes earlier). The existing free(description) under the free_desc label is not reached by this code path.

Set ret = -1 and goto free_desc instead of returning directly, so all cleanup is handled centrally at the existing free_desc label, consistent with other error paths in the same function.

Fixes Coverity CID 557340 (RESOURCE_LEAK).