### PR TITLE
micron: fix logically dead code in micron_nand_stats()

### DIFF
--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -1837,7 +1837,7 @@ static int micron_nand_stats(int argc, char **argv,
 		nsze = ((ctrl.oacs >> 3) & 0x1);
 
 	if (has_fb_log) {
-		__u8 spec = (eModel == M5410) ? 0 : 1;	/* FB spec version */
+		__u8 spec = 1; /* FB spec version */
 
 		print_nand_stats_fb((__u8 *)logFB, (__u8 *)extSmartLog, nsze, is_json, spec);
 		err = 0;


### PR DESCRIPTION
The micron_nand_stats() function conditionally fetches the 0xFB log page only for models where eModel is not M5407 or M5410. The has_fb_log flag is therefore always false for M5410, making the M5410 branch of the spec ternary unreachable.

The dead condition can never be true, so spec is always assigned 1 regardless, which causes no incorrect output but is misleading and flagged as logically dead code by static analysis.

Replace the ternary with a direct assignment of 1 and update the comment to reflect that M5410 is excluded by the guard above.