### PR TITLE
libnvme: rename dhchap-secret INI key to kxchap-secret

### DIFF
--- a/Documentation/nvme-fabrics.conf.txt
+++ b/Documentation/nvme-fabrics.conf.txt
@@ -83,8 +83,8 @@ TUNABLE (type default, '[Host]', endpoint section, or 'controller =' line):
 
 SECURITY ('[Host]' or endpoint section only, never a 'controller =' line):
 
-	tls, tls-key, tls-key-identity, keyring, concat, dhchap-secret,
-	dhchap-ctrl-secret
+	tls, tls-key, tls-key-identity, keyring, concat, kxchap-secret,
+	kxchap-ctrl-secret
 
 IDENTITY ('[Host]' only):
 

--- a/libnvme/design/CONFIG.md
+++ b/libnvme/design/CONFIG.md
@@ -22,7 +22,7 @@ The format is parsed by **libnvme**, so every cooperating consumer reads one for
 
 **Multiple host personalities.** A single host can deliberately present *different* identities — different `(Host NQN, Host Identifier)` pairs — to different fabrics, as though it were several independent hosts. Each such identity is a *personality*. Each one gets its own file under `nvme-fabrics.conf.d/`, opening with its own `[Host]` block; keeping one persona per file is what stops them from getting tangled.
 
-This distinction matters once authentication or Transport Layer Security (TLS) enter the picture. Authentication credentials, such as a TLS Pre-Shared Key (PSK) or a DH-CHAP (Diffie-Hellman HMAC-CHAP) secret, are associated with a host identity and an NVMe subsystem, not with the machine itself.
+This distinction matters once authentication or Transport Layer Security (TLS) enter the picture. Authentication credentials, such as a TLS Pre-Shared Key (PSK) or a KX-HMAC-CHAP (key-exchange HMAC-CHAP) secret, are associated with a host identity and an NVMe subsystem, not with the machine itself.
 
 Separate host identities let different credential sets be configured for different NVMe-oF deployments: a credential configured for one host identity cannot be used by another, and credentials for a single deployment can be updated or revoked by editing only that identity's configuration.
 
@@ -158,11 +158,11 @@ controller    = transport=tcp;traddr=10.0.0.9;trsvcid=4420
 
 A connection is described by an optional `[Host]` block plus one or more **endpoint sections**. By convention `[Host]` is written first, but its placement carries no meaning — a file's `[Host]` applies to every endpoint section in that file (see [Singleton vs repeatable sections](#singleton-vs-repeatable-sections)).
 
