### PR TITLE
libnvme: fix uninitialized buffer in libnvmf_tid_get_canonical()

### DIFF
--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -389,7 +389,7 @@ __libnvme_public const char *libnvmf_tid_get_canonical(
 		const struct libnvmf_tid *tid)
 {
 	struct libnvmf_tid *p = (struct libnvmf_tid *)tid;
-	char buf[CANONICAL_MAX];
+	char buf[CANONICAL_MAX] = "";
 	int n = 0;
 
 	if (!tid)


### PR DESCRIPTION
If all fields of the TID are NULL, none of the APPEND() macro invocations write anything to @buf, leaving it uninitialized when passed to strdup(). Initialize @buf to an empty string to ensure strdup() always operates on valid data.