### PR TITLE
ocp: fix out-of-bounds access in json_c7_log()

### DIFF
--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -1160,6 +1160,7 @@ static void json_c7_log(struct libnvme_transport_handle *hdl, struct tcg_configu
 				  le32_to_cpu(log_data->pro_rlc));
 	json_object_add_value_int(root, "TCG Error Count", le32_to_cpu(log_data->tcg_ec));
 
+	res = res_arr;
 	memset((__u8 *)res, 0, 458);
 	if (log_page_version == 1) {
 		res += sprintf(res, "%d%d", *(__u8 *)&log_data->no_of_ns_prov_locking_obj_ext,


### PR DESCRIPTION
res is a char pointer into the 458-byte res_arr buffer. After the first use block (encoding rsvd1[3] into res_arr), res is left pointing 3+ bytes past the start of res_arr.

The second use block then calls memset(res, 0, 458) from that advanced position, writing 3 bytes past the end of res_arr. The subsequent 456-iteration sprintf loop writes from the same advanced position, compressing the usable space.

Reset res = res_arr before the second memset so that both the memset and the following loop operate from the start of the buffer.

Addresses-Coverity: 557324