### PR TITLE
nvme: add monitor plugin

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -130,6 +130,7 @@ adoc_sources_man1 = [
     'nvme-micron-smart-add-log',
     'nvme-micron-smart-log',
     'nvme-micron-temperature-stats',
+    'nvme-monitor-smart',
     'nvme-netapp-ontapdevices',
     'nvme-netapp-smdevices',
     'nvme-ns-attach',

--- a/Documentation/nvme-monitor-smart.txt
+++ b/Documentation/nvme-monitor-smart.txt
@@ -1,0 +1,66 @@
+nvme-monitor-smart(1)
+=====================
+
+NAME
+----
+nvme-monitor-smart - Retrieve combined standard + OCP SMART/health monitoring data
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'monitor smart' <device>
+
+DESCRIPTION
+-----------
+Retrieves the standard NVMe SMART log page and, if the device supports it,
+the OCP SMART/health extended log page (LID 0xC0), and shows them together.
+Support for the OCP log page is auto-detected at runtime via the device's
+"Supported Log Pages" log; nothing needs to be known about the device ahead
+of time.
+
+The <device> parameter is mandatory and may be either the NVMe character
+device (ex: /dev/nvme0), or a namespace block device (ex: /dev/nvme0n1).
+
+This command exists for fleet-monitoring scripts that need one stable
+command to run across a mix of OCP and non-OCP devices. With '--output-format=json',
+the output is always a single JSON object with the same top-level keys
+regardless of the device:
+
+[verse]
+{
+  "device": <device name>,
+  "ocp_supported": <true|false>,
+  "smart_log": { ...standard SMART log fields... },
+  "ocp_smart_extended_log": { ...only present when ocp_supported is true... }
+}
+
+Scripts can check "ocp_supported" or simply test whether the
+"ocp_smart_extended_log" key is present, and always find the standard SMART
+fields under "smart_log". In "normal" or "binary" output format, the two log
+pages are printed one after the other instead of being merged, matching
+'nvme log smart' and 'nvme ocp smart-add-log' output.
+
+OPTIONS
+-------
+include::global-options.txt[]
+
+EXAMPLES
+--------
+* Print combined SMART/health data in a human readable format:
++
+------------
+# nvme monitor smart /dev/nvme0
+------------
++
+
+* Fetch a normalized JSON document for monitoring scripts, regardless of
+whether the device is an OCP device:
++
+------------
+# nvme monitor smart /dev/nvme0 -o json | jq .
+------------
++
+
+NVME
+----
+Part of the nvme-user suite

--- a/NEWS.md
+++ b/NEWS.md
@@ -210,6 +210,17 @@
 
 ### nvme-cli
 
+* A new `nvme monitor smart` command (part of a new `monitor` plugin,
+  built when both `ocp` and `monitor` are selected) combines the
+  standard SMART log with the OCP SMART/health extended log (LID
+  0xC0), auto-detecting OCP support at runtime. Unlike `nvme log
+  smart`/`nvme ocp smart-add-log`, which are unaffected by this
+  addition, its JSON output always uses the same top-level keys
+  (`smart_log`, and `ocp_smart_extended_log` when supported)
+  regardless of the device, so fleet-monitoring scripts get a
+  predictable shape across a mix of OCP and non-OCP drives. See
+  `nvme-monitor-smart(1)`.
+
 * A new global config file, `/etc/nvme/nvme-cli.conf`, sets
   machine-wide defaults for global options like `--timeout`,
   `--output-format`, `--no-retries`, and `--no-ioctl-probing`. 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -238,7 +238,7 @@ option(
   type : 'array',
   choices: ['amzn', 'config', 'dapustor', 'dell', 'dera', 'dir',
             'exclusion', 'fdp', 'feat', 'fw', 'huawei', 'ibm', 'id', 'innogrit', 'inspur',
-            'intel', 'io-mgmt', 'keys', 'lm', 'log', 'mangoboost', 'memblaze', 'micron', 'nbft',
+            'intel', 'io-mgmt', 'keys', 'lm', 'log', 'mangoboost', 'memblaze', 'micron', 'monitor', 'nbft',
             'netapp', 'ns', 'nvidia', 'nvme-mi', 'ocp', 'registry', 'resv', 'sandisk', 'scaleflux',
             'seagate', 'security', 'sed', 'shannon', 'solidigm', 'ssstc', 'toshiba',
             'transcend', 'utils', 'virtium', 'wdc', 'ymtc', 'zns'],

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -108,6 +108,12 @@ if 'ocp' in selected_plugins and json_c_dep.found()
   subdir('ocp')
 endif
 
+# The monitor plugin reuses OCP detection/fetch code, so it requires the ocp
+# plugin to also be selected and built.
+if 'monitor' in selected_plugins and 'ocp' in selected_plugins and json_c_dep.found()
+  subdir('monitor')
+endif
+
 if 'sed' in selected_plugins and conf.get('NVME_HAVE_SED_OPAL') != 0
   subdir('sed')
 endif

--- a/plugins/monitor/meson.build
+++ b/plugins/monitor/meson.build
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+plugin_sources += ['plugins/monitor/monitor-nvme.c']

--- a/plugins/monitor/monitor-nvme.c
+++ b/plugins/monitor/monitor-nvme.c
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include <libnvme.h>
+
+#include "argconfig.h"
+#include "cleanup.h"
+#include "global-ctx.h"
+#include "nvme-cmds.h"
+#include "nvme-json.h"
+#include "nvme-print.h"
+#include "plugin.h"
+
+#include "plugins/ocp/ocp-print.h"
+#include "plugins/ocp/ocp-smart-extended-log.h"
+#include "plugins/ocp/ocp-utils.h"
+
+static int monitor_smart(int argc, char **argv, struct command *acmd, struct plugin *plugin)
+{
+	const char *desc =
+		"Retrieve SMART/health data for cloud fleet monitoring scripts. Combines the "
+		"standard NVMe SMART log with the OCP SMART/health extended log (LID 0xC0) "
+		"when the device supports it; OCP support is auto-detected. In JSON output, "
+		"fields are always found under the same top-level keys ('smart_log', "
+		"optionally 'ocp_smart_extended_log') regardless of the device, so scripts "
+		"get a predictable shape across a mixed fleet.";
+
+	__cleanup_libnvme_free struct nvme_smart_log *smart_log = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
+	struct ocp_smart_extended_log ocp_log;
+	const char *devname;
+	nvme_print_flags_t flags;
+	bool has_ocp;
+	int err;
+
+	NVME_ARGS(opts);
+
+	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	err = validate_output_format(nvme_args.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
+
+	if (nvme_args.verbose)
+		flags |= VERBOSE;
+
+	devname = libnvme_transport_handle_get_name(hdl);
+
+	smart_log = libnvme_alloc(sizeof(*smart_log));
+	if (!smart_log)
+		return -ENOMEM;
+
+	err = nvme_get_log_smart(hdl, NVME_NSID_ALL, smart_log);
+	if (err) {
+		nvme_show_err(err, "smart log");
+		return err;
+	}
+
+	has_ocp = ocp_is_supported(hdl);
+	if (has_ocp && ocp_get_smart_extended_log(hdl, &ocp_log))
+		has_ocp = false;
+
+	if (nvme_is_output_format_json()) {
+		struct json_object *root = json_create_object();
+
+		json_object_add_value_string(root, "device", devname);
+		json_object_add_value_bool(root, "ocp_supported", has_ocp);
+		json_object_add_value_object(root, "smart_log",
+			nvme_smart_log_to_json(smart_log, NVME_NSID_ALL));
+		if (has_ocp)
+			json_object_add_value_object(root, "ocp_smart_extended_log",
+				ocp_smart_extended_log_to_json(&ocp_log,
+					nvme_args.output_format_ver));
+
+		json_print_object(root, NULL);
+		printf("\n");
+		json_free_object(root);
+	} else {
+		nvme_show_smart_log(smart_log, NVME_NSID_ALL, devname, flags);
+		if (has_ocp)
+			ocp_smart_extended_log(&ocp_log, nvme_args.output_format_ver, flags);
+	}
+
+	return 0;
+}
+
+static struct command monitor_smart_cmd = {
+	.name = "smart",
+	.help = "Retrieve combined standard + OCP SMART/health monitoring data "
+		"(auto-detects OCP support)",
+	.fn = monitor_smart,
+};
+
+static struct command *commands[] = {
+	&monitor_smart_cmd,
+	NULL,
+};
+
+static struct plugin plugin = {
+	.name = "monitor",
+	.desc = "Cloud fleet health monitoring helpers",
+	.version = NVME_VERSION,
+	.core = true,
+	.group = "Discovery & Logging",
+};
+
+static void __shr_constructor register_plugin(void)
+{
+	plugin_add_group(&plugin, NULL, commands);
+	register_extension(&plugin);
+}

--- a/plugins/ocp/ocp-print-json.c
+++ b/plugins/ocp/ocp-print-json.c
@@ -212,7 +212,7 @@ static void json_fw_activation_history(const struct fw_activation_history *fw_hi
 	printf("\n");
 }
 
-static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
+static struct json_object *json_smart_extended_log_v1_obj(struct ocp_smart_extended_log *log)
 {
 	struct json_object *root;
 	struct json_object *pmuw;
@@ -379,12 +379,19 @@ static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
 		json_object_add_value_uint(root, "Power State Change Count",
 						le64_to_cpu(log->power_state_change_count));
 	}
+	return root;
+}
+
+static void json_smart_extended_log_v1(struct ocp_smart_extended_log *log)
+{
+	struct json_object *root = json_smart_extended_log_v1_obj(log);
+
 	json_print_object(root, NULL);
 	printf("\n");
 	json_free_object(root);
 }
 
-static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
+static struct json_object *json_smart_extended_log_v2_obj(struct ocp_smart_extended_log *log)
 {
 	struct json_object *root;
 	struct json_object *pmuw;
@@ -543,6 +550,13 @@ static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
 		json_object_add_value_uint(root, "power_state_change_count",
 						le64_to_cpu(log->power_state_change_count));
 	}
+	return root;
+}
+
+static void json_smart_extended_log_v2(struct ocp_smart_extended_log *log)
+{
+	struct json_object *root = json_smart_extended_log_v2_obj(log);
+
 	json_print_object(root, NULL);
 	printf("\n");
 	json_free_object(root);
@@ -557,6 +571,18 @@ static void json_smart_extended_log(struct ocp_smart_extended_log *log, unsigned
 		break;
 	case 2:
 		json_smart_extended_log_v2(log);
+	}
+}
+
+struct json_object *ocp_smart_extended_log_to_json(struct ocp_smart_extended_log *log,
+						     unsigned int version)
+{
+	switch (version) {
+	default:
+	case 1:
+		return json_smart_extended_log_v1_obj(log);
+	case 2:
+		return json_smart_extended_log_v2_obj(log);
 	}
 }
 static void json_telemetry_log(struct ocp_telemetry_parse_options *options)

--- a/plugins/ocp/ocp-print.h
+++ b/plugins/ocp/ocp-print.h
@@ -7,6 +7,8 @@
 #include "ocp-telemetry-decode.h"
 #include "ocp-nvme.h"
 
+struct json_object;
+
 struct ocp_print_ops {
 	void (*hwcomp_log)(struct hwcomp_log *log, __u32 id, bool list);
 	void (*fw_act_history)(const struct fw_activation_history *fw_history);
@@ -28,8 +30,16 @@ struct ocp_print_ops *ocp_get_binary_print_ops(nvme_print_flags_t flags);
 
 #ifdef CONFIG_JSONC
 struct ocp_print_ops *ocp_get_json_print_ops(nvme_print_flags_t flags);
+struct json_object *ocp_smart_extended_log_to_json(struct ocp_smart_extended_log *log,
+						     unsigned int version);
 #else /* !CONFIG_JSONC */
 static inline struct ocp_print_ops *ocp_get_json_print_ops(nvme_print_flags_t flags)
+{
+	return NULL;
+}
+
+static inline struct json_object *ocp_smart_extended_log_to_json(
+		struct ocp_smart_extended_log *log, unsigned int version)
 {
 	return NULL;
 }

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -29,15 +29,43 @@ static __u8 scao_guid[GUID_LEN] = {
 	0xC9, 0x14, 0xD5, 0xAF
 };
 
+int ocp_get_smart_extended_log(struct libnvme_transport_handle *hdl,
+			       struct ocp_smart_extended_log *log)
+{
+	struct libnvme_passthru_cmd cmd;
+	__u8 uidx;
+	int ret;
+	int i;
+
+	memset(log, 0, sizeof(*log));
+
+	ocp_get_uuid_index(hdl, &uidx);
+	nvme_init_get_log(&cmd, NVME_NSID_ALL,
+			  (enum nvme_cmd_get_log_lid)OCP_LID_SMART,
+			  NVME_CSI_NVM, log, sizeof(*log));
+	cmd.cdw14 |= NVME_FIELD_ENCODE(uidx,
+				       NVME_LOG_CDW14_UUID_SHIFT,
+				       NVME_LOG_CDW14_UUID_MASK);
+	ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
+	if (ret)
+		return ret;
+
+	/* check log page guid */
+	/* Verify GUID matches */
+	for (i = 0; i < 16; i++) {
+		if (scao_guid[i] != log->log_page_guid[i])
+			return -EINVAL;
+	}
+
+	return 0;
+}
+
 static int get_c0_log_page(struct libnvme_transport_handle *hdl, char *format,
 			   unsigned int format_version)
 {
 	struct ocp_smart_extended_log *data;
-	struct libnvme_passthru_cmd cmd;
 	nvme_print_flags_t fmt;
-	__u8 uidx;
 	int ret;
-	int i;
 
 	ret = validate_output_format(format, &fmt);
 	if (ret < 0) {
@@ -50,50 +78,32 @@ static int get_c0_log_page(struct libnvme_transport_handle *hdl, char *format,
 		nvme_show_error("ERROR : OCP : malloc : %s", libnvme_strerror(errno));
 		return -1;
 	}
-	memset(data, 0, sizeof(*data));
 
-	ocp_get_uuid_index(hdl, &uidx);
-	nvme_init_get_log(&cmd, NVME_NSID_ALL,
-			  (enum nvme_cmd_get_log_lid)OCP_LID_SMART,
-			  NVME_CSI_NVM, data, sizeof(*data));
-	cmd.cdw14 |= NVME_FIELD_ENCODE(uidx,
-				       NVME_LOG_CDW14_UUID_SHIFT,
-				       NVME_LOG_CDW14_UUID_MASK);
-	ret = libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
+	ret = ocp_get_smart_extended_log(hdl, data);
 
 	if (strcmp(format, "json"))
 		nvme_show_error("NVMe Status:%s(%x)",
 			libnvme_status_to_string(ret, false), ret);
 
-	if (ret == 0) {
-		/* check log page guid */
-		/* Verify GUID matches */
-		for (i = 0; i < 16; i++) {
-			if (scao_guid[i] != data->log_page_guid[i]) {
-				int j;
+	if (ret == -EINVAL) {
+		int j;
 
-				nvme_show_error("ERROR : OCP : Unknown GUID in C0 Log Page data");
-				nvme_show_error("ERROR : OCP : Expected GUID:  0x");
-				for (j = 0; j < 16; j++)
-					nvme_show_error("%x", scao_guid[j]);
+		nvme_show_error("ERROR : OCP : Unknown GUID in C0 Log Page data");
+		nvme_show_error("ERROR : OCP : Expected GUID:  0x");
+		for (j = 0; j < 16; j++)
+			nvme_show_error("%x", scao_guid[j]);
 
-				nvme_show_error("\nERROR : OCP : Actual GUID:    0x");
-				for (j = 0; j < 16; j++)
-					nvme_show_error("%x", data->log_page_guid[j]);
-				nvme_show_error("");
-
-				ret = -1;
-				goto out;
-			}
-		}
-
+		nvme_show_error("\nERROR : OCP : Actual GUID:    0x");
+		for (j = 0; j < 16; j++)
+			nvme_show_error("%x", data->log_page_guid[j]);
+		nvme_show_error("");
+	} else if (ret == 0) {
 		/* print the data */
 		ocp_smart_extended_log(data, format_version, fmt);
 	} else {
 		nvme_show_error("ERROR : OCP : Unable to read C0 data from buffer");
 	}
 
-out:
 	free(data);
 	return ret;
 }

--- a/plugins/ocp/ocp-smart-extended-log.h
+++ b/plugins/ocp/ocp-smart-extended-log.h
@@ -13,6 +13,7 @@
 
 struct command;
 struct plugin;
+struct libnvme_transport_handle;
 
 /**
  * struct ocp_smart_extended_log -		SMART / Health Information Extended
@@ -154,3 +155,14 @@ struct ocp_smart_extended_log {
 
 int ocp_smart_add_log(int argc, char **argv, struct command *acmd,
 	struct plugin *plugin);
+
+/**
+ * ocp_get_smart_extended_log() - Fetch the OCP SMART / Health Information Extended log (LID 0xC0)
+ * @hdl:	nvme transport handle
+ * @log:	buffer to fill with the decoded log page
+ *
+ * Return: Zero on success, -EINVAL if the log page GUID doesn't match the expected OCP GUID,
+ *         or a negative POSIX/NVMe status error code otherwise.
+ */
+int ocp_get_smart_extended_log(struct libnvme_transport_handle *hdl,
+			       struct ocp_smart_extended_log *log);

--- a/plugins/ocp/ocp-utils.c
+++ b/plugins/ocp/ocp-utils.c
@@ -64,6 +64,20 @@ int ocp_get_log_simple(struct libnvme_transport_handle *hdl,
 	return libnvme_get_log(hdl, &cmd, false, NVME_LOG_PAGE_PDU_SIZE);
 }
 
+bool ocp_is_supported(struct libnvme_transport_handle *hdl)
+{
+	struct nvme_supported_log_pages supports;
+	struct libnvme_passthru_cmd cmd;
+	int err;
+
+	nvme_init_get_log_supported_log_pages(&cmd, NVME_CSI_NVM, &supports);
+	err = libnvme_get_log(hdl, &cmd, false, sizeof(supports));
+	if (err)
+		return false;
+
+	return le32_to_cpu(supports.lid_support[OCP_LID_SMART]) & 0x1;
+}
+
 bool ocp_is_tcg_activity_event(struct nvme_persistent_event_entry *pevent_entry_head,
 			       __u16 el, __u16 vsil)
 {

--- a/plugins/ocp/ocp-utils.h
+++ b/plugins/ocp/ocp-utils.h
@@ -35,6 +35,15 @@ int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, __u8 *index);
 int ocp_get_log_simple(struct libnvme_transport_handle *hdl, enum ocp_dssd_log_id lid, __u32 len, void *log);
 
 /**
+ * ocp_is_supported() - Check whether a device supports the OCP SMART/health log (LID 0xC0)
+ * @hdl:	nvme transport handle
+ *
+ * Return: true if the "Supported Log Pages" log reports LID 0xC0 as supported,
+ *         false otherwise (including on any error fetching that log).
+ */
+bool ocp_is_supported(struct libnvme_transport_handle *hdl);
+
+/**
  * ocp_is_tcg_activity_event() - Determine if persistent event is TCG activity event
  * @pevent_entry_head:	persistent event entry head pointer
  * @el:			Event Length

--- a/src/nvme-print-json.c
+++ b/src/nvme-print-json.c
@@ -828,6 +828,18 @@ static void json_smart_log(struct nvme_smart_log *smart, unsigned int nsid,
 	obj_add_uint(r, "interval_power_measurement", le32_to_cpu(smart->interval_power_measurement));
 }
 
+struct json_object *nvme_smart_log_to_json(struct nvme_smart_log *smart, unsigned int nsid)
+{
+	struct json_object *saved = json_r;
+	struct json_object *obj = json_create_object();
+
+	json_r = obj;
+	json_smart_log(smart, nsid, NULL);
+	json_r = saved;
+
+	return obj;
+}
+
 static void json_ana_log(struct nvme_ana_log *ana_log, const char *devname,
 			 size_t len)
 {

--- a/src/nvme-print.h
+++ b/src/nvme-print.h
@@ -227,10 +227,17 @@ struct nvme_bar_cap {
 #ifdef CONFIG_JSONC
 
 struct print_ops *nvme_get_json_print_ops(nvme_print_flags_t flags);
+struct json_object *nvme_smart_log_to_json(struct nvme_smart_log *smart, unsigned int nsid);
 
 #else /* !CONFIG_JSONC */
 
 static inline struct print_ops *nvme_get_json_print_ops(nvme_print_flags_t flags) { return NULL; }
+
+static inline struct json_object *nvme_smart_log_to_json(struct nvme_smart_log *smart,
+							  unsigned int nsid)
+{
+	return NULL;
+}
 
 #endif /* !CONFIG_JSONC */
 


### PR DESCRIPTION
Add a monitor plugin combining NVMe and OCP spec-compliant operations to simplify fleet monitoring.

Fixes: #2189

```
$ nvme monitor smart /dev/nvme0 -o json
{
  "device":"nvme0",
  "ocp_supported":false,
  "smart_log":{
    "critical_warning":0,
    "temperature":331,
    "avail_spare":100,
    "spare_thresh":10,
    "percent_used":19,
    "endurance_grp_critical_warning_summary":0,
    "data_units_read":182094536,
    "data_units_written":118624708,
    "host_read_commands":4971578062,
    "host_write_commands":3689075088,
    "controller_busy_time":3261,
    "power_cycles":1226,
    "power_on_hours":6028,
    "unsafe_shutdowns":134,
    "media_errors":0,
    "num_err_log_entries":0,
    "warning_temp_time":0,
    "critical_comp_time":0,
    "temperature_sensor_1":331,
    "temperature_sensor_2":361,
    "thm_temp1_trans_count":43,
    "thm_temp2_trans_count":0,
    "thm_temp1_total_time":766,
    "thm_temp2_total_time":0,
    "op_lifetime_energy_consumed":0,
    "interval_power_measurement":0
  }
}
```