### PR TITLE
libnnvme, nvme-cli: Discover rewrite

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -14,6 +14,7 @@ SYNOPSIS
 			[--config=<filename> | -J <cfg>]
 			[--persistent[=<no|auto|force>] | -p]
 			[--quiet]
+			[--no-reuse]
 			[--nbft]
 			[--no-nbft]
 			[--nbft-path=<STR>]
@@ -85,6 +86,12 @@ OPTIONS
 
 --quiet::
 	Suppress error messages.
+
+--no-reuse::
+	Always create a new discovery controller connection instead of
+	reusing an existing one that matches. Whether the new connection
+	persists afterward is still governed entirely by --persistent.
+	Deprecated alias: --force.
 
 --nbft::
 	Only look at NBFT tables

--- a/Documentation/nvme-discover.txt
+++ b/Documentation/nvme-discover.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 			[--config=<filename> | -J <filename>]
 			[--persistent[=<no|auto|force>] | -p]
 			[--quiet]
-			[--force]
+			[--no-reuse]
 			[--nbft]
 			[--no-nbft]
 			[--nbft-path=<STR>]
@@ -107,10 +107,13 @@ OPTIONS
 --quiet::
 	Suppress already connected errors.
 
+--no-reuse::
+	Always create a new discovery controller connection instead of
+	reusing an existing one that matches. Whether the new connection
+	persists afterward is still governed entirely by --persistent.
+
 --force::
-	Disable the built-in persistent discovery controller connection
-	rules. Combined with --persistent flag, always create new
-	persistent discovery controller connection.
+	Deprecated alias for --no-reuse.
 
 --nbft::
 	Only look at NBFT tables

--- a/libnvme/src/accessors-fabrics.ld
+++ b/libnvme/src/accessors-fabrics.ld
@@ -29,7 +29,6 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_disable_sqflow;
 		libnvmf_context_get_duplicate_connect;
 		libnvmf_context_get_fast_io_fail_tmo;
-		libnvmf_context_get_force;
 		libnvmf_context_get_hdr_digest;
 		libnvmf_context_get_host_iface;
 		libnvmf_context_get_host_traddr;
@@ -40,6 +39,7 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_get_keyring;
 		libnvmf_context_get_keyring_id;
 		libnvmf_context_get_nbft_path;
+		libnvmf_context_get_no_reuse;
 		libnvmf_context_get_nr_io_queues;
 		libnvmf_context_get_nr_poll_queues;
 		libnvmf_context_get_nr_write_queues;
@@ -64,11 +64,11 @@ LIBNVMF_ACCESSORS_3 {
 		libnvmf_context_set_disable_sqflow;
 		libnvmf_context_set_duplicate_connect;
 		libnvmf_context_set_fast_io_fail_tmo;
-		libnvmf_context_set_force;
 		libnvmf_context_set_hdr_digest;
 		libnvmf_context_set_keep_alive_tmo;
 		libnvmf_context_set_keyring_id;
 		libnvmf_context_set_nbft_path;
+		libnvmf_context_set_no_reuse;
 		libnvmf_context_set_nr_io_queues;
 		libnvmf_context_set_nr_poll_queues;
 		libnvmf_context_set_nr_write_queues;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -35,6 +35,7 @@
 #include <ccan/list/list.h>
 #include <ccan/str/str.h>
 
+#include <array-util.h>
 #include <compiler-attributes.h>
 
 #include <libnvme.h>
@@ -2609,8 +2610,8 @@ static int set_discovery_kato(struct libnvmf_context *fctx)
 	int tmo = fctx->ctrl_params.cfg.keep_alive_tmo;
 	/*
 	 * EPCSD isn't known until after the Discovery Log Page comes back, so
-	 * auto mode optimistically requests a KATO here; dc_should_connect()
-	 * disconnects per entry afterward if EPCSD turns out to be unset.
+	 * auto mode optimistically requests a KATO here; dc_decide()
+	 * disconnects afterward if EPCSD turns out to be unset.
 	 */
 	bool wants_kato = fctx->persistent == LIBNVMF_PERSISTENT_AUTO ||
 		fctx->persistent == LIBNVMF_PERSISTENT_FORCE;
@@ -2681,31 +2682,77 @@ static bool dc_should_disconnect(struct libnvmf_context *fctx,
 	return disconnect;
 }
 
+enum dc_ownership {
+	DC_OWNED,	/* this call created it; we may disconnect it */
+	DC_BORROWED,	/* pre-existing; never ours to disconnect */
+};
+
 /*
- * DUPRETINFO isn't checked here: the spec defines it as always 0 for
- * anything other than a SUBTYPE 03h (current discovery subsystem)
- * entry, and self entries never reach this function -- the caller
- * filters them out before calling dc_should_connect().
+ * "Hosts or Discovery controllers are not required to process referral
+ * entries deeper than eight levels" (Base Spec, Discovery Log Page).
+ * The primary is level 0; a referral discovered at level N is level
+ * N+1. Refuse to descend past this depth.
  */
-static bool dc_should_connect(struct libnvmf_context *fctx,
-		struct nvmf_disc_log_entry *e, bool *pdisconnect)
+#define NVMF_MAX_REFERRAL_DEPTH	8
+
+/*
+ * TIDs of every DC visited so far in one top-level libnvmf_discover()
+ * call, so a referral graph with more than one path to the same DC
+ * (or an outright cycle) is walked once, not once per path. Distinct
+ * from "is it currently connected": a DC visited earlier in this same
+ * walk may already have been disconnected by the time a second path
+ * reaches it, and should still not be walked again.
+ */
+SHR_PTRARRAY_DEFINE(dc_visited, struct libnvmf_tid);
+
+static bool dc_visited_has(struct dc_visited *visited,
+		const struct libnvmf_tid *tid)
 {
-	__u16 eflags;
+	const char *canonical = libnvmf_tid_get_canonical(tid);
 
-	if (e->subtype == NVME_NQN_NVME) {
-		*pdisconnect = false;
-		return fctx->connect;
-	}
+	for (size_t i = 0; i < visited->len; i++)
+		if (!strcmp(libnvmf_tid_get_canonical(visited->items[i]),
+			    canonical))
+			return true;
 
-	eflags = le16_to_cpu(e->eflags);
-	*pdisconnect = dc_should_disconnect(fctx, e->subnqn, eflags);
-	return true;
+	return false;
 }
+
+/* Register c's own identity, so a referral elsewhere in this walk that
+ * loops back to c is recognized. Best-effort: a TID construction
+ * failure here just means this one DC isn't deduplicated, not a fatal
+ * error for the walk.
+ */
+static void dc_visited_register(struct dc_visited *visited,
+		struct libnvme_ctrl *c, struct libnvmf_context *fctx)
+{
+	struct libnvmf_tid *tid;
+	int err;
+
+	err = libnvmf_tid_from_fields(libnvme_ctrl_get_transport(c),
+			libnvme_ctrl_get_traddr(c), libnvme_ctrl_get_trsvcid(c),
+			libnvme_ctrl_get_subsysnqn(c),
+			libnvme_ctrl_get_host_traddr(c),
+			libnvme_ctrl_get_host_iface(c),
+			fctx->hostnqn, fctx->hostid, &tid);
+	if (err)
+		return;
+
+	if (dc_visited_append(visited, tid))
+		libnvmf_tid_free(tid);
+}
+
+static inline void libnvmf_tid_freep(struct libnvmf_tid **p)
+{
+	if (*p)
+		libnvmf_tid_free(*p);
+}
+#define __cleanup_libnvmf_tid __cleanup(libnvmf_tid_freep)
 
 /*
  * Bundles the controller and the decisions made about it while walking a
  * Discovery Log Page, so the whole outcome for one entry (or, with @e
- * NULL, for the primary's own self entry) can be logged in one place.
+ * NULL, for the DC's own self entry) can be logged in one place.
  */
 struct dc_decision {
 	struct libnvme_ctrl *c;
@@ -2714,6 +2761,35 @@ struct dc_decision {
 	bool connect;
 	bool disconnect;
 };
+
+/*
+ * Pure: no I/O, no side effects, so this is straightforward to unit
+ * test on its own. A DC we don't own is never ours to disconnect. One
+ * we own decides from its own self entry's EPCSD when it reported one;
+ * failing that, a referral falls back to its parent's cached view
+ * (@parent_eflags, the referral entry's own eflags, as seen before
+ * ever connecting to it); the primary DC has no parent and no fallback,
+ * so an absent self entry there means EPCSD=0 -- which is exactly what
+ * the spec defines an unreported EPCSD as meaning anyway.
+ */
+static bool dc_decide(struct libnvmf_context *fctx, const char *subnqn,
+		enum dc_ownership own, bool self_seen, __u16 self_eflags,
+		const __u16 *parent_eflags)
+{
+	__u16 eflags;
+
+	if (own == DC_BORROWED)
+		return false;
+
+	if (self_seen)
+		eflags = self_eflags;
+	else if (parent_eflags)
+		eflags = *parent_eflags;
+	else
+		eflags = 0;
+
+	return dc_should_disconnect(fctx, subnqn, eflags);
+}
 
 static void dc_log_decision(struct libnvmf_context *fctx,
 		struct nvmf_disc_log_entry *e, const struct dc_decision *d,
@@ -2744,14 +2820,43 @@ static void dc_log_decision(struct libnvmf_context *fctx,
 		reason ? reason : "");
 }
 
+static void dc_already_connected(struct libnvmf_context *fctx,
+		struct libnvme_host *h, struct nvmf_disc_log_entry *e)
+{
+	if (fctx->hooks.already_connected)
+		fctx->hooks.already_connected(fctx, h, e->subnqn,
+			libnvmf_trtype_str(e->trtype), e->traddr, e->trsvcid,
+			fctx->hooks.user_data);
+}
+
+/*
+ * Walk one DC's Discovery Log Page. @own says whether this call created
+ * c (may disconnect it) or found it already connected (never ours to
+ * disconnect). @parent_eflags is NULL for the primary DC (no parent to
+ * fall back to); for a referral, it points at that referral entry's
+ * own eflags, as its parent saw it before ever connecting. @depth
+ * counts referral hops from the primary (0); @visited is the whole
+ * walk's dedup set. On return, *@disconnected says whether this call
+ * disconnected c itself, so the caller knows whether it's still safe
+ * to look c up later in the same walk (persisting) or not (torn down)
+ * -- freeing c here is the caller's job either way, but freeing a
+ * still-persisting c would incorrectly drop it from the host's tree,
+ * breaking dedup for the rest of the walk. @disconnected may be NULL
+ * (the primary's caller doesn't need it: it frees c unconditionally
+ * once the whole walk is over, by which point nothing else in this
+ * walk can still need to find it).
+ */
 static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, struct libnvme_ctrl *c,
-		bool primary, bool already_connected)
+		enum dc_ownership own, const __u16 *parent_eflags,
+		unsigned int depth, struct dc_visited *visited,
+		bool *disconnected)
 {
 	__cleanup_free struct nvmf_discovery_log *log = NULL;
 	libnvme_subsystem_t s = libnvme_ctrl_get_subsystem(c);
 	libnvme_host_t h = libnvme_subsystem_get_host(s);
 	struct nvmf_disc_log_entry *self_entry = NULL;
+	struct dc_decision d;
 	uint64_t numrec;
 	int err;
 
@@ -2759,6 +2864,9 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 		.max_retries = fctx->default_max_discovery_retries,
 		.lsp = NVMF_LOG_DISC_LSP_NONE,
 	};
