### PR TITLE
Get initial FreeBSD support rolling

### DIFF
--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -33,6 +33,15 @@ elif host_system == 'windows'
         'nvme/scan-win.c',
         'nvme/tree-win.c',
     ]
+elif host_system == 'freebsd'
+    sources += [
+        'nvme/attr-accessors-custom-freebsd.c',
+        'nvme/ioctl-freebsd.c',
+        'nvme/lib-freebsd.c',
+        'nvme/mem-freebsd.c',
+        'nvme/scan-freebsd.c',
+        'nvme/tree-freebsd.c',
+    ]
 endif
 headers = [
     'nvme/endian.h',

--- a/libnvme/src/nvme/attr-accessors-custom-freebsd.c
+++ b/libnvme/src/nvme/attr-accessors-custom-freebsd.c
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <ccan/endian/endian.h>
+#include <ccan/ilog/ilog.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <shared/compiler-attributes-util.h>
+
+#include "cleanup.h"
+#include "lib.h"
+#include "mem.h"
+
+#include "generated/attr-accessors.c"
+#include "generated/attr-accessors-freebsd.c"
+
+/*
+ * FreeBSD has no sysfs, so like attr-accessors-custom-win.c every
+ * lazily-loaded attribute below comes from an Identify command instead
+ * of a file read. Fabrics isn't wired up on FreeBSD (CONFIG_FABRICS is
+ * Linux-only), so there is no build axis to branch on here either.
+ */
+int libnvmf_ctrl_load_fabrics_attrs(__shr_unused struct libnvme_ctrl *c)
+{
+	return 0;
+}
+
+/*
+ * Trim an NVMe spec ASCII field (space-padded, not NUL-terminated) of up
+ * to @len characters into a newly allocated, NUL-terminated string.
+ */
+static char *dup_ascii_field(const char *field, size_t len)
+{
+	while (len > 0 && field[len - 1] == ' ')
+		len--;
+
+	return strndup(field, len);
+}
+
+int libnvme_ctrl_load_identity(struct libnvme_ctrl *c)
+{
+	struct nvme_id_ctrl id_ctrl;
+	int ret;
+
+	ret = libnvme_ctrl_identify(c, &id_ctrl);
+	if (ret != 0)
+		return ret;
+
+	c->attrs->firmware = dup_ascii_field(id_ctrl.fr, sizeof(id_ctrl.fr));
+	c->attrs->model = dup_ascii_field(id_ctrl.mn, sizeof(id_ctrl.mn));
+	c->attrs->serial = dup_ascii_field(id_ctrl.sn, sizeof(id_ctrl.sn));
+	if (!c->attrs->firmware || !c->attrs->model || !c->attrs->serial)
+		return -ENOMEM;
+
+	if (asprintf(&c->attrs->cntrltype, "%u", id_ctrl.cntrltype) < 0)
+		return -ENOMEM;
+
+	if (asprintf(&c->attrs->cntlid, "%u", le16_to_cpu(id_ctrl.cntlid)) < 0)
+		return -ENOMEM;
+
+	if (asprintf(&c->attrs->dctype, "%u", id_ctrl.dctype) < 0)
+		return -ENOMEM;
+
+	return 0;
+}
+
+int libnvme_ctrl_load_phy_slot(__shr_unused struct libnvme_ctrl *c)
+{
+	/* FreeBSD has no PCIe physical slot sysfs equivalent. */
+	return 0;
+}
+
+/*
+ * lba_size/lba_count/lba_util/meta_size all come from one Identify
+ * Namespace command, matching what tree-freebsd.c's libnvme_ns_init()
+ * used to do eagerly before the lazy-getter conversion. Each field's
+ * own ATTR_IS_LOADED() check keeps a caller that only reads one of
+ * these four from paying for more than one Identify command in the
+ * common case, but a prior call can leave some fields loaded and others
+ * not (e.g. -ENOMEM after lba_count's malloc but before lba_util's) --
+ * guard each field here too, so a retry never re-mallocs an
+ * already-loaded field and leaks the old allocation.
+ */
+static int ns_freebsd_load_geometry(struct libnvme_ns *n)
+{
+	__cleanup_libnvme_free struct nvme_id_ns *id = NULL;
+	uint8_t flbas;
+	int ret;
+
+	id = libnvme_alloc(sizeof(*id));
+	if (!id)
+		return -ENOMEM;
+
+	ret = libnvme_ns_identify(n, id);
+	if (ret)
+		return ret;
+
+	nvme_id_ns_flbas_to_lbaf_inuse(id->flbas, &flbas);
+
+	if (!ATTR_IS_LOADED(n->attrs->lba_size)) {
+		n->attrs->lba_size = malloc(sizeof(int));
+		if (!n->attrs->lba_size)
+			return -ENOMEM;
+		*n->attrs->lba_size = 1 << id->lbaf[flbas].ds;
+	}
+
+	if (!ATTR_IS_LOADED(n->attrs->lba_count)) {
+		n->attrs->lba_count = malloc(sizeof(uint64_t));
+		if (!n->attrs->lba_count)
+			return -ENOMEM;
+		*n->attrs->lba_count = le64_to_cpu(id->nsze);
+	}
+
+	if (!ATTR_IS_LOADED(n->attrs->lba_util)) {
+		n->attrs->lba_util = malloc(sizeof(uint64_t));
+		if (!n->attrs->lba_util)
+			return -ENOMEM;
+		*n->attrs->lba_util = le64_to_cpu(id->nuse);
+	}
+
+	if (!ATTR_IS_LOADED(n->attrs->meta_size)) {
+		n->attrs->meta_size = malloc(sizeof(int));
+		if (!n->attrs->meta_size)
+			return -ENOMEM;
+		*n->attrs->meta_size = le16_to_cpu(id->lbaf[flbas].ms);
+	}
+
+	return 0;
+}
+
+__shr_public int libnvme_ns_get_lba_size(
+		const struct libnvme_ns *p,
+		int *val,
+		int dflt)
+{
+	struct libnvme_ns *n = (struct libnvme_ns *)p;
+	int ret;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!ATTR_IS_LOADED(n->attrs->lba_size))) {
+		ret = ns_freebsd_load_geometry(n);
+		if (ret)
+			return ret;
+		if (!n->attrs->lba_size)
+			n->attrs->lba_size = (int *)NO_ATTR;
+	}
+
+	if (ATTR_IS_ABSENT(n->attrs->lba_size))
+		return -ENOENT;
+
+	*val = *n->attrs->lba_size;
+	return 0;
+}
+
+/* Pure derivation, no field of its own -- depends only on lba_size's
+ * own (already per-OS-resolved) getter, never on sysfs directly.
+ */
+__shr_public int libnvme_ns_get_lba_shift(
+		const struct libnvme_ns *p,
+		int *val,
+		int dflt)
+{
+	int lba_size;
+	int ret;
+
+	*val = dflt;
+
+	ret = libnvme_ns_get_lba_size(p, &lba_size, 0);
+	if (ret)
+		return ret;
+
+	/* lba_size is a power of two (NVMe LBADS is defined as an
+	 * exponent, 2^n), so it has exactly one bit set -- ilog32()
+	 * reports the position of that bit, i.e. the shift.
+	 */
+	*val = ilog32(lba_size) - 1;
+	return 0;
+}
+
+__shr_public int libnvme_ns_get_lba_count(
+		const struct libnvme_ns *p,
+		uint64_t *val,
+		uint64_t dflt)
+{
+	struct libnvme_ns *n = (struct libnvme_ns *)p;
+	int ret;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!ATTR_IS_LOADED(n->attrs->lba_count))) {
+		ret = ns_freebsd_load_geometry(n);
+		if (ret)
+			return ret;
+		if (!n->attrs->lba_count)
+			n->attrs->lba_count = (uint64_t *)NO_ATTR;
+	}
+
+	if (ATTR_IS_ABSENT(n->attrs->lba_count))
+		return -ENOENT;
+
+	*val = *n->attrs->lba_count;
+	return 0;
+}
+
+__shr_public int libnvme_ns_get_lba_util(
+		const struct libnvme_ns *p,
+		uint64_t *val,
+		uint64_t dflt)
+{
+	struct libnvme_ns *n = (struct libnvme_ns *)p;
+	int ret;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!ATTR_IS_LOADED(n->attrs->lba_util))) {
+		ret = ns_freebsd_load_geometry(n);
+		if (ret)
+			return ret;
+		if (!n->attrs->lba_util)
+			n->attrs->lba_util = (uint64_t *)NO_ATTR;
+	}
+
+	if (ATTR_IS_ABSENT(n->attrs->lba_util))
+		return -ENOENT;
+
+	*val = *n->attrs->lba_util;
+	return 0;
+}
+
+__shr_public int libnvme_ns_get_meta_size(
+		const struct libnvme_ns *p,
+		int *val,
+		int dflt)
+{
+	struct libnvme_ns *n = (struct libnvme_ns *)p;
+	int ret;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!ATTR_IS_LOADED(n->attrs->meta_size))) {
+		ret = ns_freebsd_load_geometry(n);
+		if (ret)
+			return ret;
+		if (!n->attrs->meta_size)
+			n->attrs->meta_size = (int *)NO_ATTR;
+	}
+
+	if (ATTR_IS_ABSENT(n->attrs->meta_size))
+		return -ENOENT;
+
+	*val = *n->attrs->meta_size;
+	return 0;
+}
+
+/*
+ * FreeBSD has no source for csi/eui64/nguid/uuid either -- same as
+ * Windows (attr-accessors-custom-win.c), which never populated these
+ * from its eager-Identify days and simply reports -ENOENT now.
+ */
+__shr_public int libnvme_ns_get_csi(
+		__shr_unused const struct libnvme_ns *p,
+		enum nvme_csi *val,
+		enum nvme_csi dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_ns_get_eui64(
+		__shr_unused const struct libnvme_ns *p,
+		const uint8_t **val,
+		const uint8_t *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_ns_get_nguid(
+		__shr_unused const struct libnvme_ns *p,
+		const uint8_t **val,
+		const uint8_t *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_ns_get_uuid(
+		__shr_unused const struct libnvme_ns *p,
+		const unsigned char **val,
+		const unsigned char *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}

--- a/libnvme/src/nvme/generated/attr-accessors-freebsd.c
+++ b/libnvme/src/nvme/generated/attr-accessors-freebsd.c
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/*
+ * This file is part of libnvme.
+ *
+ * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ *
+ *   ____                           _           _    ____          _
+ *  / ___| ___ _ __   ___ _ __ __ _| |_ ___  __| |  / ___|___   __| | ___
+ * | |  _ / _ \ '_ \ / _ \ '__/ _` | __/ _ \/ _` | | |   / _ \ / _` |/ _ \
+ * | |_| |  __/ | | |  __/ | | (_| | ||  __/ (_| | | |__| (_) | (_| |  __/
+ *  \____|\___|_| |_|\___|_|  \__,_|\__\___|\__,_|  \____\___/ \__,_|\___|
+ *
+ * Auto-generated struct member accessors (setter/getter)
+ *
+ * To update run: meson compile -C [BUILD-DIR] update-accessors
+ * Or:            make update-accessors
+ */
+
+/*
+ * PATH_ATTRS members are Linux multipath-only (dm-multipath ana paths
+ * read from sysfs). FreeBSD, like Windows, never populates any
+ * libnvme_path objects (want_fabrics is Linux-only, see top-level
+ * meson.build), so these all report -ENOENT -- same as
+ * attr-accessors-win.c.
+ */
+
+__shr_public int libnvme_path_get_ana_state(
+		__shr_unused const struct libnvme_path *p,
+		const char **val,
+		const char *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_path_get_numa_nodes(
+		__shr_unused const struct libnvme_path *p,
+		const char **val,
+		const char *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_path_get_grpid(
+		__shr_unused const struct libnvme_path *p,
+		int *val,
+		int dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_path_get_queue_depth(
+		__shr_unused const struct libnvme_path *p,
+		int *val,
+		int dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_path_get_multipath_failover_count(
+		__shr_unused const struct libnvme_path *p,
+		long *val,
+		long dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_path_get_command_retry_count(
+		__shr_unused const struct libnvme_path *p,
+		long *val,
+		long dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_path_get_command_error_count(
+		__shr_unused const struct libnvme_path *p,
+		long *val,
+		long dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}

--- a/libnvme/src/nvme/ioctl-freebsd.c
+++ b/libnvme/src/nvme/ioctl-freebsd.c
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+
+#include <shared/compiler-attributes-util.h>
+
+#include <libnvme.h>
+
+#include "private.h"
+#include "loopback.h"
+
+/*
+ * FreeBSD's nvme(4) driver implements the same "Linux compatible" NVMe
+ * ioctls as the Linux kernel (NVME_IOCTL_ID, NVME_IOCTL_ADMIN_CMD,
+ * NVME_IOCTL_IO_CMD, NVME_IOCTL_RESET; see sys/dev/nvme/nvme_linux.h in
+ * the FreeBSD source), so this mirrors ioctl-linux.c almost verbatim.
+ * Two things FreeBSD doesn't have: the 64-bit passthru ioctls (only the
+ * 32-bit struct is supported, which the existing ioctl32/64 probing in
+ * ioctl_admin_passthru()/ioctl_io_passthru() already falls back away
+ * from via -ENOTTY), and Linux's BLKBSZSET/BLKRRPART block-device
+ * ioctls.
+ */
+
+static int nvme_verify_chr(struct libnvme_transport_handle *hdl)
+{
+	static struct stat nvme_stat;
+	int err = fstat(hdl->fd, &nvme_stat);
+
+	if (err < 0)
+		return -errno;
+
+	if (!S_ISCHR(nvme_stat.st_mode))
+		return -EINVAL;
+	return 0;
+}
+
+__shr_public int libnvme_reset_subsystem(
+		struct libnvme_transport_handle *hdl)
+{
+	int ret;
+
+	ret = nvme_verify_chr(hdl);
+	if (ret)
+		return ret;
+
+	ret = ioctl(hdl->fd, LIBNVME_IOCTL_SUBSYS_RESET);
+	if (ret < 0)
+		return -errno;
+	return ret;
+}
+
+__shr_public int libnvme_reset_ctrl(struct libnvme_transport_handle *hdl)
+{
+	int ret;
+
+	ret = nvme_verify_chr(hdl);
+	if (ret)
+		return ret;
+
+	ret = ioctl(hdl->fd, LIBNVME_IOCTL_RESET);
+	if (ret < 0)
+		return -errno;
+	return ret;
+}
+
+__shr_public int libnvme_rescan_ns(struct libnvme_transport_handle *hdl)
+{
+	int ret;
+
+	ret = nvme_verify_chr(hdl);
+	if (ret)
+		return ret;
+
+	ret = ioctl(hdl->fd, LIBNVME_IOCTL_RESCAN);
+	if (ret < 0)
+		return -errno;
+	return ret;
+}
+
+__shr_public int libnvme_get_nsid(
+		struct libnvme_transport_handle *hdl, __u32 *nsid)
+{
+	__u32 tmp;
+
+	errno = 0;
+	tmp = ioctl(hdl->fd, LIBNVME_IOCTL_ID);
+	if (errno)
+		return -errno;
+
+	*nsid = tmp;
+	return 0;
+}
+
+__shr_public int libnvme_update_block_size(
+		__shr_unused struct libnvme_transport_handle *hdl,
+		__shr_unused int block_size)
+{
+	/* FreeBSD has no equivalent of Linux's BLKBSZSET/BLKRRPART. */
+	return -ENOTSUP;
+}
+
+/*
+ * The 64 bit version is the preferred version to use, but for backwards
+ * compatibility keep a 32 version.
+ */
+static int ioctl_passthru32(struct libnvme_transport_handle *hdl,
+		unsigned long ioctl_cmd, struct libnvme_passthru_cmd *cmd)
+{
+	struct linux_passthru_cmd32 cmd32 = {};
+	void *user_data;
+	int err = 0;
+
+	user_data = hdl->submit_entry(hdl, cmd);
+	if (hdl->ctx->dry_run)
+		goto out;
+
+	memcpy(&cmd32, cmd, offsetof(struct linux_passthru_cmd32, result));
+	cmd32.result = 0;
+
+	do {
+		err = ioctl(hdl->fd, ioctl_cmd, &cmd32);
+		if (err >= 0)
+			break;
+		err = -errno;
+	} while (hdl->decide_retry(hdl, cmd, err));
+
+out:
+	cmd->result = cmd32.result;
+	hdl->submit_exit(hdl, cmd, err, user_data);
+	return err;
+}
+
+/*
+ * Not supported by FreeBSD's nvme(4) Linux-compatible ioctls today, but
+ * kept symmetric with ioctl-linux.c: the 64-bit ioctl numbers below are
+ * simply never claimed by the driver, so this returns -ENOTTY and the
+ * generic probing logic in ioctl_admin_passthru()/ioctl_io_passthru()
+ * permanently falls back to the 32-bit path on first use.
+ */
+static int ioctl_passthru64(struct libnvme_transport_handle *hdl,
+		unsigned long ioctl_cmd, struct libnvme_passthru_cmd *cmd)
+{
+	void *user_data;
+	int err = 0;
+
+	user_data = hdl->submit_entry(hdl, cmd);
+	if (hdl->ctx->dry_run)
+		goto out;
+
+	do {
+		err = ioctl(hdl->fd, ioctl_cmd, cmd);
+		if (err >= 0)
+			break;
+		err = -errno;
+	} while (hdl->decide_retry(hdl, cmd, err));
+
+out:
+	hdl->submit_exit(hdl, cmd, err, user_data);
+	return err;
+}
+
+static int ioctl_io_passthru(struct libnvme_transport_handle *hdl,
+		struct libnvme_passthru_cmd *cmd)
+{
+	int err;
+
+	if (hdl->ioctl_io_state == IOCTL_STATE_IOCTL64)
+		return ioctl_passthru64(hdl,
+			LIBNVME_IOCTL_IO64_CMD, cmd);
+
+	if (hdl->ioctl_io_state == IOCTL_STATE_IOCTL32 ||
+			!hdl->ctx->ioctl_probing)
+		goto do_ioctl32;
+
+	err = ioctl_passthru64(hdl, LIBNVME_IOCTL_IO64_CMD, cmd);
+	if (err >= 0 || err != -ENOTTY) {
+		hdl->ioctl_io_state = IOCTL_STATE_IOCTL64;
+		return err;
+	}
+
+	hdl->ioctl_io_state = IOCTL_STATE_IOCTL32;
+
+do_ioctl32:
+	return ioctl_passthru32(hdl, LIBNVME_IOCTL_IO_CMD, cmd);
+}
+
+static int ioctl_admin_passthru(struct libnvme_transport_handle *hdl,
+		struct libnvme_passthru_cmd *cmd)
+{
+	int err;
+
+	if (hdl->ioctl_admin_state == IOCTL_STATE_IOCTL64)
+		return ioctl_passthru64(hdl,
+				LIBNVME_IOCTL_ADMIN64_CMD, cmd);
+
+	if (hdl->ioctl_admin_state == IOCTL_STATE_IOCTL32 ||
+			!hdl->ctx->ioctl_probing)
+		goto do_ioctl32;
+
+	err = ioctl_passthru64(hdl, LIBNVME_IOCTL_ADMIN64_CMD, cmd);
+	if (err >= 0 || err != -ENOTTY) {
+		hdl->ioctl_admin_state = IOCTL_STATE_IOCTL64;
+		return err;
+	}
+
+	hdl->ioctl_admin_state = IOCTL_STATE_IOCTL32;
+
+do_ioctl32:
+	if (cmd->opcode == nvme_admin_fabrics)
+		return -ENOTSUP;
+
+	return ioctl_passthru32(hdl, LIBNVME_IOCTL_ADMIN_CMD, cmd);
+}
+
+__shr_public int libnvme_exec_admin_passthru(
+		struct libnvme_transport_handle *hdl,
+		struct libnvme_passthru_cmd *cmd)
+{
+	if (!hdl)
+		return -ENODEV;
+
+	if (!cmd->timeout_ms && hdl->timeout)
+		cmd->timeout_ms = hdl->timeout;
+
+	switch (hdl->type) {
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT:
+		return ioctl_admin_passthru(hdl, cmd);
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_MI:
+		return libnvme_mi_admin_admin_passthru(hdl, cmd);
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_LOOPBACK:
+		return __libnvme_loopback_admin_passthru(hdl, cmd);
+	default:
+		break;
+	}
+
+	return -ENOTSUP;
+}
+
+__shr_public int libnvme_exec_io_passthru(
+		struct libnvme_transport_handle *hdl,
+		struct libnvme_passthru_cmd *cmd)
+{
+	if (!hdl)
+		return -ENODEV;
+
+	if (!cmd->timeout_ms && hdl->timeout)
+		cmd->timeout_ms = hdl->timeout;
+
+	switch (hdl->type) {
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT:
+		return ioctl_io_passthru(hdl, cmd);
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_LOOPBACK:
+		return __libnvme_loopback_io_passthru(hdl, cmd);
+	default:
+		break;
+	}
+
+	return -ENOTSUP;
+}

--- a/libnvme/src/nvme/lib-freebsd.c
+++ b/libnvme/src/nvme/lib-freebsd.c
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <libnvme.h>
+
+#include <shared/compiler-attributes-util.h>
+#include <shared/fs-util.h>
+
+#include "cleanup.h"
+#include "private.h"
+
+/*
+ * FreeBSD's nvme(4) driver exposes both the controller (/dev/nvmeX) and
+ * its namespaces (/dev/nvmeXnY) as character devices -- there is no
+ * separate block device node the way Linux has /dev/nvmeXnY as a block
+ * device, so only S_ISCHR is checked here.
+ */
+
+static int __libnvme_transport_handle_open_direct(
+		struct libnvme_transport_handle *hdl, const char *devname,
+		int flags)
+{
+	__cleanup_free char *path = NULL;
+	char *name;
+	int ret;
+
+	hdl->type = LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT;
+
+	name = shr_basename(devname);
+
+	ret = asprintf(&path, "%s/%s", "/dev", name);
+	if (ret < 0)
+		return -ENOMEM;
+
+	hdl->fd = open(path, flags);
+	if (hdl->fd < 0)
+		return -errno;
+
+	ret = fstat(hdl->fd, &hdl->stat);
+	if (ret < 0) {
+		close(hdl->fd);
+		return -errno;
+	}
+
+	if (!S_ISCHR(hdl->stat.st_mode)) {
+		close(hdl->fd);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+void __libnvme_transport_handle_close_direct(
+		struct libnvme_transport_handle *hdl)
+{
+	libnvme_close_uring(hdl);
+	close(hdl->fd);
+	free(hdl);
+}
+
+__shr_public int libnvme_open(
+		struct libnvme_global_ctx *ctx, const char *name, int flags,
+		struct libnvme_transport_handle **hdlp)
+{
+	struct libnvme_transport_handle *hdl;
+	int ret;
+
+	hdl = __libnvme_create_transport_handle(ctx);
+	if (!hdl)
+		return -ENOMEM;
+
+	hdl->name = strdup(name);
+	if (!hdl->name) {
+		free(hdl);
+		return -ENOMEM;
+	}
+
+	if (!strncmp(name, "NVME_TEST_FD", 12)) {
+		hdl->type = LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT;
+		hdl->fd = LIBNVME_TEST_FD;
+
+		if (!strcmp(name, "NVME_TEST_FD64"))
+			hdl->ioctl_admin_state = IOCTL_STATE_IOCTL64;
+
+		*hdlp = hdl;
+		return 0;
+	}
+
+	if (!strncmp(name, "mctp:", strlen("mctp:"))) {
+		libnvme_close(hdl);
+		return -ENOTSUP;
+	}
+
+	ret = __libnvme_transport_handle_open_direct(hdl, name, flags);
+	if (ret) {
+		libnvme_close(hdl);
+		return ret;
+	}
+
+	*hdlp = hdl;
+
+	return 0;
+}
+
+__shr_public void libnvme_close(struct libnvme_transport_handle *hdl)
+{
+	if (!hdl)
+		return;
+
+	free(hdl->name);
+
+	switch (hdl->type) {
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_DIRECT:
+		__libnvme_transport_handle_close_direct(hdl);
+		break;
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_MI:
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_LOOPBACK:
+	case LIBNVME_TRANSPORT_HANDLE_TYPE_UNKNOWN:
+		free(hdl);
+		break;
+	}
+}

--- a/libnvme/src/nvme/mem-freebsd.c
+++ b/libnvme/src/nvme/mem-freebsd.c
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <malloc_np.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <ccan/minmax/minmax.h>
+
+#include <shared/compiler-attributes-util.h>
+
+#include "mem.h"
+#include "private.h"
+
+/*
+ * FreeBSD: plain page-aligned allocations. Linux's transparent-hugepage
+ * mmap/madvise flags (MAP_HUGETLB, MADV_HUGEPAGE) have no FreeBSD
+ * equivalent, so libnvme_alloc_huge() always takes the small-allocation
+ * posix_memalign() path regardless of size -- correct, just without the
+ * performance benefit of real huge pages.
+ */
+
+__shr_public void *libnvme_alloc(size_t len)
+{
+	size_t _len = round_up(len, 0x1000);
+	void *p;
+
+	if (posix_memalign((void *)&p, getpagesize(), _len))
+		return NULL;
+
+	memset(p, 0, _len);
+	return p;
+}
+
+__shr_public void *libnvme_realloc(void *p, size_t len)
+{
+	size_t old_len = malloc_usable_size(p);
+	void *result = libnvme_alloc(len);
+
+	if (p && result) {
+		memcpy(result, p, min_t(size_t, old_len, len));
+		free(p);
+	}
+
+	return result;
+}
+
+__shr_public void libnvme_free(void *p)
+{
+	free(p);
+}
+
+__shr_public void *libnvme_alloc_huge(size_t len,
+		struct libnvme_mem_huge *mh)
+{
+	memset(mh, 0, sizeof(*mh));
+
+	len = round_up(len, 0x1000);
+
+	mh->p = libnvme_alloc(len);
+	if (!mh->p)
+		return NULL;
+
+	mh->libnvme_alloc = true;
+	mh->len = len;
+	return mh->p;
+}
+
+__shr_public void libnvme_free_huge(struct libnvme_mem_huge *mh)
+{
+	if (!mh || mh->len == 0)
+		return;
+
+	free(mh->p);
+
+	mh->len = 0;
+	mh->p = NULL;
+}

--- a/libnvme/src/nvme/scan-freebsd.c
+++ b/libnvme/src/nvme/scan-freebsd.c
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <shared/compiler-attributes-util.h>
+
+#include <libnvme.h>
+
+#include "private.h"
+
+#define DEV_DIR "/dev"
+
+/*
+ * FreeBSD's nvme(4) driver creates one controller device per controller
+ * (/dev/nvmeX) and one namespace device per namespace (/dev/nvmeXnY),
+ * both character devices -- there is no sysfs to enumerate, so this
+ * filters dirent entries straight out of /dev instead.
+ */
+
+static int scan_dev_dir(int (*filter)(const struct dirent *),
+		struct dirent ***entries)
+{
+	int ret;
+
+	ret = scandir(DEV_DIR, entries, filter, alphasort);
+	if (ret < 0)
+		return -errno;
+
+	return ret;
+}
+
+static int filter_ctrl(const struct dirent *d)
+{
+	unsigned int instance;
+	int consumed = -1;
+
+	sscanf(d->d_name, "nvme%u%n", &instance, &consumed);
+	return consumed > 0 && (size_t)consumed == strlen(d->d_name);
+}
+
+static int filter_ns(const struct dirent *d)
+{
+	unsigned int instance, nsid;
+	int consumed = -1;
+
+	sscanf(d->d_name, "nvme%un%u%n", &instance, &nsid, &consumed);
+	return consumed > 0 && (size_t)consumed == strlen(d->d_name);
+}
+
+__shr_public int libnvme_scan_subsystems(
+		__shr_unused struct libnvme_global_ctx *ctx,
+		__shr_unused struct dirent ***subsys)
+{
+	return 0;
+}
+
+__shr_public int libnvme_scan_subsystem_namespaces(
+		__shr_unused libnvme_subsystem_t s,
+		__shr_unused struct dirent ***ns)
+{
+	return 0;
+}
+
+__shr_public int libnvme_scan_ctrls(
+		__shr_unused struct libnvme_global_ctx *ctx,
+		struct dirent ***ctrls)
+{
+	return scan_dev_dir(filter_ctrl, ctrls);
+}
+
+__shr_public int libnvme_scan_ctrl_namespace_paths(
+		__shr_unused libnvme_ctrl_t c,
+		__shr_unused struct dirent ***paths)
+{
+	return 0;
+}
+
+__shr_public int libnvme_scan_ctrl_namespaces(
+		libnvme_ctrl_t c,
+		struct dirent ***ns)
+{
+	struct dirent **entries;
+	unsigned int instance;
+	int i, j, ret;
+
+	if (sscanf(c->name, "nvme%u", &instance) != 1)
+		return -EINVAL;
+
+	ret = scan_dev_dir(filter_ns, &entries);
+	if (ret < 0)
+		return ret;
+
+	for (i = 0, j = 0; i < ret; i++) {
+		unsigned int ns_instance, nsid;
+
+		sscanf(entries[i]->d_name, "nvme%un%u",
+				&ns_instance, &nsid);
+		if (ns_instance != instance) {
+			free(entries[i]);
+			continue;
+		}
+		entries[j++] = entries[i];
+	}
+
+	*ns = entries;
+	return j;
+}
+
+__shr_public int libnvme_scan_ns_head_paths(
+		__shr_unused libnvme_ns_head_t head,
+		__shr_unused struct dirent ***paths)
+{
+	return 0;
+}

--- a/libnvme/src/nvme/tree-freebsd.c
+++ b/libnvme/src/nvme/tree-freebsd.c
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of libnvme.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+#include <ccan/endian/endian.h>
+#include <ccan/list/list.h>
+
+#include <shared/compiler-attributes-util.h>
+
+#include <libnvme.h>
+
+#include "cleanup.h"
+#include "private-tree.h"
+#include "private.h"
+#include "util.h"
+
+/*
+ * FreeBSD has no sysfs, so unlike tree-linux.c a controller's identity
+ * (subsysnqn) is learned by opening the device and issuing an Identify
+ * Controller command rather than by reading an attribute file. This
+ * mirrors tree-win.c in spirit, but without Windows' PhysicalDriveN/
+ * ctrl-map indirection: FreeBSD's nvme(4) driver already names
+ * controller and namespace device nodes the way libnvme_open() expects
+ * (/dev/nvmeX, /dev/nvmeXnY), so they can be opened directly by name.
+ */
+
+int libnvme_reconfigure_ctrl(__shr_unused struct libnvme_global_ctx *ctx,
+		libnvme_ctrl_t c, const char *path, const char *name)
+{
+	/*
+	 * It's necessary to release any resources first because a ctrl
+	 * can be reused.
+	 */
+	libnvme_ctrl_release_transport_handle(c);
+	FREE_CTRL_ATTR(c->name);
+	FREE_CTRL_ATTR(c->sysfs_dir);
+	libnvme_ctrl_attrs_reset(c->attrs);
+
+	c->hdl = NULL;
+	c->name = shr_xstrdup(name);
+	c->sysfs_dir = shr_xstrdup(path);
+	if (!c->name || !c->sysfs_dir) {
+		FREE_CTRL_ATTR(c->name);
+		FREE_CTRL_ATTR(c->sysfs_dir);
+		return -ENOMEM;
+	}
+
+	if (!libnvme_ctrl_get_transport_handle(c))
+		return -ENODEV;
+
+	return 0;
+}
+
+__shr_public const char *libnvme_ctrl_get_state(libnvme_ctrl_t c)
+{
+	char *state = c->state;
+
+	c->state = strdup("");
+	free(state);
+	return c->state;
+}
+
+__shr_public int libnvme_init_ctrl(__shr_unused libnvme_host_t h,
+		__shr_unused libnvme_ctrl_t c,
+		__shr_unused int instance)
+{
+	return -ENOTSUP;
+}
+
+/*
+ * Look up the "domain:bus:slot.func" PCI address nvme(4) publishes for
+ * @name (e.g. "nvme0") via the dev.nvme.<N>.%location sysctl -- the
+ * closest FreeBSD equivalent of Linux's sysfs "address" attribute.
+ * Returns NULL if the instance can't be parsed out of @name or the
+ * sysctl isn't there to read.
+ */
+static char *pci_traddr_from_ctrl_name(const char *name)
+{
+	unsigned int instance, domain, bus, slot, func;
+	char oid[64], location[128] = "";
+	size_t len = sizeof(location) - 1;
+	char *dbsf, *traddr;
+
+	if (sscanf(name, "nvme%u", &instance) != 1)
+		return NULL;
+
+	snprintf(oid, sizeof(oid), "dev.nvme.%u.%%location", instance);
+	if (sysctlbyname(oid, location, &len, NULL, 0) < 0)
+		return NULL;
+	location[len] = '\0';
+
+	dbsf = strstr(location, "dbsf=pci");
+	if (!dbsf)
+		return NULL;
+
+	if (sscanf(dbsf, "dbsf=pci%u:%u:%u:%u",
+			&domain, &bus, &slot, &func) != 4)
+		return NULL;
+
+	if (asprintf(&traddr, "%04x:%02x:%02x.%x",
+			domain, bus, slot, func) < 0)
+		return NULL;
+
+	return traddr;
+}
+
+int libnvme_get_ctrl_transport(__shr_unused struct libnvme_global_ctx *ctx,
+		__shr_unused const char *path,
+		const char *name, char **transport,
+		char **traddr, char **addr, char **trsvcid,
+		char **host_traddr, char **host_iface)
+{
+	*addr = NULL;
+	*trsvcid = NULL;
+	*host_traddr = NULL;
+	*host_iface = NULL;
+
+	/*
+	 * Every other accessor of libnvme_ctrl_get_traddr() assumes a
+	 * non-NULL return once the controller is known (e.g. printing it
+	 * unconditionally), so fall back to "" rather than leaving this
+	 * NULL when the sysctl lookup doesn't pan out.
+	 */
+	*traddr = pci_traddr_from_ctrl_name(name);
+	if (!*traddr)
+		*traddr = strdup("");
+	if (!*traddr)
+		return -ENOMEM;
+
+	/*
+	 * Fabrics aren't wired up on FreeBSD yet (want_fabrics is
+	 * Linux-only, see top-level meson.build), so every controller
+	 * nvme(4) exposes is a local PCIe one.
+	 */
+	*transport = strdup("pcie");
+	if (!*transport) {
+		free(*traddr);
+		*traddr = NULL;
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+/*
+ * Trim an NVMe spec ASCII field (space-padded, not NUL-terminated) of up
+ * to @len characters into a newly allocated, NUL-terminated string.
+ */
+static char *dup_ascii_field(const char *field, size_t len)
+{
+	while (len > 0 && field[len - 1] == ' ')
+		len--;
+
+	return strndup(field, len);
+}
+
+__shr_public int libnvme_scan_ctrl(
+		struct libnvme_global_ctx *ctx,
+		const char *name,
+		libnvme_ctrl_t *cp)
+{
+	__cleanup_libnvme_free struct nvme_id_ctrl *id = NULL;
+	struct libnvme_transport_handle *hdl;
+	struct libnvme_passthru_cmd cmd;
+	__cleanup_free char *subsysnqn = NULL;
+	libnvme_host_t h;
+	libnvme_subsystem_t s;
+	libnvme_ctrl_t c;
+	int ret;
+
+	libnvme_msg(ctx, LIBNVME_LOG_DEBUG, "scan controller %s\n", name);
+
+	ret = libnvme_open(ctx, name, O_RDONLY, &hdl);
+	if (ret)
+		return ret;
+
+	id = libnvme_alloc(sizeof(*id));
+	if (!id) {
+		libnvme_close(hdl);
+		return -ENOMEM;
+	}
+
+	nvme_init_identify_ctrl(&cmd, id);
+	ret = libnvme_exec_admin_passthru(hdl, &cmd);
+	libnvme_close(hdl);
+	if (ret)
+		return ret;
+
+	if (id->subnqn[0])
+		subsysnqn = dup_ascii_field(id->subnqn, sizeof(id->subnqn));
+	else {
+		__cleanup_free char *model =
+			dup_ascii_field(id->mn, sizeof(id->mn));
+		__cleanup_free char *serial =
+			dup_ascii_field(id->sn, sizeof(id->sn));
+
+		/*
+		 * Same "no subsysnqn reported" placeholder scheme the
+		 * Linux kernel and nvme-cli already use for bare PCIe
+		 * controllers that predate mandatory SUBNQN support.
+		 */
+		ret = asprintf(&subsysnqn,
+			"nqn.2014.08.org.nvmexpress:%04x%04x%*s%*s",
+			le16_to_cpu(id->vid), le16_to_cpu(id->ssvid),
+			(int)sizeof(id->mn), model ? model : "",
+			(int)sizeof(id->sn), serial ? serial : "");
+		if (ret < 0)
+			return -ENOMEM;
+	}
+	if (!subsysnqn)
+		return -ENOMEM;
+
+	ret = libnvme_get_host(ctx, NULL, NULL, &h);
+	if (ret)
+		return ret;
+
+	/*
+	 * No sysfs, hence no "nvme-subsysN" directory name to key the
+	 * subsystem by -- every other caller of libnvme_subsystem_get_name()
+	 * assumes non-NULL (e.g. nvme-print-stdout.c hashes it unconditionally),
+	 * so this can't just pass NULL through like the FreeBSD stub used to.
+	 * The controller name is as good a stand-in as any for the common
+	 * single-controller-per-subsystem PCIe case.
+	 */
+	ret = libnvme_get_subsystem(ctx, h, name, subsysnqn, &s);
+	if (ret)
+		return ret;
+
+	ret = libnvme_ctrl_alloc(ctx, s, name, name, &c);
+	if (ret)
+		return ret;
+
+	ret = libnvme_ctrl_scan_paths(ctx, c);
+	if (ret) {
+		libnvme_free_ctrl(c);
+		return ret;
+	}
+
+	ret = libnvme_ctrl_scan_namespaces(ctx, c);
+	if (ret) {
+		libnvme_free_ctrl(c);
+		return ret;
+	}
+
+	*cp = c;
+	return 0;
+}
+
+__shr_public char *libnvme_get_subsys_attr(
+		__shr_unused libnvme_subsystem_t s,
+		__shr_unused const char *attr)
+{
+	return NULL;
+}
+
+__shr_public char *libnvme_get_path_attr(
+		__shr_unused libnvme_path_t p,
+		__shr_unused const char *attr)
+{
+	return NULL;
+}
+
+__shr_public char *libnvme_get_attr(
+		__shr_unused const char *dir,
+		__shr_unused const char *attr)
+{
+	return NULL;
+}
+
+__shr_public char *libnvme_get_ctrl_attr(
+		__shr_unused libnvme_ctrl_t c,
+		__shr_unused const char *attr)
+{
+	return NULL;
+}
+
+__shr_public char *libnvme_get_ns_attr(
+		__shr_unused libnvme_ns_t n,
+		__shr_unused const char *attr)
+{
+	return NULL;
+}
+
+const char *libnvme_subsys_sysfs_dir(
+		__shr_unused struct libnvme_global_ctx *ctx)
+{
+	return NULL;
+}
+
+const char *libnvme_ns_sysfs_dir(
+		__shr_unused struct libnvme_global_ctx *ctx)
+{
+	return NULL;
+}
+
+int libnvme_ns_init(__shr_unused const char *path, struct libnvme_ns *ns)
+{
+	ns->attrs = libnvme_ns_attrs_alloc();
+	if (!ns->attrs)
+		return -ENOMEM;
+
+	return 0;
+}
+
+int libnvme_ns_open(struct libnvme_global_ctx *ctx,
+		__shr_unused const char *sys_path,
+		const char *name, libnvme_ns_t *ns)
+{
+	struct libnvme_transport_handle *hdl;
+	struct libnvme_ns_head *head;
+	struct libnvme_ns *n;
+	int ret;
+
+	n = calloc(1, sizeof(*n));
+	if (!n)
+		return -ENOMEM;
+
+	head = calloc(1, sizeof(*head));
+	if (!head) {
+		free(n);
+		return -ENOMEM;
+	}
+
+	head->n = n;
+	list_head_init(&head->paths);
+
+	n->ctx = ctx;
+	n->head = head;
+	n->hdl = NULL;
+	n->name = strdup(name);
+	n->generic_name = strdup(name);
+	if (!n->name || !n->generic_name) {
+		ret = -ENOMEM;
+		goto free_ns;
+	}
+
+	/* Open the device to query the namespace ID */
+	ret = libnvme_open(ctx, name, O_RDONLY, &hdl);
+	if (ret)
+		goto free_ns;
+
+	ret = libnvme_get_nsid(hdl, &n->nsid);
+	libnvme_close(hdl);
+	if (ret)
+		goto free_ns;
+
+	ret = libnvme_ns_init(name, n);
+	if (ret)
+		goto free_ns;
+
+	list_node_init(&n->entry);
+
+	libnvme_ns_release_transport_handle(n);
+
+	*ns = n;
+	return 0;
+
+free_ns:
+	free(n->generic_name);
+	free(n->name);
+	free(head);
+	free(n);
+	return ret;
+}
+
+int __libnvme_scan_namespace(struct libnvme_global_ctx *ctx,
+		__shr_unused const char *sysfs_dir,
+		const char *name, libnvme_ns_t *ns)
+{
+	struct libnvme_ns *n = NULL;
+	int ret;
+
+	ret = libnvme_ns_open(ctx, NULL, name, &n);
+	if (ret)
+		return ret;
+
+	n->sysfs_dir = strdup(name);
+	if (!n->sysfs_dir) {
+		libnvme_free_ns(n);
+		return -ENOMEM;
+	}
+
+	*ns = n;
+	return 0;
+}
+
+int libnvme_init_subsystem(libnvme_subsystem_t s, const char *name)
+{
+	s->subsystype = strdup("nvm");
+	if (!s->subsystype)
+		return -ENOMEM;
+
+	s->name = strdup(name);
+	if (!s->name) {
+		free(s->subsystype);
+		return -ENOMEM;
+	}
+
+	return 0;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,6 +37,10 @@ elif host_system == 'windows'
     sources += [
         'src/nvme-pci-ids-win.c',
     ]
+elif host_system == 'freebsd'
+    sources += [
+        'src/nvme-pci-ids-freebsd.c',
+    ]
 endif
 
 if json_c_dep.found()

--- a/src/nvme-pci-ids-freebsd.c
+++ b/src/nvme-pci-ids-freebsd.c
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+
+#include <nvme/types.h>
+
+#include "nvme-pci-ids.h"
+
+/*
+ * FreeBSD has no sysfs, so there is no directory to hand back here.
+ * Instead, smuggle the controller name (e.g. "nvme0") through the
+ * 'sysfs_dir' out-param -- __nvme_get_pci_ids() below uses it to build
+ * the "dev.nvme.<N>.%pnpinfo" sysctl name nvme(4) publishes the PCI IDs
+ * under.
+ */
+int __nvme_get_sysfs_dir(__attribute__((__unused__)) struct libnvme_global_ctx *ctx,
+		const char *ctrl_name, char **sysfs_dir)
+{
+	*sysfs_dir = strdup(ctrl_name);
+	if (!*sysfs_dir)
+		return -ENOMEM;
+
+	return 0;
+}
+
+int __nvme_get_pci_ids(const char *sysfs_dir,
+		__u32 *vid, __u32 *did,
+		__u32 *subsys_vid, __u32 *subsys_did,
+		__u32 *class_code)
+{
+	unsigned int instance;
+	char oid[64], pnpinfo[256] = "";
+	char *p;
+	size_t len = sizeof(pnpinfo) - 1;
+	unsigned int v = 0, d = 0, sv = 0, sd = 0, cls = 0;
+
+	if (sscanf(sysfs_dir, "nvme%u", &instance) != 1)
+		return -EINVAL;
+
+	snprintf(oid, sizeof(oid), "dev.nvme.%u.%%pnpinfo", instance);
+	if (sysctlbyname(oid, pnpinfo, &len, NULL, 0) < 0)
+		return -errno;
+	pnpinfo[len] = '\0';
+
+	/*
+	 * pnpinfo is a space-separated "key=value" list, e.g.:
+	 *   vendor=0x1b36 device=0x0010 subvendor=0x1af4 subdevice=0x1100 class=0x010802
+	 */
+	p = strstr(pnpinfo, "vendor=");
+	if (p)
+		sscanf(p, "vendor=%x", &v);
+	p = strstr(pnpinfo, "device=");
+	if (p)
+		sscanf(p, "device=%x", &d);
+	p = strstr(pnpinfo, "subvendor=");
+	if (p)
+		sscanf(p, "subvendor=%x", &sv);
+	p = strstr(pnpinfo, "subdevice=");
+	if (p)
+		sscanf(p, "subdevice=%x", &sd);
+	p = strstr(pnpinfo, "class=");
+	if (p)
+		sscanf(p, "class=%x", &cls);
+
+	if (vid)
+		*vid = v;
+	if (did)
+		*did = d;
+	if (subsys_vid)
+		*subsys_vid = sv;
+	if (subsys_did)
+		*subsys_did = sd;
+	if (class_code)
+		*class_code = cls;
+
+	return 0;
+}


### PR DESCRIPTION
Usually, porting to a new platform, architecture, or compiler uncovers generic problems throughout the codebase. The initial porting attempt to FreeBSD is no exception. We need to fix generic build dependencies and add dummy implementations for FreeBSD. These dummy implementations require further review, as some parts can and should be shared with Linux.