### PR TITLE
solidigm: remove trailing space from clear-pcie-correctable-errors name

### DIFF
--- a/plugins/solidigm/solidigm-nvme.h
+++ b/plugins/solidigm/solidigm-nvme.h
@@ -25,7 +25,7 @@ PLUGIN(NAME("solidigm", "Solidigm vendor specific extensions", SOLIDIGM_PLUGIN_V
 		ENTRY("market-log", "Retrieve Market Log", get_market_log)
 		ENTRY("latency-tracking-log", "Enable/Retrieve Latency tracking Log", get_latency_tracking_log)
 		ENTRY("parse-telemetry-log", "Parse Telemetry Log binary", get_telemetry_log)
-		ENTRY("clear-pcie-correctable-errors ", "Clear PCIe Correctable Error Counters (redirects to ocp plug-in)", clear_pcie_correctable_error_counters)
+		ENTRY("clear-pcie-correctable-errors", "Clear PCIe Correctable Error Counters (redirects to ocp plug-in)", clear_pcie_correctable_error_counters)
 		ENTRY("clear-fw-activate-history", "Clear firmware update history log (redirects to ocp plug-in)", clear_fw_update_history)
 		ENTRY("vs-fw-activate-history", "Get firmware activation history log (redirects to ocp plug-in)", fw_activation_history)
 		ENTRY("log-page-directory", "Retrieve log page directory", get_log_page_directory_log)


### PR DESCRIPTION
The command name string had a trailing space, so the argv word "clear-pcie-correctable-errors" never matched it and the sub-command could not be invoked. Drop the space so the command is reachable.