### PR TITLE
ocp: sanitize tainted ascii_id_length before memcpy

### DIFF
--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -635,7 +635,8 @@ int get_statistic_id_ascii_string(int identifier, char *description)
 				SIZE_OF_DWORD));
 
 			memcpy(description, pdescription,
-			       peach_statistic_entry->ascii_id_length + 1);
+			       peach_statistic_entry->ascii_id_length);
+			description[peach_statistic_entry->ascii_id_length] = '\0';
 
 			return 0;
 		}
@@ -679,7 +680,8 @@ int get_event_id_ascii_string(int identifier, int debug_event_class, char *descr
 				(peach_event_entry->ascii_id_offset * SIZE_OF_DWORD));
 
 			memcpy(description, pdescription,
-			       peach_event_entry->ascii_id_length + 1);
+			       peach_event_entry->ascii_id_length);
+			description[peach_event_entry->ascii_id_length] = '\0';
 			return 0;
 		}
 	}
@@ -717,7 +719,8 @@ int get_vu_event_id_ascii_string(int identifier, int debug_event_class, char *de
 				(peach_vu_event_entry->ascii_id_offset * SIZE_OF_DWORD));
 
 			memcpy(description, pdescription,
-			       peach_vu_event_entry->ascii_id_length + 1);
+			       peach_vu_event_entry->ascii_id_length);
+			description[peach_vu_event_entry->ascii_id_length] = '\0';
 			return 0;
 		}
 	}


### PR DESCRIPTION
ascii_id_length is a __u8 field read from device-supplied telemetry
data (pstring_buffer). Passing it directly as the memcpy size without
bounds checking allows a corrupt or malicious value to write beyond
the description buffer.

Replace 'memcpy(desc, src, len + 1)' with an explicit copy of len
bytes followed by a null terminator. Since ascii_id_length is __u8
(max 255) and all callers provide a 256-byte buffer, the copy and
terminator always fit without needing an additional clamp.

The same fix is applied consistently across all three string lookup
functions: get_statistic_id_ascii_string(), get_event_id_ascii_string()
and get_vu_event_id_ascii_string().

Fixes Coverity CIDs 557416, 557331, 557323 (TAINTED_SCALAR).
Signed-off-by: Brooke Ellis <Brooke.Ellis@ibm.com>