### PR TITLE
Sort core plugins into groups and update help text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ static struct command *commands[] = {
 
 static void __attribute__((constructor)) register_group(void)
 {
-	plugin_add_group(&builtin, "Discovery & Logging", commands);
+	plugin_add_group(&builtin, "Log Page & Identify", commands);
 }
 ```
 
@@ -99,7 +99,7 @@ Use `.alias = "other-name"` for an alias, and `.deprecated = true` for a
 deprecated command (deprecated built-ins live in
 `src/nvme-cmds-deprecated.c`, gated by `#ifdef CONFIG_DEPRECATED_CMDS`).
 
-The `title` passed to `plugin_add_group()` (`"Discovery & Logging"` above)
+The `title` passed to `plugin_add_group()` (`"Log Page & Identify"` above)
 is the heading shown for that group's commands in `nvme help`; pass `NULL`
 for no heading (that's what plugins normally do, see below).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,10 @@ You may wish to add a new command or possibly an entirely new plug-in
 for some special extension outside the spec.
 
 Every command (built-in or plugin) is a `struct command`: a name, a help
-string, a callback, and optionally an alias or a `deprecated` flag. A
-group of commands is registered together with `plugin_add_group()`, and
-a named plugin additionally calls `register_extension()` once. 
+string, a callback, and optionally an alias, a `deprecated` flag, or a
+`no_device` flag. A group of commands is registered together with
+`plugin_add_group()`, and a named plugin additionally calls
+`register_extension()` once. 
 
 ### Add a command to an existing group
 
@@ -67,19 +68,19 @@ fit -- just add the one line to `src/meson.build`'s `sources` list. Each
 such file ends with a block like this one from `src/nvme-cmds-discovery.c`:
 
 ```c
-static struct command list_cmd = {
-	.name = "list",
-	.help = "List all NVMe devices and namespaces on machine",
-	.fn = list,
+static struct command get_log_cmd = {
+	.name = "get-log",
+	.help = "Generic NVMe get log, returns log in raw format",
+	.fn = get_log,
 };
 
 static struct command *commands[] = {
-	&list_cmd,
+	&get_log_cmd,
 	/* ... */
 	NULL,
 };
 
-static void __attribute__((constructor)) register_group(void)
+static void __shr_constructor register_group(void)
 {
 	plugin_add_group(&builtin, "Log Page & Identify", commands);
 }
@@ -98,6 +99,10 @@ int f(int argc, char **argv, struct command *command, struct plugin *plugin);
 Use `.alias = "other-name"` for an alias, and `.deprecated = true` for a
 deprecated command (deprecated built-ins live in
 `src/nvme-cmds-deprecated.c`, gated by `#ifdef CONFIG_DEPRECATED_CMDS`).
+Set `.no_device = true` for a command that doesn't take a positional
+`<device>` argument (e.g. `nvme list` or `nvme gen-hostnqn`) -- this drops
+`<device>` from its usage line and, when none of a plugin's commands need
+one, from that plugin's `--help` output too.
 
 The `title` passed to `plugin_add_group()` (`"Log Page & Identify"` above)
 is the heading shown for that group's commands in `nvme help`; pass `NULL`

--- a/plugins/config/config-nvme.c
+++ b/plugins/config/config-nvme.c
@@ -56,30 +56,35 @@ static struct command config_validate_cmd_cmd = {
 	.name = "validate",
 	.help = "Validate an NVMeoF connection configuration",
 	.fn = config_validate_cmd,
+	.no_device = true,
 };
 
 static struct command config_show_cmd_cmd = {
 	.name = "show",
 	.help = "Show the resolved NVMeoF connection configuration",
 	.fn = config_show_cmd,
+	.no_device = true,
 };
 
 static struct command config_status_cmd_cmd = {
 	.name = "status",
 	.help = "Report config status",
 	.fn = config_status_cmd,
+	.no_device = true,
 };
 
 static struct command config_convert_cmd_cmd = {
 	.name = "convert",
 	.help = "Convert config.json/discovery.conf to INI",
 	.fn = config_convert_cmd,
+	.no_device = true,
 };
 
 static struct command config_create_cmd_cmd = {
 	.name = "create",
 	.help = "Create an NVMeoF connection entry in the INI configuration",
 	.fn = config_create_cmd,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/plugins/dir/dir-plugin.c
+++ b/plugins/dir/dir-plugin.c
@@ -294,6 +294,7 @@ static struct plugin plugin = {
 	.desc = "Submit NVMe Directive commands",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "I/O Commands",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/exclusion/exclusion-nvme.c
+++ b/plugins/exclusion/exclusion-nvme.c
@@ -607,36 +607,42 @@ static struct command excl_create_cmd = {
 	.name = "create",
 	.help = "Create an exclusion list",
 	.fn = excl_create,
+	.no_device = true,
 };
 
 static struct command excl_delete_cmd = {
 	.name = "delete",
 	.help = "Delete an exclusion list",
 	.fn = excl_delete,
+	.no_device = true,
 };
 
 static struct command excl_edit_cmd = {
 	.name = "edit",
 	.help = "Edit an exclusion list interactively",
 	.fn = excl_edit,
+	.no_device = true,
 };
 
 static struct command excl_list_cmd = {
 	.name = "list",
 	.help = "List exclusion lists or entries",
 	.fn = excl_list,
+	.no_device = true,
 };
 
 static struct command excl_add_cmd = {
 	.name = "add",
 	.help = "Add an entry to an exclusion list",
 	.fn = excl_add,
+	.no_device = true,
 };
 
 static struct command excl_remove_cmd = {
 	.name = "remove",
 	.help = "Remove an entry from an exclusion list",
 	.fn = excl_remove,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/plugins/fdp/fdp.c
+++ b/plugins/fdp/fdp.c
@@ -632,6 +632,7 @@ static struct plugin plugin = {
 	.desc = "Manage Flexible Data Placement enabled devices",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "I/O Commands",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/fw/fw-plugin.c
+++ b/plugins/fw/fw-plugin.c
@@ -518,6 +518,7 @@ static struct plugin plugin = {
 	.desc = "Manage NVMe controller firmware",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "Controller Management",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/huawei/huawei-nvme.c
+++ b/plugins/huawei/huawei-nvme.c
@@ -402,6 +402,7 @@ static struct command huawei_list_cmd = {
 	.name = "list",
 	.help = "List all Huawei NVMe devices and namespaces on machine",
 	.fn = huawei_list,
+	.no_device = true,
 };
 
 static struct command huawei_id_ctrl_cmd = {

--- a/plugins/id/id-plugin.c
+++ b/plugins/id/id-plugin.c
@@ -1203,6 +1203,7 @@ static struct plugin plugin = {
 	.desc = "Send NVMe Identify commands, show the results",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "Log Page & Identify",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/io-mgmt/io-mgmt-plugin.c
+++ b/plugins/io-mgmt/io-mgmt-plugin.c
@@ -214,6 +214,7 @@ static struct plugin plugin = {
 	.desc = "Submit NVMe I/O Management commands",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "I/O Commands",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/keys/keys-plugin.c
+++ b/plugins/keys/keys-plugin.c
@@ -1073,48 +1073,56 @@ static struct command gen_kxchap_cmd = {
 	.name = "gen-kxchap-secret",
 	.help = "Generate NVMeoF KX-HMAC-CHAP host secret",
 	.fn = gen_kxchap,
+	.no_device = true,
 };
 
 static struct command check_kxchap_cmd = {
 	.name = "check-kxchap-secret",
 	.help = "Validate NVMeoF KX-HMAC-CHAP host secret format or check if loaded",
 	.fn = check_kxchap,
+	.no_device = true,
 };
 
 static struct command gen_tls_cmd = {
 	.name = "gen-tls",
 	.help = "Generate NVMeoF TLS PSK",
 	.fn = gen_tls,
+	.no_device = true,
 };
 
 static struct command check_tls_cmd = {
 	.name = "check-tls",
 	.help = "Validate NVMeoF TLS PSK format or check if loaded",
 	.fn = check_tls,
+	.no_device = true,
 };
 
 static struct command insert_tls_cmd = {
 	.name = "insert-tls",
 	.help = "Insert NVMeoF TLS PSK into a keyring",
 	.fn = insert_tls,
+	.no_device = true,
 };
 
 static struct command key_import_cmd = {
 	.name = "import",
 	.help = "Import NVMeoF TLS PSKs and KX-HMAC-CHAP secrets into a keyring",
 	.fn = key_import,
+	.no_device = true,
 };
 
 static struct command key_export_cmd = {
 	.name = "export",
 	.help = "Export NVMeoF TLS PSKs from a keyring",
 	.fn = key_export,
+	.no_device = true,
 };
 
 static struct command key_revoke_cmd = {
 	.name = "revoke",
 	.help = "Revoke an NVMeoF TLS PSK from a keyring",
 	.fn = key_revoke,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/plugins/lm/lm-nvme.c
+++ b/plugins/lm/lm-nvme.c
@@ -662,6 +662,7 @@ static struct plugin plugin = {
 	.desc = "Live Migration NVMe extensions",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "Controller Management",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/log/log-plugin.c
+++ b/plugins/log/log-plugin.c
@@ -2950,7 +2950,7 @@ static struct plugin plugin = {
 	.desc = "Retrieve and show NVMe log pages",
 	.version = NVME_VERSION,
 	.core = true,
-	.group = "Discovery & Logging",
+	.group = "Log Page & Identify",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/log/log-plugin.c
+++ b/plugins/log/log-plugin.c
@@ -76,6 +76,51 @@ static const char *raw_log = "show log in binary format";
 static const char *raw_output = "output in binary format";
 static const char *raw_use = "use binary output";
 
+static int get_supported_log_pages(int argc, char **argv, struct command *acmd,
+	struct plugin *plugin)
+{
+	const char *desc = "Retrieve supported logs and print the table.";
+
+	__cleanup_libnvme_free struct nvme_supported_log_pages *supports = NULL;
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
+	struct libnvme_passthru_cmd cmd;
+	nvme_print_flags_t flags;
+	int err = -1;
+
+	NVME_ARGS(opts);
+
+	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	err = validate_output_format(nvme_args.output_format, &flags);
+	if (err < 0) {
+		nvme_show_error("Invalid output format");
+		return err;
+	}
+
+	if (nvme_args.verbose)
+		flags |= VERBOSE;
+
+	supports = libnvme_alloc(sizeof(*supports));
+	if (!supports)
+		return -ENOMEM;
+
+	nvme_init_get_log(&cmd, NVME_NSID_ALL, NVME_LOG_LID_SUPPORTED_LOG_PAGES,
+		NVME_CSI_NVM, supports, sizeof(*supports));
+	err = libnvme_get_log(hdl, &cmd, false, sizeof(*supports));
+	if (err) {
+		nvme_show_err(err, "supported log pages");
+		return err;
+	}
+
+	nvme_show_supported_log(supports, libnvme_transport_handle_get_name(hdl),
+				flags);
+
+	return err;
+}
+
 static int get_smart_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Retrieve SMART log for the given device "
@@ -2665,6 +2710,12 @@ static int get_pull_model_ddc_req_log(int argc, char **argv, struct command *acm
 	return err;
 }
 
+static struct command supported_pages_cmd = {
+	.name = "supported-pages",
+	.help = "Retrieve the Supported Log pages details, show it",
+	.fn = get_supported_log_pages,
+};
+
 static struct command smart_cmd = {
 	.name = "smart",
 	.help = "Retrieve SMART Log, show it",
@@ -2858,6 +2909,7 @@ static struct command sanitize_cmd = {
 };
 
 static struct command *commands[] = {
+	&supported_pages_cmd,
 	&smart_cmd,
 	&ana_cmd,
 	&telemetry_cmd,

--- a/plugins/micron/micron-nvme.c
+++ b/plugins/micron/micron-nvme.c
@@ -4415,12 +4415,14 @@ static struct command plugin_version_cmd = {
 	.name = "plugin-version",
 	.help = "Display plugin version info",
 	.fn = micron_plugin_version,
+	.no_device = true,
 };
 
 static struct command cloud_ssd_plugin_version_cmd = {
 	.name = "cloud-SSD-plugin-version",
 	.help = "Display plugin version info",
 	.fn = micron_cloud_ssd_plugin_version,
+	.no_device = true,
 };
 
 static struct command log_page_directory_cmd = {

--- a/plugins/nbft/nbft-plugin.c
+++ b/plugins/nbft/nbft-plugin.c
@@ -703,6 +703,7 @@ static struct command show_nbft_cmd = {
 	.name = "show",
 	.help = "Show contents of ACPI NBFT tables",
 	.fn = show_nbft,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/plugins/netapp/netapp-nvme.c
+++ b/plugins/netapp/netapp-nvme.c
@@ -1131,12 +1131,14 @@ static struct command netapp_smdevices_cmd = {
 	.name = "smdevices",
 	.help = "NetApp SMdevices",
 	.fn = netapp_smdevices,
+	.no_device = true,
 };
 
 static struct command netapp_ontapdevices_cmd = {
 	.name = "ontapdevices",
 	.help = "NetApp ONTAPdevices",
 	.fn = netapp_ontapdevices,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/plugins/ns/ns-plugin.c
+++ b/plugins/ns/ns-plugin.c
@@ -669,6 +669,7 @@ static struct plugin plugin = {
 	.desc = "Manage NVMe namespaces",
 	.version = NVME_VERSION,
 	.core = true,
+	.group = "Controller Management",
 };
 
 static void __shr_constructor register_plugin(void)

--- a/plugins/registry/registry-nvme.c
+++ b/plugins/registry/registry-nvme.c
@@ -256,6 +256,7 @@ static struct command registry_list_cmd = {
 	.name = "list",
 	.help = "List live registry entries",
 	.fn = registry_list,
+	.no_device = true,
 };
 
 static struct command registry_retrieve_cmd = {

--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1956,12 +1956,14 @@ static struct command seagate_plugin_version_cmd = {
 	.name = "plugin-version",
 	.help = "Shows Seagate plugin's version information ",
 	.fn = seagate_plugin_version,
+	.no_device = true,
 };
 
 static struct command stx_ocp_plugin_version_cmd = {
 	.name = "cloud-SSD-plugin-version",
 	.help = "Shows OCP Seagate plugin's version information ",
 	.fn = stx_ocp_plugin_version,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/plugins/solidigm/solidigm-nvme.c
+++ b/plugins/solidigm/solidigm-nvme.c
@@ -203,6 +203,7 @@ static struct command get_cloud_SSDplugin_version_cmd = {
 	.name = "cloud-SSDplugin-version",
 	.help = "Prints plug-in OCP version",
 	.fn = get_cloud_SSDplugin_version,
+	.no_device = true,
 };
 
 static struct command get_workload_tracker_cmd = {

--- a/plugins/utils/utils.c
+++ b/plugins/utils/utils.c
@@ -22,6 +22,7 @@ static struct command dump_command_metadata_cmd_cmd = {
 	.name = "dump-command-metadata",
 	.help = "Dump all commands and their options as JSON",
 	.fn = dump_command_metadata_cmd,
+	.no_device = true,
 };
 #endif /* CONFIG_JSONC */
 

--- a/plugins/zns/zns.c
+++ b/plugins/zns/zns.c
@@ -1126,6 +1126,7 @@ static struct command list_cmd = {
 	.name = "list",
 	.help = "List all NVMe devices with Zoned Namespace Command Set support",
 	.fn = list,
+	.no_device = true,
 };
 
 static struct command id_ctrl_cmd = {

--- a/src/nvme-cmds-deprecated.c
+++ b/src/nvme-cmds-deprecated.c
@@ -355,6 +355,11 @@ static int forward_to_log_plugin(const char *old_name, const char *subcmd,
 	return handle_plugin(argc + 1, sub_argv, log);
 }
 
+static int get_supported_log_pages(int argc, char **argv, struct command *acmd, struct plugin *plugin)
+{
+	return forward_to_log_plugin("supported-log-pages", "supported-pages", argc, argv);
+}
+
 static int get_telemetry_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	return forward_to_log_plugin("telemetry-log", "telemetry", argc, argv);
@@ -1167,6 +1172,14 @@ static struct command get_ns_id_cmd = {
 	.deprecated = true,
 };
 
+static struct command get_supported_log_pages_cmd = {
+	.name = "supported-log-pages",
+	.help = "Retrieve the Supported Log pages details, show it (deprecated, use 'nvme log "
+		"supported-pages')",
+	.fn = get_supported_log_pages,
+	.deprecated = true,
+};
+
 static struct command get_telemetry_log_cmd = {
 	.name = "telemetry-log",
 	.help = "Retrieve FW Telemetry log write to file (deprecated, use 'nvme log telemetry')",
@@ -1571,6 +1584,7 @@ static struct command *commands[] = {
 	&attach_ns_cmd,
 	&detach_ns_cmd,
 	&get_ns_id_cmd,
+	&get_supported_log_pages_cmd,
 	&get_telemetry_log_cmd,
 	&get_fw_log_cmd,
 	&get_changed_attach_ns_list_log_cmd,

--- a/src/nvme-cmds-deprecated.c
+++ b/src/nvme-cmds-deprecated.c
@@ -1485,6 +1485,7 @@ static struct command gen_dhchap_key_cmd = {
 	.help = "Generate NVMeoF DH-HMAC-CHAP host secret (deprecated, use 'nvme keys gen-kxchap-secret')",
 	.fn = gen_dhchap_key,
 	.deprecated = true,
+	.no_device = true,
 };
 
 static struct command check_dhchap_key_cmd = {
@@ -1493,6 +1494,7 @@ static struct command check_dhchap_key_cmd = {
 		"check-kxchap-secret')",
 	.fn = check_dhchap_key,
 	.deprecated = true,
+	.no_device = true,
 };
 
 static struct command gen_tls_key_cmd = {
@@ -1500,6 +1502,7 @@ static struct command gen_tls_key_cmd = {
 	.help = "Generate NVMeoF TLS PSK (deprecated, use 'nvme keys gen-tls')",
 	.fn = gen_tls_key,
 	.deprecated = true,
+	.no_device = true,
 };
 
 static struct command check_tls_key_cmd = {
@@ -1507,6 +1510,7 @@ static struct command check_tls_key_cmd = {
 	.help = "Validate NVMeoF TLS PSK (deprecated, use 'nvme keys check-tls')",
 	.fn = check_tls_key,
 	.deprecated = true,
+	.no_device = true,
 };
 
 static struct command tls_key_cmd = {
@@ -1514,6 +1518,7 @@ static struct command tls_key_cmd = {
 	.help = "Manage NVMeoF TLS PSKs (deprecated, use 'nvme keys import/export/revoke')",
 	.fn = tls_key,
 	.deprecated = true,
+	.no_device = true,
 };
 
 #endif /* CONFIG_FABRICS */

--- a/src/nvme-cmds-discovery.c
+++ b/src/nvme-cmds-discovery.c
@@ -34,51 +34,6 @@ static const char *csi = "command set identifier";
 static const char *namespace_desired = "desired namespace";
 static const char *ish = "Ignore Shutdown (for NVMe-MI command)";
 
-static int get_supported_log_pages(int argc, char **argv, struct command *acmd,
-	struct plugin *plugin)
-{
-	const char *desc = "Retrieve supported logs and print the table.";
-
-	__cleanup_libnvme_free struct nvme_supported_log_pages *supports = NULL;
-	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
-	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
-	struct libnvme_passthru_cmd cmd;
-	nvme_print_flags_t flags;
-	int err = -1;
-
-	NVME_ARGS(opts);
-
-	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
-	if (err)
-		return err;
-
-	err = validate_output_format(nvme_args.output_format, &flags);
-	if (err < 0) {
-		nvme_show_error("Invalid output format");
-		return err;
-	}
-
-	if (nvme_args.verbose)
-		flags |= VERBOSE;
-
-	supports = libnvme_alloc(sizeof(*supports));
-	if (!supports)
-		return -ENOMEM;
-
-	nvme_init_get_log(&cmd, NVME_NSID_ALL, NVME_LOG_LID_SUPPORTED_LOG_PAGES,
-		NVME_CSI_NVM, supports, sizeof(*supports));
-	err = libnvme_get_log(hdl, &cmd, false, sizeof(*supports));
-	if (err) {
-		nvme_show_err(err, "supported log pages");
-		return err;
-	}
-
-	nvme_show_supported_log(supports, libnvme_transport_handle_get_name(hdl),
-				flags);
-
-	return err;
-}
-
 static int get_log(int argc, char **argv, struct command *acmd, struct plugin *plugin)
 {
 	const char *desc = "Retrieve desired number of bytes "
@@ -301,15 +256,8 @@ static struct command get_log_cmd = {
 	.fn = get_log,
 };
 
-static struct command get_supported_log_pages_cmd = {
-	.name = "supported-log-pages",
-	.help = "Retrieve the Supported Log pages details, show it",
-	.fn = get_supported_log_pages,
-};
-
 static struct command *commands[] = {
 	&get_log_cmd,
-	&get_supported_log_pages_cmd,
 	NULL,
 };
 

--- a/src/nvme-cmds-discovery.c
+++ b/src/nvme-cmds-discovery.c
@@ -263,5 +263,5 @@ static struct command *commands[] = {
 
 static void __shr_constructor register_group(void)
 {
-	plugin_add_group(&builtin, "Discovery & Logging", commands);
+	plugin_add_group(&builtin, "Log Page & Identify", commands);
 }

--- a/src/nvme-cmds-enumerate.c
+++ b/src/nvme-cmds-enumerate.c
@@ -261,12 +261,14 @@ static struct command list_cmd = {
 	.name = "list",
 	.help = "List all NVMe devices and namespaces on machine",
 	.fn = list,
+	.no_device = true,
 };
 
 static struct command list_subsys_cmd = {
 	.name = "list-subsys",
 	.help = "List nvme subsystems",
 	.fn = list_subsys,
+	.no_device = true,
 };
 
 #ifdef CONFIG_TOP
@@ -275,6 +277,7 @@ static struct command top_cmd = {
 	.name = "top",
 	.help = "nvme top",
 	.fn = top,
+	.no_device = true,
 };
 
 #endif /* CONFIG_TOP */
@@ -283,6 +286,7 @@ static struct command show_topology_cmd_cmd = {
 	.name = "show-topology",
 	.help = "Show the topology",
 	.fn = show_topology_cmd,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/src/nvme-cmds-fabrics.c
+++ b/src/nvme-cmds-fabrics.c
@@ -158,48 +158,56 @@ static struct command discover_cmd_cmd = {
 	.name = "discover",
 	.help = "Discover NVMeoF subsystems",
 	.fn = discover_cmd,
+	.no_device = true,
 };
 
 static struct command connect_all_cmd_cmd = {
 	.name = "connect-all",
 	.help = "Discover and Connect to NVMeoF subsystems",
 	.fn = connect_all_cmd,
+	.no_device = true,
 };
 
 static struct command connect_cmd_cmd = {
 	.name = "connect",
 	.help = "Connect to NVMeoF subsystem",
 	.fn = connect_cmd,
+	.no_device = true,
 };
 
 static struct command disconnect_cmd_cmd = {
 	.name = "disconnect",
 	.help = "Disconnect from NVMeoF subsystem",
 	.fn = disconnect_cmd,
+	.no_device = true,
 };
 
 static struct command disconnect_all_cmd_cmd = {
 	.name = "disconnect-all",
 	.help = "Disconnect from all connected NVMeoF subsystems",
 	.fn = disconnect_all_cmd,
+	.no_device = true,
 };
 
 static struct command dim_cmd_cmd = {
 	.name = "dim",
 	.help = "Send Discovery Information Management command to a Discovery Controller",
 	.fn = dim_cmd,
+	.no_device = true,
 };
 
 static struct command gen_hostnqn_cmd_cmd = {
 	.name = "gen-hostnqn",
 	.help = "Generate NVMeoF host NQN",
 	.fn = gen_hostnqn_cmd,
+	.no_device = true,
 };
 
 static struct command show_hostnqn_cmd_cmd = {
 	.name = "show-hostnqn",
 	.help = "Show NVMeoF host NQN",
 	.fn = show_hostnqn_cmd,
+	.no_device = true,
 };
 
 static struct command *commands[] = {

--- a/src/nvme.c
+++ b/src/nvme.c
@@ -65,10 +65,8 @@ static struct program nvme = {
 	.name = "nvme",
 	.version = nvme_version_string,
 	.usage = "<command> [<device>] [<args>]",
-	.desc = "The '<device>' may be either an NVMe controller "
-		"device (ex: /dev/nvme0), an nvme namespace device "
-		"(ex: /dev/nvme0n1), or a mctp address in the form "
-		"mctp:<net>,<eid>[:ctrl-id]",
+	.desc = "Send NVMe Admin and I/O commands, manage NVMe devices, "
+		"and configure NVMe-oF fabrics connections.",
 	.extensions = &builtin,
 };
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -133,6 +133,18 @@ static void usage_cmd(struct plugin *plugin)
 		printf("usage: %s %s\n", prog->name, prog->usage);
 }
 
+static void build_command_usage(char *use, size_t size, struct program *prog,
+				struct plugin *plugin, struct command *cmd)
+{
+	const char *device = cmd->no_device ? "" : " <device>";
+
+	if (!plugin->name)
+		snprintf(use, size, "%s %s%s [OPTIONS]", prog->name, cmd->name, device);
+	else
+		snprintf(use, size, "%s %s %s%s [OPTIONS]", prog->name, plugin->name,
+			cmd->name, device);
+}
+
 void plugin_add_group(struct plugin *plugin, const char *title,
 		      struct command **commands)
 {
@@ -165,6 +177,16 @@ void plugin_add_group(struct plugin *plugin, const char *title,
 	plugin->commands = merged;
 }
 
+static void print_device_desc(void)
+{
+	printf("'<device>' is one of:\n");
+	printf("  - an NVMe controller device (ex: /dev/nvme0)\n");
+	printf("  - an NVMe namespace device (ex: /dev/nvme0n1)\n");
+#ifdef CONFIG_MI
+	printf("  - a mctp address (ex: mctp:<net>,<eid>[:ctrl-id])\n");
+#endif
+}
+
 void general_help(struct plugin *plugin, char *str)
 {
 	struct program *prog = plugin->parent;
@@ -173,14 +195,29 @@ void general_help(struct plugin *plugin, char *str)
 	unsigned int padding = 15;
 	unsigned int curr_length = 0;
 	bool have_deprecated = false;
+	bool needs_device = false;
+
+	for (i = 0; plugin->commands[i]; i++) {
+		if (!plugin->commands[i]->no_device) {
+			needs_device = true;
+			break;
+		}
+	}
 
 	printf("%s-%s\n", prog->name, prog->version);
 
 	usage_cmd(plugin);
 
-	printf("\n");
-	shr_print_word_wrapped(prog->desc, 0, 0, stdout);
-	printf("\n");
+	if (prog->desc) {
+		printf("\n");
+		shr_print_word_wrapped(prog->desc, 0, 0, stdout);
+		printf("\n");
+	}
+
+	if (needs_device) {
+		printf("\n");
+		print_device_desc();
+	}
 
 	if (plugin->desc) {
 		printf("\n");
@@ -196,7 +233,7 @@ void general_help(struct plugin *plugin, char *str)
 	 * iterate through all commands to get maximum length
 	 * Still need to handle the case of ultra long strings, help messages, etc
 	 */
-	for (; plugin->commands[i]; i++) {
+	for (i = 0; plugin->commands[i]; i++) {
 		curr_length = 2 + strlen(plugin->commands[i]->name);
 		if (padding < curr_length)
 			padding = curr_length;
@@ -406,12 +443,6 @@ int handle_plugin(int argc, char **argv, struct plugin *plugin)
 
 	str = argv[0];
 
-	if (!plugin->name)
-		snprintf(use, sizeof(use), "%s %s <device> [OPTIONS]", prog->name, str);
-	else
-		snprintf(use, sizeof(use), "%s %s %s <device> [OPTIONS]", prog->name, plugin->name, str);
-	argconfig_append_usage(use);
-
 	if (!strcmp(str, "help"))
 		return help(argc, argv, plugin);
 	if (!strcmp(str, "version"))
@@ -419,8 +450,11 @@ int handle_plugin(int argc, char **argv, struct plugin *plugin)
 
 	while (*cmd) {
 		if (!strcmp(str, (*cmd)->name) ||
-		    ((*cmd)->alias && !strcmp(str, (*cmd)->alias)))
+		    ((*cmd)->alias && !strcmp(str, (*cmd)->alias))) {
+			build_command_usage(use, sizeof(use), prog, plugin, *cmd);
+			argconfig_append_usage(use);
 			return (*cmd)->fn(argc, argv, *cmd, plugin);
+		}
 		if (!strncmp(str, (*cmd)->name, strlen(str))) {
 			if (cr) {
 				cr_valid = false;
@@ -433,7 +467,7 @@ int handle_plugin(int argc, char **argv, struct plugin *plugin)
 	}
 
 	if (cr && cr_valid) {
-		snprintf(use, sizeof(use), "%s %s <device> [OPTIONS]", prog->name, cr->name);
+		build_command_usage(use, sizeof(use), prog, plugin, cr);
 		argconfig_append_usage(use);
 		return cr->fn(argc, argv, cr, plugin);
 	}

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -11,7 +11,6 @@ struct program {
 	const char *version;
 	const char *usage;
 	const char *desc;
-	const char *more;
 	struct command **commands;
 	struct plugin *extensions;
 };
@@ -47,6 +46,8 @@ struct command {
 	int (*fn)(int argc, char **argv, struct command *acmd, struct plugin *plugin);
 	char *alias;
 	bool deprecated;
+	/* Set for commands that don't take a positional <device> argument. */
+	bool no_device;
 };
 
 /*


### PR DESCRIPTION
Move many of the core plugins into the top groups. While at it also make the help text more useful.