### PR TITLE
netapp: fix null pointer dereference in netapp_ontapdevices_print_regular()

### DIFF
--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -635,6 +635,8 @@ static void netapp_ontapdevices_print_regular(struct ontapdevice_info *devices,
 			"---------");
 		formatstr = columnstr;
 	}
+	else
+		return;
 
 	for (i = 0; i < count; i++) {
 		if (devname && !strcmp(devname, basename(devices[i].dev))) {


### PR DESCRIPTION
If format is neither NNORMAL nor NCOLUMN, formatstr remains NULL and is subsequently passed to printf(), causing a null pointer dereference.

Add an else-return guard so an unexpected format value causes an early return before formatstr is used.

Coverity-Id: 557362