### PR TITLE
nvme-print: revert outer loop bound change in json_nvme_fdp_configs()

### DIFF
--- a/src/nvme-print-json.c
+++ b/src/nvme-print-json.c
@@ -2527,7 +2527,7 @@ static void json_nvme_fdp_configs(struct nvme_fdp_config_log *log, size_t len)
 
 	obj_add_uint(r, "n", n);
 
-	for (int i = 0; i < n; i++) {
+	for (int i = 0; i < n + 1; i++) {
 		struct nvme_fdp_config_desc *config = p;
 		uint16_t nruh = le16_to_cpu(config->nruh);
 


### PR DESCRIPTION
Per NVMe spec section "5.2.12.1.29 Flexible Data Placement (FDP) Configurations (Log Page Identifier 20h)", the log->n field is a 0-based value. A value of 0 means one configuration, a value of 1 means two configurations, and so on. Therefore the loop must iterate n + 1 times to cover all configurations reported by the device.

The earlier change to use i < n was incorrect and is reverted here. The Coverity TAINTED_SCALAR report on this loop bound is a false positive: the loop bound i < n + 1 is correct per spec.

Fixes: a7bf8a9 ("nvme-print: fix untrusted loop bounds in json_nvme_fdp_configs()")

Partially reverts https://github.com/linux-nvme/nvme-cli/pull/3727