### PR TITLE
tests: add mocked fabrics CLI integration tests

### DIFF
--- a/libnvme/scripts/kernel-doc-check
+++ b/libnvme/scripts/kernel-doc-check
@@ -3,6 +3,10 @@
 
 kernel_doc=$(dirname $0)/kernel-doc
 
+# Use C only when LC_ALL isn't already set. This avoids overriding a valid
+# locale supplied by the environment.
+export LC_ALL="${LC_ALL:-C}"
+
 "$kernel_doc" -none "$@" 2>&1 |
   grep '\(warning\|error\)'
 

--- a/libnvme/tests/mem.c
+++ b/libnvme/tests/mem.c
@@ -3,11 +3,11 @@
  * Test the ordinary-memory fallback used when huge pages are unavailable.
  */
 
+#include <dlfcn.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <sys/mman.h>
-#include <sys/syscall.h>
 #include <unistd.h>
 
 #include <compiler-attributes.h>
@@ -17,15 +17,22 @@
 
 static bool madvise_called;
 
+typedef void *(*mmap_func_t)(void *, size_t, int, int, int, off_t);
+
 void *mmap(void *addr, size_t length, int prot, int flags, int fd,
 	   off_t offset)
 {
+	mmap_func_t real_mmap;
+
 	if (flags & MAP_HUGETLB) {
 		errno = EINVAL;
 		return MAP_FAILED;
 	}
 
-	return (void *)syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+	real_mmap = (mmap_func_t)dlsym(RTLD_NEXT, "mmap");
+	shr_assert(real_mmap);
+
+	return real_mmap(addr, length, prot, flags, fd, offset);
 }
 
 int madvise(__shr_unused void *addr, __shr_unused size_t length,

--- a/libnvme/tests/meson.build
+++ b/libnvme/tests/meson.build
@@ -130,7 +130,7 @@ uuid = executable(
 
 test('libnvme - uuid', uuid)
 
-if host_system == 'linux' and (not meson.is_cross_build())
+if host_system == 'linux' and (not is_static)
     mem = executable(
         'test-mem',
         ['mem.c'],

--- a/libnvme/tests/meson.build
+++ b/libnvme/tests/meson.build
@@ -138,6 +138,7 @@ if host_system == 'linux' and (not meson.is_cross_build())
             config_dep,
             ccan_dep,
             libnvme_dep,
+            dl_dep,
         ],
     )
 

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ want_docs = get_option('docs')
 want_docs_build = get_option('docs-build')
 
 is_static = get_option('default_library') == 'static'
+is_cross = meson.is_cross_build()
 
 feature_python = get_option('python')
 if not want_fabrics or feature_python.disabled()
@@ -644,7 +645,7 @@ if want_nvme
         install_dir: sbindir,
     )
 
-    if host_system == 'windows' and want_libnvme and not is_static
+    if host_system == 'windows' and want_libnvme and (not is_static)
         # Copy libnvme DLL next to nvme.exe so it can be found at
         # runtime without modifying PATH.
         cp = find_program('cp')

