### PR TITLE
Enable assert-util testing on windows using new shared spawn and wait utilities.

### DIFF
--- a/shared/meson.build
+++ b/shared/meson.build
@@ -33,6 +33,7 @@ if host_system == 'windows'
     sources += [
         'fs-util-win.c',
         'crypto-util-win.c',
+        'proc-util-win.c',
         'sig-util-win.c',
     ]
 else
@@ -40,6 +41,7 @@ else
         'fs-util-linux.c',
         'net-util-linux.c',
         'crypto-util-linux.c',
+        'proc-util-linux.c',
         'sig-util-linux.c',
     ]
 endif

--- a/shared/proc-util-linux.c
+++ b/shared/proc-util-linux.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "proc-util.h"
+
+int shr_pipe(int fds[2])
+{
+	/*
+	 * O_CLOEXEC so a forked child does not leak the raw pipe fds: the
+	 * dup2() onto stdout/stderr in shr_spawn() clears close-on-exec on the
+	 * copies it keeps, while the originals close at execv().
+	 *
+	 * pipe2() sets O_CLOEXEC atomically but its glibc declaration is gated
+	 * behind _GNU_SOURCE; fall back to pipe() + fcntl() where _GNU_SOURCE
+	 * is not defined (e.g. the musl-style CI build).
+	 */
+#ifdef _GNU_SOURCE
+	if (pipe2(fds, O_CLOEXEC) < 0)
+		return -errno;
+#else
+	if (pipe(fds) < 0)
+		return -errno;
+	if (fcntl(fds[0], F_SETFD, FD_CLOEXEC) < 0 ||
+	    fcntl(fds[1], F_SETFD, FD_CLOEXEC) < 0) {
+		int e = -errno;
+
+		close(fds[0]);
+		close(fds[1]);
+		return e;
+	}
+#endif
+	return 0;
+}
+
+int shr_spawn(const char *const argv[], int out_fd, int err_fd,
+	      shr_proc_t *proc)
+{
+	pid_t pid;
+
+	pid = fork();
+	if (pid < 0)
+		return -errno;
+
+	if (pid == 0) {
+		/*
+		 * Abort on a failed redirect: exec'ing with the parent's
+		 * unredirected stdout would leave a caller draining a pipe that
+		 * never receives the child's output, blocking until exit.
+		 */
+		if (out_fd >= 0 && dup2(out_fd, STDOUT_FILENO) < 0)
+			_exit(127);
+		if (err_fd >= 0 && dup2(err_fd, STDERR_FILENO) < 0)
+			_exit(127);
+
+		execv(argv[0], (char *const *)argv);
+		_exit(127); /* exec failed */
+	}
+
+	*proc = (shr_proc_t)pid;
+
+	return 0;
+}
+
+int shr_wait_proc(shr_proc_t proc, bool *exited, int *code)
+{
+	int status;
+
+	while (waitpid((pid_t)proc, &status, 0) < 0) {
+		if (errno != EINTR)
+			return -errno;
+	}
+
+	*exited = WIFEXITED(status);
+	*code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+
+	return 0;
+}

