### PR TITLE
nvme: tolerate unavailable huge pages during firmware download

### DIFF
--- a/Documentation/nvme-fw-download.txt
+++ b/Documentation/nvme-fw-download.txt
@@ -12,6 +12,7 @@ SYNOPSIS
 			[--fw=<firmware-file> | -f <firmware-file>]
 			[--xfer=<transfer-size> | -x <transfer-size>]
 			[--offset=<offset> | -O <offset>]
+			[--stream]
 
 DESCRIPTION
 -----------
@@ -38,8 +39,12 @@ the Firmware Commit command (nvme fw-commit <args>).
 Note: nvme-cli must allocate a contiguous (linear) memory buffer and map
 the firmware binary into it. To do this, nvme-cli first attempts to
 allocate the buffer using huge TLB pages. If allocation using huge pages
-fails, it falls back to using posix_memalign() combined with madvise(),
-though this is also likely to fail.
+fails, it falls back to using posix_memalign() combined with madvise(). If
+the kernel rejects the huge page advice, nvme-cli keeps the aligned buffer
+and lets the I/O path attempt to map it.
+
+The optional `--stream` mode avoids allocating a buffer for the complete
+firmware image. It reads and downloads one transfer-sized portion at a time.
 
 To increase the likelihood of success, you may want to pre-allocate a
 number of huge pages before initiating the firmware download:
@@ -70,6 +75,11 @@ OPTIONS
 	the offset starts at zero and automatically adjusts based on the
 	'xfer' size given.
 
+--stream::
+	Read and download one transfer-sized portion of the firmware image at
+	a time instead of mapping the complete image into memory. This avoids
+	the huge page requirement and limits memory use to the transfer size.
+
 include::global-options.txt[]
 
 EXAMPLES
@@ -78,6 +88,12 @@ EXAMPLES
 +
 ------------
 # nvme fw-download /dev/nvme0 --fw=/path/to/nvme.fw --xfer=0x20000
+------------
+
+* Read and download a firmware image one transfer-sized portion at a time:
++
+------------
+# nvme fw-download /dev/nvme0 --fw=/path/to/nvme.fw --stream
 ------------
 
 NVME

--- a/libnvme/src/nvme/mem-linux.c
+++ b/libnvme/src/nvme/mem-linux.c
@@ -99,10 +99,12 @@ __shr_public void *libnvme_alloc_huge(size_t len,
 
 	memset(mh->p, 0, mh->len);
 
-	if (madvise(mh->p, mh->len, MADV_HUGEPAGE) < 0) {
-		libnvme_free_huge(mh);
-		return NULL;
-	}
+	/*
+	 * MADV_HUGEPAGE is advisory. Keep the aligned allocation when
+	 * transparent huge pages are unavailable. Let the I/O path try to map
+	 * the buffer.
+	 */
+	madvise(mh->p, mh->len, MADV_HUGEPAGE);
 
 	return mh->p;
 }

--- a/libnvme/tests/mem.c
+++ b/libnvme/tests/mem.c
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * Test the ordinary-memory fallback used when huge pages are unavailable.
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <compiler-attributes.h>
+#include <shr-assert.h>
+
+#include <libnvme.h>
+
+static bool madvise_called;
+
+void *mmap(void *addr, size_t length, int prot, int flags, int fd,
+	   off_t offset)
+{
+	if (flags & MAP_HUGETLB) {
+		errno = EINVAL;
+		return MAP_FAILED;
+	}
+
+	return (void *)syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+}
+
+int madvise(__shr_unused void *addr, __shr_unused size_t length,
+	    __shr_unused int advice)
+{
+	madvise_called = true;
+	errno = EINVAL;
+	return -1;
+}
+
+int main(void)
+{
+	struct libnvme_mem_huge mh = { 0 };
+	unsigned char *buf;
+
+	buf = libnvme_alloc_huge(2 * 1024 * 1024, &mh);
+	shr_assert(madvise_called);
+	shr_assert(buf);
+	shr_assert(mh.p == buf);
+	shr_assert(mh.libnvme_alloc);
+	shr_assert(mh.len == 2 * 1024 * 1024);
+	shr_assert(buf[0] == 0);
+	shr_assert(buf[mh.len - 1] == 0);
+
+	buf[mh.len - 1] = 0xa5;
+	libnvme_free_huge(&mh);
+	shr_assert(!mh.p);
+	shr_assert(!mh.len);
+
+	return 0;
+}

