### PR TITLE
NEWS: document silent nvme ns create in 3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -107,6 +107,15 @@
   `nvme ns` plugin, e.g. `nvme create-ns` is now `nvme ns create`.
   The old top-level commands still work as deprecated aliases.
 
+* `nvme ns create`, `nvme ns delete`, `nvme ns attach`, and
+  `nvme ns detach` (and their deprecated `create-ns`/`delete-ns`/
+  `attach-ns`/`detach-ns` aliases) no longer print a confirmation
+  message on success by default; `nvme ns create` also no longer
+  prints the assigned `nsid`. Both are now gated behind
+  `-v`/`--verbose`. The exit code alone indicates success/failure;
+  the assigned `nsid` can still be found with `nvme ns list` or
+  `nvme id ctrl`. See `nvme-ns-create(1)`.
+
 * Reservation commands (`resv-acquire`, `resv-register`,
   `resv-release`, `resv-report`) have moved into a new `nvme resv`
   plugin, e.g. `nvme resv-acquire` is now `nvme resv acquire`. The


### PR DESCRIPTION
The success confirmation (and, for 'ns create', the assigned nsid) moved behind -v/--verbose and was never called out in NEWS.md. Users upgrading from 1.x/2.x get no output on success, only the exit code, which was reported as issue #3877.