--- a/shared/proc-util-win.c
+++ b/shared/proc-util-win.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <io.h>
+#include <process.h>
+#include <stdio.h>
+#include <windows.h>
+
+#include "proc-util.h"
+
+/*
+ * _dup() returns an inheritable fd, so the stdout/stderr backups would leak
+ * into the child spawned with _P_NOWAIT (created before they are restored and
+ * closed). Clear the inherit flag on the underlying handle so the child
+ * inherits only its redirected streams.
+ *
+ * Note: _spawnv() passes fds 0/1/2 to the child as its standard handles via
+ * the CRT startup block, regardless of the pipe's _O_NOINHERIT flag.
+ * The child still receives the redirected stdout/stderr, while the raw
+ * (high-numbered) pipe fds stay uninherited, which is what lets the pipe
+ * reach EOF once the child exits instead of hanging the drain.
+ */
+static void clear_inherit(int fd)
+{
+	intptr_t h = _get_osfhandle(fd);
+
+	if (h != -1)
+		SetHandleInformation((HANDLE)h, HANDLE_FLAG_INHERIT, 0);
+}
+
+int shr_pipe(int fds[2])
+{
+	/*
+	 * _O_NOINHERIT so a spawned child does not inherit the raw pipe fds:
+	 * the _dup2() onto stdout/stderr in shr_spawn() gives the child only
+	 * its redirected streams. Binary mode avoids CRLF translation.
+	 */
+	return _pipe(fds, 1 << 16, _O_BINARY | _O_NOINHERIT) ? -errno : 0;
+}
+
+int shr_spawn(const char *const argv[], int out_fd, int err_fd,
+	      shr_proc_t *proc)
+{
+	int saved_out = -1, saved_err = -1;
+	intptr_t rc = -1;
+	int err = 0;
+
+	/*
+	 * Windows has no fork(): _spawnv() runs a fresh process that inherits
+	 * this process's stdout/stderr. Redirect ours onto the caller's fds for
+	 * the duration of the spawn, then restore them.
+	 *
+	 * Flush first: stdout/stderr are buffered stdio streams, and _dup2()
+	 * swaps the underlying fd without touching the buffer, so any pending
+	 * parent output would otherwise drain into the child's capture pipe.
+	 */
+	if (out_fd >= 0) {
+		fflush(stdout);
+		saved_out = _dup(_fileno(stdout));
+		if (saved_out < 0 || _dup2(out_fd, _fileno(stdout)) < 0) {
+			err = errno;
+			goto restore;
+		}
+		clear_inherit(saved_out);
+	}
+	if (err_fd >= 0) {
+		fflush(stderr);
+		saved_err = _dup(_fileno(stderr));
+		if (saved_err < 0 || _dup2(err_fd, _fileno(stderr)) < 0) {
+			err = errno;
+			goto restore;
+		}
+		clear_inherit(saved_err);
+	}
+
+	/*
+	 * _P_NOWAIT so the child runs concurrently: the caller must drain a
+	 * pipe target before shr_wait_proc(); waiting here would deadlock.
+	 */
+	rc = _spawnv(_P_NOWAIT, argv[0], argv);
+	if (rc == -1)
+		err = errno;
+
+restore:
+	/* Flush the child-directed streams before restoring the parent fds. */
+	fflush(stdout);
+	fflush(stderr);
+	if (saved_out >= 0) {
+		_dup2(saved_out, _fileno(stdout));
+		_close(saved_out);
+	}
+	if (saved_err >= 0) {
+		_dup2(saved_err, _fileno(stderr));
+		_close(saved_err);
+	}
+
+	if (rc == -1)
+		return err ? -err : -EIO;
+
+	*proc = rc;
+
+	return 0;
+}
+
+int shr_wait_proc(shr_proc_t proc, bool *exited, int *code)
+{
+	unsigned int u;
+	int status;
+
+	if (_cwait(&status, proc, 0) == -1)
+		return -errno;
+
+	/*
+	 * _cwait() reports the child's exit code in status. Windows has no
+	 * signals, but a crash surfaces as a Microsoft-defined error-severity
+	 * NTSTATUS code in 0xC0000000-0xCFFFFFFF (e.g. 0xC0000005 access
+	 * violation, 0xC00000FD stack overflow). Bound both ends so a normal
+	 * exit(-1) (0xFFFFFFFF, which is above that range) is preserved as a
+	 * clean exit with *code == -1 rather than misread as a crash.
+	 */
+	u = (unsigned int)status;
+	*exited = !(u >= 0xC0000000u && u <= 0xCFFFFFFFu);
+	*code = status;
+
+	return 0;
+}