--- a/tests/cli/libmock_fabrics.c
+++ b/tests/cli/libmock_fabrics.c
@@ -1,0 +1,650 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ *
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * Authors: Daniel Wagner <dwagner@suse.com>
+ */
+
+/*
+ * LD_PRELOAD shim for the fabrics CLI tests (see nvme_fabrics_mock_test.py).
+ *
+ * It intercepts open()/write()/ioctl()/close() on /dev/nvme-fabrics and
+ * /dev/nvme<N> so that "nvme discover"/"connect"/"connect-all" can run
+ * against a fake target without a kernel nvme-fabrics module or root
+ * privileges. Every intercepted write() (connect args) and ioctl() (admin
+ * passthru command) is forwarded over a Unix socket to a Python-side IPC
+ * server that supplies the response, so all test scenarios are steered from
+ * the Python test file rather than from this shim.
+ */
+
+#undef _FILE_OFFSET_BITS
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <dlfcn.h>
+#include <endian.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/types.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+/*
+ * Mirrors struct linux_passthru_cmd32/64 in libnvme/src/nvme/private.h --
+ * the layout libnvme's own ioctl() callers use -- so casting the ioctl()
+ * argp we're handed back to this type lines up with the real fields.
+ */
+struct linux_passthru_cmd32 {
+	__u8	opcode;
+	__u8	flags;
+	__u16	rsvd1;
+	__u32	nsid;
+	__u32	cdw2;
+	__u32	cdw3;
+	__u64	metadata;
+	__u64	addr;
+	__u32	metadata_len;
+	__u32	data_len;
+	__u32	cdw10;
+	__u32	cdw11;
+	__u32	cdw12;
+	__u32	cdw13;
+	__u32	cdw14;
+	__u32	cdw15;
+	__u32	timeout_ms;
+	__u32	result;
+};
+
+struct linux_passthru_cmd64 {
+	__u8	opcode;
+	__u8	flags;
+	__u16	rsvd1;
+	__u32	nsid;
+	__u32	cdw2;
+	__u32	cdw3;
+	__u64	metadata;
+	__u64	addr;
+	__u32	metadata_len;
+	__u32	data_len;
+	__u32	cdw10;
+	__u32	cdw11;
+	__u32	cdw12;
+	__u32	cdw13;
+	__u32	cdw14;
+	__u32	cdw15;
+	__u32	timeout_ms;
+	__u32	rsvd2;
+	__u64	result;
+};
+
+#define LIBNVME_IOCTL_ADMIN_CMD		_IOWR('N', 0x41, struct linux_passthru_cmd32)
+#define LIBNVME_IOCTL_ADMIN64_CMD	_IOWR('N', 0x47, struct linux_passthru_cmd64)
+
+/* Wire format shared with the Python IPC server -- keep both sides in sync. */
+struct __attribute__((packed)) ipc_request {
+	uint32_t type;		/* 1 == WRITE, 2 == IOCTL */
+	uint32_t fd;		/* instance number for IOCTL */
+	uint32_t data_len;	/* payload length (follows immediately) */
+	uint32_t request;	/* ioctl request code */
+	uint8_t  opcode;	/* nvme opcode */
+	uint8_t  rsvd[3];
+	uint32_t nsid;
+	uint32_t cdw10;
+	uint32_t cdw11;
+	uint32_t cdw12;
+	uint32_t cdw13;
+	uint32_t cdw14;
+	uint32_t cdw15;
+	uint64_t lpo;
+	uint32_t req_len;	/* command data length */
+};
+
+struct __attribute__((packed)) ipc_response {
+	int32_t  status;	/* 0 for success, -1 for error */
+	int32_t  errno_val;	/* errno to return on error */
+	uint32_t result;	/* cmd->result */
+	uint32_t data_len;	/* payload length (follows immediately) */
+};
+
+typedef int (*orig_open_t)(const char *pathname, int flags, ...);
+typedef int (*orig_open64_t)(const char *pathname, int flags, ...);
+typedef int (*orig_openat_t)(int dirfd, const char *pathname, int flags, ...);
+typedef int (*orig_openat64_t)(int dirfd, const char *pathname, int flags, ...);
+typedef ssize_t (*orig_write_t)(int fd, const void *buf, size_t count);
+typedef ssize_t (*orig_read_t)(int fd, void *buf, size_t count);
+typedef int (*orig_ioctl_t)(int fd, unsigned long request, ...);
+typedef int (*orig_close_t)(int fd);
+
+static orig_open_t orig_open;
+static orig_open64_t orig_open64;
+static orig_openat_t orig_openat;
+static orig_openat64_t orig_openat64;
+static orig_write_t orig_write;
+static orig_read_t orig_read;
+static orig_ioctl_t orig_ioctl;
+static orig_close_t orig_close;
+
+static int mock_fabrics_fd = -1;
+static int mock_fabrics_manager_fd = -1;
+static bool mock_debug;
+
+#define MAX_MOCK_CTRLS 16
+static struct {
+	int fd;
+	int instance;
+} mock_ctrl_fds[MAX_MOCK_CTRLS];
+static int num_mock_ctrls;
+
+#define mock_dbg(fmt, ...) \
+	do { \
+		if (mock_debug) \
+			fprintf(stderr, "[MOCK_DEBUG] " fmt, ##__VA_ARGS__); \
+	} while (0)
+
+__attribute__((constructor))
+static void mock_init(void)
+{
+	mock_debug = !!getenv("MOCK_DEBUG");
+	mock_dbg("libmock_fabrics loaded, sizeof(ipc_request)=%zu, sizeof(ipc_response)=%zu\n",
+		 sizeof(struct ipc_request), sizeof(struct ipc_response));
+}
+
+static void init_orig_functions(void)
+{
+	if (orig_open)
+		return;
+
+	orig_open = (orig_open_t)dlsym(RTLD_NEXT, "open");
+	orig_open64 = (orig_open64_t)dlsym(RTLD_NEXT, "open64");
+	orig_openat = (orig_openat_t)dlsym(RTLD_NEXT, "openat");
+	orig_openat64 = (orig_openat64_t)dlsym(RTLD_NEXT, "openat64");
+	orig_write = (orig_write_t)dlsym(RTLD_NEXT, "write");
+	orig_read = (orig_read_t)dlsym(RTLD_NEXT, "read");
+	orig_ioctl = (orig_ioctl_t)dlsym(RTLD_NEXT, "ioctl");
+	orig_close = (orig_close_t)dlsym(RTLD_NEXT, "close");
+}
+
+static int connect_ipc_socket(void)
+{
+	const char *sock_path = getenv("MOCK_IPC_SOCK");
+	struct sockaddr_un addr;
+	int fd;
+
+	if (!sock_path) {
+		mock_dbg("MOCK_IPC_SOCK env var not set!\n");
+		return -1;
+	}
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) {
+		mock_dbg("failed to create socket: %s\n", strerror(errno));
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path) - 1);
+	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		mock_dbg("connect failed to '%s': %s\n", sock_path, strerror(errno));
+		orig_close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+/* Returns -2 when @pathname is not one we intercept. */
+static int handle_open_intercept(const char *pathname, int flags)
+{
+	int instance, real_fd, sv[2];
+	char *endp;
+
+	if (!pathname)
+		return -2;
+
+	if (!strcmp(pathname, "/dev/nvme-fabrics")) {
+		if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) < 0)
+			return -1;
+
+		mock_fabrics_manager_fd = sv[0];
+		mock_fabrics_fd = sv[1];
+
+		mock_dbg("intercepted /dev/nvme-fabrics open\n");
+
+		if ((flags & O_ACCMODE) == O_RDONLY) {
+			const char *opts = getenv("MOCK_SUPPORTED_OPTIONS");
+
+			if (!opts)
+				opts = "instance,cntlid,concat,ctrl_loss_tmo,data_digest,"
+				       "dhchap_ctrl_secret,dhchap_secret,disable_sqflow,"
+				       "discovery,duplicate_connect,fast_io_fail_tmo,"
+				       "hdr_digest,host_iface,host_traddr,hostid,hostnqn,"
+				       "keep_alive_tmo,keyring,nqn,nr_io_queues,"
+				       "nr_poll_queues,nr_write_queues,queue_size,"
+				       "reconnect_delay,tls,tls_key,tos,traddr,transport,"
+				       "trsvcid\n";
+			orig_write(mock_fabrics_manager_fd, opts, strlen(opts));
+			orig_close(mock_fabrics_manager_fd);
+			mock_fabrics_manager_fd = -1;
+		}
+
+		return mock_fabrics_fd;
+	}
+
+	if (strncmp(pathname, "/dev/nvme", 9) ||
+			pathname[9] < '0' ||
+			pathname[9] > '9')
+		return -2;
+
+	instance = strtol(pathname + 9, &endp, 10);
+	if (!endp || *endp != '\0')
+		return -2;
+
+	real_fd = orig_open("/dev/null", flags);
+	if (real_fd >= 0) {
+		if (num_mock_ctrls < MAX_MOCK_CTRLS) {
+			mock_ctrl_fds[num_mock_ctrls].fd = real_fd;
+			mock_ctrl_fds[num_mock_ctrls].instance = instance;
+			num_mock_ctrls++;
+		}
+		mock_dbg("intercepted /dev/nvme%d open (mapped to fd %d)\n",
+			 instance, real_fd);
+	}
+
+	return real_fd;
+}
+
+static mode_t open_mode_arg(int flags, va_list args)
+{
+	if (flags & (O_CREAT | O_TMPFILE))
+		return va_arg(args, mode_t);
+
+	return 0;
+}
+
+int open(const char *pathname, int flags, ...)
+{
+	va_list args;
+	mode_t mode;
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	va_start(args, flags);
+	mode = open_mode_arg(flags, args);
+	va_end(args);
+
+	return orig_open(pathname, flags, mode);
+}
+
+int open64(const char *pathname, int flags, ...)
+{
+	va_list args;
+	mode_t mode;
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	va_start(args, flags);
+	mode = open_mode_arg(flags, args);
+	va_end(args);
+
+	return orig_open64(pathname, flags, mode);
+}
+
+int openat(int dirfd, const char *pathname, int flags, ...)
+{
+	va_list args;
+	mode_t mode;
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	va_start(args, flags);
+	mode = open_mode_arg(flags, args);
+	va_end(args);
+
+	return orig_openat(dirfd, pathname, flags, mode);
+}
+
+int openat64(int dirfd, const char *pathname, int flags, ...)
+{
+	va_list args;
+	mode_t mode;
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	va_start(args, flags);
+	mode = open_mode_arg(flags, args);
+	va_end(args);
+
+	return orig_openat64(dirfd, pathname, flags, mode);
+}
+
+/*
+ * With _FORTIFY_SOURCE >= 1 and optimization enabled, glibc's <fcntl.h>
+ * rewrites the 2-argument form of open()/openat() (no O_CREAT, so no mode)
+ * at the call site into a call to these symbols instead of open()/openat().
+ * Callers built that way (e.g. the Tumbleweed release CI job, which passes
+ * -D_FORTIFY_SOURCE=3 -O2) bypass our open()/openat() overrides entirely
+ * unless these are intercepted too. No mode argument is needed here since
+ * the 2-argument form implies O_CREAT/O_TMPFILE weren't set.
+ */
+int __open_2(const char *pathname, int flags)
+{
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	return orig_open(pathname, flags, 0);
+}
+
+int __open64_2(const char *pathname, int flags)
+{
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	return orig_open64(pathname, flags, 0);
+}
+
+int __openat_2(int dirfd, const char *pathname, int flags)
+{
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	return orig_openat(dirfd, pathname, flags, 0);
+}
+
+int __openat64_2(int dirfd, const char *pathname, int flags)
+{
+	int fd;
+
+	init_orig_functions();
+	fd = handle_open_intercept(pathname, flags);
+	if (fd != -2)
+		return fd;
+
+	return orig_openat64(dirfd, pathname, flags, 0);
+}
+
+/* read() on a stream socket may return fewer bytes than requested even
+ * when more are on the way; loop until @len bytes are read, an orig_read()
+ * error/EOF occurs, or a short read is treated as an error by the caller.
+ * Returns true if all @len bytes were read.
+ */
+static bool read_full(int fd, void *buf, size_t len)
+{
+	size_t total_read = 0;
+
+	while (total_read < len) {
+		ssize_t n = orig_read(fd, (char *)buf + total_read,
+				       len - total_read);
+		if (n <= 0)
+			return false;
+		total_read += n;
+	}
+
+	return true;
+}
+
+/* Reads the fixed-size ipc_response header, then its variable-length
+ * payload (if any) into a freshly malloc()'d buffer. Returns the payload
+ * (NULL if empty or on error) and fills in @resp.
+ */
+static void *read_ipc_response(int ipc_fd, struct ipc_response *resp)
+{
+	char *payload;
+
+	memset(resp, 0, sizeof(*resp));
+	if (!read_full(ipc_fd, resp, sizeof(*resp))) {
+		mock_dbg("failed to read full IPC response header\n");
+		resp->status = -1;
+		resp->errno_val = EIO;
+		return NULL;
+	}
+
+	if (!resp->data_len)
+		return NULL;
+
+	payload = malloc(resp->data_len);
+	if (!payload)
+		return NULL;
+
+	if (!read_full(ipc_fd, payload, resp->data_len)) {
+		mock_dbg("failed to read full IPC response payload\n");
+		free(payload);
+		resp->status = -1;
+		resp->errno_val = EIO;
+		return NULL;
+	}
+
+	return payload;
+}
+
+ssize_t write(int fd, const void *buf, size_t count)
+{
+	struct ipc_response resp;
+	char *resp_data;
+	int ipc_fd;
+
+	init_orig_functions();
+
+	if (fd != mock_fabrics_fd)
+		return orig_write(fd, buf, count);
+
+	mock_dbg("intercepted connect args on fabrics fd %d\n", fd);
+
+	ipc_fd = connect_ipc_socket();
+	if (ipc_fd < 0) {
+		mock_dbg("could not connect to IPC socket\n");
+		return orig_write(fd, buf, count);
+	}
+
+	struct ipc_request req = {
+		.type = 1, /* WRITE */
+		.fd = fd,
+		.data_len = count,
+	};
+
+	orig_write(ipc_fd, &req, sizeof(req));
+	orig_write(ipc_fd, buf, count);
+
+	resp_data = read_ipc_response(ipc_fd, &resp);
+	mock_dbg("connect IPC response status %d, data_len %u\n",
+		 resp.status, resp.data_len);
+
+	if (resp.status == -1) {
+		free(resp_data);
+		orig_close(ipc_fd);
+		errno = resp.errno_val;
+		return -1;
+	}
+
+	if (resp_data && mock_fabrics_manager_fd >= 0)
+		orig_write(mock_fabrics_manager_fd, resp_data, resp.data_len);
+	free(resp_data);
+	orig_close(ipc_fd);
+
+	return count;
+}
+
+static int mock_ctrl_instance(int fd)
+{
+	for (int i = 0; i < num_mock_ctrls; i++)
+		if (mock_ctrl_fds[i].fd == fd)
+			return mock_ctrl_fds[i].instance;
+
+	return -1;
+}
+
+static int handle_admin_ioctl(int instance, unsigned long request,
+			       struct linux_passthru_cmd64 *cmd)
+{
+	struct ipc_response resp;
+	void *resp_data;
+	int ipc_fd;
+
+	mock_dbg("ioctl intercepted on instance %d\n", instance);
+
+	ipc_fd = connect_ipc_socket();
+	if (ipc_fd < 0) {
+		mock_dbg("ioctl could not connect to IPC socket\n");
+		return -2;
+	}
+
+	struct ipc_request req = {
+		.type = 2, /* IOCTL */
+		.fd = instance, /* controller instance, not a real fd */
+		.request = request,
+		.opcode = cmd->opcode,
+		.nsid = cmd->nsid,
+		.cdw10 = cmd->cdw10,
+		.cdw11 = cmd->cdw11,
+		.cdw12 = cmd->cdw12,
+		.cdw13 = cmd->cdw13,
+		.cdw14 = cmd->cdw14,
+		.cdw15 = cmd->cdw15,
+		.lpo = ((uint64_t)cmd->cdw13 << 32) | cmd->cdw12,
+		.req_len = cmd->data_len,
+	};
+
+	orig_write(ipc_fd, &req, sizeof(req));
+
+	resp_data = read_ipc_response(ipc_fd, &resp);
+	mock_dbg("ioctl received IPC response status %d, result %u, data_len %u\n",
+		 resp.status, resp.result, resp.data_len);
+
+	if (resp.status == -1) {
+		free(resp_data);
+		orig_close(ipc_fd);
+		errno = resp.errno_val;
+		return -1;
+	}
+
+	/*
+	 * argp is only guaranteed to be a full struct linux_passthru_cmd64
+	 * for the ADMIN64_CMD request; for the legacy ADMIN_CMD request it
+	 * really points at the smaller struct linux_passthru_cmd32, whose
+	 * result field is 4 bytes narrower and sits 4 bytes earlier. Writing
+	 * through the wider cmd64 view in that case scribbles 8 bytes past
+	 * the end of the caller's 32-bit struct.
+	 */
+	if (request == LIBNVME_IOCTL_ADMIN_CMD) {
+		struct linux_passthru_cmd32 *cmd32 = (struct linux_passthru_cmd32 *)cmd;
+
+		cmd32->result = resp.result;
+	} else {
+		cmd->result = resp.result;
+	}
+
+	if (resp_data) {
+		if (resp.data_len > cmd->data_len) {
+			mock_dbg("ioctl response data_len %u exceeds caller buffer %u, truncating\n",
+				 resp.data_len, cmd->data_len);
+			resp.data_len = cmd->data_len;
+		}
+		memcpy((void *)(uintptr_t)cmd->addr, resp_data, resp.data_len);
+	}
+	free(resp_data);
+	orig_close(ipc_fd);
+
+	return 0;
+}
+
+int ioctl(int fd, unsigned long request, ...)
+{
+	int instance = mock_ctrl_instance(fd);
+	va_list args;
+	void *argp;
+	int ret;
+
+	init_orig_functions();
+
+	va_start(args, request);
+	argp = va_arg(args, void *);
+	va_end(args);
+
+	if (instance >= 0 &&
+	    (request == LIBNVME_IOCTL_ADMIN_CMD || request == LIBNVME_IOCTL_ADMIN64_CMD)) {
+		ret = handle_admin_ioctl(instance, request, argp);
+		if (ret != -2)
+			return ret;
+	}
+
+	return orig_ioctl(fd, request, argp);
+}
+
+/*
+ * Some libc admin-passthru call sites resolve ioctl() through this alias
+ * rather than the public symbol; keep it in sync with ioctl() above so
+ * those calls are intercepted too.
+ */
+int __ioctl(int fd, unsigned long request, ...)
+{
+	va_list args;
+	void *argp;
+
+	va_start(args, request);
+	argp = va_arg(args, void *);
+	va_end(args);
+
+	return ioctl(fd, request, argp);
+}
+
+int close(int fd)
+{
+	init_orig_functions();
+
+	if (fd == mock_fabrics_fd)
+		mock_fabrics_fd = -1;
+	if (fd == mock_fabrics_manager_fd)
+		mock_fabrics_manager_fd = -1;
+
+	for (int i = 0; i < num_mock_ctrls; i++) {
+		if (mock_ctrl_fds[i].fd != fd)
+			continue;
+		for (int j = i; j < num_mock_ctrls - 1; j++)
+			mock_ctrl_fds[j] = mock_ctrl_fds[j + 1];
+		num_mock_ctrls--;
+		break;
+	}
+
+	return orig_close(fd);
+}

