### PR TITLE
Add shr_spawnp and refactor Micron plugin to use shared spawn and wait utilities

### DIFF
--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -9,21 +9,20 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
-#include <spawn.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include <libnvme.h>
 
 #include <ccan/array_size/array_size.h>
 
+#include <shared/io-util.h>
+#include <shared/proc-util.h>
+
 #include "micron-utils.h"
 #include "nvme-print.h"
 #include "src/cleanup.h"
-
-extern char **environ;
 
 /*
  * Validates that a string is a canonical PCI address in the
@@ -141,78 +140,6 @@ static int get_pcie_bdf(struct libnvme_transport_handle *hdl,
 }
 
 /*
- * Waits for a spawned child, retrying across signal interruptions, and maps its
- * termination to a return code.
- *
- * @pid: PID of the child to wait for.
- *
- * Return: 0 if the child exited with status 0, negative errno on a wait
- * failure, or -EIO if the child did not exit cleanly with status 0.
- */
-static int wait_for_child(pid_t pid)
-{
-	int status;
-
-	while (waitpid(pid, &status, 0) == -1) {
-		if (errno != EINTR)
-			return -errno;
-	}
-	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
-		return -EIO;
-
-	return 0;
-}
-
-/*
- * Reads all data from @fd into @out (NUL-terminated), keeping at most
- * @out_len - 1 bytes and discarding any excess. Always reads to EOF so the
- * writer never blocks on a full pipe, which would otherwise hang.
- *
- * @fd:      File descriptor to read from.
- * @out:     Buffer to receive up to @out_len - 1 bytes (NUL-terminated).
- * @out_len: Size of @out; must be at least 1.
- *
- * Return: 0 on success, negative errno on a read failure.
- */
-static int read_to_eof(int fd, char *out, size_t out_len)
-{
-	size_t total = 0;
-	ssize_t n = 1; /* non-zero to ensure drain loop runs */
-	char discard[512];
-
-	out[0] = '\0';
-
-	/* Fill the output buffer with up to out_len - 1 bytes. */
-	while (total < out_len - 1) {
-		n = read(fd, out + total, out_len - 1 - total);
-
-		if (n == -1) {
-			if (errno == EINTR)
-				continue;
-			return -errno;
-		}
-		if (n == 0)
-			break;
-		total += (size_t)n;
-	}
-	out[total] = '\0';
-
-	/* Drain any remaining output so the writer never blocks on a full pipe. */
-	while (n > 0) {
-		n = read(fd, discard, sizeof(discard));
-		if (n == -1) {
-			if (errno == EINTR)
-				continue;
-			return -errno;
-		}
-		if (n == 0)
-			break;
-	}
-
-	return 0;
-}
-
-/*
  * Runs a command (given as an argv vector) without a shell and captures its
  * standard output into @out.
  *
@@ -224,54 +151,42 @@ static int read_to_eof(int fd, char *out, size_t out_len)
  */
 static int spawn_and_capture(char *const argv[], char *out, size_t out_len)
 {
-	posix_spawn_file_actions_t actions;
-	int pipefd[2];
-	pid_t pid;
+	shr_proc_t proc;
+	int fds[2];
+	bool exited;
+	int code;
 	int ret;
-	int err = 0;
+	int err;
 
 	if (!out || out_len == 0)
 		return -EINVAL;
 
 	out[0] = '\0';
 
-	if (pipe(pipefd) == -1)
-		return -errno;
+	ret = shr_pipe(fds);
+	if (ret)
+		return ret;
 
-	err = posix_spawn_file_actions_init(&actions);
-	if (err) {
-		close(pipefd[0]);
-		close(pipefd[1]);
-		return -err;
-	}
-
-	/* Child: redirect stdout to the pipe write end, close both raw fds. */
-	err = posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
-	if (!err)
-		err = posix_spawn_file_actions_addclose(&actions, pipefd[0]);
-	if (!err)
-		err = posix_spawn_file_actions_addclose(&actions, pipefd[1]);
-	if (err) {
-		posix_spawn_file_actions_destroy(&actions);
-		close(pipefd[0]);
-		close(pipefd[1]);
-		return -err;
-	}
-
-	err = posix_spawnp(&pid, argv[0], &actions, NULL, argv, environ);
-	posix_spawn_file_actions_destroy(&actions);
-	close(pipefd[1]);
-	if (err) {
-		close(pipefd[0]);
-		return -err;
+	/* Child: stdout to the pipe write end; stderr inherited. */
+	ret = shr_spawnp((const char *const *)argv, fds[1], -1, &proc);
+	close(fds[1]); /* only the child holds a writer now */
+	if (ret) {
+		close(fds[0]);
+		return ret;
 	}
 
 	/* Parent: read the child's output, always draining to EOF. */
-	err = read_to_eof(pipefd[0], out, out_len);
-	close(pipefd[0]);
+	err = shr_read_all(fds[0], out, out_len);
+	close(fds[0]);
 
-	ret = wait_for_child(pid);
-	return err ? err : ret;
+	ret = shr_wait_proc(proc, &exited, &code);
+	if (ret)
+		return err ? err : ret;
+
+	if (err)
+		return err;
+
+	return (exited && code == 0) ? 0 : -EIO;
 }
 
 int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,

--- a/plugins/micron/micron-utils-linux.c
+++ b/plugins/micron/micron-utils-linux.c
@@ -341,46 +341,6 @@ int micron_clear_pcie_aer_correctable_errors(
 	return 0;
 }
 
-int micron_run_spawn(char *const argv[], const char *outfile, bool append)
-{
-	posix_spawn_file_actions_t actions;
-	posix_spawn_file_actions_t *actionsp = NULL;
-	pid_t pid;
-	int ret;
-	int oflags = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
-
-	if (outfile) {
-		ret = posix_spawn_file_actions_init(&actions);
-		if (ret)
-			return -ret;
-		actionsp = &actions;
-
-		ret = posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO,
-						       outfile, oflags, 0644);
-		if (ret)
-			goto out_destroy;
-
-		ret = posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO,
-						       STDERR_FILENO);
-		if (ret)
-			goto out_destroy;
-	}
-
-	ret = posix_spawnp(&pid, argv[0], actionsp, NULL, argv, environ);
-
-	if (actionsp)
-		posix_spawn_file_actions_destroy(actionsp);
-
-	if (ret)
-		return -ret;
-
-	return wait_for_child(pid);
-
-out_destroy:
-	posix_spawn_file_actions_destroy(actionsp);
-	return -ret;
-}
-
 void micron_write_os_config_to_file(const char *file_name)
 {
 	FILE *fpOSConfig = NULL;

--- a/plugins/micron/micron-utils-win.c
+++ b/plugins/micron/micron-utils-win.c
@@ -15,59 +15,6 @@
 #include "nvme-print.h"
 #include "src/cleanup.h"
 
-int micron_run_spawn(char *const argv[], const char *outfile, bool append)
-{
-	STARTUPINFOA si = { .cb = sizeof(si) };
-	PROCESS_INFORMATION pi = { 0 };
-	HANDLE hFile = INVALID_HANDLE_VALUE;
-	char cmdline[MAX_PATH + 256] = { 0 };
-	int i, off = 0;
-	DWORD exit_code;
-
-	for (i = 0; argv[i]; i++) {
-		int ret = snprintf(cmdline + off, sizeof(cmdline) - off,
-				   "%s\"%s\"", i ? " " : "", argv[i]);
-		if (ret < 0 || (size_t)ret >= sizeof(cmdline) - off)
-			return -ENOMEM;
-		off += ret;
-	}
-
-	if (outfile) {
-		SECURITY_ATTRIBUTES sa = {
-			.nLength = sizeof(sa),
-			.bInheritHandle = TRUE,
-		};
-
-		hFile = CreateFileA(outfile, GENERIC_WRITE, 0, &sa,
-				    append ? OPEN_ALWAYS : CREATE_ALWAYS,
-				    FILE_ATTRIBUTE_NORMAL, NULL);
-		if (hFile == INVALID_HANDLE_VALUE)
-			return -EIO;
-		if (append)
-			SetFilePointer(hFile, 0, NULL, FILE_END);
-		si.dwFlags = STARTF_USESTDHANDLES;
-		si.hStdOutput = hFile;
-		si.hStdError = hFile;
-		si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
-	}
-
-	if (!CreateProcessA(NULL, cmdline, NULL, NULL, outfile ? TRUE : FALSE,
-			    0, NULL, NULL, &si, &pi)) {
-		if (hFile != INVALID_HANDLE_VALUE)
-			CloseHandle(hFile);
-		return -EIO;
-	}
-
-	WaitForSingleObject(pi.hProcess, INFINITE);
-	GetExitCodeProcess(pi.hProcess, &exit_code);
-	CloseHandle(pi.hProcess);
-	CloseHandle(pi.hThread);
-	if (hFile != INVALID_HANDLE_VALUE)
-		CloseHandle(hFile);
-
-	return exit_code == 0 ? 0 : -EIO;
-}
-
 int micron_get_pcie_aer_errors(struct libnvme_transport_handle *hdl,
 	__u32 *correctable_errors, __u32 *uncorrectable_errors)
 {

--- a/plugins/micron/micron-utils.c
+++ b/plugins/micron/micron-utils.c
@@ -5,9 +5,15 @@
  * Authors: Broc Going <bgoing@micron.com>
  */
 
+#include <errno.h>
+#include <fcntl.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <libnvme.h>
+
+#include <fs-util.h>
+#include <proc-util.h>
 
 #include "micron-utils.h"
 
@@ -40,4 +46,45 @@ char *micron_get_ns_name(struct libnvme_transport_handle *hdl)
 	}
 
 	return ns_name;
+}
+
+int micron_run_spawn(char *const argv[], const char *outfile, bool append)
+{
+	int fd = -1;
+	shr_proc_t proc;
+	bool exited;
+	int code;
+	int ret;
+
+	if (outfile) {
+		int oflags = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
+
+		fd = shr_open_rawdata(outfile, oflags, 0644);
+		if (fd < 0)
+			return -errno;
+
+		/*
+		 * The child inherits this fd and writes through it directly.
+		 * On Windows O_APPEND is a per-write lseek done by the parent's
+		 * CRT, not a kernel append flag, so the inherited handle starts
+		 * at offset 0 and would overwrite existing content. Position it
+		 * at EOF once before the spawn. On Linux, O_APPEND already
+		 * forces writes to EOF, so this seek is a no-op.
+		 */
+		if (append)
+			lseek(fd, 0, SEEK_END);
+	}
+
+	/* Redirect both stdout and stderr to the file, matching prior behavior. */
+	ret = shr_spawnp((const char *const *)argv, fd, fd, &proc);
+	if (fd >= 0)
+		close(fd);
+	if (ret)
+		return ret;
+
+	ret = shr_wait_proc(proc, &exited, &code);
+	if (ret)
+		return ret;
+
+	return (exited && code == 0) ? 0 : -EIO;
 }

