### PR TITLE
Enable nvme-mi-send/recv admin command support unconditionally and add Windows support

### DIFF
--- a/libnvme/src/libnvme-mi.ld
+++ b/libnvme/src/libnvme-mi.ld
@@ -32,7 +32,6 @@ LIBNVME_MI_3 {
 		libnvme_mi_scan_ep;
 		libnvme_mi_scan_mctp;
 		libnvme_mi_set_csi;
-		libnvme_mi_status_to_string;
 	local:
 		*;
 };

--- a/libnvme/src/libnvme.ld
+++ b/libnvme/src/libnvme.ld
@@ -59,6 +59,7 @@ LIBNVME_3 {
 		libnvme_host_get_global_ctx;
 		libnvme_host_release_fds;
 		libnvme_init_ctrl;
+		libnvme_mi_status_to_string;
 		libnvme_namespace_first_path;
 		libnvme_namespace_next_path;
 		libnvme_next_host;

--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -1984,6 +1984,8 @@ __shr_public int libnvme_exec_admin_passthru(
 		return submit_admin_get_features(hdl, cmd);
 	case nvme_admin_ns_mgmt:
 	case nvme_admin_ns_attach:
+	case nvme_admin_nvme_mi_send:
+	case nvme_admin_nvme_mi_recv:
 		/* Only supported on WinPE */
 		if (get_is_win_pe())
 			return submit_storage_protocol_command(hdl, cmd);

--- a/libnvme/src/nvme/mi-types.h
+++ b/libnvme/src/nvme/mi-types.h
@@ -88,53 +88,6 @@ enum nvme_mi_ror {
 };
 
 /**
- * enum nvme_mi_resp_status - values for the response status field
- * @NVME_MI_RESP_SUCCESS: success
- * @NVME_MI_RESP_MPR: More Processing Required
- * @NVME_MI_RESP_INTERNAL_ERR: Internal Error
- * @NVME_MI_RESP_INVALID_OPCODE: Invalid command opcode
- * @NVME_MI_RESP_INVALID_PARAM: Invalid command parameter
- * @NVME_MI_RESP_INVALID_CMD_SIZE: Invalid command size
- * @NVME_MI_RESP_INVALID_INPUT_SIZE: Invalid command input data size
- * @NVME_MI_RESP_ACCESS_DENIED: Access Denied
- * @NVME_MI_RESP_VPD_UPDATES_EXCEEDED: More VPD updates than allowed
- * @NVME_MI_RESP_PCIE_INACCESSIBLE: PCIe functionality currently unavailable
- * @NVME_MI_RESP_MEB_SANITIZED: MEB has been cleared due to sanitize
- * @NVME_MI_RESP_ENC_SERV_FAILURE: Enclosure services process failed
- * @NVME_MI_RESP_ENC_SERV_XFER_FAILURE: Transfer with enclosure services failed
- * @NVME_MI_RESP_ENC_FAILURE: Unreoverable enclosure failure
- * @NVME_MI_RESP_ENC_XFER_REFUSED: Enclosure services transfer refused
- * @NVME_MI_RESP_ENC_FUNC_UNSUP: Unsupported enclosure services function
- * @NVME_MI_RESP_ENC_SERV_UNAVAIL: Enclosure services unavailable
- * @NVME_MI_RESP_ENC_DEGRADED: Noncritical failure detected by enc. services
- * @NVME_MI_RESP_SANITIZE_IN_PROGRESS: Command prohibited during sanitize
- */
-enum nvme_mi_resp_status {
-	NVME_MI_RESP_SUCCESS = 0x00,
-	NVME_MI_RESP_MPR = 0x01,
-	NVME_MI_RESP_INTERNAL_ERR = 0x02,
-	NVME_MI_RESP_INVALID_OPCODE = 0x03,
-	NVME_MI_RESP_INVALID_PARAM = 0x04,
-	NVME_MI_RESP_INVALID_CMD_SIZE = 0x05,
-	NVME_MI_RESP_INVALID_INPUT_SIZE = 0x06,
-	NVME_MI_RESP_ACCESS_DENIED = 0x07,
-	/* 0x08 - 0x1f: reserved */
-	NVME_MI_RESP_VPD_UPDATES_EXCEEDED = 0x20,
-	NVME_MI_RESP_PCIE_INACCESSIBLE = 0x21,
-	NVME_MI_RESP_MEB_SANITIZED = 0x22,
-	NVME_MI_RESP_ENC_SERV_FAILURE = 0x23,
-	NVME_MI_RESP_ENC_SERV_XFER_FAILURE = 0x24,
-	NVME_MI_RESP_ENC_FAILURE = 0x25,
-	NVME_MI_RESP_ENC_XFER_REFUSED = 0x26,
-	NVME_MI_RESP_ENC_FUNC_UNSUP = 0x27,
-	NVME_MI_RESP_ENC_SERV_UNAVAIL = 0x28,
-	NVME_MI_RESP_ENC_DEGRADED = 0x29,
-	NVME_MI_RESP_SANITIZE_IN_PROGRESS = 0x2a,
-	/* 0x2b - 0xdf: reserved */
-	/* 0xe0 - 0xff: vendor specific */
-};
-
-/**
  * struct nvme_mi_msg_hdr - General MI message header.
  * @type: MCTP message type, will always be NVME_MI_MSGTYPE_NVME
  * @nmp: NVMe-MI message parameters (including MI message type)

--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -1387,39 +1387,6 @@ struct libnvme_transport_handle *libnvme_mi_next_transport_handle(libnvme_mi_ep_
 	return hdl ? list_next(&ep->controllers, hdl, ep_entry) : NULL;
 }
 
-static const char *const mi_status[] = {
-        [NVME_MI_RESP_MPR]                   = "More Processing Required: The command message is in progress and requires more time to complete processing",
-        [NVME_MI_RESP_INTERNAL_ERR]          = "Internal Error: The request message could not be processed due to a vendor-specific error",
-        [NVME_MI_RESP_INVALID_OPCODE]        = "Invalid Command Opcode",
-        [NVME_MI_RESP_INVALID_PARAM]         = "Invalid Parameter",
-        [NVME_MI_RESP_INVALID_CMD_SIZE]      = "Invalid Command Size: The size of the message body of the request was different than expected",
-        [NVME_MI_RESP_INVALID_INPUT_SIZE]    = "Invalid Command Input Data Size: The command requires data and contains too much or too little data",
-        [NVME_MI_RESP_ACCESS_DENIED]         = "Access Denied. Processing prohibited due to a vendor-specific mechanism of the Command and Feature lockdown function",
-        [NVME_MI_RESP_VPD_UPDATES_EXCEEDED]  = "VPD Updates Exceeded",
-        [NVME_MI_RESP_PCIE_INACCESSIBLE]     = "PCIe Inaccessible. The PCIe functionality is not available at this time",
-        [NVME_MI_RESP_MEB_SANITIZED]         = "Management Endpoint Buffer Cleared Due to Sanitize",
-        [NVME_MI_RESP_ENC_SERV_FAILURE]      = "Enclosure Services Failure",
-        [NVME_MI_RESP_ENC_SERV_XFER_FAILURE] = "Enclosure Services Transfer Failure: Communication with the Enclosure Services Process has failed",
-        [NVME_MI_RESP_ENC_FAILURE]           = "An unrecoverable enclosure failure has been detected by the Enclosuer Services Process",
-        [NVME_MI_RESP_ENC_XFER_REFUSED]      = "Enclosure Services Transfer Refused: The NVM Subsystem or Enclosure Services Process indicated an error or an invalid format in communication",
-        [NVME_MI_RESP_ENC_FUNC_UNSUP]        = "Unsupported Enclosure Function: An SES Send command has been attempted to a simple Subenclosure",
-        [NVME_MI_RESP_ENC_SERV_UNAVAIL]      = "Enclosure Services Unavailable: The NVM Subsystem or Enclosure Services Process has encountered an error but may become available again",
-        [NVME_MI_RESP_ENC_DEGRADED]          = "Enclosure Degraded: A noncritical failure has been detected by the Enclosure Services Process",
-        [NVME_MI_RESP_SANITIZE_IN_PROGRESS]  = "Sanitize In Progress: The requested command is prohibited while a sanitize operation is in progress",
-};
-
-/* kept in mi.c while we have a split libnvme/libnvme-mi; consider moving
- * to utils.c (with libnvme_status_to_string) if we ever merge. */
-__shr_public const char *libnvme_mi_status_to_string(int status)
-{
-	const char *s = "Unknown status";
-
-	if (status < ARRAY_SIZE(mi_status) && mi_status[status])
-                s = mi_status[status];
-
-        return s;
-}
-
 bool nvme_mi_aem_aeei_get_aee(__le16 aeei)
 {
 	return !!(le16_to_cpu(aeei) & 0x8000);

--- a/libnvme/src/nvme/mi.h
+++ b/libnvme/src/nvme/mi.h
@@ -85,21 +85,6 @@
 #include <nvme/mi-types.h>
 #include <nvme/tree.h>
 
-/**
- * libnvme_mi_status_to_string() - return a string representation of the MI
- * status.
- * @status: MI response status
- *
- * Gives a string description of @status, as per section 4.1.2 of the NVMe-MI
- * spec. The status value should be of type NVME_STATUS_MI, and extracted
- * from the return value using nvme_status_get_value().
- *
- * Returned string is const, and should not be free()ed.
- *
- * Return: A string representing the status value
- */
-const char *libnvme_mi_status_to_string(int status);
-
 /* Top level management object: NVMe-MI Management Endpoint */
 struct libnvme_mi_ep;
 

--- a/libnvme/src/nvme/no-mi.c
+++ b/libnvme/src/nvme/no-mi.c
@@ -12,11 +12,6 @@
 
 #include <libnvme.h>
 
-__shr_public const char *libnvme_mi_status_to_string(int status)
-{
-	return "MI support disabled";
-}
-
 int __libnvme_transport_handle_open_mi(struct libnvme_transport_handle *hdl,
 		const char *devname)
 {

--- a/libnvme/src/nvme/nvme-types-mi.h
+++ b/libnvme/src/nvme/nvme-types-mi.h
@@ -32,6 +32,7 @@
  * - MI log page structures
  * - Command effects and capabilities
  * - Spec-defined data payloads
+ * - Response status values
  */
 
 /**
@@ -506,4 +507,51 @@ struct nvme_mi_vpd_hdr {
 	__u8	rsvd6;
 	__u8	chchk;
 	__u8	vpd[];
+};
+
+/**
+ * enum nvme_mi_resp_status - values for the response status field
+ * @NVME_MI_RESP_SUCCESS: success
+ * @NVME_MI_RESP_MPR: More Processing Required
+ * @NVME_MI_RESP_INTERNAL_ERR: Internal Error
+ * @NVME_MI_RESP_INVALID_OPCODE: Invalid command opcode
+ * @NVME_MI_RESP_INVALID_PARAM: Invalid command parameter
+ * @NVME_MI_RESP_INVALID_CMD_SIZE: Invalid command size
+ * @NVME_MI_RESP_INVALID_INPUT_SIZE: Invalid command input data size
+ * @NVME_MI_RESP_ACCESS_DENIED: Access Denied
+ * @NVME_MI_RESP_VPD_UPDATES_EXCEEDED: More VPD updates than allowed
+ * @NVME_MI_RESP_PCIE_INACCESSIBLE: PCIe functionality currently unavailable
+ * @NVME_MI_RESP_MEB_SANITIZED: MEB has been cleared due to sanitize
+ * @NVME_MI_RESP_ENC_SERV_FAILURE: Enclosure services process failed
+ * @NVME_MI_RESP_ENC_SERV_XFER_FAILURE: Transfer with enclosure services failed
+ * @NVME_MI_RESP_ENC_FAILURE: Unreoverable enclosure failure
+ * @NVME_MI_RESP_ENC_XFER_REFUSED: Enclosure services transfer refused
+ * @NVME_MI_RESP_ENC_FUNC_UNSUP: Unsupported enclosure services function
+ * @NVME_MI_RESP_ENC_SERV_UNAVAIL: Enclosure services unavailable
+ * @NVME_MI_RESP_ENC_DEGRADED: Noncritical failure detected by enc. services
+ * @NVME_MI_RESP_SANITIZE_IN_PROGRESS: Command prohibited during sanitize
+ */
+enum nvme_mi_resp_status {
+	NVME_MI_RESP_SUCCESS = 0x00,
+	NVME_MI_RESP_MPR = 0x01,
+	NVME_MI_RESP_INTERNAL_ERR = 0x02,
+	NVME_MI_RESP_INVALID_OPCODE = 0x03,
+	NVME_MI_RESP_INVALID_PARAM = 0x04,
+	NVME_MI_RESP_INVALID_CMD_SIZE = 0x05,
+	NVME_MI_RESP_INVALID_INPUT_SIZE = 0x06,
+	NVME_MI_RESP_ACCESS_DENIED = 0x07,
+	/* 0x08 - 0x1f: reserved */
+	NVME_MI_RESP_VPD_UPDATES_EXCEEDED = 0x20,
+	NVME_MI_RESP_PCIE_INACCESSIBLE = 0x21,
+	NVME_MI_RESP_MEB_SANITIZED = 0x22,
+	NVME_MI_RESP_ENC_SERV_FAILURE = 0x23,
+	NVME_MI_RESP_ENC_SERV_XFER_FAILURE = 0x24,
+	NVME_MI_RESP_ENC_FAILURE = 0x25,
+	NVME_MI_RESP_ENC_XFER_REFUSED = 0x26,
+	NVME_MI_RESP_ENC_FUNC_UNSUP = 0x27,
+	NVME_MI_RESP_ENC_SERV_UNAVAIL = 0x28,
+	NVME_MI_RESP_ENC_DEGRADED = 0x29,
+	NVME_MI_RESP_SANITIZE_IN_PROGRESS = 0x2a,
+	/* 0x2b - 0xdf: reserved */
+	/* 0xe0 - 0xff: vendor specific */
 };

--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -435,7 +435,6 @@ __shr_public const char *libnvme_status_to_string(int status, bool fabrics)
 	return s;
 }
 
-
 static const char * const libnvme_status[] = {
 	[ENVME_CONNECT_RESOLVE] = "failed to resolve host",
 	[ENVME_CONNECT_ADDRFAM] = "unrecognized address family",
@@ -472,6 +471,38 @@ __shr_public const char *libnvme_strerror(int errnum)
 	if (errnum >= ENVME_CONNECT_RESOLVE)
 		return libnvme_errno_to_string(errnum);
 	return strerror(errnum);
+}
+
+static const char *const mi_status[] = {
+	[NVME_MI_RESP_SUCCESS]               = "Success",
+	[NVME_MI_RESP_MPR]                   = "More Processing Required: The command message is in progress and requires more time to complete processing",
+	[NVME_MI_RESP_INTERNAL_ERR]          = "Internal Error: The request message could not be processed due to a vendor-specific error",
+	[NVME_MI_RESP_INVALID_OPCODE]        = "Invalid Command Opcode",
+	[NVME_MI_RESP_INVALID_PARAM]         = "Invalid Parameter",
+	[NVME_MI_RESP_INVALID_CMD_SIZE]      = "Invalid Command Size: The size of the message body of the request was different than expected",
+	[NVME_MI_RESP_INVALID_INPUT_SIZE]    = "Invalid Command Input Data Size: The command requires data and contains too much or too little data",
+	[NVME_MI_RESP_ACCESS_DENIED]         = "Access Denied. Processing prohibited due to a vendor-specific mechanism of the Command and Feature lockdown function",
+	[NVME_MI_RESP_VPD_UPDATES_EXCEEDED]  = "VPD Updates Exceeded",
+	[NVME_MI_RESP_PCIE_INACCESSIBLE]     = "PCIe Inaccessible. The PCIe functionality is not available at this time",
+	[NVME_MI_RESP_MEB_SANITIZED]         = "Management Endpoint Buffer Cleared Due to Sanitize",
+	[NVME_MI_RESP_ENC_SERV_FAILURE]      = "Enclosure Services Failure",
+	[NVME_MI_RESP_ENC_SERV_XFER_FAILURE] = "Enclosure Services Transfer Failure: Communication with the Enclosure Services Process has failed",
+	[NVME_MI_RESP_ENC_FAILURE]           = "An unrecoverable enclosure failure has been detected by the Enclosure Services Process",
+	[NVME_MI_RESP_ENC_XFER_REFUSED]      = "Enclosure Services Transfer Refused: The NVM Subsystem or Enclosure Services Process indicated an error or an invalid format in communication",
+	[NVME_MI_RESP_ENC_FUNC_UNSUP]        = "Unsupported Enclosure Function: An SES Send command has been attempted to a simple Subenclosure",
+	[NVME_MI_RESP_ENC_SERV_UNAVAIL]      = "Enclosure Services Unavailable: The NVM Subsystem or Enclosure Services Process has encountered an error but may become available again",
+	[NVME_MI_RESP_ENC_DEGRADED]          = "Enclosure Degraded: A noncritical failure has been detected by the Enclosure Services Process",
+	[NVME_MI_RESP_SANITIZE_IN_PROGRESS]  = "Sanitize In Progress: The requested command is prohibited while a sanitize operation is in progress",
+};
+
+__shr_public const char *libnvme_mi_status_to_string(int status)
+{
+	const char *s = "Unknown status";
+
+	if (status < ARRAY_SIZE(mi_status) && mi_status[status])
+		s = mi_status[status];
+
+	return s;
 }
 
 __shr_public const char *libnvme_get_version(enum libnvme_version type)

--- a/libnvme/src/nvme/util.h
+++ b/libnvme/src/nvme/util.h
@@ -85,6 +85,21 @@ __u8 libnvme_status_to_errno(int status, bool fabrics);
 const char *libnvme_status_to_string(int status, bool fabrics);
 
 /**
+ * libnvme_mi_status_to_string() - return a string representation of the MI
+ * status.
+ * @status: MI response status
+ *
+ * Gives a string description of @status, as per section 4.1.2 of the NVMe-MI
+ * spec. The status value should be of type NVME_STATUS_MI, and extracted
+ * from the return value using nvme_status_get_value().
+ *
+ * Returned string is const, and should not be free()ed.
+ *
+ * Return: A string representing the status value
+ */
+const char *libnvme_mi_status_to_string(int status);
+
+/**
  * libnvme_sanitize_ns_status_to_string() - Returns sanitize ns status string.
  * @sc: Return status code from an sanitize ns command
  *

--- a/src/nvme-builtin.h
+++ b/src/nvme-builtin.h
@@ -131,10 +131,8 @@ COMMAND_LIST(
 	ENTRY("show-topology", "Show the topology", show_topology_cmd)
 	ENTRY("io-mgmt-recv", "I/O Management Receive", io_mgmt_recv)
 	ENTRY("io-mgmt-send", "I/O Management Send", io_mgmt_send)
-#ifdef CONFIG_MI
 	ENTRY("nvme-mi-recv", "Submit a NVMe-MI Receive command, return results", nmi_recv)
 	ENTRY("nvme-mi-send", "Submit a NVMe-MI Send command, return results", nmi_send)
-#endif /* CONFIG_MI */
 );
 
 #endif

--- a/src/nvme.c
+++ b/src/nvme.c
@@ -10324,7 +10324,6 @@ static int tls_key(int argc, char **argv, struct command *acmd, struct plugin *p
 #endif /* CONFIG_DEPRECATED_CMDS */
 #endif /* CONFIG_FABRICS */
 
-#ifdef CONFIG_MI
 static int libnvme_mi(int argc, char **argv, __u8 admin_opcode, const char *desc)
 {
 	const char *opcode = "opcode (required)";
@@ -10466,7 +10465,6 @@ static int nmi_send(int argc, char **argv, struct command *acmd, struct plugin *
 
 	return libnvme_mi(argc, argv, nvme_admin_nvme_mi_send, desc);
 }
-#endif /* CONFIG_MI */
 
 static int get_mgmt_addr_list_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {


### PR DESCRIPTION
Makes the in-band nvme-mi-send / nvme-mi-recv CLI commands available regardless of CONFIG_MI (since they’re NVMe admin passthrough commands, not out-of-band MI transport), adds Windows (WinPE-only) passthrough support for those opcodes, and relocates the MI status string helper into the core libnvme utilities so it’s available without MI transport support.

Changes:
* Remove CONFIG_MI gating for nvme-mi-send / nvme-mi-recv command registration and implementation in the CLI.
* Move libnvme_mi_status_to_string() implementation into libnvme/src/nvme/util.c and export it from the base version script.
* Add WinPE handling for NVMe-MI Send/Recv admin opcodes in the Windows ioctl backend.