### PR TITLE
plugins/ymtc: fix unterminated string passed to strtol in ReadSysFile

### DIFF
--- a/plugins/ymtc/ymtc-nvme.c
+++ b/plugins/ymtc/ymtc-nvme.c
@@ -59,7 +59,7 @@ static int ReadSysFile(const char *file, unsigned short *id)
 		return fd;
 	}
 
-	ret = read(fd, idstr, sizeof(idstr));
+	ret = read(fd, idstr, sizeof(idstr) - 1);
 	close(fd);
 	if (ret < 0)
 		perror("read");


### PR DESCRIPTION
read() was called with sizeof(idstr) which could fill the entire
buffer leaving no room for a null terminator. Pass sizeof(idstr) - 1
instead so the zero-initialised final byte is always preserved as the
terminator that strtol requires.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>