### PR TITLE
build: add Windows arm64 CI job (MSYS2 CLANGARM64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,3 +329,48 @@ jobs:
           name: windows-msys2-ucrt64-logs
           path: |
             .build-ci/meson-logs/*.txt
+
+  # This job uses clang rather than gcc because MSYS2 has no gcc toolchain for
+  # native Windows-on-ARM64: CLANGARM64 is its only aarch64 environment, and
+  # gcc's aarch64-w64-mingw32 target exists only as an experimental
+  # cross-compiler (mingw-w64-cross-mingwarm64-gcc, still versioned 15.0.1dev).
+  # Note that "pacman -S mingw-w64-clang-aarch64-gcc" does resolve, but it is a
+  # virtual package satisfied by mingw-w64-clang-aarch64-gcc-compat, which only
+  # installs gcc-named aliases for clang -- not a second compiler.
+  windows-msys2-clangarm64:
+    runs-on: windows-11-arm
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: >-
+            git
+            mingw-w64-clang-aarch64-clang
+            mingw-w64-clang-aarch64-pkgconf
+            mingw-w64-clang-aarch64-meson
+            mingw-w64-clang-aarch64-ninja
+            mingw-w64-clang-aarch64-ccache
+            mingw-w64-clang-aarch64-json-c
+            mingw-w64-clang-aarch64-python-jsonschema
+
+      - name: Build nvme-cli
+        shell: msys2 {0}
+        run: |
+          set -euxo pipefail
+          which bash
+          bash --version
+          which git
+          git --version
+          clang --version
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          scripts/build.sh -b release -c /clangarm64/bin/clang
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: failure()
+        with:
+          name: windows-msys2-clangarm64-logs
+          path: |
+            .build-ci/meson-logs/*.txt

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -136,6 +136,7 @@ if host_system == 'windows'
         bcrypt_dep,
         setupapi_dep,
         cfgmgr32_dep,
+        winpthread_dep,
     ]
 endif
 
@@ -148,27 +149,47 @@ ctrl_sysfs_ld = meson.current_source_dir() / 'ctrl-sysfs.ld'
 path_sysfs_ld = meson.current_source_dir() / 'path-sysfs.ld'
 ns_sysfs_ld = meson.current_source_dir() / 'ns-sysfs.ld'
 
-link_args = [
-    '-Wl,--version-script=@0@'.format(nvme_ld),
-    '-Wl,--version-script=@0@'.format(accessors_ld),
-    '-Wl,--version-script=@0@'.format(ctrl_sysfs_ld),
-    '-Wl,--version-script=@0@'.format(path_sysfs_ld),
-    '-Wl,--version-script=@0@'.format(ns_sysfs_ld),
-]
+# Version scripts filter the exported symbols. GNU ld honours
+# --version-script for PE/COFF too, but LLVM's lld does not accept the option
+# at all, so the MSYS2 CLANG64/CLANGARM64 environments cannot use them.
+#
+# Dropping them does not lose the public API: it is annotated with
+# __shr_public (visibility("default")), which clang honours on PE, so
+# -fvisibility=hidden below still keeps libnvme's own internals unexported.
+# What is lost is the filtering of symbols pulled in from static libraries
+# (mingw's GUID/CLSID constants and similar), which PE auto-export then adds
+# to the export table. Those extra exports are inert - nothing links against
+# them - so this is a cosmetically larger export table, not an ABI change.
+want_version_scripts = cc.has_link_argument(
+    '-Wl,--version-script=@0@'.format(nvme_ld)
+)
+
+link_args = []
+if want_version_scripts
+    link_args += [
+        '-Wl,--version-script=@0@'.format(nvme_ld),
+        '-Wl,--version-script=@0@'.format(accessors_ld),
+        '-Wl,--version-script=@0@'.format(ctrl_sysfs_ld),
+        '-Wl,--version-script=@0@'.format(path_sysfs_ld),
+        '-Wl,--version-script=@0@'.format(ns_sysfs_ld),
+    ]
+endif
 
 libconf = configuration_data()
 if want_fabrics
-    link_args += [
-        '-Wl,--version-script=@0@'.format(nvmf_ld),
-        '-Wl,--version-script=@0@'.format(nvmf_accessors_ld),
-    ]
+    if want_version_scripts
+        link_args += [
+            '-Wl,--version-script=@0@'.format(nvmf_ld),
+            '-Wl,--version-script=@0@'.format(nvmf_accessors_ld),
+        ]
+    endif
     libconf.set('FABRICS_INCLUDE',
                 fs.read('fabrics-includes.h.in').strip())
 else
     libconf.set('FABRICS_INCLUDE', '')
 endif
 
-if want_mi
+if want_mi and want_version_scripts
     link_args += [
         '-Wl,--version-script=@0@'.format(mi_ld),
     ]

--- a/meson.build
+++ b/meson.build
@@ -174,6 +174,7 @@ if host_system == 'windows'
     bcrypt_dep = cc.find_library('bcrypt', required: true)
     setupapi_dep = cc.find_library('setupapi', required: true)
     cfgmgr32_dep = cc.find_library('cfgmgr32', required: true)
+    winpthread_dep = cc.find_library('winpthread', required: true)
 endif
 
 conf.set10(
@@ -669,6 +670,8 @@ if want_nvme
                 link_args_list += ['-ljson-c']
             endif
             link_args_list += ['-lwinpthread', '-Wl,-Bdynamic']
+        else
+            link_deps += [winpthread_dep]
         endif
     else
         link_args_list = ['-ldl']


### PR DESCRIPTION
nvme-cli builds and runs on native Windows-on-ARM64, but nothing in CI covered it, so aarch64-specific breakage could land unnoticed. This adds a `windows-msys2-clangarm64` job on the `windows-11-arm` runner, alongside the existing `windows-msys2-ucrt64` one.

Getting that job to build surfaced two real portability problems, which are fixed here rather than worked around in the job definition.

## Why clang, not gcc

The new job uses clang because MSYS2 has no gcc toolchain for native Windows-on-ARM64:

- CLANGARM64 is MSYS2's only `aarch64` environment. Per the [environments table](https://www.msys2.org/docs/environments/), the gcc-based environments cover `x86_64`, `i686`, and `cygwin` only.
- gcc's `aarch64-w64-mingw32` target exists solely as an experimental cross-compiler — `mingw-w64-cross-mingwarm64-gcc`, still versioned `15.0.1dev`, sourced from the [Windows-on-ARM-Experiments/gcc-woarm64](https://github.com/Windows-on-ARM-Experiments/gcc-woarm64) fork rather than upstream gcc.

Worth knowing because it looks like a contradiction: `pacman -S mingw-w64-clang-aarch64-gcc` *does* resolve. It is a virtual package provided by `mingw-w64-clang-aarch64-gcc-compat` ("GCC compatibility aliases for Clang"), which depends on `mingw-w64-clang-aarch64-clang` and installs a `gcc` that is clang. Switching the job's `-c` to `/clangarm64/bin/gcc` would build identically while reading as though a real gcc had been found. The rationale is recorded in a comment above the job so it isn't rediscovered.

## Fix 1: version scripts are not portable to lld

`libnvme/src/meson.build` passed `-Wl,--version-script=` unconditionally. GNU ld honours it for PE/COFF, but **LLVM's lld rejects the option outright**, so the link failed immediately under CLANGARM64.

Fixed by probing with `cc.has_link_argument()` and passing the version scripts only when the linker accepts them.

The obvious worry is that dropping them changes the exported ABI. It does not, because the public API is exported by *annotation*, not by version script: `__shr_public` is `visibility("default")`, which clang honours on PE and which overrides the `-fvisibility=hidden` already used for the library. I verified this by diffing the actual PE export tables rather than reasoning about it — building this branch both ways with identical options:

| | version scripts | total exports | public (`nvme_*`/`libnvme_*`) |
|---|---|---|---|
| gcc 16.1.0 (UCRT64) | on | 330 | 330 |
| clang 22.1.8 + lld (CLANG64) | off | 797 | 331 |

**No public symbol is lost.** The single difference is `libnvme_mi_status_to_string`, the `no-mi.c` stub, which is `__shr_public` but listed in `libnvme-mi.ld` and so filtered out by the gcc build when MI is disabled — benign.

What the version scripts *additionally* filter is symbols dragged in from static libraries: the extra 466 are mingw GUID/CLSID constants (`ALL_POWERSCHEMES_GUID`, `CLSID_DOMDocument`, `DXVA2_Mode*`). Nothing links against them, so this is a cosmetically larger export table on clang targets, not an ABI change.

All eight `.ld` files — including `path-sysfs.ld` and `ns-sysfs.ld` — are inside the guard.

## Fix 2: winpthread linked only on the static path

`winpthread` was pulled in via a bare `-lwinpthread` on the static path only, leaving the shared Windows build to find it implicitly. It is now looked up with `cc.find_library()` and added to the dependency list so both paths link it explicitly.

## Verification

Built and tested on both toolchains with `--werror`, on this branch's base:

| | probe result | build | tests |
|---|---|---|---|
| gcc 16.1.0, UCRT64 | `YES` (scripts on) | clean, all targets | 38 Ok / 0 Fail / 1 Skip |
| clang 22.1.8 + lld, CLANG64 | `NO` (scripts off) | clean, all targets | 38 Ok / 0 Fail / 1 Skip |

The skip is `command-metadata-schema`, which wants `python-jsonschema`; it is pre-existing and unrelated.

`checkpatch.pl` reports `0 errors, 0 warnings` on the patch.

One limitation stated plainly: **the two builds above are x86_64.** The CLANG64 configuration exercises the same clang/lld code path this change exists for — the probe resolves `NO` and the fallback is taken — but I do not have arm64 hardware locally, so the aarch64 build itself has been verified only by this job running green on a `windows-11-arm` runner in a fork. Once CI runs here, the `windows-msys2-clangarm64` job is the authoritative check.

## Note on a follow-up worth doing separately

This change makes the version scripts conditional, which introduces a gap: any `.ld` file added outside the `if want_version_scripts` block will fail on clang targets only, passing on Linux and on gcc/UCRT64. `check-public-symbols` cannot catch it because it reads the `.ld` files rather than inspecting the linked binary.

That is not hypothetical — rebasing this work onto current master hit exactly that case, as `path-sysfs.ld` and `ns-sysfs.ld` had been added in the meantime and needed moving inside the guard. A test comparing the DLL's real export table against the union of the `.ld` files would close it. Happy to send that as its own patch if you think it is worth having.
