### PR TITLE
libnvme/mi: fix overflowed constant in subsystem_health_status_poll

### DIFF
--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -1152,7 +1152,7 @@ __shr_public int libnvme_mi_mi_subsystem_health_status_poll(
 
 	libnvme_mi_mi_init_req(ep, &req, &req_hdr, 0,
 		nvme_mi_mi_opcode_subsys_health_status_poll);
-	req_hdr.cdw1 = (clear ? 1 : 0) << 31;
+	req_hdr.cdw1 = cpu_to_le32((clear ? 1U : 0U) << 31);
 
 	memset(&resp, 0, sizeof(resp));
 	resp.hdr = &resp_hdr.hdr;


### PR DESCRIPTION
The clear flag is encoded into bit 31 of CDW1 (the CLRS bit per
NVMe-MI spec section 5).  The original expression:
        req_hdr.cdw1 = (clear ? 1 : 0) << 31;
shifts a signed int literal left into its sign bit, which is
undefined behaviour in C.  Additionally, cdw1 is typed __le32
so a raw integer assignment skips the required endian conversion,
producing incorrect wire bytes on big-endian hosts (e.g. IBM POWER).

Fix both issues by using an unsigned literal and wrapping the
result with cpu_to_le32(), consistent with every other cdw
assignment in this file.

Addresses-Coverity-ID: 559299 (Overflowed constant)
Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>