### PR TITLE
nvme-print: fix untrusted loop bounds in json_nvme_fdp_configs()

### DIFF
--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2527,8 +2527,9 @@ static void json_nvme_fdp_configs(struct nvme_fdp_config_log *log, size_t len)
 
 	obj_add_uint(r, "n", n);
 
-	for (int i = 0; i < n + 1; i++) {
+	for (int i = 0; i < n; i++) {
 		struct nvme_fdp_config_desc *config = p;
+		uint16_t nruh = le16_to_cpu(config->nruh);
 
 		struct json_object *obj_config = json_create_object();
 		struct json_object *obj_ruhs = json_create_array();
@@ -2536,12 +2537,12 @@ static void json_nvme_fdp_configs(struct nvme_fdp_config_log *log, size_t len)
 		obj_add_uint(obj_config, "fdpa", config->fdpa);
 		obj_add_uint(obj_config, "vss", config->vss);
 		obj_add_uint(obj_config, "nrg", le32_to_cpu(config->nrg));
-		obj_add_uint(obj_config, "nruh", le16_to_cpu(config->nruh));
+		obj_add_uint(obj_config, "nruh", nruh);
 		obj_add_uint(obj_config, "nnss", le32_to_cpu(config->nnss));
 		obj_add_uint64(obj_config, "runs", le64_to_cpu(config->runs));
 		obj_add_uint(obj_config, "erutl", le32_to_cpu(config->erutl));
 
-		for (int j = 0; j < le16_to_cpu(config->nruh); j++) {
+		for (int j = 0; j < nruh; j++) {
 			struct nvme_fdp_ruh_desc *ruh = &config->ruhs[j];
 
 			struct json_object *obj_ruh = json_create_object();


### PR DESCRIPTION
The json_nvme_fdp_configs() function iterates over FDP configuration descriptors using n as the loop bound, where n is read from the device-supplied log page field log->n. The outer loop used n + 1 as its bound, iterating one past the number of configurations reported by the device.

Iterating beyond the allocated buffer results in out-of-bounds memory access and undefined behavior.

The inner loop used le16_to_cpu(config->nruh) directly as a loop bound, re-evaluating the device-supplied field on each iteration. Reading a device-controlled value as an unsanitized loop bound is a tainted scalar defect.

Fix the outer loop to iterate exactly n times. Extract nruh into a local variable before the inner loop to make it clear the value is read once and used as a sanitized loop bound.