### PR TITLE
plugins/config: add 'nvme config status' command

### DIFF
--- a/Documentation/cmds-main.txt
+++ b/Documentation/cmds-main.txt
@@ -181,6 +181,9 @@ linknvme:nvme-config-validate[1]::
 linknvme:nvme-config-show[1]::
 	Show the resolved NVMe-oF INI connection configuration
 
+linknvme:nvme-config-status[1]::
+	Report legacy config.json/discovery.conf conversion status
+
 linknvme:nvme-get-property[1]::
 	Reads and shows NVMe-over-Fabrics controller property
 

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -18,6 +18,7 @@ adoc_sources_man1 = [
     'nvme-config-convert',
     'nvme-config-create',
     'nvme-config-show',
+    'nvme-config-status',
     'nvme-config-validate',
     'nvme-connect',
     'nvme-connect-all',

--- a/Documentation/nvme-config-convert.txt
+++ b/Documentation/nvme-config-convert.txt
@@ -87,6 +87,7 @@ SEE ALSO
 --------
 nvme-config-validate(1)
 nvme-config-show(1)
+nvme-config-status(1)
 nvme-connect-all(1)
 nvme-discover(1)
 https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md

--- a/Documentation/nvme-config-show.txt
+++ b/Documentation/nvme-config-show.txt
@@ -71,6 +71,7 @@ SEE ALSO
 --------
 nvme-config-validate(1)
 nvme-config-convert(1)
+nvme-config-status(1)
 nvme-connect-all(1)
 nvme-discover(1)
 https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md

--- a/Documentation/nvme-config-status.txt
+++ b/Documentation/nvme-config-status.txt
@@ -1,0 +1,98 @@
+nvme-config-status(1)
+======================
+
+NAME
+----
+nvme-config-status - Report legacy NVMe-oF config.json/discovery.conf conversion status
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'config status'
+
+DESCRIPTION
+-----------
+Reports the on-disk state of the legacy pre-3.0 configuration files,
+@SYSCONFDIR@/nvme/config.json and @SYSCONFDIR@/nvme/discovery.conf, and of
+the '*.converted' marker 'nvme config convert' leaves next to each one it
+converts. This command never modifies or converts anything; it only
+reports state.
+
+One line is printed for each legacy file that has something to report:
+
+* 'present, not yet converted' -- the file exists and has never been
+  converted.
+* 'present, already converted' -- the file exists and a
+  '<file>.converted' marker (a symlink pointing back at the file itself,
+  left in place deliberately so a rollback to a pre-INI installation
+  still finds the original legacy file) confirms it was converted. Both
+  the file and the marker can be deleted once rollback is no longer a
+  concern.
+* 'not present (a stale marker exists)' -- the file is gone but its
+  '<file>.converted' marker is still there, dangling. This is left over
+  from an earlier conversion and is always safe to delete.
+
+A file with neither itself nor a marker present is silently skipped --
+there is nothing to say about it. If this is true of both config.json
+and discovery.conf, a single 'no legacy configuration found' line is
+printed instead of two silent files and no output at all.
+
+Because the marker is a symlink keyed on the file's *path*, not its
+content, a file that is deleted and later replaced by a different,
+never-converted file at the same path (for example, a package rollback
+followed by a reinstall) makes the marker resolve again even though the
+new file itself was never converted. This command does not try to detect
+that case -- when a file and a resolving marker are both present, it adds
+a note that the marker may be stale and the file's contents should be
+verified against the INI configuration, so a human can decide. Use
+'nvme config convert' if in doubt: converting an already-converted file
+is a safe no-op.
+
+OPTIONS
+-------
+include::global-options.txt[]
+
+EXIT STATUS
+-----------
+Returns 0 if neither legacy file has anything to report. Returns a
+non-zero status if config.json or discovery.conf, or a '.converted'
+marker for either, is present -- regardless of which of the states
+listed above applies. Use the printed output, not the exit status, to
+tell those states apart.
+
+EXAMPLES
+--------
+* Check the system's legacy configuration state, config.json already
+  converted and no discovery.conf ever present:
++
+------------
+# nvme config status
+------------
++
+------------
+/usr/local/etc/nvme/config.json: present, already converted (/usr/local/etc/nvme/config.json.converted exists) -- delete both once rollback is no longer a concern
+note: if /usr/local/etc/nvme/config.json was replaced after conversion (for example, a package rollback followed by reinstall), this marker may be stale; verify its contents against the INI configuration before deleting either file
+------------
+
+* Check a system that never had a legacy configuration:
++
+------------
+# nvme config status
+------------
++
+------------
+no legacy configuration found; nothing to convert
+------------
+
+SEE ALSO
+--------
+nvme-config-convert(1)
+nvme-config-show(1)
+nvme-config-validate(1)
+nvme-connect-all(1)
+nvme-discover(1)
+https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md
+
+NVME
+----
+Part of the nvme-user suite

--- a/Documentation/nvme-config-validate.txt
+++ b/Documentation/nvme-config-validate.txt
@@ -58,6 +58,7 @@ SEE ALSO
 --------
 nvme-config-show(1)
 nvme-config-convert(1)
+nvme-config-status(1)
 nvme-connect-all(1)
 nvme-discover(1)
 https://github.com/linux-nvme/nvme-cli/blob/master/libnvme/design/CONFIG.md

--- a/plugins/config/config-nvme.c
+++ b/plugins/config/config-nvme.c
@@ -29,6 +29,14 @@ static int config_show_cmd(int argc, char **argv, struct command *cmd,
 	return fabrics_config_show(desc, argc, argv);
 }
 
+static int config_status_cmd(int argc, char **argv, struct command *cmd,
+		struct plugin *plugin)
+{
+	const char *desc = "Report legacy config.json/discovery.conf status";
+
+	return nvme_config_status(desc, argc, argv);
+}
+
 static int config_convert_cmd(int argc, char **argv, struct command *cmd,
 		struct plugin *plugin)
 {

--- a/plugins/config/config-nvme.h
+++ b/plugins/config/config-nvme.h
@@ -17,6 +17,7 @@ PLUGIN(NAME_CORE("config", "NVMeoF connection configuration", NVME_VERSION),
 	COMMAND_LIST(
 		ENTRY("validate", "Validate an NVMeoF connection configuration", config_validate_cmd)
 		ENTRY("show",     "Show the resolved NVMeoF connection configuration", config_show_cmd)
+		ENTRY("status",   "Report config status", config_status_cmd)
 		ENTRY("convert",  "Convert config.json/discovery.conf to INI", config_convert_cmd)
 		ENTRY("create",   "Create an NVMeoF connection entry in the INI configuration", config_create_cmd)
 	)

--- a/src/config-convert.c
+++ b/src/config-convert.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <libnvme.h>
@@ -630,4 +631,79 @@ out:
 	libnvmf_config_emit_free(emitter);
 
 	return ret;
+}
+
+/*
+ * Report @path's legacy-conversion state in one line, if there is
+ * anything to report. Returns false, printing nothing, when neither
+ * @path nor its marker exists.
+ *
+ * The "*.converted" marker (see mark_converted()) is a symlink whose
+ * target is @path itself, so whether it resolves is not independent
+ * information from whether @path exists -- it is the same fact observed
+ * two ways. That leaves four real states: no file and no marker; a file
+ * not yet converted; a converted file (marker resolves, @path exists by
+ * construction); and a dangling marker left over after @path was removed
+ * post-conversion (@path absent by construction).
+ */
+static bool report_legacy_status(const char *path)
+{
+	__cleanup_free char *marker = NULL;
+	struct stat sb;
+	bool file_exists;
+	bool marker_present;
+
+	if (asprintf(&marker, "%s.converted", path) < 0)
+		return false;
+
+	file_exists = !access(path, F_OK);
+	marker_present = !lstat(marker, &sb);
+
+	if (!marker_present) {
+		if (!file_exists)
+			return false;
+
+		nvme_show_result("%s: present, not yet converted", path);
+		return true;
+	}
+
+	if (!file_exists) {
+		nvme_show_result(
+			"%s: not present (a stale %s marker exists -- safe to delete)",
+			path, marker);
+		return true;
+	}
+
+	nvme_show_result(
+		"%s: present, already converted (%s exists) -- delete both once rollback is no longer a concern",
+		path, marker);
+	nvme_show_result(
+		"note: if %s was replaced after conversion (for example, a package rollback followed by reinstall), this marker may be stale; verify its contents against the INI configuration before deleting either file",
+		path);
+
+	return true;
+}
+
+int nvme_config_status(const char *desc, int argc, char **argv)
+{
+	OPT_ARGS(opts) = {
+		OPT_END()
+	};
+	bool json_found, disc_found;
+	int ret;
+
+	ret = parse_args(argc, argv, desc, opts);
+	if (ret)
+		return ret;
+
+	json_found = report_legacy_status(PATH_NVMF_CONFIG);
+	disc_found = report_legacy_status(PATH_NVMF_DISC);
+
+	if (!json_found && !disc_found) {
+		nvme_show_result(
+			"no legacy configuration found; nothing to convert");
+		return 0;
+	}
+
+	return 1;
 }

--- a/src/config-convert.h
+++ b/src/config-convert.h
@@ -62,3 +62,17 @@ int nvme_config_convert_auto(struct libnvme_global_ctx *ctx,
  * existing target unless --force is used.
  */
 int nvme_config_convert(const char *desc, int argc, char **argv);
+
+/*
+ * Implement the "nvme config-status" command.
+ *
+ * Report, for each of the default legacy config.json and discovery.conf
+ * locations that has something to report, whether the file has never
+ * been converted, was converted (a "*.converted" marker next to it
+ * resolves, see mark_converted() in config-convert.c), or is gone but
+ * left behind a dangling marker. A location with neither the file nor a
+ * marker present is silently skipped; if that is true of both
+ * locations, a single summary line is printed instead. Purely
+ * informational: never modifies or converts anything.
+ */
+int nvme_config_status(const char *desc, int argc, char **argv);


### PR DESCRIPTION
Add a command that reports on the legacy config files. It checks whether config.json/discovery.conf are present and whether they have already been converted to the new INI format (nvme-fabrics.conf), based on whether the rollback symlink is present next to each one. When a file has been converted, it hints that both the file and its symlink are safe to delete once rollback is no longer a concern.