### PR TITLE
plugins/ocp: check return value of ocp_get_uuid_index

### DIFF
--- a/plugins/ocp/ocp-hardware-component-log.c
+++ b/plugins/ocp/ocp-hardware-component-log.c
@@ -175,9 +175,11 @@ static int get_hwcomp_log_data(struct libnvme_transport_handle *hdl, struct hwco
 	long double log_bytes;
 	__u32 len;
 	__u8 uidx;
-	int ret = 0;
+	int ret;
 
-	ocp_get_uuid_index(hdl, &uidx);
+	ret = ocp_get_uuid_index(hdl, &uidx);
+	if (ret < 0)
+		return ret;
 
 #ifdef HWCOMP_DUMMY
 	memcpy(log, hwcomp_dummy, desc_offset);


### PR DESCRIPTION
In get_hwcomp_log_data(), ocp_get_uuid_index() was called without
checking its return value. If ocp_get_uuid_index() fails, uidx
remains uninitialized, causing log page requests to be constructed
with invalid UUID indices.
    
Check ret = ocp_get_uuid_index(hdl, &uidx) and return ret if it
fails, matching the error checking pattern used elsewhere in the OCP
plugin.
    
Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>