### PR TITLE
nvme-print: fix unintended sign extension in json_eom_printable_eye()

### DIFF
--- a/src/nvme-print-json.c
+++ b/src/nvme-print-json.c
@@ -2254,7 +2254,7 @@ static char *json_eom_printable_eye(struct nvme_eom_lane_desc *lane,
 	 * Allocate buffer for full printable string (with newlines)
 	 * +1 for null terminator
 	 */
-	printable = malloc(nrows * ncols + nrows + 1);
+	printable = malloc((size_t)nrows * ncols + nrows + 1);
 	printable_start = printable;
 
 	if (!printable)


### PR DESCRIPTION
The json_eom_printable_eye() function uses nrows and ncols, both of type uint16_t, to compute the allocation size for the printable eye string buffer.

Because uint16_t operands are promoted to int (32-bit signed) before multiplication, the expression nrows * ncols + nrows + 1 is evaluated as a signed 32-bit value. When passed to malloc(), the compiler widens it to size_t (64-bit unsigned) via sign extension. If the product exceeds 0x7FFFFFFF the sign bit is set, the result sign-extends to a very large 64-bit value, and malloc() will either fail or trigger an out-of-memory condition.

Cast nrows to size_t before the multiplication so the entire expression is evaluated in 64-bit unsigned arithmetic, preventing the sign extension.