### PR TITLE
ocp: fix unused value of temp_sz in get_telemetry_dump()

### DIFF
--- a/plugins/ocp/ocp-nvme.c
+++ b/plugins/ocp/ocp-nvme.c
@@ -960,7 +960,7 @@ static int get_telemetry_dump(struct libnvme_transport_handle *hdl, char *filena
 		}
 
 		print_telemetry_da_stat((void *)(da1_stat + (temp_ofst - da1_off)), tele_type,
-					le64_to_cpu(da1->da1_stat_size) * 4, 1);
+					temp_sz, 1);
 	}
 
 	/* Print the Data Area 1 Event FIFO's */


### PR DESCRIPTION
The get_telemetry_dump() function captures the original unpadded DA1 stats size into temp_sz before the size may be rounded up to a 512-byte boundary for the read. The subsequent print_telemetry_da_stat() call re-derives that same value inline instead of using temp_sz, leaving the stored value unread before it is overwritten by the FIFO loop.

The dead assignment is misleading and inconsistent with the FIFO loop blocks in the same function, which correctly assign temp_sz and pass it to print_telemetry_da_fifo().

Pass temp_sz to print_telemetry_da_stat() so the stored value is used as intended.