### PR TITLE
libnvme: convert lazy getters to return error codes

### DIFF
--- a/libnvme/examples/display-columnar.c
+++ b/libnvme/examples/display-columnar.c
@@ -64,12 +64,19 @@ int main()
 		libnvme_for_each_subsystem(h, s) {
 			libnvme_subsystem_for_each_ctrl(s, c) {
 				bool first = true;
+				const char *serial;
+				const char *model;
+				const char *firmware;
+
+				libnvme_ctrl_get_serial(c, &serial, "");
+				libnvme_ctrl_get_model(c, &model, "");
+				libnvme_ctrl_get_firmware(c, &firmware, "");
 
 				printf("%-8s %-20s %-40s %-8s %-6s %-14s %-12s ",
 				       libnvme_ctrl_get_name(c),
-				       libnvme_ctrl_get_serial(c),
-				       libnvme_ctrl_get_model(c),
-				       libnvme_ctrl_get_firmware(c),
+				       serial,
+				       model,
+				       firmware,
 				       libnvme_ctrl_get_transport(c),
 				       libnvme_ctrl_get_traddr(c),
 				       libnvme_subsystem_get_name(s));

--- a/libnvme/libnvme3/ctrl-sysfs.i
+++ b/libnvme/libnvme3/ctrl-sysfs.i
@@ -1,3 +1,23 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/*
+ * This file is part of libnvme.
+ *
+ * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ *
+ *   ____                           _           _    ____          _
+ *  / ___| ___ _ __   ___ _ __ __ _| |_ ___  __| |  / ___|___   __| | ___
+ * | |  _ / _ \ '_ \ / _ \ '__/ _` | __/ _ \/ _` | | |   / _ \ / _` |/ _ \
+ * | |_| |  __/ | | |  __/ | | (_| | ||  __/ (_| | | |__| (_) | (_| |  __/
+ *  \____|\___|_| |_|\___|_|  \__,_|\__\___|\__,_|  \____\___/ \__,_|\___|
+ *
+ * Auto-generated struct member accessors (setter/getter)
+ *
+ * To update run: meson compile -C [BUILD-DIR] update-accessors
+ * Or:            make update-accessors
+ */
+
 /* struct libnvme_ctrl -- sysfs-backed properties */
 %rename(libnvme_ctrl_firmware_set) libnvme_ctrl_set_firmware;
 %rename(libnvme_ctrl_model_set) libnvme_ctrl_set_model;

--- a/libnvme/libnvme3/ctrl-sysfs.i
+++ b/libnvme/libnvme3/ctrl-sysfs.i
@@ -1,56 +1,300 @@
 /* struct libnvme_ctrl -- sysfs-backed properties */
-%rename(libnvme_ctrl_numa_node_get) libnvme_ctrl_get_numa_node;
-%rename(libnvme_ctrl_queue_count_get) libnvme_ctrl_get_queue_count;
-%rename(libnvme_ctrl_sqsize_get) libnvme_ctrl_get_sqsize;
-%rename(libnvme_ctrl_command_error_count_get) libnvme_ctrl_get_command_error_count;
-%rename(libnvme_ctrl_reset_count_get) libnvme_ctrl_get_reset_count;
-%rename(libnvme_ctrl_reconnect_count_get) libnvme_ctrl_get_reconnect_count;
-%rename(libnvme_ctrl_firmware_get) libnvme_ctrl_get_firmware;
 %rename(libnvme_ctrl_firmware_set) libnvme_ctrl_set_firmware;
-%rename(libnvme_ctrl_model_get) libnvme_ctrl_get_model;
 %rename(libnvme_ctrl_model_set) libnvme_ctrl_set_model;
-%rename(libnvme_ctrl_serial_get) libnvme_ctrl_get_serial;
 %rename(libnvme_ctrl_serial_set) libnvme_ctrl_set_serial;
-%rename(libnvme_ctrl_cntrltype_get) libnvme_ctrl_get_cntrltype;
 %rename(libnvme_ctrl_cntrltype_set) libnvme_ctrl_set_cntrltype;
-%rename(libnvme_ctrl_cntlid_get) libnvme_ctrl_get_cntlid;
 %rename(libnvme_ctrl_cntlid_set) libnvme_ctrl_set_cntlid;
-%rename(libnvme_ctrl_dctype_get) libnvme_ctrl_get_dctype;
 %rename(libnvme_ctrl_dctype_set) libnvme_ctrl_set_dctype;
-%rename(libnvme_ctrl_phy_slot_get) libnvme_ctrl_get_phy_slot;
-%rename(libnvme_ctrl_dhchap_host_key_get) libnvme_ctrl_get_dhchap_host_key;
 %rename(libnvme_ctrl_dhchap_host_key_set) libnvme_ctrl_set_dhchap_host_key;
-%rename(libnvme_ctrl_dhchap_ctrl_key_get) libnvme_ctrl_get_dhchap_ctrl_key;
 %rename(libnvme_ctrl_dhchap_ctrl_key_set) libnvme_ctrl_set_dhchap_ctrl_key;
-%rename(libnvme_ctrl_keyring_get) libnvme_ctrl_get_keyring;
 %rename(libnvme_ctrl_keyring_set) libnvme_ctrl_set_keyring;
 %{
-	#define libnvme_ctrl_numa_node_get libnvme_ctrl_get_numa_node
-	#define libnvme_ctrl_queue_count_get libnvme_ctrl_get_queue_count
-	#define libnvme_ctrl_sqsize_get libnvme_ctrl_get_sqsize
-	#define libnvme_ctrl_command_error_count_get libnvme_ctrl_get_command_error_count
-	#define libnvme_ctrl_reset_count_get libnvme_ctrl_get_reset_count
-	#define libnvme_ctrl_reconnect_count_get libnvme_ctrl_get_reconnect_count
-	#define libnvme_ctrl_firmware_get libnvme_ctrl_get_firmware
 	#define libnvme_ctrl_firmware_set libnvme_ctrl_set_firmware
-	#define libnvme_ctrl_model_get libnvme_ctrl_get_model
 	#define libnvme_ctrl_model_set libnvme_ctrl_set_model
-	#define libnvme_ctrl_serial_get libnvme_ctrl_get_serial
 	#define libnvme_ctrl_serial_set libnvme_ctrl_set_serial
-	#define libnvme_ctrl_cntrltype_get libnvme_ctrl_get_cntrltype
 	#define libnvme_ctrl_cntrltype_set libnvme_ctrl_set_cntrltype
-	#define libnvme_ctrl_cntlid_get libnvme_ctrl_get_cntlid
 	#define libnvme_ctrl_cntlid_set libnvme_ctrl_set_cntlid
-	#define libnvme_ctrl_dctype_get libnvme_ctrl_get_dctype
 	#define libnvme_ctrl_dctype_set libnvme_ctrl_set_dctype
-	#define libnvme_ctrl_phy_slot_get libnvme_ctrl_get_phy_slot
-	#define libnvme_ctrl_dhchap_host_key_get libnvme_ctrl_get_dhchap_host_key
 	#define libnvme_ctrl_dhchap_host_key_set libnvme_ctrl_set_dhchap_host_key
-	#define libnvme_ctrl_dhchap_ctrl_key_get libnvme_ctrl_get_dhchap_ctrl_key
 	#define libnvme_ctrl_dhchap_ctrl_key_set libnvme_ctrl_set_dhchap_ctrl_key
-	#define libnvme_ctrl_keyring_get libnvme_ctrl_get_keyring
 	#define libnvme_ctrl_keyring_set libnvme_ctrl_set_keyring
+	static const char *libnvme_ctrl_numa_node_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_numa_node(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_queue_count_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_queue_count(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_sqsize_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_sqsize(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static PyObject *libnvme_ctrl_command_error_count_get(const struct libnvme_ctrl *p)
+	{
+		long val;
+		int ret = libnvme_ctrl_get_command_error_count(p, &val, 0);
+
+		if (ret == -ENOENT)
+			Py_RETURN_NONE;
+		if (ret) {
+			raise_nvme(NvmeError, ret);
+			return NULL;
+		}
+
+		return PyLong_FromLong(val);
+	}
+	static PyObject *libnvme_ctrl_reset_count_get(const struct libnvme_ctrl *p)
+	{
+		long val;
+		int ret = libnvme_ctrl_get_reset_count(p, &val, 0);
+
+		if (ret == -ENOENT)
+			Py_RETURN_NONE;
+		if (ret) {
+			raise_nvme(NvmeError, ret);
+			return NULL;
+		}
+
+		return PyLong_FromLong(val);
+	}
+	static PyObject *libnvme_ctrl_reconnect_count_get(const struct libnvme_ctrl *p)
+	{
+		long val;
+		int ret = libnvme_ctrl_get_reconnect_count(p, &val, 0);
+
+		if (ret == -ENOENT)
+			Py_RETURN_NONE;
+		if (ret) {
+			raise_nvme(NvmeError, ret);
+			return NULL;
+		}
+
+		return PyLong_FromLong(val);
+	}
+	static const char *libnvme_ctrl_firmware_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_firmware(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_model_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_model(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_serial_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_serial(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_cntrltype_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_cntrltype(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_cntlid_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_cntlid(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_dctype_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_dctype(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_phy_slot_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_phy_slot(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_dhchap_host_key_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_dhchap_host_key(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_dhchap_ctrl_key_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_dhchap_ctrl_key(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_ctrl_keyring_get(const struct libnvme_ctrl *p)
+	{
+		const char *val;
+		int ret = libnvme_ctrl_get_keyring(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
 %}
+
+%exception libnvme_ctrl::numa_node {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::queue_count {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::sqsize {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::command_error_count {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::reset_count {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::reconnect_count {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::firmware {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::model {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::serial {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::cntrltype {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::cntlid {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::dctype {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::phy_slot {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::dhchap_host_key {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::dhchap_ctrl_key {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_ctrl::keyring {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
 
 %extend struct libnvme_ctrl {
 	%immutable numa_node;
@@ -60,11 +304,11 @@
 	%immutable sqsize;
 	const char * sqsize;
 	%immutable command_error_count;
-	long command_error_count;
+	PyObject * command_error_count;
 	%immutable reset_count;
-	long reset_count;
+	PyObject * reset_count;
 	%immutable reconnect_count;
-	long reconnect_count;
+	PyObject * reconnect_count;
 	const char * firmware;
 	const char * model;
 	const char * serial;

--- a/libnvme/src/nvme/crypto.c
+++ b/libnvme/src/nvme/crypto.c
@@ -1290,8 +1290,7 @@ int __libnvmf_import_keys_from_config(libnvme_host_t h, libnvme_ctrl_t c,
 	if (!key)
 		goto out;
 
-	keyring = libnvme_ctrl_get_keyring(c);
-	if (keyring) {
+	if (libnvme_ctrl_get_keyring(c, &keyring, NULL) == 0) {
 		ret = libnvmf_lookup_keyring(h->ctx, keyring, &kr_id);
 		if (ret)
 			return ret;

--- a/libnvme/src/nvme/ctrl-sysfs.c
+++ b/libnvme/src/nvme/ctrl-sysfs.c
@@ -18,6 +18,7 @@
  * Or:            make update-accessors
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -82,10 +83,14 @@ void libnvme_ctrl_sysfs_free(
 	free(sysfs);
 }
 
-__shr_public const char *libnvme_ctrl_get_numa_node(
-		const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_numa_node(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->numa_node))) {
 		c->sysfs->numa_node = libnvme_get_ctrl_attr(c, "numa_node");
@@ -93,13 +98,21 @@ __shr_public const char *libnvme_ctrl_get_numa_node(
 			c->sysfs->numa_node = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->numa_node);
+	if (SYSFS_IS_ABSENT(c->sysfs->numa_node))
+		return -ENOENT;
+
+	*val = c->sysfs->numa_node;
+	return 0;
 }
 
-__shr_public const char *libnvme_ctrl_get_queue_count(
-		const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_queue_count(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->queue_count))) {
 		c->sysfs->queue_count = libnvme_get_ctrl_attr(c, "queue_count");
@@ -107,12 +120,21 @@ __shr_public const char *libnvme_ctrl_get_queue_count(
 			c->sysfs->queue_count = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->queue_count);
+	if (SYSFS_IS_ABSENT(c->sysfs->queue_count))
+		return -ENOENT;
+
+	*val = c->sysfs->queue_count;
+	return 0;
 }
 
-__shr_public const char *libnvme_ctrl_get_sqsize(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_sqsize(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->sqsize))) {
 		c->sysfs->sqsize = libnvme_get_ctrl_attr(c, "sqsize");
@@ -120,47 +142,74 @@ __shr_public const char *libnvme_ctrl_get_sqsize(const struct libnvme_ctrl *p)
 			c->sysfs->sqsize = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->sqsize);
+	if (SYSFS_IS_ABSENT(c->sysfs->sqsize))
+		return -ENOENT;
+
+	*val = c->sysfs->sqsize;
+	return 0;
 }
 
-__shr_public long libnvme_ctrl_get_command_error_count(
-		const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_command_error_count(
+		const struct libnvme_ctrl *p,
+		long *val,
+		long dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
-	char *val;
+	__cleanup_free char *str = NULL;
 
-	val = libnvme_get_ctrl_attr(c, "diag/command_error_count");
-	if (val)
-		sscanf(val, "%ld", &c->sysfs->command_error_count);
-	free(val);
+	*val = dflt;
 
-	return c->sysfs->command_error_count;
+	str = libnvme_get_ctrl_attr(c, "diag/command_error_count");
+	if (!str)
+		return -ENOENT;
+
+	if (sscanf(str, "%ld", &c->sysfs->command_error_count) != 1)
+		return -EINVAL;
+
+	*val = c->sysfs->command_error_count;
+	return 0;
 }
 
-__shr_public long libnvme_ctrl_get_reset_count(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_reset_count(
+		const struct libnvme_ctrl *p,
+		long *val,
+		long dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
-	char *val;
+	__cleanup_free char *str = NULL;
 
-	val = libnvme_get_ctrl_attr(c, "diag/reset_count");
-	if (val)
-		sscanf(val, "%ld", &c->sysfs->reset_count);
-	free(val);
+	*val = dflt;
 
-	return c->sysfs->reset_count;
+	str = libnvme_get_ctrl_attr(c, "diag/reset_count");
+	if (!str)
+		return -ENOENT;
+
+	if (sscanf(str, "%ld", &c->sysfs->reset_count) != 1)
+		return -EINVAL;
+
+	*val = c->sysfs->reset_count;
+	return 0;
 }
 
-__shr_public long libnvme_ctrl_get_reconnect_count(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_reconnect_count(
+		const struct libnvme_ctrl *p,
+		long *val,
+		long dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
-	char *val;
+	__cleanup_free char *str = NULL;
 
-	val = libnvme_get_ctrl_attr(c, "diag/reconnect_count");
-	if (val)
-		sscanf(val, "%ld", &c->sysfs->reconnect_count);
-	free(val);
+	*val = dflt;
 
-	return c->sysfs->reconnect_count;
+	str = libnvme_get_ctrl_attr(c, "diag/reconnect_count");
+	if (!str)
+		return -ENOENT;
+
+	if (sscanf(str, "%ld", &c->sysfs->reconnect_count) != 1)
+		return -EINVAL;
+
+	*val = c->sysfs->reconnect_count;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_firmware(
@@ -171,17 +220,29 @@ __shr_public void libnvme_ctrl_set_firmware(
 	p->sysfs->firmware = firmware ? strdup(firmware) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_firmware(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_firmware(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->firmware))) {
-		libnvme_ctrl_load_identity(c);
+		ret = libnvme_ctrl_load_identity(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->firmware)
 			c->sysfs->firmware = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->firmware);
+	if (SYSFS_IS_ABSENT(c->sysfs->firmware))
+		return -ENOENT;
+
+	*val = c->sysfs->firmware;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_model(
@@ -192,17 +253,29 @@ __shr_public void libnvme_ctrl_set_model(
 	p->sysfs->model = model ? strdup(model) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_model(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_model(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->model))) {
-		libnvme_ctrl_load_identity(c);
+		ret = libnvme_ctrl_load_identity(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->model)
 			c->sysfs->model = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->model);
+	if (SYSFS_IS_ABSENT(c->sysfs->model))
+		return -ENOENT;
+
+	*val = c->sysfs->model;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_serial(
@@ -213,17 +286,29 @@ __shr_public void libnvme_ctrl_set_serial(
 	p->sysfs->serial = serial ? strdup(serial) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_serial(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_serial(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->serial))) {
-		libnvme_ctrl_load_identity(c);
+		ret = libnvme_ctrl_load_identity(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->serial)
 			c->sysfs->serial = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->serial);
+	if (SYSFS_IS_ABSENT(c->sysfs->serial))
+		return -ENOENT;
+
+	*val = c->sysfs->serial;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_cntrltype(
@@ -234,18 +319,29 @@ __shr_public void libnvme_ctrl_set_cntrltype(
 	p->sysfs->cntrltype = cntrltype ? strdup(cntrltype) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_cntrltype(
-		const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_cntrltype(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->cntrltype))) {
-		libnvme_ctrl_load_identity(c);
+		ret = libnvme_ctrl_load_identity(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->cntrltype)
 			c->sysfs->cntrltype = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->cntrltype);
+	if (SYSFS_IS_ABSENT(c->sysfs->cntrltype))
+		return -ENOENT;
+
+	*val = c->sysfs->cntrltype;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_cntlid(
@@ -256,17 +352,29 @@ __shr_public void libnvme_ctrl_set_cntlid(
 	p->sysfs->cntlid = cntlid ? strdup(cntlid) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_cntlid(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_cntlid(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->cntlid))) {
-		libnvme_ctrl_load_identity(c);
+		ret = libnvme_ctrl_load_identity(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->cntlid)
 			c->sysfs->cntlid = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->cntlid);
+	if (SYSFS_IS_ABSENT(c->sysfs->cntlid))
+		return -ENOENT;
+
+	*val = c->sysfs->cntlid;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_dctype(
@@ -277,30 +385,54 @@ __shr_public void libnvme_ctrl_set_dctype(
 	p->sysfs->dctype = dctype ? strdup(dctype) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_dctype(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_dctype(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->dctype))) {
-		libnvme_ctrl_load_identity(c);
+		ret = libnvme_ctrl_load_identity(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->dctype)
 			c->sysfs->dctype = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->dctype);
+	if (SYSFS_IS_ABSENT(c->sysfs->dctype))
+		return -ENOENT;
+
+	*val = c->sysfs->dctype;
+	return 0;
 }
 
-__shr_public const char *libnvme_ctrl_get_phy_slot(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_phy_slot(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->phy_slot))) {
-		libnvme_ctrl_load_phy_slot(c);
+		ret = libnvme_ctrl_load_phy_slot(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->phy_slot)
 			c->sysfs->phy_slot = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->phy_slot);
+	if (SYSFS_IS_ABSENT(c->sysfs->phy_slot))
+		return -ENOENT;
+
+	*val = c->sysfs->phy_slot;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_dhchap_host_key(
@@ -312,18 +444,29 @@ __shr_public void libnvme_ctrl_set_dhchap_host_key(
 		dhchap_host_key ? strdup(dhchap_host_key) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_dhchap_host_key(
-		const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_dhchap_host_key(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->dhchap_host_key))) {
-		libnvmf_ctrl_load_fabrics_attrs(c);
+		ret = libnvmf_ctrl_load_fabrics_attrs(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->dhchap_host_key)
 			c->sysfs->dhchap_host_key = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->dhchap_host_key);
+	if (SYSFS_IS_ABSENT(c->sysfs->dhchap_host_key))
+		return -ENOENT;
+
+	*val = c->sysfs->dhchap_host_key;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_dhchap_ctrl_key(
@@ -335,18 +478,29 @@ __shr_public void libnvme_ctrl_set_dhchap_ctrl_key(
 		dhchap_ctrl_key ? strdup(dhchap_ctrl_key) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_dhchap_ctrl_key(
-		const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_dhchap_ctrl_key(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->dhchap_ctrl_key))) {
-		libnvmf_ctrl_load_fabrics_attrs(c);
+		ret = libnvmf_ctrl_load_fabrics_attrs(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->dhchap_ctrl_key)
 			c->sysfs->dhchap_ctrl_key = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->dhchap_ctrl_key);
+	if (SYSFS_IS_ABSENT(c->sysfs->dhchap_ctrl_key))
+		return -ENOENT;
+
+	*val = c->sysfs->dhchap_ctrl_key;
+	return 0;
 }
 
 __shr_public void libnvme_ctrl_set_keyring(
@@ -357,16 +511,28 @@ __shr_public void libnvme_ctrl_set_keyring(
 	p->sysfs->keyring = keyring ? strdup(keyring) : NO_SYSFS_ATTR;
 }
 
-__shr_public const char *libnvme_ctrl_get_keyring(const struct libnvme_ctrl *p)
+__shr_public int libnvme_ctrl_get_keyring(
+		const struct libnvme_ctrl *p,
+		const char **val,
+		const char *dflt)
 {
 	struct libnvme_ctrl *c = (struct libnvme_ctrl *)p;
+	int ret;
+
+	*val = dflt;
 
 	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->keyring))) {
-		libnvmf_ctrl_load_fabrics_attrs(c);
+		ret = libnvmf_ctrl_load_fabrics_attrs(c);
+		if (ret)
+			return ret;
 		if (!c->sysfs->keyring)
 			c->sysfs->keyring = NO_SYSFS_ATTR;
 	}
 
-	return SYSFS_GET(c->sysfs->keyring);
+	if (SYSFS_IS_ABSENT(c->sysfs->keyring))
+		return -ENOENT;
+
+	*val = c->sysfs->keyring;
+	return 0;
 }
 

--- a/libnvme/src/nvme/ctrl-sysfs.h
+++ b/libnvme/src/nvme/ctrl-sysfs.h
@@ -48,50 +48,86 @@ int libnvmf_ctrl_load_fabrics_attrs(struct libnvme_ctrl *c);
 /**
  * libnvme_ctrl_get_numa_node() - Get numa_node.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @numa_node: Where to store the value on success.
+ * @dflt: Value to store in @numa_node on failure.
  *
- * Return: The value of the numa_node field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_numa_node(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_numa_node(
+		const struct libnvme_ctrl *p,
+		const char **numa_node,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_get_queue_count() - Get queue_count.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @queue_count: Where to store the value on success.
+ * @dflt: Value to store in @queue_count on failure.
  *
- * Return: The value of the queue_count field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_queue_count(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_queue_count(
+		const struct libnvme_ctrl *p,
+		const char **queue_count,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_get_sqsize() - Get sqsize.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @sqsize: Where to store the value on success.
+ * @dflt: Value to store in @sqsize on failure.
  *
- * Return: The value of the sqsize field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_sqsize(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_sqsize(
+		const struct libnvme_ctrl *p,
+		const char **sqsize,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_get_command_error_count() - Get command_error_count.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @command_error_count: Where to store the value on success.
+ * @dflt: Value to store in @command_error_count on failure.
  *
- * Return: The value of the command_error_count field.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-long libnvme_ctrl_get_command_error_count(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_command_error_count(
+		const struct libnvme_ctrl *p,
+		long *command_error_count,
+		long dflt);
 
 /**
  * libnvme_ctrl_get_reset_count() - Get reset_count.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @reset_count: Where to store the value on success.
+ * @dflt: Value to store in @reset_count on failure.
  *
- * Return: The value of the reset_count field.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-long libnvme_ctrl_get_reset_count(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_reset_count(
+		const struct libnvme_ctrl *p,
+		long *reset_count,
+		long dflt);
 
 /**
  * libnvme_ctrl_get_reconnect_count() - Get reconnect_count.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @reconnect_count: Where to store the value on success.
+ * @dflt: Value to store in @reconnect_count on failure.
  *
- * Return: The value of the reconnect_count field.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-long libnvme_ctrl_get_reconnect_count(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_reconnect_count(
+		const struct libnvme_ctrl *p,
+		long *reconnect_count,
+		long dflt);
 
 /**
  * libnvme_ctrl_set_firmware() - Set firmware.
@@ -103,10 +139,16 @@ void libnvme_ctrl_set_firmware(struct libnvme_ctrl *p, const char *firmware);
 /**
  * libnvme_ctrl_get_firmware() - Get firmware.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @firmware: Where to store the value on success.
+ * @dflt: Value to store in @firmware on failure.
  *
- * Return: The value of the firmware field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_firmware(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_firmware(
+		const struct libnvme_ctrl *p,
+		const char **firmware,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_model() - Set model.
@@ -118,10 +160,16 @@ void libnvme_ctrl_set_model(struct libnvme_ctrl *p, const char *model);
 /**
  * libnvme_ctrl_get_model() - Get model.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @model: Where to store the value on success.
+ * @dflt: Value to store in @model on failure.
  *
- * Return: The value of the model field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_model(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_model(
+		const struct libnvme_ctrl *p,
+		const char **model,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_serial() - Set serial.
@@ -133,10 +181,16 @@ void libnvme_ctrl_set_serial(struct libnvme_ctrl *p, const char *serial);
 /**
  * libnvme_ctrl_get_serial() - Get serial.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @serial: Where to store the value on success.
+ * @dflt: Value to store in @serial on failure.
  *
- * Return: The value of the serial field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_serial(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_serial(
+		const struct libnvme_ctrl *p,
+		const char **serial,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_cntrltype() - Set cntrltype.
@@ -148,10 +202,16 @@ void libnvme_ctrl_set_cntrltype(struct libnvme_ctrl *p, const char *cntrltype);
 /**
  * libnvme_ctrl_get_cntrltype() - Get cntrltype.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @cntrltype: Where to store the value on success.
+ * @dflt: Value to store in @cntrltype on failure.
  *
- * Return: The value of the cntrltype field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_cntrltype(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_cntrltype(
+		const struct libnvme_ctrl *p,
+		const char **cntrltype,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_cntlid() - Set cntlid.
@@ -163,10 +223,16 @@ void libnvme_ctrl_set_cntlid(struct libnvme_ctrl *p, const char *cntlid);
 /**
  * libnvme_ctrl_get_cntlid() - Get cntlid.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @cntlid: Where to store the value on success.
+ * @dflt: Value to store in @cntlid on failure.
  *
- * Return: The value of the cntlid field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_cntlid(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_cntlid(
+		const struct libnvme_ctrl *p,
+		const char **cntlid,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_dctype() - Set dctype.
@@ -178,18 +244,30 @@ void libnvme_ctrl_set_dctype(struct libnvme_ctrl *p, const char *dctype);
 /**
  * libnvme_ctrl_get_dctype() - Get dctype.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @dctype: Where to store the value on success.
+ * @dflt: Value to store in @dctype on failure.
  *
- * Return: The value of the dctype field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_dctype(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_dctype(
+		const struct libnvme_ctrl *p,
+		const char **dctype,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_get_phy_slot() - Get phy_slot.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @phy_slot: Where to store the value on success.
+ * @dflt: Value to store in @phy_slot on failure.
  *
- * Return: The value of the phy_slot field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_phy_slot(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_phy_slot(
+		const struct libnvme_ctrl *p,
+		const char **phy_slot,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_dhchap_host_key() - Set dhchap_host_key.
@@ -203,10 +281,16 @@ void libnvme_ctrl_set_dhchap_host_key(
 /**
  * libnvme_ctrl_get_dhchap_host_key() - Get dhchap_host_key.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @dhchap_host_key: Where to store the value on success.
+ * @dflt: Value to store in @dhchap_host_key on failure.
  *
- * Return: The value of the dhchap_host_key field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_dhchap_host_key(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_dhchap_host_key(
+		const struct libnvme_ctrl *p,
+		const char **dhchap_host_key,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_dhchap_ctrl_key() - Set dhchap_ctrl_key.
@@ -220,10 +304,16 @@ void libnvme_ctrl_set_dhchap_ctrl_key(
 /**
  * libnvme_ctrl_get_dhchap_ctrl_key() - Get dhchap_ctrl_key.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @dhchap_ctrl_key: Where to store the value on success.
+ * @dflt: Value to store in @dhchap_ctrl_key on failure.
  *
- * Return: The value of the dhchap_ctrl_key field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_dhchap_ctrl_key(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_dhchap_ctrl_key(
+		const struct libnvme_ctrl *p,
+		const char **dhchap_ctrl_key,
+		const char *dflt);
 
 /**
  * libnvme_ctrl_set_keyring() - Set keyring.
@@ -235,8 +325,14 @@ void libnvme_ctrl_set_keyring(struct libnvme_ctrl *p, const char *keyring);
 /**
  * libnvme_ctrl_get_keyring() - Get keyring.
  * @p: The &struct libnvme_ctrl instance to query.
+ * @keyring: Where to store the value on success.
+ * @dflt: Value to store in @keyring on failure.
  *
- * Return: The value of the keyring field, or NULL if not set.
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
  */
-const char *libnvme_ctrl_get_keyring(const struct libnvme_ctrl *p);
+int libnvme_ctrl_get_keyring(
+		const struct libnvme_ctrl *p,
+		const char **keyring,
+		const char *dflt);
 

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1258,10 +1258,10 @@ static int build_options(libnvme_host_t h, libnvme_ctrl_t c, char **argstr)
 	hostid = libnvme_host_get_hostid(h);
 	hostkey = libnvme_host_get_dhchap_host_key(h);
 	if (!hostkey)
-		hostkey = libnvme_ctrl_get_dhchap_host_key(c);
+		libnvme_ctrl_get_dhchap_host_key(c, &hostkey, NULL);
 
 	if (hostkey)
-		ctrlkey = libnvme_ctrl_get_dhchap_ctrl_key(c);
+		libnvme_ctrl_get_dhchap_ctrl_key(c, &ctrlkey, NULL);
 
 	if (c->cfg.tls && c->cfg.concat) {
 		libnvme_msg(h->ctx, LIBNVME_LOG_ERR, "cannot specify --tls and --concat together\n");
@@ -1586,14 +1586,13 @@ __shr_public int libnvmf_add_ctrl(libnvme_host_t h, libnvme_ctrl_t c)
 			 * in @cfg, so ensure to update @c with the correct
 			 * controller key.
 			 */
-			key = libnvme_ctrl_get_dhchap_host_key(fc);
-			if (key)
+			if (libnvme_ctrl_get_dhchap_host_key(fc, &key,
+							      NULL) == 0)
 				libnvme_ctrl_set_dhchap_host_key(c, key);
-			key = libnvme_ctrl_get_dhchap_ctrl_key(fc);
-			if (key)
+			if (libnvme_ctrl_get_dhchap_ctrl_key(fc, &key,
+							      NULL) == 0)
 				libnvme_ctrl_set_dhchap_ctrl_key(c, key);
-			key = libnvme_ctrl_get_keyring(fc);
-			if (key)
+			if (libnvme_ctrl_get_keyring(fc, &key, NULL) == 0)
 				libnvme_ctrl_set_keyring(c, key);
 			key = libnvme_ctrl_get_tls_key_identity(fc);
 			if (key)
@@ -2247,6 +2246,7 @@ static const char *dctype_str[] = {
 static int nvme_fetch_cntrltype_dctype_from_id(libnvme_ctrl_t c)
 {
 	__cleanup_libnvme_free struct nvme_id_ctrl *id = NULL;
+	const char *val;
 	int ret;
 
 	id = libnvme_alloc(sizeof(*id));
@@ -2257,7 +2257,7 @@ static int nvme_fetch_cntrltype_dctype_from_id(libnvme_ctrl_t c)
 	if (ret)
 		return ret;
 
-	if (!libnvme_ctrl_get_cntrltype(c)) {
+	if (libnvme_ctrl_get_cntrltype(c, &val, NULL)) {
 		if (id->cntrltype > NVME_CTRL_CNTRLTYPE_ADMIN || !cntrltype_str[id->cntrltype])
 			libnvme_ctrl_set_cntrltype(c, "reserved");
 		else
@@ -2265,7 +2265,7 @@ static int nvme_fetch_cntrltype_dctype_from_id(libnvme_ctrl_t c)
 					cntrltype_str[id->cntrltype]);
 	}
 
-	if (!libnvme_ctrl_get_dctype(c)) {
+	if (libnvme_ctrl_get_dctype(c, &val, NULL)) {
 		if (id->dctype > NVME_CTRL_DCTYPE_CDC || !dctype_str[id->dctype])
 			libnvme_ctrl_set_dctype(c, "reserved");
 		else
@@ -2276,13 +2276,14 @@ static int nvme_fetch_cntrltype_dctype_from_id(libnvme_ctrl_t c)
 
 __shr_public bool libnvmf_is_registration_supported(libnvme_ctrl_t c)
 {
-	const char *dctype;
+	const char *cntrltype, *dctype;
 
-	if (!libnvme_ctrl_get_cntrltype(c) || !libnvme_ctrl_get_dctype(c))
+	if (libnvme_ctrl_get_cntrltype(c, &cntrltype, NULL) ||
+	    libnvme_ctrl_get_dctype(c, &dctype, NULL))
 		if (nvme_fetch_cntrltype_dctype_from_id(c))
 			return false;
 
-	dctype = libnvme_ctrl_get_dctype(c);
+	libnvme_ctrl_get_dctype(c, &dctype, NULL);
 	return !strcmp(dctype, "ddc") || !strcmp(dctype, "cdc");
 }
 

--- a/libnvme/src/nvme/private-tree.h
+++ b/libnvme/src/nvme/private-tree.h
@@ -21,7 +21,7 @@
 extern char NO_SYSFS_ATTR[];
 
 #define SYSFS_IS_LOADED(p) ((p) != NULL)
-#define SYSFS_GET(p) (((p) == NO_SYSFS_ATTR) ? NULL : (p))
+#define SYSFS_IS_ABSENT(p) ((p) == NO_SYSFS_ATTR)
 #define SYSFS_FREE(p) \
 	do { \
 		if ((p) != NULL && (p) != NO_SYSFS_ATTR) \

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1652,17 +1652,35 @@ const char *libnvme_ns_head_get_sysfs_dir(libnvme_ns_head_t head)
 
 __shr_public const char *libnvme_ns_get_model(libnvme_ns_t n)
 {
-	return n->c ? libnvme_ctrl_get_model(n->c) : n->s->model;
+	const char *val;
+
+	if (!n->c)
+		return n->s->model;
+
+	libnvme_ctrl_get_model(n->c, &val, NULL);
+	return val;
 }
 
 __shr_public const char *libnvme_ns_get_serial(libnvme_ns_t n)
 {
-	return n->c ? libnvme_ctrl_get_serial(n->c) : n->s->serial;
+	const char *val;
+
+	if (!n->c)
+		return n->s->serial;
+
+	libnvme_ctrl_get_serial(n->c, &val, NULL);
+	return val;
 }
 
 __shr_public const char *libnvme_ns_get_firmware(libnvme_ns_t n)
 {
-	return n->c ? libnvme_ctrl_get_firmware(n->c) : n->s->firmware;
+	const char *val;
+
+	if (!n->c)
+		return n->s->firmware;
+
+	libnvme_ctrl_get_firmware(n->c, &val, NULL);
+	return val;
 }
 
 __shr_public void libnvme_ns_copy_uuid(libnvme_ns_t n,

--- a/libnvme/tools/generator/generate_accessors.py
+++ b/libnvme/tools/generator/generate_accessors.py
@@ -1316,6 +1316,48 @@ def emit_hdr_getter(f, prefix, sname, type_name, mname, mtype, is_dyn_str):
         )
 
 
+def emit_hdr_getter_lazy(f, prefix, sname, type_name, mname, mtype):
+    """Emit a header declaration for a lazy sysfs getter.
+
+    Unlike a plain getter, a sysfs read (or the loader behind it) can
+    fail, and a bare return value has no room to say so -- lazy getters
+    return int and deliver the value through an out-param instead. A
+    third argument, dflt, is what gets stored in that out-param when the
+    call fails, so a caller who only wants a display fallback (not the
+    fine-grained reason) never has to pre-initialize its own local or
+    check the return code: pass NULL (or 0 for a numeric member) to opt
+    out and get nothing back on failure but a return code to check.
+    """
+    fn = _get_name(prefix, sname, mname)
+    is_str = mtype == 'const char *'
+    out_type = 'const char **' if is_str else f'{mtype} *'
+    dflt_type = 'const char *' if is_str else mtype
+    dflt_sep = type_sep(dflt_type)
+    f.write(
+        f'/**\n'
+        f'{kdoc_summary(fn, f"Get {mname}.", "Getter.")}\n'
+        f' * @p: The &struct {type_name} instance to query.\n'
+        f' * @{mname}: Where to store the value on success.\n'
+        f' * @dflt: Value to store in @{mname} on failure.\n'
+        f' *\n'
+        f' * Return: 0 on success, -ENOENT if the attribute does not\n'
+        f' *	   exist, or a negative errno on failure.\n'
+        f' */\n'
+    )
+
+    single = (f'int {fn}(const struct {type_name} *p, {out_type}{mname}, '
+              f'{dflt_type}{dflt_sep}dflt);')
+    if fits_80(single):
+        f.write(single + '\n\n')
+    else:
+        f.write(
+            f'int {fn}(\n'
+            f'\t\tconst struct {type_name} *p,\n'
+            f'\t\t{out_type}{mname},\n'
+            f'\t\t{dflt_type}{dflt_sep}dflt);\n\n'
+        )
+
+
 def emit_hdr_setter_scalar_array(f, prefix, sname, type_name, mname, elem_type,
                                  array_size):
     """Emit a header declaration for a fixed-size scalar-array setter."""
@@ -1391,8 +1433,12 @@ def generate_hdr(f, prefix, sname, type_name, members):
                 emit_hdr_setter_val(f, prefix, sname, type_name,
                                     member.name, member.type)
         if member.read_mode == 'generated':
-            emit_hdr_getter(f, prefix, sname, type_name,
-                            member.name, member.type, is_dyn_str)
+            if member.is_sysfs_lazy:
+                emit_hdr_getter_lazy(f, prefix, sname, type_name,
+                                     member.name, member.type)
+            else:
+                emit_hdr_getter(f, prefix, sname, type_name,
+                                member.name, member.type, is_dyn_str)
 
 
 # ---------------------------------------------------------------------------
@@ -1598,27 +1644,28 @@ def emit_src_setter_lazy_dynstr(f, prefix, sname, type_name, mname, field_path):
 
 def emit_src_getter_lazy_attr(f, prefix, sname, type_name, mname, field_path,
                               sysfs_attr):
-    """Emit a lazy pointer getter that caches one plain sysfs attribute.
+    """Emit a lazy getter that caches one plain sysfs attribute.
 
     First call reads the attribute and caches the result: a real pointer
     if the attribute exists, or the NO_SYSFS_ATTR sentinel if it does not
     (a raw NULL there would look "not yet read" and re-fire every call).
     Every later call returns the cached value without touching sysfs
-    again. SYSFS_GET() translates the sentinel back to NULL on return so
-    callers never see it.
+    again. Returns -ENOENT when the attribute does not exist, so the
+    caller can tell "absent" from "not yet checked". *val is set to dflt
+    unconditionally before anything else, so a failure path never leaves
+    it unset -- a caller who does not want the fine-grained distinction
+    can skip checking the return code and get a safe value regardless.
     """
-    sig = (f'{PUB}const char *{_get_name(prefix, sname, mname)}'
-           f'(const struct {type_name} *p)')
-    if fits_80(sig):
-        f.write(sig + '\n')
-    else:
-        f.write(
-            f'{PUB}const char *{_get_name(prefix, sname, mname)}(\n'
-            f'\t\tconst struct {type_name} *p)\n'
-        )
+    f.write(
+        f'{PUB}int {_get_name(prefix, sname, mname)}(\n'
+        f'\t\tconst struct {type_name} *p,\n'
+        f'\t\tconst char **val,\n'
+        f'\t\tconst char *dflt)\n'
+    )
     f.write(
         '{\n'
         f'\tstruct {type_name} *c = (struct {type_name} *)p;\n\n'
+        '\t*val = dflt;\n\n'
         f'\tif (__shr_unlikely(!SYSFS_IS_LOADED(c->{field_path}))) {{\n'
     )
     load = f'\t\tc->{field_path} = libnvme_get_ctrl_attr(c, "{sysfs_attr}");'
@@ -1634,50 +1681,55 @@ def emit_src_getter_lazy_attr(f, prefix, sname, type_name, mname, field_path,
         f'\t\t\tc->{field_path} = NO_SYSFS_ATTR;\n'
         '\t}\n\n'
     )
-    ret = f'\treturn SYSFS_GET(c->{field_path});'
-    if fits_80_ntabs(1, ret.lstrip()):
-        f.write(ret + '\n')
-    else:
-        f.write(f'\treturn SYSFS_GET(\n\t\t\tc->{field_path});\n')
-    f.write('}\n\n')
+    f.write(
+        f'\tif (SYSFS_IS_ABSENT(c->{field_path}))\n'
+        f'\t\treturn -ENOENT;\n\n'
+        f'\t*val = c->{field_path};\n'
+        f'\treturn 0;\n'
+        '}\n\n'
+    )
 
 
 def emit_src_getter_lazy_loader(f, prefix, sname, type_name, mname,
                                 field_path, sysfs_loader):
-    """Emit a lazy pointer getter backed by a loader-function call.
+    """Emit a lazy getter backed by a loader-function call.
 
     The loader may populate several members of the same group in one call
     (e.g. dhchap_host_key/dhchap_ctrl_key/keyring from one sysfs read
     pass), writing NULL to any it leaves absent. After it returns, a
     member still at NULL means no value exists for it -- stamp the
     NO_SYSFS_ATTR sentinel so the guard doesn't re-fire the loader on
-    every subsequent call. SYSFS_GET() translates the sentinel back to
-    NULL on return so callers never see it.
+    every subsequent call. A negative loader return means the load
+    itself failed (not just "attribute absent") and is propagated to
+    the caller unchanged. *val is set to dflt unconditionally before
+    anything else -- see emit_src_getter_lazy_attr()'s docstring.
     """
-    sig = (f'{PUB}const char *{_get_name(prefix, sname, mname)}'
-           f'(const struct {type_name} *p)')
-    if fits_80(sig):
-        f.write(sig + '\n')
-    else:
-        f.write(
-            f'{PUB}const char *{_get_name(prefix, sname, mname)}(\n'
-            f'\t\tconst struct {type_name} *p)\n'
-        )
+    f.write(
+        f'{PUB}int {_get_name(prefix, sname, mname)}(\n'
+        f'\t\tconst struct {type_name} *p,\n'
+        f'\t\tconst char **val,\n'
+        f'\t\tconst char *dflt)\n'
+    )
     f.write(
         '{\n'
-        f'\tstruct {type_name} *c = (struct {type_name} *)p;\n\n'
+        f'\tstruct {type_name} *c = (struct {type_name} *)p;\n'
+        '\tint ret;\n\n'
+        '\t*val = dflt;\n\n'
         f'\tif (__shr_unlikely(!SYSFS_IS_LOADED(c->{field_path}))) {{\n'
-        f'\t\t{sysfs_loader}(c);\n'
+        f'\t\tret = {sysfs_loader}(c);\n'
+        '\t\tif (ret)\n'
+        '\t\t\treturn ret;\n'
         f'\t\tif (!c->{field_path})\n'
         f'\t\t\tc->{field_path} = NO_SYSFS_ATTR;\n'
         '\t}\n\n'
     )
-    ret = f'\treturn SYSFS_GET(c->{field_path});'
-    if fits_80_ntabs(1, ret.lstrip()):
-        f.write(ret + '\n')
-    else:
-        f.write(f'\treturn SYSFS_GET(\n\t\t\tc->{field_path});\n')
-    f.write('}\n\n')
+    f.write(
+        f'\tif (SYSFS_IS_ABSENT(c->{field_path}))\n'
+        f'\t\treturn -ENOENT;\n\n'
+        f'\t*val = c->{field_path};\n'
+        f'\treturn 0;\n'
+        '}\n\n'
+    )
 
 
 def emit_src_getter_volatile_num(f, prefix, sname, type_name, mname, mtype,
@@ -1685,27 +1737,31 @@ def emit_src_getter_volatile_num(f, prefix, sname, type_name, mname, mtype,
     """Emit an always-live numeric getter for a volatile lazy member.
 
     No sentinel, no cache: every call re-reads the sysfs attribute and
-    parses it into the member, preserving stale-on-failure semantics (a
-    transient read error leaves the last known value in place).
+    parses it into the member. Returns -ENOENT when the attribute cannot
+    be read and -EINVAL when it can be read but not parsed, rather than
+    the previous value -- the caller can tell a real absence, or bad
+    content, from a transient read error the same way every other lazy
+    getter does. *val is set to dflt unconditionally before anything
+    else -- see emit_src_getter_lazy_attr()'s docstring.
     """
-    sig = (f'{PUB}{mtype} {_get_name(prefix, sname, mname)}'
-           f'(const struct {type_name} *p)')
-    if fits_80(sig):
-        f.write(sig + '\n')
-    else:
-        f.write(
-            f'{PUB}{mtype} {_get_name(prefix, sname, mname)}(\n'
-            f'\t\tconst struct {type_name} *p)\n'
-        )
+    f.write(
+        f'{PUB}int {_get_name(prefix, sname, mname)}(\n'
+        f'\t\tconst struct {type_name} *p,\n'
+        f'\t\t{mtype} *val,\n'
+        f'\t\t{mtype} dflt)\n'
+    )
     f.write(
         '{\n'
         f'\tstruct {type_name} *c = (struct {type_name} *)p;\n'
-        '\tchar *val;\n\n'
-        f'\tval = libnvme_get_ctrl_attr(c, "{sysfs_attr}");\n'
-        '\tif (val)\n'
-        f'\t\tsscanf(val, "%ld", &c->{field_path});\n'
-        '\tfree(val);\n\n'
-        f'\treturn c->{field_path};\n'
+        '\t__cleanup_free char *str = NULL;\n\n'
+        '\t*val = dflt;\n\n'
+        f'\tstr = libnvme_get_ctrl_attr(c, "{sysfs_attr}");\n'
+        '\tif (!str)\n'
+        '\t\treturn -ENOENT;\n\n'
+        f'\tif (sscanf(str, "%ld", &c->{field_path}) != 1)\n'
+        '\t\treturn -EINVAL;\n\n'
+        f'\t*val = c->{field_path};\n'
+        '\treturn 0;\n'
         '}\n\n'
     )
 

--- a/libnvme/tools/generator/generate_sysfs_accessors.py
+++ b/libnvme/tools/generator/generate_sysfs_accessors.py
@@ -371,6 +371,7 @@ def generate_swig(spec, members):
     writable = [m for m in members if m.write_mode != 'none']
 
     buf = io.StringIO()
+    buf.write(f'{SPDX_C}\n\n{BANNER}\n\n')
     buf.write(f'/* struct {owner_type} -- sysfs-backed properties */\n')
 
     for m in writable:

--- a/libnvme/tools/generator/generate_sysfs_accessors.py
+++ b/libnvme/tools/generator/generate_sysfs_accessors.py
@@ -262,6 +262,7 @@ def generate_source(spec, members):
     buf = io.StringIO()
     buf.write(
         f'{SPDX_C}\n\n{BANNER}\n\n'
+        '#include <errno.h>\n'
         '#include <stdio.h>\n'
         '#include <stdlib.h>\n'
         '#include <string.h>\n\n'
@@ -283,6 +284,66 @@ def generate_source(spec, members):
 # ---------------------------------------------------------------------------
 
 
+# Python conversion for each non-string lazy getter type this generator
+# has ever needed. Deliberately not a general type->conversion mapper --
+# add an entry only when a real member needs it (see generate_accessors.py's
+# own restraint on generalizing emit_src_getter_volatile_num's "%ld").
+_PY_FROM = {
+    'long': 'PyLong_FromLong',
+}
+
+
+def emit_swig_getter_wrapper(owner_type, m):
+    """Return the C source of one SWIG getter-property wrapper.
+
+    SWIG's %extend member-variable convention expects a getter shaped
+    like ``TYPE owner_member_get(const struct owner *)`` -- the real
+    lazy getter's shape (int return, out-param) cannot be wrapped that
+    way directly, so this interposes a small function with the name
+    SWIG expects, resolving the three states a lazy read can produce:
+    a value (return it), -ENOENT (Python None), any other error (raise
+    NvmeError). raise_nvme()/NvmeError come from nvme.i's own preamble;
+    the %exception block emitted alongside this wrapper is what turns
+    the pending Python exception into an actual failure -- see the
+    comment above the existing libnvme_ctrl::connect/disconnect/discover
+    %exception blocks in nvme.i for why that check cannot live in the
+    wrapper body itself.
+    """
+    fn = f'{owner_type}_get_{m.name}'
+    getter = f'{owner_type}_{m.name}_get'
+
+    if m.type == 'const char *':
+        return (
+            f'\tstatic const char *{getter}(const struct {owner_type} *p)\n'
+            '\t{\n'
+            '\t\tconst char *val;\n'
+            f'\t\tint ret = {fn}(p, &val, NULL);\n\n'
+            '\t\tif (ret == 0)\n'
+            '\t\t\treturn val;\n'
+            '\t\tif (ret == -ENOENT)\n'
+            '\t\t\treturn NULL;\n\n'
+            '\t\traise_nvme(NvmeError, ret);\n'
+            '\t\treturn NULL;\n'
+            '\t}\n'
+        )
+
+    py_from = _PY_FROM[m.type]
+    return (
+        f'\tstatic PyObject *{getter}(const struct {owner_type} *p)\n'
+        '\t{\n'
+        f'\t\t{m.type} val;\n'
+        f'\t\tint ret = {fn}(p, &val, 0);\n\n'
+        '\t\tif (ret == -ENOENT)\n'
+        '\t\t\tPy_RETURN_NONE;\n'
+        '\t\tif (ret) {\n'
+        '\t\t\traise_nvme(NvmeError, ret);\n'
+        '\t\t\treturn NULL;\n'
+        '\t\t}\n\n'
+        f'\t\treturn {py_from}(val);\n'
+        '\t}\n'
+    )
+
+
 def generate_swig(spec, members):
     """SWIG fragment: extend the already-wrapped struct libnvme_ctrl
     (declared in accessors.i) with these sysfs-backed properties.
@@ -297,38 +358,59 @@ def generate_swig(spec, members):
     it parsed from a header); here there is no new struct, only more
     properties on one SWIG has already wrapped, so its "Pass 2: plain
     field vs. %extend" struct-declaration logic does not apply.
+
+    Readable members get a hand-written getter wrapper (emit_swig_getter_
+    wrapper()) rather than the %rename+#define alias used everywhere
+    else in this file -- the real getter's int-return/out-param shape
+    does not match SWIG's member-variable property convention, so a
+    plain alias cannot work here. Writable members are unaffected: a
+    setter's shape has not changed, so it keeps the alias.
     """
     owner_type = spec['owner_type']
+    readable = [m for m in members if m.read_mode != 'none']
+    writable = [m for m in members if m.write_mode != 'none']
+
     buf = io.StringIO()
     buf.write(f'/* struct {owner_type} -- sysfs-backed properties */\n')
 
-    for m in members:
-        if m.read_mode != 'none':
-            buf.write(
-                f'%rename({owner_type}_{m.name}_get) ' f'{owner_type}_get_{m.name};\n'
-            )
-        if m.write_mode != 'none':
-            buf.write(
-                f'%rename({owner_type}_{m.name}_set) ' f'{owner_type}_set_{m.name};\n'
-            )
+    for m in writable:
+        buf.write(
+            f'%rename({owner_type}_{m.name}_set) ' f'{owner_type}_set_{m.name};\n'
+        )
 
     buf.write('%{\n')
-    for m in members:
-        if m.read_mode != 'none':
-            buf.write(
-                f'\t#define {owner_type}_{m.name}_get ' f'{owner_type}_get_{m.name}\n'
-            )
-        if m.write_mode != 'none':
-            buf.write(
-                f'\t#define {owner_type}_{m.name}_set ' f'{owner_type}_set_{m.name}\n'
-            )
+    for m in writable:
+        buf.write(
+            f'\t#define {owner_type}_{m.name}_set ' f'{owner_type}_set_{m.name}\n'
+        )
+    for m in readable:
+        buf.write(emit_swig_getter_wrapper(owner_type, m))
     buf.write('%}\n\n')
+
+    for m in readable:
+        buf.write(
+            f'%exception {owner_type}::{m.name} {{\n'
+            '\t$action\n'
+            '\tif (PyErr_Occurred()) SWIG_fail;\n'
+            '}\n'
+        )
+    if readable:
+        buf.write('\n')
 
     buf.write(f'%extend struct {owner_type} {{\n')
     for m in members:
         if m.write_mode == 'none':
             buf.write(f'\t%immutable {m.name};\n')
-        buf.write(f'\t{m.type} {m.name};\n')
+        # SWIG's member-variable wrapper picks its typemap from the type
+        # declared here, not from the getter wrapper's own C return type
+        # -- for a non-string readable member that wrapper always returns
+        # PyObject* (see emit_swig_getter_wrapper()), so the member must
+        # be declared PyObject* too, or SWIG force-casts the pointer to
+        # the real type (e.g. `(long)a_PyObject_pointer`), corrupting it.
+        decl_type = m.type
+        if m.read_mode != 'none' and m.type != 'const char *':
+            decl_type = 'PyObject *'
+        buf.write(f'\t{decl_type} {m.name};\n')
     buf.write('}\n')
 
     return buf.getvalue()

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -4597,6 +4597,10 @@ static void json_print_detail_list_multipath(libnvme_subsystem_t s,
 			libnvme_ctrl_t c;
 			struct json_object *jpath = json_create_object();
 			const char *slot;
+			const char *cntlid;
+			const char *serial;
+			const char *model;
+			const char *firmware;
 
 			obj_add_str(jpath, "Path", libnvme_path_get_name(p));
 			obj_add_str(jpath, "ANAState", libnvme_path_get_ana_state(p));
@@ -4607,12 +4611,16 @@ static void json_print_detail_list_multipath(libnvme_subsystem_t s,
 			 * controller  attributes.
 			 */
 			c = libnvme_path_get_ctrl(p);
-			slot = libnvme_ctrl_get_phy_slot(c);
+			libnvme_ctrl_get_phy_slot(c, &slot, NULL);
+			libnvme_ctrl_get_cntlid(c, &cntlid, NULL);
+			libnvme_ctrl_get_serial(c, &serial, NULL);
+			libnvme_ctrl_get_model(c, &model, NULL);
+			libnvme_ctrl_get_firmware(c, &firmware, NULL);
 			obj_add_str(jpath, "Controller", libnvme_ctrl_get_name(c));
-			obj_add_str(jpath, "Cntlid", libnvme_ctrl_get_cntlid(c));
-			obj_add_str(jpath, "SerialNumber", libnvme_ctrl_get_serial(c));
-			obj_add_str(jpath, "ModelNumber", libnvme_ctrl_get_model(c));
-			obj_add_str(jpath, "Firmware", libnvme_ctrl_get_firmware(c));
+			obj_add_str(jpath, "Cntlid", cntlid);
+			obj_add_str(jpath, "SerialNumber", serial);
+			obj_add_str(jpath, "ModelNumber", model);
+			obj_add_str(jpath, "Firmware", firmware);
 			obj_add_str(jpath, "Transport", libnvme_ctrl_get_transport(c));
 			obj_add_str(jpath, "Address", libnvme_ctrl_get_address(c));
 			obj_add_ctrl_address_details(jpath, "AddressDetails", c);
@@ -4636,13 +4644,23 @@ static void json_print_detail_list(libnvme_subsystem_t s, struct json_object *js
 	libnvme_subsystem_for_each_ctrl(s, c) {
 		struct json_object *jctrl = json_create_object();
 		struct json_object *jnss = json_create_array();
-		const char *slot = libnvme_ctrl_get_phy_slot(c);
+		const char *slot;
+		const char *cntlid;
+		const char *serial;
+		const char *model;
+		const char *firmware;
+
+		libnvme_ctrl_get_phy_slot(c, &slot, NULL);
+		libnvme_ctrl_get_cntlid(c, &cntlid, NULL);
+		libnvme_ctrl_get_serial(c, &serial, NULL);
+		libnvme_ctrl_get_model(c, &model, NULL);
+		libnvme_ctrl_get_firmware(c, &firmware, NULL);
 
 		obj_add_str(jctrl, "Controller", libnvme_ctrl_get_name(c));
-		obj_add_str(jctrl, "Cntlid", libnvme_ctrl_get_cntlid(c));
-		obj_add_str(jctrl, "SerialNumber", libnvme_ctrl_get_serial(c));
-		obj_add_str(jctrl, "ModelNumber", libnvme_ctrl_get_model(c));
-		obj_add_str(jctrl, "Firmware", libnvme_ctrl_get_firmware(c));
+		obj_add_str(jctrl, "Cntlid", cntlid);
+		obj_add_str(jctrl, "SerialNumber", serial);
+		obj_add_str(jctrl, "ModelNumber", model);
+		obj_add_str(jctrl, "Firmware", firmware);
 		obj_add_str(jctrl, "Transport", libnvme_ctrl_get_transport(c));
 		obj_add_str(jctrl, "Address", libnvme_ctrl_get_address(c));
 		obj_add_ctrl_address_details(jctrl, "AddressDetails", c);
@@ -4744,16 +4762,27 @@ static void json_detail_list(struct libnvme_global_ctx *ctx)
 				struct json_object *jctrl = json_create_object();
 				struct json_object *jnss = json_create_array();
 				struct json_object *jpaths = json_create_array();
+				const char *cntlid;
+				const char *serial;
+				const char *model;
+				const char *firmware;
+				const char *slot;
+
+				libnvme_ctrl_get_cntlid(c, &cntlid, NULL);
+				libnvme_ctrl_get_serial(c, &serial, NULL);
+				libnvme_ctrl_get_model(c, &model, NULL);
+				libnvme_ctrl_get_firmware(c, &firmware, NULL);
+				libnvme_ctrl_get_phy_slot(c, &slot, NULL);
 
 				obj_add_str(jctrl, "Controller", libnvme_ctrl_get_name(c));
-				obj_add_str(jctrl, "Cntlid", libnvme_ctrl_get_cntlid(c));
-				obj_add_str(jctrl, "SerialNumber", libnvme_ctrl_get_serial(c));
-				obj_add_str(jctrl, "ModelNumber", libnvme_ctrl_get_model(c));
-				obj_add_str(jctrl, "Firmware", libnvme_ctrl_get_firmware(c));
+				obj_add_str(jctrl, "Cntlid", cntlid);
+				obj_add_str(jctrl, "SerialNumber", serial);
+				obj_add_str(jctrl, "ModelNumber", model);
+				obj_add_str(jctrl, "Firmware", firmware);
 				obj_add_str(jctrl, "Transport", libnvme_ctrl_get_transport(c));
 				obj_add_str(jctrl, "Address", libnvme_ctrl_get_address(c));
 				obj_add_ctrl_address_details(jctrl, "AddressDetails", c);
-				obj_add_str(jctrl, "Slot", libnvme_ctrl_get_phy_slot(c));
+				obj_add_str(jctrl, "Slot", slot);
 
 				libnvme_ctrl_for_each_ns(c, n) {
 					struct json_object *jns = json_create_object();

--- a/nvme-print-stdout-top.c
+++ b/nvme-print-stdout-top.c
@@ -474,6 +474,7 @@ static int stdout_top_print_ctrl_summary(FILE *stream,
 	char r_iops_str[16], w_iops_str[16];
 	char r_clat_str[16], w_clat_str[16];
 	const char *node;
+	long reset_count, reconnect_count, command_error_count;
 	struct table *t;
 	bool is_fabric = false;
 	struct table_column columns[] = {
@@ -557,7 +558,7 @@ static int stdout_top_print_ctrl_summary(FILE *stream,
 		nvme_format_lat(max_rlat, r_clat_str, sizeof(r_clat_str));
 		nvme_format_lat(max_wlat, w_clat_str, sizeof(w_clat_str));
 
-		node = libnvme_ctrl_get_numa_node(c);
+		libnvme_ctrl_get_numa_node(c, &node, "-1");
 		if (!strcmp(node, "-1"))
 			node = "NUMA_NO_NODE";
 
@@ -575,14 +576,20 @@ static int stdout_top_print_ctrl_summary(FILE *stream,
 				libnvme_ctrl_get_traddr(c), LEFT);
 		table_set_value_str(t, ++col, row,
 				libnvme_ctrl_get_state(c), LEFT);
-		table_set_value_long(t, ++col, row,
-				libnvme_ctrl_get_reset_count(c), LEFT);
-		if (is_fabric)
-			table_set_value_long(t, ++col, row,
-				libnvme_ctrl_get_reconnect_count(c), LEFT);
 
-		table_set_value_long(t, ++col, row,
-				libnvme_ctrl_get_command_error_count(c), LEFT);
+		libnvme_ctrl_get_reset_count(c, &reset_count, 0);
+		table_set_value_long(t, ++col, row, reset_count, LEFT);
+
+		if (is_fabric) {
+			libnvme_ctrl_get_reconnect_count(c, &reconnect_count,
+							  0);
+			table_set_value_long(t, ++col, row,
+					reconnect_count, LEFT);
+		}
+
+		libnvme_ctrl_get_command_error_count(c, &command_error_count,
+						      0);
+		table_set_value_long(t, ++col, row, command_error_count, LEFT);
 		table_set_value_str(t, ++col, row, r_iops_str, LEFT);
 		table_set_value_str(t, ++col, row, w_iops_str, LEFT);
 		table_set_value_str(t, ++col, row, r_clat_str, LEFT);

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -5948,8 +5948,18 @@ static bool stdout_detailed_ctrl(const char *name, void *arg)
 	{
 		const char *tr = libnvme_ctrl_get_transport(c);
 		__cleanup_free char *reg_owner = libnvme_ctrl_owner(c);
-		const char *slot = libnvme_ctrl_get_phy_slot(c);
+		const char *slot;
+		const char *cntlid;
+		const char *serial;
+		const char *model;
+		const char *firmware;
 		const char *owner_str;
+
+		libnvme_ctrl_get_phy_slot(c, &slot, NULL);
+		libnvme_ctrl_get_cntlid(c, &cntlid, "");
+		libnvme_ctrl_get_serial(c, &serial, "");
+		libnvme_ctrl_get_model(c, &model, "");
+		libnvme_ctrl_get_firmware(c, &firmware, "");
 
 		if (!libnvme_ctrl_is_transport_fabric(c))
 			owner_str = "kernel";
@@ -5959,10 +5969,10 @@ static bool stdout_detailed_ctrl(const char *name, void *arg)
 		printf("%-16s %-12s %-6s %-20s %-40s %-8s %-6s %-14s %-6s %-12s ",
 		       libnvme_ctrl_get_name(c),
 		       owner_str,
-		       libnvme_ctrl_get_cntlid(c),
-		       libnvme_ctrl_get_serial(c),
-		       libnvme_ctrl_get_model(c),
-		       libnvme_ctrl_get_firmware(c),
+		       cntlid,
+		       serial,
+		       model,
+		       firmware,
 		       tr,
 		       libnvme_ctrl_get_address(c),
 		       slot ? slot : "",


### PR DESCRIPTION
A lazy getter could not distinguish an absent attribute from a failed read: a string getter returned NULL for both, and a numeric getter returned 0, indistinguishable from a real zero value. Every lazy getter now returns int (0, -ENOENT, or a negative errno) with the value delivered through an out-param.

Each getter also takes a caller-supplied default value, written to the out-param before any other logic runs. This lets callers use the getter directly in an expression without a separate declaration and initializer.

SWIG keeps the existing Python property syntax; a real failure now raises NvmeError instead of looking like absence.