+
+	if (disconnected)
+		*disconnected = false;
 
 	err = nvme_discovery_log(c, &args, &log);
 	if (err) {
@@ -2774,133 +2882,195 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 		fctx->hooks.discovery_log(fctx, log, numrec,
 			fctx->hooks.user_data);
 
+	dc_visited_register(visited, c, fctx);
+
+	/* Pass 1: find our own self entry, if any -- the only place our
+	 * own EPCSD is ever reported. Also sanitizes every entry once,
+	 * up front, so pass 2 doesn't need to.
+	 */
 	for (int i = 0; i < numrec; i++) {
 		struct nvmf_disc_log_entry *e = &log->entries[i];
-		struct dc_decision d = { 0 };
-		libnvme_ctrl_t cl;
-		bool discover = false;
-		struct libnvmf_context nfctx = *fctx;
 
 		sanitize_discovery_log_entry(c->ctx, e);
+		if (e->subtype == NVME_NQN_CURR && !self_entry)
+			self_entry = e;
+	}
 
-		if (e->subtype == NVME_NQN_CURR) {
-			/*
-			 * This entry describes c's own port. It is the
-			 * only place c's own EPCSD is ever reported, so
-			 * remember it instead of silently discarding it.
-			 * Take the first one seen; every copy describes
-			 * the same DC, regardless of which port it came
-			 * back on.
-			 */
-			if (!self_entry)
-				self_entry = e;
-			d.c = c;
-			d.already_connected = true;
-			dc_log_decision(fctx, e, &d,
-				"self entry, decision deferred to primary");
+	/* Decide and act on our own fate before touching any referral:
+	 * nothing past this point needs c's own connection, only
+	 * independent connections to whatever c's log points at.
+	 */
+	d = (struct dc_decision){
+		.c = c,
+		.primary = !parent_eflags,
+		.already_connected = own == DC_BORROWED,
+	};
+	d.disconnect = dc_decide(fctx, libnvme_ctrl_get_subsysnqn(c), own,
+			self_entry != NULL,
+			self_entry ? le16_to_cpu(self_entry->eflags) : 0,
+			parent_eflags);
+
+	if (self_entry) {
+		dc_log_decision(fctx, self_entry, &d, NULL);
+	} else if (own == DC_BORROWED) {
+		dc_log_decision(fctx, NULL, &d,
+			"pre-existing, not ours to disconnect");
+	} else if (parent_eflags) {
+		dc_log_decision(fctx, NULL, &d,
+			"no self entry, using parent's view");
+	} else {
+		dc_log_decision(fctx, NULL, &d,
+			"no self entry, EPCSD assumed 0");
+	}
+
+	if (d.disconnect) {
+		/*
+		 * Safe to disconnect now, before walking c's own referrals:
+		 * this connection is only ever needed to fetch c's own DLP,
+		 * and dc_visited already recorded c, independent of whether
+		 * the connection stays open.
+		 */
+		libnvmf_disconnect_ctrl(c);
+		if (disconnected)
+			*disconnected = true;
+	}
+
+	/* Pass 2: everything else -- referrals to walk, NVM subsystem
+	 * entries to connect per --connect. Self entries are already
+	 * handled above.
+	 */
+	for (int i = 0; i < numrec; i++) {
+		__cleanup_libnvmf_tid struct libnvmf_tid *tid = NULL;
+		struct nvmf_disc_log_entry *e = &log->entries[i];
+		struct libnvmf_context nfctx = *fctx;
+		bool child_disconnected = false;
+		struct dc_decision cd = { 0 };
+		enum dc_ownership child_own;
+		bool discover = false;
+		libnvme_ctrl_t cl;
+		__u16 eflags;
+		int cerr;
+
+		if (e->subtype == NVME_NQN_CURR)
 			continue;
-		}
 
 		nfctx.ctrl_params.subsysnqn = e->subnqn;
 		nfctx.ctrl_params.transport = libnvmf_trtype_str(e->trtype);
-		nfctx.ctrl_params.traddr = e->traddr;
 		nfctx.ctrl_params.trsvcid = e->trsvcid;
-
-		/* Already connected ? */
-		cl = lookup_ctrl(h, &nfctx);
-		if (cl && libnvme_ctrl_get_name(cl)) {
-			d.c = cl;
-			d.already_connected = true;
-			dc_log_decision(fctx, e, &d, "already connected");
-			continue;
-		}
+		nfctx.ctrl_params.traddr = e->traddr;
+		eflags = le16_to_cpu(e->eflags);
 
 		/* Skip connect if the transport types don't match */
 		if (strcmp(libnvme_ctrl_get_transport(c),
 			   nfctx.ctrl_params.transport)) {
-			dc_log_decision(fctx, e, &d, "transport mismatch");
+			dc_log_decision(fctx, e, &cd, "transport mismatch");
 			continue;
 		}
 
-		if (!dc_should_connect(&nfctx, e, &d.disconnect)) {
-			dc_log_decision(fctx, e, &d,
-				"not connecting (duplicate info, or connect not requested)");
+		if (e->subtype == NVME_NQN_NVME) {
+			if (!fctx->connect) {
+				dc_log_decision(fctx, e, &cd,
+					"connect not requested");
+				continue;
+			}
+
+			cerr = nvmf_connect_disc_entry(h, e, &nfctx, NULL,
+					&cd.c);
+			if (cd.c) {
+				cd.connect = true;
+				dc_log_decision(fctx, e, &cd, NULL);
+			} else if (cerr == -ENVME_CONNECT_ALREADY) {
+				dc_already_connected(fctx, h, e);
+			} else {
+				dc_log_decision(fctx, e, &cd,
+					libnvme_strerror(-cerr));
+			}
 			continue;
 		}
-		d.connect = true;
+
+		/* NVME_NQN_DISC: a referral to another Discovery Service. */
+		if (depth >= NVMF_MAX_REFERRAL_DEPTH) {
+			dc_log_decision(fctx, e, &cd,
+				"referral depth limit reached, not descending");
+			continue;
+		}
+
+		if (!libnvmf_tid_from_fields(nfctx.ctrl_params.transport,
+				nfctx.ctrl_params.traddr,
+				nfctx.ctrl_params.trsvcid,
+				nfctx.ctrl_params.subsysnqn,
+				nfctx.ctrl_params.host_traddr,
+				nfctx.ctrl_params.host_iface,
+				fctx->hostnqn, fctx->hostid, &tid) &&
+		    dc_visited_has(visited, tid)) {
+			dc_log_decision(fctx, e, &cd,
+				"already visited this walk");
+			continue;
+		}
+
+		cl = lookup_ctrl(h, &nfctx);
+		if (cl && libnvme_ctrl_get_name(cl)) {
+			cd.c = cl;
+			child_own = DC_BORROWED;
+		} else {
+			set_discovery_kato(&nfctx);
+			cerr = nvmf_connect_disc_entry(h, e, &nfctx, &discover,
+					&cd.c);
+			if (!cd.c) {
+				if (cerr == -ENVME_CONNECT_ALREADY)
+					dc_already_connected(fctx, h, e);
+				else
+					dc_log_decision(fctx, e, &cd,
+						libnvme_strerror(-cerr));
+				continue;
+			}
+			child_own = DC_OWNED;
+		}
+		cd.connect = true;
+		dc_log_decision(fctx, e, &cd, NULL);
+
+		if (tid) {
+			if (!dc_visited_append(visited, tid))
+				tid = NULL; /* ownership transferred */
+		}
 
 		/*
-		 * Only discovery controllers need their KATO set here.
-		 * NVM subsystems (I/O controllers) get theirs set elsewhere.
+		 * fctx, not nfctx: nfctx is a per-entry clone that dies
+		 * with this iteration. Recursing with it would hand every
+		 * deeper level a stack alias of fctx's owned pointers
+		 * (hostnqn, hostid, tls_key, nbft_path) instead of the
+		 * real, single owner.
 		 */
-		if (e->subtype != NVME_NQN_NVME)
-			set_discovery_kato(&nfctx);
+		_nvmf_discover(ctx, fctx, cd.c, child_own, &eflags,
+				depth + 1, visited, &child_disconnected);
 
-		err = nvmf_connect_disc_entry(h, e, &nfctx, &discover, &d.c);
-		if (err && err != -ENVME_CONNECT_ALREADY)
-			dc_log_decision(fctx, e, &d, libnvme_strerror(-err));
-		else
-			dc_log_decision(fctx, e, &d, NULL);
-
-		if (d.c) {
-			/*
-			 * fctx, not nfctx: nfctx is a per-entry clone that
-			 * dies with this iteration. Recursing with it would
-			 * hand every deeper level a stack alias of fctx's
-			 * owned pointers (hostnqn, hostid, tls_key,
-			 * nbft_path) instead of the real, single owner.
-			 */
-			if (discover)
-				_nvmf_discover(ctx, fctx, d.c, false, false);
-
-			if (d.disconnect) {
-				libnvmf_disconnect_ctrl(d.c);
-				libnvme_free_ctrl(d.c);
-			}
-		} else if (err == -ENVME_CONNECT_ALREADY) {
-			if (fctx->hooks.already_connected)
-				fctx->hooks.already_connected(fctx, h,
-					e->subnqn,
-					libnvmf_trtype_str(e->trtype),
-					e->traddr, e->trsvcid,
-					fctx->hooks.user_data);
-		}
-	}
-
-	/*
-	 * c has no parent to make this decision for it. Its own EPCSD is
-	 * only ever reported in its own self entry (SUBTYPE 03h); an
-	 * absent self entry means EPCSD is not reported, which the spec
-	 * defines identically to EPCSD=0.
-	 */
-	if (primary) {
-		struct dc_decision d = {
-			.c = c,
-			.primary = true,
-			.already_connected = already_connected,
-		};
-
-		if (already_connected) {
-			dc_log_decision(fctx, self_entry, &d,
-				"pre-existing, not ours to disconnect");
-		} else {
-			__u16 eflags = self_entry ?
-				le16_to_cpu(self_entry->eflags) : 0;
-
-			d.disconnect = dc_should_disconnect(fctx,
-					libnvme_ctrl_get_subsysnqn(c), eflags);
-			if (self_entry)
-				dc_log_decision(fctx, self_entry, &d, NULL);
-			else
-				dc_log_decision(fctx, NULL, &d,
-					"no self entry, EPCSD assumed 0");
-
-			if (d.disconnect)
-				libnvmf_disconnect_ctrl(c);
-		}
+		if (child_disconnected)
+			libnvme_free_ctrl(cd.c);
 	}
 
 	return 0;
+}
+
+/*
+ * Owns the whole-walk dc_visited set: allocate it, run the recursive
+ * walk starting at c, then free it. Keeps _nvmf_discover()'s recursion
+ * ignorant of dc_visited's lifetime, and its caller ignorant of
+ * dc_visited existing at all.
+ */
+static int dc_walk(struct libnvme_global_ctx *ctx,
+		struct libnvmf_context *fctx, struct libnvme_ctrl *c,
+		enum dc_ownership own)
+{
+	struct dc_visited visited = { 0 };
+	int err;
+
+	err = _nvmf_discover(ctx, fctx, c, own, NULL, 0, &visited, NULL);
+
+	for (size_t i = 0; i < visited.len; i++)
+		libnvmf_tid_free(visited.items[i]);
+	dc_visited_free(&visited);
+
+	return err;
 }
 
 __shr_public const char *libnvmf_get_default_trsvcid(const char *transport,
@@ -3616,11 +3786,6 @@ out_free:
 	return ret;
 }
 
-enum dc_ownership {
-	DC_OWNED,	/* this call created it; we may disconnect it */
-	DC_BORROWED,	/* pre-existing; never ours to disconnect */
-};
-
 /* Resolve fctx->device to a usable, already-connected discovery ctrl. */
 static struct libnvme_ctrl *dc_open_by_device(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, enum dc_ownership *own)
@@ -3740,7 +3905,7 @@ __shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
 		return err;
 	}
 