--- a/plugins/micron/micron-utils.c
+++ b/plugins/micron/micron-utils.c
@@ -12,8 +12,8 @@
 
 #include <libnvme.h>
 
-#include <fs-util.h>
-#include <proc-util.h>
+#include <shared/fs-util.h>
+#include <shared/proc-util.h>
 
 #include "micron-utils.h"
 

--- a/shared/io-util.h
+++ b/shared/io-util.h
@@ -32,3 +32,50 @@ static inline int shr_write_all(int fd, const void *buf, size_t len)
 	}
 	return 0;
 }
+
+/*
+ * Read fd into out until EOF, keeping at most out_len - 1 bytes
+ * (NUL-terminated) and discarding any excess. Always reads to EOF so a writer
+ * on the other end of a pipe never blocks on a full buffer. An out_len of 0
+ * keeps nothing but still drains to EOF.
+ * Return: 0 on success, -errno on a read failure.
+ */
+static inline int shr_read_all(int fd, char *out, size_t out_len)
+{
+	size_t total = 0;
+	ssize_t n = 1; /* non-zero to ensure the drain loop runs */
+	char discard[512];
+
+	if (!out && out_len)
+		return -EINVAL;
+
+	/* Fill the output buffer with up to out_len - 1 bytes. */
+	if (out_len) {
+		out[0] = '\0';
+		while (total < out_len - 1) {
+			n = read(fd, out + total, out_len - 1 - total);
+			if (n < 0) {
+				if (errno == EINTR)
+					continue;
+				out[total] = '\0';
+				return -errno;
+			}
+			if (n == 0)
+				break;
+			total += (size_t)n;
+		}
+		out[total] = '\0';
+	}
+
+	/* Drain any remainder so the writer never blocks on a full pipe. */
+	while (n > 0) {
+		n = read(fd, discard, sizeof(discard));
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -errno;
+		}
+	}
+
+	return 0;
+}

