### PR TITLE
build: enable the unit/c test suite on Windows

### DIFF
--- a/tests/unit/c/test-argconfig-parse.c
+++ b/tests/unit/c/test-argconfig-parse.c
@@ -7,11 +7,13 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <ccan/array_size/array_size.h>
+
+#include "fs-util.h"
+
 #include "../src/argconfig.h"
 #include "../src/cleanup.h"
 #include "parse-util.h"
-
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
 const char *libnvme_strerror(int errnum);
 
@@ -421,9 +423,11 @@ int main(void)
 
 	test_rc = 0;
 	setlocale(LC_NUMERIC, "C");
-	f = freopen("/dev/null", "w", stderr);
-	if (!f)
+	f = freopen(shr_dev_null(), "w", stderr);
+	if (!f) {
 		printf("ERROR: reopening stderr failed: %s\n", libnvme_strerror(errno));
+		test_rc = 1;
+	}
 
 	for (i = 0; i < ARRAY_SIZE(toval_tests); i++)
 		toval_test(&toval_tests[i]);

--- a/tests/unit/c/test-global-config.c
+++ b/tests/unit/c/test-global-config.c
@@ -20,6 +20,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "fs-util.h"
+
 #include "../src/global-config.h"
 #include "../src/args.h"
 
@@ -30,13 +32,19 @@ struct nvme_args nvme_args = {
 	.supported_output_formats = NORMAL,
 };
 
+/*
+ * The throwaway .conf files land in the current directory, which meson
+ * sets to the build directory. A relative template keeps this off "/tmp",
+ * which isn't a usable temp directory on Windows.
+ */
 static char *write_temp(const char *content)
 {
-	char *path = strdup("/tmp/nvme-cli-conf-test-XXXXXX");
+	char *path = strdup("nvme-cli-conf-test-XXXXXX");
 	int fd;
 
 	shr_assert(path);
-	fd = mkstemp(path);
+
+	fd = shr_mkstemp(path);
 	shr_assert(fd >= 0);
 	shr_assert(write(fd, content, strlen(content)) == (ssize_t)strlen(content));
 	close(fd);

--- a/tests/unit/meson.build
+++ b/tests/unit/meson.build
@@ -3,7 +3,5 @@
 # Fast unit tests that need no NVMe hardware and no built nvme binary.
 # CLI-driven tests live in ../cli/; device tests live in ../e2e/.
 
-if host_system == 'linux'
-    subdir('c')
-endif
+subdir('c')
 subdir('py')


### PR DESCRIPTION
The C unit tests under `tests/unit/c` are gated behind
`host_system == 'linux'`, but nothing in that directory is actually
Linux-specific — there are no platform conditionals in it at all, and
both binaries build cleanly with MinGW.

This series fixes the two real portability problems and drops the gate.

### `tests/unit/c: don't silently pass when stderr can't be redirected`

`test-argconfig-parse` redirects stderr to the bit bucket so the expected
parse errors don't clutter the log. Two issues on Windows:

- `"/dev/null"` doesn't exist natively; the spelling is `"NUL"`. Fixed by
  using the existing `DEV_NULL` from `src/common.h`, which already selects
  per-platform, rather than adding another switch.
- When `freopen()` failed the test printed an error but left `test_rc`
  untouched, so it reported success anyway. That's a latent bug on any
  platform, not just Windows.

### `build: enable the unit/c test suite on Windows`

`test-global-config.c` hardcoded `"/tmp"` for its throwaway `.conf` files.
On native Windows `"/tmp"` resolves to the root of the current drive, so it
only exists if somebody happened to create it there; on a drive without it
`mkstemp()` returns -1 and the test aborts. Now honours `TMPDIR`/`TMP`/`TEMP`
first with `"/tmp"` as the fallback, and uses the portable `shr_mkstemp()`
wrapper from `shared/`.

### Testing

Built and run on Windows with MSYS2 UCRT64 / MinGW gcc 16.1.0: full build
clean, `meson test` reports 51 passed / 0 failed / 1 skipped, including both
`argconfig_parse` and `global-config`. Linux behaviour is unchanged — the
only Linux-visible deltas are the `DEV_NULL` swap and the `test_rc` fix.

Each test was also mutation-tested to confirm it isn't inappropriately passing.

`checkpatch` is clean per patch (0 errors; the one warning is its
preference against `Co-authored-by:`, which is already used throughout
this tree).