### PR TITLE
libnvme: add lazy sysfs read to subsystems (libnvme_subsystem)

### DIFF
--- a/libnvme/libnvme3/accessors.i
+++ b/libnvme/libnvme3/accessors.i
@@ -102,10 +102,6 @@ Ctrl.__setattr__ = _nvme_guarded_setattr
 
 /* struct libnvme_subsystem */
 %rename(Subsystem) libnvme_subsystem;
-%rename(libnvme_subsystem_iopolicy_get) libnvme_subsystem_get_iopolicy;
-%{
-	#define libnvme_subsystem_iopolicy_get libnvme_subsystem_get_iopolicy
-%}
 struct libnvme_subsystem {
 	%immutable name;
 	const char * name;
@@ -113,18 +109,8 @@ struct libnvme_subsystem {
 	const char * sysfs_dir;
 	%immutable subsysnqn;
 	const char * subsysnqn;
-	%immutable model;
-	const char * model;
-	%immutable serial;
-	const char * serial;
-	%immutable firmware;
-	const char * firmware;
 	%immutable subsystype;
 	const char * subsystype;
-	%extend {
-		%immutable iopolicy;
-		const char * iopolicy;
-	}
 };
 
 %pythoncode %{

--- a/libnvme/libnvme3/meson.build
+++ b/libnvme/libnvme3/meson.build
@@ -27,6 +27,7 @@ if want_python
             'accessors.i',
             'accessors-fabrics.i',
             'ctrl-sysfs.i',
+            'subsys-sysfs.i',
             'nvme-manual-bridges.i',
             'fctx_field_tables.h',
         ],

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -1303,6 +1303,7 @@ def exclusion_match(ctx, transport=None, traddr=None, trsvcid=None,
 %include "ctrl-sysfs.i"
 %include "path-sysfs.i"
 %include "ns-sysfs.i"
+%include "subsys-sysfs.i"
 %include "accessors-fabrics.i"
 
 /* Propagate any Python exception set inside the helper function.

--- a/libnvme/libnvme3/subsys-sysfs.i
+++ b/libnvme/libnvme3/subsys-sysfs.i
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/*
+ * This file is part of libnvme.
+ *
+ * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ *
+ *   ____                           _           _    ____          _
+ *  / ___| ___ _ __   ___ _ __ __ _| |_ ___  __| |  / ___|___   __| | ___
+ * | |  _ / _ \ '_ \ / _ \ '__/ _` | __/ _ \/ _` | | |   / _ \ / _` |/ _ \
+ * | |_| |  __/ | | |  __/ | | (_| | ||  __/ (_| | | |__| (_) | (_| |  __/
+ *  \____|\___|_| |_|\___|_|  \__,_|\__\___|\__,_|  \____\___/ \__,_|\___|
+ *
+ * Auto-generated struct member accessors (setter/getter)
+ *
+ * To update run: meson compile -C [BUILD-DIR] update-accessors
+ * Or:            make update-accessors
+ */
+
+/* struct libnvme_subsystem -- sysfs-backed properties */
+%rename(libnvme_subsystem_model_set) libnvme_subsystem_set_model;
+%rename(libnvme_subsystem_serial_set) libnvme_subsystem_set_serial;
+%rename(libnvme_subsystem_firmware_set) libnvme_subsystem_set_firmware;
+%{
+	#define libnvme_subsystem_model_set libnvme_subsystem_set_model
+	#define libnvme_subsystem_serial_set libnvme_subsystem_set_serial
+	#define libnvme_subsystem_firmware_set libnvme_subsystem_set_firmware
+	static const char *libnvme_subsystem_model_get(const struct libnvme_subsystem *p)
+	{
+		const char *val;
+		int ret = libnvme_subsystem_get_model(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_subsystem_serial_get(const struct libnvme_subsystem *p)
+	{
+		const char *val;
+		int ret = libnvme_subsystem_get_serial(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_subsystem_firmware_get(const struct libnvme_subsystem *p)
+	{
+		const char *val;
+		int ret = libnvme_subsystem_get_firmware(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+	static const char *libnvme_subsystem_iopolicy_get(const struct libnvme_subsystem *p)
+	{
+		const char *val;
+		int ret = libnvme_subsystem_get_iopolicy(p, &val, NULL);
+
+		if (ret == 0)
+			return val;
+		if (ret == -ENOENT)
+			return NULL;
+
+		raise_nvme(NvmeError, ret);
+		return NULL;
+	}
+%}
+
+%exception libnvme_subsystem::model {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_subsystem::serial {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_subsystem::firmware {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%exception libnvme_subsystem::iopolicy {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+
+%extend struct libnvme_subsystem {
+	const char * model;
+	const char * serial;
+	const char * firmware;
+	%immutable iopolicy;
+	const char * iopolicy;
+}

--- a/libnvme/src/accessors.ld
+++ b/libnvme/src/accessors.ld
@@ -142,10 +142,7 @@ LIBNVME_ACCESSORS_3 {
 		libnvme_set_hostnqn;
 		libnvme_set_ioctl_probing;
 		libnvme_set_mi_probe_enabled;
-		libnvme_subsystem_get_firmware;
-		libnvme_subsystem_get_model;
 		libnvme_subsystem_get_name;
-		libnvme_subsystem_get_serial;
 		libnvme_subsystem_get_subsysnqn;
 		libnvme_subsystem_get_subsystype;
 		libnvme_subsystem_get_sysfs_dir;

--- a/libnvme/src/libnvme.h.in
+++ b/libnvme/src/libnvme.h.in
@@ -16,6 +16,7 @@ extern "C" {
 #include <nvme/ctrl-sysfs.h>
 #include <nvme/path-sysfs.h>
 #include <nvme/ns-sysfs.h>
+#include <nvme/subsys-sysfs.h>
 #include <nvme/ioctl.h>
 #include <nvme/lib-types.h>
 #include <nvme/lib.h>

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -133,7 +133,6 @@ LIBNVME_3 {
 		libnvme_subsystem_first_ctrl;
 		libnvme_subsystem_first_ns;
 		libnvme_subsystem_get_host;
-		libnvme_subsystem_get_iopolicy;
 		libnvme_subsystem_lookup_namespace;
 		libnvme_subsystem_next_ctrl;
 		libnvme_subsystem_next_ns;

--- a/libnvme/src/meson.build
+++ b/libnvme/src/meson.build
@@ -11,6 +11,7 @@ sources = [
     'nvme/lib.c',
     'nvme/log.c',
     'nvme/nvme-cmds.c',
+    'nvme/subsys-sysfs.c',
     'nvme/tree.c',
     'nvme/util.c',
 ]
@@ -61,6 +62,7 @@ headers = [
     'nvme/nvme-types-zns.h',
     'nvme/nvme-types.h',
     'nvme/scan.h',
+    'nvme/subsys-sysfs.h',
     'nvme/tree.h',
     'nvme/types.h',
     'nvme/util.h',
@@ -148,6 +150,7 @@ nvmf_accessors_ld = meson.current_source_dir() / 'accessors-fabrics.ld'
 ctrl_sysfs_ld = meson.current_source_dir() / 'ctrl-sysfs.ld'
 path_sysfs_ld = meson.current_source_dir() / 'path-sysfs.ld'
 ns_sysfs_ld = meson.current_source_dir() / 'ns-sysfs.ld'
+subsys_sysfs_ld = meson.current_source_dir() / 'subsys-sysfs.ld'
 
 # Version scripts filter the exported symbols. GNU ld honours --version-script
 # for PE/COFF too, but LLVM's lld does not accept the option at all, so the
@@ -157,7 +160,7 @@ ns_sysfs_ld = meson.current_source_dir() / 'ns-sysfs.ld'
 # (visibility("default")), which clang honours on PE. So -fvisibility=hidden
 # below still keeps libnvme's own internals unexported. What is lost is the
 # filtering of symbols pulled in from static libraries, which PE auto-export
-# then adds to the export table. 
+# then adds to the export table.
 want_version_scripts = cc.has_link_argument(
     '-Wl,--version-script=@0@'.format(nvme_ld)
 )
@@ -170,6 +173,7 @@ if want_version_scripts
         '-Wl,--version-script=@0@'.format(ctrl_sysfs_ld),
         '-Wl,--version-script=@0@'.format(path_sysfs_ld),
         '-Wl,--version-script=@0@'.format(ns_sysfs_ld),
+        '-Wl,--version-script=@0@'.format(subsys_sysfs_ld),
     ]
 endif
 

--- a/libnvme/src/nvme/accessors.c
+++ b/libnvme/src/nvme/accessors.c
@@ -340,24 +340,6 @@ __shr_public const char *libnvme_subsystem_get_subsysnqn(
 	return p->subsysnqn;
 }
 
-__shr_public const char *libnvme_subsystem_get_model(
-		const struct libnvme_subsystem *p)
-{
-	return p->model;
-}
-
-__shr_public const char *libnvme_subsystem_get_serial(
-		const struct libnvme_subsystem *p)
-{
-	return p->serial;
-}
-
-__shr_public const char *libnvme_subsystem_get_firmware(
-		const struct libnvme_subsystem *p)
-{
-	return p->firmware;
-}
-
 __shr_public const char *libnvme_subsystem_get_subsystype(
 		const struct libnvme_subsystem *p)
 {

--- a/libnvme/src/nvme/accessors.h
+++ b/libnvme/src/nvme/accessors.h
@@ -466,30 +466,6 @@ const char *libnvme_subsystem_get_sysfs_dir(const struct libnvme_subsystem *p);
 const char *libnvme_subsystem_get_subsysnqn(const struct libnvme_subsystem *p);
 
 /**
- * libnvme_subsystem_get_model() - Get model.
- * @p: The &struct libnvme_subsystem instance to query.
- *
- * Return: The value of the model field, or NULL if not set.
- */
-const char *libnvme_subsystem_get_model(const struct libnvme_subsystem *p);
-
-/**
- * libnvme_subsystem_get_serial() - Get serial.
- * @p: The &struct libnvme_subsystem instance to query.
- *
- * Return: The value of the serial field, or NULL if not set.
- */
-const char *libnvme_subsystem_get_serial(const struct libnvme_subsystem *p);
-
-/**
- * libnvme_subsystem_get_firmware() - Get firmware.
- * @p: The &struct libnvme_subsystem instance to query.
- *
- * Return: The value of the firmware field, or NULL if not set.
- */
-const char *libnvme_subsystem_get_firmware(const struct libnvme_subsystem *p);
-
-/**
  * libnvme_subsystem_get_subsystype() - Get subsystype.
  * @p: The &struct libnvme_subsystem instance to query.
  *

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -27,13 +27,13 @@
 struct libnvme_passthru_completion;
 struct libnvme_async_req;
 
-/* Opaque: defined only in the generated ctrl-sysfs.c / path-sysfs.c /
- * ns-sysfs.c -- see generate_sysfs_accessors.py. No other file may see
- * their layout.
+/* Opaque: each is defined only in its own generated .c file -- see
+ * generate_sysfs_accessors.py. No other file may see their layout.
  */
 struct libnvme_ctrl_sysfs;
 struct libnvme_path_sysfs;
 struct libnvme_ns_sysfs;
+struct libnvme_subsystem_sysfs;
 
 const char *libnvme_subsys_sysfs_dir(struct libnvme_global_ctx *ctx);
 const char *libnvme_ctrl_sysfs_dir(struct libnvme_global_ctx *ctx);
@@ -352,11 +352,8 @@ struct libnvme_subsystem {  // !generate-accessors:read=generated,write=none !ge
 	char *name;
 	char *sysfs_dir;
 	char *subsysnqn;
-	char *model;
-	char *serial;
-	char *firmware;
 	char *subsystype;
-	char *iopolicy;			// !access:read=custom
+	struct libnvme_subsystem_sysfs *sysfs;	// !access:read=none
 };
 
 struct libnvme_host {  // !generate-accessors:read=generated,write=none !generate-python:alias=Host

--- a/libnvme/src/nvme/subsys-sysfs.c
+++ b/libnvme/src/nvme/subsys-sysfs.c
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/*
+ * This file is part of libnvme.
+ *
+ * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ *
+ *   ____                           _           _    ____          _
+ *  / ___| ___ _ __   ___ _ __ __ _| |_ ___  __| |  / ___|___   __| | ___
+ * | |  _ / _ \ '_ \ / _ \ '__/ _` | __/ _ \/ _` | | |   / _ \ / _` |/ _ \
+ * | |_| |  __/ | | |  __/ | | (_| | ||  __/ (_| | | |__| (_) | (_| |  __/
+ *  \____|\___|_| |_|\___|_|  \__,_|\__\___|\__,_|  \____\___/ \__,_|\___|
+ *
+ * Auto-generated struct member accessors (setter/getter)
+ *
+ * To update run: meson compile -C [BUILD-DIR] update-accessors
+ * Or:            make update-accessors
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <compiler-attributes.h>
+
+#include "private.h"
+#include "private-tree.h"
+#include "subsys-sysfs.h"
+
+struct libnvme_subsystem_sysfs {
+	char *model;
+	char *serial;
+	char *firmware;
+	char *iopolicy;
+};
+
+struct libnvme_subsystem_sysfs *libnvme_subsystem_sysfs_alloc(void)
+{
+	return calloc(1, sizeof(struct libnvme_subsystem_sysfs));
+}
+
+void libnvme_subsystem_sysfs_reset(
+		struct libnvme_subsystem_sysfs *sysfs)
+{
+	if (!sysfs)
+		return;
+
+}
+
+void libnvme_subsystem_sysfs_free(
+		struct libnvme_subsystem_sysfs *sysfs)
+{
+	if (!sysfs)
+		return;
+
+	SYSFS_FREE(sysfs->model);
+	SYSFS_FREE(sysfs->serial);
+	SYSFS_FREE(sysfs->firmware);
+	SYSFS_FREE(sysfs->iopolicy);
+	free(sysfs);
+}
+
+__shr_public void libnvme_subsystem_set_model(
+		struct libnvme_subsystem *p,
+		const char *model)
+{
+	SYSFS_FREE(p->sysfs->model);
+	p->sysfs->model = model ? strdup(model) : NO_SYSFS_ATTR;
+}
+
+__shr_public int libnvme_subsystem_get_model(
+		const struct libnvme_subsystem *p,
+		const char **val,
+		const char *dflt)
+{
+	struct libnvme_subsystem *c = (struct libnvme_subsystem *)p;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->model))) {
+		c->sysfs->model = libnvme_get_subsys_attr(c, "model");
+		if (!c->sysfs->model)
+			c->sysfs->model = NO_SYSFS_ATTR;
+	}
+
+	if (SYSFS_IS_ABSENT(c->sysfs->model))
+		return -ENOENT;
+
+	*val = c->sysfs->model;
+	return 0;
+}
+
+__shr_public void libnvme_subsystem_set_serial(
+		struct libnvme_subsystem *p,
+		const char *serial)
+{
+	SYSFS_FREE(p->sysfs->serial);
+	p->sysfs->serial = serial ? strdup(serial) : NO_SYSFS_ATTR;
+}
+
+__shr_public int libnvme_subsystem_get_serial(
+		const struct libnvme_subsystem *p,
+		const char **val,
+		const char *dflt)
+{
+	struct libnvme_subsystem *c = (struct libnvme_subsystem *)p;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->serial))) {
+		c->sysfs->serial = libnvme_get_subsys_attr(c, "serial");
+		if (!c->sysfs->serial)
+			c->sysfs->serial = NO_SYSFS_ATTR;
+	}
+
+	if (SYSFS_IS_ABSENT(c->sysfs->serial))
+		return -ENOENT;
+
+	*val = c->sysfs->serial;
+	return 0;
+}
+
+__shr_public void libnvme_subsystem_set_firmware(
+		struct libnvme_subsystem *p,
+		const char *firmware)
+{
+	SYSFS_FREE(p->sysfs->firmware);
+	p->sysfs->firmware = firmware ? strdup(firmware) : NO_SYSFS_ATTR;
+}
+
+__shr_public int libnvme_subsystem_get_firmware(
+		const struct libnvme_subsystem *p,
+		const char **val,
+		const char *dflt)
+{
+	struct libnvme_subsystem *c = (struct libnvme_subsystem *)p;
+
+	*val = dflt;
+
+	if (__shr_unlikely(!SYSFS_IS_LOADED(c->sysfs->firmware))) {
+		c->sysfs->firmware = libnvme_get_subsys_attr(c, "firmware_rev");
+		if (!c->sysfs->firmware)
+			c->sysfs->firmware = NO_SYSFS_ATTR;
+	}
+
+	if (SYSFS_IS_ABSENT(c->sysfs->firmware))
+		return -ENOENT;
+
+	*val = c->sysfs->firmware;
+	return 0;
+}
+
+__shr_public int libnvme_subsystem_get_iopolicy(
+		const struct libnvme_subsystem *p,
+		const char **val,
+		const char *dflt)
+{
+	struct libnvme_subsystem *c = (struct libnvme_subsystem *)p;
+	__cleanup_free char *str = NULL;
+
+	*val = dflt;
+
+	str = libnvme_get_subsys_attr(c, "iopolicy");
+	if (!str)
+		return -ENOENT;
+
+	if (!c->sysfs->iopolicy || strcmp(str, c->sysfs->iopolicy)) {
+		free(c->sysfs->iopolicy);
+		c->sysfs->iopolicy = strdup(str);
+		if (!c->sysfs->iopolicy)
+			return -ENOMEM;
+	}
+
+	*val = c->sysfs->iopolicy;
+	return 0;
+}
+

--- a/libnvme/src/nvme/subsys-sysfs.h
+++ b/libnvme/src/nvme/subsys-sysfs.h
@@ -1,0 +1,120 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+/*
+ * This file is part of libnvme.
+ *
+ * Copyright (c) 2025, Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ *
+ *   ____                           _           _    ____          _
+ *  / ___| ___ _ __   ___ _ __ __ _| |_ ___  __| |  / ___|___   __| | ___
+ * | |  _ / _ \ '_ \ / _ \ '__/ _` | __/ _ \/ _` | | |   / _ \ / _` |/ _ \
+ * | |_| |  __/ | | |  __/ | | (_| | ||  __/ (_| | | |__| (_) | (_| |  __/
+ *  \____|\___|_| |_|\___|_|  \__,_|\__\___|\__,_|  \____\___/ \__,_|\___|
+ *
+ * Auto-generated struct member accessors (setter/getter)
+ *
+ * To update run: meson compile -C [BUILD-DIR] update-accessors
+ * Or:            make update-accessors
+ */
+
+#pragma once
+
+/* Opaque: defined only in the generated subsys-sysfs.c. No
+ * other file may see its layout -- every field is reachable
+ * only through the accessors below.
+ */
+struct libnvme_subsystem_sysfs;
+
+/* Internal: allocate/reset/free the opaque struct. Not part
+ * of the public API, not listed in any .ld.
+ */
+struct libnvme_subsystem_sysfs *libnvme_subsystem_sysfs_alloc(void);
+void libnvme_subsystem_sysfs_reset(
+		struct libnvme_subsystem_sysfs *sysfs);
+void libnvme_subsystem_sysfs_free(
+		struct libnvme_subsystem_sysfs *sysfs);
+
+/**
+ * libnvme_subsystem_set_model() - Set model.
+ * @p: The &struct libnvme_subsystem instance to update.
+ * @model: New string; a copy is stored. Pass NULL to clear.
+ */
+void libnvme_subsystem_set_model(
+		struct libnvme_subsystem *p,
+		const char *model);
+
+/**
+ * libnvme_subsystem_get_model() - Get model.
+ * @p: The &struct libnvme_subsystem instance to query.
+ * @model: Where to store the value on success.
+ * @dflt: Value to store in @model on failure.
+ *
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
+ */
+int libnvme_subsystem_get_model(
+		const struct libnvme_subsystem *p,
+		const char **model,
+		const char *dflt);
+
+/**
+ * libnvme_subsystem_set_serial() - Set serial.
+ * @p: The &struct libnvme_subsystem instance to update.
+ * @serial: New string; a copy is stored. Pass NULL to clear.
+ */
+void libnvme_subsystem_set_serial(
+		struct libnvme_subsystem *p,
+		const char *serial);
+
+/**
+ * libnvme_subsystem_get_serial() - Get serial.
+ * @p: The &struct libnvme_subsystem instance to query.
+ * @serial: Where to store the value on success.
+ * @dflt: Value to store in @serial on failure.
+ *
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
+ */
+int libnvme_subsystem_get_serial(
+		const struct libnvme_subsystem *p,
+		const char **serial,
+		const char *dflt);
+
+/**
+ * libnvme_subsystem_set_firmware() - Set firmware.
+ * @p: The &struct libnvme_subsystem instance to update.
+ * @firmware: New string; a copy is stored. Pass NULL to clear.
+ */
+void libnvme_subsystem_set_firmware(
+		struct libnvme_subsystem *p,
+		const char *firmware);
+
+/**
+ * libnvme_subsystem_get_firmware() - Get firmware.
+ * @p: The &struct libnvme_subsystem instance to query.
+ * @firmware: Where to store the value on success.
+ * @dflt: Value to store in @firmware on failure.
+ *
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
+ */
+int libnvme_subsystem_get_firmware(
+		const struct libnvme_subsystem *p,
+		const char **firmware,
+		const char *dflt);
+
+/**
+ * libnvme_subsystem_get_iopolicy() - Get iopolicy.
+ * @p: The &struct libnvme_subsystem instance to query.
+ * @iopolicy: Where to store the value on success.
+ * @dflt: Value to store in @iopolicy on failure.
+ *
+ * Return: 0 on success, -ENOENT if the attribute does not
+ *	   exist, or a negative errno on failure.
+ */
+int libnvme_subsystem_get_iopolicy(
+		const struct libnvme_subsystem *p,
+		const char **iopolicy,
+		const char *dflt);
+

--- a/libnvme/src/nvme/sysfs_accessors_specs.py
+++ b/libnvme/src/nvme/sysfs_accessors_specs.py
@@ -325,9 +325,69 @@ NS_SYSFS = {
     'groups': [],
 }
 
+SUBSYS_SYSFS = {
+    'struct_name': 'libnvme_subsystem_sysfs',
+    'owner_type': 'libnvme_subsystem',
+    'owner_field': 'sysfs',
+    'attr_reader': 'libnvme_get_subsys_attr',
+    'source': 'subsys-sysfs.c',
+    'header': 'subsys-sysfs.h',
+    'ld': 'subsys-sysfs.ld',
+    'swig': 'subsys-sysfs.i',
+    # See CTRL_SYSFS's ld_section comment above: NEXT, not a real
+    # version number.
+    'ld_section': 'LIBNVME_SUBSYS_SYSFS_NEXT',
+    # No reconfigure_reset on any member: a subsystem is never updated
+    # in place -- libnvme_get_subsystem() always looks up an existing
+    # one by name/subsysnqn or creates a fresh one, there is no
+    # deconfigure/rescan hook that touches an existing subsystem's
+    # cached fields -- same rationale as PATH_SYSFS.
+    'members': [
+        # No group/loader needed, unlike CTRL_SYSFS's identity group:
+        # Windows already has model/serial/firmware for free from the
+        # ctrl map by the time a subsystem is scanned (no extra
+        # Identify round trip to batch), so each is just a plain
+        # attr member with writable=True and pushed in directly --
+        # the exact "platform with no sysfs at all" backfill case
+        # generate_sysfs_accessors.md's writable section already
+        # names by example.
+        {
+            'name': 'model',
+            'attr': 'model',
+            'type': 'char *',
+            'writable': True,
+        },
+        {
+            'name': 'serial',
+            'attr': 'serial',
+            'type': 'char *',
+            'writable': True,
+        },
+        {
+            'name': 'firmware',
+            'attr': 'firmware_rev',
+            'type': 'char *',
+            'writable': True,
+        },
+        # iopolicy can change at runtime (a user can rewrite the
+        # sysfs attribute directly), so it is never cached -- matches
+        # its pre-lazy hand-written getter, which always re-read
+        # sysfs and only replaced the cached copy when the value
+        # actually changed.
+        {
+            'name': 'iopolicy',
+            'attr': 'iopolicy',
+            'type': 'char *',
+            'volatile': True,
+        },
+    ],
+    'groups': [],
+}
+
 # generate_sysfs_accessors.py generates every entry here in one run.
 SYSFS_SPECS = [
     CTRL_SYSFS,
     PATH_SYSFS,
     NS_SYSFS,
+    SUBSYS_SYSFS,
 ]

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -673,11 +673,6 @@ int libnvme_init_subsystem(libnvme_subsystem_t s, const char *name)
 			libnvme_subsys_sysfs_dir(s->h->ctx), name) < 0)
 		return -ENOMEM;
 
-	s->model = libnvme_get_attr(path, "model");
-	if (!s->model)
-		s->model = strdup("undefined");
-	s->serial = libnvme_get_attr(path, "serial");
-	s->firmware = libnvme_get_attr(path, "firmware_rev");
 	s->subsystype = libnvme_get_attr(path, "subsystype");
 	if (!s->subsystype) {
 		if (!strcmp(s->subsysnqn, NVME_DISC_SUBSYS_NAME))
@@ -687,7 +682,6 @@ int libnvme_init_subsystem(libnvme_subsystem_t s, const char *name)
 	}
 	s->name = strdup(name);
 	s->sysfs_dir = (char *)path;
-	s->iopolicy = libnvme_get_attr(path, "iopolicy");
 
 	return 0;
 }

--- a/libnvme/src/nvme/tree-win.c
+++ b/libnvme/src/nvme/tree-win.c
@@ -141,13 +141,31 @@ static libnvme_subsystem_t libnvme_get_subsystem_windows(libnvme_host_t h,
 	if (ret)
 		return NULL;
 
-	/* Populate subsystem info from first controller */
-	if (!s->serial)
-		s->serial = libnvme_ctrl_map_entry_get_serial(ctrl_entry);
-	if (!s->model)
-		s->model = libnvme_ctrl_map_entry_get_model(ctrl_entry);
-	if (!s->firmware)
-		s->firmware = libnvme_ctrl_map_entry_get_firmware(ctrl_entry);
+	/*
+	 * Populate subsystem info from first controller. Windows has no
+	 * sysfs to lazily read these from, so push them in from the ctrl
+	 * map instead -- but only the first time this subsystem is seen,
+	 * matching the sysfs-backed getters' own "cache once" semantics.
+	 */
+	{
+		const char *cur;
+
+		if (libnvme_subsystem_get_serial(s, &cur, NULL)) {
+			__cleanup_free char *serial =
+				libnvme_ctrl_map_entry_get_serial(ctrl_entry);
+			libnvme_subsystem_set_serial(s, serial);
+		}
+		if (libnvme_subsystem_get_model(s, &cur, NULL)) {
+			__cleanup_free char *model =
+				libnvme_ctrl_map_entry_get_model(ctrl_entry);
+			libnvme_subsystem_set_model(s, model);
+		}
+		if (libnvme_subsystem_get_firmware(s, &cur, NULL)) {
+			__cleanup_free char *firmware =
+				libnvme_ctrl_map_entry_get_firmware(ctrl_entry);
+			libnvme_subsystem_set_firmware(s, firmware);
+		}
+	}
 
 	return s;
 }

--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -241,21 +241,6 @@ __shr_public libnvme_host_t libnvme_subsystem_get_host(
 	return s->h;
 }
 
-__shr_public char *libnvme_subsystem_get_iopolicy(libnvme_subsystem_t s)
-{
-	__cleanup_free char *iopolicy = NULL;
-
-	iopolicy = libnvme_get_subsys_attr(s, "iopolicy");
-	if (iopolicy) {
-		if (!s->iopolicy || strcmp(iopolicy, s->iopolicy)) {
-			free(s->iopolicy);
-			s->iopolicy = strdup(iopolicy);
-		}
-	}
-
-	return s->iopolicy;
-}
-
 __shr_public libnvme_ns_t libnvme_subsystem_first_ns(libnvme_subsystem_t s)
 {
 	return list_top(&s->namespaces, struct libnvme_ns, entry);
@@ -322,11 +307,8 @@ static void __nvme_free_subsystem(struct libnvme_subsystem *s)
 	free(s->name);
 	free(s->sysfs_dir);
 	free(s->subsysnqn);
-	free(s->model);
-	free(s->serial);
-	free(s->firmware);
 	free(s->subsystype);
-	free(s->iopolicy);
+	libnvme_subsystem_sysfs_free(s->sysfs);
 	free(s);
 }
 
@@ -366,6 +348,13 @@ int libnvme_create_subsystem(struct libnvme_host *h,
 	s->h = h;
 	s->subsysnqn = shr_xstrdup(subsysnqn);
 	if (!s->subsysnqn) {
+		free(s);
+		return -ENOMEM;
+	}
+
+	s->sysfs = libnvme_subsystem_sysfs_alloc();
+	if (!s->sysfs) {
+		free(s->subsysnqn);
 		free(s);
 		return -ENOMEM;
 	}
@@ -1574,9 +1563,10 @@ __shr_public const char *libnvme_ns_get_model(libnvme_ns_t n)
 	const char *val;
 
 	if (!n->c)
-		return n->s->model;
+		libnvme_subsystem_get_model(n->s, &val, NULL);
+	else
+		libnvme_ctrl_get_model(n->c, &val, NULL);
 
-	libnvme_ctrl_get_model(n->c, &val, NULL);
 	return val;
 }
 
@@ -1585,9 +1575,10 @@ __shr_public const char *libnvme_ns_get_serial(libnvme_ns_t n)
 	const char *val;
 
 	if (!n->c)
-		return n->s->serial;
+		libnvme_subsystem_get_serial(n->s, &val, NULL);
+	else
+		libnvme_ctrl_get_serial(n->c, &val, NULL);
 
-	libnvme_ctrl_get_serial(n->c, &val, NULL);
 	return val;
 }
 
@@ -1596,9 +1587,10 @@ __shr_public const char *libnvme_ns_get_firmware(libnvme_ns_t n)
 	const char *val;
 
 	if (!n->c)
-		return n->s->firmware;
+		libnvme_subsystem_get_firmware(n->s, &val, NULL);
+	else
+		libnvme_ctrl_get_firmware(n->c, &val, NULL);
 
-	libnvme_ctrl_get_firmware(n->c, &val, NULL);
 	return val;
 }
 

--- a/libnvme/src/nvme/tree.h
+++ b/libnvme/src/nvme/tree.h
@@ -142,14 +142,6 @@ void libnvme_free_subsystem(struct libnvme_subsystem *s);
 libnvme_host_t libnvme_subsystem_get_host(libnvme_subsystem_t s);
 
 /**
- * libnvme_subsystem_get_iopolicy() - Get subsystem iopolicy name
- * @s:	subsystem
- *
- * Return: The iopolicy configured in subsystem @s
- */
-char *libnvme_subsystem_get_iopolicy(libnvme_subsystem_t s);
-
-/**
  * libnvme_ctrl_first_ns() - Start namespace iterator
  * @c:	Controller instance
  *

--- a/libnvme/src/subsys-sysfs.ld
+++ b/libnvme/src/subsys-sysfs.ld
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+/*
+ * This file is part of libnvme.
+ *
+ * Copyright (c) 2026, Dell Technologies Inc. or its subsidiaries.
+ * Authors: Martin Belanger <Martin.Belanger@dell.com>
+ *
+ * This symbol list is maintained by hand, not auto-generated. When
+ * you run the update below, it does not rewrite this file -- it
+ * prints which symbols should be added or removed. Add or remove
+ * those symbols yourself, in the correct ABI version section.
+ *
+ * To check: meson compile -C [BUILD-DIR] update-accessors
+ * Or:       make update-accessors
+ */
+
+LIBNVME_SUBSYS_SYSFS_3 {
+	global:
+		libnvme_subsystem_get_model;
+		libnvme_subsystem_set_model;
+		libnvme_subsystem_get_serial;
+		libnvme_subsystem_set_serial;
+		libnvme_subsystem_get_firmware;
+		libnvme_subsystem_set_firmware;
+		libnvme_subsystem_get_iopolicy;
+};

--- a/libnvme/tools/check-public-symbols.py
+++ b/libnvme/tools/check-public-symbols.py
@@ -43,6 +43,7 @@ LD_FILES = [
     ROOT / 'src' / 'ctrl-sysfs.ld',
     ROOT / 'src' / 'path-sysfs.ld',
     ROOT / 'src' / 'ns-sysfs.ld',
+    ROOT / 'src' / 'subsys-sysfs.ld',
 ]
 
 # ---------------------------------------------------------------------------

--- a/nvme-print-json.c
+++ b/nvme-print-json.c
@@ -2742,14 +2742,24 @@ static void json_print_nvme_subsystem_list(struct libnvme_global_ctx *ctx,
 			obj_add_str(subsystem_attrs, "NQN", libnvme_subsystem_get_subsysnqn(s));
 
 			if (verbose_mode()) {
-				obj_add_str(subsystem_attrs, "Model",
-						libnvme_subsystem_get_model(s));
-				obj_add_str(subsystem_attrs, "Serial",
-						libnvme_subsystem_get_serial(s));
+				const char *model;
+				const char *serial;
+				const char *firmware;
+				const char *iopolicy;
+
+				libnvme_subsystem_get_model(s, &model, NULL);
+				libnvme_subsystem_get_serial(s, &serial, NULL);
+				libnvme_subsystem_get_firmware(s, &firmware,
+								NULL);
+				libnvme_subsystem_get_iopolicy(s, &iopolicy,
+								NULL);
+
+				obj_add_str(subsystem_attrs, "Model", model);
+				obj_add_str(subsystem_attrs, "Serial", serial);
 				obj_add_str(subsystem_attrs, "Firmware",
-						libnvme_subsystem_get_firmware(s));
+						firmware);
 				obj_add_str(subsystem_attrs, "IOPolicy",
-						libnvme_subsystem_get_iopolicy(s));
+						iopolicy);
 				obj_add_str(subsystem_attrs, "Type",
 						libnvme_subsystem_get_subsystype(s));
 			}
@@ -4953,7 +4963,9 @@ static unsigned int json_subsystem_topology_multipath(libnvme_subsystem_t s,
 	libnvme_ns_t n;
 	libnvme_path_t p;
 	unsigned int i = 0;
-	const char *iopolicy = libnvme_subsystem_get_iopolicy(s);
+	const char *iopolicy;
+
+	libnvme_subsystem_get_iopolicy(s, &iopolicy, "");
 
 	libnvme_subsystem_for_each_ns(s, n) {
 		struct json_object *ns_attrs;
@@ -5069,19 +5081,28 @@ static void json_simple_topology(struct libnvme_global_ctx *ctx)
 			obj_add_str(host_attrs, "HostID", hostid);
 		subsystems = json_create_array();
 		libnvme_for_each_subsystem(h, s) {
+			const char *iopolicy;
+
 			subsystem_attrs = json_create_object();
 			obj_add_str(subsystem_attrs, "Name", libnvme_subsystem_get_name(s));
 			obj_add_str(subsystem_attrs, "NQN", libnvme_subsystem_get_subsysnqn(s));
-			obj_add_str(subsystem_attrs, "IOPolicy",
-					libnvme_subsystem_get_iopolicy(s));
+			libnvme_subsystem_get_iopolicy(s, &iopolicy, NULL);
+			obj_add_str(subsystem_attrs, "IOPolicy", iopolicy);
 
 			if (verbose_mode()) {
-				obj_add_str(subsystem_attrs, "Model",
-						libnvme_subsystem_get_model(s));
-				obj_add_str(subsystem_attrs, "Serial",
-						libnvme_subsystem_get_serial(s));
+				const char *model;
+				const char *serial;
+				const char *firmware;
+
+				libnvme_subsystem_get_model(s, &model, NULL);
+				libnvme_subsystem_get_serial(s, &serial, NULL);
+				libnvme_subsystem_get_firmware(s, &firmware,
+								NULL);
+
+				obj_add_str(subsystem_attrs, "Model", model);
+				obj_add_str(subsystem_attrs, "Serial", serial);
 				obj_add_str(subsystem_attrs, "Firmware",
-						libnvme_subsystem_get_firmware(s));
+						firmware);
 				obj_add_str(subsystem_attrs, "Type",
 						libnvme_subsystem_get_subsystype(s));
 			}

--- a/nvme-print-stdout-top.c
+++ b/nvme-print-stdout-top.c
@@ -850,7 +850,7 @@ static int stdout_top_print_path_perf(FILE *stream, libnvme_subsystem_t s)
 	char r_bw_str[16], w_bw_str[16];
 	bool first;
 	struct shr_table *t;
-	const char *iopolicy = libnvme_subsystem_get_iopolicy(s);
+	const char *iopolicy;
 	struct shr_table_column columns[] = {
 		{"NSHead",    LEFT, AUTO_WIDTH},
 		{"NSID",      LEFT, AUTO_WIDTH},
@@ -880,6 +880,8 @@ static int stdout_top_print_path_perf(FILE *stream, libnvme_subsystem_t s)
 		ret = 1;
 		goto free_tbl;
 	}
+
+	libnvme_subsystem_get_iopolicy(s, &iopolicy, "");
 
 	fprintf(stream, "\n---------- Path Performance ----------\n\n");
 	libnvme_subsystem_for_each_ns(s, n) {
@@ -978,20 +980,25 @@ static void  stdout_top_print_subsys_topology_config(FILE *stream,
 		libnvme_subsystem_t s)
 {
 	int len = strlen(libnvme_subsystem_get_name(s));
+	const char *iopolicy;
+	const char *model;
+	const char *serial;
+	const char *firmware;
+
+	libnvme_subsystem_get_iopolicy(s, &iopolicy, "");
+	libnvme_subsystem_get_model(s, &model, "undefined");
+	libnvme_subsystem_get_serial(s, &serial, "");
+	libnvme_subsystem_get_firmware(s, &firmware, "");
 
 	fprintf(stream, "%s - NQN=%s\n", libnvme_subsystem_get_name(s),
 		libnvme_subsystem_get_subsysnqn(s));
 	fprintf(stream, "%*s   hostnqn=%s\n", len, " ",
 		libnvme_host_get_hostnqn(libnvme_subsystem_get_host(s)));
-	fprintf(stream, "%*s   iopolicy=%s\n", len, " ",
-		libnvme_subsystem_get_iopolicy(s));
+	fprintf(stream, "%*s   iopolicy=%s\n", len, " ", iopolicy);
 
-	fprintf(stream, "%*s   model=%s\n", len, " ",
-		libnvme_subsystem_get_model(s));
-	fprintf(stream, "%*s   serial=%s\n", len, " ",
-		libnvme_subsystem_get_serial(s));
-	fprintf(stream, "%*s   firmware=%s\n", len, " ",
-		libnvme_subsystem_get_firmware(s));
+	fprintf(stream, "%*s   model=%s\n", len, " ", model);
+	fprintf(stream, "%*s   serial=%s\n", len, " ", serial);
+	fprintf(stream, "%*s   firmware=%s\n", len, " ", firmware);
 	fprintf(stream, "%*s   type=%s\n", len, " ",
 		libnvme_subsystem_get_subsystype(s));
 
@@ -1357,7 +1364,7 @@ static int stdout_top_draw_subsys_screen(struct dashboard_ctx *db_ctx,
 	char r_bw_str[16], w_bw_str[16];
 	char r_iops_str[16], w_iops_str[16];
 	char r_clat_str[16], w_clat_str[16];
-	char *iopolicy;
+	const char *iopolicy;
 	struct shr_table *t;
 	struct shr_table_column columns[] = {
 		{"Subsystem",  LEFT, AUTO_WIDTH},
@@ -1408,7 +1415,7 @@ static int stdout_top_draw_subsys_screen(struct dashboard_ctx *db_ctx,
 		r_bw = w_bw = 0;
 		max_rlat = max_wlat = 0;
 		max_util = 0;
-		iopolicy = libnvme_subsystem_get_iopolicy(s);
+		libnvme_subsystem_get_iopolicy(s, &iopolicy, "NA");
 
 		libnvme_subsystem_for_each_ctrl(s, c)
 			num_ctrl++;
@@ -1467,8 +1474,7 @@ static int stdout_top_draw_subsys_screen(struct dashboard_ctx *db_ctx,
 		shr_table_set_value_int(t, ++col, row, num_ns, LEFT);
 		shr_table_set_value_int(t, ++col, row, num_path, LEFT);
 		shr_table_set_value_int(t, ++col, row, num_ctrl, LEFT);
-		shr_table_set_value_str(t, ++col, row,
-				iopolicy ? iopolicy : "NA", LEFT);
+		shr_table_set_value_str(t, ++col, row, iopolicy, LEFT);
 		shr_table_set_value_str(t, ++col, row, r_iops_str, LEFT);
 		shr_table_set_value_str(t, ++col, row, w_iops_str, LEFT);
 		shr_table_set_value_str(t, ++col, row, r_clat_str, LEFT);

--- a/nvme-print-stdout.c
+++ b/nvme-print-stdout.c
@@ -1316,17 +1316,25 @@ static void stdout_subsys_config(libnvme_subsystem_t s, bool show_iopolicy)
 	       libnvme_subsystem_get_subsysnqn(s));
 	printf("%*s   hostnqn=%s\n", len, " ",
 	       libnvme_host_get_hostnqn(libnvme_subsystem_get_host(s)));
-	if (show_iopolicy)
-		printf("%*s   iopolicy=%s\n", len, " ",
-				libnvme_subsystem_get_iopolicy(s));
+	if (show_iopolicy) {
+		const char *iopolicy;
+
+		libnvme_subsystem_get_iopolicy(s, &iopolicy, "");
+		printf("%*s   iopolicy=%s\n", len, " ", iopolicy);
+	}
 
 	if (stdout_print_ops.flags & VERBOSE) {
-		printf("%*s   model=%s\n", len, " ",
-			libnvme_subsystem_get_model(s));
-		printf("%*s   serial=%s\n", len, " ",
-			libnvme_subsystem_get_serial(s));
-		printf("%*s   firmware=%s\n", len, " ",
-			libnvme_subsystem_get_firmware(s));
+		const char *model;
+		const char *serial;
+		const char *firmware;
+
+		libnvme_subsystem_get_model(s, &model, "undefined");
+		libnvme_subsystem_get_serial(s, &serial, "");
+		libnvme_subsystem_get_firmware(s, &firmware, "");
+
+		printf("%*s   model=%s\n", len, " ", model);
+		printf("%*s   serial=%s\n", len, " ", serial);
+		printf("%*s   firmware=%s\n", len, " ", firmware);
 		printf("%*s   type=%s\n", len, " ",
 			libnvme_subsystem_get_subsystype(s));
 	}
@@ -6140,7 +6148,7 @@ static void stdout_tabular_subsystem_topology_multipath(libnvme_subsystem_t s)
 	char iopolicy_info[256];
 	int ret, num_path;
 	struct shr_table *t;
-	const char *iopolicy = libnvme_subsystem_get_iopolicy(s);
+	const char *iopolicy;
 	struct shr_table_column columns[] = {
 		{"NSHead",     LEFT, AUTO_WIDTH},
 		{"NSID",       LEFT, AUTO_WIDTH},
@@ -6165,6 +6173,8 @@ static void stdout_tabular_subsystem_topology_multipath(libnvme_subsystem_t s)
 		nvme_show_error("Failed to add subsys topology multipath columns");
 		goto free_tbl;
 	}
+
+	libnvme_subsystem_get_iopolicy(s, &iopolicy, "");
 
 	libnvme_subsystem_for_each_ns(s, n) {
 		first = true;
@@ -6256,7 +6266,9 @@ static void stdout_subsystem_topology_multipath(libnvme_subsystem_t s,
 	libnvme_ns_t n;
 	libnvme_path_t p;
 	libnvme_ctrl_t c;
-	const char *iopolicy = libnvme_subsystem_get_iopolicy(s);
+	const char *iopolicy;
+
+	libnvme_subsystem_get_iopolicy(s, &iopolicy, "");
 
 	if (ranking == NVME_CLI_TOPO_NAMESPACE) {
 		libnvme_subsystem_for_each_ns(s, n) {

--- a/nvme.h
+++ b/nvme.h
@@ -52,7 +52,9 @@ static inline bool nvme_is_multipath(libnvme_subsystem_t s)
 static inline bool subsystem_iopolicy_filter(const char *name, void *arg)
 {
 	libnvme_subsystem_t s = arg;
-	const char *iopolicy = libnvme_subsystem_get_iopolicy(s);
+	const char *iopolicy;
+
+	libnvme_subsystem_get_iopolicy(s, &iopolicy, "");
 
 	if (!strcmp(iopolicy, "queue-depth")) {
 		/* exclude "Nodes" for iopolicy queue-depth */


### PR DESCRIPTION
Follow-on to #3757: extends the lazy sysfs read pattern to `libnvme_subsystem`'s.

This is the last PR in the lazy-sysfs series -- it converts the fourth and final struct (`libnvme_ctrl`, `libnvme_path`, `libnvme_ns`, now `libnvme_subsystem`).

One commit.

Measured against 4 real controllers (1 PCIe, 3 NVMe-oF/TCP), same method as before -- strace'd sysfs `openat` calls, before/after this PR, plus the overall reduction across the whole lazy-sysfs series (against the fully-eager baseline, before #3711):

| Command | Before this PR | After this PR | This PR | Fully eager | Overall reduction |
|---|---|---|---|---|---|
| `nvme list` | 221 | 211 | -10 (-4.5%) | 295 | -84 (-28.5%) |
| `nvme list-subsys` | 199 | 183 | -16 (-8.0%) | 299 | -116 (-38.8%) |
| `nvme list -vv` | 255 | 239 | -16 (-6.3%) | 299 | -60 (-20.1%) |
