### PR TITLE
libnvme/fabrics: fix negative errno passed to libnvme_strerror in nbft_discovery

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3021,7 +3021,7 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 	if (ret) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,
 			"Discovery Descriptor %d: failed to get discovery log: %s\n",
-			dd->index, libnvme_strerror(ret));
+			dd->index, libnvme_strerror(-ret));
 		return ret;
 	}
 


### PR DESCRIPTION
nvme_discovery_log() returns a negative errno on failure, but the value
was passed directly to libnvme_strerror() which requires a positive errno.
Negate ret at the call site, consistent with all other libnvme_strerror()
calls in this file.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>