### PR TITLE
micron: fix missing break in switch in micron_internal_logs()

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -3740,6 +3740,7 @@ static int micron_internal_logs(int argc, char **argv, struct command *acmd,
 				(void)NVMEResetLog(hdl, aVendorLogs[i].ucLogPage,
 						   aVendorLogs[i].nLogSize, aVendorLogs[i].nMaxSize);
 
+			break;
 		default:
 			bSize = aVendorLogs[i].nLogSize;
 			dataBuffer = (unsigned char *)libnvme_alloc(bSize);


### PR DESCRIPTION
The micron_internal_logs() function dispatches log page collection via a switch statement. The cases for log pages 0xF7, 0xF9, 0xFC, and 0xFD optionally call NVMEResetLog() to reset the log on the device and are then intended to exit the switch.

Without a break statement the execution falls through into the default case, which allocates a buffer and fetches the log page with nvme_get_log_simple(). This causes an unintended read of log pages that should only be reset, not collected.

Add a break statement to terminate the 0xF7/0xF9/0xFC/0xFD cases after the optional NVMEResetLog() call.