### PR TITLE
libnvme: normalize a comma-separated FC WWN pair in TID construction

### DIFF
--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -80,11 +80,23 @@ static int canon_ip(const char *in, char **out)
 }
 
 /*
+ * Some discovery controllers report an FC WWN pair as "nn-0x...,pn-0x..."
+ * (comma) instead of the spec's "nn-0x...:pn-0x..." (colon). Normalize in
+ * place -- same length, no reallocation needed -- before validating.
+ */
+static void fc_wwn_normalize(char *s)
+{
+	char *comma = strchr(s, ',');
+
+	if (comma)
+		*comma = ':';
+}
+
+/*
  * A lightweight structural check for FC addressing: "nn-0x<hex>:pn-0x<hex>"
- * (node name + port name, each up to a 64-bit WWN in hex) -- the same shape
- * sanitize_discovery_log_entry() already normalizes discovery-log traddr
- * into.  Not a deep WWN semantic check (OUI bits etc.), the same spirit as
- * canon_ip() below for tcp/rdma: catch a malformed value, not police it.
+ * (node name + port name, each up to a 64-bit WWN in hex). Not a deep WWN
+ * semantic check (OUI bits etc.), the same spirit as canon_ip() below for
+ * tcp/rdma: catch a malformed value, not police it.
  */
 static bool fc_wwn_is_valid(const char *in)
 {
@@ -102,9 +114,9 @@ static bool fc_wwn_is_valid(const char *in)
  * Sanitize the addressing fields once the transport is known.  IP
  * transports: canonicalize a numeric traddr/host_traddr via canon_ip(); a
  * hostname is rejected outright -- resolving one is the caller's job, not
- * libnvme's.  FC: validate the "nn-0x:pn-0x" shape via fc_wwn_is_valid();
- * left as-is on success, since it's already in canonical form once it
- * matches. loop is left untouched.
+ * libnvme's.  FC: normalize a comma-separated WWN pair to the canonical
+ * colon form via fc_wwn_normalize(), then validate the "nn-0x:pn-0x" shape
+ * via fc_wwn_is_valid(); loop is left untouched.
  *
  * Return: 0 on success; -EINVAL if traddr or host_traddr is set but
  * malformed for the transport; -ENOMEM on allocation failure.
@@ -118,6 +130,11 @@ static int tid_sanitize_addr(struct libnvmf_tid *t)
 		return 0;
 
 	if (!strcmp(t->transport, "fc")) {
+		if (t->traddr)
+			fc_wwn_normalize(t->traddr);
+		if (t->host_traddr)
+			fc_wwn_normalize(t->host_traddr);
+
 		if (t->traddr && !fc_wwn_is_valid(t->traddr))
 			return -EINVAL;
 		if (t->host_traddr && !fc_wwn_is_valid(t->host_traddr))

--- a/libnvme/tests/test-tid.c
+++ b/libnvme/tests/test-tid.c
@@ -646,6 +646,35 @@ static bool test_tid_sanitize(void)
 	pass &= p;
 	libnvmf_tid_free(t);
 
+	/*
+	 * A comma-separated FC WWN pair, as some discovery controllers
+	 * report it, is normalized to the canonical colon form rather than
+	 * rejected.
+	 */
+	libnvmf_tid_from_fields("fc", "nn-0x1,pn-0x2", NULL, "nqn.t",
+				NULL, NULL, NULL, NULL, &t);
+	p = t && streq(libnvmf_tid_get_traddr(t), "nn-0x1:pn-0x2");
+	CHECK(p, "fc traddr comma normalized to colon");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* Same normalization applies to host_traddr. */
+	libnvmf_tid_from_fields("fc", "nn-0x1:pn-0x2", NULL, "nqn.t",
+				"nn-0x3,pn-0x4", NULL, NULL, NULL, &t);
+	p = t && streq(libnvmf_tid_get_host_traddr(t), "nn-0x3:pn-0x4");
+	CHECK(p, "fc host_traddr comma normalized to colon");
+	pass &= p;
+	libnvmf_tid_free(t);
+
+	/* parse() gets the same normalization, not just from_fields(). */
+	p = libnvmf_tid_parse(ctx,
+			      "transport=fc;traddr=nn-0x1,pn-0x2;subsysnqn=nqn.t",
+			      &t) == 0 &&
+	    streq(libnvmf_tid_get_traddr(t), "nn-0x1:pn-0x2");
+	CHECK(p, "parse() normalizes a comma-separated fc traddr too");
+	pass &= p;
+	libnvmf_tid_free(t);
+
 	/* loop has no addressing shape at all: truly untouched. */
 	libnvmf_tid_from_fields("loop", "anything goes", NULL, "nqn.t",
 				NULL, NULL, NULL, NULL, &t);


### PR DESCRIPTION
fabrics.c already fixes this for discovery-log entries before they're used for candidate matching, but any other caller building a TID directly from FC fields (connect, a config file, ...) got a hard rejection instead. tid_sanitize_addr() already silently canonicalizes IP addresses the same way, so extend the same treatment to FC.