-	err = _nvmf_discover(ctx, fctx, c, true, own == DC_BORROWED);
+	err = dc_walk(ctx, fctx, c, own);
 	libnvme_free_ctrl(c);
 
 	return err;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3671,7 +3671,7 @@ static struct libnvme_ctrl *dc_open_by_device(struct libnvme_global_ctx *ctx,
 /*
  * Resolve the primary discovery controller connection: reuse one via
  * --device if given, reuse one found by matching connection
- * parameters otherwise, or create a fresh one if --force was given
+ * parameters otherwise, or create a fresh one if --no-reuse was given
  * or neither lookup found anything. Never touches fctx->persistent;
  * ownership is reported separately so the caller knows what it may
  * disconnect later.
@@ -3687,7 +3687,7 @@ static int dc_open(struct libnvme_global_ctx *ctx,
 
 	*own = DC_OWNED;
 
-	if (!fctx->force) {
+	if (!fctx->no_reuse) {
 		if (fctx->device)
 			c = dc_open_by_device(ctx, fctx, own);
 

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3617,65 +3617,45 @@ out_free:
 	return ret;
 }
 
-static struct libnvme_ctrl *discover_lookup_ctrl_by_device(
-		struct libnvme_global_ctx *ctx, struct libnvmf_context *fctx,
-		bool *already_connected)
+enum dc_ownership {
+	DC_OWNED,	/* this call created it; we may disconnect it */
+	DC_BORROWED,	/* pre-existing; never ours to disconnect */
+};
+
+/* Resolve fctx->device to a usable, already-connected discovery ctrl. */
+static struct libnvme_ctrl *dc_open_by_device(struct libnvme_global_ctx *ctx,
+		struct libnvmf_context *fctx, enum dc_ownership *own)
 {
 	struct libnvme_ctrl *c;
 	int err;
 
 	err = libnvme_scan_ctrl(ctx, fctx->device, &c);
 	if (err) {
-		/*
-		 * No controller found, fall back to create one.
-		 * But that controller cannot be persistent.
-		 */
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,
-			"ctrl device %s not found%s\n", fctx->device,
-			fctx->persistent == LIBNVMF_PERSISTENT_AUTO ||
-			fctx->persistent == LIBNVMF_PERSISTENT_FORCE ?
-				", ignoring --persistent" : "");
-
-		fctx->persistent = LIBNVMF_PERSISTENT_NO;
-
+			"ctrl device %s not found, falling back to a new connection\n",
+			fctx->device);
 		return NULL;
 	}
 
-	/* Check if device matches command-line options */
-	if (!libnvmf_ctrl_match_config(c, fctx)) {
+	if (!libnvmf_ctrl_match_config(c, fctx))
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,
 			"ctrl device %s found, ignoring non matching command-line options\n",
 			fctx->device);
-	}
 
 	if (!libnvme_ctrl_get_discovery_ctrl(c)) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,
 			"ctrl device %s found, ignoring non discovery controller\n",
 			fctx->device);
-
-		fctx->persistent = LIBNVMF_PERSISTENT_NO;
-
 		libnvme_free_ctrl(c);
 		return NULL;
 	}
 
 	/*
-	 * The controller device was found, so this is an already-existing
-	 * connection: it must not be disconnected on exit. Record that fact
-	 * locally instead of overriding fctx->persistent, which must keep
-	 * reflecting what the user actually asked for.
-	 */
-	*already_connected = true;
-
-	/*
-	 * When --host-traddr/--host-iface are not specified on the
-	 * command line, use the discovery controller's (c) host-
-	 * traddr/host-iface for the connections to controllers
-	 * returned in the Discovery Log Pages. This is essential
-	 * when invoking "connect-all" with --device to reuse an
-	 * existing persistent discovery controller (as is done
-	 * for the udev rules). This ensures that host-traddr/
-	 * host-iface are consistent with the discovery controller (c).
+	 * When --host-traddr/--host-iface are not specified, use the
+	 * reused discovery controller's own so connections to entries
+	 * in its Discovery Log Pages stay consistent with it.
+	 * Essential for "connect-all --device" against a persistent
+	 * DC (e.g. the udev rules).
 	 */
 	if (!fctx->ctrl_params.host_traddr)
 		fctx->ctrl_params.host_traddr =
@@ -3684,50 +3664,56 @@ static struct libnvme_ctrl *discover_lookup_ctrl_by_device(
 		fctx->ctrl_params.host_iface =
 			(char *)libnvme_ctrl_get_host_iface(c);
 
+	*own = DC_BORROWED;
 	return c;
 }
 
