### PR TITLE
libnvme: stop reporting every ENOKEY as a missing TLS key

### DIFF
--- a/libnvme/src/nvme/util.c
+++ b/libnvme/src/nvme/util.c
@@ -456,7 +456,7 @@ static const char * const libnvme_status[] = {
 	[ENVME_CONNECT_CONNREFUSED] = "connection refused",
 	[ENVME_CONNECT_ADDRNOTAVAIL] = "cannot assign requested address",
 	[ENVME_CONNECT_IGNORED] = "connection ignored",
-	[ENVME_CONNECT_NOKEY] = "pre-shared TLS key is missing"
+	[ENVME_CONNECT_NOKEY] = "TLS PSK or KX-HMAC-CHAP secret not available"
 };
 
 __shr_public const char *libnvme_errno_to_string(int status)

--- a/libnvme/src/nvme/util.h
+++ b/libnvme/src/nvme/util.h
@@ -38,7 +38,7 @@
  * @ENVME_CONNECT_CONNREFUSED:	connection refused
  * @ENVME_CONNECT_ADDRNOTAVAIL:	cannot assign requested address
  * @ENVME_CONNECT_IGNORED:	connect attempt is ignored due to configuration
- * @ENVME_CONNECT_NOKEY:	the TLS key is missing
+ * @ENVME_CONNECT_NOKEY:	TLS PSK or KX-HMAC-CHAP secret not available
  */
 enum libnvme_connect_err {
 	ENVME_CONNECT_RESOLVE	= 1000,


### PR DESCRIPTION
Single patch against `master` (`5fd1ef488`).

`ENVME_CONNECT_NOKEY` reports `pre-shared TLS key is missing`, but the kernel also returns `ENOKEY` when the KX-HMAC-CHAP secret is missing, and when a key is present but cannot be looked up. The message now says what the errno means, the way `strerror(ENOKEY)` does; `dmesg` still identifies which key it was.

## Testing

- `meson test`: 111 ok / 2 expected fail / 0 fail
- `checkpatch.pl --no-tree --strict`: 0 errors, 0 warnings, 0 checks
- `ENOKEY` call sites checked against mainline `3d6d817622b0`