-- **`[Host]`** — the host identity (`hostnqn`, `hostid`, `hostsymname`, `dhchap-secret`, …) used for every connection in that file. **A file with no `[Host]` connects as the system default identity** (`/etc/nvme/hostnqn` / `hostid`) — see [Host identity and multiple personalities](#host-identity-and-multiple-personalities).
+- **`[Host]`** — the host identity (`hostnqn`, `hostid`, `hostsymname`, `kxchap-secret`, …) used for every connection in that file. **A file with no `[Host]` connects as the system default identity** (`/etc/nvme/hostnqn` / `hostid`) — see [Host identity and multiple personalities](#host-identity-and-multiple-personalities).
 - **`[Discovery Controller]`** — a Discovery Controller to connect to. Its NQN is the section's `nqn =`; if omitted it defaults to the well-known discovery NQN (`nqn.2014-08.org.nvmexpress.discovery`).
 - **`[Subsystem]`** — an I/O subsystem to connect to, named by its `nqn =`.
 
-The **role is the section name** — there is no `type =` key. **Both `[Discovery Controller]` and `[Subsystem]` may be repeated** — list one section per controller or subsystem you want to connect. Within an endpoint section, each **`controller =` line is one path** to that endpoint; repeating it expresses multipath. Per-endpoint keys (`tls`, `tls-key`, `dhchap-*`, `ctrl-loss-tmo`, …) override the type defaults for that endpoint and all its paths.
+The **role is the section name** — there is no `type =` key. **Both `[Discovery Controller]` and `[Subsystem]` may be repeated** — list one section per controller or subsystem you want to connect. Within an endpoint section, each **`controller =` line is one path** to that endpoint; repeating it expresses multipath. Per-endpoint keys (`tls`, `tls-key`, `kxchap-*`, `ctrl-loss-tmo`, …) override the type defaults for that endpoint and all its paths.
 
 ### `controller =` address syntax
 
@@ -194,30 +194,30 @@ The one non-obvious rung is `[Host]` sitting **above** the type defaults: a `kee
 
 The type-default rungs are computed per file this way, so the result never depends on the order drop-ins are read in.
 
-**Exception — per-link security stays at the section level.** The TLS and DH-CHAP parameters (see [Security parameters](#security-parameters)) are *not* overridable on a `controller =` line: the PSK and authentication secrets are bound to the `(hostnqn, subsysnqn)` pair, so they are constant across all paths to an endpoint and belong on `[Host]` or an endpoint section. Everything else — `ctrl-loss-tmo`, `keep-alive-tmo`, digests, queue counts, `reconnect-delay`, … — can be overridden per path on the `controller =` line.
+**Exception — per-link security stays at the section level.** The TLS and KX-HMAC-CHAP parameters (see [Security parameters](#security-parameters)) are *not* overridable on a `controller =` line: the PSK and authentication secrets are bound to the `(hostnqn, subsysnqn)` pair, so they are constant across all paths to an endpoint and belong on `[Host]` or an endpoint section. Everything else — `ctrl-loss-tmo`, `keep-alive-tmo`, digests, queue counts, `reconnect-delay`, … — can be overridden per path on the `controller =` line.
 
 ### Security parameters
 
-A connection's security settings fall into two families — **authentication** (DH-CHAP, which proves the host and controller identities in-band) and **encryption** (TLS, which protects the data on the wire) — plus one parameter that bridges them. Because they are bound to the host+subsystem relationship, they live on **`[Host]` or an endpoint section**, never on a `controller =` path (the exception above): set on `[Host]` when a persona uses the same credential for everything, on `[Discovery Controller]`/`[Subsystem]` when one endpoint needs its own.
+A connection's security settings fall into two families — **authentication** (KX-HMAC-CHAP, which proves the host and controller identities in-band) and **encryption** (TLS, which protects the data on the wire) — plus one parameter that bridges them. Because they are bound to the host+subsystem relationship, they live on **`[Host]` or an endpoint section**, never on a `controller =` path (the exception above): set on `[Host]` when a persona uses the same credential for everything, on `[Discovery Controller]`/`[Subsystem]` when one endpoint needs its own.
 
-**Authentication — DH-CHAP**
+**Authentication — KX-HMAC-CHAP**
 
 | Key | Meaning |
 |---|---|
-| `dhchap-secret` | the host's secret — authenticates the host to the controller |
-| `dhchap-ctrl-secret` | the controller's secret — adds bidirectional (mutual) authentication |
+| `kxchap-secret` | the host's secret — authenticates the host to the controller |
+| `kxchap-ctrl-secret` | the controller's secret — adds bidirectional (mutual) authentication |
 
 Bidirectional auth for one specific subsystem, rather than the whole persona:
 
 ```ini
 [Subsystem]
 nqn                = nqn.2024-01.com.example:secure.vol1
-dhchap-secret      = DHHC-1:00:…    # this host, proving itself to the controller
-dhchap-ctrl-secret = DHHC-1:00:…    # this controller, proving itself back
+kxchap-secret      = DHHC-1:00:…    # this host, proving itself to the controller
+kxchap-ctrl-secret = DHHC-1:00:…    # this controller, proving itself back
 controller         = transport=tcp;traddr=10.0.0.9;trsvcid=4420
 ```
 
-> **`dhchap-secret`/`dhchap-ctrl-secret` are always literal in this file.** Unlike `tls-key` below, DH-CHAP has no keyring-reference form, so the secret sits in the clear in whatever reads `nvme-fabrics.conf` — typically world-readable, like the rest of `/etc/nvme/`. Fine for testing, not for production; a real secret-at-rest story for DH-CHAP is still an open item.
+> **`kxchap-secret`/`kxchap-ctrl-secret` are always literal in this file.** Unlike `tls-key` below, KX-HMAC-CHAP has no keyring-reference form, so the secret sits in the clear in whatever reads `nvme-fabrics.conf` — typically world-readable, like the rest of `/etc/nvme/`. Fine for testing, not for production; a real secret-at-rest story for KX-HMAC-CHAP is still an open item.
 
 **Encryption — TLS**
 
@@ -232,7 +232,7 @@ controller         = transport=tcp;traddr=10.0.0.9;trsvcid=4420
 
 | Key | Meaning |
 |---|---|
-| `concat` | *secure concatenation* — derive the TLS PSK from a successful DH-CHAP authentication rather than a pre-provisioned key, chaining the two steps (so it requires the DH-CHAP secrets to be set) |
+| `concat` | *secure concatenation* — derive the TLS PSK from a successful KX-HMAC-CHAP authentication rather than a pre-provisioned key, chaining the two steps (so it requires the KX-HMAC-CHAP secrets to be set) |
 
 The key *material* lives in the kernel keyring, not in this file: `tls-key` names a key, it does not store one (except in the interchange-format spelling). libnvme provisions and looks those keys up — `nvme gen-tls-key` / `nvme tls-key`, default keyring `.nvme` — and the kernel's TLS handshake daemon (`tlshd`, from ktls-utils) reads the PSK from the keyring when the connection is made. This file only says *which* key and keyring to use and whether TLS and authentication are on.
 
@@ -301,7 +301,7 @@ The shared parser validates a configuration when it is read and reports problems
 
 The parser follows systemd conventions. Boolean values accept `1`/`yes`/`y`/`true`/`t`/`on` and `0`/`no`/`n`/`false`/`f`/`off` (all case-insensitive), matching systemd's `parse_boolean()`. Lines beginning with `#` are comments; blank lines are ignored. An empty value (`key =`) is meaningful — it resets a cascade-able tunable to the kernel default (above) — so the parser distinguishes a key that is absent from one present with an empty value. Every key has **exactly one spelling**: no hidden aliases, no underscore variants, and the subsystem NQN is written `nqn` (not `subsysnqn`). This is greenfield work — there are no legacy INI files to stay compatible with, so there is nothing ambiguous to parse or document.
 
-Connection-parameter keys are the **same names as the `nvme connect` command-line options** — `keep-alive-tmo`, `ctrl-loss-tmo`, `reconnect-delay`, `host-iface`, `dhchap-secret`, and so on (hyphenated, not the underscored spellings the legacy `config.json` used). What you write here is exactly what you would pass on the command line, which is the rule to reach for when in doubt about a key's name. The one key with no connect option is `hostsymname`: the host's symbolic name, sent to a Discovery Controller by the Discovery Information Management (DIM) command (`nvme dim`, TP8010). It is carried here for nvme-stas (which reads this format through the Python bindings) and for eventual TP8010 support in nvme-discoverd.
+Connection-parameter keys are the **same names as the `nvme connect` command-line options** — `keep-alive-tmo`, `ctrl-loss-tmo`, `reconnect-delay`, `host-iface`, `kxchap-secret`, and so on (hyphenated, not the underscored spellings the legacy `config.json` used). What you write here is exactly what you would pass on the command line, which is the rule to reach for when in doubt about a key's name. The one key with no connect option is `hostsymname`: the host's symbolic name, sent to a Discovery Controller by the Discovery Information Management (DIM) command (`nvme dim`, TP8010). It is carried here for nvme-stas (which reads this format through the Python bindings) and for eventual TP8010 support in nvme-discoverd.
 
 ## Relationship to the registry and exclusion list
 
@@ -321,12 +321,12 @@ All three rest on the same transport-ID identity (`src/nvme/tid.h`) and the same
 |---|---|
 | AEN | Asynchronous Event Notification — a controller-initiated event, e.g. a Discovery Controller signalling that its log page changed. |
 | DC | Discovery Controller — a controller whose Discovery Log Page lists the controllers a host may connect; it exposes no namespaces. |
-| DH-CHAP | Diffie-Hellman HMAC-CHAP — the NVMe in-band authentication protocol; its secret is bound to a (host, subsystem) pair. |
 | DLP | Discovery Log Page — the list of connectable controllers a host retrieves from a Discovery Controller. |
 | FC | Fibre Channel — an NVMe-oF transport. |
 | HostID | Host Identifier — a 128-bit value identifying a host for reservations and registrations; the same HostID implies the same host. |
 | IOC | I/O Controller — a controller that exposes namespaces (storage), as opposed to a Discovery Controller. |
 | `kato` | Keep Alive Time-Out — the spec/kernel term for the `keep-alive-tmo` connection parameter (named `--keep-alive-tmo` on the CLI and `keep-alive-tmo` here). |
+| KX-HMAC-CHAP | Key-exchange HMAC-CHAP — the NVMe in-band authentication protocol; its secret is bound to a (host, subsystem) pair. Named DH-HMAC-CHAP before TP4201 added post-quantum key-exchange groups alongside classic Diffie-Hellman; the secret string format (`DHHC-1:…`) is unchanged by the rename. |
 | mDNS | multicast DNS — zero-configuration discovery used to find Discovery Controllers (a future feature). |
 | NQN | NVMe Qualified Name — the name identifying a host (Host NQN) or a subsystem (Subsystem NQN) on a fabric. |
 | NVMe | Non-Volatile Memory Express. |
@@ -346,6 +346,7 @@ Specification documents this design cites (section numbers refer to the revision
 - **TP4126** — NVMe-oF Boot HostNQN and HostID (Ratified 2023-01-25)
 - **TP8010** — NVMe-oF Centralized Discovery Controller (Ratified 2022-01-12) — the Discovery Information Management (DIM) command that carries `hostsymname`
 - **TP8009** — Automated Discovery of NVMe-oF Discovery Controllers in IP Networks (Ratified 2022-01-11) and **TP8024** — mDNS Discovery update (Ratified 2024-06-11) — the mDNS discovery behind auto-discovered DCs
+- **TP4201** — Enhancements for Post-Quantum Crypto Algorithms (Ratified) — renamed DH-HMAC-CHAP to KX-HMAC-CHAP; the secret string format is unchanged
 
 ## Further reading
 

--- a/libnvme/src/nvme/config-ini.c
+++ b/libnvme/src/nvme/config-ini.c
@@ -57,8 +57,8 @@ static const struct libnvmf_key keys[] = {
 	{ "tls-key",			LIBNVMF_KEY_STRING,	LIBNVMF_KEY_SECURITY },
 	{ "tls-key-identity",		LIBNVMF_KEY_STRING,	LIBNVMF_KEY_SECURITY },
 	{ "keyring",			LIBNVMF_KEY_STRING,	LIBNVMF_KEY_SECURITY },
-	{ "dhchap-secret",		LIBNVMF_KEY_STRING,	LIBNVMF_KEY_SECURITY },
-	{ "dhchap-ctrl-secret",		LIBNVMF_KEY_STRING,	LIBNVMF_KEY_SECURITY },
+	{ "kxchap-secret",		LIBNVMF_KEY_STRING,	LIBNVMF_KEY_SECURITY },
+	{ "kxchap-ctrl-secret",		LIBNVMF_KEY_STRING,	LIBNVMF_KEY_SECURITY },
 
 	/* host identity -- [Host] only */
 	{ "hostnqn",			LIBNVMF_KEY_STRING,	LIBNVMF_KEY_IDENTITY },

--- a/libnvme/src/nvme/config.c
+++ b/libnvme/src/nvme/config.c
@@ -342,8 +342,8 @@ __shr_public int libnvmf_context_apply_params(struct libnvmf_context *fctx,
 
 	libnvmf_params_for_each(params, apply_param, &state);
 
-	hostkey = get_param_nonempty(params, "dhchap-secret");
-	ctrlkey = get_param_nonempty(params, "dhchap-ctrl-secret");
+	hostkey = get_param_nonempty(params, "kxchap-secret");
+	ctrlkey = get_param_nonempty(params, "kxchap-ctrl-secret");
 	keyring = get_param_nonempty(params, "keyring");
 	tls_key = get_param_nonempty(params, "tls-key");
 	tls_key_identity = get_param_nonempty(params, "tls-key-identity");

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1344,7 +1344,7 @@ static int build_options(libnvme_host_t h, libnvme_ctrl_t c, char **argstr)
 	}
 
 	if (c->cfg.concat && !hostkey) {
-		libnvme_msg(h->ctx, LIBNVME_LOG_ERR, "required argument [--dhchap-secret | -S] not specified with --concat\n");
+		libnvme_msg(h->ctx, LIBNVME_LOG_ERR, "required argument [--kxchap-secret | -S] not specified with --concat\n");
 		return -ENVME_CONNECT_INVAL;
 	}
 

--- a/libnvme/tests/config-api.c
+++ b/libnvme/tests/config-api.c
@@ -503,8 +503,8 @@ static bool test_apply_params(struct libnvme_global_ctx *ctx)
 	shr_assert(!libnvmf_params_set(params, "tls-key", "deadbeef"));
 	shr_assert(!libnvmf_params_set(params, "tls-key-identity",
 				    "NVMe1R02 my-id"));
-	shr_assert(!libnvmf_params_set(params, "dhchap-secret", "DHHC-1:00:host:"));
-	shr_assert(!libnvmf_params_set(params, "dhchap-ctrl-secret",
+	shr_assert(!libnvmf_params_set(params, "kxchap-secret", "DHHC-1:00:host:"));
+	shr_assert(!libnvmf_params_set(params, "kxchap-ctrl-secret",
 				    "DHHC-1:00:ctrl:"));
 
 	shr_assert(!libnvmf_context_create(ctx, NULL, NULL, NULL, NULL, &fctx));

--- a/libnvme/tests/config-emit.c
+++ b/libnvme/tests/config-emit.c
@@ -562,7 +562,7 @@ static bool test_params_set_validation(void)
 	}
 
 	/* A value with an embedded newline can't survive an INI round trip. */
-	if (libnvmf_params_set(p, "dhchap-secret", "abc\ndef") != -EINVAL) {
+	if (libnvmf_params_set(p, "kxchap-secret", "abc\ndef") != -EINVAL) {
 		printf(" - value with newline accepted [FAIL]\n");
 		pass = false;
 	} else {

--- a/libnvme/tests/config-ini.c
+++ b/libnvme/tests/config-ini.c
@@ -141,7 +141,7 @@ static bool test_key_table(void)
 		{ "hdr-digest",		LIBNVMF_KEY_TUNABLE },
 		{ "persistent",		LIBNVMF_KEY_DC_TUNABLE },
 		{ "tls-key",		LIBNVMF_KEY_SECURITY },
-		{ "dhchap-secret",	LIBNVMF_KEY_SECURITY },
+		{ "kxchap-secret",	LIBNVMF_KEY_SECURITY },
 		{ "hostnqn",		LIBNVMF_KEY_IDENTITY },
 		{ "hostsymname",	LIBNVMF_KEY_IDENTITY },
 		{ "nqn",		LIBNVMF_KEY_NQN },
@@ -280,7 +280,7 @@ static bool test_parse_model(struct libnvme_global_ctx *ctx)
 		"[Host]\n"
 		"hostnqn = nqn.2014-08.org.nvmexpress:host\n"
 		"hostid = 46ba5037-7ce5-41fa-9452-48477bf00080\n"
-		"dhchap-secret = DHHC-1:00:abc\n"
+		"kxchap-secret = DHHC-1:00:abc\n"
 		"\n"
 		"[Discovery Controller]\n"
 		"persistent = auto\n"
@@ -322,7 +322,7 @@ static bool test_parse_model(struct libnvme_global_ctx *ctx)
 
 	if (!f->has_host || strcmp(f->hostnqn, "nqn.2014-08.org.nvmexpress:host") ||
 	    strcmp(f->hostid, "46ba5037-7ce5-41fa-9452-48477bf00080") ||
-	    strcmp(libnvmf_params_get(f->host_params, "dhchap-secret"),
+	    strcmp(libnvmf_params_get(f->host_params, "kxchap-secret"),
 		   "DHHC-1:00:abc")) {
 		printf(" - [Host] identity + params [FAIL]\n");
 		pass = false;
@@ -650,7 +650,7 @@ static bool test_resolve_cascade(struct libnvme_global_ctx *ctx)
 		"[Host]\n"
 		"hostnqn = nqn.2014-08.org.nvmexpress:prod-host\n"
 		"hostid = 46ba5037-7ce5-41fa-9452-48477bf00080\n"
-		"dhchap-secret = DHHC-1:00:abc\n"
+		"kxchap-secret = DHHC-1:00:abc\n"
 		"[Discovery Controller]\n"
 		"controller = transport=tcp;traddr=10.0.0.5;trsvcid=8009\n"
 		"[Subsystem]\n"
@@ -717,7 +717,7 @@ static bool test_resolve_cascade(struct libnvme_global_ctx *ctx)
 		   "46ba5037-7ce5-41fa-9452-48477bf00080") ||
 	    strcmp(libnvmf_params_get(dc->params, "keep-alive-tmo"), "30") ||
 	    strcmp(libnvmf_params_get(dc->params, "tos"), "7") ||
-	    strcmp(libnvmf_params_get(dc->params, "dhchap-secret"),
+	    strcmp(libnvmf_params_get(dc->params, "kxchap-secret"),
 		   "DHHC-1:00:abc")) {
 		printf(" - drop-in DC [FAIL]\n");
 		pass = false;

--- a/src/config-convert.c
+++ b/src/config-convert.c
@@ -56,8 +56,8 @@ static const struct legacy_key string_keys[] = {
 	{ "tls_key",          "tls-key" },
 	{ "tls_key_identity", "tls-key-identity" },
 	{ "keyring",          "keyring" },
-	{ "dhchap_key",       "dhchap-secret" },
-	{ "dhchap_ctrl_key",  "dhchap-ctrl-secret" },
+	{ "dhchap_key",       "kxchap-secret" },
+	{ "dhchap_ctrl_key",  "kxchap-ctrl-secret" },
 };
 
 static const char *map_key(const struct legacy_key *table, size_t n,
@@ -118,8 +118,8 @@ static void apply_port_params(struct libnvmf_params *params,
 }
 
 /*
- * The DH-HMAC-CHAP secret is defined per (hostnqn, subsysnqn), not per path
- * (NVMe Base Specification 2.3, section 8.3.5.5.7). If a port does not
+ * The KX-HMAC-CHAP secret is defined per (hostnqn, subsysnqn), not per path
+ * (NVMe Base Specification 2.4, section 8.3.4.5.7). If a port does not
  * specify a secret, inherit the host-level default. If both are present but
  * differ, keep the port-specific value and log the mismatch.
  */
@@ -132,7 +132,7 @@ static void apply_dhchap_default(struct libnvmf_params *params,
 		return;
 
 	if (!port_value) {
-		libnvmf_params_set(params, "dhchap-secret", host_default);
+		libnvmf_params_set(params, "kxchap-secret", host_default);
 	} else if (strcmp(port_value, host_default)) {
 		nvme_show_verbose_info(
 			"config convert: dhchap_key differs between host default and one connection; keeping the connection's own value");

--- a/src/fabrics.c
+++ b/src/fabrics.c
@@ -129,9 +129,9 @@ void nvmf_args_to_params(struct libnvmf_params *params,
 	if (fa->concat)
 		libnvmf_params_set(params, "concat", "true");
 	if (fa->hostkey)
-		libnvmf_params_set(params, "dhchap-secret", fa->hostkey);
+		libnvmf_params_set(params, "kxchap-secret", fa->hostkey);
 	if (fa->ctrlkey)
-		libnvmf_params_set(params, "dhchap-ctrl-secret", fa->ctrlkey);
+		libnvmf_params_set(params, "kxchap-ctrl-secret", fa->ctrlkey);
 	if (fa->keyring)
 		libnvmf_params_set(params, "keyring", fa->keyring);
 	if (fa->tls_key)

--- a/tests/cli/nvme_config_convert_test.py
+++ b/tests/cli/nvme_config_convert_test.py
@@ -181,7 +181,7 @@ class ConfigConvertCLITest(TestNVMeBase):
         })
         self._convert()
         content = self._read_output()
-        self.assertIn('dhchap-secret = DHHC-1:00:host-default-key:', content)
+        self.assertIn('kxchap-secret = DHHC-1:00:host-default-key:', content)
 
     def test_dhchap_port_value_overrides_default(self):
         self._write_json({
@@ -200,7 +200,7 @@ class ConfigConvertCLITest(TestNVMeBase):
         })
         self._convert()
         content = self._read_output()
-        self.assertIn('dhchap-secret = DHHC-1:00:port-specific-key:', content)
+        self.assertIn('kxchap-secret = DHHC-1:00:port-specific-key:', content)
         self.assertNotIn('DHHC-1:00:host-default-key:', content)
 
     def test_discovery_persistent_true_is_mapped_to_force(self):


### PR DESCRIPTION
Rename the `dhchap-secret`/`dhchap-ctrl-secret` INI keys to `kxchap-secret`/`kxchap-ctrl-secret`, following TP4201's rename of the DH-HMAC-CHAP protocol to KX-HMAC-CHAP. The secret string format (`DHHC-1:...`) is unchanged.

The INI config format has never had a stable release, so there is no back-compat requirement at the INI level. `nvme config-convert` still reads the legacy `dhchap_key`/`dhchap_ctrl_key` `config.json` fields and writes the new `kxchap-*` INI keys.

Also fixes a stale `--dhchap-secret` reference in the `--concat` error message (the CLI flag itself was already renamed in an earlier PR; `--dhchap-secret` remains as a hidden alias).