### PR TITLE
sandisk: remove logically dead code in sndk_do_cap_telemetry_log

### DIFF
--- a/plugins/sandisk/sandisk-nvme.c
+++ b/plugins/sandisk/sandisk-nvme.c
@@ -42,7 +42,6 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 	struct nvme_telemetry_log *log;
 	size_t full_size = 0;
 	int err = 0, output;
-	__u32 host_gen = 1;
 	int ctrl_init = 0;
 	__u8 *data_ptr = NULL;
 	int data_written = 0, data_remaining = 0;
@@ -82,7 +81,6 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 	}
 
 	if (type == SNDK_TELEMETRY_TYPE_HOST) {
-		host_gen = 1;
 		ctrl_init = 0;
 	} else if (type == SNDK_TELEMETRY_TYPE_CONTROLLER) {
 		if (capabilities & SNDK_DRIVE_CAP_INTERNAL_LOG) {
@@ -90,7 +88,6 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 			if (err)
 				return err;
 		}
-		host_gen = 0;
 		ctrl_init = 1;
 	} else if (type == SNDK_TELEMETRY_TYPE_BOTH) {
 		nvme_show_error(
@@ -117,12 +114,9 @@ static int sndk_do_cap_telemetry_log(struct libnvme_global_ctx *ctx,
 	if (ctrl_init)
 		err = libnvme_get_ctrl_telemetry(hdl, true, &log,
 					  data_area, &full_size);
-	else if (host_gen)
+	else
 		err = libnvme_get_new_host_telemetry(hdl, &log,
 						  data_area, &full_size);
-	else
-		err = libnvme_get_host_telemetry(hdl, &log, data_area,
-					  &full_size);
 
 	if (err < 0) {
 		nvme_show_err(err, "get-telemetry-log");


### PR DESCRIPTION
The function uses host_gen and ctrl_init flags to select which libnvme telemetry API to call. host_gen is initialized to 1 and only ever set to 0 in the CONTROLLER branch, which also sets ctrl_init to 1.

Because the BOTH and invalid-type branches return early, the only code paths that reach the dispatch block are HOST (ctrl_init=0, host_gen=1) and CONTROLLER (ctrl_init=1). The else branch calling libnvme_get_host_telemetry() is therefore unreachable - no defined telemetry type produces ctrl_init=0 and host_gen=0 simultaneously.

Remove host_gen and the dead libnvme_get_host_telemetry() branch. Replace the else if (host_gen) guard with a plain else, making the two-way dispatch match the two reachable states.