### PR TITLE
solidigm: fix unchecked return value in solidigm_config_get_nlog_formats()

### DIFF
--- a/plugins/solidigm/solidigm-telemetry/config.c
+++ b/plugins/solidigm/solidigm-telemetry/config.c
@@ -134,7 +134,8 @@ struct json_object *solidigm_config_get_nlog_formats(const struct json_object *c
 {
 	struct json_object *nlog_formats = NULL;
 
-	json_object_object_get_ex(config, "NLOG_FORMATS", &nlog_formats);
+	if (!json_object_object_get_ex(config, "NLOG_FORMATS", &nlog_formats))
+		return NULL;
 	return nlog_formats;
 }
 


### PR DESCRIPTION

The solidigm_config_get_nlog_formats() function looks up the "NLOG_FORMATS" key from the JSON config object using json_object_object_get_ex(). The return value of the call was not checked.

If "NLOG_FORMATS" is absent from the config, the lookup silently fails and nlog_formats remains NULL. While the caller guards against a NULL return, the function itself makes no distinction between a successful lookup that returned NULL and a failed one, violating the consistent error-checking contract of the codebase.

Check the return value and return NULL explicitly when the key is not found to make the error path consistent with all other call sites.