### PR TITLE
ocp: fix untrusted allocation size in parse_event_fifos()

### DIFF
--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1377,7 +1377,16 @@ int parse_event_fifos(struct json_object *root, struct nvme_ocp_telemetry_offset
 				(event_fifo[fifo_no].event_fifo_start  * SIZE_OF_DWORD);
 			__u64 fifo_size =
 				(event_fifo[fifo_no].event_fifo_size  * SIZE_OF_DWORD);
+			__u64 da_size = (poffsets->data_area == 1) ?
+				poffsets->da1_size : poffsets->da2_size;
 			__u8 *pfifo_start = NULL;
+
+			if (!fifo_size || fifo_offset + fifo_size > da_size) {
+				nvme_show_error(
+					"Invalid FIFO bounds for FIFO %d",
+					fifo_no);
+				return -1;
+			}
 
 			if (event_fifo[fifo_no].event_fifo_da == 1)
 				pfifo_start = pda1_header_offset + fifo_offset;


### PR DESCRIPTION
The parse_event_fifos() function reads event_fifo_start and event_fifo_size directly from the device-supplied telemetry buffer and uses them to compute a FIFO data pointer and size without any bounds validation.

A malicious or corrupt device can supply out-of-range values, causing the computed pfifo_start pointer to exceed the telemetry buffer boundary. Passing an unbounded fifo_size to parse_event_fifo() then drives an inner loop well past the end of the buffer, resulting in an out-of-bounds read and potential heap corruption.

Validate fifo_offset and fifo_size against the known data area size from poffsets before using them to compute the FIFO pointer or calling parse_event_fifo().