### PR TITLE
scaleflux: fix divide-by-zero in nvme_parse_evtlog()

### DIFF
--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1187,7 +1187,7 @@ static int nvme_parse_evtlog(void *pevent_log_info, __u32 log_len, char *output)
 		offset++;
 		length--;
 
-		if (!(offset % (log_len / 100)) || (offset == log_len))
+		if ((log_len >= 100 && !(offset % (log_len / 100))) || (offset == log_len))
 			shr_spinner("Parse", (float) (offset) / (float) (log_len), stdout);
 	}
 


### PR DESCRIPTION
The nvme_parse_evtlog() function uses a progress spinner driven by a modulo expression against log_len divided by 100.

When log_len is less than 100, integer division produces zero, and the subsequent modulo operation is undefined behaviour.

Guard the modulo-based check with a log_len >= 100 condition so the divisor is only evaluated when it is non-zero. The final-byte check remains unconditional, ensuring the spinner fires even for small log buffers.