--- a/tests/cli/meson.build
+++ b/tests/cli/meson.build
@@ -64,4 +64,19 @@ if python3.found()
              env: cli_test_env,
              depends: nvme_exe)
     endif
+
+    if want_fabrics and (not is_static) and (not is_cross)
+        mock_fabrics_lib = shared_library(
+            'mock_fabrics',
+            'libmock_fabrics.c',
+            dependencies: dl_dep,
+            install: false
+        )
+        # cli_test_env.prepend('MOCK_DEBUG', '1')
+        test('nvme-cli - fabrics-mock-cli',
+             python3,
+             args: [files('nvme_fabrics_mock_test.py'), nvme_exe, mock_fabrics_lib],
+             env: cli_test_env,
+             depends: [nvme_exe, mock_fabrics_lib])
+    endif
 endif

--- a/tests/cli/nvme_fabrics_mock_test.py
+++ b/tests/cli/nvme_fabrics_mock_test.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+# Copyright (c) 2026 SUSE LLC
+#
+# Authors: Daniel Wagner <dwagner@suse.com>
+"""Integration tests for 'nvme discover', 'nvme connect', and 'nvme connect-all'.
+
+Uses LD_PRELOAD mocking (see libmock_fabrics.c), so no real NVMe hardware or
+root privileges are required. The mock shim forwards every connect() write
+and admin passthru ioctl() over a Unix socket to the MockIPCServer below,
+which is steered per-test to fabricate discovery log pages, Identify data,
+and simulated errno failures.
+
+Usage: python3 nvme_fabrics_mock_test.py <path-to-nvme-binary> <path-to-mock-lib>
+"""
+import os
+import shlex
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+# Capture the nvme binary path and preload library path from argv before
+# unittest.main() strips them.
+_NVME_BIN = sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith('-') else 'nvme'
+
+# NVMe-oF well-known discovery subsystem NQN (NVME_DISC_SUBSYS_NAME).
+DISCOVERY_NQN = "nqn.2014-08.org.nvmexpress.discovery"
+# Default TCP port used for discovery controller connections (NVME_DISC_IP_PORT).
+DISCOVERY_PORT = "8009"
+
+# struct nvmf_disc_log_entry SUBTYPE field (enum nvmf_disc_subtype).
+NVME_NQN_DISC = 1   # Referral to another Discovery Controller
+NVME_NQN_NVME = 2   # I/O (non-discovery) NVM subsystem
+NVME_NQN_CURR = 3   # This Discovery Controller's own port
+
+# struct nvmf_disc_log_entry EFLAGS bit (enum nvmf_disc_eflags).
+NVMF_DISC_EFLAGS_EPCSD = 1 << 1
+
+# IPC wire format shared with libmock_fabrics.c -- keep both sides in sync.
+_IPC_REQUEST_FMT = "=IIII B3x I IIIIII QI"
+_IPC_REQUEST_LEN = struct.calcsize(_IPC_REQUEST_FMT)
+_IPC_RESPONSE_FMT = "=iiII"
+
+_NVME_OPCODE_GET_LOG_PAGE = 0x02
+_NVME_OPCODE_IDENTIFY = 0x06
+_DISCOVERY_LOG_LID = 0x70
+
+
+def resolve_mock_lib_path():
+    if len(sys.argv) > 2:
+        raw_path = sys.argv[2]
+        candidates = (
+            Path(raw_path),
+            Path(raw_path).resolve(),
+            Path(os.getcwd()) / ".build" / raw_path,
+            Path(__file__).parent.parent.parent / ".build" / raw_path,
+        )
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate.resolve())
+    return "./libmock_fabrics.so"
+
+
+_MOCK_LIB = resolve_mock_lib_path()
+
+
+def _pack_disc_log_entry(portid, entry):
+    """Packs one 1024-byte struct nvmf_disc_log_entry from a test-supplied dict.
+
+    Recognized keys: transport, traddr, trsvcid, subsysnqn, eflags, subtype.
+    'subtype' defaults to NVME_NQN_DISC for referral-looking NQNs (containing
+    "discovery" or "dc-") and NVME_NQN_NVME otherwise; 'eflags' defaults to 0.
+    """
+    transport = entry.get('transport', 'tcp')
+    traddr = entry.get('traddr', '')
+    trsvcid = entry.get('trsvcid', '4420')
+    subsysnqn = entry.get('subsysnqn', '')
+    eflags = entry.get('eflags', 0)
+
+    subtype = entry.get('subtype')
+    if subtype is None:
+        subtype = NVME_NQN_DISC if ('discovery' in subsysnqn or 'dc-' in subsysnqn) else NVME_NQN_NVME
+
+    trtype = {'tcp': 3, 'rdma': 1, 'fc': 2}.get(transport, 254)
+    adrfam = 4 if transport == 'fc' else (1 if transport in ('tcp', 'rdma') else 254)
+
+    header = struct.pack("=BBBBHHHH", trtype, adrfam, subtype, 0, portid, 0xffff, 32, eflags)
+    rsvd12 = b"\x00" * 20
+    trsvcid_bytes = trsvcid.encode('utf-8').ljust(32, b"\x00")
+    rsvd64 = b"\x00" * 192
+    subnqn_bytes = subsysnqn.encode('utf-8').ljust(256, b"\x00")
+    traddr_bytes = traddr.encode('utf-8').ljust(256, b"\x00")
+    tsas = b"\x00" * 256
+
+    return header + rsvd12 + trsvcid_bytes + rsvd64 + subnqn_bytes + traddr_bytes + tsas
+
+
+class MockIPCServer(threading.Thread):
+    def __init__(self, sock_path):
+        super().__init__()
+        self.sock_path = sock_path
+        self.running = True
+        self.server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.server_sock.bind(self.sock_path)
+        self.server_sock.listen(5)
+        self.server_sock.settimeout(0.5)
+
+        # Test-specific state overrides, steered from Python tests.
+        self.connect_errno = 0
+        self.ioctl_errno = 0
+        self.discovery_entries = []  # fallback list of dicts (see _pack_disc_log_entry)
+        self.discovery_map = {}      # maps subsysnqn (str) -> list of dicts
+        self.model_number = "Mock NVMe Controller"
+        self.serial_number = "MOCK_SERIAL_NUM_123"
+        self.next_instance = 0
+        self.sysfs_dir = None
+        self.controllers = {}        # maps instance (int) -> dict of connect options
+
+    def run(self):
+        while self.running:
+            try:
+                conn, _ = self.server_sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            self.handle_client(conn)
+
+    @staticmethod
+    def _send_response(conn, status, errno_val=0, result=0, payload=b""):
+        conn.sendall(struct.pack(_IPC_RESPONSE_FMT, status, errno_val, result, len(payload)))
+        if payload:
+            conn.sendall(payload)
+
+    def _handle_connect(self, conn, payload):
+        if self.connect_errno != 0:
+            self._send_response(conn, -1, errno_val=self.connect_errno)
+            return
+
+        opts = {}
+        for part in payload.decode('utf-8', errors='ignore').split(','):
+            if '=' in part:
+                k, v = part.split('=', 1)
+                opts[k.strip()] = v.strip()
+
+        inst = int(opts.get('instance', self.next_instance))
+        if 'instance' not in opts:
+            self.next_instance += 1
+
+        subsysnqn = opts.get('nqn', opts.get('subsysnqn', ''))
+        transport = opts.get('transport', 'tcp')
+        traddr = opts.get('traddr', '')
+        trsvcid = opts.get('trsvcid', '4420')
+        host_traddr = opts.get('host_traddr', 'none')
+        host_iface = opts.get('host_iface', 'none')
+        hostnqn = opts.get('hostnqn', '')
+        hostid = opts.get('hostid', '')
+
+        self.controllers[inst] = {
+            'subsysnqn': subsysnqn,
+            'transport': transport,
+            'traddr': traddr,
+            'trsvcid': trsvcid,
+        }
+
+        if self.sysfs_dir:
+            self._write_sysfs_ctrl(inst, subsysnqn, transport, traddr, trsvcid,
+                                    host_traddr, host_iface, hostnqn, hostid)
+
+        resp_payload = f"instance={inst}\n".encode('utf-8')
+        self._send_response(conn, 0, payload=resp_payload)
+
+    def _write_sysfs_ctrl(self, inst, subsysnqn, transport, traddr, trsvcid,
+                           host_traddr, host_iface, hostnqn, hostid):
+        ctrl_path = Path(self.sysfs_dir) / f"sys/class/nvme/nvme{inst}"
+        ctrl_path.mkdir(parents=True, exist_ok=True)
+
+        (ctrl_path / "transport").write_text(f"{transport}\n")
+
+        addr_str = f"traddr={traddr},trsvcid={trsvcid}"
+        if host_traddr not in ('none', ''):
+            addr_str += f",host_traddr={host_traddr}"
+        if host_iface not in ('none', ''):
+            addr_str += f",host_iface={host_iface}"
+        (ctrl_path / "address").write_text(addr_str + "\n")
+
+        (ctrl_path / "subsysnqn").write_text(f"{subsysnqn}\n")
+        (ctrl_path / "state").write_text("live\n")
+        (ctrl_path / "delete_controller").write_text("")
+
+        if hostnqn:
+            (ctrl_path / "hostnqn").write_text(f"{hostnqn}\n")
+        if hostid:
+            (ctrl_path / "hostid").write_text(f"{hostid}\n")
+
+        sub_path = Path(self.sysfs_dir) / f"sys/class/nvme-subsystem/nvme-subsys{inst}"
+        sub_path.mkdir(parents=True, exist_ok=True)
+        (sub_path / "subsysnqn").write_text(f"{subsysnqn}\n")
+        (sub_path / f"nvme{inst}").mkdir(exist_ok=True)
+
+    def _handle_ioctl(self, conn, fd, opcode, cdw10, lpo, req_len):
+        if self.ioctl_errno != 0:
+            self._send_response(conn, -1, errno_val=self.ioctl_errno)
+            return
+
+        resp_payload = b""
+
+        if opcode == _NVME_OPCODE_GET_LOG_PAGE and (cdw10 & 0xff) == _DISCOVERY_LOG_LID:
+            # fd carries the controller instance for IOCTLs (see libmock_fabrics.c).
+            ctrl_nqn = self.controllers.get(fd, {}).get('subsysnqn', '')
+            entries = self.discovery_map.get(ctrl_nqn, self.discovery_entries)
+
+            log_entries = b"".join(_pack_disc_log_entry(i + 1, e) for i, e in enumerate(entries))
+            log_header = struct.pack("<QQH", 1, len(entries), 0) + b"\x00" * 1006
+            full_log = log_header + log_entries
+
+            if lpo < len(full_log):
+                resp_payload = full_log[lpo:lpo + req_len]
+
+        elif opcode == _NVME_OPCODE_IDENTIFY:
+            vid = struct.pack("<HH", 0x105b, 0x105b)
+            sn_bytes = self.serial_number.encode('utf-8').ljust(20, b" ")[:20]
+            mn_bytes = self.model_number.encode('utf-8').ljust(40, b" ")[:40]
+            fr_bytes = b"MOCK1234".ljust(8, b" ")[:8]
+            rsvd = b"\x00" * (4096 - len(vid) - len(sn_bytes) - len(mn_bytes) - len(fr_bytes))
+            resp_payload = (vid + sn_bytes + mn_bytes + fr_bytes + rsvd)[:req_len]
+
+        self._send_response(conn, 0, payload=resp_payload)
+
+    def handle_client(self, conn):
+        try:
+            req_header = conn.recv(_IPC_REQUEST_LEN)
+            if len(req_header) < _IPC_REQUEST_LEN:
+                return
+
+            req_type, fd, data_len, _ioctl_request, opcode, _nsid, \
+                cdw10, _cdw11, _cdw12, _cdw13, _cdw14, _cdw15, lpo, req_len = \
+                struct.unpack(_IPC_REQUEST_FMT, req_header)
+
+            payload = conn.recv(data_len) if data_len > 0 else b""
+
+            if req_type == 1:    # WRITE (connect args)
+                self._handle_connect(conn, payload)
+            elif req_type == 2:  # IOCTL (admin passthru)
+                self._handle_ioctl(conn, fd, opcode, cdw10, lpo, req_len)
+        except OSError as e:
+            print(f"Exception handling IPC client: {e}", file=sys.stderr)
+        finally:
+            conn.close()
+
+    def shutdown(self):
+        self.running = False
+        try:
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.connect(self.sock_path)
+            client.close()
+        except OSError:
+            pass
+        self.server_sock.close()
+
+
+class FabricsMockCLITest(unittest.TestCase):
+
+    def setUp(self):
+        print(f"\n[DIAG] os.getcwd(): {os.getcwd()}", file=sys.stderr)
+        print(f"[DIAG] _MOCK_LIB: {_MOCK_LIB}", file=sys.stderr)
+        print(f"[DIAG] _MOCK_LIB exists: {Path(_MOCK_LIB).exists()}", file=sys.stderr)
+
+        self.sysfs_dir = tempfile.mkdtemp(prefix='nvme-mock-sysfs-', dir='/tmp')
+        self.base_dir = tempfile.mkdtemp(prefix='nvme-mock-base-', dir='/tmp')
+
+        Path(f"{self.sysfs_dir}/sys/class/nvme").mkdir(parents=True, exist_ok=True)
+        Path(f"{self.sysfs_dir}/sys/class/nvme-subsystem").mkdir(parents=True, exist_ok=True)
+
+        self.ipc_dir = tempfile.mkdtemp(prefix='nvme-mock-ipc-', dir='/tmp')
+        self.ipc_sock_path = os.path.join(self.ipc_dir, "ipc.sock")
+
+        self.server = MockIPCServer(self.ipc_sock_path)
+        self.server.sysfs_dir = self.sysfs_dir
+        self.server.start()
+
+        self.env = os.environ.copy()
+        # Append (don't clobber) LD_PRELOAD so an existing entry, e.g.
+        # libasan, is kept. If libasan isn't first in the LD_PRELOAD list,
+        # ASan warns/aborts because its interceptors weren't installed
+        # first; verify_asan_link_order=0 silences that check, since we
+        # can't control the order and it isn't a real problem here.
+        existing_preload = self.env.get("LD_PRELOAD", "")
+        self.env["LD_PRELOAD"] = f"{existing_preload} {_MOCK_LIB}".strip()
+        existing_asan_options = self.env.get("ASAN_OPTIONS", "")
+        self.env["ASAN_OPTIONS"] = f"{existing_asan_options}:verify_asan_link_order=0".strip(':')
+        self.env["MOCK_IPC_SOCK"] = self.ipc_sock_path
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.join()
+
+        shutil.rmtree(self.sysfs_dir, ignore_errors=True)
+        shutil.rmtree(self.base_dir, ignore_errors=True)
+        shutil.rmtree(self.ipc_dir, ignore_errors=True)
+
+    def _run(self, *args, expect_fail=False):
+        cmd = [
+            _NVME_BIN,
+            '--set-options', f'test-sysfs-dir={self.sysfs_dir},test-base-dir={self.base_dir}',
+        ] + list(args)
+
+        # Under 'meson test --setup=valgrind' this script itself runs under
+        # valgrind, but nvme must run natively. Valgrind rewrites LD_PRELOAD
+        # on every execve() it traps (to strip its own vgpreload bookkeeping),
+        # which wipes out our appended mock lib entry too since it's part of
+        # the same string. Route through a shell: the exec() below is what
+        # valgrind sees and mangles, but the shell's own subsequent exec of
+        # nvme happens in a process valgrind no longer traces, so the
+        # LD_PRELOAD it sets there reaches nvme intact.
+        env = dict(self.env)
+        ld_preload = env.pop("LD_PRELOAD", "")
+        wrapped_cmd = [
+            '/bin/sh', '-c', f'export LD_PRELOAD={shlex.quote(ld_preload)}; exec "$@"',
+            'nvme-mock-wrapper',
+        ] + cmd
+
+        result = subprocess.run(wrapped_cmd, env=env,
+                                stdin=subprocess.DEVNULL,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                encoding='utf-8')
+
+        # Print outputs to sys.stderr so they are displayed by unittest on failure.
+        print(f"\n--- RUN: {' '.join(cmd)} ---", file=sys.stderr)
+        print(f"STDOUT:\n{result.stdout}", file=sys.stderr)
+        print(f"STDERR:\n{result.stderr}", file=sys.stderr)
+        print("-----------------------------------", file=sys.stderr)
+
+        if not expect_fail:
+            self.assertEqual(result.returncode, 0,
+                             f'Command {cmd} failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+        else:
+            self.assertNotEqual(result.returncode, 0,
+                                f'Command {cmd} was expected to fail but succeeded')
+        return result
+
+    def _ctrl_path(self, instance):
+        return Path(f"{self.sysfs_dir}/sys/class/nvme/nvme{instance}")
+
+    def _subsysnqn(self, instance):
+        return (self._ctrl_path(instance) / "subsysnqn").read_text().strip()
+
+    def _assert_persisted(self, instance, msg=""):
+        """delete_controller stays empty as long as libnvmf_disconnect_ctrl()
+        (which writes "1" to it) is never called for this controller."""
+        content = (self._ctrl_path(instance) / "delete_controller").read_text()
+        self.assertEqual(content, "", msg or f"nvme{instance} was disconnected, expected it to persist")
+
+    def _assert_disconnected(self, instance, msg=""):
+        content = (self._ctrl_path(instance) / "delete_controller").read_text()
+        self.assertEqual(content, "1", msg or f"nvme{instance} was not disconnected")
+
+    # ------------------------------------------------------------------ #
+    # Test cases                                                         #
+    # ------------------------------------------------------------------ #
+
+    def test_discover_simple(self):
+        """Test simple discovery retrieval."""
+        self.server.discovery_entries = [
+            {
+                'transport': 'tcp',
+                'traddr': '192.168.1.200',
+                'trsvcid': '4420',
+                'subsysnqn': 'nqn.2014-08.org.nvmexpress:uuid:mock-target-nvm-subsystem',
+            },
+        ]
+        res = self._run('discover', '-t', 'tcp', '-a', '192.168.1.1')
+
+        # Verify stdout contains our mock subsystem NQN and address.
+        self.assertIn("mock-target-nvm-subsystem", res.stdout)
+        self.assertIn("192.168.1.200", res.stdout)
+        self.assertIn("4420", res.stdout)
+
+    def test_connect_simple(self):
+        """Test connecting to a single target."""
+        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn)
+
+        # The command should succeed, and our mock should have created the sysfs entries.
+        ctrl_path = self._ctrl_path(0)
+        self.assertTrue(ctrl_path.exists(), "Mock controller directory was not created under sysfs")
+
+        self.assertEqual((ctrl_path / "transport").read_text().strip(), "tcp")
+        self.assertEqual(self._subsysnqn(0), subsysnqn)
+        self.assertIn("traddr=192.168.1.10", (ctrl_path / "address").read_text())
+
+    def test_connect_all_recursive(self):
+        """Test connect-all recursive discovery cascade."""
+        # Setup pre-configured mock discovery log entries pointing to two standard I/O controllers.
+        subsys1 = "nqn.2014-08.org.nvmexpress:uuid:io-subsys-A"
+        subsys2 = "nqn.2014-08.org.nvmexpress:uuid:io-subsys-B"
+        self.server.discovery_entries = [
+            {'transport': 'tcp', 'traddr': '192.168.5.1', 'trsvcid': '4420', 'subsysnqn': subsys1},
+            {'transport': 'tcp', 'traddr': '192.168.5.2', 'trsvcid': '4420', 'subsysnqn': subsys2},
+        ]
+
+        self._run('connect-all', '-t', 'tcp', '-a', '192.168.1.1')
+
+        # Connecting with connect-all to a discovery controller should first connect to the
+        # discovery controller (nvme0), read the discovery log (returning our 2 entries),
+        # and then connect to the two listed I/O controllers (nvme2 and nvme3).
+        self.assertTrue(self._ctrl_path(0).exists(), "Discovery controller (nvme0) not created")
+        self.assertTrue(self._ctrl_path(2).exists(), "First I/O controller (nvme2) not created")
+        self.assertTrue(self._ctrl_path(3).exists(), "Second I/O controller (nvme3) not created")
+
+        self.assertEqual(self._subsysnqn(2), subsys1)
+        self.assertEqual(self._subsysnqn(3), subsys2)
+
+    def test_connect_already_connected(self):
+        """Test how connect handles EALREADY (already connected) error gracefully."""
+        self.server.connect_errno = 114  # EALREADY
+        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        res = self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn,
+                        expect_fail=True)
+        # nvme-cli connect handles EALREADY gracefully and prints 'already connected' to stdout.
+        self.assertIn("already connected", res.stdout)
+
+    def test_custom_identify(self):
+        """Test getting custom Identify Controller fields steered by environment."""
+        # Create a mock controller nvme0 in sysfs first, so nvme list has something to read.
+        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        inst_dir = self._ctrl_path(0)
+        inst_dir.mkdir(parents=True, exist_ok=True)
+        (inst_dir / "transport").write_text("tcp\n")
+        (inst_dir / "address").write_text("traddr=192.168.1.10,trsvcid=4420\n")
+        (inst_dir / "subsysnqn").write_text(f"{subsysnqn}\n")
+        (inst_dir / "state").write_text("live\n")
+
+        sub_dir = Path(f"{self.sysfs_dir}/sys/class/nvme-subsystem/nvme-subsys0")
+        sub_dir.mkdir(parents=True, exist_ok=True)
+        (sub_dir / "subsysnqn").write_text(f"{subsysnqn}\n")
+        (sub_dir / "nvme0").mkdir(exist_ok=True)
+
+        custom_sn = "SN_MOCK_XYZ_999"
+        custom_mn = "Model_Mock_SuperFast_PRO"
+        self.server.serial_number = custom_sn
+        self.server.model_number = custom_mn
+
+        # Use admin-passthru to submit an Identify Controller admin command (opcode 0x06, CNS 1)
+        # to our mock character device and assert that it receives our customized parameters.
+        res = self._run('admin-passthru', '/dev/nvme0', '-O', '0x06', '-4', '1', '-l', '4096', '-r')
+
+        # The output printed contains ASCII interpretation of the hex dump.
+        # Since it can be formatted/wrapped, we search for contiguous parts.
+        self.assertIn("SN_MOCK_XYZ_", res.stdout)
+        self.assertIn("999", res.stdout)
+        self.assertIn("Model_Mo", res.stdout)
+        self.assertIn("ck_SuperFast", res.stdout)
+
+    def test_connect_all_three_hop_referral_cascade(self):
+        """Test connect-all with three Discovery Controllers in a referral chain: DC a -> DC b -> DC c -> IO subsys C."""
+        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-B"
+        dc_c = "nqn.2014-08.org.nvmexpress:uuid:dc-C"
+        io_c = "nqn.2014-08.org.nvmexpress:uuid:io-subsys-C"
+
+        # Configure our Python mock server to map each subsystem NQN to its specific log entries.
+        self.server.discovery_map = {
+            dc_a: [{'transport': 'tcp', 'traddr': '192.168.100.2', 'trsvcid': '4420', 'subsysnqn': dc_b}],
+            dc_b: [{'transport': 'tcp', 'traddr': '192.168.100.3', 'trsvcid': '4420', 'subsysnqn': dc_c}],
+            dc_c: [{'transport': 'tcp', 'traddr': '192.168.100.4', 'trsvcid': '4420', 'subsysnqn': io_c}],
+        }
+
+        # Connect to the first discovery controller (DC a), which should trigger the recursive cascade.
+        self._run('connect-all', '-t', 'tcp', '-a', '192.168.100.1', '-n', dc_a)
+
+        # Verify that all controllers are successfully connected under sysfs:
+        # DC a -> nvme0, DC b -> nvme1, DC c -> nvme2, IO C -> nvme3.
+        self.assertTrue(self._ctrl_path(0).exists(), "DC a (nvme0) not created")
+        self.assertTrue(self._ctrl_path(1).exists(), "DC b (nvme1) not created")
+        self.assertTrue(self._ctrl_path(2).exists(), "DC c (nvme2) not created")
+        self.assertTrue(self._ctrl_path(3).exists(), "IO c (nvme3) not created")
+
+        self.assertEqual(self._subsysnqn(0), dc_a)
+        self.assertEqual(self._subsysnqn(1), dc_b)
+        self.assertEqual(self._subsysnqn(2), dc_c)
+        self.assertEqual(self._subsysnqn(3), io_c)
+
+    # ------------------------------------------------------------------ #
+    # --persistent=[no|auto|force] and EPCSD corner cases                #
+    # ------------------------------------------------------------------ #
+    #
+    # A discovery controller's own EPCSD (Explicit Persistent Connection
+    # Support for Discovery) is only ever reported in the "current discovery
+    # subsystem" entry it returns about itself (SUBTYPE=03h, NVME_NQN_CURR).
+    # These tests supply that self-entry with traddr/trsvcid matching the
+    # connection actually opened by `discover`/`connect-all` (no transport
+    # options, default TCP discovery port 8009) so libnvme recognizes it as
+    # describing the very connection it's deciding whether to keep.
+    #
+    # Every `discover` invocation below first does a throwaway probe connect
+    # to look up any registered owner (nvme0 -- always torn down regardless
+    # of --persistent) before opening the real discovery connection whose
+    # persistence is under test (nvme1).
+    _PROBE_INSTANCE = 0
+    _DISCOVERY_INSTANCE = 1
+
+    def _self_entry(self, addr, eflags=0):
+        return {
+            'subtype': NVME_NQN_CURR,
+            'transport': 'tcp',
+            'traddr': addr,
+            'trsvcid': DISCOVERY_PORT,
+            'subsysnqn': DISCOVERY_NQN,
+            'eflags': eflags,
+        }
+
+    def test_discover_persistent_default_disconnects(self):
+        """Without --persistent, the discovery controller is always torn down, EPCSD or not."""
+        addr = '192.168.10.1'
+        self.server.discovery_entries = [self._self_entry(addr, eflags=NVMF_DISC_EFLAGS_EPCSD)]
+
+        self._run('discover', '-t', 'tcp', '-a', addr)
+        self._assert_disconnected(self._DISCOVERY_INSTANCE)
+
+    def test_discover_persistent_no_ignores_epcsd(self):
+        """--persistent=no behaves like the default: always disconnect, even with EPCSD set."""
+        addr = '192.168.10.2'
+        self.server.discovery_entries = [self._self_entry(addr, eflags=NVMF_DISC_EFLAGS_EPCSD)]
+
+        self._run('discover', '-t', 'tcp', '-a', addr, '--persistent=no')
+        self._assert_disconnected(self._DISCOVERY_INSTANCE)
+
+    def test_discover_persistent_auto_epcsd_set_persists(self):
+        """--persistent (bare => auto) keeps the connection when the entry's own EPCSD is set."""
+        addr = '192.168.10.3'
+        self.server.discovery_entries = [self._self_entry(addr, eflags=NVMF_DISC_EFLAGS_EPCSD)]
+
+        self._run('discover', '-t', 'tcp', '-a', addr, '--persistent')
+        self._assert_persisted(self._DISCOVERY_INSTANCE)
+
+    def test_discover_persistent_auto_epcsd_unset_disconnects(self):
+        """--persistent=auto degrades to non-persistent (with a warning) when EPCSD isn't set."""
+        addr = '192.168.10.4'
+        self.server.discovery_entries = [self._self_entry(addr, eflags=0)]
+
+        # -v raises the log level to WARN so the "not persisting" message shows up.
+        res = self._run('discover', '-t', 'tcp', '-a', addr, '--persistent=auto', '-v')
+        self._assert_disconnected(self._DISCOVERY_INSTANCE)
+        self.assertIn("EPCSD", res.stdout)
+
+    def test_discover_persistent_auto_no_self_entry_disconnects(self):
+        """No self-entry (SUBTYPE=03h) at all is defined identically to EPCSD=0."""
+        addr = '192.168.10.5'
+        self.server.discovery_entries = []
+
+        self._run('discover', '-t', 'tcp', '-a', addr, '--persistent=auto')
+        self._assert_disconnected(self._DISCOVERY_INSTANCE)
+
+    def test_discover_persistent_force_ignores_epcsd(self):
+        """--persistent=force keeps the connection regardless of what EPCSD reports."""
+        addr = '192.168.10.6'
+        self.server.discovery_entries = [self._self_entry(addr, eflags=0)]
+
+        self._run('discover', '-t', 'tcp', '-a', addr, '--persistent=force')
+        self._assert_persisted(self._DISCOVERY_INSTANCE)
+
+    def test_discover_persistent_separate_value_arg_is_dropped(self):
+        """A value given as a separate argv token (not glued with '=') is silently
+        dropped; --persistent is treated as bare (mode "auto"), not "force"."""
+        addr = '192.168.10.7'
+        self.server.discovery_entries = [self._self_entry(addr, eflags=0)]
+
+        # If "force" were actually parsed as the option's value this would persist;
+        # since it's dropped and auto degrades on EPCSD=0, it must disconnect.
+        self._run('discover', '-t', 'tcp', '-a', addr, '--persistent', 'force')
+        self._assert_disconnected(self._DISCOVERY_INSTANCE)
+
+    def test_connect_all_persistent_auto_epcsd_referral_hop(self):
+        """Referral (non-self) Discovery Controller entries decide persistence
+        from their own EFLAGS directly, without needing a self-entry."""
+        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-epcsd-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-epcsd-B"  # EPCSD set: should persist
+        dc_c = "nqn.2014-08.org.nvmexpress:uuid:dc-epcsd-C"  # EPCSD unset: should disconnect
+
+        self.server.discovery_map = {
+            dc_a: [
+                {'transport': 'tcp', 'traddr': '192.168.110.2', 'trsvcid': '4420',
+                 'subsysnqn': dc_b, 'eflags': NVMF_DISC_EFLAGS_EPCSD},
+                {'transport': 'tcp', 'traddr': '192.168.110.3', 'trsvcid': '4420',
+                 'subsysnqn': dc_c, 'eflags': 0},
+            ],
+        }
+
+        self._run('connect-all', '-t', 'tcp', '-a', '192.168.110.1', '-n', dc_a, '--persistent')
+
+        self.assertEqual(self._subsysnqn(1), dc_b)
+        self.assertEqual(self._subsysnqn(2), dc_c)
+        self._assert_persisted(1, "dc-epcsd-B (EPCSD set) should have stayed connected")
+        self._assert_disconnected(2, "dc-epcsd-C (EPCSD unset) should have been disconnected")
+
+
+if __name__ == '__main__':
+    # If called standalone, strip the arguments parsed by FabricsMockCLITest
+    # and run standard unittest main.
+    unittest_args = [sys.argv[0]]
+    if len(sys.argv) > 3:
+        unittest_args.extend(sys.argv[3:])
+    unittest.main(argv=unittest_args)


