### PR TITLE
solidigm: fix STRING_OVERFLOW in join_options

### DIFF
--- a/plugins/solidigm/solidigm-workload-tracker.c
+++ b/plugins/solidigm/solidigm-workload-tracker.c
@@ -466,12 +466,12 @@ static int find_option(char const *list[], int size, const char *val)
 	return -EINVAL;
 }
 
-static void join_options(char *dest, char const *list[], size_t list_size)
+static void join_options(char *dest, size_t dest_size, char const *list[], size_t list_size)
 {
-	strcat(dest, list[0]);
+	strncat(dest, list[0], dest_size - strlen(dest) - 1);
 	for (int i = 1; i < list_size; i++) {
-		strcat(dest, "|");
-		strcat(dest, list[i]);
+		strncat(dest, "|", dest_size - strlen(dest) - 1);
+		strncat(dest, list[i], dest_size - strlen(dest) - 1);
 	}
 }
 
@@ -535,8 +535,8 @@ int sldgm_get_workload_tracker(int argc, char **argv, struct command *acmd, stru
 		.trigger_field = "",
 	};
 
-	join_options(type_options, trk_types, ARRAY_SIZE(trk_types));
-	join_options(sample_options, samplet, ARRAY_SIZE(samplet));
+	join_options(type_options, sizeof(type_options), trk_types, ARRAY_SIZE(trk_types));
+	join_options(sample_options, sizeof(sample_options), samplet, ARRAY_SIZE(samplet));
 
 	NVME_ARGS(opts,
 		OPT_BYTE("uuid-index",   'U', &wlt.uuid_index, "specify uuid index"),


### PR DESCRIPTION
The join_options() function builds a pipe-delimited option string by concatenating each entry from a string array into dest using strcat(). No bounds checking is performed against the size of the destination buffer.

Passing a fixed-size stack buffer to strcat() without a length limit allows the written string to silently overflow the buffer if the total length of the joined options exceeds the buffer size, resulting in undefined behavior.

Add a dest_size parameter and replace strcat() with strncat(), limiting each concatenation to the remaining space in the buffer. Update both call sites to pass sizeof() of their buffer.