### PR TITLE
solidigm: fix heap-buffer-overflow in COD telemetry parser

### DIFF
--- a/plugins/solidigm/solidigm-telemetry/cod.c
+++ b/plugins/solidigm/solidigm-telemetry/cod.c
@@ -152,12 +152,14 @@ void solidigm_telemetry_log_cod_parse(struct telemetry_log *tl)
 			return;
 		}
 		struct cod_item item = data->items[i];
+		uint64_t off = le64_to_cpu(item.DataFieldOffset);
+		uint32_t size = le32_to_cpu(item.DataFieldSizeInBytes);
 
-		if (item.DataFieldOffset + item.DataFieldOffset > tl->log_size)
+		if (off > tl->log_size || size > tl->log_size - off)
 			continue;
 		if (item.dataInvalid)
 			continue;
-		uint8_t *val = ((uint8_t *)tl->log) + item.DataFieldOffset;
+		uint8_t *val = ((uint8_t *)tl->log) + off;
 		const char *key =  getOemDataMapDescription(item.DataFieldMapUid);
 
 		switch (item.dataFieldType) {
@@ -174,7 +176,7 @@ void solidigm_telemetry_log_cod_parse(struct telemetry_log *tl)
 		case STRING: {
 			struct json_object *str_obj = NULL;
 
-			sldm_uint8_array_to_string(val, item.DataFieldSizeInBytes, &str_obj);
+			sldm_uint8_array_to_string(val, size, &str_obj);
 			json_object_object_add(cod, key, str_obj);
 			break;
 		}


### PR DESCRIPTION
The bounds check in `solidigm_telemetry_log_cod_parse()` at `cod.c:156` has a copy-paste bug where `DataFieldOffset` is added to itself instead of `DataFieldSizeInBytes`:

 
  // Bug: offset doubled instead of offset + size
  if (item.DataFieldOffset + item.DataFieldOffset > tl->log_size)

 This allows out-of-bounds heap reads when DataFieldOffset ≤ log_size/2 but DataFieldOffset + DataFieldSizeInBytes > log_size. For STRING-type COD entries, this causes sldm_uint8_array_to_string() to read past the allocated telemetry log buffer.

  Fix

  - Correct the bounds check to off > tl->log_size || size > tl->log_size - off (overflow-safe form)
  - Add proper endianness conversion with le64_to_cpu()/le32_to_cpu() for DataFieldOffset and DataFieldSizeInBytes
  - Use the converted values throughout the function body

  Verification

  Tested with a crafted telemetry binary containing a STRING COD entry with DataFieldOffset=8100 and DataFieldSizeInBytes=0x2100 (8448 bytes) against a 16384-byte log buffer:

  - Before fix: 143 invalid reads detected by Valgrind (Invalid read of size 1 in sldm_uint8_array_to_string → _json_object_new_string → memcpy)
  - After fix: 0 errors, clean Valgrind run