### PR TITLE
micron: unused value in micron_write_os_config_to_file()

### DIFF
--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -418,7 +418,6 @@ void micron_write_os_config_to_file(const char *file_name)
 				"\n\n\n\n%s\n-----------------------------------------------\n",
 				cmds[i].header);
 			fclose(fpOSConfig);
-			fpOSConfig = NULL;
 		}
 		ret = micron_run_spawn(cmds[i].argv, file_name, true);
 		if (ret) {


### PR DESCRIPTION
The micron_write_os_config_to_file() function writes system configuration headers to a log file before spawning diagnostic commands. Inside the loop, fpOSConfig is assigned NULL immediately after calling fclose().

This assignment is never read because fpOSConfig is re-assigned on the next iteration of the loop, resulting in an unused value.

Remove the unused assignment to fpOSConfig to clean up the code.