### PR TITLE
scaleflux: fix strcpy into fixed-size buffer in nvme_expand_cap()

### DIFF
--- a/plugins/scaleflux/sfx-nvme.c
+++ b/plugins/scaleflux/sfx-nvme.c
@@ -1439,7 +1439,8 @@ static int nvme_expand_cap(struct libnvme_transport_handle *hdl, __u32 namespace
 	if (libnvme_transport_handle_is_ctrl(hdl))
 		snprintf(dev_name, 32, "%sn%u", libnvme_transport_handle_get_name(hdl), namespace_id);
 	else
-		strcpy(dev_name, libnvme_transport_handle_get_name(hdl));
+		snprintf(dev_name, sizeof(dev_name), "%s",
+			 libnvme_transport_handle_get_name(hdl));
 
 	num = scandir("/dev", &devices, filter_namespace, alphasort);
 	if (num <= 0) {


### PR DESCRIPTION
The nvme_expand_cap() function stores the device name in the fixed-size dev_name buffer. When the transport handle is not a controller, the device name is copied into dev_name using strcpy() without checking the length of the source string.

Copying an unbounded string into a fixed-size buffer can overflow the buffer, corrupting adjacent stack memory and causing undefined behavior.

Replace strcpy() with snprintf() bounded by sizeof(dev_name) to prevent the overflow.