### PR TITLE
libnvme: take only pairs of hexadecimal digits in a secret

### DIFF
--- a/libnvme/src/nvme/crypto.c
+++ b/libnvme/src/nvme/crypto.c
@@ -39,6 +39,7 @@
 
 #include <base64.h>
 #include <crc32.h>
+#include <hex-util.h>
 #include <compiler-attributes.h>
 
 #include <libnvme.h>
@@ -725,7 +726,6 @@ __shr_public int libnvmf_create_raw_secret(struct libnvme_global_ctx *ctx,
 {
 	__cleanup_free unsigned char *buf = NULL;
 	int secret_len = 0, i, err;
-	unsigned int c;
 
 	if (key_len != 32 && key_len != 48 && key_len != 64) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR, "Invalid key length %ld", key_len);
@@ -758,7 +758,10 @@ __shr_public int libnvmf_create_raw_secret(struct libnvme_global_ctx *ctx,
 	}
 
 	for (i = 0; i < strlen(secret); i += 2) {
-		if (sscanf(&secret[i], "%02x", &c) != 1) {
+		int hi = shr_hex_to_int(secret[i]);
+		int lo = shr_hex_to_int(secret[i + 1]);
+
+		if (hi < 0 || lo < 0) {
 			libnvme_msg(ctx, LIBNVME_LOG_ERR,
 				"Invalid secret '%s'", secret);
 			return -EINVAL;
@@ -768,7 +771,7 @@ __shr_public int libnvmf_create_raw_secret(struct libnvme_global_ctx *ctx,
 				"Skipping excess secret bytes\n");
 			break;
 		}
-		buf[secret_len++] = (unsigned char)c;
+		buf[secret_len++] = (unsigned char)(hi << 4 | lo);
 	}
 	if (secret_len != key_len) {
 		libnvme_msg(ctx, LIBNVME_LOG_ERR,

--- a/libnvme/tests/meson.build
+++ b/libnvme/tests/meson.build
@@ -272,6 +272,20 @@ if want_fabrics
     )
 
     test('libnvme - psk', psk)
+
+    if openssl_dep.found()
+        raw_secret = executable(
+            'test-raw-secret',
+            ['raw-secret.c'],
+            dependencies: [
+                config_dep,
+                ccan_dep,
+                libnvme_dep,
+            ],
+        )
+
+        test('libnvme - raw-secret', raw_secret)
+    endif
 endif
 
 if want_fabrics

--- a/libnvme/tests/raw-secret.c
+++ b/libnvme/tests/raw-secret.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/**
+ * This file is part of libnvme.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ccan/array_size/array_size.h>
+
+#include <libnvme.h>
+
+static int test_rc;
+
+/* Each of these used to yield a secret the caller never gave. */
+static const struct {
+	const char *unit;
+	size_t times;
+	const char *tail;
+} rejected[] = {
+	{ "g0", 32, "" },	/* a stray character, on an even offset */
+	{ "0g", 32, "" },	/* and on an odd one, which was skipped */
+	{ "-1", 32, "" },	/* a sign, which read as 0xff */
+	{ "+1", 32, "" },
+	{ " f", 32, "" },	/* whitespace, skipped without being counted */
+	{ "f ", 32, "" },
+	{ "\t1", 32, "" },
+	{ " ", 63, "f" },	/* one digit built all 32 bytes */
+	{ "ab", 31, "a" },	/* one character short of the length */
+};
+
+static const struct {
+	const char *unit;
+	size_t times;
+	size_t key_len;
+	unsigned char expect;
+} accepted[] = {
+	{ "0f", 32, 32, 0x0f },
+	{ "AB", 32, 32, 0xab },	/* upper case is a hexadecimal digit too */
+	{ "ab", 48, 48, 0xab },
+	{ "ab", 48, 32, 0xab },	/* longer than key_len is still truncated */
+};
+
+static char *build(const char *unit, size_t times, const char *tail)
+{
+	size_t unit_len = strlen(unit);
+	char *secret = malloc(unit_len * times + strlen(tail) + 1);
+	size_t i;
+
+	if (!secret)
+		exit(EXIT_FAILURE);
+
+	for (i = 0; i < times; i++)
+		memcpy(secret + i * unit_len, unit, unit_len);
+	memcpy(secret + unit_len * times, tail, strlen(tail) + 1);
+
+	return secret;
+}
+
+static void reject_test(struct libnvme_global_ctx *ctx, const char *secret)
+{
+	unsigned char *raw_secret = NULL;
+	int ret;
+
+	printf("test libnvmf_create_raw_secret rejects '%s'\n", secret);
+
+	ret = libnvmf_create_raw_secret(ctx, secret, 32, &raw_secret);
+	if (ret >= 0) {
+		test_rc = 1;
+		printf("ERROR: '%s' was accepted\n", secret);
+		free(raw_secret);
+	}
+}
+
+static void accept_test(struct libnvme_global_ctx *ctx, const char *secret,
+			size_t key_len, unsigned char expect)
+{
+	unsigned char *raw_secret = NULL;
+	int ret;
+	size_t i;
+
+	printf("test libnvmf_create_raw_secret takes %zu bytes of 0x%02x\n",
+	       key_len, expect);
+
+	ret = libnvmf_create_raw_secret(ctx, secret, key_len, &raw_secret);
+	if (ret) {
+		test_rc = 1;
+		printf("ERROR: libnvmf_create_raw_secret() failed with %d\n",
+		       ret);
+		return;
+	}
+
+	for (i = 0; i < key_len; i++) {
+		if (raw_secret[i] == expect)
+			continue;
+
+		test_rc = 1;
+		printf("ERROR: byte %zu is 0x%02x, expected 0x%02x\n",
+		       i, raw_secret[i], expect);
+		break;
+	}
+	free(raw_secret);
+}
+
+int main(void)
+{
+	struct libnvme_global_ctx *ctx = libnvme_create_global_ctx();
+	char *secret;
+	int i;
+
+	libnvme_set_logging_file(ctx, stdout);
+
+	for (i = 0; i < ARRAY_SIZE(rejected); i++) {
+		secret = build(rejected[i].unit, rejected[i].times,
+			       rejected[i].tail);
+		reject_test(ctx, secret);
+		free(secret);
+	}
+
+	for (i = 0; i < ARRAY_SIZE(accepted); i++) {
+		secret = build(accepted[i].unit, accepted[i].times, "");
+		accept_test(ctx, secret, accepted[i].key_len,
+			    accepted[i].expect);
+		free(secret);
+	}
+
+	libnvme_free_global_ctx(ctx);
+
+	return test_rc ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
`libnvmf_create_raw_secret()` means to reject a secret that is not hexadecimal,
but `sscanf("%02x")` takes a sign, skips leading whitespace without counting it
towards the field width, and reports a conversion where it stopped at a
character it could not convert. So a secret of `-1` repeated comes out
byte-identical to `ff` repeated, and 63 spaces followed by `f` builds all 32
bytes out of that one digit.

It also reads a lone trailing character as a byte of its own, zero padded, which
reaches `nvme keys gen-tls` as well.

`libnvme/tests/raw-secret.c` covers both, and fails on the parent commit.

Independent of #3827, which fixes the KX-HMAC-CHAP side of this in the plugin.
