### PR TITLE
fabrics: fix swapped arguments in nbft_connect()

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2935,8 +2935,8 @@ static int nbft_connect(struct libnvme_global_ctx *ctx,
 	bool saved_log_pid;
 	int ret;
 
-	saved_log_level = libnvme_get_logging_level(ctx, &saved_log_tstamp,
-		&saved_log_pid);
+	saved_log_level = libnvme_get_logging_level(ctx, &saved_log_pid,
+		&saved_log_tstamp);
 
 	c = lookup_ctrl(h, fctx);
 	if (c && libnvme_ctrl_get_name(c))


### PR DESCRIPTION
The nbft_connect() function saves the current logging state by calling libnvme_get_logging_level(), which takes log_pid as its second parameter and log_tstamp as its third. The two pointer arguments were passed in the wrong order: saved_log_tstamp was passed to log_pid and saved_log_pid was passed to log_tstamp.

As a result, the two saved values are crossed. When the logging state is later restored via libnvme_set_logging_level(), the log_pid and log_tstamp flags are swapped, silently corrupting the logging configuration after each call for unavailable SSNSs.

Pass saved_log_pid and saved_log_tstamp in the correct order to match the parameter list of libnvme_get_logging_level().