### PR DESCRIPTION
Add an integration test harness for 'nvme discover', 'nvme connect', and
'nvme connect-all' that requires neither real NVMe-oF hardware nor root
privileges.

libmock_fabrics.c is an LD_PRELOAD shim that intercepts open/write/
ioctl/close on /dev/nvme-fabrics and /dev/nvme<N>, forwarding each
connect and admin passthru command over a Unix socket to a Python-side
IPC server (nvme_fabrics_mock_test.py) that fabricates discovery log
pages, Identify data, and simulated errno failures on demand.

Test coverage includes:
   - basic discover/connect and sysfs attribute verification
   - connect-all recursive discovery cascades, including multi-hop
     Discovery Controller referral chains
   - graceful handling of an already-connected (EALREADY) target
   - admin-passthru round-tripping custom Identify Controller fields
   - the --persistent=[no|auto|force] connection modes, including how
     each interacts with a target's self-reported EPCSD (Explicit
     Persistent Connection Support for Discovery) flag, both for the
     primary discovery controller and for referral hops during
     connect-all
   - the documented quirk where a --persistent value given as a separate
     argv token (rather than glued with '=') is silently dropped

Wire the new libmock_fabrics.so and its test into meson.build, built
and run only when fabrics support is enabled.

Signed-off-by: Daniel Wagner <dwagner@suse.com>

