### PR TITLE
libnvme: check return value of libnvmf_tid_set_identity in test

### DIFF
--- a/libnvme/test/test-tid.c
+++ b/libnvme/test/test-tid.c
@@ -393,7 +393,9 @@ static bool test_tid_setter_invalidates_cache(void)
 	/* Prime the cache, mutate via set_identity, confirm it rebuilt. */
 	snprintf(before, sizeof(before), "%s", libnvmf_tid_get_canonical(t));
 
-	libnvmf_tid_set_identity(t, "nqn.sub", NULL, NULL);
+	p = libnvmf_tid_set_identity(t, "nqn.sub", NULL, NULL) == 0;
+	CHECK(p, "set_identity succeeds");
+	pass &= p;
 
 	after = libnvmf_tid_get_canonical(t);
 	p = after && !streq(before, after) && strstr(after, "nqn=nqn.sub");


### PR DESCRIPTION
The call to libnvmf_tid_set_identity() in
test_tid_setter_invalidates_cache() did not check the return value,
unlike all other call sites in the same file. Add the check so a
failure is reported explicitly rather than silently producing a
misleading cache-invalidation test result.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>