### PR TITLE
nvme: fix negative error formatting in wait_self_test

### DIFF
--- a/nvme.c
+++ b/nvme.c
@@ -4754,7 +4754,7 @@ static int wait_self_test(struct libnvme_transport_handle *hdl)
 
 	err = nvme_identify_ctrl(hdl, ctrl);
 	if (err) {
-		nvme_show_error("identify-ctrl: %s", libnvme_strerror(err));
+		nvme_show_err(err, "identify-ctrl");
 		return err;
 	}
 


### PR DESCRIPTION
In wait_self_test(), when nvme_identify_ctrl() fails, it returns a negative
error code (e.g. -EIO). The function previously called: 
nvme_show_error("identify-ctrl: %s", libnvme_strerror(err));

Passing a negative value to libnvme_strerror() is improper because it
expects a positive status/error code.

Use nvme_show_err(err, "identify-ctrl") instead, which properly formats
negative error values in line with the rest of the codebase.

Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>