### PR TITLE
solidigm-telemetry: fix missing fallthrough annotations in debug info switch

### DIFF
--- a/plugins/solidigm/solidigm-telemetry/debug-info.c
+++ b/plugins/solidigm/solidigm-telemetry/debug-info.c
@@ -273,9 +273,11 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 				break;
 			case DEBUG_INFO_ID_TRACKER_INFO:
 				tracker_log_name = "TrackerInfo";
+				fallthrough;
 			case DEBUG_INFO_ID_TRACKER_BUFFER:
 				if (!tracker_log_name)
 					tracker_log_name = "TrackerBuffer";
+				fallthrough;
 			case DEBUG_INFO_ID_TRACKER_CONTEXT:
 				if (!tracker_log_name)
 					tracker_log_name = "TrackerContext";


### PR DESCRIPTION

The sldm_debug_info_parse() function uses an intentional fallthrough chain in its segment-ID switch to set tracker_log_name before reaching the shared tracker parsing body. The DEBUG_INFO_ID_TRACKER_INFO and DEBUG_INFO_ID_TRACKER_BUFFER cases fall through to the next case without a fallthrough annotation.

Unannotated fallthrough triggers -Wimplicit-fallthrough warnings from the compiler and is flagged by static analysis tools as a control flow defect (CID 557320, CID 557398).

Add fallthrough; after each intentional fall-through to match the convention used throughout the rest of the codebase and suppress the warning.