### PR TITLE
nvme: hyphenate --fast-io-fail-tmo, keep old spelling as alias

### DIFF
--- a/src/fabrics.h
+++ b/src/fabrics.h
@@ -99,7 +99,8 @@ struct nvmf_args {
 		OPT_INT("keep-alive-tmo",     'k', &f.keep_alive_tmo,     DESC_NVMF_KEEP_ALIVE_TMO),  \
 		OPT_INT("reconnect-delay",    'c', &f.reconnect_delay,    DESC_NVMF_RECONNECT_DELAY), \
 		OPT_INT("ctrl-loss-tmo",      'l', &f.ctrl_loss_tmo,      DESC_NVMF_CTRL_LOSS_TMO),   \
-		OPT_INT("fast_io_fail_tmo",   'F', &f.fast_io_fail_tmo,   DESC_NVMF_FAST_IO_FAIL_TMO),\
+		OPT_INT("fast-io-fail-tmo",   'F', &f.fast_io_fail_tmo,   DESC_NVMF_FAST_IO_FAIL_TMO),\
+		OPT_INT("fast_io_fail_tmo",   'F', &f.fast_io_fail_tmo,   DESC_NVMF_FAST_IO_FAIL_TMO, NULL, true), \
 		OPT_INT("tos",                'T', &f.tos,                DESC_NVMF_TOS),             \
 		OPT_INT("tls_key",              0, &f.tls_key_id,         DESC_NVMF_TLS_KEY_LEGACY),  \
 		OPT_FLAG("duplicate-connect", 'D', &f.duplicate_connect,  DESC_NVMF_DUP_CONNECT),     \


### PR DESCRIPTION
Every other fabrics option uses hyphens, and the INI config key is already "fast-io-fail-tmo". Add the hyphenated form as the documented option; keep --fast_io_fail_tmo working as a hidden alias, same pattern as --dhchap-secret.