-static int discover_lookup_ctrl(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, struct libnvme_host *h,
-		struct libnvme_ctrl **ctrl, bool *already_connected)
+/*
+ * Resolve the primary discovery controller connection: reuse one via
+ * --device if given, reuse one found by matching connection
+ * parameters otherwise, or create a fresh one if --force was given
+ * or neither lookup found anything. Never touches fctx->persistent;
+ * ownership is reported separately so the caller knows what it may
+ * disconnect later.
+ */
+static int dc_open(struct libnvme_global_ctx *ctx,
+		   struct libnvmf_context *fctx,
+		   struct libnvme_host *h,
+		   struct libnvme_ctrl **ctrl,
+		   enum dc_ownership *own)
 {
 	struct libnvme_ctrl *c = NULL;
 	int err;
 
-	if (fctx->device)
-		c = discover_lookup_ctrl_by_device(ctx, fctx,
-						    already_connected);
+	*own = DC_OWNED;
 
-	if (!c) {
-		c = lookup_ctrl(h, fctx);
-		if (c) {
-			/*
-			 * It was not created by us: record that fact
-			 * locally, do not touch fctx->persistent.
-			 */
-			*already_connected = true;
+	if (!fctx->force) {
+		if (fctx->device)
+			c = dc_open_by_device(ctx, fctx, own);
+
+		if (!c) {
+			c = lookup_ctrl(h, fctx);
+			if (c)
+				*own = DC_BORROWED;
+		}
+
+		if (c && !libnvme_ctrl_get_transport_handle(c)) {
+			/* Found existing, but no device handle yet */
+			err = libnvme_open(ctx, c->name, O_RDONLY, &c->hdl);
+			if (err) {
+				libnvme_msg(ctx, LIBNVME_LOG_ERR,
+					"failed to open %s\n", c->name);
+				return err;
+			}
 		}
 	}
 
-	if (!c)
+	if (c) {
+		*ctrl = c;
 		return 0;
-
-	if (!libnvme_ctrl_get_transport_handle(c)) {
-		/*
-		 * When we found an existing controller it might not have a
-		 * device handle yet
-		 */
-		err = libnvme_open(ctx, c->name, O_RDONLY, &c->hdl);
-		if (err) {
-			libnvme_msg(ctx, LIBNVME_LOG_ERR,
-				"failed to open %s\n", c->name);
-
-			return err;
-		}
 	}
 
-	*ctrl = c;
-	return 0;
+	return nvmf_create_discovery_ctrl(ctx, fctx, h, ctrl);
 }
 
 __shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
@@ -3735,7 +3721,7 @@ __shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
 {
 	struct libnvme_ctrl *c = NULL;
 	struct libnvme_host *h;
-	bool already_connected = false;
+	enum dc_ownership own;
 	int err;
 
 	err = libnvme_get_host(ctx, fctx->hostnqn, fctx->hostid, &h);
@@ -3746,37 +3732,16 @@ __shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
 	if (err)
 		return err;
 
-	if (!fctx->force) {
-		/*
-		 * When --force is used, always create a controller, otherwise
-		 * try to lookup an already existing controller first.
-		 */
-		err = discover_lookup_ctrl(ctx, fctx, h, &c,
-					   &already_connected);
-		if (err) {
+	err = dc_open(ctx, fctx, h, &c, &own);
+	if (err) {
+		if (err != -ENVME_CONNECT_IGNORED)
 			libnvme_msg(ctx, LIBNVME_LOG_ERR,
-				 "failed to lookup controller, error %s\n",
+				 "failed to add controller, error %s\n",
 				 libnvme_strerror(-err));
-			return err;
-		}
+		return err;
 	}
 
-	if (!c) {
-		/*
-		 * No existing controller or --force has been used, thus create
-		 * a new controller.
-		 */
-		err = nvmf_create_discovery_ctrl(ctx, fctx, h, &c);
-		if (err) {
-			if (err != -ENVME_CONNECT_IGNORED)
-				libnvme_msg(ctx, LIBNVME_LOG_ERR,
-					 "failed to add controller, error %s\n",
-					 libnvme_strerror(-err));
-			return err;
-		}
-	}
-
-	err = _nvmf_discover(ctx, fctx, c, true, already_connected);
+	err = _nvmf_discover(ctx, fctx, c, true, own == DC_BORROWED);
 	libnvme_free_ctrl(c);
 
 	return err;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3126,7 +3126,8 @@ retry:
 	err = libnvmf_add_ctrl(h, c);
 	if (!err)
 		return 0;
-	if (fctx->hooks.decide_retry(fctx, err, fctx->hooks.user_data))
+	if (fctx->hooks.decide_retry &&
+	    fctx->hooks.decide_retry(fctx, err, fctx->hooks.user_data))
 		goto retry;
 
 	return err;
@@ -3947,11 +3948,13 @@ __shr_public int libnvmf_connect(
 		write_devid_file(fctx, devid_fd, c);
 		if (instance >= 0)
 			registry_update_on_connect(ctx, instance);
-		fctx->hooks.already_connected(fctx, h,
-			libnvme_ctrl_get_subsysnqn(c),
-			libnvme_ctrl_get_transport(c),
-			libnvme_ctrl_get_traddr(c),
-			libnvme_ctrl_get_trsvcid(c), fctx->hooks.user_data);
+		if (fctx->hooks.already_connected)
+			fctx->hooks.already_connected(fctx, h,
+				libnvme_ctrl_get_subsysnqn(c),
+				libnvme_ctrl_get_transport(c),
+				libnvme_ctrl_get_traddr(c),
+				libnvme_ctrl_get_trsvcid(c),
+				fctx->hooks.user_data);
 		return -EALREADY;
 	}
 
@@ -4003,7 +4006,8 @@ __shr_public int libnvmf_connect(
 	}
 
 	write_devid_file(fctx, devid_fd, c);
-	fctx->hooks.connected(fctx, c, fctx->hooks.user_data);
+	if (fctx->hooks.connected)
+		fctx->hooks.connected(fctx, c, fctx->hooks.user_data);
 
 	return 0;
 }

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2987,12 +2987,16 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 				continue;
 			}
 
-			if (fctx->hooks.connect_leaf)
+			if (fctx->hooks.connect_leaf) {
 				cerr = fctx->hooks.connect_leaf(h, e, &nfctx,
 						fctx, &cd.c);
-			else
+			} else {
 				cerr = nvmf_connect_disc_entry(h, e, &nfctx,
 						NULL, &cd.c);
+				if (cd.c && fctx->hooks.connected)
+					fctx->hooks.connected(fctx, cd.c,
+						fctx->hooks.user_data);
+			}
 
 			if (cerr == -ENVME_CONNECT_ALREADY) {
 				dc_already_connected(fctx, h, e);
@@ -3042,6 +3046,9 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 						libnvme_strerror(-cerr));
 				continue;
 			}
+			if (fctx->hooks.connected)
+				fctx->hooks.connected(fctx, cd.c,
+					fctx->hooks.user_data);
 			child_own = DC_OWNED;
 		}
 		cd.connect = true;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2830,6 +2830,13 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 		}
 		d.connect = true;
 
+		/*
+		 * Only discovery controllers need their KATO set here.
+		 * NVM subsystems (I/O controllers) get theirs set elsewhere.
+		 */
+		if (e->subtype != NVME_NQN_NVME)
+			set_discovery_kato(&nfctx);
+
 		err = nvmf_connect_disc_entry(h, e, &nfctx, &discover, &d.c);
 		if (err && err != -ENVME_CONNECT_ALREADY)
 			dc_log_decision(fctx, e, &d, libnvme_strerror(-err));
@@ -2837,20 +2844,27 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 			dc_log_decision(fctx, e, &d, NULL);
 
 		if (d.c) {
-			if (discover) {
-				set_discovery_kato(&nfctx);
-				_nvmf_discover(ctx, &nfctx, d.c, false,
-					       false);
-			}
+			/*
+			 * fctx, not nfctx: nfctx is a per-entry clone that
+			 * dies with this iteration. Recursing with it would
+			 * hand every deeper level a stack alias of fctx's
+			 * owned pointers (hostnqn, hostid, tls_key,
+			 * nbft_path) instead of the real, single owner.
+			 */
+			if (discover)
+				_nvmf_discover(ctx, fctx, d.c, false, false);
 
 			if (d.disconnect) {
 				libnvmf_disconnect_ctrl(d.c);
 				libnvme_free_ctrl(d.c);
 			}
 		} else if (err == -ENVME_CONNECT_ALREADY) {
-			nfctx.hooks.already_connected(&nfctx, h, e->subnqn,
-				libnvmf_trtype_str(e->trtype), e->traddr,
-				e->trsvcid, nfctx.hooks.user_data);
+			if (fctx->hooks.already_connected)
+				fctx->hooks.already_connected(fctx, h,
+					e->subnqn,
+					libnvmf_trtype_str(e->trtype),
+					e->traddr, e->trsvcid,
+					fctx->hooks.user_data);
 		}
 	}
 
@@ -3109,8 +3123,8 @@ static bool validate_uri(struct libnvme_global_ctx *ctx,
 }
 
 static int nbft_connect(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, struct libnvme_host *h,
-		struct nvmf_disc_log_entry *e,
+		struct libnvmf_context *fctx, struct libnvmf_context *hook_fctx,
+		struct libnvme_host *h, struct nvmf_disc_log_entry *e,
 		struct libnbft_subsystem_ns *ss)
 {
 	libnvme_ctrl_t c;
@@ -3170,15 +3184,17 @@ static int nbft_connect(struct libnvme_global_ctx *ctx,
 		return ret;
 	}
 
-	if (fctx->hooks.connected)
-		fctx->hooks.connected(fctx, c, fctx->hooks.user_data);
+	if (hook_fctx->hooks.connected)
+		hook_fctx->hooks.connected(hook_fctx, c,
+			hook_fctx->hooks.user_data);
 
 	return 0;
 }
 
 static int nbft_discovery(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, struct libnbft_discovery *dd,
-		struct libnvme_host *h, struct libnvme_ctrl *c)
+		struct libnvmf_context *fctx, struct libnvmf_context *hook_fctx,
+		struct libnbft_discovery *dd, struct libnvme_host *h,
+		struct libnvme_ctrl *c)
 {
 	struct nvmf_discovery_log *log = NULL;
 	int ret;
@@ -3201,7 +3217,6 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 		struct nvmf_disc_log_entry *e = &log->entries[i];
 		struct libnvmf_context nfctx = *fctx;
 		libnvme_ctrl_t cl;
-		int tmo = fctx->ctrl_params.cfg.keep_alive_tmo;
 
 		sanitize_discovery_log_entry(c->ctx, e);
 
@@ -3230,11 +3245,12 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 				NULL, &child);
 			if (ret)
 				continue;
