### PR TITLE
solidigm: fix integer overflow in sldm_parse_cd_uart_log()

### DIFF
--- a/plugins/solidigm/solidigm-telemetry/uart-log.c
+++ b/plugins/solidigm/solidigm-telemetry/uart-log.c
@@ -108,7 +108,7 @@ int sldm_parse_cd_uart_log(struct telemetry_log *tl, uint32_t offset, uint32_t s
 
 	/* Parse entries using dynamic structure parsing */
 	for (i = 0; i < num_entries; i++) {
-		entry_offset_bit = (offset + (i * 192)) * 8;  /* Convert to bit offset */
+		entry_offset_bit = ((uint64_t)offset + (uint64_t)i * 192) * 8;  /* Convert to bit offset */
 		parse_uart_entry(tl, entry_offset_bit, uart_array);
 	}
 


### PR DESCRIPTION
The sldm_parse_cd_uart_log() function computes a bit offset from offset and the loop index i, both of which are 32-bit unsigned integers. The expression (offset + i * 192) * 8 is evaluated entirely in 32-bit arithmetic before being assigned to the 64-bit entry_offset_bit variable.

For large telemetry buffers, this expression can exceed the 32-bit unsigned maximum, silently wrapping to a wrong value before the result is widened to 64 bits. This causes the subsequent entry parser to read data from an incorrect bit offset in the telemetry log.

Cast offset and i to uint64_t before the multiplication so that the entire expression is computed in 64-bit arithmetic, preventing the overflow.