### PR TITLE
plugins/lm: fix NULL pointer check for fopen in lm_migration_recv

### DIFF
--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -471,7 +471,7 @@ static int lm_migration_recv(int argc, char **argv, struct command *acmd, struct
 
 	if (cfg.output && strlen(cfg.output)) {
 		fd = fopen(cfg.output, "w");
-		if (fd < 0) {
+		if (!fd) {
 			nvme_show_perror(cfg.output);
 			return -errno;
 		}


### PR DESCRIPTION
When opening the output file in lm_migration_recv(), fopen() returns a
FILE pointer on success or NULL on failure. The code incorrectly checked
'if (fd < 0)', which is an integer file descriptor check pattern rather
than a pointer check.

Because pointer addresses are never negative, 'fd < 0' always evaluated
to false, causing fopen() failures to go undetected and subsequently
leading to a NULL pointer dereference in fwrite().

Fix the condition to check 'if (!fd)'.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>