--- a/libnvme/tests/meson.build
+++ b/libnvme/tests/meson.build
@@ -130,6 +130,20 @@ uuid = executable(
 
 test('libnvme - uuid', uuid)
 
+if host_system == 'linux' and (not meson.is_cross_build())
+    mem = executable(
+        'test-mem',
+        ['mem.c'],
+        dependencies: [
+            config_dep,
+            ccan_dep,
+            libnvme_dep,
+        ],
+    )
+
+    test('libnvme - mem', mem)
+endif
+
 tree = executable(
     'test-tree',
     ['tree.c'],

--- a/src/nvme.c
+++ b/src/nvme.c
@@ -5287,6 +5287,26 @@ static int fw_download_single(struct libnvme_transport_handle *hdl, void *fw_buf
 	return -1;
 }
 
+static int fw_read_full(int fd, void *buf, size_t len)
+{
+	size_t offset = 0;
+
+	while (offset < len) {
+		ssize_t ret = read(fd, (char *)buf + offset, len - offset);
+
+		if (ret < 0) {
+			if (errno == EINTR)
+				continue;
+			return -errno;
+		}
+		if (!ret)
+			return -EIO;
+		offset += ret;
+	}
+
+	return 0;
+}
+
 static int fw_download(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Copy all or part of a firmware image to "
@@ -5302,10 +5322,12 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 	const char *offset = "starting dword offset, default 0";
 	const char *progress = "display firmware transfer progress";
 	const char *ignore_ovr = "ignore overwrite errors";
+	const char *stream = "read firmware in transfer-sized chunks";
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
 	__cleanup_huge struct libnvme_mem_huge mh = { 0, };
+	__cleanup_libnvme_free void *stream_buf = NULL;
 	__cleanup_fd int fw_fd = -1;
 	unsigned int fw_size, pos;
 	int err;
@@ -5321,6 +5343,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 		__u32	offset;
 		bool	progress;
 		bool	ignore_ovr;
+		bool	stream;
 	};
 
 	struct config cfg = {
@@ -5330,6 +5353,7 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 		.offset     = 0,
 		.progress   = false,
 		.ignore_ovr = false,
+		.stream     = false,
 	};
 
 	NVME_ARGS(opts,
@@ -5338,7 +5362,8 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 		  OPT_UINT("xfer",       'x', &cfg.xfer,       xfer),
 		  OPT_UINT("offset",     'O', &cfg.offset,     offset),
 		  OPT_FLAG("progress",   'p', &cfg.progress,   progress),
-		  OPT_FLAG("ignore-ovr", 'i', &cfg.ignore_ovr, ignore_ovr));
+		  OPT_FLAG("ignore-ovr", 'i', &cfg.ignore_ovr, ignore_ovr),
+		  OPT_FLAG("stream",       0, &cfg.stream,      stream));
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (err)
@@ -5386,16 +5411,24 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 		nvme_show_error("WARNING: firmware file size %u not conform to FWUG alignment %lu",
 				fw_size, cfg.xfer);
 
-	fw_buf = libnvme_alloc_huge(fw_size, &mh);
+	if (cfg.stream) {
+		stream_buf = libnvme_alloc(cfg.xfer);
+		fw_buf = stream_buf;
+	} else {
+		fw_buf = libnvme_alloc_huge(fw_size, &mh);
+	}
 	if (!fw_buf) {
-		nvme_show_error("failed to allocate huge memory");
+		nvme_show_error("failed to allocate firmware buffer");
 		return -ENOMEM;
 	}
 
-	if (read(fw_fd, fw_buf, fw_size) != ((ssize_t)(fw_size))) {
-		err = -errno;
-		nvme_show_error("read :%s :%s", cfg.fw, libnvme_strerror(errno));
-		return err;
+	if (!cfg.stream) {
+		err = fw_read_full(fw_fd, fw_buf, fw_size);
+		if (err) {
+			nvme_show_error("read %s: %s", cfg.fw,
+					libnvme_strerror(err));
+			return err;
+		}
 	}
 
 	if (cfg.ish && !libnvme_transport_handle_is_mi(hdl)) {
@@ -5403,9 +5436,19 @@ static int fw_download(int argc, char **argv, struct command *acmd, struct plugi
 	}
 
 	for (pos = 0; pos < fw_size; pos += cfg.xfer) {
-		cfg.xfer = min(cfg.xfer, fw_size - pos);
+		void *xfer_buf = cfg.stream ? fw_buf : fw_buf + pos;
 
-		err = fw_download_single(hdl, fw_buf + pos, cfg.ish, fw_size,
+		cfg.xfer = min(cfg.xfer, fw_size - pos);
+		if (cfg.stream) {
+			err = fw_read_full(fw_fd, fw_buf, cfg.xfer);
+			if (err) {
+				nvme_show_error("read %s: %s", cfg.fw,
+						libnvme_strerror(err));
+				break;
+			}
+		}
+
+		err = fw_download_single(hdl, xfer_buf, cfg.ish, fw_size,
 					 cfg.offset + pos, cfg.xfer,
 					 cfg.progress, cfg.ignore_ovr);
 		if (err)


### PR DESCRIPTION
## Summary

`libnvme_alloc_huge()` currently discards its aligned fallback buffer when
`MADV_HUGEPAGE` fails. The advice is optional, so keep the allocation and let
the I/O path try to map it.

This also adds an opt-in `fw-download --stream` mode. It reads and submits one
transfer-sized portion at a time, which limits memory use and avoids allocating
a full-image buffer.

## Testing

- `meson compile -C /tmp/nvme-cli-build`
- `meson test -C /tmp/nvme-cli-build --print-errorlogs`: 104 passed, 2 expected failures, 2 skipped
- `checkpatch.pl`: 0 errors, 0 warnings
- Added an allocator test that forces `MAP_HUGETLB` and `MADV_HUGEPAGE` to fail
- Tested both the default and `--stream` paths on the affected 16 KiB-page ARM64 system with a Samsung PM991. Both firmware downloads completed successfully. No firmware commit or activation was performed during this test.

Fixes #3793
