### PR TITLE
solidigm-telemetry: check return value of sldm_telemetry_structure_parse

### DIFF
--- a/plugins/solidigm/solidigm-telemetry/data-area.c
+++ b/plugins/solidigm/solidigm-telemetry/data-area.c
@@ -520,9 +520,10 @@ static void telemetry_log_data_area_toc_parse(const struct telemetry_log *tl,
 		}
 		object_file_offset = ((uint64_t)da_offset) + obj_offset + header_offset;
 		if (has_struct) {
-			sldm_telemetry_structure_parse(tl, structure_definition,
-						NUM_BITS_IN_BYTE * object_file_offset,
-						parsed_struct, toc_item);
+			if (sldm_telemetry_structure_parse(tl, structure_definition,
+							NUM_BITS_IN_BYTE * object_file_offset,
+							parsed_struct, toc_item))
+				continue;
 		}
 		// NLOGs have different parser from other Telemetry objects
 		if (nlog_name) {


### PR DESCRIPTION
The return value of sldm_telemetry_structure_parse() was not being checked before proceeding to use the parsed_struct object for NLOG and side trace processing. If parsing fails, the incomplete structure data would lead to invalid results in downstream operations.

Check the return value and skip to the next iteration if parsing fails.