### PR TITLE
nvme-discoverd: gate persistent connections on EPCSD

### DIFF
--- a/discoverd/src/config.c
+++ b/discoverd/src/config.c
@@ -25,6 +25,7 @@ static void config_set_defaults(struct discoverd_config *cfg)
 	cfg->nbft = true;
 	cfg->debug_level = DISC_LOG_INFO;
 	cfg->fc_kickstart_interval_minutes = 0;
+	cfg->epcsd_poll_interval_minutes = 15;
 }
 
 static int parse_debug_level(const char *val, int *out)
@@ -61,6 +62,15 @@ static int parse_uint(const char *val, unsigned int *out)
 	return 0;
 }
 
+static int parse_epcsd_poll_interval(const char *val, unsigned int *out)
+{
+	int r = parse_uint(val, out);
+
+	if (r < 0)
+		return r;
+	return *out > 0 ? 0 : -EINVAL; // 0 would mean "never wait"
+}
+
 /* Apply one "key = value" line from [Global]; @lineno is for diagnostics. */
 static void apply_global_key(struct discoverd_config *cfg, const char *key,
 			     const char *val, const char *conf_path,
@@ -74,6 +84,9 @@ static void apply_global_key(struct discoverd_config *cfg, const char *key,
 		r = parse_debug_level(val, &cfg->debug_level);
 	else if (streq(key, "fc-kickstart-interval-minutes"))
 		r = parse_uint(val, &cfg->fc_kickstart_interval_minutes);
+	else if (streq(key, "epcsd-poll-interval-minutes"))
+		r = parse_epcsd_poll_interval(
+			val, &cfg->epcsd_poll_interval_minutes);
 	else
 		disc_warn("%s:%u: unknown key '%s', ignored", conf_path,
 			  lineno, key);

--- a/discoverd/src/config.h
+++ b/discoverd/src/config.h
@@ -18,6 +18,7 @@
  *   nbft = true
  *   debug-level = info
  *   fc-kickstart-interval-minutes = 0
+ *   epcsd-poll-interval-minutes = 15
  */
 struct discoverd_config {
 	bool nbft; // adopt/connect NBFT-listed controllers; default true
@@ -35,6 +36,15 @@ struct discoverd_config {
 	 * additionally re-issue every N minutes.
 	 */
 	unsigned int fc_kickstart_interval_minutes;
+
+	/*
+	 * How often, in minutes, to reconnect and re-check a DC whose
+	 * effective EPCSD is 0. Such a DC is disconnected between checks —
+	 * it does not support persistent connections, so there is nothing
+	 * to hold open. Default 15; never 0 (unlike fc_kickstart_interval,
+	 * this poll is not optional).
+	 */
+	unsigned int epcsd_poll_interval_minutes;
 };
 
 /*

--- a/discoverd/src/dlp.c
+++ b/discoverd/src/dlp.c
@@ -49,6 +49,7 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 				   void *user_data),
 	      void (*dc_callback)(const struct libnvmf_tid *t,
 				 void *user_data),
+	      void (*self_callback)(bool epcsd, void *user_data),
 	      void *user_data)
 {
 	libnvme_ctrl_t ctrl = NULL;
@@ -93,6 +94,11 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 		case NVME_NQN_DISC:
 			if (dc_callback)
 				dc_callback(t, user_data);
+			break;
+		case NVME_NQN_CURR:
+			if (self_callback)
+				self_callback(eflags & NVMF_DISC_EFLAGS_EPCSD,
+					      user_data);
 			break;
 		default:
 			break;

--- a/discoverd/src/dlp.c
+++ b/discoverd/src/dlp.c
@@ -47,7 +47,7 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 	      const struct libnvmf_tid *dc_tid,
 	      void (*ioc_callback)(const struct libnvmf_tid *t,
 				   void *user_data),
-	      void (*dc_callback)(const struct libnvmf_tid *t,
+	      void (*dc_callback)(const struct libnvmf_tid *t, bool epcsd,
 				 void *user_data),
 	      void (*self_callback)(bool epcsd, void *user_data),
 	      void *user_data)
@@ -93,7 +93,8 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 			break;
 		case NVME_NQN_DISC:
 			if (dc_callback)
-				dc_callback(t, user_data);
+				dc_callback(t, eflags & NVMF_DISC_EFLAGS_EPCSD,
+					    user_data);
 			break;
 		case NVME_NQN_CURR:
 			if (self_callback)

--- a/discoverd/src/dlp.h
+++ b/discoverd/src/dlp.h
@@ -14,9 +14,14 @@
  * Fetch the Discovery Log Page from a connected DC and parse all entries.
  *
  * For each DLPE:
- *   subtype == NVME_NQN_NVME (I/O controller): ioc_callback is called.
- *   subtype == NVME_NQN_DISC (referral DC):    dc_callback is called.
+ *   subtype == NVME_NQN_NVME (I/O controller):       ioc_callback is called.
+ *   subtype == NVME_NQN_DISC (referral DC):          dc_callback is called.
+ *   subtype == NVME_NQN_CURR (this DC's self entry): self_callback is called.
  *   DUPRETINFO flag set: entry is skipped.
+ *
+ * self_callback is called at most once, with the self entry's EPCSD bit
+ * (EFLAGS bit 1). It is not called at all if the log page carries no self
+ * entry; the caller must supply its own fallback for that case.
  *
  * devname: kernel device name, e.g. "nvme0".
  * dc_tid: TID of the DC (used as the cache key in the caller).
@@ -29,4 +34,5 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 				   void *user_data),
 	      void (*dc_callback)(const struct libnvmf_tid *t,
 				 void *user_data),
+	      void (*self_callback)(bool epcsd, void *user_data),
 	      void *user_data);

--- a/discoverd/src/dlp.h
+++ b/discoverd/src/dlp.h
@@ -23,6 +23,11 @@
  * (EFLAGS bit 1). It is not called at all if the log page carries no self
  * entry; the caller must supply its own fallback for that case.
  *
+ * dc_callback is passed the referral entry's own EPCSD bit, i.e. this DC's
+ * report of whether the referred-to DC supports persistent connections.
+ * The caller can keep it as a fallback for when that DC is later connected
+ * to and its own self entry turns out to be absent.
+ *
  * devname: kernel device name, e.g. "nvme0".
  * dc_tid: TID of the DC (used as the cache key in the caller).
  *
@@ -32,7 +37,7 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 	      const struct libnvmf_tid *dc_tid,
 	      void (*ioc_callback)(const struct libnvmf_tid *t,
 				   void *user_data),
-	      void (*dc_callback)(const struct libnvmf_tid *t,
+	      void (*dc_callback)(const struct libnvmf_tid *t, bool epcsd,
 				 void *user_data),
 	      void (*self_callback)(bool epcsd, void *user_data),
 	      void *user_data);

--- a/discoverd/src/main.c
+++ b/discoverd/src/main.c
@@ -69,6 +69,8 @@ struct active_ctrl {
 	 */
 	bool parent_epcsd_known;
 	bool parent_epcsd; // meaningful only if parent_epcsd_known
+
+	sd_event_source *epcsd_poll_timer; // NULL when not EPCSD-parked
 };
 
 static LIST_HEAD(g_ctrls);
@@ -101,6 +103,7 @@ static void ctrl_free(struct active_ctrl *e)
 	if (!e)
 		return;
 	sd_event_source_unref(e->retry_timer);
+	sd_event_source_unref(e->epcsd_poll_timer);
 	tid_free(e->tid);
 	free(e->unit_name);
 	free(e->devname);
@@ -353,6 +356,8 @@ static bool dc_effective_epcsd(const struct dlp_fetch_ctx *fctx,
 	return false;
 }
 
+static void epcsd_park(struct active_ctrl *e);
+
 static void fetch_and_process_dlp(const char *devname,
 				  const struct libnvmf_tid *dc_tid)
 {
@@ -360,13 +365,18 @@ static void fetch_and_process_dlp(const char *devname,
 		.via_dc = inventory_config_conn_for(ctx.inventory, dc_tid),
 	};
 	struct active_ctrl *e = ctrl_find_by_devname(devname);
+	bool epcsd;
 
 	dlp_fetch(&ctx, devname, dc_tid, dlp_ioc_callback, dlp_dc_callback,
 		  dlp_self_callback, &fctx);
 
+	epcsd = dc_effective_epcsd(&fctx, e);
 	disc_dbg("%s: self entry %s, effective EPCSD=%d",
 		 libnvmf_tid_str(dc_tid), fctx.self_seen ? "seen" : "absent",
-		 dc_effective_epcsd(&fctx, e));
+		 epcsd);
+
+	if (e && e->is_dc && !epcsd)
+		epcsd_park(e);
 
 	if (fctx.iocs.len) {
 		if (ioc_list_append(&fctx.iocs, NULL) == 0) {
@@ -497,6 +507,66 @@ static int retry_timeout(sd_event_source *src,
 	return 0;
 }
 
+static int epcsd_poll_timeout(sd_event_source *src,
+			      uint64_t usec __attribute__((unused)),
+			      void *user_data)
+{
+	struct active_ctrl *e = user_data;
+	int r;
+
+	sd_event_source_unref(src);
+	e->epcsd_poll_timer = NULL;
+
+	if (!inventory_is_desired(ctx.inventory, e->tid)) {
+		disc_info("%s - no longer desired, dropping",
+			  libnvmf_tid_str(e->tid));
+		ctrl_remove(e);
+		return 0;
+	}
+
+	disc_dbg("%s - EPCSD poll: reconnecting to re-check",
+		 libnvmf_tid_str(e->tid));
+	r = restart_or_start(e);
+	if (r < 0) {
+		disc_err("%s - EPCSD poll reconnect failed: %s",
+			 libnvmf_tid_str(e->tid), strerror(-r));
+		schedule_retry(e);
+	}
+	return 0;
+}
+
+/*
+ * Disconnect a DC whose effective EPCSD is 0 and arm a long poll timer to
+ * reconnect and re-check it later. Never retried with the failure
+ * backoff/give-up path — EPCSD=0 is an expected, stable outcome, not a
+ * connect failure.
+ */
+static void epcsd_park(struct active_ctrl *e)
+{
+	uint64_t now, interval;
+
+	if (e->epcsd_poll_timer)
+		return; // already parked
+
+	unit_stop(ctx.umgr, e->unit_name);
+
+	if (sd_event_now(ctx.event, CLOCK_BOOTTIME, &now) < 0)
+		return;
+
+	interval = (uint64_t)ctx.cfg->epcsd_poll_interval_minutes *
+		   60 * UINT64_C(1000000);
+
+	if (sd_event_add_time(ctx.event, &e->epcsd_poll_timer, CLOCK_BOOTTIME,
+			      now + interval, 0, epcsd_poll_timeout, e) < 0) {
+		disc_warn("%s - failed to arm EPCSD poll timer",
+			  libnvmf_tid_str(e->tid));
+		return;
+	}
+
+	disc_info("%s - EPCSD=0, disconnecting; re-checking in %u min",
+		 libnvmf_tid_str(e->tid), ctx.cfg->epcsd_poll_interval_minutes);
+}
+
 // Periodic FC kickstart (opt-in via fc-kickstart-interval-minutes).
 static int fc_kickstart_timeout(sd_event_source *src,
 				uint64_t usec __attribute__((unused)),
@@ -622,6 +692,12 @@ static void on_nvme_remove(const char *devname,
 		disc_info("%s | %s - removed, not desired, dropping",
 			  libnvmf_tid_str(e->tid), devname);
 		ctrl_remove(e);
+		return;
+	}
+
+	if (e->epcsd_poll_timer) {
+		// Intentionally disconnected (EPCSD=0); the poll timer
+		// reconnects it, not this removal handler.
 		return;
 	}
 

--- a/discoverd/src/main.c
+++ b/discoverd/src/main.c
@@ -264,6 +264,8 @@ SHR_PTRARRAY_DEFINE(ioc_list, struct libnvmf_tid);
 struct dlp_fetch_ctx {
 	const struct libnvmf_config_conn *via_dc; // dc_tid's own conn, if any
 	struct ioc_list iocs;
+	bool self_seen;
+	bool epcsd; // meaningful only if self_seen
 };
 
 static void dlp_ioc_callback(const struct libnvmf_tid *t, void *user_data)
@@ -292,6 +294,14 @@ static void dlp_dc_callback(const struct libnvmf_tid *t, void *user_data)
 		start_ctrl(t, true, is_nbft, fctx->via_dc);
 }
 
+static void dlp_self_callback(bool epcsd, void *user_data)
+{
+	struct dlp_fetch_ctx *fctx = user_data;
+
+	fctx->self_seen = true;
+	fctx->epcsd = epcsd;
+}
+
 static void fetch_and_process_dlp(const char *devname,
 				  const struct libnvmf_tid *dc_tid)
 {
@@ -300,7 +310,11 @@ static void fetch_and_process_dlp(const char *devname,
 	};
 
 	dlp_fetch(&ctx, devname, dc_tid, dlp_ioc_callback, dlp_dc_callback,
-		  &fctx);
+		  dlp_self_callback, &fctx);
+
+	disc_dbg("%s: self entry %s, EPCSD=%d", libnvmf_tid_str(dc_tid),
+		 fctx.self_seen ? "seen" : "absent",
+		 fctx.self_seen && fctx.epcsd);
 
 	if (fctx.iocs.len) {
 		if (ioc_list_append(&fctx.iocs, NULL) == 0) {

--- a/discoverd/src/main.c
+++ b/discoverd/src/main.c
@@ -58,6 +58,17 @@ struct active_ctrl {
 	unsigned int attempts;   // consecutive failed (re)connect attempts
 	uint64_t giveup_at_usec; // 0 = no deadline armed (ctrl_arm_giveup)
 	sd_event_source *retry_timer; // NULL when no retry pending
+
+	/*
+	 * EPCSD this DC's own referral entry carried in its parent's
+	 * Discovery Log Page, if this DC was reached via referral. Fallback
+	 * for when this DC's own self entry (SUBTYPE 03h) turns out to be
+	 * absent from its own Discovery Log Page. Unset for primary DCs
+	 * (statically configured, mDNS-discovered, or NBFT) — they have no
+	 * parent.
+	 */
+	bool parent_epcsd_known;
+	bool parent_epcsd; // meaningful only if parent_epcsd_known
 };
 
 static LIST_HEAD(g_ctrls);
@@ -285,13 +296,38 @@ static void dlp_ioc_callback(const struct libnvmf_tid *t, void *user_data)
 		start_ctrl(t, false, is_nbft, fctx->via_dc);
 }
 
-static void dlp_dc_callback(const struct libnvmf_tid *t, void *user_data)
+/*
+ * Record the EPCSD bit @t's own referral entry carried in its parent's
+ * Discovery Log Page, as a fallback for when @t is later connected to and
+ * its own self entry turns out to be absent. A no-op if @t is not tracked
+ * yet (should_connect() rejected it, or start_ctrl() failed).
+ */
+static void record_parent_epcsd(const struct libnvmf_tid *t, bool epcsd)
+{
+	char *unit_name = tid_unit_name(t);
+	struct active_ctrl *e;
+
+	if (!unit_name)
+		return;
+
+	e = ctrl_find_by_unit(unit_name);
+	if (e) {
+		e->parent_epcsd_known = true;
+		e->parent_epcsd = epcsd;
+	}
+	free(unit_name);
+}
+
+static void dlp_dc_callback(const struct libnvmf_tid *t, bool epcsd,
+			    void *user_data)
 {
 	struct dlp_fetch_ctx *fctx = user_data;
 	bool is_nbft = inventory_is_nbft(ctx.inventory, t);
 
-	if (should_connect(t, NULL))
+	if (should_connect(t, NULL)) {
 		start_ctrl(t, true, is_nbft, fctx->via_dc);
+		record_parent_epcsd(t, epcsd);
+	}
 }
 
 static void dlp_self_callback(bool epcsd, void *user_data)
@@ -302,19 +338,35 @@ static void dlp_self_callback(bool epcsd, void *user_data)
 	fctx->epcsd = epcsd;
 }
 
+/*
+ * Self entry seen: its own EPCSD. Else the parent's referral-entry view
+ * of this DC, if any. Else assume EPCSD=0, matching core libnvme's
+ * dc_decide().
+ */
+static bool dc_effective_epcsd(const struct dlp_fetch_ctx *fctx,
+			       const struct active_ctrl *e)
+{
+	if (fctx->self_seen)
+		return fctx->epcsd;
+	if (e && e->parent_epcsd_known)
+		return e->parent_epcsd;
+	return false;
+}
+
 static void fetch_and_process_dlp(const char *devname,
 				  const struct libnvmf_tid *dc_tid)
 {
 	struct dlp_fetch_ctx fctx = {
 		.via_dc = inventory_config_conn_for(ctx.inventory, dc_tid),
 	};
+	struct active_ctrl *e = ctrl_find_by_devname(devname);
 
 	dlp_fetch(&ctx, devname, dc_tid, dlp_ioc_callback, dlp_dc_callback,
 		  dlp_self_callback, &fctx);
 
-	disc_dbg("%s: self entry %s, EPCSD=%d", libnvmf_tid_str(dc_tid),
-		 fctx.self_seen ? "seen" : "absent",
-		 fctx.self_seen && fctx.epcsd);
+	disc_dbg("%s: self entry %s, effective EPCSD=%d",
+		 libnvmf_tid_str(dc_tid), fctx.self_seen ? "seen" : "absent",
+		 dc_effective_epcsd(&fctx, e));
 
 	if (fctx.iocs.len) {
 		if (ioc_list_append(&fctx.iocs, NULL) == 0) {


### PR DESCRIPTION
## Summary

nvme-discoverd now honors EPCSD (Explicit Persistent Connection Support
for Discovery) instead of always keeping a persistent connection to every
DC.

- Read the EPCSD bit off a DC's own self entry (SUBTYPE 03h) in its
  Discovery Log Page, previously dropped silently.
- Fall back to the parent's referral-entry view when a self entry is
  absent; default to EPCSD=0 if neither is available.
- EPCSD=0: disconnect the DC and reconnect on a configurable interval
  (`epcsd-poll-interval-minutes`, default 15) to re-check.
- EPCSD=1: unchanged — already persistent, already refreshes via AER.