--- a/shared/proc-util-linux.c
+++ b/shared/proc-util-linux.c
@@ -41,8 +41,8 @@ int shr_pipe(int fds[2])
 	return 0;
 }
 
-int shr_spawn(const char *const argv[], int out_fd, int err_fd,
-	      shr_proc_t *proc)
+static int _spawn(const char *const argv[], int out_fd, int err_fd,
+		  shr_proc_t *proc, bool search)
 {
 	pid_t pid;
 
@@ -61,13 +61,28 @@ int shr_spawn(const char *const argv[], int out_fd, int err_fd,
 		if (err_fd >= 0 && dup2(err_fd, STDERR_FILENO) < 0)
 			_exit(127);
 
-		execv(argv[0], (char *const *)argv);
+		if (search)
+			execvp(argv[0], (char *const *)argv);
+		else
+			execv(argv[0], (char *const *)argv);
 		_exit(127); /* exec failed */
 	}
 
 	*proc = (shr_proc_t)pid;
 
 	return 0;
+}
+
+int shr_spawn(const char *const argv[], int out_fd, int err_fd,
+	      shr_proc_t *proc)
+{
+	return _spawn(argv, out_fd, err_fd, proc, false);
+}
+
+int shr_spawnp(const char *const argv[], int out_fd, int err_fd,
+	       shr_proc_t *proc)
+{
+	return _spawn(argv, out_fd, err_fd, proc, true);
 }
 
 int shr_wait_proc(shr_proc_t proc, bool *exited, int *code)

