### PR TITLE
plugins/ocp: Fixed propagation of nsid when getting error injection.

### DIFF
--- a/Documentation/nvme-ocp-get-error-injection.txt
+++ b/Documentation/nvme-ocp-get-error-injection.txt
@@ -47,7 +47,8 @@ OPTIONS
 -a::
 --all-ns::
 	Send the command to all namespaces. This option is used to specify
-	whether to target all namespaces or no specific namespace.
+	whether to target all namespaces or no specific namespace. This option
+	is required for OCP 2.0 only devices, optional for OCP 2.5.
 
 include::global-options.txt[]
 

--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -2694,7 +2694,7 @@ static int error_injection_get(struct libnvme_transport_handle *hdl, const __u8 
 		return -ENOMEM;
 	}
 
-	err = nvme_get_features(hdl, 0, fid, sel, 0, uidx, entry,
+	err = nvme_get_features(hdl, nsid, fid, sel, 0, uidx, entry,
 			data_len, &result);
 	if (!err) {
 		cq_entry.nume = result;


### PR DESCRIPTION
get-error-injection was not respecting --all-ns flag.