### PR TITLE
nvme / libnvme: rename discovery to discover

### DIFF
--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -91,9 +91,9 @@ OPTIONS
 	Suppress already connected errors.
 
 --force::
-	Disable the built-in persistent discover connection rules.
-	Combined with --persistent flag, always create new
-	persistent discovery connection.
+	Disable the built-in persistent discovery controller connection
+	rules. Combined with --persistent flag, always create new
+	persistent discovery controller connection.
 
 --nbft::
 	Only look at NBFT tables

--- a/fabrics.c
+++ b/fabrics.c
@@ -455,7 +455,7 @@ static void consume_conn(const struct libnvmf_config_conn *conn,
 				MAX_DISC_RETRIES);
 		libnvmf_context_set_default_keep_alive_timeout(fctx,
 				NVMF_DEF_DISC_TMO);
-		err = libnvmf_discovery(st->ctx, fctx, st->connect, st->force);
+		err = libnvmf_discover(st->ctx, fctx, st->connect, st->force);
 	} else {
 		err = libnvmf_connect(st->ctx, fctx);
 	}
@@ -755,7 +755,7 @@ static int check_ctrl_owner(struct libnvme_global_ctx *ctx,
 	return 1;
 }
 
-int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
+int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 {
 	__cleanup_free char *hnqn = NULL;
 	__cleanup_free char *hid = NULL;
@@ -882,7 +882,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 
 	if (!device && !fa.transport && !fa.traddr) {
 		if (!nonbft) {
-			ret = libnvmf_discovery_nbft(ctx, fctx, connect,
+			ret = libnvmf_discover_nbft(ctx, fctx, connect,
 				nbft_path);
 		}
 		if (!nbft && config_file)
@@ -899,7 +899,7 @@ int fabrics_discovery(const char *desc, int argc, char **argv, bool connect)
 		if (ret)
 			return 0;
 
-		ret = libnvmf_discovery(ctx, fctx, connect, force);
+		ret = libnvmf_discover(ctx, fctx, connect, force);
 	}
 
 	return ret;

--- a/fabrics.h
+++ b/fabrics.h
@@ -109,7 +109,7 @@ struct nvmf_args {
 		##__VA_ARGS__                                                                    \
 	)
 
-int fabrics_discovery(const char *desc, int argc, char **argv, bool connect);
+int fabrics_discover(const char *desc, int argc, char **argv, bool connect);
 int fabrics_connect(const char *desc, int argc, char **argv);
 int fabrics_disconnect(const char *desc, int argc, char **argv);
 int fabrics_disconnect_all(const char *desc, int argc, char **argv);
@@ -134,7 +134,7 @@ void nvmf_args_to_params(struct libnvmf_params *params,
 /*
  * Legacy config.json/discovery.conf support -- both the explicit converter
  * ("nvme config-convert", config-convert.c/.h) and the implicit fallback
- * (fabrics_discovery()/fabrics_connect() auto-converting these files before
+ * (fabrics_discover()/fabrics_connect() auto-converting these files before
  * reading the INI) go away together when legacy config support is
  * eventually dropped; this section (and nvmf_convert_discovery_line() in
  * fabrics.c) goes with them.

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -45,8 +45,8 @@ LIBNVMF_3 {
 		libnvmf_create_raw_secret;
 		libnvmf_describe_key_serial;
 		libnvmf_disconnect_ctrl;
-		libnvmf_discovery;
-		libnvmf_discovery_nbft;
+		libnvmf_discover;
+		libnvmf_discover_nbft;
 		libnvmf_eflags_str;
 		libnvmf_exat_ptr_next;
 		libnvmf_exclusion_add;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2590,7 +2590,7 @@ static void nvme_parse_tls_args(const char *keyring, const char *tls_key,
 }
 
 
-static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
+static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, bool connect,
 		struct libnvme_ctrl *c)
 {
@@ -2700,7 +2700,7 @@ static int _nvmf_discovery(struct libnvme_global_ctx *ctx,
 
 		if (child) {
 			if (discover)
-				_nvmf_discovery(ctx, &nfctx, true, child);
+				_nvmf_discover(ctx, &nfctx, true, child);
 
 			if (disconnect) {
 				libnvmf_disconnect_ctrl(child);
@@ -3170,7 +3170,7 @@ static char *nbft_find_hfi_iface(struct libnbft_hfi *hfi)
 	return result;
 }
 
-__shr_public int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
+__shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, bool connect, char *nbft_path)
 {
 	const char *hostnqn = NULL, *hostid = NULL, *host_traddr = NULL;
@@ -3426,7 +3426,7 @@ out_free:
 	return ret;
 }
 
-__shr_public int libnvmf_discovery(
+__shr_public int libnvmf_discover(
 		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
 		bool connect, bool force)
 {
@@ -3524,7 +3524,7 @@ __shr_public int libnvmf_discovery(
 		}
 	}
 
-	ret = _nvmf_discovery(ctx, fctx, connect, c);
+	ret = _nvmf_discover(ctx, fctx, connect, c);
 	if (fctx->persistent != LIBNVMF_TRISTATE_TRUE)
 		libnvmf_disconnect_ctrl(c);
 	libnvme_free_ctrl(c);

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -579,7 +579,7 @@ int libnvmf_get_owner_from_fctx(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, char **owner);
 
 /**
- * libnvmf_discovery() - Perform fabrics discovery
+ * libnvmf_discover() - Discover fabrics subsystems
  * @ctx: Global context
  * @fctx: Fabrics context
  * @connect: Whether to connect discovered subsystems
@@ -589,11 +589,11 @@ int libnvmf_get_owner_from_fctx(struct libnvme_global_ctx *ctx,
  *
  * Return: 0 on success, negative error code otherwise.
  */
-int libnvmf_discovery(struct libnvme_global_ctx *ctx,
+int libnvmf_discover(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, bool connect, bool force);
 
 /**
- * libnvmf_discovery_nbft() - Perform discovery using NBFT
+ * libnvmf_discover_nbft() - Discover fabrics subsystems using NBFT
  * @ctx: Global context
  * @fctx: Fabrics context
  * @connect: Whether to connect discovered subsystems
@@ -603,7 +603,7 @@ int libnvmf_discovery(struct libnvme_global_ctx *ctx,
  *
  * Return: 0 on success, negative error code otherwise.
  */
-int libnvmf_discovery_nbft(struct libnvme_global_ctx *ctx,
+int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, bool connect, char *nbft_path);
 
 /**

--- a/libnvme/src/nvme/nvme-cmds-fabrics.h
+++ b/libnvme/src/nvme/nvme-cmds-fabrics.h
@@ -53,7 +53,7 @@ nvme_init_get_log_discovery(struct libnvme_passthru_cmd *cmd,
  */
 static inline void
 nvme_init_get_log_host_discovery(struct libnvme_passthru_cmd *cmd,
-		bool allhoste, struct nvme_host_discover_log *log, __u32 len)
+		bool allhoste, struct nvme_host_discovery_log *log, __u32 len)
 {
 	nvme_init_get_log(cmd, NVME_NSID_ALL,
 		NVME_LOG_LID_HOST_DISCOVERY, NVME_CSI_NVM,
@@ -75,7 +75,7 @@ nvme_init_get_log_host_discovery(struct libnvme_passthru_cmd *cmd,
  */
 static inline void
 nvme_init_get_log_ave_discovery(struct libnvme_passthru_cmd *cmd,
-		struct nvme_ave_discover_log *log, __u32 len)
+		struct nvme_ave_discovery_log *log, __u32 len)
 {
 	nvme_init_get_log(cmd, NVME_NSID_ALL,
 		NVME_LOG_LID_AVE_DISCOVERY, NVME_CSI_NVM,

--- a/libnvme/src/nvme/nvme-types-fabrics.h
+++ b/libnvme/src/nvme/nvme-types-fabrics.h
@@ -530,7 +530,7 @@ struct nvmf_connect_data {
 };
 
 /**
- * struct nvme_host_ext_discover_log - Host Extended Discovery Log
+ * struct nvme_host_ext_discovery_log - Host Extended Discovery Log
  * @trtype:	Transport Type
  * @adrfam:	Address Family
  * @rsvd2:	Reserved
@@ -544,7 +544,7 @@ struct nvmf_connect_data {
  * @rsvd1030:	Reserved
  * @exat:	Extended Attributes List
  */
-struct nvme_host_ext_discover_log {
+struct nvme_host_ext_discovery_log {
 	__u8			trtype;
 	__u8			adrfam;
 	__u8			rsvd2[8];
@@ -560,7 +560,7 @@ struct nvme_host_ext_discover_log {
 };
 
 /**
- * struct nvme_host_discover_log - Host Discovery Log
+ * struct nvme_host_discovery_log - Host Discovery Log
  * @genctr:	Generation Counter
  * @numrec:	Number of Records
  * @recfmt:	Record Format
@@ -570,7 +570,7 @@ struct nvme_host_ext_discover_log {
  * @rsvd24:	Reserved
  * @hedlpe:	Host Extended Discovery Log Page Entry List
  */
-struct nvme_host_discover_log {
+struct nvme_host_discovery_log {
 	__le64					genctr;
 	__le64					numrec;
 	__le16					recfmt;
@@ -578,7 +578,7 @@ struct nvme_host_discover_log {
 	__u8					rsvd19;
 	__le32					thdlpl;
 	__u8					rsvd24[1000];
-	struct nvme_host_ext_discover_log	hedlpe[];
+	struct nvme_host_ext_discovery_log	hedlpe[];
 };
 
 /**
@@ -596,14 +596,14 @@ struct nvme_ave_tr_record {
 };
 
 /**
- * struct nvme_ave_discover_log_entry - AVE Discovery Log Entry
+ * struct nvme_ave_discovery_log_entry - AVE Discovery Log Entry
  * @tel:	Total Entry Length
  * @avenqn:	AVE NQN
  * @numatr:	Number of AVE Transport Records
  * @rsvd229:	Reserved
  * @atr:	AVE Transport Record List
  */
-struct nvme_ave_discover_log_entry {
+struct nvme_ave_discovery_log_entry {
 	__le32				tel;
 	char				avenqn[224];
 	__u8				numatr;
@@ -612,7 +612,7 @@ struct nvme_ave_discover_log_entry {
 };
 
 /**
- * struct nvme_ave_discover_log - AVE Discovery Log
+ * struct nvme_ave_discovery_log - AVE Discovery Log
  * @genctr:	Generation Counter
  * @numrec:	Number of Records
  * @recfmt:	Record Format
@@ -621,13 +621,13 @@ struct nvme_ave_discover_log_entry {
  * @rsvd24:	Reserved
  * @adlpe:	AVE Discovery Log Page Entry List
  */
-struct nvme_ave_discover_log {
+struct nvme_ave_discovery_log {
 	__le64					genctr;
 	__le64					numrec;
 	__le16					recfmt;
 	__u8					rsvd18[2];
 	__le32					tadlpl;
 	__u8					rsvd24[1000];
-	struct nvme_ave_discover_log_entry	adlpe[];
+	struct nvme_ave_discovery_log_entry	adlpe[];
 };
 

--- a/libnvme/test/ioctl/logs.c
+++ b/libnvme/test/ioctl/logs.c
@@ -870,9 +870,9 @@ static void test_get_log_discovery(void)
 	cmp(&log, &expected_log, sizeof(log), "incorrect log data");
 }
 
-static void test_get_log_host_discover(void)
+static void test_get_log_host_discovery(void)
 {
-	struct nvme_host_discover_log expected_log, log = {};
+	struct nvme_host_discovery_log expected_log, log = {};
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_get_log_page,
 		.nsid = NVME_NSID_ALL,
@@ -896,9 +896,9 @@ static void test_get_log_host_discover(void)
 	cmp(&log, &expected_log, sizeof(log), "incorrect log data");
 }
 
-static void test_get_log_ave_discover(void)
+static void test_get_log_ave_discovery(void)
 {
-	struct nvme_ave_discover_log expected_log, log = {};
+	struct nvme_ave_discovery_log expected_log, log = {};
 	struct mock_cmd mock_admin_cmd = {
 		.opcode = nvme_admin_get_log_page,
 		.nsid = NVME_NSID_ALL,
@@ -1142,8 +1142,8 @@ int main(void)
 	RUN_TEST(get_log_reachability_associations);
 	RUN_TEST(get_log_changed_alloc_ns);
 	RUN_TEST(get_log_discovery);
-	RUN_TEST(get_log_host_discover);
-	RUN_TEST(get_log_ave_discover);
+	RUN_TEST(get_log_host_discovery);
+	RUN_TEST(get_log_ave_discovery);
 	RUN_TEST(get_log_pull_model_ddc_req);
 	RUN_TEST(get_log_media_unit_stat);
 	RUN_TEST(get_log_support_cap_config_list);

--- a/nvme-cmds.h
+++ b/nvme-cmds.h
@@ -1283,7 +1283,7 @@ nvme_get_log_discovery(struct libnvme_transport_handle *hdl,
  * @hdl:	Transport handle for the controller.
  * @rae:	Retain asynchronous events
  * @allhoste:	All Host Entries. Set to true to report all host entries.
- * @log:	Pointer to the buffer (@struct nvme_host_discover_log)
+ * @log:	Pointer to the buffer (@struct nvme_host_discovery_log)
  *		where the log page data will be stored.
  * @len:	Length of the buffer provided in @log.
  *
@@ -1299,7 +1299,7 @@ nvme_get_log_discovery(struct libnvme_transport_handle *hdl,
 static inline int
 nvme_get_log_host_discovery(struct libnvme_transport_handle *hdl,
 			   bool rae, bool allhoste,
-			   struct nvme_host_discover_log *log, __u32 len)
+			   struct nvme_host_discovery_log *log, __u32 len)
 {
 	struct libnvme_passthru_cmd cmd;
 
@@ -1313,7 +1313,7 @@ nvme_get_log_host_discovery(struct libnvme_transport_handle *hdl,
  * Group (AVE) Discovery Log Page
  * @hdl:	Transport handle for the controller.
  * @rae:	Retain asynchronous events
- * @log:	Pointer to the buffer (@struct nvme_ave_discover_log) where
+ * @log:	Pointer to the buffer (@struct nvme_ave_discovery_log) where
  *		the log page data will be stored.
  * @len:	Length of the buffer provided in @log.
  *
@@ -1325,7 +1325,7 @@ nvme_get_log_host_discovery(struct libnvme_transport_handle *hdl,
  */
 static inline int
 nvme_get_log_ave_discovery(struct libnvme_transport_handle *hdl,
-		bool rae, struct nvme_ave_discover_log *log, __u32 len)
+		bool rae, struct nvme_ave_discovery_log *log, __u32 len)
 {
 	struct libnvme_passthru_cmd cmd;
 

--- a/nvme-print-binary.c
+++ b/nvme-print-binary.c
@@ -332,12 +332,12 @@ static void binary_reachability_associations_log(struct nvme_reachability_associ
 	d_raw((unsigned char *)log, len);
 }
 
-static void binary_host_discovery_log(struct nvme_host_discover_log *log)
+static void binary_host_discovery_log(struct nvme_host_discovery_log *log)
 {
 	d_raw((unsigned char *)log, le32_to_cpu(log->thdlpl));
 }
 
-static void binary_ave_discovery_log(struct nvme_ave_discover_log *log)
+static void binary_ave_discovery_log(struct nvme_ave_discovery_log *log)
 {
 	d_raw((unsigned char *)log, le32_to_cpu(log->tadlpl));
 }

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -5571,12 +5571,12 @@ static void json_reachability_associations_log(struct nvme_reachability_associat
 }
 
 #ifdef CONFIG_FABRICS
-static void json_host_discovery_log(struct nvme_host_discover_log *log)
+static void json_host_discovery_log(struct nvme_host_discovery_log *log)
 {
 	struct json_object *r = json_r;
 	__u32 i;
 	__u16 j;
-	struct nvme_host_ext_discover_log *hedlpe;
+	struct nvme_host_ext_discovery_log *hedlpe;
 	struct nvmf_ext_attr *exat;
 	__u32 thdlpl = le32_to_cpu(log->thdlpl);
 	__u32 tel;
@@ -5661,12 +5661,12 @@ static void obj_add_traddr(struct json_object *o, const char *k, __u8 adrfam, __
 		obj_add_str(o, k, dst);
 }
 
-static void json_ave_discovery_log(struct nvme_ave_discover_log *log)
+static void json_ave_discovery_log(struct nvme_ave_discovery_log *log)
 {
 	struct json_object *r = json_r;
 	__u32 i;
 	__u8 j;
-	struct nvme_ave_discover_log_entry *adlpe;
+	struct nvme_ave_discovery_log_entry *adlpe;
 	struct nvme_ave_tr_record *atr;
 	__u32 tadlpl = le32_to_cpu(log->tadlpl);
 	__u32 tel;
@@ -5705,8 +5705,8 @@ static void json_ave_discovery_log(struct nvme_ave_discover_log *log)
 	}
 }
 #else
-static void json_host_discovery_log(struct nvme_host_discover_log *log) {}
-static void json_ave_discovery_log(struct nvme_ave_discover_log *log) {}
+static void json_host_discovery_log(struct nvme_host_discovery_log *log) {}
+static void json_ave_discovery_log(struct nvme_ave_discovery_log *log) {}
 #endif
 
 static void json_pull_model_ddc_req_log(struct nvme_pull_model_ddc_req_log *log)

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -6660,7 +6660,7 @@ static void stdout_print_conn(const struct libnvmf_config_conn *conn,
 			hostnqn, hostid, &tid);
 
 	/*
-	 * A DC entry is consumed via libnvmf_discovery() (log in, fetch the
+	 * A DC entry is consumed via libnvmf_discover() (log in, fetch the
 	 * discovery log, connect everything returned) -- "nvme connect-all"
 	 * is its real equivalent, not a bare "nvme connect" (which would
 	 * only open the admin queue, matching just the niche "connect -J"

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -6800,11 +6800,11 @@ static void stdout_reachability_associations_log(struct nvme_reachability_associ
 }
 
 #ifdef CONFIG_FABRICS
-static void stdout_host_discovery_log(struct nvme_host_discover_log *log)
+static void stdout_host_discovery_log(struct nvme_host_discovery_log *log)
 {
 	__u32 i;
 	__u16 j;
-	struct nvme_host_ext_discover_log *hedlpe;
+	struct nvme_host_ext_discovery_log *hedlpe;
 	struct nvmf_ext_attr *exat;
 	__u32 thdlpl = le32_to_cpu(log->thdlpl);
 	__u32 tel;
@@ -6881,11 +6881,11 @@ static void print_traddr(char *field, __u8 adrfam, __u8 *traddr)
 		printf("%s: %s\n", field, dst);
 }
 
-static void stdout_ave_discovery_log(struct nvme_ave_discover_log *log)
+static void stdout_ave_discovery_log(struct nvme_ave_discovery_log *log)
 {
 	__u32 i;
 	__u8 j;
-	struct nvme_ave_discover_log_entry *adlpe;
+	struct nvme_ave_discovery_log_entry *adlpe;
 	struct nvme_ave_tr_record *atr;
 	__u32 tadlpl = le32_to_cpu(log->tadlpl);
 	__u32 tel;
@@ -6917,8 +6917,8 @@ static void stdout_ave_discovery_log(struct nvme_ave_discover_log *log)
 	}
 }
 #else
-static void stdout_host_discovery_log(struct nvme_host_discover_log *log) {}
-static void stdout_ave_discovery_log(struct nvme_ave_discover_log *log) {}
+static void stdout_host_discovery_log(struct nvme_host_discovery_log *log) {}
+static void stdout_ave_discovery_log(struct nvme_ave_discovery_log *log) {}
 #endif
 
 static void stdout_pull_model_ddc_req_log(struct nvme_pull_model_ddc_req_log *log)
@@ -7188,10 +7188,12 @@ static void stdout_log(const char *devname, struct nvme_get_log_args *args)
 		stdout_discovery_log(discovery_log, le64_to_cpu(discovery_log->numrec));
 		break;
 	case NVME_LOG_LID_HOST_DISCOVERY:
-		stdout_host_discovery_log((struct nvme_host_discover_log *)args->log);
+		stdout_host_discovery_log(
+			(struct nvme_host_discovery_log *)args->log);
 		break;
 	case NVME_LOG_LID_AVE_DISCOVERY:
-		stdout_ave_discovery_log((struct nvme_ave_discover_log *)args->log);
+		stdout_ave_discovery_log(
+			(struct nvme_ave_discovery_log *)args->log);
 		break;
 	case NVME_LOG_LID_PULL_MODEL_DDC_REQ:
 		stdout_pull_model_ddc_req_log((struct nvme_pull_model_ddc_req_log *)args->log);

--- a/nvme-print.c
+++ b/nvme-print.c
@@ -1879,12 +1879,14 @@ void nvme_show_reachability_associations_log(struct nvme_reachability_associatio
 	nvme_print(reachability_associations_log, flags, log, len);
 }
 
-void nvme_show_host_discovery_log(struct nvme_host_discover_log *log, nvme_print_flags_t flags)
+void nvme_show_host_discovery_log(struct nvme_host_discovery_log *log,
+		nvme_print_flags_t flags)
 {
 	nvme_print(host_discovery_log, flags, log);
 }
 
-void nvme_show_ave_discovery_log(struct nvme_ave_discover_log *log, nvme_print_flags_t flags)
+void nvme_show_ave_discovery_log(struct nvme_ave_discovery_log *log,
+		nvme_print_flags_t flags)
 {
 	nvme_print(ave_discovery_log, flags, log);
 }

--- a/nvme-print.h
+++ b/nvme-print.h
@@ -120,8 +120,8 @@ struct print_ops {
 	void (*reachability_groups_log)(struct nvme_reachability_groups_log *log, __u64 len);
 	void (*reachability_associations_log)(struct nvme_reachability_associations_log *log,
 					      __u64 len);
-	void (*host_discovery_log)(struct nvme_host_discover_log *log);
-	void (*ave_discovery_log)(struct nvme_ave_discover_log *log);
+	void (*host_discovery_log)(struct nvme_host_discovery_log *log);
+	void (*ave_discovery_log)(struct nvme_ave_discovery_log *log);
 	void (*pull_model_ddc_req_log)(struct nvme_pull_model_ddc_req_log *log);
 	void (*log)(const char *devname, struct nvme_get_log_args *args);
 
@@ -417,8 +417,10 @@ void nvme_show_reachability_groups_log(struct nvme_reachability_groups_log *log,
 				       __u64 len, nvme_print_flags_t flags);
 void nvme_show_reachability_associations_log(struct nvme_reachability_associations_log *log,
 					     __u64 len, nvme_print_flags_t flags);
-void nvme_show_host_discovery_log(struct nvme_host_discover_log *log, nvme_print_flags_t flags);
-void nvme_show_ave_discovery_log(struct nvme_ave_discover_log *log, nvme_print_flags_t flags);
+void nvme_show_host_discovery_log(struct nvme_host_discovery_log *log,
+				  nvme_print_flags_t flags);
+void nvme_show_ave_discovery_log(struct nvme_ave_discovery_log *log,
+				 nvme_print_flags_t flags);
 void nvme_show_pull_model_ddc_req_log(struct nvme_pull_model_ddc_req_log *log,
 				      nvme_print_flags_t flags);
 void nvme_show_log(const char *devname, struct nvme_get_log_args *args, nvme_print_flags_t flags);

--- a/nvme.c
+++ b/nvme.c
@@ -10117,14 +10117,14 @@ static int discover_cmd(int argc, char **argv, struct command *acmd, struct plug
 {
 	const char *desc = "Send Get Log Page request to Discovery Controller.";
 
-	return fabrics_discovery(desc, argc, argv, false);
+	return fabrics_discover(desc, argc, argv, false);
 }
 
 static int connect_all_cmd(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Discover NVMeoF subsystems and connect to them";
 
-	return fabrics_discovery(desc, argc, argv, true);
+	return fabrics_discover(desc, argc, argv, true);
 }
 
 static int connect_cmd(int argc, char **argv, struct command *acmd, struct plugin *plugin)

--- a/nvme.c
+++ b/nvme.c
@@ -10977,10 +10977,10 @@ static int get_reachability_associations_log(int argc, char **argv, struct comma
 }
 
 static int get_host_discovery(struct libnvme_transport_handle *hdl, bool allhoste, bool rae,
-			      struct nvme_host_discover_log **logp)
+			      struct nvme_host_discovery_log **logp)
 {
 	int err;
-	struct nvme_host_discover_log *log;
+	struct nvme_host_discovery_log *log;
 	__u64 log_len = sizeof(*log);
 	struct nvme_get_log_args args = {
 		.lid = NVME_LOG_LID_HOST_DISCOVERY,
@@ -11017,7 +11017,7 @@ static int get_host_discovery_log(int argc, char **argv, struct command *acmd, s
 	const char *allhoste = "All Host Entries";
 	nvme_print_flags_t flags;
 	int err;
-	__cleanup_libnvme_free struct nvme_host_discover_log *log = NULL;
+	__cleanup_libnvme_free struct nvme_host_discovery_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 
@@ -11057,10 +11057,11 @@ static int get_host_discovery_log(int argc, char **argv, struct command *acmd, s
 	return err;
 }
 
-static int get_ave_discovery(struct libnvme_transport_handle *hdl, bool rae, struct nvme_ave_discover_log **logp)
+static int get_ave_discovery(struct libnvme_transport_handle *hdl, bool rae,
+			     struct nvme_ave_discovery_log **logp)
 {
 	int err;
-	struct nvme_ave_discover_log *log;
+	struct nvme_ave_discovery_log *log;
 	__u64 log_len = sizeof(*log);
 	struct nvme_get_log_args args = {
 		.lid = NVME_LOG_LID_AVE_DISCOVERY,
@@ -11096,7 +11097,7 @@ static int get_ave_discovery_log(int argc, char **argv, struct command *acmd, st
 	nvme_print_flags_t flags;
 	int err;
 
-	__cleanup_libnvme_free struct nvme_ave_discover_log *log = NULL;
+	__cleanup_libnvme_free struct nvme_ave_discovery_log *log = NULL;
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 


### PR DESCRIPTION
@igaw - Per you request, I reviewed all the instances of "discover" and "discovery".  

Three commits, each independent -- feel free to accept/reject them separately:

1. `fabrics_discovery()`, `libnvmf_discovery()`, `libnvmf_discovery_nbft()`, and the internal `_nvmf_discovery()` are action functions -- to be consistent with sibling action functions like `libnvmf_connect()`/`libnvmf_disconnect_ctrl()`, they need to be `libnvmf_discover()` etc. "discovery" stays everywhere it's a noun (Discovery Controller, Discovery Log, etc).
2. A documentation wording fix in `nvme-discover.txt` found along the way.
3. While auditing the whole codebase for discover/discovery spelling, found an unrelated pre-existing issue: `nvme_host_discover_log` and three sibling structs were missing the "y" against their own kdoc titles and every function that touches them. Confirmed against the actual specs (TP8019 for the AVE Discovery Log, Base Spec 2.3 for the Host Discovery Log) that "Discovery" is correct. Predates this rename entirely.

If you'd rather have these as a single commit, GitHub's "Squash and merge" handles that on merge.
