### PR TITLE
libnvme: Add missing lazy sysfs namespace attributes

### DIFF
--- a/libnvme/design/tooling/generate_sysfs_accessors.md
+++ b/libnvme/design/tooling/generate_sysfs_accessors.md
@@ -1,6 +1,6 @@
 # Generate Sysfs Accessors Tool
 
-This tool generates an **opaque, sysfs-backed C struct** and its accessor functions from a **Python dict**, rather than from an annotated header the way `generate_accessors.py` does. It drives `struct libnvme_ctrl_sysfs` and `struct libnvme_path_sysfs` today; `NS_SYSFS`/`SUBSYS_SYSFS` are the anticipated follow-on.
+This tool generates an **opaque, sysfs-backed C struct** and its accessor functions from a **Python dict**, rather than from an annotated header the way `generate_accessors.py` does. It drives `struct libnvme_ctrl_sysfs`, `struct libnvme_path_sysfs`, `struct libnvme_ns_sysfs`, and `struct libnvme_subsystem_sysfs`.
 
 ------
 
@@ -145,7 +145,7 @@ Use a group instead of a plain member when one sysfs read naturally produces **s
 2. `loader` is a C function name. The generated getter calls it as `loader(w)`, passing the owning struct pointer, and propagates a nonzero return to its own caller unchanged (the load itself failed, not just "attribute absent"). Declare it once in the generated header (automatic — `generate_header()` emits a prototype for every group's `loader`, but only when the spec has at least one group) and define it in whichever hand-written `*-custom-*.c` file(s) actually need to fill this group — see "Generated file layout" below.
 3. The first access to *any* member of the group triggers the loader; every other member's cache-miss guard then finds its value already loaded and never calls the loader again. Loaders must leave every member they don't fill at `NULL` (not garbage) so the generated accessor can stamp the "read, absent" sentinel correctly.
 4. If the loader body genuinely needs to differ by `CONFIG_FABRICS` (or any axis other than OS), that's a fact about the hand-written `.c` files, not about this dict — there's no key to set. A one-line comment above the group entry noting "loader body varies by CONFIG_FABRICS" (or similar) is enough; see the existing `identity` and `fabrics` groups for the pattern. If the loader (or the *grouping itself*) needs to differ by **OS**, see "Per-OS resolution" below instead — that is a real, first-class axis this generator understands, unlike fabrics-or-other build flags.
-5. Groups themselves are not yet OS-resolved (a spec's `['groups']` list is a single, OS-invariant list) — no current spec needs a group whose loader or membership differs per OS. `NS_SYSFS`'s geometry group will be the first one that does; extend `build_members()` the same way member resolution works, when it lands.
+5. Groups themselves are not yet OS-resolved (a spec's `['groups']` list is a single, OS-invariant list) — no current spec needs a group whose loader or membership differs per OS. Extend `build_members()` the same way member resolution works, if one ever does.
 
 ------
 
@@ -154,15 +154,11 @@ Use a group instead of a plain member when one sysfs read naturally produces **s
 A member only needs a `'linux'`/`'win'` override when its **value source** — which function gets called, or how members are grouped — genuinely differs per platform:
 
 ```python
-{'name': 'lba_util', 'type': 'uint64_t',
- 'linux': {'group': 'capacity'},
- 'win':   {'group': 'identify'}},
-
 {'name': 'ana_state', 'type': 'char *', 'attr': 'ana_state', 'volatile': True,
  'win': {'absent': True}},
 ```
 
-**Most members do not need this.** `libnvme_get_{ctrl,ns,path,subsys}_attr()` already has a Windows implementation that unconditionally returns `NULL` — so for a plain `'attr'` member, Windows absence falls out of the existing attr-reader stub for free; the generated getter body is identical C on both platforms, it just behaves differently at runtime because the function it calls does. Only add an override when a *different function* needs to be called, or the *grouping* itself changes (`NS_SYSFS`'s `lba_*` members: Linux calls two small loaders, Windows calls one big Identify loader — that is not expressible by changing what one function returns).
+**Most members do not need this.** `libnvme_get_{ctrl,ns,path,subsys}_attr()` already has a Windows implementation that unconditionally returns `NULL` — so for a plain `'attr'` member, Windows absence falls out of the existing attr-reader stub for free; the generated getter body is identical C on both platforms, it just behaves differently at runtime because the function it calls does. Only add an override when a *different function* needs to be called, or the *grouping* itself changes — no current spec needs that case; `'absent': True` (every `PATH_SYSFS` member on Windows) is the only override in use today. A member whose OS difference can't be expressed by changing what one function returns (e.g. `NS_SYSFS`'s `lba_*` members: Linux calls two small loaders, Windows calls one big Identify command) uses `'custom': True` instead — a hand-written getter body in `*-custom-<os>.c`, with only the prototype and the struct field generated (see `sysfs_accessors_specs.py`'s `NS_SYSFS` entry for worked examples).
 
 `'absent': True` means the platform has no source for the member at all: the generated getter writes `dflt` to the out-param and always returns `-ENOENT`, no attribute read or loader call ever happens, and (for `PATH_SYSFS`, where every member is absent on Windows) the owning-struct parameter is `__shr_unused` since the body never touches it.
 
@@ -177,7 +173,7 @@ The generator resolves each member's effective Linux and Windows definition and 
 
 The struct definition, `_alloc()`/`_reset()`/`_free()`, and every OS-common getter always live in the shared file — **the struct never splits**, even when some of its members' getters do, because every cached member (string or boxed numeric) has the same storage shape regardless of which loader fills it.
 
-For `PATH_SYSFS`, every member differs (absent on Windows), so the shared file holds only the struct definition and lifecycle functions, and both `path-sysfs-linux.c` and `path-sysfs-win.c` exist. For `CTRL_SYSFS` today, no member differs at all, so only the shared `ctrl-sysfs.c` exists — exactly the file this generator has always produced. `NS_SYSFS`'s geometry members will be the first case where a spec's shared file is non-trivial *and* both per-OS files exist alongside it.
+For `PATH_SYSFS`, every member differs (absent on Windows), so the shared file holds only the struct definition and lifecycle functions, and both `path-sysfs-linux.c` and `path-sysfs-win.c` exist. For `CTRL_SYSFS`, no member differs at all, so only the shared `ctrl-sysfs.c` exists — exactly the file this generator has always produced. `NS_SYSFS` is the case where a spec's shared file is non-trivial *and* both per-OS files exist alongside it (its `lba_*`/`csi`/`eui64`/`nguid`/`uuid` members are `'custom': True`, hand-written in `ns-sysfs-custom-linux.c`/`ns-sysfs-custom-win.c`, while its `diag/*` counters are OS-common and live in the shared `ns-sysfs.c`).
 
 The per-OS `.c` files carry no `#include`s of their own — they rely on being `#include`d *after* the shared file in the hand-written `*-custom-<os>.c`, which brings the struct definition and everything else into scope first:
 

--- a/libnvme/libnvme3/accessors.i
+++ b/libnvme/libnvme3/accessors.i
@@ -53,10 +53,6 @@ struct libnvme_ns {
 	%immutable generic_name;
 	const char * generic_name;
 	const char * sysfs_dir;
-	%immutable eui64;
-	uint8_t eui64[8];
-	%immutable nguid;
-	uint8_t nguid[16];
 };
 
 %pythoncode %{

--- a/libnvme/src/accessors.ld
+++ b/libnvme/src/accessors.ld
@@ -126,10 +126,8 @@ LIBNVME_ACCESSORS_3 {
 		libnvme_host_get_hostsymname;
 		libnvme_host_set_dhchap_host_key;
 		libnvme_host_set_hostsymname;
-		libnvme_ns_get_eui64;
 		libnvme_ns_get_generic_name;
 		libnvme_ns_get_name;
-		libnvme_ns_get_nguid;
 		libnvme_ns_get_nsid;
 		libnvme_ns_get_sysfs_dir;
 		libnvme_ns_set_nsid;

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -64,10 +64,8 @@ LIBNVME_3 {
 		libnvme_next_host;
 		libnvme_next_subsystem;
 		libnvme_ns_compare;
-		libnvme_ns_copy_uuid;
 		libnvme_ns_flush;
 		libnvme_ns_get_ctrl;
-		libnvme_ns_get_eui64;
 		libnvme_ns_get_firmware;
 		libnvme_ns_get_inflights;
 		libnvme_ns_get_io_ticks;

--- a/libnvme/src/ns-sysfs.ld
+++ b/libnvme/src/ns-sysfs.ld
@@ -23,6 +23,9 @@ LIBNVME_NS_SYSFS_3 {
 		libnvme_ns_get_lba_util;
 		libnvme_ns_get_meta_size;
 		libnvme_ns_get_csi;
+		libnvme_ns_get_eui64;
+		libnvme_ns_get_nguid;
+		libnvme_ns_get_uuid;
 		libnvme_ns_get_command_retry_count;
 		libnvme_ns_get_command_error_count;
 		libnvme_ns_get_io_requeue_no_usable_path_count;

--- a/libnvme/src/nvme/accessors.c
+++ b/libnvme/src/nvme/accessors.c
@@ -95,16 +95,6 @@ __shr_public const char *libnvme_ns_get_sysfs_dir(const struct libnvme_ns *p)
 	return p->sysfs_dir;
 }
 
-__shr_public const uint8_t *libnvme_ns_get_eui64(const struct libnvme_ns *p)
-{
-	return p->eui64;
-}
-
-__shr_public const uint8_t *libnvme_ns_get_nguid(const struct libnvme_ns *p)
-{
-	return p->nguid;
-}
-
 /****************************************************************************
  * Accessors for: struct libnvme_ctrl
  ****************************************************************************/

--- a/libnvme/src/nvme/accessors.h
+++ b/libnvme/src/nvme/accessors.h
@@ -121,22 +121,6 @@ void libnvme_ns_set_sysfs_dir(struct libnvme_ns *p, const char *sysfs_dir);
  */
 const char *libnvme_ns_get_sysfs_dir(const struct libnvme_ns *p);
 
-/**
- * libnvme_ns_get_eui64() - Get eui64.
- * @p: The &struct libnvme_ns instance to query.
- *
- * Return: Pointer to the eui64 array of 8 uint8_t elements.
- */
-const uint8_t *libnvme_ns_get_eui64(const struct libnvme_ns *p);
-
-/**
- * libnvme_ns_get_nguid() - Get nguid.
- * @p: The &struct libnvme_ns instance to query.
- *
- * Return: Pointer to the nguid array of 16 uint8_t elements.
- */
-const uint8_t *libnvme_ns_get_nguid(const struct libnvme_ns *p);
-
 /****************************************************************************
  * Accessors for: struct libnvme_ctrl
  ****************************************************************************/

--- a/libnvme/src/nvme/ns-sysfs-custom-linux.c
+++ b/libnvme/src/nvme/ns-sysfs-custom-linux.c
@@ -10,6 +10,7 @@
 #include <ccan/ilog/ilog.h>
 
 #include "mem.h"
+#include "util.h"
 
 #include "ns-sysfs.c"
 
@@ -359,5 +360,111 @@ __shr_public int libnvme_ns_get_csi(
 		return -ENOENT;
 
 	*val = *n->sysfs->csi;
+	return 0;
+}
+
+/*
+ * eui64/nguid/uuid each live in their own optional sysfs attribute,
+ * read lazily and independently on first use, and cached for the
+ * lifetime of the namespace object -- the returned pointer stays valid
+ * until the namespace is freed, same lifetime guarantee every other
+ * pointer-returning lazy getter (e.g. libnvme_ctrl_get_model()) already
+ * gives its caller. "eui" is raw text copied byte-for-byte;
+ * "nguid"/"uuid" are hyphenated hex strings decoded with
+ * libnvme_uuid_from_string(), the same helper used everywhere else a
+ * UUID-shaped attribute is parsed.
+ */
+__shr_public int libnvme_ns_get_eui64(
+		const struct libnvme_ns *p,
+		const uint8_t **val,
+		const uint8_t *dflt)
+{
+	struct libnvme_ns *n = (struct libnvme_ns *)p;
+	__cleanup_free char *str = NULL;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!SYSFS_IS_LOADED(n->sysfs->eui64))) {
+		str = libnvme_get_ns_attr(n, "eui");
+		if (!str) {
+			n->sysfs->eui64 = (uint8_t *)NO_SYSFS_ATTR;
+		} else {
+			n->sysfs->eui64 = malloc(8);
+			if (!n->sysfs->eui64)
+				return -ENOMEM;
+			memcpy(n->sysfs->eui64, str, 8);
+		}
+	}
+
+	if (SYSFS_IS_ABSENT(n->sysfs->eui64))
+		return -ENOENT;
+
+	*val = n->sysfs->eui64;
+	return 0;
+}
+
+__shr_public int libnvme_ns_get_nguid(
+		const struct libnvme_ns *p,
+		const uint8_t **val,
+		const uint8_t *dflt)
+{
+	struct libnvme_ns *n = (struct libnvme_ns *)p;
+	__cleanup_free char *str = NULL;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!SYSFS_IS_LOADED(n->sysfs->nguid))) {
+		str = libnvme_get_ns_attr(n, "nguid");
+		if (!str) {
+			n->sysfs->nguid = (uint8_t *)NO_SYSFS_ATTR;
+		} else {
+			n->sysfs->nguid = malloc(16);
+			if (!n->sysfs->nguid)
+				return -ENOMEM;
+			if (libnvme_uuid_from_string(str, n->sysfs->nguid)) {
+				free(n->sysfs->nguid);
+				n->sysfs->nguid = NULL;
+				return -EINVAL;
+			}
+		}
+	}
+
+	if (SYSFS_IS_ABSENT(n->sysfs->nguid))
+		return -ENOENT;
+
+	*val = n->sysfs->nguid;
+	return 0;
+}
+
+__shr_public int libnvme_ns_get_uuid(
+		const struct libnvme_ns *p,
+		const unsigned char **val,
+		const unsigned char *dflt)
+{
+	struct libnvme_ns *n = (struct libnvme_ns *)p;
+	__cleanup_free char *str = NULL;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!SYSFS_IS_LOADED(n->sysfs->uuid))) {
+		str = libnvme_get_ns_attr(n, "uuid");
+		if (!str) {
+			n->sysfs->uuid = (unsigned char *)NO_SYSFS_ATTR;
+		} else {
+			n->sysfs->uuid = malloc(NVME_UUID_LEN);
+			if (!n->sysfs->uuid)
+				return -ENOMEM;
+			if (libnvme_uuid_from_string(str, n->sysfs->uuid)) {
+				free(n->sysfs->uuid);
+				n->sysfs->uuid = NULL;
+				return -EINVAL;
+			}
+		}
+	}
+
+	if (SYSFS_IS_ABSENT(n->sysfs->uuid))
+		return -ENOENT;
+
+	*val = n->sysfs->uuid;
 	return 0;
 }

--- a/libnvme/src/nvme/ns-sysfs-custom-win.c
+++ b/libnvme/src/nvme/ns-sysfs-custom-win.c
@@ -212,3 +212,37 @@ __shr_public int libnvme_ns_get_csi(
 
 	return -ENOENT;
 }
+
+/*
+ * Windows never had a source for eui64/nguid/uuid either -- same call
+ * as csi above.
+ */
+__shr_public int libnvme_ns_get_eui64(
+		__shr_unused const struct libnvme_ns *p,
+		const uint8_t **val,
+		const uint8_t *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_ns_get_nguid(
+		__shr_unused const struct libnvme_ns *p,
+		const uint8_t **val,
+		const uint8_t *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}
+
+__shr_public int libnvme_ns_get_uuid(
+		__shr_unused const struct libnvme_ns *p,
+		const unsigned char **val,
+		const unsigned char *dflt)
+{
+	*val = dflt;
+
+	return -ENOENT;
+}

--- a/libnvme/src/nvme/ns-sysfs.c
+++ b/libnvme/src/nvme/ns-sysfs.c
@@ -36,6 +36,9 @@ struct libnvme_ns_sysfs {
 	uint64_t *lba_util;
 	int *meta_size;
 	enum nvme_csi *csi;
+	uint8_t *eui64;
+	uint8_t *nguid;
+	unsigned char *uuid;
 	long command_retry_count;
 	long command_error_count;
 	long io_requeue_no_usable_path_count;
@@ -67,6 +70,9 @@ void libnvme_ns_sysfs_free(
 	SYSFS_FREE(sysfs->lba_util);
 	SYSFS_FREE(sysfs->meta_size);
 	SYSFS_FREE(sysfs->csi);
+	SYSFS_FREE(sysfs->eui64);
+	SYSFS_FREE(sysfs->nguid);
+	SYSFS_FREE(sysfs->uuid);
 	free(sysfs);
 }
 

--- a/libnvme/src/nvme/ns-sysfs.h
+++ b/libnvme/src/nvme/ns-sysfs.h
@@ -120,6 +120,48 @@ int libnvme_ns_get_csi(
 		enum nvme_csi dflt);
 
 /**
+ * libnvme_ns_get_eui64() - Get eui64.
+ * @p: The &struct libnvme_ns instance to query.
+ * @eui64: Where to store the value on success.
+ * @dflt: Value to store in @eui64 on failure.
+ *
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
+ */
+int libnvme_ns_get_eui64(
+		const struct libnvme_ns *p,
+		const uint8_t **eui64,
+		const uint8_t *dflt);
+
+/**
+ * libnvme_ns_get_nguid() - Get nguid.
+ * @p: The &struct libnvme_ns instance to query.
+ * @nguid: Where to store the value on success.
+ * @dflt: Value to store in @nguid on failure.
+ *
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
+ */
+int libnvme_ns_get_nguid(
+		const struct libnvme_ns *p,
+		const uint8_t **nguid,
+		const uint8_t *dflt);
+
+/**
+ * libnvme_ns_get_uuid() - Get uuid.
+ * @p: The &struct libnvme_ns instance to query.
+ * @uuid: Where to store the value on success.
+ * @dflt: Value to store in @uuid on failure.
+ *
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
+ */
+int libnvme_ns_get_uuid(
+		const struct libnvme_ns *p,
+		const unsigned char **uuid,
+		const unsigned char *dflt);
+
+/**
  * libnvme_ns_get_command_retry_count() - Get command_retry_count.
  * @p: The &struct libnvme_ns instance to query.
  * @command_retry_count: Where to store the value on success.

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -309,10 +309,6 @@ struct libnvme_ns {  // !generate-accessors:read=generated,write=none !generate-
 	char *generic_name;
 	char *sysfs_dir;		     // !access:write=generated
 
-	uint8_t eui64[8];
-	uint8_t nguid[16];
-	unsigned char uuid[NVME_UUID_LEN];   // !access:read=none
-
 	/* Opaque: field list is NS_SYSFS in sysfs_accessors_specs.py. */
 	struct libnvme_ns_sysfs *sysfs;	// !access:read=none
 };

--- a/libnvme/src/nvme/sysfs_accessors_specs.py
+++ b/libnvme/src/nvme/sysfs_accessors_specs.py
@@ -263,6 +263,34 @@ NS_SYSFS = {
             'type': 'enum nvme_csi',
             'custom': True,
         },
+        # eui64/nguid/uuid are also 'custom': True, and their raw type
+        # is itself a pointer ("uint8_t *"/"unsigned char *") instead of
+        # a plain scalar -- a cached fixed-size byte buffer, following
+        # exactly the same storage-vs-public-type split a "char *"
+        # string member gets: the struct field stays a plain mutable
+        # pointer (see emit_struct_def()'s "already a pointer" branch),
+        # while the public getter hands back a pointer-to-const view of
+        # it (see _pub_type()) -- int fn(p, const TYPE **val, const
+        # TYPE *dflt), same shape as any other lazy getter, no new axis
+        # needed. Bodies are hand-written in ns-sysfs-custom-linux.c
+        # (real sysfs reads) and ns-sysfs-custom-win.c (always -ENOENT,
+        # Windows never had a source for these either -- same as csi's
+        # Windows getter).
+        {
+            'name': 'eui64',
+            'type': 'uint8_t *',
+            'custom': True,
+        },
+        {
+            'name': 'nguid',
+            'type': 'uint8_t *',
+            'custom': True,
+        },
+        {
+            'name': 'uuid',
+            'type': 'unsigned char *',
+            'custom': True,
+        },
         # The four diag/* counters need no per-OS override: like most
         # CTRL_SYSFS members, Windows absence falls out of the existing
         # libnvme_get_ns_attr() stub (unconditionally NULL) for free --

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -416,23 +416,6 @@ static int libnvme_strtou32(const char *str, void *res)
 	return 0;
 }
 
-static int libnvme_strtoeuid(const char *str, void *res)
-{
-	memcpy(res, str, 8);
-	return 0;
-}
-
-static int libnvme_strtouuid(const char *str, void *res)
-{
-	unsigned char uuid[NVME_UUID_LEN];
-
-	if (libnvme_uuid_from_string(str, uuid))
-		return -EINVAL;
-
-	memcpy(res, uuid, NVME_UUID_LEN);
-	return 0;
-}
-
 struct sysfs_attr_table {
 	void *var;
 	int (*parse)(const char *str, void *res);
@@ -471,9 +454,6 @@ int libnvme_ns_init(const char *path, struct libnvme_ns *ns)
 
 	struct sysfs_attr_table base[] = {
 		{ &ns->nsid,      libnvme_strtou32,  true, "nsid" },
-		{ ns->eui64,      libnvme_strtoeuid, false, "eui" },
-		{ ns->nguid,      libnvme_strtouuid, false, "nguid" },
-		{ ns->uuid,       libnvme_strtouuid, false, "uuid" }
 	};
 
 	ret = parse_attrs(path, base, ARRAY_SIZE(base));

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1602,12 +1602,6 @@ __shr_public const char *libnvme_ns_get_firmware(libnvme_ns_t n)
 	return val;
 }
 
-__shr_public void libnvme_ns_copy_uuid(libnvme_ns_t n,
-		unsigned char out[NVME_UUID_LEN])
-{
-	memcpy(out, n->uuid, NVME_UUID_LEN);
-}
-
 __shr_public int libnvme_ns_identify(libnvme_ns_t n, struct nvme_id_ns *ns)
 {
 	struct libnvme_transport_handle *hdl;

--- a/libnvme/src/nvme/tree.h
+++ b/libnvme/src/nvme/tree.h
@@ -383,15 +383,6 @@ libnvme_ns_t libnvme_subsystem_next_ns(libnvme_subsystem_t s, libnvme_ns_t n);
 		p = libnvme_namespace_next_path(n, p))
 
 /**
- * libnvme_ns_copy_uuid() - Copy UUID of a namespace into a caller buffer
- * @n:		Namespace instance
- * @out:	buffer for the UUID
- *
- * Copies the namespace's uuid into @out
- */
-void libnvme_ns_copy_uuid(libnvme_ns_t n, unsigned char out[NVME_UUID_LEN]);
-
-/**
  * libnvme_ns_get_firmware() - Firmware string of a namespace
  * @n:	Namespace instance
  *

--- a/libnvme/test/test.c
+++ b/libnvme/test/test.c
@@ -378,6 +378,11 @@ static void print_hex(const uint8_t *x, int len)
 		printf("%02x", x[i]);
 }
 
+/* Safe display fallbacks for the lazy eui64/nguid/uuid getters below. */
+static const uint8_t zero_eui64[8];
+static const uint8_t zero_nguid[16];
+static const unsigned char zero_uuid[NVME_UUID_LEN];
+
 int main(int argc, char **argv)
 {
 	struct libnvme_global_ctx *ctx;
@@ -444,7 +449,9 @@ int main(int argc, char **argv)
 
 				libnvme_ctrl_for_each_ns(c, n) {
 					char uuid_str[NVME_UUID_LEN_STRING];
-					unsigned char uuid[NVME_UUID_LEN];
+					const unsigned char *uuid;
+					const uint8_t *eui64;
+					const uint8_t *nguid;
 					int lba_size;
 					uint64_t lba_count;
 					enum nvme_csi csi;
@@ -457,11 +464,18 @@ int main(int argc, char **argv)
 					       libnvme_ns_get_name(n),
 					       lba_size, lba_count);
 					printf("      eui:");
-					print_hex(libnvme_ns_get_eui64(n), 8);
+					libnvme_ns_get_eui64(n, &eui64,
+							zero_eui64);
+					print_hex(eui64, 8);
 					printf(" nguid:");
-					print_hex(libnvme_ns_get_nguid(n), 16);
-					libnvme_ns_copy_uuid(n, uuid);
-					libnvme_uuid_to_string(uuid, uuid_str);
+					libnvme_ns_get_nguid(n, &nguid,
+							zero_nguid);
+					print_hex(nguid, 16);
+					libnvme_ns_get_uuid(n, &uuid,
+							zero_uuid);
+					libnvme_uuid_to_string(
+							(unsigned char *)uuid,
+							uuid_str);
 					libnvme_ns_get_csi(n, &csi,
 							NVME_CSI_NVM);
 					printf(" uuid:%s csi:%d\n",

--- a/libnvme/tools/generator/generate_accessors.py
+++ b/libnvme/tools/generator/generate_accessors.py
@@ -1339,7 +1339,11 @@ def emit_hdr_getter_lazy(f, prefix, sname, type_name, mname, mtype):
     """
     fn = _get_name(prefix, sname, mname)
     is_str = mtype == 'const char *'
-    out_type = 'const char **' if is_str else f'{mtype} *'
+    # mtype itself may already end in '*' (e.g. a cached-buffer pointer
+    # member) -- type_sep() decides whether boxing it as an out-param
+    # needs a space before the extra '*' or not, same as dflt_sep below,
+    # so two adjacent '*'s never end up with a stray space between them.
+    out_type = 'const char **' if is_str else f'{mtype}{type_sep(mtype)}*'
     dflt_type = 'const char *' if is_str else mtype
     dflt_sep = type_sep(dflt_type)
     f.write(

--- a/libnvme/tools/generator/generate_sysfs_accessors.py
+++ b/libnvme/tools/generator/generate_sysfs_accessors.py
@@ -82,15 +82,31 @@ def _os_variants_equal(m):
     return _resolve_os(m, 'linux') == _resolve_os(m, 'win')
 
 
+def _pub_type(raw_type):
+    """Public API type for a raw storage type.
+
+    A raw pointer storage type is a mutable field the cache fills in
+    once (see emit_struct_def()'s matching "already a pointer, don't
+    box it again" branch); the public getter hands back a read-only
+    view into that cache, so it is exposed as pointer-to-const. "char
+    *" -> "const char *" is the original, single-type version of this
+    rule (see generate_accessors.parse_members's identical translation
+    for annotated headers); generalized here so any raw pointer type
+    (e.g. "uint8_t *" for a cached fixed-size byte buffer) gets the
+    same treatment, not just strings.
+    """
+    if raw_type.endswith('*') and not raw_type.startswith('const '):
+        return f'const {raw_type}'
+    return raw_type
+
+
 def _make_member(spec, resolved, is_absent=False):
     owner_field = spec['owner_field']
     name = resolved['name']
-    # Member.type is the *public* API type, not the storage type: a
-    # "char *" field is exposed as "const char *" (see
-    # generate_accessors.parse_members's identical translation for
-    # annotated headers) -- generate_hdr()'s generic getter/setter
-    # emitters use member.type verbatim for the public signature.
-    pub_type = 'const char *' if resolved['type'] == 'char *' else resolved['type']
+    # Member.type is the *public* API type, not the storage type --
+    # generate_hdr()'s generic getter/setter emitters use member.type
+    # verbatim for the public signature. See _pub_type()'s docstring.
+    pub_type = _pub_type(resolved['type'])
     field_path = f"{owner_field}->{name}"
     write_mode = 'generated' if resolved.get('writable') else 'none'
     read_mode = 'custom' if resolved.get('custom') else 'generated'
@@ -241,13 +257,16 @@ def loader_names(spec):
 def emit_struct_def(f, spec):
     f.write(f"struct {spec['struct_name']} {{\n")
     for m in spec['members']:
-        if m['type'] == 'char *':
-            # Never volatile-qualified even for a volatile *string*
-            # member: "volatile char *" qualifies the pointed-to chars,
-            # not the pointer -- not what a re-strdup'd cache wants. The
-            # 'volatile' spec flag means "no caching" at the generator
-            # level; it does not always map to the C keyword.
-            f.write(f"\tchar *{m['name']};\n")
+        if m['type'].endswith('*'):
+            # Already a pointer (a string, or a cached fixed-size
+            # buffer like eui64/nguid/uuid) -- stored directly, one
+            # level, not boxed again. Never volatile-qualified even for
+            # a volatile *string* member: "volatile char *" qualifies
+            # the pointed-to chars, not the pointer -- not what a
+            # re-strdup'd cache wants. The 'volatile' spec flag means
+            # "no caching" at the generator level; it does not always
+            # map to the C keyword.
+            f.write(f"\t{m['type']}{m['name']};\n")
         elif m.get('volatile'):
             # Never cached, so never boxed either: a plain value
             # re-read on every call. Not C `volatile`-qualified: every
@@ -499,8 +518,22 @@ def generate_swig(spec, members):
     does not match SWIG's member-variable property convention, so a
     plain alias cannot work here. Writable members are unaffected: a
     setter's shape has not changed, so it keeps the alias.
+
+    Readable members whose type emit_swig_getter_wrapper() has no
+    conversion for (not 'const char *', not in _PY_FROM -- e.g. a
+    pointer-to-cached-buffer member like eui64/nguid/uuid) are dropped
+    entirely, not just left out of 'readable': declaring a property
+    with no matching getter wrapper would reference an undefined SWIG
+    symbol. Left unexposed to Python -- no prior pointer-to-buffer
+    accessor in this codebase was ever SWIG-wrapped either.
     """
     owner_type = spec['owner_type']
+
+    def _py_representable(m):
+        return m.type == 'const char *' or m.type in _PY_FROM
+
+    members = [m for m in members
+               if m.read_mode == 'none' or _py_representable(m)]
     readable = [m for m in members if m.read_mode != 'none']
     writable = [m for m in members if m.write_mode != 'none']
 


### PR DESCRIPTION
Follow-on to #3754: converts the last three eager `libnvme_ns` fields -- `eui64`, `nguid`, `uuid` -- to the same lazy sysfs pattern.

Three commits:

1. Generator infra -- generalizes a `char *`-only special case in the sysfs-accessor generator to any pointer-typed member.
2. `eui64`/`nguid`/`uuid` -- needed a bit of custom handling since their sysfs parsing doesn't fit the generator's existing plain-attr/volatile-attr shapes.
3. Doc refresh -- `generate_sysfs_accessors.md`

Measured against 4 real controllers (1 PCIe, 3 NVMe-oF/TCP), same method as before -- strace'd sysfs `openat` calls, this time against a fully-eager baseline (before any of the lazy-sysfs work):

| Command | Before (eager) | After | Reduction |
|---|---|---|---|
| `nvme list` | 295 | 221 | -74 (-25.1%) |
| `nvme list-subsys` | 299 | 199 | -100 (-33.4%) |
| `nvme list -vv` | 299 | 255 | -44 (-14.7%) |
