### PR TITLE
test: fix integer overflow in test_write_zeros

### DIFF
--- a/libnvme/test/ioctl/misc.c
+++ b/libnvme/test/ioctl/misc.c
@@ -870,7 +870,7 @@ static void test_write_zeros(void)
 		.nsid = TEST_NSID,
 		.cdw10 = slba & 0xffffffff,
 		.cdw11 = slba >> 32,
-		.cdw12 = nlb | (control << 16),
+		.cdw12 = nlb | ((__u32)control << 16),
 		.cdw13 = dsm | (dspec << 16),
 		.cdw15 = apptag | (appmask << 16),
 	};


### PR DESCRIPTION
control is __u16, so (control << 16) promotes to signed int before
shifting, which can overflow. Cast to __u32 first to keep the
arithmetic in unsigned 32-bit.

Fixes CID 557377 (INTEGER_OVERFLOW)
Signed-off-by: Brooke Ellis <brooke.ellis@ibm.com>