### PR TITLE
nvme-print: fix sign extension in stdout_phy_rx_eom_descs()

### DIFF
--- a/src/nvme-print-stdout.c
+++ b/src/nvme-print-stdout.c
@@ -984,7 +984,7 @@ static void stdout_phy_rx_eom_descs(struct nvme_phy_rx_eom_log *log)
 	for (i = 0; i < log->nd; i++) {
 		struct nvme_eom_lane_desc *desc = p;
 		unsigned char *vsdata = NULL;
-		unsigned int vsdataoffset = 0;
+		size_t vsdataoffset;
 		uint16_t nrows, ncols, edlen;
 
 		nrows = le16_to_cpu(desc->nrows);
@@ -1010,8 +1010,9 @@ static void stdout_phy_rx_eom_descs(struct nvme_phy_rx_eom_log *log)
 		if (edlen == 0)
 			continue;
 
-		vsdataoffset = (nrows * ncols) + sizeof(struct nvme_eom_lane_desc);
-		vsdata = (unsigned char *)((unsigned char *)desc + vsdataoffset);
+		vsdataoffset = (size_t)nrows * ncols +
+			       sizeof(struct nvme_eom_lane_desc);
+		vsdata = (unsigned char *)desc + vsdataoffset;
 		printf("Eye Data:\n");
 		d(vsdata, edlen, 16, 1);
 		printf("\n");


### PR DESCRIPTION
The stdout_phy_rx_eom_descs() function computes a byte offset vsdataoffset by multiplying nrows and ncols, both uint16_t. C integer promotion rules first convert both operands to signed int before the multiply, making the product a 32-bit signed value. That signed result is then sign-extended to 64 bits when added to the sizeof() term, which is unsigned long.

If the product of nrows and ncols exceeds 0x7FFFFFFF, all upper bits of the offset become 1, producing an out-of-bounds pointer when desc is advanced by vsdataoffset.

Cast nrows to uint32_t before the multiply to force unsigned 32-bit arithmetic and prevent sign extension, and change the type of vsdataoffset from unsigned int to size_t to match its use as a pointer-arithmetic byte offset.