### PR TITLE
libnvme/test: fix use after free in test_nvmf_sanitize_addrs()

### DIFF
--- a/libnvme/test/test-fabrics.c
+++ b/libnvme/test/test-fabrics.c
@@ -488,9 +488,11 @@ static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
 	params.subsysnqn = "nqn.2024-01.com.example:test";
 	params.traddr = "192.168.1.10";
 	params.host_traddr = "storage.example.com";
-	ret = libnvme_create_ctrl(ctx, &params, &c);
-	p = !ret && c && !strcmp(libnvme_ctrl_get_host_traddr(c),
-			"storage.example.com");
+	libnvme_create_ctrl(ctx, &params, &c);
+	CHECK(c, "ctrl created with hostname host_traddr");
+	if (!c)
+		return false;
+	p = !strcmp(libnvme_ctrl_get_host_traddr(c), "storage.example.com");
 	CHECK(p, "hostname host_traddr stored verbatim at creation");
 	pass &= p;
 
@@ -504,10 +506,10 @@ static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
 	/* A hostname traddr is rejected the same way. */
 	params.traddr = "storage.example.com";
 	params.host_traddr = NULL;
-	ret = libnvme_create_ctrl(ctx, &params, &c);
-	p = !ret && c != NULL;
-	CHECK(p, "ctrl created with hostname traddr");
-	pass &= p;
+	libnvme_create_ctrl(ctx, &params, &c);
+	CHECK(c, "ctrl created with hostname traddr");
+	if (!c)
+		return false;
 
 	ret = nvmf_sanitize_addrs(ctx, c);
 	p = ret == -ENVME_CONNECT_TRADDR;
@@ -518,10 +520,10 @@ static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
 
 	/* An uncompressed IPv6 traddr is canonicalized. */
 	params.traddr = "2001:0db8:0000:0000:0000:0000:0000:0001";
-	ret = libnvme_create_ctrl(ctx, &params, &c);
-	p = !ret && c != NULL;
-	CHECK(p, "ctrl created with uncompressed IPv6 traddr");
-	pass &= p;
+	libnvme_create_ctrl(ctx, &params, &c);
+	CHECK(c, "ctrl created with uncompressed IPv6 traddr");
+	if (!c)
+		return false;
 
 	ret = nvmf_sanitize_addrs(ctx, c);
 	p = !ret && !strcmp(libnvme_ctrl_get_traddr(c), "2001:db8::1");
@@ -537,10 +539,10 @@ static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
 	 * call, same as host_iface.
 	 */
 	params.traddr = "fe80::1%nonexistent0";
-	ret = libnvme_create_ctrl(ctx, &params, &c);
-	p = !ret && c != NULL;
-	CHECK(p, "ctrl created with bad-zone scoped IPv6 traddr");
-	pass &= p;
+	libnvme_create_ctrl(ctx, &params, &c);
+	CHECK(c, "ctrl created with bad-zone scoped IPv6 traddr");
+	if (!c)
+		return false;
 
 	ret = nvmf_sanitize_addrs(ctx, c);
 	p = !ret && !strcmp(libnvme_ctrl_get_traddr(c), "fe80::1%nonexistent0");
@@ -553,10 +555,10 @@ static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
 	/* fc: a WWN traddr is left untouched (not an IP transport). */
 	params.transport = "fc";
 	params.traddr = "nn-0x1:pn-0x2";
-	ret = libnvme_create_ctrl(ctx, &params, &c);
-	p = !ret && c != NULL;
-	CHECK(p, "ctrl created with fc WWN traddr");
-	pass &= p;
+	libnvme_create_ctrl(ctx, &params, &c);
+	CHECK(c, "ctrl created with fc WWN traddr");
+	if (!c)
+		return false;
 
 	ret = nvmf_sanitize_addrs(ctx, c);
 	p = !ret && !strcmp(libnvme_ctrl_get_traddr(c), "nn-0x1:pn-0x2");
@@ -569,10 +571,10 @@ static bool test_nvmf_sanitize_addrs(struct libnvme_global_ctx *ctx)
 	/* loop: no traddr at all -- nothing to sanitize. */
 	params.transport = "loop";
 	params.traddr = NULL;
-	ret = libnvme_create_ctrl(ctx, &params, &c);
-	p = !ret && c != NULL;
-	CHECK(p, "ctrl created for loop transport");
-	pass &= p;
+	libnvme_create_ctrl(ctx, &params, &c);
+	CHECK(c, "ctrl created for loop transport");
+	if (!c)
+		return false;
 
 	ret = nvmf_sanitize_addrs(ctx, c);
 	p = ret == 0;


### PR DESCRIPTION
If libnvme_create_ctrl() fails, @c is NULL. The subsequent calls to nvmf_sanitize_addrs() and libnvme_free_ctrl() are then made with a NULL pointer, resulting in a use after free.

Guard each nvmf_sanitize_addrs() and libnvme_free_ctrl() block with if (c) to skip the sanitize and free steps when controller creation failed.