### PR TITLE
fabrics: fix JSON error-severity bugs in connect/verbose messages

### DIFF
--- a/fabrics.c
+++ b/fabrics.c
@@ -1095,8 +1095,13 @@ do_connect:
 	if (idempotent && (ret == -EALREADY || ret == -ENVME_CONNECT_ALREADY))
 		ret = 0;
 	if (ret) {
-		nvme_show_error("failed to connect: %s",
-			libnvme_strerror(-ret));
+		/*
+		 * hook_already_connected() already reported the specific
+		 * reason; the generic message here would just overwrite it.
+		 */
+		if (ret != -EALREADY && ret != -ENVME_CONNECT_ALREADY)
+			nvme_show_error("failed to connect: %s",
+				libnvme_strerror(-ret));
 		return ret;
 	}
 

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1761,7 +1761,7 @@ void nvme_show_verbose_message(const char *msg, ...)
 
 	va_start(ap, msg);
 
-	show_message(true, msg, ap);
+	show_message(false, msg, ap);
 
 	va_end(ap);
 }


### PR DESCRIPTION
Fixes two JSON-message bugs reported in #3721, both in the message layer, not `--idempotent` itself:

1. `connect()` clobbered `hook_already_connected()`'s specific message  with a generic "failed to connect: %s" fallback whenever `libnvmf_connect()` returned `-EALREADY`/`-ENVME_CONNECT_ALREADY` --  in `-o json` this overwrote the single mutable `"error"` key, and    everywhere else it replaced a useful message with "Operation already in progress".
2. `nvme_show_verbose_message()` hardcoded `error=true`, so `nvme_show_verbose_info()`/`nvme_show_verbose_result()` -- meant to be the non-error, verbose-only counterparts to `nvme_show_error()` -- rendered as `{"error": ...}` in JSON for a successful no-op. Not connect-specific; reproduces standalone with any `-vv -o json` combination.

Fixes: #3721
