### PR TITLE
libnvme: fix logically dead error check in derive_psk_digest()

### DIFF
--- a/libnvme/src/nvme/crypto.c
+++ b/libnvme/src/nvme/crypto.c
@@ -589,7 +589,7 @@ static int derive_psk_digest(struct libnvme_global_ctx *ctx,
 	size_t hmac_len;
 	char *progq = NULL;
 	char *dig = NULL;
-	size_t len;
+	int len;
 
 	lib_ctx = OSSL_LIB_CTX_new();
 	if (!lib_ctx)


### PR DESCRIPTION
The derive_psk_digest() function stores the return value of shr_base64_encode() in a len variable declared as size_t. Because size_t is an unsigned type, the subsequent check "if (len < 0)" can never be true, making the error-propagation path permanently unreachable.

This means any failure returned by shr_base64_encode() is silently discarded and the function proceeds as if encoding succeeded, which can produce a corrupt or empty digest.

Declare len as int to match the signed return type of shr_base64_encode() and allow the error path to be reached.