### PR TITLE
plugins/huawei: fix unsigned return code check in huawei_list

### DIFF
--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -316,9 +316,10 @@ static int huawei_list(int argc, char **argv, struct command *acmd,
 	char path[264];
 	struct dirent **devices;
 	struct huawei_list_item *list_items;
-	unsigned int i, n, ret;
+	unsigned int i, n;
 	unsigned int huawei_num = 0;
 	nvme_print_flags_t fmt;
+	int ret;
 
 	NVME_ARGS(opts);
 


### PR DESCRIPTION
In huawei_list(), ret is declared as unsigned int.

The function calls validate_output_format(), which returns a signed int
(-EINVAL on failure). Because ret is unsigned, storing the negative
return code in ret converts it to a large positive value. As a result,
the check 'ret < 0' always evaluates to false, allowing invalid output
format errors to go undetected.
   
Declare ret as signed int so 'ret < 0' correctly catches negative error
codes.
    
Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>