### PR TITLE
seagate: remove duplicate nvme_set_features_simple call in vs_clr_pci e_correctable_errs

### DIFF
--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1521,8 +1521,6 @@ static int vs_clr_pcie_correctable_errs(int argc, char **argv, struct command *a
 			nvme_show_error("%s: couldn't clear PCIe correctable errors", __func__);
 	}
 
-	err = nvme_set_features_simple(hdl, 0, 0xE1, cfg.save, 0xCB, &result);
-
 	if (err < 0) {
 		nvme_show_err(err, "set-feature");
 		return errno;


### PR DESCRIPTION

The vs_clr_pcie_correctable_errs() function dispatches between two different NVMe feature commands based on device model using an if/else block. Each branch correctly assigns err from the appropriate command.

An unconditional call to nvme_set_features_simple() after the if/else block overwrites err before it can be checked. For Jaguar/Panther devices this silently discards the result of nvme_set_features() and re-issues the wrong command; for other devices the command runs twice.

Remove the duplicate call so that err reflects the result of the device-appropriate command selected by the if/else block.