### PR TITLE
plugins add resv to group "I/O Commands"

### DIFF
--- a/plugins/resv/resv-plugin.c
+++ b/plugins/resv/resv-plugin.c
@@ -396,6 +396,7 @@ static struct plugin plugin = {
 	.desc = "Submit NVMe Reservation commands",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "I/O Commands",
 };
 
 static void __shr_constructor register_plugin(void)


### PR DESCRIPTION
The resv plugin didn't show up anymore because it lost it group assignemnt.