--- a/shared/proc-util.h
+++ b/shared/proc-util.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Micron Technology, Inc.
+ *
+ * Authors: Broc Going <bgoing@micron.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Create a pipe. fds[0] is the read end, fds[1] the write end. On Windows the
+ * pipe is opened in binary mode (no CRLF translation).
+ * Return: 0 on success, -errno otherwise.
+ */
+int shr_pipe(int fds[2]);
+
+/* Opaque child handle: a pid_t on POSIX, a process HANDLE on Windows. */
+typedef intptr_t shr_proc_t;
+
+/*
+ * Spawn argv[0] with arguments argv (NULL-terminated) WITHOUT a shell and
+ * return immediately; the child runs concurrently. No command string is built,
+ * so there is no shell to interpret metacharacters. argv[0] must be a path to
+ * the executable (no PATH search), mirroring _spawnv()/execv().
+ *
+ * If out_fd/err_fd are >= 0, the child's stdout/stderr are redirected to them
+ * (pass the same fd for both to merge, the 2>&1 equivalent; pass distinct pipes
+ * to keep them separate; either may point at a real file); -1 means inherit.
+ *
+ * If a redirect target is a pipe, drain its read end while the child runs and
+ * only THEN call shr_wait_proc(); a child that fills the pipe buffer blocks on
+ * write() until the reader drains it, so waiting first would deadlock.
+ *
+ * On success *proc receives the child handle for shr_wait_proc().
+ * Return: 0 on success, -errno if the child could not be spawned.
+ */
+int shr_spawn(const char *const argv[], int out_fd, int err_fd,
+	      shr_proc_t *proc);
+
+/*
+ * Wait for a child from shr_spawn() and report how it ended. On success *exited
+ * is set true if the child terminated normally and *code to its exit status;
+ * *exited is false if it crashed or was killed by a signal.
+ * Return: 0 on success, -errno if the child could not be waited for.
+ */
+int shr_wait_proc(shr_proc_t proc, bool *exited, int *code);

