### PR TITLE
wdc: Remove unused value assignment in drive essentials

### DIFF
--- a/plugins/wdc/wdc-nvme.c
+++ b/plugins/wdc/wdc-nvme.c
@@ -10313,7 +10313,6 @@ static int wdc_do_drive_essentials(struct libnvme_global_ctx *ctx, struct libnvm
 		}
 
 		free(dataBuffer);
-		dataBuffer = NULL;
 	}
 
 	free(vuLogInput);


### PR DESCRIPTION
The drive essentials log page loop frees dataBuffer at the end of each iteration. The pointer is immediately overwritten by a new allocation on the next iteration, so assigning NULL to it is never observed.

The extra assignment has no effect and is reported by Coverity as an unused value.

Remove the dead assignment after free() and keep the existing loop logic unchanged.