### PR TITLE
tree-fabrics: fix null pointer dereference in ctrl_lookups()

### DIFF
--- a/libnvme/test/tree-fabrics.c
+++ b/libnvme/test/tree-fabrics.c
@@ -255,6 +255,7 @@ static bool ctrl_lookups(struct libnvme_global_ctx *ctx)
 	bool pass = true;
 
 	h = libnvme_first_host(ctx);
+	shr_assert(h);
 	shr_assert(!libnvme_get_subsystem(ctx, h, DEFAULT_SUBSYSNAME,
 			      DEFAULT_SUBSYSNQN, &s));
 	shr_assert(s);


### PR DESCRIPTION
The ctrl_lookups() function calls libnvme_first_host() to get the first host entry, then immediately passes h to
libnvme_get_subsystem() without checking whether the return value is NULL.

libnvme_first_host() returns NULL when the host list is empty. Dereferencing a NULL h inside libnvme_get_subsystem() causes undefined behavior.

Add shr_assert(h) after the call to libnvme_first_host() to catch a NULL return and abort early, consistent with the existing check used after libnvme_create_host() in the same file.