### PR TITLE
nvme: fix use-after-free of args->log in get_log_offset()

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -10730,7 +10730,7 @@ static int get_log_offset(struct libnvme_transport_handle *hdl,
 	if (!*log)
 		return -ENOMEM;
 
-	args->log = *log + args->lpo;
+	args->log = (char *)*log + args->lpo;
 
 	nvme_init_get_log(&cmd, args->nsid, args->lid,
 			  args->csi, args->log, args->len);


### PR DESCRIPTION
@args->log was assigned from @*log before calling
libnvme_realloc(), which may move the buffer to a new address, leaving @args->log pointing into freed memory.

Move the assignment of @args->log to after the realloc so it always derives from the updated @*log pointer, using the already saved @args->lpo as the offset.

Detected by Coverity: CID 557492 (Use after free, High).