### PR TITLE
util: fix resource leak in dump_command_metadata()

### DIFF
--- a/plugins/utils/command-metadata.c
+++ b/plugins/utils/command-metadata.c
@@ -703,6 +703,8 @@ int dump_command_metadata(struct program *prog)
 
 	json_program(model);
 
+	free(model->plugins);
+	free(model);
 	return 0;
 }
 


### PR DESCRIPTION
The dump_command_metadata() function calls build_model() which heap-allocates model and its model->plugins sub-array. After json_program() emits the JSON output, both allocations are never freed before the function returns.

This results in model->plugins and model leaking on every successful invocation of the dump-command-metadata subcommand.

Free model->plugins and model after json_program() returns to prevent the resource leak.