### PR TITLE
tests/e2e: close per-test log files after tearDown cleanup runs

### DIFF
--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -179,6 +179,8 @@ class TestNVMe(TestNVMeBase):
 
     def tearDown(self):
         """ Post Section for TestNVMe. """
+        if self.ns_mgmt_supported:
+            self.create_and_attach_default_ns()
         self._write_device_data()
         if getattr(self, 'stdout_log', None):
             self.stdout_log.close()
@@ -186,8 +188,6 @@ class TestNVMe(TestNVMeBase):
             self.stderr_log.close()
         if self.clear_log_dir is True:
             shutil.rmtree(self.log_dir, ignore_errors=True)
-        if self.ns_mgmt_supported:
-            self.create_and_attach_default_ns()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
tearDown closed stdout_log/stderr_log before calling create_and_attach_default_ns, which still runs nvme commands via run_cmd. Those writes hit the closed file handles, raising "ValueError: I/O operation on closed file" and failing every e2e test whose controller supports namespace management.

Signed-off-by: Daniel Wagner dwagner@suse.com

Fixes: #3817 