### PR TITLE
libnvme: fix the pin secret expansion

### DIFF
--- a/libnvme/src/nvme/crypto.c
+++ b/libnvme/src/nvme/crypto.c
@@ -683,6 +683,7 @@ static ssize_t getswordfish(struct libnvme_global_ctx *ctx,
 		const char *seed, void *buf, size_t buflen)
 {
 	unsigned char hash[EVP_MAX_MD_SIZE];
+	unsigned int counter = 0;
 	EVP_MD_CTX *md_ctx;
 	size_t copied = 0;
 
@@ -691,15 +692,17 @@ static ssize_t getswordfish(struct libnvme_global_ctx *ctx,
 		return -ENOMEM;
 
 	while (copied < buflen) {
-		unsigned int counter = 0;
+		beint32_t be_counter;
 		unsigned int hash_len;
 		size_t to_copy;
 
 		if (EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL) != 1)
 			goto err;
 
+		be_counter = cpu_to_be32(counter);
+
 		EVP_DigestUpdate(md_ctx, seed, strlen(seed));
-		EVP_DigestUpdate(md_ctx, &counter, sizeof(counter));
+		EVP_DigestUpdate(md_ctx, &be_counter, sizeof(be_counter));
 
 		if (EVP_DigestFinal_ex(md_ctx, hash, &hash_len) != 1)
 			goto err;

--- a/libnvme/tests/raw-secret.c
+++ b/libnvme/tests/raw-secret.c
@@ -3,6 +3,7 @@
  * This file is part of libnvme.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -41,6 +42,27 @@ static const struct {
 	{ "ab", 48, 48, 0xab },
 	{ "ab", 48, 32, 0xab },	/* longer than key_len is still truncated */
 };
+
+/*
+ * A 'pin:' secret is the concatenation of SHA-256(pin || counter) blocks,
+ * where the counter starts at zero, advances once per block and is encoded
+ * as four big endian bytes. Every length therefore extends the shorter
+ * ones, so a single 64 byte expansion covers all three cases.
+ */
+static const char pin_secret[] = "pin:1234";
+
+static const unsigned char pin_expansion[64] = {
+	0xf7, 0x00, 0x98, 0x55, 0x0a, 0x83, 0xbc, 0x00,
+	0xe3, 0x18, 0x86, 0x68, 0xea, 0xaf, 0xef, 0xd9,
+	0x27, 0xe6, 0x5d, 0x9a, 0xaa, 0x90, 0xd6, 0xbd,
+	0x4d, 0xcb, 0xd8, 0xbb, 0xde, 0xcb, 0xcb, 0x74,
+	0x6a, 0x3a, 0x48, 0x57, 0x67, 0x20, 0x48, 0xe9,
+	0x1b, 0x35, 0x9b, 0xae, 0x1d, 0xe4, 0xbb, 0xa9,
+	0x17, 0xe2, 0x00, 0x5f, 0xac, 0x88, 0x19, 0xe4,
+	0x0c, 0x16, 0x8e, 0xe0, 0x4e, 0xd3, 0xe8, 0x0b,
+};
+
+static const size_t key_lengths[] = { 32, 48, 64 };
 
 static char *build(const char *unit, size_t times, const char *tail)
 {
@@ -100,6 +122,47 @@ static void accept_test(struct libnvme_global_ctx *ctx, const char *secret,
 		       i, raw_secret[i], expect);
 		break;
 	}
+
+	free(raw_secret);
+}
+
+static void pin_test(struct libnvme_global_ctx *ctx, size_t key_len)
+{
+	unsigned char *raw_secret;
+	int ret;
+
+	printf("test libnvmf_create_raw_secret '%s' key_len %zu\n",
+	       pin_secret, key_len);
+
+	ret = libnvmf_create_raw_secret(ctx, pin_secret, key_len, &raw_secret);
+	if (ret) {
+		if (ret == -ENOTSUP)
+			return;
+		test_rc = 1;
+		printf("ERROR: libnvmf_create_raw_secret() failed with %d\n",
+		       ret);
+		return;
+	}
+
+	if (memcmp(pin_expansion, raw_secret, key_len)) {
+		test_rc = 1;
+		printf("ERROR: unexpected expansion for key_len %zu\n",
+		       key_len);
+		goto out;
+	}
+
+	/*
+	 * The counter used to be reset on every iteration, which made each
+	 * block a copy of the first one. Guard the property directly.
+	 */
+	if (key_len > 32 &&
+	    !memcmp(raw_secret, raw_secret + 32, key_len - 32)) {
+		test_rc = 1;
+		printf("ERROR: block repeats the first one for key_len %zu\n",
+		       key_len);
+	}
+
+out:
 	free(raw_secret);
 }
 
@@ -124,6 +187,9 @@ int main(void)
 			    accepted[i].expect);
 		free(secret);
 	}
+
+	for (i = 0; i < ARRAY_SIZE(key_lengths); i++)
+		pin_test(ctx, key_lengths[i]);
 
 	libnvme_free_global_ctx(ctx);
 


### PR DESCRIPTION
Single patch against `master` (`5fd1ef488`).

`getswordfish()` declares the block counter inside the fill loop, so it is reset before every block and the increment at the end of the body is discarded. Every block comes out as the same `SHA-256(pin || 0)`, and a `pin:` secret longer than one digest just repeats its first 32 bytes rather than advancing the counter per block the way the algorithm it was added with does.

The counter also reached the digest as the raw bytes of an `unsigned int`, which is harmless only while it stays zero — the state this bug happens to keep it in. It is now serialized as four big endian bytes, so the expansion does not depend on the host byte order once the counter advances. A 32 byte secret is a single block and is unchanged; longer ones now differ, but `pin:` is an undocumented testing aid that has never appeared in a stable release.

## Testing

- `meson test`: 111 ok / 2 expected fail / 0 fail
- `checkpatch.pl --strict`: 0 errors, 0 warnings, 0 checks
- `libnvme/tests/raw-secret.c` gains the three valid lengths, checking the expansion against a fixed vector and asserting that a later block does not repeat the first; confirmed to fail on the parent commit
- binaries built before and after compared for `--secret=pin:1234`: the 32 byte secret is byte-identical, the 64 byte one no longer repeats its first block
