### PR TITLE
util/argconfig: fix always-false range check in comma-sep array parser

### DIFF
--- a/util/argconfig.c
+++ b/util/argconfig.c
@@ -522,10 +522,12 @@ int argconfig_parse_comma_sep_array ## name(char *string,		\
 		if (ret >= max_length)					\
 			return -1;					\
 									\
+		errno = 0;						\
 		v = strtoumax(tmp, &p, 0);				\
 		if (*p != 0)						\
 			return -1;					\
-		if (v > ret_max) {					\
+		if (errno == ERANGE ||					\
+			v > ret_max) {					\
 			fprintf(stderr, "%s out of range\n", tmp);	\
 			return -1;					\
 		}							\


### PR DESCRIPTION
strtoumax() returns uintmax_t, so comparing the result against ULLONG_MAX
is always false and overflowed values are silently accepted. Add an errno
check after strtoumax() to catch values that exceed UINTMAX_MAX, fixing
the dead range check in the _long instantiation of the macro.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>