### PR TITLE
util: fix double close of bin_file in read_binary_file

### DIFF
--- a/util/utils.c
+++ b/util/utils.c
@@ -121,9 +121,6 @@ unsigned char *read_binary_file(char *data_dir_path, const char *bin_path,
 	/* Read data */
 	n_data = fread(buffer, 1, *buffer_size, bin_file);
 
-	/* Close file */
-	fclose(bin_file);
-	
 	/* Validate we read data */
 	if (n_data != (size_t)*buffer_size) {
 		nvme_show_result("\nFailed to read %ld bytes from %s", *buffer_size, file_path);


### PR DESCRIPTION
bin_file was declared with __cleanup_file, which inserts an implicit
fclose() at every scope exit. The additional explicit fclose() call
after fread() caused a double close on every successful code path,
which is undefined behaviour. Remove the redundant explicit call and
let __cleanup_file handle it exclusively.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>