--- a/shared/tests/meson.build
+++ b/shared/tests/meson.build
@@ -277,15 +277,13 @@ test_sig_util = executable(
 
 test('shared - sig-util', test_sig_util)
 
-if host_system != 'windows'
-    test_assert_util = executable(
-        'test-assert-util',
-        ['test-assert-util.c'],
-        dependencies: [
-            config_dep,
-            shared_dep,
-        ],
-    )
+test_assert_util = executable(
+    'test-assert-util',
+    ['test-assert-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
 
-    test('shared - assert-util', test_assert_util)
-endif
+test('shared - assert-util', test_assert_util)

--- a/shared/tests/test-assert-util.c
+++ b/shared/tests/test-assert-util.c
@@ -10,10 +10,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include <shared/assert-util.h>
+#include <shared/proc-util.h>
+
+#if defined(_WIN32)
+#include <io.h>
+#define read _read
+#define close _close
+#else
+#include <unistd.h>
+#endif
+
+/*
+ * Re-invoked with this argument, the test becomes the child whose failing
+ * assertion is under test. Windows has no fork(), so the child is a fresh
+ * process running this same binary rather than a copy of it.
+ */
+#define CHILD_ARG "--assert-child"
 
 static bool check_bool(const char *name, bool got, bool want)
 {
@@ -40,6 +54,18 @@ static bool test_pass_is_silent(void)
 }
 
 /*
+ * The child half of test_fail_flushes_and_reports(): print unterminated
+ * (buffered) output, then fail a shr_assert(). Never returns.
+ */
+static void assert_child(void)
+{
+	/* Unterminated: only survives if something flushes it. */
+	printf("marker-before-failure");
+	shr_assert(1 == 2);
+	_Exit(EXIT_SUCCESS); /* unreachable */
+}
+
+/*
  * Run a child that prints unterminated (buffered) output, then fails a
  * shr_assert(). Capture everything the child writes to stdout/stderr and
  * how it exits, to verify:
@@ -50,52 +76,58 @@ static bool test_pass_is_silent(void)
  *  - the process exits normally instead of being killed by a signal
  *    (contrasts with assert()'s SIGABRT via abort()).
  */
-static bool test_fail_flushes_and_reports(void)
+static bool test_fail_flushes_and_reports(const char *self)
 {
+	const char *const argv[] = { self, CHILD_ARG, NULL };
 	char buf[4096] = { 0 };
-	int pipefd[2];
-	ssize_t total = 0, n;
-	pid_t pid;
-	int status;
+	char scratch[4096];
+	size_t total = 0;
 	bool pass = true;
+	bool exited = false;
+	int code = 0;
+	int fds[2];
+	ssize_t n;
+	shr_proc_t proc;
 
 	printf("test_fail_flushes_and_reports:\n");
 
-	if (pipe(pipefd)) {
-		printf(" - pipe() failed [FAIL]\n");
+	if (shr_pipe(fds)) {
+		printf(" - shr_pipe() failed [FAIL]\n");
 		return false;
 	}
 
-	pid = fork();
-	if (pid < 0) {
-		printf(" - fork() failed [FAIL]\n");
+	if (shr_spawn(argv, fds[1], fds[1], &proc)) {
+		close(fds[0]);
+		close(fds[1]);
+		printf(" - shr_spawn() failed [FAIL]\n");
 		return false;
 	}
+	close(fds[1]); /* only the child holds a writer now */
 
-	if (pid == 0) {
-		close(pipefd[0]);
-		dup2(pipefd[1], STDOUT_FILENO);
-		dup2(pipefd[1], STDERR_FILENO);
-		close(pipefd[1]);
+	/*
+	 * Drain the pipe to EOF before waiting. Keep the first sizeof(buf)-1
+	 * bytes and discard any overflow, but keep reading either way: stopping
+	 * early would leave the child's next write() to a full pipe unread, and
+	 * closing fds[0] would then SIGPIPE it (reported as signaled, not
+	 * exited). Reading to EOF also avoids a deadlock on a full buffer.
+	 */
+	while ((n = read(fds[0], scratch, sizeof(scratch))) > 0) {
+		size_t room = sizeof(buf) - 1 - total;
+		size_t take = ((size_t)n < room) ? (size_t)n : room;
 
-		/* Unterminated: only survives if something flushes it. */
-		printf("marker-before-failure");
-		shr_assert(1 == 2);
-		_exit(EXIT_SUCCESS); /* unreachable */
+		memcpy(buf + total, scratch, take);
+		total += take;
 	}
-
-	close(pipefd[1]);
-	while (total < (ssize_t)sizeof(buf) - 1 &&
-	       (n = read(pipefd[0], buf + total, sizeof(buf) - 1 - total)) > 0)
-		total += n;
-	close(pipefd[0]);
+	close(fds[0]);
 	buf[total] = '\0';
 
-	waitpid(pid, &status, 0);
+	if (shr_wait_proc(proc, &exited, &code)) {
+		printf(" - shr_wait_proc() failed [FAIL]\n");
+		return false;
+	}
 
-	pass &= check_bool("child exited (not signaled)", WIFEXITED(status), true);
-	if (WIFEXITED(status))
-		pass &= check_bool("child exit status nonzero", WEXITSTATUS(status) != 0, true);
+	pass &= check_bool("child exited (not signaled)", exited, true);
+	pass &= check_bool("child exit status nonzero", code != 0, true);
 
 	pass &= check_bool("buffered output before failure survived",
 			   strstr(buf, "marker-before-failure") != NULL, true);
@@ -110,12 +142,15 @@ static bool test_fail_flushes_and_reports(void)
 	return pass;
 }
 
-int main(void)
+int main(int argc, char *argv[])
 {
 	bool pass = true;
 
+	if (argc > 1 && !strcmp(argv[1], CHILD_ARG))
+		assert_child();
+
 	pass &= test_pass_is_silent();
-	pass &= test_fail_flushes_and_reports();
+	pass &= test_fail_flushes_and_reports(argv[0]);
 
 	fflush(stdout);
 	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);


### PR DESCRIPTION
Windows doesn't support fork, so the assert-util tests needed to be redesigned slightly to work across platforms.
* Adds new shr_pipe, shr_spawn, and shr_wait_proc utils with Linux and Windows implementations.
* Redesigns the assert-util tests to use the new shared pipe and spawn utilities.  Since fork is not supported on Windows, the test design now re-spawns the test binary as a child process.
* Enables test-assert-utils on Windows.