### PR TITLE
ocp: fix resource leak of fp in print_ocp_telemetry_normal

### DIFF
--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1727,6 +1727,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			status = parse_statistics(NULL, &offsets, fp);
 			if (status != 0) {
 				nvme_show_error("status: %d", status);
+				fclose(fp);
 				return -1;
 			}
 
@@ -1734,8 +1735,10 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 			fprintf(fp, "%s\n", STR_DA_1_EVENT_FIFO_INFO);
 			fprintf(fp, STR_LINE);
 			status = parse_event_fifos(NULL, &offsets, fp);
-			if (status != 0)
+			if (status != 0) {
+				fclose(fp);
 				return -1;
+			}
 
 			//Set the DA to 2
 			if (options->data_area == 2) {
@@ -1747,6 +1750,7 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 
 				if (status != 0) {
 					nvme_show_error("status: %d", status);
+					fclose(fp);
 					return -1;
 				}
 
@@ -1754,8 +1758,10 @@ int print_ocp_telemetry_normal(struct ocp_telemetry_parse_options *options)
 				fprintf(fp, "%s\n", STR_DA_2_EVENT_FIFO_INFO);
 				fprintf(fp, STR_LINE);
 				status = parse_event_fifos(NULL, &offsets, fp);
-				if (status != 0)
+				if (status != 0) {
+					fclose(fp);
 					return -1;
+				}
 			}
 
 			fprintf(fp, STR_LINE);


### PR DESCRIPTION
The print_ocp_telemetry_normal() function opens a file @fp for writing the telemetry output. On four error return paths inside the if (fp) block, the file is returned from without being closed: after parse_statistics() failure for DA1, after parse_event_fifos() failure for DA1, and after the same two failures for DA2.

The open file descriptor is leaked each time one of these error paths is taken.

Close @fp on all four error return paths before returning to prevent the resource leak.