--- a/shared/proc-util-win.c
+++ b/shared/proc-util-win.c
@@ -44,8 +44,8 @@ int shr_pipe(int fds[2])
 	return _pipe(fds, 1 << 16, _O_BINARY | _O_NOINHERIT) ? -errno : 0;
 }
 
-int shr_spawn(const char *const argv[], int out_fd, int err_fd,
-	      shr_proc_t *proc)
+static int _spawn(const char *const argv[], int out_fd, int err_fd,
+		  shr_proc_t *proc, bool search)
 {
 	int saved_out = -1, saved_err = -1;
 	intptr_t rc = -1;
@@ -83,7 +83,8 @@ int shr_spawn(const char *const argv[], int out_fd, int err_fd,
 	 * _P_NOWAIT so the child runs concurrently: the caller must drain a
 	 * pipe target before shr_wait_proc(); waiting here would deadlock.
 	 */
-	rc = _spawnv(_P_NOWAIT, argv[0], argv);
+	rc = search ? _spawnvp(_P_NOWAIT, argv[0], argv) :
+		      _spawnv(_P_NOWAIT, argv[0], argv);
 	if (rc == -1)
 		err = errno;
 
@@ -106,6 +107,18 @@ restore:
 	*proc = rc;
 
 	return 0;
+}
+
+int shr_spawn(const char *const argv[], int out_fd, int err_fd,
+	      shr_proc_t *proc)
+{
+	return _spawn(argv, out_fd, err_fd, proc, false);
+}
+
+int shr_spawnp(const char *const argv[], int out_fd, int err_fd,
+	       shr_proc_t *proc)
+{
+	return _spawn(argv, out_fd, err_fd, proc, true);
 }
 
 int shr_wait_proc(shr_proc_t proc, bool *exited, int *code)

--- a/shared/proc-util.h
+++ b/shared/proc-util.h
@@ -42,6 +42,20 @@ int shr_spawn(const char *const argv[], int out_fd, int err_fd,
 	      shr_proc_t *proc);
 
 /*
+ * Like shr_spawn(), but resolve argv[0] through PATH when it contains no path
+ * separator, mirroring execvp()/_spawnvp(). An argv[0] that already contains a
+ * path separator is used as-is (no PATH search). Because PATH search widens the
+ * set of binaries that may run, prefer shr_spawn() with an absolute path when
+ * the executable location is known.
+ *
+ * The out_fd/err_fd redirection, pipe-drain-before-wait, and *proc semantics
+ * are identical to shr_spawn().
+ * Return: 0 on success, -errno if the child could not be spawned.
+ */
+int shr_spawnp(const char *const argv[], int out_fd, int err_fd,
+	       shr_proc_t *proc);
+
+/*
  * Wait for a child from shr_spawn() and report how it ended. On success *exited
  * is set true if the child terminated normally and *code to its exit status;
  * *exited is false if it crashed or was killed by a signal.

--- a/shared/tests/test-io-util.c
+++ b/shared/tests/test-io-util.c
@@ -93,6 +93,67 @@ static bool test_bad_fd(void)
 	return pass;
 }
 
+static bool test_read_all(void)
+{
+	static const char *path = "shr-test-io-util-read";
+	static const char *msg = "0123456789abcdef";
+	char buf[64];
+	bool pass = true;
+	int fd, ret;
+
+	printf("test_read_all:\n");
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (!check_bool("temp file opened for writing", fd >= 0))
+		return false;
+	shr_write_all(fd, msg, strlen(msg));
+	close(fd);
+
+	/* Buffer large enough: whole content read back, NUL-terminated. */
+	fd = open(path, O_RDONLY);
+	if (check_bool("temp file reopened for reading", fd >= 0)) {
+		memset(buf, 'x', sizeof(buf));
+		ret = shr_read_all(fd, buf, sizeof(buf));
+		close(fd);
+		pass &= check_ret("read to EOF succeeds", ret, 0);
+		pass &= check_bool("content matches", !strcmp(buf, msg));
+	} else {
+		pass = false;
+	}
+
+	/* Buffer too small: keeps out_len-1 bytes, still drains to EOF. */
+	fd = open(path, O_RDONLY);
+	if (check_bool("temp file reopened for short read", fd >= 0)) {
+		ret = shr_read_all(fd, buf, 8);
+		close(fd);
+		pass &= check_ret("short buffer still succeeds (drains rest)",
+				  ret, 0);
+		pass &= check_bool("keeps exactly out_len-1 bytes",
+				   strlen(buf) == 7 && !strncmp(buf, msg, 7));
+	} else {
+		pass = false;
+	}
+
+	/* NULL out with a non-zero length is rejected. */
+	pass &= check_ret("NULL buffer with non-zero length is -EINVAL",
+			  shr_read_all(-1, NULL, 8), -EINVAL);
+
+	/* out_len == 0 keeps nothing but still drains the fd to EOF. */
+	fd = open(path, O_RDONLY);
+	if (check_bool("temp file reopened for zero-length read", fd >= 0)) {
+		ret = shr_read_all(fd, buf, 0);
+		close(fd);
+		pass &= check_ret("zero-length buffer drains and succeeds",
+				  ret, 0);
+	} else {
+		pass = false;
+	}
+
+	unlink(path);
+
+	return pass;
+}
+
 int main(void)
 {
 	bool pass = true;
@@ -100,6 +161,7 @@ int main(void)
 	pass &= test_round_trip();
 	pass &= test_zero_length();
 	pass &= test_bad_fd();
+	pass &= test_read_all();
 
 	fflush(stdout);
 	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);


### PR DESCRIPTION
The Micron plugin had its own cross-platform spawn helper implementations.  This change adds path searching versions of the shared spawn utilities and uses them in the Micron plugin instead of having separate implementations.  Also adds a shr_read_all method that reads until EOF, which is needed for draining a pipe.
* Adds path-searching shr_spawnp(), based on execvp on Linux and _spawnvp() on Windows.
* Adds shr_read_all to read a until EOL, handling EINTR as needed.
* Refactors Micron's spawn helpers to use the new shared utilities.