### PR TITLE
nvme: fix negative errno passed to libnvme_strerror in get_register_properties

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -6098,7 +6098,7 @@ static int get_register_properties(struct libnvme_transport_handle *hdl, void **
 		if (nvme_status_equals(err, NVME_STATUS_TYPE_NVME, NVME_SC_INVALID_FIELD)) {
 			value = -1;
 		} else if (err) {
-			nvme_show_error("get-property: %s", libnvme_strerror(err));
+			nvme_show_error("get-property: %s", libnvme_strerror(-err));
 			free(bar);
 			return err;
 		} else {


### PR DESCRIPTION
libnvme_exec_admin_passthru() can return a negative errno value.
Passing that negative value directly to libnvme_strerror(), which
expects a non-negative code, produces an incorrect error string.
Negate err before passing it to libnvme_strerror() to produce the
correct human-readable error string.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>