-			nbft_discovery(ctx, &nfctx, dd, h, child);
+			/* fctx: subtree baseline. hook_fctx: for hooks */
+			nbft_discovery(ctx, fctx, hook_fctx, dd, h, child);
 			libnvmf_disconnect_ctrl(child);
 			libnvme_free_ctrl(child);
 		} else {
-			ret = nbft_connect(ctx, &nfctx, h, e, NULL);
+			ret = nbft_connect(ctx, &nfctx, hook_fctx, h, e, NULL);
 
 			/*
 			 * With TCP/DHCP, it can happen that the OS
@@ -3248,7 +3264,8 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 					nfctx.ctrl_params.host_traddr;
 
 				nfctx.ctrl_params.host_traddr = NULL;
-				ret = nbft_connect(ctx, &nfctx, h, e, NULL);
+				ret = nbft_connect(ctx, &nfctx, hook_fctx, h,
+						    e, NULL);
 
 				if (ret == 0)
 					libnvme_msg(ctx, LIBNVME_LOG_INFO,
@@ -3264,8 +3281,6 @@ static int nbft_discovery(struct libnvme_global_ctx *ctx,
 			if (ret == -ENOMEM)
 				break;
 		}
-
-		fctx->ctrl_params.cfg.keep_alive_tmo = tmo;
 	}
 
 	libnvme_free(log);
@@ -3446,7 +3461,8 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 						"SSNS %d: could not find host interface for HFI %d\n",
 						(*ss)->index, hfi->index);
 
-				rr = nbft_connect(ctx, &nfctx, h, NULL, *ss);
+				rr = nbft_connect(ctx, &nfctx, fctx, h, NULL,
+						   *ss);
 
 				/*
 				 * With TCP/DHCP, it can happen that the OS
@@ -3459,8 +3475,8 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 				    strlen(hfi->tcp_info.dhcp_server_ipaddr) > 0) {
 					nfctx.ctrl_params.host_traddr = NULL;
 
-					rr = nbft_connect(ctx, &nfctx, h, NULL,
-						*ss);
+					rr = nbft_connect(ctx, &nfctx, fctx, h,
+						NULL, *ss);
 
 					if (rr == 0)
 						libnvme_msg(ctx, LIBNVME_LOG_INFO,
@@ -3586,7 +3602,7 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 				goto out_free;
 			}
 
-			rr = nbft_discovery(ctx, &nfctx, *dd, h, c);
+			rr = nbft_discovery(ctx, &nfctx, fctx, *dd, h, c);
 			if (!persistent)
 				libnvmf_disconnect_ctrl(c);
 			libnvme_free_ctrl(c);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3727,7 +3727,8 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 					strdup(libnvmf_get_default_trsvcid(
 						uri->protocol, true));
 
-			fctx->ctrl_params.subsysnqn = NVME_DISC_SUBSYS_NAME;
+			fctx->ctrl_params.subsysnqn =
+				(*dd)->nqn ? (*dd)->nqn : NVME_DISC_SUBSYS_NAME;
 			fctx->ctrl_params.transport = uri->protocol;
 			fctx->ctrl_params.traddr = uri->host;
 			fctx->ctrl_params.trsvcid = trsvcid;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1858,12 +1858,12 @@ static int nvmf_connect_disc_entry(libnvme_host_t h,
 		return ret;
 	}
 
+	/*
+	 * NVME_NQN_CURR (self entries) never reach here -- _nvmf_discover()
+	 * filters them out before calling this function, since they
+	 * describe c itself rather than something to connect to.
+	 */
 	switch (e->subtype) {
-	case NVME_NQN_CURR:
-		libnvme_ctrl_set_discovered(c, true);
-		libnvme_ctrl_set_unique_discovery_ctrl(c,
-				strcmp(e->subnqn, NVME_DISC_SUBSYS_NAME));
-		break;
 	case NVME_NQN_DISC:
 		if (discover)
 			*discover = true;
@@ -1879,11 +1879,6 @@ static int nvmf_connect_disc_entry(libnvme_host_t h,
 		libnvme_ctrl_set_discovery_ctrl(c, false);
 		libnvme_ctrl_set_unique_discovery_ctrl(c, false);
 		break;
-	}
-
-	if (libnvme_ctrl_get_discovered(c)) {
-		libnvme_free_ctrl(c);
-		return -EAGAIN;
 	}
 
 	if (e->treq & NVMF_TREQ_DISABLE_SQFLOW &&
@@ -2686,6 +2681,12 @@ static bool dc_should_disconnect(struct libnvmf_context *fctx,
 	return disconnect;
 }
 
+/*
+ * DUPRETINFO isn't checked here: the spec defines it as always 0 for
+ * anything other than a SUBTYPE 03h (current discovery subsystem)
+ * entry, and self entries never reach this function -- the caller
+ * filters them out before calling dc_should_connect().
+ */
 static bool dc_should_connect(struct libnvmf_context *fctx,
 		struct nvmf_disc_log_entry *e, bool *pdisconnect)
 {
@@ -2697,11 +2698,6 @@ static bool dc_should_connect(struct libnvmf_context *fctx,
 	}
 
 	eflags = le16_to_cpu(e->eflags);
-
-	/* Discovery controller returns duplicate information. */
-	if (eflags & NVMF_DISC_EFLAGS_DUPRETINFO)
-		return false;
-
 	*pdisconnect = dc_should_disconnect(fctx, e->subnqn, eflags);
 	return true;
 }
@@ -2787,19 +2783,14 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 
 		sanitize_discovery_log_entry(c->ctx, e);
 
-		nfctx.ctrl_params.subsysnqn = e->subnqn;
-		nfctx.ctrl_params.transport = libnvmf_trtype_str(e->trtype);
-		nfctx.ctrl_params.traddr = e->traddr;
-		nfctx.ctrl_params.trsvcid = e->trsvcid;
-
-		/* Already connected ? */
-		cl = lookup_ctrl(h, &nfctx);
-		if (cl == c) {
+		if (e->subtype == NVME_NQN_CURR) {
 			/*
-			 * This entry describes c's own port (SUBTYPE 03h,
-			 * "current discovery subsystem"). It is the only
-			 * place c's own EPCSD is ever reported, so remember
-			 * it instead of silently discarding it below.
+			 * This entry describes c's own port. It is the
+			 * only place c's own EPCSD is ever reported, so
+			 * remember it instead of silently discarding it.
+			 * Take the first one seen; every copy describes
+			 * the same DC, regardless of which port it came
+			 * back on.
 			 */
 			if (!self_entry)
 				self_entry = e;
@@ -2809,6 +2800,14 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 				"self entry, decision deferred to primary");
 			continue;
 		}
+
+		nfctx.ctrl_params.subsysnqn = e->subnqn;
+		nfctx.ctrl_params.transport = libnvmf_trtype_str(e->trtype);
+		nfctx.ctrl_params.traddr = e->traddr;
+		nfctx.ctrl_params.trsvcid = e->trsvcid;
+
+		/* Already connected ? */
+		cl = lookup_ctrl(h, &nfctx);
 		if (cl && libnvme_ctrl_get_name(cl)) {
 			d.c = cl;
 			d.already_connected = true;

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -2515,6 +2515,19 @@ static libnvme_ctrl_t lookup_ctrl(libnvme_host_t h, struct libnvmf_context *fctx
 	return NULL;
 }
 
+/*
+ * Same as lookup_ctrl(), but only returns a controller that's actually
+ * connected. lookup_ctrl() can also match a scanned-but-unconnected
+ * draft, which has no kernel-assigned name yet.
+ */
+static libnvme_ctrl_t lookup_live_ctrl(libnvme_host_t h,
+		struct libnvmf_context *fctx)
+{
+	libnvme_ctrl_t c = lookup_ctrl(h, fctx);
+
+	return (c && libnvme_ctrl_get_name(c)) ? c : NULL;
+}
+
 __shr_public int libnvmf_get_owner_from_tid(struct libnvme_global_ctx *ctx,
 		const struct libnvmf_tid *tid, char **owner)
 {
@@ -2974,13 +2987,18 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 				continue;
 			}
 
-			cerr = nvmf_connect_disc_entry(h, e, &nfctx, NULL,
-					&cd.c);
-			if (cd.c) {
+			if (fctx->hooks.connect_leaf)
+				cerr = fctx->hooks.connect_leaf(h, e, &nfctx,
+						fctx, &cd.c);
+			else
+				cerr = nvmf_connect_disc_entry(h, e, &nfctx,
+						NULL, &cd.c);
+
+			if (cerr == -ENVME_CONNECT_ALREADY) {
+				dc_already_connected(fctx, h, e);
+			} else if (cd.c) {
 				cd.connect = true;
 				dc_log_decision(fctx, e, &cd, NULL);
-			} else if (cerr == -ENVME_CONNECT_ALREADY) {
-				dc_already_connected(fctx, h, e);
 			} else {
 				dc_log_decision(fctx, e, &cd,
 					libnvme_strerror(-cerr));
@@ -3008,8 +3026,8 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 			continue;
 		}
 
-		cl = lookup_ctrl(h, &nfctx);
-		if (cl && libnvme_ctrl_get_name(cl)) {
+		cl = lookup_live_ctrl(h, &nfctx);
+		if (cl) {
 			cd.c = cl;
 			child_own = DC_BORROWED;
 		} else {
@@ -3294,7 +3312,7 @@ static bool validate_uri(struct libnvme_global_ctx *ctx,
 static int nbft_connect(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, struct libnvmf_context *hook_fctx,
 		struct libnvme_host *h, struct nvmf_disc_log_entry *e,
-		struct libnbft_subsystem_ns *ss)
+		struct libnbft_subsystem_ns *ss, libnvme_ctrl_t *cp)
 {
 	libnvme_ctrl_t c;
 	int saved_log_level;
@@ -3305,8 +3323,7 @@ static int nbft_connect(struct libnvme_global_ctx *ctx,
 	saved_log_level = libnvme_get_logging_level(ctx, &saved_log_pid,
 		&saved_log_tstamp);
 
-	c = lookup_ctrl(h, fctx);
-	if (c && libnvme_ctrl_get_name(c))
+	if (lookup_live_ctrl(h, fctx))
 		return 0;
 
 	if (nvmf_excluded(ctx, fctx->ctrl_params.transport,
@@ -3357,103 +3374,69 @@ static int nbft_connect(struct libnvme_global_ctx *ctx,
 		hook_fctx->hooks.connected(hook_fctx, c,
 			hook_fctx->hooks.user_data);
 
+	if (cp)
+		*cp = c;
+
 	return 0;
 }
 
-static int nbft_discovery(struct libnvme_global_ctx *ctx,
-		struct libnvmf_context *fctx, struct libnvmf_context *hook_fctx,
-		struct libnbft_discovery *dd, struct libnvme_host *h,
-		struct libnvme_ctrl *c)
+/*
+ * connect_leaf hook for the NBFT-driven walk: nbft_connect() plus the
+ * checks _nvmf_discover()'s general leaf-connect path gets for free from
+ * distinguishable lookup_ctrl()/nvmf_excluded() outcomes. nbft_connect()
+ * has its own copies of both checks internally, but folds every
+ * "nothing to do" outcome into a plain 0 -- fine for its other caller
+ * (the SSNS list below), but not enough to fit dc_log_decision()'s
+ * connected/already-connected/reason contract. Re-checking here, before
+ * calling nbft_connect(), keeps nbft_connect() itself untouched for that
+ * other caller.
+ */
+static int nbft_connect_leaf(struct libnvme_host *h,
+			     struct nvmf_disc_log_entry *e,
+			     struct libnvmf_context *nfctx,
+			     struct libnvmf_context *fctx,
+			     libnvme_ctrl_t *cp)
 {
-	struct nvmf_discovery_log *log = NULL;
+	libnvme_ctrl_t c;
 	int ret;
-	int i;
 
-	struct libnvmf_discovery_args args = {
-		.max_retries = 10 /* MAX_DISC_RETRIES */,
-		.lsp = NVMF_LOG_DISC_LSP_NONE,
-	};
+	*cp = NULL;
 
-	ret = nvme_discovery_log(c, &args, &log);
-	if (ret) {
-		libnvme_msg(ctx, LIBNVME_LOG_ERR,
-			"Discovery Descriptor %d: failed to get discovery log: %s\n",
-			dd->index, libnvme_strerror(-ret));
-		return ret;
+	c = lookup_live_ctrl(h, nfctx);
+	if (c) {
+		*cp = c;
+		return -ENVME_CONNECT_ALREADY;
 	}
 
-	for (i = 0; i < le64_to_cpu(log->numrec); i++) {
-		struct nvmf_disc_log_entry *e = &log->entries[i];
-		struct libnvmf_context nfctx = *fctx;
-		libnvme_ctrl_t cl;
+	if (nvmf_excluded(fctx->ctx, nfctx->ctrl_params.transport,
+			  nfctx->ctrl_params.traddr,
+			  nfctx->ctrl_params.trsvcid,
+			  nfctx->ctrl_params.subsysnqn,
+			  nfctx->ctrl_params.host_traddr,
+			  nfctx->ctrl_params.host_iface,
+			  libnvme_host_get_hostnqn(h),
+			  libnvme_host_get_hostid(h)))
+		return -EPERM;
 
-		sanitize_discovery_log_entry(c->ctx, e);
+	ret = nbft_connect(fctx->ctx, nfctx, fctx, h, e, NULL, &c);
 
-		nfctx.ctrl_params.subsysnqn = e->subnqn;
-		nfctx.ctrl_params.transport = libnvmf_trtype_str(e->trtype);
-		nfctx.ctrl_params.traddr = e->traddr;
-		nfctx.ctrl_params.trsvcid = e->trsvcid;
-
-		if (e->subtype == NVME_NQN_CURR)
-			continue;
-
-		/* Already connected ? */
-		cl = lookup_ctrl(h, &nfctx);
-		if (cl && libnvme_ctrl_get_name(cl))
-			continue;
-
-		/* Skip connect if the transport types don't match */
-		if (strcmp(libnvme_ctrl_get_transport(c),
-			   nfctx.ctrl_params.transport))
-			continue;
-
-		if (e->subtype == NVME_NQN_DISC) {
-			libnvme_ctrl_t child;
-
-			ret = nvmf_connect_disc_entry(h, e, &nfctx,
-				NULL, &child);
-			if (ret)
-				continue;
-			/* fctx: subtree baseline. hook_fctx: for hooks */
-			nbft_discovery(ctx, fctx, hook_fctx, dd, h, child);
-			libnvmf_disconnect_ctrl(child);
-			libnvme_free_ctrl(child);
-		} else {
-			ret = nbft_connect(ctx, &nfctx, hook_fctx, h, e, NULL);
-
-			/*
-			 * With TCP/DHCP, it can happen that the OS
-			 * obtains a different local IP address than the
-			 * firmware had. Retry without host_traddr.
-			 */
-			if (ret == -ENVME_CONNECT_ADDRNOTAVAIL &&
-			    !strcmp(nfctx.ctrl_params.transport, "tcp") &&
-			    strlen(dd->hfi->tcp_info.dhcp_server_ipaddr) > 0) {
-				const char *htradr =
-					nfctx.ctrl_params.host_traddr;
-
-				nfctx.ctrl_params.host_traddr = NULL;
-				ret = nbft_connect(ctx, &nfctx, hook_fctx, h,
-						    e, NULL);
-
-				if (ret == 0)
-					libnvme_msg(ctx, LIBNVME_LOG_INFO,
-						"Discovery Descriptor %d: connect with host_traddr=\"%s\" failed, success after omitting host_traddr\n",
-						dd->index,
-						htradr);
-			}
-
-			if (ret)
-				libnvme_msg(ctx, LIBNVME_LOG_ERR,
-					"Discovery Descriptor %d: no controller found\n",
-					dd->index);
-			if (ret == -ENOMEM)
-				break;
-		}
+	/*
+	 * With TCP/DHCP, the OS's own DHCP client can obtain a different
+	 * local address for this HFI than the firmware had. Retry once
+	 * without host_traddr.
+	 */
+	if (ret == -ENVME_CONNECT_ADDRNOTAVAIL &&
+	    !strcmp(nfctx->ctrl_params.transport, "tcp") &&
+	    fctx->nbft_hfi &&
+	    strlen(fctx->nbft_hfi->tcp_info.dhcp_server_ipaddr) > 0) {
+		nfctx->ctrl_params.host_traddr = NULL;
+		ret = nbft_connect(fctx->ctx, nfctx, fctx, h, e, NULL, &c);
 	}
 
-	libnvme_free(log);
-	return 0;
+	if (!ret)
+		*cp = c;
+
+	return ret;
 }
 
 #define VLAN_PROC_PATH "/proc/net/vlan"
@@ -3525,6 +3508,13 @@ static char *nbft_find_hfi_iface(struct libnbft_hfi *hfi)
 	freeifaddrs(ifaddr);
 	return result;
 }
+
+static int dc_open(struct libnvme_global_ctx *ctx,
+		   struct libnvmf_context *fctx,
+		   struct libnvme_host *h,
+		   struct libnvme_ctrl **ctrl,
+		   enum dc_ownership *own,
+		   bool honor_no_reuse);
 
 __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx)
@@ -3631,7 +3621,7 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 						(*ss)->index, hfi->index);
 
 				rr = nbft_connect(ctx, &nfctx, fctx, h, NULL,
-						   *ss);
+						   *ss, NULL);
 
 				/*
 				 * With TCP/DHCP, it can happen that the OS
@@ -3645,7 +3635,7 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 					nfctx.ctrl_params.host_traddr = NULL;
 
 					rr = nbft_connect(ctx, &nfctx, fctx, h,
-						NULL, *ss);
+						NULL, *ss, NULL);
 
 					if (rr == 0)
 						libnvme_msg(ctx, LIBNVME_LOG_INFO,
@@ -3673,8 +3663,7 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 		for (dd = entry->nbft->discovery_list; dd && *dd; dd++) {
 			__cleanup_uri struct libnvmf_uri *uri = NULL;
 			__cleanup_free char *trsvcid = NULL;
-			struct libnvmf_context nfctx = *fctx;
-			bool persistent = false;
+			enum dc_ownership own;
 			bool linked = false;
 			libnvme_ctrl_t c;
 
@@ -3731,50 +3720,43 @@ __shr_public int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
 					strdup(libnvmf_get_default_trsvcid(
 						uri->protocol, true));
 
-			nfctx.ctrl_params.subsysnqn = NVME_DISC_SUBSYS_NAME;
-			nfctx.ctrl_params.transport =  uri->protocol;
-			nfctx.ctrl_params.traddr = uri->host;
-			nfctx.ctrl_params.trsvcid = trsvcid;
-			nfctx.ctrl_params.host_traddr = host_traddr;
-			nfctx.ctrl_params.host_iface = nbft_find_hfi_iface(hfi);
-			if (!nfctx.ctrl_params.host_iface)
+			fctx->ctrl_params.subsysnqn = NVME_DISC_SUBSYS_NAME;
+			fctx->ctrl_params.transport = uri->protocol;
+			fctx->ctrl_params.traddr = uri->host;
+			fctx->ctrl_params.trsvcid = trsvcid;
+			fctx->ctrl_params.host_traddr = host_traddr;
+			fctx->ctrl_params.host_iface = nbft_find_hfi_iface(hfi);
+			if (!fctx->ctrl_params.host_iface)
 				libnvme_msg(ctx, LIBNVME_LOG_INFO,
 					"Discovery Descriptor %d: could not find host interface for HFI %d\n",
 					(*dd)->index, hfi->index);
+			fctx->nbft_hfi = hfi;
+			fctx->hooks.connect_leaf = nbft_connect_leaf;
+			/*
+			 * NBFT boot discovery is a one-shot operation: never
+			 * honor --no-reuse (dc_open()'s honor_no_reuse=false
+			 * below) and never keep a freshly created connection
+			 * alive past this walk (--persistent has no meaning
+			 * here either).
+			 */
+			fctx->persistent = LIBNVMF_PERSISTENT_NO;
 
-			/* Lookup existing discovery controller */
-			c = lookup_ctrl(h, &nfctx);
-			if (c && libnvme_ctrl_get_name(c))
-				persistent = true;
-
-			if (!c) {
-				ret = nvmf_create_discovery_ctrl(ctx, &nfctx,
-					h, &c);
-				if (ret == -ENVME_CONNECT_ADDRNOTAVAIL &&
-				    !strcmp(nfctx.ctrl_params.transport,
-					    "tcp") &&
-				    strlen(hfi->tcp_info.dhcp_server_ipaddr) > 0) {
-					nfctx.ctrl_params.traddr = NULL;
-					ret = nvmf_create_discovery_ctrl(ctx,
-						&nfctx, h, &c);
-				}
-			} else
-				ret = 0;
-
-			if (nfctx.ctrl_params.host_iface)
-				free((char *)nfctx.ctrl_params.host_iface);
+			ret = dc_open(ctx, fctx, h, &c, &own, false);
 
 			if (ret) {
+				free((char *)fctx->ctrl_params.host_iface);
+				fctx->ctrl_params.host_iface = NULL;
 				libnvme_msg(ctx, LIBNVME_LOG_ERR,
 					"Discovery Descriptor %d: failed to add discovery controller: %s\n",
 					(*dd)->index, libnvme_strerror(-ret));
 				goto out_free;
 			}
 
-			rr = nbft_discovery(ctx, &nfctx, fctx, *dd, h, c);
-			if (!persistent)
-				libnvmf_disconnect_ctrl(c);
+			rr = dc_walk(ctx, fctx, c, own);
 			libnvme_free_ctrl(c);
+			free((char *)fctx->ctrl_params.host_iface);
+			fctx->ctrl_params.host_iface = NULL;
+
 			if (rr == -ENOMEM) {
 				ret = rr;
 				goto out_free;
@@ -3844,14 +3826,16 @@ static int dc_open(struct libnvme_global_ctx *ctx,
 		   struct libnvmf_context *fctx,
 		   struct libnvme_host *h,
 		   struct libnvme_ctrl **ctrl,
-		   enum dc_ownership *own)
+		   enum dc_ownership *own,
+		   bool honor_no_reuse)
 {
 	struct libnvme_ctrl *c = NULL;
+	bool try_reuse = !honor_no_reuse || !fctx->no_reuse;
 	int err;
 
 	*own = DC_OWNED;
 
-	if (!fctx->no_reuse) {
+	if (try_reuse) {
 		if (fctx->device)
 			c = dc_open_by_device(ctx, fctx, own);
 
@@ -3877,7 +3861,21 @@ static int dc_open(struct libnvme_global_ctx *ctx,
 		return 0;
 	}
 
-	return nvmf_create_discovery_ctrl(ctx, fctx, h, ctrl);
+	err = nvmf_create_discovery_ctrl(ctx, fctx, h, ctrl);
+
+	/*
+	 * NBFT only: the OS's own DHCP client can obtain a different local
+	 * address for this HFI than the firmware had when it built the
+	 * NBFT table. Retry once without host_traddr.
+	 */
+	if (err == -ENVME_CONNECT_ADDRNOTAVAIL && fctx->nbft_hfi &&
+	    !strcmp(fctx->ctrl_params.transport, "tcp") &&
+	    strlen(fctx->nbft_hfi->tcp_info.dhcp_server_ipaddr) > 0) {
+		fctx->ctrl_params.host_traddr = NULL;
+		err = nvmf_create_discovery_ctrl(ctx, fctx, h, ctrl);
+	}
+
+	return err;
 }
 
 __shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
@@ -3896,7 +3894,7 @@ __shr_public int libnvmf_discover(struct libnvme_global_ctx *ctx,
 	if (err)
 		return err;
 
-	err = dc_open(ctx, fctx, h, &c, &own);
+	err = dc_open(ctx, fctx, h, &c, &own, true);
 	if (err) {
 		if (err != -ENVME_CONNECT_IGNORED)
 			libnvme_msg(ctx, LIBNVME_LOG_ERR,
@@ -3934,9 +3932,8 @@ __shr_public int libnvmf_connect(
 	if (err)
 		return err;
 
-	c = lookup_ctrl(h, fctx);
-	if (c && libnvme_ctrl_get_name(c) &&
-	    !fctx->ctrl_params.cfg.duplicate_connect) {
+	c = lookup_live_ctrl(h, fctx);
+	if (c && !fctx->ctrl_params.cfg.duplicate_connect) {
 		int instance = ctrl_instance(c);
 
 		write_devid_file(fctx, devid_fd, c);

--- a/libnvme/src/nvme/generated/accessors-fabrics.c
+++ b/libnvme/src/nvme/generated/accessors-fabrics.c
@@ -343,16 +343,16 @@ __shr_public bool libnvmf_context_get_connect(const struct libnvmf_context *p)
 	return p->connect;
 }
 
-__shr_public void libnvmf_context_set_force(
+__shr_public void libnvmf_context_set_no_reuse(
 		struct libnvmf_context *p,
-		bool force)
+		bool no_reuse)
 {
-	p->force = force;
+	p->no_reuse = no_reuse;
 }
 
-__shr_public bool libnvmf_context_get_force(const struct libnvmf_context *p)
+__shr_public bool libnvmf_context_get_no_reuse(const struct libnvmf_context *p)
 {
-	return p->force;
+	return p->no_reuse;
 }
 
 __shr_public void libnvmf_context_set_nbft_path(

--- a/libnvme/src/nvme/generated/accessors-fabrics.h
+++ b/libnvme/src/nvme/generated/accessors-fabrics.h
@@ -446,19 +446,19 @@ void libnvmf_context_set_connect(struct libnvmf_context *p, bool connect);
 bool libnvmf_context_get_connect(const struct libnvmf_context *p);
 
 /**
- * libnvmf_context_set_force() - Set force.
+ * libnvmf_context_set_no_reuse() - Set no_reuse.
  * @p: The &struct libnvmf_context instance to update.
- * @force: Value to assign to the force field.
+ * @no_reuse: Value to assign to the no_reuse field.
  */
-void libnvmf_context_set_force(struct libnvmf_context *p, bool force);
+void libnvmf_context_set_no_reuse(struct libnvmf_context *p, bool no_reuse);
 
 /**
- * libnvmf_context_get_force() - Get force.
+ * libnvmf_context_get_no_reuse() - Get no_reuse.
  * @p: The &struct libnvmf_context instance to query.
  *
- * Return: The value of the force field.
+ * Return: The value of the no_reuse field.
  */
-bool libnvmf_context_get_force(const struct libnvmf_context *p);
+bool libnvmf_context_get_no_reuse(const struct libnvmf_context *p);
 
 /**
  * libnvmf_context_set_nbft_path() - Set nbft_path.

--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -567,8 +567,14 @@ static int read_discovery(struct libnvme_global_ctx *ctx,
 			1, &discovery->uri))
 		goto error;
 
-	if (get_heap_obj(ctx, raw_discovery, discovery_ctrl_nqn_obj,
-			1, &discovery->nqn))
+	/*
+	 * DCNQNHOR is optional: "if cleared to 0h ... the OS shall use the
+	 * well known discovery NQN" (NVMe Boot Specification). -ENOENT here
+	 * just means it's absent, not that the descriptor is malformed.
+	 */
+	r = get_heap_obj(ctx, raw_discovery, discovery_ctrl_nqn_obj,
+			1, &discovery->nqn);
+	if (r && r != -ENOENT)
 		goto error;
 
 	discovery->hfi = hfi_from_index(nbft, raw_discovery->hfi_index);

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -54,6 +54,18 @@ struct libnvmf_hooks {
 			struct nvmf_discovery_log *log,
 			uint64_t numrec, void *user_data);
 
+	/*
+	 * NBFT-only: internal seam between the shared discovery walker and
+	 * NBFT's leaf-connect quirks (DHCP retry, firing hooks.connected).
+	 * Set only by libnvmf_discover_nbft() itself; never exposed to a
+	 * public setter.
+	 */
+	int (*connect_leaf)(struct libnvme_host *h,
+			struct nvmf_disc_log_entry *e,
+			struct libnvmf_context *nfctx,
+			struct libnvmf_context *fctx,
+			libnvme_ctrl_t *cp);
+
 	void *user_data;
 };
 
@@ -77,6 +89,7 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 	bool connect;			// !access
 	bool no_reuse;			// !access
 	char *nbft_path;		// !access
+	const struct libnbft_hfi *nbft_hfi;  // !access:read=none,write=none
 
 	/* host configuration */
 	char *hostnqn;			// !access:write=custom

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -75,7 +75,7 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
 
 	/* discovery invocation options */
 	bool connect;			// !access
-	bool force;			// !access
+	bool no_reuse;			// !access
 	char *nbft_path;		// !access
 
 	/* host configuration */

--- a/libnvme/tests/test-fabrics.c
+++ b/libnvme/tests/test-fabrics.c
@@ -641,6 +641,76 @@ static bool test_unescape_uri(void)
 }
 
 /* -------------------------------------------------------------------------
+ * dc_decide — decide whether to disconnect a DC after walking its DLP
+ * -------------------------------------------------------------------------
+ */
+static bool test_dc_decide(struct libnvme_global_ctx *ctx)
+{
+	struct libnvmf_context fctx = { .ctx = ctx };
+	const char *subnqn = "nqn.2014-08.org.nvmexpress.discovery";
+	__u16 parent_eflags;
+	bool pass = true, p;
+
+	printf("\ntest_dc_decide:\n");
+
+	/* A borrowed DC is never ours to disconnect, whatever else is true. */
+	fctx.persistent = LIBNVMF_PERSISTENT_NO;
+	p = !dc_decide(&fctx, subnqn, DC_BORROWED, true, 0, NULL);
+	CHECK(p, "borrowed, self_seen, EPCSD=0, persistent=no -> keep");
+	pass &= p;
+
+	fctx.persistent = LIBNVMF_PERSISTENT_FORCE;
+	p = !dc_decide(&fctx, subnqn, DC_BORROWED, false, 0, NULL);
+	CHECK(p, "borrowed, no self entry, persistent=force -> keep");
+	pass &= p;
+
+	/* Owned, self entry seen: decide from the self entry's own EPCSD. */
+	fctx.persistent = LIBNVMF_PERSISTENT_AUTO;
+	p = !dc_decide(&fctx, subnqn, DC_OWNED, true,
+			NVMF_DISC_EFLAGS_EPCSD, NULL);
+	CHECK(p, "owned, self EPCSD=1, persistent=auto -> keep");
+	pass &= p;
+
+	p = dc_decide(&fctx, subnqn, DC_OWNED, true, 0, NULL);
+	CHECK(p, "owned, self EPCSD=0, persistent=auto -> disconnect");
+	pass &= p;
+
+	/* Owned, no self entry: a referral falls back to its parent's
+	 * cached view of its own eflags.
+	 */
+	parent_eflags = NVMF_DISC_EFLAGS_EPCSD;
+	p = !dc_decide(&fctx, subnqn, DC_OWNED, false, 0, &parent_eflags);
+	CHECK(p, "owned, no self entry, parent EPCSD=1 -> keep");
+	pass &= p;
+
+	parent_eflags = 0;
+	p = dc_decide(&fctx, subnqn, DC_OWNED, false, 0, &parent_eflags);
+	CHECK(p, "owned, no self entry, parent EPCSD=0 -> disconnect");
+	pass &= p;
+
+	/* Owned, no self entry, no parent (the primary): EPCSD defaults
+	 * to 0, matching how the spec defines an unreported EPCSD.
+	 */
+	p = dc_decide(&fctx, subnqn, DC_OWNED, false, 0, NULL);
+	CHECK(p, "owned, no self entry, no parent -> disconnect");
+	pass &= p;
+
+	/* persistent=force and persistent=no override EPCSD either way. */
+	fctx.persistent = LIBNVMF_PERSISTENT_FORCE;
+	p = !dc_decide(&fctx, subnqn, DC_OWNED, true, 0, NULL);
+	CHECK(p, "owned, self EPCSD=0, persistent=force -> keep");
+	pass &= p;
+
+	fctx.persistent = LIBNVMF_PERSISTENT_NO;
+	p = dc_decide(&fctx, subnqn, DC_OWNED, true,
+			NVMF_DISC_EFLAGS_EPCSD, NULL);
+	CHECK(p, "owned, self EPCSD=1, persistent=no -> disconnect");
+	pass &= p;
+
+	return pass;
+}
+
+/* -------------------------------------------------------------------------
  * main
  * -------------------------------------------------------------------------
  */
@@ -674,6 +744,7 @@ int main(int argc, char *argv[])
 	test_traddr_is_hostname(ctx);
 	test_nvmf_sanitize_addrs(ctx);
 	test_unescape_uri();
+	test_dc_decide(ctx);
 
 	libnvme_free_global_ctx(ctx);
 

--- a/src/fabrics.c
+++ b/src/fabrics.c
@@ -382,7 +382,7 @@ struct consume_state {
 	struct libnvme_global_ctx *ctx;
 	enum consume_mode mode;
 	bool connect;
-	bool force;
+	bool no_reuse;
 	nvme_print_flags_t flags;
 	char *raw;
 	const char *hostnqn;
@@ -478,7 +478,7 @@ static void consume_conn(const struct libnvmf_config_conn *conn,
 		libnvmf_context_set_default_keep_alive_timeout(fctx,
 				NVMF_DEF_DISC_TMO);
 		libnvmf_context_set_connect(fctx, st->connect);
-		libnvmf_context_set_force(fctx, st->force);
+		libnvmf_context_set_no_reuse(fctx, st->no_reuse);
 		err = libnvmf_discover(st->ctx, fctx);
 	} else {
 		err = libnvmf_connect(st->ctx, fctx);
@@ -521,7 +521,7 @@ int nvmf_convert_discovery_line(struct libnvmf_config_emitter *emitter,
 	char *argv[MAX_DISC_ARGS] = { "discovery.conf" };
 	char *ptr, *p = line;
 	int argc = 1;
-	bool force = false;
+	bool no_reuse = false;
 	char *persistent_arg = NULL;
 
 	NVMF_ARGS(opts, fa,
@@ -529,8 +529,11 @@ int nvmf_convert_discovery_line(struct libnvmf_config_emitter *emitter,
 			   &persistent_arg,
 			   "persistent discovery connection mode "
 			   "(default: no; auto if given bare)"),
-		  OPT_FLAG("force",        0, &force,
-			   "Force persistent discovery controller creation"));
+		  OPT_FLAG("no-reuse",     0, &no_reuse,
+			   "always create a new discovery controller "
+			   "connection instead of reusing an existing one"),
+		  OPT_FLAG("force",        0, &no_reuse,
+			   "deprecated alias for --no-reuse"));
 
 	if (line[0] == '#' || line[0] == '\n' || line[0] == '\0')
 		return 0;
@@ -692,7 +695,7 @@ unref:
  */
 static int fabrics_discovery_config(struct libnvme_global_ctx *ctx,
 		char *config_file, const char *hostnqn_arg,
-		const char *hostid_arg, bool connect, bool force,
+		const char *hostid_arg, bool connect, bool no_reuse,
 		nvme_print_flags_t flags)
 {
 	__cleanup_free char *ini_path = NULL;
@@ -736,7 +739,7 @@ static int fabrics_discovery_config(struct libnvme_global_ctx *ctx,
 		.ctx = ctx,
 		.mode = CONSUME_ROLE_BASED,
 		.connect = connect,
-		.force = force,
+		.no_reuse = no_reuse,
 		.flags = flags,
 		.raw = raw,
 		.hostnqn = hostnqn,
@@ -757,20 +760,21 @@ static int fabrics_discovery_config(struct libnvme_global_ctx *ctx,
  * exemption -- a mismatched or missing --owner is skipped the same way;
  * the escape hatch is passing the owner's own identity.
  *
- * --force skips the check entirely: it means the caller will never reuse
- * an existing controller, so there is nothing to check ownership against.
+ * --no-reuse skips the check entirely: it means the caller will never
+ * reuse an existing controller, so there is nothing to check ownership
+ * against.
  *
  * Returns 0 to proceed, 1 to skip, or a negative errno on a registry
  * read failure.
  */
 static int check_ctrl_owner(struct libnvme_global_ctx *ctx,
 			     struct libnvmf_context *fctx,
-			     const char *owner, bool force)
+			     const char *owner, bool no_reuse)
 {
 	__cleanup_free char *reg_owner = NULL;
 	int ret;
 
-	if (force)
+	if (no_reuse)
 		return 0;
 
 	ret = libnvmf_get_owner_from_fctx(ctx, fctx, &reg_owner);
@@ -798,7 +802,7 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 	int ret;
 	struct nvmf_args fa = { .subsysnqn = NVME_DISC_SUBSYS_NAME };
 	char *device = NULL;
-	bool force = false;
+	bool no_reuse = false;
 	char *persistent_arg = NULL;
 	const char *persistent;
 	bool nbft = false, nonbft = false;
@@ -813,7 +817,11 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 			   "persistent discovery connection mode "
 			   "(default: no; auto if given bare)"),
 		  OPT_STRING("config",     'J', "FILE", &config_file, nvmf_config_file),
-		  OPT_FLAG("force",          0, &force,               "Force persistent discovery controller creation"),
+		  OPT_FLAG("no-reuse",       0, &no_reuse,
+			   "always create a new discovery controller "
+			   "connection instead of reusing an existing one"),
+		  OPT_FLAG("force",          0, &no_reuse,
+			   "deprecated alias for --no-reuse"),
 		  OPT_FLAG("nbft",           0, &nbft,                "Only look at NBFT tables"),
 		  OPT_FLAG("no-nbft",        0, &nonbft,              "Do not look at NBFT tables"),
 		  OPT_STRING("owner",        0, "NAME", &owner,       "record this owner in the registry"),
@@ -889,7 +897,7 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 		return ret;
 
 	libnvmf_context_set_connect(fctx, connect);
-	libnvmf_context_set_force(fctx, force);
+	libnvmf_context_set_no_reuse(fctx, no_reuse);
 
 	if (persistent && libnvmf_context_set_persistent(fctx, persistent)) {
 		nvme_show_error(
@@ -909,10 +917,12 @@ int fabrics_discover(const char *desc, int argc, char **argv, bool connect)
 		}
 		if (!nbft && config_file)
 			ret = fabrics_discovery_config(ctx, config_file,
-				fa.hostnqn, fa.hostid, connect, force, flags);
+				fa.hostnqn, fa.hostid, connect, no_reuse,
+				flags);
 	} else {
 		ret = check_ctrl_owner(ctx, fctx,
-				owner ? owner : (nbft ? "nbft" : NULL), force);
+				owner ? owner : (nbft ? "nbft" : NULL),
+				no_reuse);
 		if (ret < 0) {
 			nvme_show_error("failed to check owner: %s",
 					libnvme_strerror(-ret));


### PR DESCRIPTION
Rewrites libnvme's Discovery Controller walk (`_nvmf_discover()`, `libnvmf_discover()`, `libnvmf_discover_nbft()`) and its supporting connection-resolution code in `fabrics.c`. This backs `nvme discover`, `nvme connect-all`, and NBFT boot discovery.

Four main things in here:
1. Several real bugs, found and fixed along the way (list below).
2. NBFT discovery now walks through the same code `nvme discover`/`connect-all` use, instead of a second, forked implementation of the same walk.
3. `--force` renamed to `--no-reuse` (kept as a deprecated alias): `--force`'s original job was working around a persistence bug that's since been fixed elsewhere, so what's left is only its narrower meaning, "never reuse an existing connection." This is also the one commit that touches more than one file -- every other commit is mostly just `fabrics.c`.
4. A new TID-keyed visited list, so the Discovery Log Page walk tracks every Discovery Controller it has already visited in this walk -- closes a gap where a referral graph with more than one path to the same DC, or an outright cycle, could be walked more than once, or skipped incorrectly.

**Bugs found and fixed along the way (mostly NBFT related)**, none part of the original plan, all found while working through the surrounding code:
- `_nvmf_discover()` never fired `hooks.connected` for anything it discovered and connected itself, referrals or IOC entries -- `connect-all` has never reported per-device progress for its own discovery-driven connects, even though the hook exists and fires correctly everywhere else.
- Three `fctx->hooks.*` calls (`connected`, `already_connected`, `decide_retry` in `libnvmf_connect()`) had no NULL check, even though the hooks are documented-optional and every other call site in the file guards them. Any external libnvme caller passing NULL for a hook it doesn't need would crash.
- **NBFT**: An NBFT Discovery Descriptor's `host_iface` was freed before its own walk started, then read (use-after-free) by every connect made during that walk.
- **NBFT**: The Discovery Descriptor connection's own DHCP retry cleared the destination address instead of the local one -- a retry that could never succeed.
- **NBFT**: `read_discovery()` (`nbft.c`) treated an absent DC NQN reference as a parse failure, silently dropping the whole Discovery Descriptor. Per the Boot Specification, absent just means "use the well-known NQN" -- the common case, not a malformed table.
- **NBFT**: Once that parsing bug was fixed, `libnvmf_discover_nbft()` still never read the parsed NQN when present, always connecting with the well-known one instead.

**Commits, in order.** Commit 5 is the substantial one -- the actual rewrite; the rest are mostly small and mechanical:

1. `62779e721` -- stop handing per-entry context clones to hooks/recursion (a real unsoundness: the clone shallow-aliases owned pointers a hook could free via a public setter)
2. `0f5e6d8a4` -- unify the four resolve-or-create-a-DC paths into one `dc_open()`
3. `a1150d09d` -- rename `--force` to `--no-reuse` (kept as a deprecated alias); the old name never described what it did
4. `02c75ab01` -- identify a discovery self entry by its spec-defined SUBTYPE instead of a pointer-identity coincidence
5. `32e6c0bae` -- the core rewrite: depth-first walk with a visited-set and depth cap, `dc_decide()` extraction, and its first unit tests
6. `ac3caf4b6` -- fold NBFT's forked walk onto the same machinery (UAF and dead-retry fixes included)
7. `56b9f0221` -- fire `hooks.connected` for discovery-walk connects
8. `663dfcca5` -- NBFT Discovery Descriptor NQN parsing and consumption fixes
9. `9a703c7f5` -- guard the three unchecked hook calls

**Verification**: every commit builds and tests standalone; `-Dwerror=true` and `-Dfabrics=disabled` both clean throughout;  full unit suite green, including the 9 new `dc_decide()` cases. Live-smoke-tested `nvme discover` against a real TCP discovery controller. Not tested against a real NBFT boot environment.