### PR TITLE
completions: regenerate from a complete Linux build

### DIFF
--- a/completions/_nvme
+++ b/completions/_nvme
@@ -18,6 +18,12 @@ _nvme () {
 	_cmds=(
 		'list:List all NVMe devices and namespaces on machine'
 		'list-subsys:List nvme subsystems'
+		'show-topology:Show the topology'
+		'top:nvme top'
+		'reset:Resets the controller'
+		'subsystem-reset:Resets the subsystem'
+		'ns-rescan:Rescans the NVME namespaces'
+		'virt-mgmt:Manage Flexible Resources between Primary and Secondary Controller'
 		'id-ctrl:Send NVMe Identify Controller (deprecated, use '\''nvme id ctrl'\'')'
 		'id-ns:Send NVMe Identify Namespace, display structure (deprecated, use '\''nvme id ns'\'')'
 		'id-ns-granularity:Send NVMe Identify Namespace Granularity List, display structure (deprecated, use '\''nvme id ns-granularity'\'')'
@@ -41,7 +47,7 @@ _nvme () {
 		'attach-ns:Attaches a namespace to requested controller(s) (deprecated, use '\''nvme ns attach'\'')'
 		'detach-ns:Detaches a namespace from requested controller(s) (deprecated, use '\''nvme ns detach'\'')'
 		'get-ns-id:Retrieve the namespace ID of opened block device (deprecated, use '\''nvme ns get-id'\'')'
-		'get-log:Generic NVMe get log, returns log in raw format'
+		'supported-log-pages:Retrieve the Supported Log pages details, show it (deprecated, use '\''nvme log supported-pages'\'')'
 		'telemetry-log:Retrieve FW Telemetry log write to file (deprecated, use '\''nvme log telemetry'\'')'
 		'fw-log:Retrieve FW Log, show it (deprecated, use '\''nvme log fw'\'')'
 		'changed-ns-list-log:Retrieve Changed Attached Namespace List, show it (deprecated, use '\''nvme log changed-ns-list'\'')'
@@ -58,10 +64,7 @@ _nvme () {
 		'resv-notif-log:Retrieve Reservation Notification Log, show it (deprecated, use '\''nvme log resv-notif'\'')'
 		'boot-part-log:Retrieve Boot Partition Log, show it (deprecated, use '\''nvme log boot-part'\'')'
 		'phy-rx-eom-log:Retrieve Physical Interface Receiver Eye Opening Measurement, show it (deprecated, use '\''nvme log phy-rx-eom'\'')'
-		'get-feature:Get feature and show the resulting value'
-		'device-self-test:Perform the necessary tests to observe the performance'
 		'self-test-log:Retrieve the SELF-TEST Log, show it (deprecated, use '\''nvme log self-test'\'')'
-		'supported-log-pages:Retrieve the Supported Log pages details, show it'
 		'fid-support-effects-log:Retrieve FID Support and Effects log and show it (deprecated, use '\''nvme log fid-support-effects'\'')'
 		'mi-cmd-support-effects-log:Retrieve MI Command Support and Effects log and show it (deprecated, use '\''nvme log mi-cmd-support-effects'\'')'
 		'media-unit-stat-log:Retrieve the configuration and wear of media units, show it (deprecated, use '\''nvme log media-unit-stat'\'')'
@@ -76,23 +79,38 @@ _nvme () {
 		'ave-discovery-log:Retrieve AVE Discovery Log, show it (deprecated, use '\''nvme log ave-discovery'\'')'
 		'pull-model-ddc-req-log:Retrieve Pull Model DDC Request Log, show it (deprecated, use '\''nvme log pull-model-ddc-req'\'')'
 		'power-measurement-log:Retrieve Power Measurement Log, show it (deprecated, use '\''nvme log power-measurement'\'')'
-		'set-feature:Set a feature and show the resulting value'
-		'set-property:Set a property and show the resulting value'
-		'get-property:Get a property and show the resulting value'
-		'format:Format namespace with new block format'
 		'fw-commit:Verify and commit firmware to a specific slot (fw-activate in old version < 1.2) (deprecated, use '\''nvme fw commit'\'')'
 		'fw-activate:Verify and commit firmware to a specific slot (fw-activate in old version < 1.2) (deprecated, use '\''nvme fw commit'\'')'
 		'fw-download:Download new firmware (deprecated, use '\''nvme fw download'\'')'
-		'admin-passthru:Submit an arbitrary admin command, return results'
-		'io-passthru:Submit an arbitrary IO command, return results'
 		'security-send:Submit a Security Send command, return results (deprecated, use '\''nvme security send'\'')'
 		'security-recv:Submit a Security Receive command, return results (deprecated, use '\''nvme security recv'\'')'
-		'get-lba-status:Submit a Get LBA Status command, return results'
-		'capacity-mgmt:Submit Capacity Management Command, return results'
 		'resv-acquire:Submit a Reservation Acquire, return results (deprecated, use '\''nvme resv acquire'\'')'
 		'resv-register:Submit a Reservation Register, return results (deprecated, use '\''nvme resv register'\'')'
 		'resv-release:Submit a Reservation Release, return results (deprecated, use '\''nvme resv release'\'')'
 		'resv-report:Submit a Reservation Report, return results (deprecated, use '\''nvme resv report'\'')'
+		'sanitize-log:Retrieve sanitize log, show it (deprecated, use '\''nvme log sanitize'\'')'
+		'gen-dhchap-key:Generate NVMeoF DH-HMAC-CHAP host secret (deprecated, use '\''nvme keys gen-kxchap-secret'\'')'
+		'check-dhchap-key:Validate NVMeoF DH-HMAC-CHAP host secret (deprecated, use '\''nvme keys check-kxchap-secret'\'')'
+		'gen-tls-key:Generate NVMeoF TLS PSK (deprecated, use '\''nvme keys gen-tls'\'')'
+		'check-tls-key:Validate NVMeoF TLS PSK (deprecated, use '\''nvme keys check-tls'\'')'
+		'tls-key:Manage NVMeoF TLS PSKs (deprecated, use '\''nvme keys import/export/revoke'\'')'
+		'dir-receive:Submit a Directive Receive command, return results (deprecated, use '\''nvme dir receive'\'')'
+		'dir-send:Submit a Directive Send command, return results (deprecated, use '\''nvme dir send'\'')'
+		'io-mgmt-recv:I/O Management Receive (deprecated, use '\''nvme io-mgmt recv'\'')'
+		'io-mgmt-send:I/O Management Send (deprecated, use '\''nvme io-mgmt send'\'')'
+		'nvme-mi-recv:Submit a NVMe-MI Receive command, return results (deprecated, use '\''nvme nvme-mi recv'\'')'
+		'nvme-mi-send:Submit a NVMe-MI Send command, return results (deprecated, use '\''nvme nvme-mi send'\'')'
+		'get-log:Generic NVMe get log, returns log in raw format'
+		'discover:Discover NVMeoF subsystems'
+		'connect-all:Discover and Connect to NVMeoF subsystems'
+		'connect:Connect to NVMeoF subsystem'
+		'disconnect:Disconnect from NVMeoF subsystem'
+		'disconnect-all:Disconnect from all connected NVMeoF subsystems'
+		'dim:Send Discovery Information Management command to a Discovery Controller'
+		'gen-hostnqn:Generate NVMeoF host NQN'
+		'show-hostnqn:Show NVMeoF host NQN'
+		'get-feature:Get feature and show the resulting value'
+		'set-feature:Set a feature and show the resulting value'
 		'dsm:Submit a Data Set Management command, return results'
 		'copy:Submit a Simple Copy command, return results'
 		'flush:Submit a Flush command, return results'
@@ -102,45 +120,30 @@ _nvme () {
 		'write-zeroes:Submit a write zeroes command, return results'
 		'write-uncor:Submit a write uncorrectable command, return results'
 		'verify:Submit a verify command, return results'
-		'sanitize:Submit a sanitize command'
-		'sanitize-log:Retrieve sanitize log, show it (deprecated, use '\''nvme log sanitize'\'')'
-		'sanitize-ns:Submit a sanitize namespace command'
-		'reset:Resets the controller'
-		'subsystem-reset:Resets the subsystem'
-		'ns-rescan:Rescans the NVME namespaces'
+		'get-lba-status:Submit a Get LBA Status command, return results'
+		'capacity-mgmt:Submit Capacity Management Command, return results'
+		'admin-passthru:Submit an arbitrary admin command, return results'
+		'io-passthru:Submit an arbitrary IO command, return results'
 		'show-regs:Shows the controller registers or properties. Requires character device'
 		'set-reg:Set a register and show the resulting value'
 		'get-reg:Get a register and show the resulting value'
-		'top:nvme top'
-		'discover:Discover NVMeoF subsystems'
-		'connect-all:Discover and Connect to NVMeoF subsystems'
-		'connect:Connect to NVMeoF subsystem'
-		'disconnect:Disconnect from NVMeoF subsystem'
-		'disconnect-all:Disconnect from all connected NVMeoF subsystems'
-		'dim:Send Discovery Information Management command to a Discovery Controller'
-		'gen-hostnqn:Generate NVMeoF host NQN'
-		'show-hostnqn:Show NVMeoF host NQN'
-		'gen-dhchap-key:Generate NVMeoF DH-HMAC-CHAP host secret (deprecated, use '\''nvme keys gen-kxchap-secret'\'')'
-		'check-dhchap-key:Validate NVMeoF DH-HMAC-CHAP host secret (deprecated, use '\''nvme keys check-kxchap-secret'\'')'
-		'gen-tls-key:Generate NVMeoF TLS PSK (deprecated, use '\''nvme keys gen-tls'\'')'
-		'check-tls-key:Validate NVMeoF TLS PSK (deprecated, use '\''nvme keys check-tls'\'')'
-		'tls-key:Manage NVMeoF TLS PSKs (deprecated, use '\''nvme keys import/export/revoke'\'')'
-		'dir-receive:Submit a Directive Receive command, return results (deprecated, use '\''nvme dir receive'\'')'
-		'dir-send:Submit a Directive Send command, return results (deprecated, use '\''nvme dir send'\'')'
-		'virt-mgmt:Manage Flexible Resources between Primary and Secondary Controller'
+		'set-property:Set a property and show the resulting value'
+		'get-property:Get a property and show the resulting value'
+		'device-self-test:Perform the necessary tests to observe the performance'
+		'sanitize:Submit a sanitize command'
+		'sanitize-ns:Submit a sanitize namespace command'
+		'format:Format namespace with new block format'
 		'rpmb:Replay Protection Memory Block commands'
 		'lockdown:Submit a Lockdown command,return result'
-		'show-topology:Show the topology'
-		'io-mgmt-recv:I/O Management Receive (deprecated, use '\''nvme io-mgmt recv'\'')'
-		'io-mgmt-send:I/O Management Send (deprecated, use '\''nvme io-mgmt send'\'')'
-		'nvme-mi-recv:Submit a NVMe-MI Receive command, return results (deprecated, use '\''nvme nvme-mi recv'\'')'
-		'nvme-mi-send:Submit a NVMe-MI Send command, return results (deprecated, use '\''nvme nvme-mi send'\'')'
 		'amzn:Amazon vendor specific extensions'
+		'config:NVMeoF connection configuration'
 		'dapustor:DapuStor vendor specific extensions'
 		'dell:DELL vendor specific extensions'
 		'dera:Dera vendor specific extensions'
 		'dir:Submit NVMe Directive commands'
+		'exclusion:NVMeoF system-wide exclusion list'
 		'fdp:Manage Flexible Data Placement enabled devices'
+		'feat:NVMe feature extensions'
 		'fw:Manage NVMe controller firmware'
 		'huawei:Huawei vendor specific extensions'
 		'ibm:IBM vendor specific extensions'
@@ -149,20 +152,27 @@ _nvme () {
 		'inspur:Inspur vendor specific extensions'
 		'intel:Intel vendor specific extensions'
 		'io-mgmt:Submit NVMe I/O Management commands'
+		'keys:Manage NVMeoF KX-HMAC-CHAP and TLS keys'
+		'lm:Live Migration NVMe extensions'
 		'log:Retrieve and show NVMe log pages'
 		'mangoboost:MangoBoost vendor specific extensions'
 		'memblaze:Memblaze vendor specific extensions'
 		'micron:Micron vendor specific extensions'
+		'nbft:ACPI NBFT table extensions'
 		'netapp:NetApp vendor specific extensions'
 		'ns:Manage NVMe namespaces'
 		'nvidia:NVIDIA vendor specific extensions'
 		'nvme-mi:Submit NVMe-MI commands'
+		'ocp:OCP cloud SSD extensions'
+		'registry:NVMeoF controller ownership registry'
 		'resv:Submit NVMe Reservation commands'
 		'sndk:Sandisk vendor specific extensions'
 		'sfx:ScaleFlux vendor specific extensions'
 		'seagate:Seagate vendor specific extensions'
 		'security:Submit NVMe Security Send/Receive commands'
+		'sed:SED Opal Command Set'
 		'shannon:Shannon vendor specific extensions'
+		'solidigm:Solidigm vendor specific extensions'
 		'ssstc:SSSTC vendor specific extensions'
 		'toshiba:Toshiba NVME plugin'
 		'transcend:Transcend vendor specific extensions'
@@ -171,16 +181,6 @@ _nvme () {
 		'wdc:Western Digital vendor specific extensions'
 		'ymtc:YMTC vendor specific extensions'
 		'zns:Zoned Namespace Command Set'
-		'nbft:ACPI NBFT table extensions'
-		'keys:Manage NVMeoF KX-HMAC-CHAP and TLS keys'
-		'exclusion:NVMeoF system-wide exclusion list'
-		'registry:NVMeoF controller ownership registry'
-		'config:NVMeoF connection configuration'
-		'feat:NVMe feature extensions'
-		'lm:Live Migration NVMe extensions'
-		'ocp:OCP cloud SSD extensions'
-		'sed:SED Opal Command Set'
-		'solidigm:Solidigm vendor specific extensions'
 		'help'
 		'version'
 	)
@@ -341,6 +341,170 @@ _nvme () {
 					)
 					_arguments '*:: :->subcmds'
 					_nvme_describe "nvme amzn stats options" _amzn_stats
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
+		(config)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'validate:Validate an NVMeoF connection configuration'
+					'show:Show the resolved NVMeoF connection configuration'
+					'status:Report config status'
+					'convert:Convert config.json/discovery.conf to INI'
+					'create:Create an NVMeoF connection entry in the INI configuration'
+				)
+				_describe -t commands "nvme config commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(validate)
+					_nvme_opt_files "--config -J" && return
+					local _config_validate
+					_config_validate=(
+						--config=':INI configuration file (default: /usr/local/etc/nvme/nvme-fabrics.conf)'
+						-J':alias for --config'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme config validate options" _config_validate
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(show)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--config -J" && return
+					local _config_show
+					_config_show=(
+						--config=':INI configuration file (default: /usr/local/etc/nvme/nvme-fabrics.conf)'
+						-J':alias for --config'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme config show options" _config_show
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(status)
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(convert)
+					_nvme_opt_files "--config -J" \
+					                "--output -o" && return
+					local _config_convert
+					_config_convert=(
+						--config=':convert this JSON file (default: config.json)'
+						-J':alias for --config'
+						--output=':write result here (default: nvme-fabrics.conf)'
+						-o':alias for --output'
+						--force':overwrite an existing target'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme config convert options" _config_convert
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(create)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--output" && return
+					local _config_create
+					_config_create=(
+						--transport=':transport type'
+						-t':alias for --transport'
+						--nqn=':subsystem nqn'
+						-n':alias for --nqn'
+						--traddr=':transport address'
+						-a':alias for --traddr'
+						--trsvcid=':transport service id (e.g. IP port)'
+						-s':alias for --trsvcid'
+						--host-traddr=':host traddr (e.g. FC WWN'\''s)'
+						-w':alias for --host-traddr'
+						--host-iface=':host interface (for tcp transport)'
+						-f':alias for --host-iface'
+						--hostnqn=':user-defined hostnqn'
+						-q':alias for --hostnqn'
+						--hostid=':user-defined hostid (if default not used)'
+						-I':alias for --hostid'
+						--kxchap-secret=':user-defined kxchap secret (if default not used)'
+						-S':alias for --kxchap-secret'
+						--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
+						-C':alias for --kxchap-ctrl-secret'
+						--keyring=':Keyring for TLS key lookup (key id or keyring name)'
+						--tls-key=':TLS key to use (key id or key in interchange format)'
+						--tls-key-identity=':TLS key identity'
+						--nr-io-queues=':number of io queues to use (default is core count)'
+						-i':alias for --nr-io-queues'
+						--nr-write-queues=':number of write queues to use (default 0)'
+						-W':alias for --nr-write-queues'
+						--nr-poll-queues=':number of poll queues to use (default 0)'
+						-P':alias for --nr-poll-queues'
+						--queue-size=':number of io queue elements to use (default 128)'
+						-Q':alias for --queue-size'
+						--keep-alive-tmo=':keep alive timeout period in seconds'
+						-k':alias for --keep-alive-tmo'
+						--reconnect-delay=':reconnect timeout period in seconds'
+						-c':alias for --reconnect-delay'
+						--ctrl-loss-tmo=':controller loss timeout period in seconds'
+						-l':alias for --ctrl-loss-tmo'
+						--fast-io-fail-tmo=':fast I/O fail timeout (default off)'
+						-F':alias for --fast-io-fail-tmo'
+						--tos=':type of service'
+						-T':alias for --tos'
+						--tls_key=':TLS key to use (key id)'
+						--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
+						-D':alias for --duplicate-connect'
+						--disable-sqflow':disable controller sq flow control (default false)'
+						--hdr-digest':enable transport protocol header digest (TCP transport)'
+						-g':alias for --hdr-digest'
+						--data-digest':enable transport protocol data digest (TCP transport)'
+						-G':alias for --data-digest'
+						--tls':enable TLS'
+						--concat':enable secure concatenation'
+						--discovery':create a discovery controller entry instead of an I/O controller (subsystem) entry; an I/O controller entry requires --nqn'
+						--persistent=':keep the discovery controller connected to receive Asynchronous Event Notifications instead of disconnecting after the discovery log page fetch; "auto" (the default when given bare) persists only where the target'\''s own EPCSD flag supports it, "force" persists regardless, "no" explicitly records non-persistence; requires --discovery'
+						--host-symname=':name this host persona, so it gets its own configuration drop-in'
+						--output=':add the entry to this INI configuration file (default: /usr/local/etc/nvme/nvme-fabrics.conf)'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme config create options" _config_create
 					_nvme_has_device || compadd -- /dev/nvme*(N)
 					;;
 
@@ -574,6 +738,186 @@ _nvme () {
 					)
 					_arguments '*:: :->subcmds'
 					_nvme_describe "nvme dir send options" _dir_send
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
+		(exclusion)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'create:Create an exclusion list'
+					'delete:Delete an exclusion list'
+					'edit:Edit an exclusion list interactively'
+					'list:List exclusion lists or entries'
+					'add:Add an entry to an exclusion list'
+					'remove:Remove an entry from an exclusion list'
+				)
+				_describe -t commands "nvme exclusion commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(create)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _exclusion_create
+					_exclusion_create=(
+						--name=':exclusion list name (omit for the default list)'
+						-N':alias for --name'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme exclusion create options" _exclusion_create
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(delete)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _exclusion_delete
+					_exclusion_delete=(
+						--name=':exclusion list name (omit for the default list)'
+						-N':alias for --name'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme exclusion delete options" _exclusion_delete
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(edit)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _exclusion_edit
+					_exclusion_edit=(
+						--name=':exclusion list name (omit for the default list)'
+						-N':alias for --name'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme exclusion edit options" _exclusion_edit
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(list)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _exclusion_list
+					_exclusion_list=(
+						--name=':exclusion list name (omit to list all lists)'
+						-N':alias for --name'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme exclusion list options" _exclusion_list
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(add)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _exclusion_add
+					_exclusion_add=(
+						--name=':exclusion list name (omit for the default list)'
+						-N':alias for --name'
+						--entry=':semicolon-separated key=value entry (e.g. "transport=tcp;traddr=192.168.1.1")'
+						-e':alias for --entry'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme exclusion add options" _exclusion_add
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(remove)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _exclusion_remove
+					_exclusion_remove=(
+						--name=':exclusion list name (omit for the default list)'
+						-N':alias for --name'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme exclusion remove options" _exclusion_remove
 					_nvme_has_device || compadd -- /dev/nvme*(N)
 					;;
 
@@ -834,6 +1178,496 @@ _nvme () {
 					)
 					_arguments '*:: :->subcmds'
 					_nvme_describe "nvme fdp feature options" _fdp_feature
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
+		(feat)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'arbitration:Get and set arbitration feature'
+					'power-mgmt:Get and set power management feature'
+					'temp-thresh:Get and set temperature threshold feature'
+					'volatile-wc:Get and set volatile write cache feature'
+					'num-queues:Get and set number of queues feature'
+					'timestamp:Get and set timestamp feature'
+					'hctm:Get and set host controlled thermal management feature'
+					'host-behavior-support:Get and set host behavior support feature'
+					'perf-characteristics:Get and set perf characteristics feature'
+					'power-limit:Get and set power limit feature'
+					'power-thresh:Get and set power threshold feature'
+					'power-meas:Get and set power measurement feature'
+					'err-recovery:Get and set error recovery feature'
+				)
+				_describe -t commands "nvme feat commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(arbitration)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_arbitration
+					_feat_arbitration=(
+						--ab=':arbitration burst'
+						-a':alias for --ab'
+						--lpw=':low priority weight'
+						-l':alias for --lpw'
+						--mpw=':medium priority weight'
+						-m':alias for --mpw'
+						--hpw=':high priority weight'
+						-H':alias for --hpw'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat arbitration options" _feat_arbitration
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(power-mgmt)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_power_mgmt
+					_feat_power_mgmt=(
+						--ps=':power state'
+						-p':alias for --ps'
+						--wh=':workload hint'
+						-w':alias for --wh'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat power-mgmt options" _feat_power_mgmt
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(temp-thresh)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_temp_thresh
+					_feat_temp_thresh=(
+						--tmpth=':temperature threshold'
+						-T':alias for --tmpth'
+						--tmpsel=':threshold temperature select'
+						-m':alias for --tmpsel'
+						--thsel=':threshold type select'
+						-H':alias for --thsel'
+						--tmpthh=':temperature threshold hysteresis'
+						-M':alias for --tmpthh'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat temp-thresh options" _feat_temp_thresh
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(volatile-wc)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_volatile_wc
+					_feat_volatile_wc=(
+						--wce':volatile write cache enable'
+						-w':alias for --wce'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat volatile-wc options" _feat_volatile_wc
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(num-queues)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_num_queues
+					_feat_num_queues=(
+						--nsqr=':number of I/O submission queues requested'
+						-n':alias for --nsqr'
+						--ncqr=':number of I/O completion queues requested'
+						-c':alias for --ncqr'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat num-queues options" _feat_num_queues
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(timestamp)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_timestamp
+					_feat_timestamp=(
+						--tstmp=':timestamp'
+						-t':alias for --tstmp'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat timestamp options" _feat_timestamp
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(hctm)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_hctm
+					_feat_hctm=(
+						--tmt1=':thermal management temperature 1'
+						-t':alias for --tmt1'
+						--tmt2=':thermal management temperature 2'
+						-T':alias for --tmt2'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat hctm options" _feat_hctm
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(host-behavior-support)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_host_behavior_support
+					_feat_host_behavior_support=(
+						--acre=':Advanced Command Retry Enable (0 or 1)'
+						-a':alias for --acre'
+						--etdas=':Extended Telemetry Data Area 4 Supported (0 or 1)'
+						-e':alias for --etdas'
+						--lbafee=':LBA Format Extension Enable (0 or 1)'
+						-l':alias for --lbafee'
+						--hdisns=':Host Dispersed Namespace Support (0 or 1)'
+						-H':alias for --hdisns'
+						--cdfe=':Copy Descriptor Formats Enable bitmask'
+						-c':alias for --cdfe'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat host-behavior-support options" _feat_host_behavior_support
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(perf-characteristics)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--vs-data -V" && return
+					local _feat_perf_characteristics
+					_feat_perf_characteristics=(
+						--namespace-id=':optional namespace attached to controller'
+						-n':alias for --namespace-id'
+						--attri=':attribute index'
+						-a':alias for --attri'
+						--rvspa':revert vendor specific performance attribute'
+						-r':alias for --rvspa'
+						--r4karl=':random 4 kib average read latency'
+						-R':alias for --r4karl'
+						--paid=':performance attribute identifier'
+						-p':alias for --paid'
+						--attrl=':attribute length'
+						-A':alias for --attrl'
+						--vs-data=':vendor specific data'
+						-V':alias for --vs-data'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat perf-characteristics options" _feat_perf_characteristics
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(power-limit)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_power_limit
+					_feat_power_limit=(
+						--plv=':power limit value'
+						-p':alias for --plv'
+						--pls=':power limit scale'
+						-l':alias for --pls'
+						--uuid-index=':UUID index'
+						-u':alias for --uuid-index'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat power-limit options" _feat_power_limit
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(power-thresh)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_power_thresh
+					_feat_power_thresh=(
+						--ptv=':power threshold value'
+						-p':alias for --ptv'
+						--pts=':power threshold scale'
+						-t':alias for --pts'
+						--pmts=':power measurement type select'
+						-m':alias for --pmts'
+						--ept=':enable power threshold'
+						-e':alias for --ept'
+						--uuid-index=':UUID index'
+						-u':alias for --uuid-index'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat power-thresh options" _feat_power_thresh
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(power-meas)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_power_meas
+					_feat_power_meas=(
+						--act=':action [0-1]: stop|start'
+						--pmts=':power measurement type select'
+						--smt=':stop measurement time'
+						--uuid-index=':UUID index'
+						-u':alias for --uuid-index'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat power-meas options" _feat_power_meas
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(err-recovery)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _feat_err_recovery
+					_feat_err_recovery=(
+						--nsid=':identifier of desired namespace'
+						-n':alias for --nsid'
+						--tler=':time limited error recovery'
+						-t':alias for --tler'
+						--dulbe':deallocated or unwritten logical block error enable'
+						-d':alias for --dulbe'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme feat err-recovery options" _feat_err_recovery
 					_nvme_has_device || compadd -- /dev/nvme*(N)
 					;;
 
@@ -2066,10 +2900,570 @@ _nvme () {
 			esac
 			;;
 
+		(keys)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'gen-kxchap-secret:Generate NVMeoF KX-HMAC-CHAP host secret'
+					'check-kxchap-secret:Validate NVMeoF KX-HMAC-CHAP host secret format or check if loaded'
+					'gen-tls:Generate NVMeoF TLS PSK'
+					'check-tls:Validate NVMeoF TLS PSK format or check if loaded'
+					'insert-tls:Insert NVMeoF TLS PSK into a keyring'
+					'import:Import NVMeoF TLS PSKs and KX-HMAC-CHAP secrets into a keyring'
+					'export:Export NVMeoF TLS PSKs from a keyring'
+					'revoke:Revoke an NVMeoF TLS PSK from a keyring'
+				)
+				_describe -t commands "nvme keys commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(gen-kxchap-secret)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_gen_kxchap_secret
+					_keys_gen_kxchap_secret=(
+						--secret=':Optional secret (in hexadecimal characters) to be placed in the representation.'
+						-s':alias for --secret'
+						--secret-length=':Length of the secret (32, 48, or 64 bytes).'
+						-l':alias for --secret-length'
+						--hmac=':Hash function the consumer is to apply to the secret (0 = none, 1 = SHA-256, 2 = SHA-384, 3 = SHA-512).'
+						-m':alias for --hmac'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys gen-kxchap-secret options" _keys_gen_kxchap_secret
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(check-kxchap-secret)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_check_kxchap_secret
+					_keys_check_kxchap_secret=(
+						--keydata=':KX-HMAC-CHAP secret (in DHHC-1 interchange format) to be validated. Reads from stdin if not given.'
+						-d':alias for --keydata'
+						--keyring=':Keyring to check for an already loaded secret.'
+						-k':alias for --keyring'
+						--keytype=':Key type of the secret to look up.'
+						-t':alias for --keytype'
+						--identity=':Identity to look up in the keyring to check if the secret is already loaded.'
+						-i':alias for --identity'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys check-kxchap-secret options" _keys_check_kxchap_secret
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(gen-tls)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_gen_tls
+					_keys_gen_tls=(
+						--keyring=':Keyring for the retained key.'
+						-k':alias for --keyring'
+						--keytype=':Key type of the retained key.'
+						-t':alias for --keytype'
+						--hostnqn=':Host NQN for the retained key.'
+						-n':alias for --hostnqn'
+						--subsysnqn=':Subsystem NQN for the retained key.'
+						-c':alias for --subsysnqn'
+						--secret=':Optional secret (in hexadecimal characters) to be used for the TLS key.'
+						-s':alias for --secret'
+						--keyfile=':Update key file with the derived TLS PSK.'
+						-f':alias for --keyfile'
+						--hmac=':HMAC function to use for the retained key (1 = SHA-256, 2 = SHA-384).'
+						-m':alias for --hmac'
+						--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
+						-I':alias for --identity'
+						--insert':Insert retained key into the keyring.'
+						-i':alias for --insert'
+						--compat':Use non-RFC 8446 compliant algorithm for deriving TLS PSK for older implementations.'
+						-C':alias for --compat'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys gen-tls options" _keys_gen_tls
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(check-tls)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_check_tls
+					_keys_check_tls=(
+						--keyring=':Keyring to check for an already loaded key.'
+						-k':alias for --keyring'
+						--keytype=':Key type of the key to look up.'
+						-t':alias for --keytype'
+						--hostnqn=':Host NQN to use when checking whether the key is already loaded.'
+						-n':alias for --hostnqn'
+						--subsysnqn=':Subsystem NQN to use when checking whether the key is already loaded.'
+						-c':alias for --subsysnqn'
+						--keydata=':TLS key (in PSK Interchange format) to be validated. Reads from stdin if not given.'
+						-d':alias for --keydata'
+						--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
+						-I':alias for --identity'
+						--compat':Use non-RFC 8446 compliant algorithm for checking TLS PSK for older implementations.'
+						-C':alias for --compat'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys check-tls options" _keys_check_tls
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(insert-tls)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_insert_tls
+					_keys_insert_tls=(
+						--keyring=':Keyring for the retained key.'
+						-k':alias for --keyring'
+						--keytype=':Key type of the retained key.'
+						-t':alias for --keytype'
+						--hostnqn=':Host NQN for the retained key.'
+						-n':alias for --hostnqn'
+						--subsysnqn=':Subsystem NQN for the retained key.'
+						-c':alias for --subsysnqn'
+						--keydata=':TLS key (in PSK Interchange format) to be inserted. Reads from stdin if not given.'
+						-d':alias for --keydata'
+						--keyfile=':Append the derived TLS PSK to keyfile.'
+						-f':alias for --keyfile'
+						--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
+						-I':alias for --identity'
+						--compat':Use non-RFC 8446 compliant algorithm for older implementations.'
+						-C':alias for --compat'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys insert-tls options" _keys_insert_tls
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(import)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_import
+					_keys_import=(
+						--keyring=':Keyring to import the keys into.'
+						-k':alias for --keyring'
+						--keyfile=':File to read the keys from (default: stdin).'
+						-f':alias for --keyfile'
+						--keydata=':Key to insert directly under --identity. Reads from stdin if not given.'
+						-d':alias for --keydata'
+						--identity=':Identity to store a single key under. If given, --keydata (or stdin) is read as a single key instead of a bulk <identity> <key> list.'
+						-i':alias for --identity'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys import options" _keys_import
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(export)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_export
+					_keys_export=(
+						--keyring=':Keyring to export the retained keys from.'
+						-k':alias for --keyring'
+						--keyfile=':File to write the exported keys to (default: stdout).'
+						-f':alias for --keyfile'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys export options" _keys_export
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(revoke)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _keys_revoke
+					_keys_revoke=(
+						--keyring=':Keyring to revoke the key from.'
+						-k':alias for --keyring'
+						--keytype=':Key type of the key to revoke.'
+						-t':alias for --keytype'
+						--identity=':Identity (description) of the key to revoke.'
+						-i':alias for --identity'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme keys revoke options" _keys_revoke
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
+		(lm)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'create-cdq:Create Controller Data Queue'
+					'delete-cdq:Delete Controller Data Queue'
+					'track-send:Track Send Command'
+					'migration-send:Migration Send'
+					'migration-recv:Migration Receive'
+					'set-cdq:Set Feature - Controller Data Queue (FID 21h)'
+					'get-cdq:Get Feature - Controller Data Queue (FID 21h)'
+				)
+				_describe -t commands "nvme lm commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(create-cdq)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _lm_create_cdq
+					_lm_create_cdq=(
+						--size=':CDQ Size (in dwords)'
+						-s':alias for --size'
+						--cntlid=':Controller ID'
+						-c':alias for --cntlid'
+						--queue-type=':Queue Type (default: 0 = User Data Migration Queue)'
+						-q':alias for --queue-type'
+						--consent':I consent this will not work and understand a CDQ cannot be mapped to user space. If I proceed with the creation of a CDQ, the device will write to invalid memory, inevitably leading to MMU faults or worse.'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme lm create-cdq options" _lm_create_cdq
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(delete-cdq)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _lm_delete_cdq
+					_lm_delete_cdq=(
+						--cdqid=':Controller Data Queue ID'
+						-C':alias for --cdqid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme lm delete-cdq options" _lm_delete_cdq
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(track-send)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _lm_track_send
+					_lm_track_send=(
+						--sel=':Type of management operation to perform 0h = Log User Data Changes 1h = Track Memory Changes'
+						-s':alias for --sel'
+						--mos=':Management operation specific'
+						-m':alias for --mos'
+						--cdqid=':Controller Data Queue ID'
+						-C':alias for --cdqid'
+						--start':Equivalent to start tracking with defaults'
+						--stop':Equivalent to stop tracking with defaults'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme lm track-send options" _lm_track_send
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(migration-send)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--input-file -f" && return
+					local _lm_migration_send
+					_lm_migration_send=(
+						--sel=':Select (SEL) the type of management operation to perform (CDW10[07:00]) 0h = Suspend 1h = Resume 2h = Set Controller State'
+						-s':alias for --sel'
+						--cntlid=':Controller Identifier (CDW11[15:00])'
+						-c':alias for --cntlid'
+						--stype=':Type of suspend (STYPE) (CDW11[23:16] 0h = Suspend Notification 1h = Suspend'
+						-t':alias for --stype'
+						--dudmq':Delete user data migration queue (DUDMQ) as part of suspend operation (CDW11[31])'
+						-d':alias for --dudmq'
+						--seq-ind=':Sequence Indicator (CDW10[17:16]) 0h = Not first not last 1h = First in two or more 2h = Last in two or more 3h = Entire state info'
+						-S':alias for --seq-ind'
+						--csuuidi=':Controller State UUID Index (CSUUIDI) (CDW11[31:24])'
+						-U':alias for --csuuidi'
+						--csvi=':Controller State Version Index (CSVI) (CDW11[23:16])'
+						-V':alias for --csvi'
+						--uidx=':UUID Index (UIDX) (CDW14[16:00])'
+						-u':alias for --uidx'
+						--offset=':Controller State Offset'
+						-O':alias for --offset'
+						--numd=':Number of Dwords (NUMD)'
+						-n':alias for --numd'
+						--input-file=':Controller State Data input file'
+						-f':alias for --input-file'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme lm migration-send options" _lm_migration_send
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(migration-recv)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--output-file -f" && return
+					local _lm_migration_recv
+					_lm_migration_recv=(
+						--sel=':Select (SEL) the type of management operation to perform (CDW10[07:00]) 0h = Get Controller State'
+						-s':alias for --sel'
+						--cntlid=':Controller Identifier (CDW10[31:16])'
+						-c':alias for --cntlid'
+						--csuuidi=':Controller State UUID Index (CSUUIDI) (CDW11[23:16])'
+						-U':alias for --csuuidi'
+						--csvi=':Controller State Version Index (CSVI) (CDW11[7:0])'
+						-V':alias for --csvi'
+						--uidx=':UUID Index (UIDX) (CDW14[16:00])'
+						-u':alias for --uidx'
+						--offset=':Controller State Offset'
+						-O':alias for --offset'
+						--numd=':Number of Dwords (NUMD)'
+						-n':alias for --numd'
+						--output-file=':Controller State Data output file'
+						-f':alias for --output-file'
+						--human-readable':show info in readable format'
+						-H':alias for --human-readable'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme lm migration-recv options" _lm_migration_recv
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-cdq)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _lm_set_cdq
+					_lm_set_cdq=(
+						--cdqid=':Controller Data Queue ID'
+						-C':alias for --cdqid'
+						--hp=':The slot of the head pointer for the specified CDQ'
+						-H':alias for --hp'
+						--tpt=':If specified, the slot that causes the controller to issue a CDQ Tail Pointer event'
+						-T':alias for --tpt'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme lm set-cdq options" _lm_set_cdq
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-cdq)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _lm_get_cdq
+					_lm_get_cdq=(
+						--cdqid=':Controller Data Queue ID'
+						-C':alias for --cdqid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme lm get-cdq options" _lm_get_cdq
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
 		(log)
 			if (( CURRENT == 2 )); then
 				local -a _sub
 				_sub=(
+					'supported-pages:Retrieve the Supported Log pages details, show it'
 					'smart:Retrieve SMART Log, show it'
 					'ana:Retrieve ANA Log, show it'
 					'telemetry:Retrieve FW Telemetry log write to file'
@@ -2108,6 +3502,30 @@ _nvme () {
 			fi
 
 			case ${words[2]} in
+				(supported-pages)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _log_supported_pages
+					_log_supported_pages=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme log supported-pages options" _log_supported_pages
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
 				(smart)
 					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 					               "--output-format-version" "1 2" && return
@@ -4149,6 +5567,54 @@ _nvme () {
 			esac
 			;;
 
+		(nbft)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'show:Show contents of ACPI NBFT tables'
+				)
+				_describe -t commands "nvme nbft commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(show)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _nbft_show
+					_nbft_show=(
+						--subsystem':show NBFT subsystems'
+						-s':alias for --subsystem'
+						--hfi':show NBFT HFIs'
+						-H':alias for --hfi'
+						--discovery':show NBFT discovery controllers'
+						-d':alias for --discovery'
+						--nbft-path=':user-defined path for NBFT tables'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme nbft show options" _nbft_show
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
 		(netapp)
 			if (( CURRENT == 2 )); then
 				local -a _sub
@@ -4544,6 +6010,1044 @@ _nvme () {
 					)
 					_arguments '*:: :->subcmds'
 					_nvme_describe "nvme nvme-mi send options" _nvme_mi_send
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
+		(ocp)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'smart-add-log:Retrieve Extended SMART Information'
+					'latency-monitor-log:Retrieve Latency Monitor Log Page'
+					'set-latency-monitor-feature:Set Latency Monitor Feature'
+					'internal-log:Retrieve and Save Internal Device Telemetry Log'
+					'clear-fw-activate-history:Clear Firmware Update History'
+					'eol-plp-failure-mode:Define EOL or PLP Circuitry Failure Mode'
+					'clear-pcie-correctable-errors:Clear PCIe Correctable Error Counters'
+					'fw-activate-history:Retrieve Firmware Activation History Log Page'
+					'unsupported-reqs-log:Retrieve Unsupported Requirements Log Page'
+					'error-recovery-log:Retrieve Error Recovery Log Page'
+					'device-capability-log:Retrieve Device Capabilities Log Page'
+					'set-dssd-power-state-feature:Set DSSD Power State Feature'
+					'get-dssd-power-state-feature:Get DSSD Power State Feature'
+					'set-plp-health-check-interval:Set PLP Health Check Interval'
+					'get-plp-health-check-interval:Get PLP Health Check Interval'
+					'telemetry-string-log:Retrieve Telemetry String Log Page'
+					'set-telemetry-profile:Set Telemetry Profile Feature'
+					'set-dssd-async-event-config:Set DSSD Asynchronous Event Configuration'
+					'get-dssd-async-event-config:Get DSSD Asynchronous Event Configuration'
+					'tcg-configuration-log:Retrieve TCG Configuration Log Page'
+					'get-error-injection:Get Error Injection Feature'
+					'set-error-injection:Set Error Injection Feature'
+					'get-enable-ieee1667-silo:Get Enable IEEE1667 Silo Feature'
+					'set-enable-ieee1667-silo:Set Enable IEEE1667 Silo Feature'
+					'hardware-component-log:Retrieve Hardware Component Log Page'
+					'get-latency-monitor:Get Latency Monitor Feature'
+					'get-clear-pcie-correctable-errors:Get Clear PCIe Correctable Error Counters Feature'
+					'get-telemetry-profile:Get Telemetry Profile Feature'
+					'persistent-event-log:Retrieve Persistent Event Log with OCP Events'
+					'get-idle-wakeup-time:Get Idle Wake Up Time Configuration'
+				)
+				_describe -t commands "nvme ocp commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(smart-add-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_smart_add_log
+					_ocp_smart_add_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp smart-add-log options" _ocp_smart_add_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(latency-monitor-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_latency_monitor_log
+					_ocp_latency_monitor_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp latency-monitor-log options" _ocp_latency_monitor_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-latency-monitor-feature)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_set_latency_monitor_feature
+					_ocp_set_latency_monitor_feature=(
+						--active_bucket_timer_threshold=':This is the value that loads the Active Bucket Timer Threshold.'
+						-t':alias for --active_bucket_timer_threshold'
+						--active_threshold_a=':This is the value that loads into the Active Threshold A.'
+						-a':alias for --active_threshold_a'
+						--active_threshold_b=':This is the value that loads into the Active Threshold B.'
+						-b':alias for --active_threshold_b'
+						--active_threshold_c=':This is the value that loads into the Active Threshold C.'
+						-c':alias for --active_threshold_c'
+						--active_threshold_d=':This is the value that loads into the Active Threshold D.'
+						-d':alias for --active_threshold_d'
+						--active_latency_config=':This is the value that loads into the Active Latency Configuration.'
+						-f':alias for --active_latency_config'
+						--active_latency_minimum_window=':This is the value that loads into the Active Latency Minimum Window.'
+						-w':alias for --active_latency_minimum_window'
+						--debug_log_trigger_enable=':This is the value that loads into the Debug Log Trigger Enable.'
+						-r':alias for --debug_log_trigger_enable'
+						--discard_debug_log=':Discard Debug Log.'
+						-l':alias for --discard_debug_log'
+						--latency_monitor_feature_enable=':Latency Monitor Feature Enable.'
+						-e':alias for --latency_monitor_feature_enable'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp set-latency-monitor-feature options" _ocp_set_latency_monitor_feature
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(internal-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--output-file -f" && return
+					local _ocp_internal_log
+					_ocp_internal_log=(
+						--telemetry-log=':Telemetry log binary; '\''host.bin'\'' or '\''controller.bin'\'''
+						-l':alias for --telemetry-log'
+						--string-log=':String log binary; '\''C9.bin'\'''
+						-s':alias for --string-log'
+						--output-file=':Output file name with path; e.g. '\''-f ./path/name'\'' '\''-f ./path1/path2/'\''; If requested path does not exist, the directory will be newly created.'
+						-f':alias for --output-file'
+						--data-area=':Telemetry Data Area; 1, 2, 3, or 4; e.g. '\''-a 1 for Data Area 1.'\'' e.g. '\''-a 2 for Data Areas 1 and 2.'\'' e.g. '\''-a 3 for Data Areas 1, 2, and 3.'\'' e.g. '\''-a 4 for Data Areas 1, 2, 3, and 4.'\'';'
+						-a':alias for --data-area'
+						--telemetry-type=':Telemetry Type; '\''host'\'', '\''host0'\'', '\''host1'\'' or '\''controller'\'''
+						-t':alias for --telemetry-type'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp internal-log options" _ocp_internal_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(clear-fw-activate-history)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_clear_fw_activate_history
+					_ocp_clear_fw_activate_history=(
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp clear-fw-activate-history options" _ocp_clear_fw_activate_history
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(eol-plp-failure-mode)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_eol_plp_failure_mode
+					_ocp_eol_plp_failure_mode=(
+						--mode=':[0-3]: default/rom/wtm/normal'
+						-m':alias for --mode'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp eol-plp-failure-mode options" _ocp_eol_plp_failure_mode
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(clear-pcie-correctable-errors)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_clear_pcie_correctable_errors
+					_ocp_clear_pcie_correctable_errors=(
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp clear-pcie-correctable-errors options" _ocp_clear_pcie_correctable_errors
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(fw-activate-history)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_fw_activate_history
+					_ocp_fw_activate_history=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp fw-activate-history options" _ocp_fw_activate_history
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(unsupported-reqs-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_unsupported_reqs_log
+					_ocp_unsupported_reqs_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp unsupported-reqs-log options" _ocp_unsupported_reqs_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(error-recovery-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_error_recovery_log
+					_ocp_error_recovery_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp error-recovery-log options" _ocp_error_recovery_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(device-capability-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_device_capability_log
+					_ocp_device_capability_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp device-capability-log options" _ocp_device_capability_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-dssd-power-state-feature)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_set_dssd_power_state_feature
+					_ocp_set_dssd_power_state_feature=(
+						--power-state=':DSSD Power State to set in watts'
+						-p':alias for --power-state'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp set-dssd-power-state-feature options" _ocp_set_dssd_power_state_feature
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-dssd-power-state-feature)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_dssd_power_state_feature
+					_ocp_get_dssd_power_state_feature=(
+						--sel=':[0-3]: current/default/saved/supported/'
+						-S':alias for --sel'
+						--all':Print out all 3 values at once - Current, Default, and Saved'
+						-a':alias for --all'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-dssd-power-state-feature options" _ocp_get_dssd_power_state_feature
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-plp-health-check-interval)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_set_plp_health_check_interval
+					_ocp_set_plp_health_check_interval=(
+						--plp_health_interval=':[31:16]:PLP Health Check Interval'
+						-p':alias for --plp_health_interval'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp set-plp-health-check-interval options" _ocp_set_plp_health_check_interval
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-plp-health-check-interval)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_plp_health_check_interval
+					_ocp_get_plp_health_check_interval=(
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-plp-health-check-interval options" _ocp_get_plp_health_check_interval
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(telemetry-string-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--output-file -f" && return
+					local _ocp_telemetry_string_log
+					_ocp_telemetry_string_log=(
+						--output-file=':Output file name with path; e.g. '\''-f ./path/name'\'' '\''-f ./path1/path2/'\''; If requested path does not exist, the directory will be newly created.'
+						-f':alias for --output-file'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp telemetry-string-log options" _ocp_telemetry_string_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-telemetry-profile)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_set_telemetry_profile
+					_ocp_set_telemetry_profile=(
+						--telemetry-profile-select=':Telemetry Profile Select for device debug data collection'
+						-t':alias for --telemetry-profile-select'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp set-telemetry-profile options" _ocp_set_telemetry_profile
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-dssd-async-event-config)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_set_dssd_async_event_config
+					_ocp_set_dssd_async_event_config=(
+						--enable-panic-notices':[0]:Enable Panic Notices'
+						-e':alias for --enable-panic-notices'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp set-dssd-async-event-config options" _ocp_set_dssd_async_event_config
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-dssd-async-event-config)
+					_nvme_opt_vals "--sel -S" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_dssd_async_event_config
+					_ocp_get_dssd_async_event_config=(
+						--sel=':[0-3]: current/default/saved/supported'
+						-S':alias for --sel'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-dssd-async-event-config options" _ocp_get_dssd_async_event_config
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(tcg-configuration-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_tcg_configuration_log
+					_ocp_tcg_configuration_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp tcg-configuration-log options" _ocp_tcg_configuration_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-error-injection)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_error_injection
+					_ocp_get_error_injection=(
+						--sel=':[0-3]: current/default/saved/supported'
+						-s':alias for --sel'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--all-ns':Apply to all namespaces'
+						-a':alias for --all-ns'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-error-injection options" _ocp_get_error_injection
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-error-injection)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--data -d" && return
+					local _ocp_set_error_injection
+					_ocp_set_error_injection=(
+						--data=':Error injection data structure entries'
+						-d':alias for --data'
+						--number=':Number of valid error injection data entries'
+						-n':alias for --number'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-N':alias for --no-uuid'
+						--all-ns':Apply to all namespaces'
+						-a':alias for --all-ns'
+						--type=':Error injection type'
+						-t':alias for --type'
+						--nrtdp=':Number of reads to trigger device panic'
+						-r':alias for --nrtdp'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp set-error-injection options" _ocp_set_error_injection
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-enable-ieee1667-silo)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_enable_ieee1667_silo
+					_ocp_get_enable_ieee1667_silo=(
+						--sel=':[0-3]: current/default/saved/supported'
+						-s':alias for --sel'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-enable-ieee1667-silo options" _ocp_get_enable_ieee1667_silo
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(set-enable-ieee1667-silo)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_set_enable_ieee1667_silo
+					_ocp_set_enable_ieee1667_silo=(
+						--enable':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-e':alias for --enable'
+						--save':Specifies that the controller shall save the attribute'
+						-s':alias for --save'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp set-enable-ieee1667-silo options" _ocp_set_enable_ieee1667_silo
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(hardware-component-log)
+					_nvme_opt_vals "--comp-id -i" "asic nand dram pmic pcb cap reg case sn country hw-rev born-on-date vendor" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_hardware_component_log
+					_ocp_hardware_component_log=(
+						--comp-id=':component identifier'
+						-i':alias for --comp-id'
+						--list':list component descriptions'
+						-l':alias for --list'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp hardware-component-log options" _ocp_hardware_component_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-latency-monitor)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_latency_monitor
+					_ocp_get_latency_monitor=(
+						--sel=':[0-3]: current/default/saved/supported/'
+						-s':alias for --sel'
+						--namespace-id=':Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive'
+						-n':alias for --namespace-id'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-u':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-latency-monitor options" _ocp_get_latency_monitor
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-clear-pcie-correctable-errors)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_clear_pcie_correctable_errors
+					_ocp_get_clear_pcie_correctable_errors=(
+						--sel=':[0-3]: current/default/saved/supported/'
+						-s':alias for --sel'
+						--namespace-id=':Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive'
+						-n':alias for --namespace-id'
+						--no-uuid':Do not try to automatically detect UUID index'
+						-u':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-clear-pcie-correctable-errors options" _ocp_get_clear_pcie_correctable_errors
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-telemetry-profile)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_telemetry_profile
+					_ocp_get_telemetry_profile=(
+						--sel=':[0-3]: current/default/saved/supported/'
+						-s':alias for --sel'
+						--namespace-id=':Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive'
+						-n':alias for --namespace-id'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-u':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-telemetry-profile options" _ocp_get_telemetry_profile
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(persistent-event-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_persistent_event_log
+					_ocp_persistent_event_log=(
+						--action=':action the controller shall take during processing this persistent log page command.'
+						-a':alias for --action'
+						--log_len=':number of bytes to retrieve'
+						-l':alias for --log_len'
+						--raw-binary':use binary output'
+						-b':alias for --raw-binary'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp persistent-event-log options" _ocp_persistent_event_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(get-idle-wakeup-time)
+					_nvme_opt_vals "--sel -s" "0 1 2 3" \
+					               "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _ocp_get_idle_wakeup_time
+					_ocp_get_idle_wakeup_time=(
+						--sel=':[0-3]: current/default/saved/supported/'
+						-s':alias for --sel'
+						--namespace-id=':Byte[04-07]: NSID Valid/Invalid/Inactive'
+						-n':alias for --namespace-id'
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-u':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme ocp get-idle-wakeup-time options" _ocp_get_idle_wakeup_time
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
+		(registry)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'list:List live registry entries'
+					'retrieve:Read an attribute from a controller'\''s entry'
+					'update:Write an attribute to a controller'\''s entry'
+					'delete:Remove a controller'\''s registry entry'
+				)
+				_describe -t commands "nvme registry commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(list)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _registry_list
+					_registry_list=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme registry list options" _registry_list
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(retrieve)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _registry_retrieve
+					_registry_retrieve=(
+						--attr=':attribute name (e.g. owner, note)'
+						-a':alias for --attr'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme registry retrieve options" _registry_retrieve
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(update)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _registry_update
+					_registry_update=(
+						--attr=':attribute name (e.g. note, owner)'
+						-a':alias for --attr'
+						--value=':new attribute value'
+						-V':alias for --value'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme registry update options" _registry_update
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(delete)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _registry_delete
+					_registry_delete=(
+						--attr=':attribute to remove (default: whole entry)'
+						-a':alias for --attr'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme registry delete options" _registry_delete
 					_nvme_has_device || compadd -- /dev/nvme*(N)
 					;;
 
@@ -6237,6 +8741,106 @@ _nvme () {
 			esac
 			;;
 
+		(sed)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'discover:Discover SED Opal Locking Features'
+					'1:Discover SED Opal Locking Features'
+					'initialize:Initialize a SED Opal Device for locking'
+					'revert:Revert a SED Opal Device from locking'
+					'lock:Lock a SED Opal Device'
+					'unlock:Unlock a SED Opal Device'
+					'password:Change the SED Opal Device password'
+				)
+				_describe -t commands "nvme sed commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(discover|1)
+					local _sed_discover
+					_sed_discover=(
+						--verbose':Print extended discovery information'
+						-V':alias for --verbose'
+						--udev':Print locking information in form suitable for udev rules'
+						-u':alias for --udev'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme sed discover options" _sed_discover
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(initialize)
+					local _sed_initialize
+					_sed_initialize=(
+						--read-only':Set locking range to read-only'
+						-r':alias for --read-only'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme sed initialize options" _sed_initialize
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(revert)
+					local _sed_revert
+					_sed_revert=(
+						--destructive':destructive revert'
+						-e':alias for --destructive'
+						--psid':PSID revert'
+						-p':alias for --psid'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme sed revert options" _sed_revert
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(lock)
+					local _sed_lock
+					_sed_lock=(
+						--read-only':Set locking range to read-only'
+						-r':alias for --read-only'
+						--ask-key':prompt for SED authentication key'
+						-k':alias for --ask-key'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme sed lock options" _sed_lock
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(unlock)
+					local _sed_unlock
+					_sed_unlock=(
+						--read-only':Set locking range to read-only'
+						-r':alias for --read-only'
+						--ask-key':prompt for SED authentication key'
+						-k':alias for --ask-key'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme sed unlock options" _sed_unlock
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(password)
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
 		(shannon)
 			if (( CURRENT == 2 )); then
 				local -a _sub
@@ -6380,6 +8984,489 @@ _nvme () {
 					)
 					_arguments '*:: :->subcmds'
 					_nvme_describe "nvme shannon id-ctrl options" _shannon_id_ctrl
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(*)
+					_files
+					;;
+			esac
+			;;
+
+		(solidigm)
+			if (( CURRENT == 2 )); then
+				local -a _sub
+				_sub=(
+					'id-ctrl:Send NVMe Identify Controller'
+					'smart-log-add:Retrieve Solidigm SMART Log'
+					'vs-smart-add-log:Get SMART / health extended log (redirects to ocp plug-in)'
+					'vs-internal-log:Retrieve Debug log binaries'
+					'garbage-collect-log:Retrieve Garbage Collection Log'
+					'market-log:Retrieve Market Log'
+					'latency-tracking-log:Enable/Retrieve Latency tracking Log'
+					'parse-telemetry-log:Parse Telemetry Log binary'
+					'clear-pcie-correctable-errors:Clear PCIe Correctable Error Counters (redirects to ocp plug-in)'
+					'clear-fw-activate-history:Clear firmware update history log (redirects to ocp plug-in)'
+					'vs-fw-activate-history:Get firmware activation history log (redirects to ocp plug-in)'
+					'log-page-directory:Retrieve log page directory'
+					'temp-stats:Retrieve Temperature Statistics log'
+					'vs-drive-info:Retrieve drive information'
+					'cloud-SSDplugin-version:Prints plug-in OCP version'
+					'workload-tracker:Real Time capture Workload Tracker samples'
+				)
+				_describe -t commands "nvme solidigm commands" _sub
+				return
+			fi
+
+			case ${words[2]} in
+				(id-ctrl)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_id_ctrl
+					_solidigm_id_ctrl=(
+						--vendor-specific':dump binary vendor field'
+						-V':alias for --vendor-specific'
+						--raw-binary':show identify in binary format'
+						-b':alias for --raw-binary'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm id-ctrl options" _solidigm_id_ctrl
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(smart-log-add)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_smart_log_add
+					_solidigm_smart_log_add=(
+						--namespace-id=':(optional) desired namespace'
+						-n':alias for --namespace-id'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm smart-log-add options" _solidigm_smart_log_add
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(vs-smart-add-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_vs_smart_add_log
+					_solidigm_vs_smart_add_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm vs-smart-add-log options" _solidigm_vs_smart_add_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(vs-internal-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--dir-name -d" && return
+					local _solidigm_vs_internal_log
+					_solidigm_vs_internal_log=(
+						--type=':Log type; Defaults to ALL.'
+						-t':alias for --type'
+						--dir-name=':Output directory; defaults to current working directory.'
+						-d':alias for --dir-name'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm vs-internal-log options" _solidigm_vs_internal_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(garbage-collect-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_garbage_collect_log
+					_solidigm_garbage_collect_log=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm garbage-collect-log options" _solidigm_garbage_collect_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(market-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_market_log
+					_solidigm_market_log=(
+						--raw-binary':dump output in binary format'
+						-b':alias for --raw-binary'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm market-log options" _solidigm_market_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(latency-tracking-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_latency_tracking_log
+					_solidigm_latency_tracking_log=(
+						--enable':Enable Latency Tracking'
+						-e':alias for --enable'
+						--disable':Disable Latency Tracking'
+						-d':alias for --disable'
+						--read':Get read statistics'
+						-r':alias for --read'
+						--write':Get write statistics'
+						-w':alias for --write'
+						--type=':Log type to get'
+						-t':alias for --type'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm latency-tracking-log options" _solidigm_latency_tracking_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(parse-telemetry-log)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					_nvme_opt_files "--config-file -j" \
+					                "--source-file -s" && return
+					local _solidigm_parse_telemetry_log
+					_solidigm_parse_telemetry_log=(
+						--host-generate=':Controls when to generate new host initiated report. Default value '\''1'\'' generates new host initiated report, value '\''0'\'' causes retrieval of existing log.'
+						-g':alias for --host-generate'
+						--controller-init':Gather report generated by the controller.'
+						-c':alias for --controller-init'
+						--data-area=':Pick which telemetry data area to report. Default is 3 to fetch areas 1-3. Valid options are 1, 2, 3, 4.'
+						-d':alias for --data-area'
+						--config-file=':JSON configuration file'
+						-j':alias for --config-file'
+						--source-file=':binary file containing log dump'
+						-s':alias for --source-file'
+						--jq-filter=':JSON config entry name containing jq filter'
+						-q':alias for --jq-filter'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm parse-telemetry-log options" _solidigm_parse_telemetry_log
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(clear-pcie-correctable-errors)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_clear_pcie_correctable_errors
+					_solidigm_clear_pcie_correctable_errors=(
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm clear-pcie-correctable-errors options" _solidigm_clear_pcie_correctable_errors
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(clear-fw-activate-history)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_clear_fw_activate_history
+					_solidigm_clear_fw_activate_history=(
+						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
+						-n':alias for --no-uuid'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm clear-fw-activate-history options" _solidigm_clear_fw_activate_history
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(vs-fw-activate-history)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_vs_fw_activate_history
+					_solidigm_vs_fw_activate_history=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm vs-fw-activate-history options" _solidigm_vs_fw_activate_history
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(log-page-directory)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_log_page_directory
+					_solidigm_log_page_directory=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm log-page-directory options" _solidigm_log_page_directory
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(temp-stats)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_temp_stats
+					_solidigm_temp_stats=(
+						--raw-binary':dump output in binary format'
+						-b':alias for --raw-binary'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm temp-stats options" _solidigm_temp_stats
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(vs-drive-info)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_vs_drive_info
+					_solidigm_vs_drive_info=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm vs-drive-info options" _solidigm_vs_drive_info
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(cloud-SSDplugin-version)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_cloud_SSDplugin_version
+					_solidigm_cloud_SSDplugin_version=(
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm cloud-SSDplugin-version options" _solidigm_cloud_SSDplugin_version
+					_nvme_has_device || compadd -- /dev/nvme*(N)
+					;;
+
+				(workload-tracker)
+					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+					               "--output-format-version" "1 2" && return
+					local _solidigm_workload_tracker
+					_solidigm_workload_tracker=(
+						--uuid-index=':specify uuid index'
+						-U':alias for --uuid-index'
+						--enable':tracker enable'
+						-e':alias for --enable'
+						--disable':tracker disable'
+						-d':alias for --disable'
+						--sample-time=':Sample interval'
+						-s':alias for --sample-time'
+						--type=':Tracker type'
+						-t':alias for --type'
+						--run-time=':Limit runtime capture time in seconds'
+						-r':alias for --run-time'
+						--flush-freq=':Samples (1 to 126) to wait for extracting data. Default 100 samples'
+						-f':alias for --flush-freq'
+						--wall-clock':Logs current wall timestamp when entry was retrieved'
+						-w':alias for --wall-clock'
+						--trigger-field=':Field name to stop trigger on'
+						-T':alias for --trigger-field'
+						--trigger-threshold=':Field value to trigger stop sampling'
+						-V':alias for --trigger-threshold'
+						--trigger-on-delta':Trigger on delta to stop sampling'
+						-D':alias for --trigger-on-delta'
+						--trigger-on-latency':Use latency tracker to trigger stop sampling'
+						-L':alias for --trigger-on-latency'
+						--verbose':Increase output verbosity'
+						-v':alias for --verbose'
+						--quiet':suppress output messages, overwrites verbose mode'
+						--output-format=':Output format: normal|json|binary'
+						-o':alias for --output-format'
+						--timeout=':timeout value, in milliseconds'
+						--dry-run':show command instead of executing'
+						--no-retries':disable retry logic on errors'
+						--no-ioctl-probing':disable 64-bit IOCTL support probing'
+						--output-format-version=':output format version: 1|2'
+						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+						--help':show help'
+						-h':alias for --help'
+					)
+					_arguments '*:: :->subcmds'
+					_nvme_describe "nvme solidigm workload-tracker options" _solidigm_workload_tracker
 					_nvme_has_device || compadd -- /dev/nvme*(N)
 					;;
 
@@ -8284,3068 +11371,6 @@ _nvme () {
 			esac
 			;;
 
-		(nbft)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'show:Show contents of ACPI NBFT tables'
-				)
-				_describe -t commands "nvme nbft commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(show)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _nbft_show
-					_nbft_show=(
-						--subsystem':show NBFT subsystems'
-						-s':alias for --subsystem'
-						--hfi':show NBFT HFIs'
-						-H':alias for --hfi'
-						--discovery':show NBFT discovery controllers'
-						-d':alias for --discovery'
-						--nbft-path=':user-defined path for NBFT tables'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme nbft show options" _nbft_show
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(keys)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'gen-kxchap-secret:Generate NVMeoF KX-HMAC-CHAP host secret'
-					'check-kxchap-secret:Validate NVMeoF KX-HMAC-CHAP host secret format or check if loaded'
-					'gen-tls:Generate NVMeoF TLS PSK'
-					'check-tls:Validate NVMeoF TLS PSK format or check if loaded'
-					'insert-tls:Insert NVMeoF TLS PSK into a keyring'
-					'import:Import NVMeoF TLS PSKs and KX-HMAC-CHAP secrets into a keyring'
-					'export:Export NVMeoF TLS PSKs from a keyring'
-					'revoke:Revoke an NVMeoF TLS PSK from a keyring'
-				)
-				_describe -t commands "nvme keys commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(gen-kxchap-secret)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_gen_kxchap_secret
-					_keys_gen_kxchap_secret=(
-						--secret=':Optional secret (in hexadecimal characters) to be placed in the representation.'
-						-s':alias for --secret'
-						--secret-length=':Length of the secret (32, 48, or 64 bytes).'
-						-l':alias for --secret-length'
-						--hmac=':Hash function the consumer is to apply to the secret (0 = none, 1 = SHA-256, 2 = SHA-384, 3 = SHA-512).'
-						-m':alias for --hmac'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys gen-kxchap-secret options" _keys_gen_kxchap_secret
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(check-kxchap-secret)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_check_kxchap_secret
-					_keys_check_kxchap_secret=(
-						--keydata=':KX-HMAC-CHAP secret (in DHHC-1 interchange format) to be validated. Reads from stdin if not given.'
-						-d':alias for --keydata'
-						--keyring=':Keyring to check for an already loaded secret.'
-						-k':alias for --keyring'
-						--keytype=':Key type of the secret to look up.'
-						-t':alias for --keytype'
-						--identity=':Identity to look up in the keyring to check if the secret is already loaded.'
-						-i':alias for --identity'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys check-kxchap-secret options" _keys_check_kxchap_secret
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(gen-tls)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_gen_tls
-					_keys_gen_tls=(
-						--keyring=':Keyring for the retained key.'
-						-k':alias for --keyring'
-						--keytype=':Key type of the retained key.'
-						-t':alias for --keytype'
-						--hostnqn=':Host NQN for the retained key.'
-						-n':alias for --hostnqn'
-						--subsysnqn=':Subsystem NQN for the retained key.'
-						-c':alias for --subsysnqn'
-						--secret=':Optional secret (in hexadecimal characters) to be used for the TLS key.'
-						-s':alias for --secret'
-						--keyfile=':Update key file with the derived TLS PSK.'
-						-f':alias for --keyfile'
-						--hmac=':HMAC function to use for the retained key (1 = SHA-256, 2 = SHA-384).'
-						-m':alias for --hmac'
-						--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
-						-I':alias for --identity'
-						--insert':Insert retained key into the keyring.'
-						-i':alias for --insert'
-						--compat':Use non-RFC 8446 compliant algorithm for deriving TLS PSK for older implementations.'
-						-C':alias for --compat'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys gen-tls options" _keys_gen_tls
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(check-tls)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_check_tls
-					_keys_check_tls=(
-						--keyring=':Keyring to check for an already loaded key.'
-						-k':alias for --keyring'
-						--keytype=':Key type of the key to look up.'
-						-t':alias for --keytype'
-						--hostnqn=':Host NQN to use when checking whether the key is already loaded.'
-						-n':alias for --hostnqn'
-						--subsysnqn=':Subsystem NQN to use when checking whether the key is already loaded.'
-						-c':alias for --subsysnqn'
-						--keydata=':TLS key (in PSK Interchange format) to be validated. Reads from stdin if not given.'
-						-d':alias for --keydata'
-						--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
-						-I':alias for --identity'
-						--compat':Use non-RFC 8446 compliant algorithm for checking TLS PSK for older implementations.'
-						-C':alias for --compat'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys check-tls options" _keys_check_tls
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(insert-tls)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_insert_tls
-					_keys_insert_tls=(
-						--keyring=':Keyring for the retained key.'
-						-k':alias for --keyring'
-						--keytype=':Key type of the retained key.'
-						-t':alias for --keytype'
-						--hostnqn=':Host NQN for the retained key.'
-						-n':alias for --hostnqn'
-						--subsysnqn=':Subsystem NQN for the retained key.'
-						-c':alias for --subsysnqn'
-						--keydata=':TLS key (in PSK Interchange format) to be inserted. Reads from stdin if not given.'
-						-d':alias for --keydata'
-						--keyfile=':Append the derived TLS PSK to keyfile.'
-						-f':alias for --keyfile'
-						--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
-						-I':alias for --identity'
-						--compat':Use non-RFC 8446 compliant algorithm for older implementations.'
-						-C':alias for --compat'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys insert-tls options" _keys_insert_tls
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(import)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_import
-					_keys_import=(
-						--keyring=':Keyring to import the keys into.'
-						-k':alias for --keyring'
-						--keyfile=':File to read the keys from (default: stdin).'
-						-f':alias for --keyfile'
-						--keydata=':Key to insert directly under --identity. Reads from stdin if not given.'
-						-d':alias for --keydata'
-						--identity=':Identity to store a single key under. If given, --keydata (or stdin) is read as a single key instead of a bulk <identity> <key> list.'
-						-i':alias for --identity'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys import options" _keys_import
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(export)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_export
-					_keys_export=(
-						--keyring=':Keyring to export the retained keys from.'
-						-k':alias for --keyring'
-						--keyfile=':File to write the exported keys to (default: stdout).'
-						-f':alias for --keyfile'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys export options" _keys_export
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(revoke)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _keys_revoke
-					_keys_revoke=(
-						--keyring=':Keyring to revoke the key from.'
-						-k':alias for --keyring'
-						--keytype=':Key type of the key to revoke.'
-						-t':alias for --keytype'
-						--identity=':Identity (description) of the key to revoke.'
-						-i':alias for --identity'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme keys revoke options" _keys_revoke
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(exclusion)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'create:Create an exclusion list'
-					'delete:Delete an exclusion list'
-					'edit:Edit an exclusion list interactively'
-					'list:List exclusion lists or entries'
-					'add:Add an entry to an exclusion list'
-					'remove:Remove an entry from an exclusion list'
-				)
-				_describe -t commands "nvme exclusion commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(create)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _exclusion_create
-					_exclusion_create=(
-						--name=':exclusion list name (omit for the default list)'
-						-N':alias for --name'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme exclusion create options" _exclusion_create
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(delete)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _exclusion_delete
-					_exclusion_delete=(
-						--name=':exclusion list name (omit for the default list)'
-						-N':alias for --name'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme exclusion delete options" _exclusion_delete
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(edit)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _exclusion_edit
-					_exclusion_edit=(
-						--name=':exclusion list name (omit for the default list)'
-						-N':alias for --name'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme exclusion edit options" _exclusion_edit
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(list)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _exclusion_list
-					_exclusion_list=(
-						--name=':exclusion list name (omit to list all lists)'
-						-N':alias for --name'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme exclusion list options" _exclusion_list
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(add)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _exclusion_add
-					_exclusion_add=(
-						--name=':exclusion list name (omit for the default list)'
-						-N':alias for --name'
-						--entry=':semicolon-separated key=value entry (e.g. "transport=tcp;traddr=192.168.1.1")'
-						-e':alias for --entry'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme exclusion add options" _exclusion_add
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(remove)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _exclusion_remove
-					_exclusion_remove=(
-						--name=':exclusion list name (omit for the default list)'
-						-N':alias for --name'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme exclusion remove options" _exclusion_remove
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(registry)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'list:List live registry entries'
-					'retrieve:Read an attribute from a controller'\''s entry'
-					'update:Write an attribute to a controller'\''s entry'
-					'delete:Remove a controller'\''s registry entry'
-				)
-				_describe -t commands "nvme registry commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(list)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _registry_list
-					_registry_list=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme registry list options" _registry_list
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(retrieve)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _registry_retrieve
-					_registry_retrieve=(
-						--attr=':attribute name (e.g. owner, note)'
-						-a':alias for --attr'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme registry retrieve options" _registry_retrieve
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(update)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _registry_update
-					_registry_update=(
-						--attr=':attribute name (e.g. note, owner)'
-						-a':alias for --attr'
-						--value=':new attribute value'
-						-V':alias for --value'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme registry update options" _registry_update
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(delete)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _registry_delete
-					_registry_delete=(
-						--attr=':attribute to remove (default: whole entry)'
-						-a':alias for --attr'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme registry delete options" _registry_delete
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(config)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'validate:Validate an NVMeoF connection configuration'
-					'show:Show the resolved NVMeoF connection configuration'
-					'status:Report config status'
-					'convert:Convert config.json/discovery.conf to INI'
-					'create:Create an NVMeoF connection entry in the INI configuration'
-				)
-				_describe -t commands "nvme config commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(validate)
-					_nvme_opt_files "--config -J" && return
-					local _config_validate
-					_config_validate=(
-						--config=':INI configuration file (default: /usr/local/etc/nvme/nvme-fabrics.conf)'
-						-J':alias for --config'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme config validate options" _config_validate
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(show)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--config -J" && return
-					local _config_show
-					_config_show=(
-						--config=':INI configuration file (default: /usr/local/etc/nvme/nvme-fabrics.conf)'
-						-J':alias for --config'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme config show options" _config_show
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(status)
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(convert)
-					_nvme_opt_files "--config -J" \
-					                "--output -o" && return
-					local _config_convert
-					_config_convert=(
-						--config=':convert this JSON file (default: config.json)'
-						-J':alias for --config'
-						--output=':write result here (default: nvme-fabrics.conf)'
-						-o':alias for --output'
-						--force':overwrite an existing target'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme config convert options" _config_convert
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(create)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--output" && return
-					local _config_create
-					_config_create=(
-						--transport=':transport type'
-						-t':alias for --transport'
-						--nqn=':subsystem nqn'
-						-n':alias for --nqn'
-						--traddr=':transport address'
-						-a':alias for --traddr'
-						--trsvcid=':transport service id (e.g. IP port)'
-						-s':alias for --trsvcid'
-						--host-traddr=':host traddr (e.g. FC WWN'\''s)'
-						-w':alias for --host-traddr'
-						--host-iface=':host interface (for tcp transport)'
-						-f':alias for --host-iface'
-						--hostnqn=':user-defined hostnqn'
-						-q':alias for --hostnqn'
-						--hostid=':user-defined hostid (if default not used)'
-						-I':alias for --hostid'
-						--kxchap-secret=':user-defined kxchap secret (if default not used)'
-						-S':alias for --kxchap-secret'
-						--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
-						-C':alias for --kxchap-ctrl-secret'
-						--keyring=':Keyring for TLS key lookup (key id or keyring name)'
-						--tls-key=':TLS key to use (key id or key in interchange format)'
-						--tls-key-identity=':TLS key identity'
-						--nr-io-queues=':number of io queues to use (default is core count)'
-						-i':alias for --nr-io-queues'
-						--nr-write-queues=':number of write queues to use (default 0)'
-						-W':alias for --nr-write-queues'
-						--nr-poll-queues=':number of poll queues to use (default 0)'
-						-P':alias for --nr-poll-queues'
-						--queue-size=':number of io queue elements to use (default 128)'
-						-Q':alias for --queue-size'
-						--keep-alive-tmo=':keep alive timeout period in seconds'
-						-k':alias for --keep-alive-tmo'
-						--reconnect-delay=':reconnect timeout period in seconds'
-						-c':alias for --reconnect-delay'
-						--ctrl-loss-tmo=':controller loss timeout period in seconds'
-						-l':alias for --ctrl-loss-tmo'
-						--fast_io_fail_tmo=':fast I/O fail timeout (default off)'
-						-F':alias for --fast_io_fail_tmo'
-						--tos=':type of service'
-						-T':alias for --tos'
-						--tls_key=':TLS key to use (key id)'
-						--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
-						-D':alias for --duplicate-connect'
-						--disable-sqflow':disable controller sq flow control (default false)'
-						--hdr-digest':enable transport protocol header digest (TCP transport)'
-						-g':alias for --hdr-digest'
-						--data-digest':enable transport protocol data digest (TCP transport)'
-						-G':alias for --data-digest'
-						--tls':enable TLS'
-						--concat':enable secure concatenation'
-						--discovery':create a discovery controller entry instead of an I/O controller (subsystem) entry; an I/O controller entry requires --nqn'
-						--persistent=':keep the discovery controller connected to receive Asynchronous Event Notifications instead of disconnecting after the discovery log page fetch; "auto" (the default when given bare) persists only where the target'\''s own EPCSD flag supports it, "force" persists regardless, "no" explicitly records non-persistence; requires --discovery'
-						--host-symname=':name this host persona, so it gets its own configuration drop-in'
-						--output=':add the entry to this INI configuration file (default: /usr/local/etc/nvme/nvme-fabrics.conf)'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme config create options" _config_create
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(feat)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'arbitration:Get and set arbitration feature'
-					'power-mgmt:Get and set power management feature'
-					'temp-thresh:Get and set temperature threshold feature'
-					'volatile-wc:Get and set volatile write cache feature'
-					'num-queues:Get and set number of queues feature'
-					'timestamp:Get and set timestamp feature'
-					'hctm:Get and set host controlled thermal management feature'
-					'host-behavior-support:Get and set host behavior support feature'
-					'perf-characteristics:Get and set perf characteristics feature'
-					'power-limit:Get and set power limit feature'
-					'power-thresh:Get and set power threshold feature'
-					'power-meas:Get and set power measurement feature'
-					'err-recovery:Get and set error recovery feature'
-				)
-				_describe -t commands "nvme feat commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(arbitration)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_arbitration
-					_feat_arbitration=(
-						--ab=':arbitration burst'
-						-a':alias for --ab'
-						--lpw=':low priority weight'
-						-l':alias for --lpw'
-						--mpw=':medium priority weight'
-						-m':alias for --mpw'
-						--hpw=':high priority weight'
-						-H':alias for --hpw'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat arbitration options" _feat_arbitration
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(power-mgmt)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_power_mgmt
-					_feat_power_mgmt=(
-						--ps=':power state'
-						-p':alias for --ps'
-						--wh=':workload hint'
-						-w':alias for --wh'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat power-mgmt options" _feat_power_mgmt
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(temp-thresh)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_temp_thresh
-					_feat_temp_thresh=(
-						--tmpth=':temperature threshold'
-						-T':alias for --tmpth'
-						--tmpsel=':threshold temperature select'
-						-m':alias for --tmpsel'
-						--thsel=':threshold type select'
-						-H':alias for --thsel'
-						--tmpthh=':temperature threshold hysteresis'
-						-M':alias for --tmpthh'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat temp-thresh options" _feat_temp_thresh
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(volatile-wc)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_volatile_wc
-					_feat_volatile_wc=(
-						--wce':volatile write cache enable'
-						-w':alias for --wce'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat volatile-wc options" _feat_volatile_wc
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(num-queues)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_num_queues
-					_feat_num_queues=(
-						--nsqr=':number of I/O submission queues requested'
-						-n':alias for --nsqr'
-						--ncqr=':number of I/O completion queues requested'
-						-c':alias for --ncqr'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat num-queues options" _feat_num_queues
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(timestamp)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_timestamp
-					_feat_timestamp=(
-						--tstmp=':timestamp'
-						-t':alias for --tstmp'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat timestamp options" _feat_timestamp
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(hctm)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_hctm
-					_feat_hctm=(
-						--tmt1=':thermal management temperature 1'
-						-t':alias for --tmt1'
-						--tmt2=':thermal management temperature 2'
-						-T':alias for --tmt2'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat hctm options" _feat_hctm
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(host-behavior-support)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_host_behavior_support
-					_feat_host_behavior_support=(
-						--acre=':Advanced Command Retry Enable (0 or 1)'
-						-a':alias for --acre'
-						--etdas=':Extended Telemetry Data Area 4 Supported (0 or 1)'
-						-e':alias for --etdas'
-						--lbafee=':LBA Format Extension Enable (0 or 1)'
-						-l':alias for --lbafee'
-						--hdisns=':Host Dispersed Namespace Support (0 or 1)'
-						-H':alias for --hdisns'
-						--cdfe=':Copy Descriptor Formats Enable bitmask'
-						-c':alias for --cdfe'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat host-behavior-support options" _feat_host_behavior_support
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(perf-characteristics)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--vs-data -V" && return
-					local _feat_perf_characteristics
-					_feat_perf_characteristics=(
-						--namespace-id=':optional namespace attached to controller'
-						-n':alias for --namespace-id'
-						--attri=':attribute index'
-						-a':alias for --attri'
-						--rvspa':revert vendor specific performance attribute'
-						-r':alias for --rvspa'
-						--r4karl=':random 4 kib average read latency'
-						-R':alias for --r4karl'
-						--paid=':performance attribute identifier'
-						-p':alias for --paid'
-						--attrl=':attribute length'
-						-A':alias for --attrl'
-						--vs-data=':vendor specific data'
-						-V':alias for --vs-data'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat perf-characteristics options" _feat_perf_characteristics
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(power-limit)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_power_limit
-					_feat_power_limit=(
-						--plv=':power limit value'
-						-p':alias for --plv'
-						--pls=':power limit scale'
-						-l':alias for --pls'
-						--uuid-index=':UUID index'
-						-u':alias for --uuid-index'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat power-limit options" _feat_power_limit
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(power-thresh)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_power_thresh
-					_feat_power_thresh=(
-						--ptv=':power threshold value'
-						-p':alias for --ptv'
-						--pts=':power threshold scale'
-						-t':alias for --pts'
-						--pmts=':power measurement type select'
-						-m':alias for --pmts'
-						--ept=':enable power threshold'
-						-e':alias for --ept'
-						--uuid-index=':UUID index'
-						-u':alias for --uuid-index'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat power-thresh options" _feat_power_thresh
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(power-meas)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_power_meas
-					_feat_power_meas=(
-						--act=':action [0-1]: stop|start'
-						--pmts=':power measurement type select'
-						--smt=':stop measurement time'
-						--uuid-index=':UUID index'
-						-u':alias for --uuid-index'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat power-meas options" _feat_power_meas
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(err-recovery)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _feat_err_recovery
-					_feat_err_recovery=(
-						--nsid=':identifier of desired namespace'
-						-n':alias for --nsid'
-						--tler=':time limited error recovery'
-						-t':alias for --tler'
-						--dulbe':deallocated or unwritten logical block error enable'
-						-d':alias for --dulbe'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme feat err-recovery options" _feat_err_recovery
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(lm)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'create-cdq:Create Controller Data Queue'
-					'delete-cdq:Delete Controller Data Queue'
-					'track-send:Track Send Command'
-					'migration-send:Migration Send'
-					'migration-recv:Migration Receive'
-					'set-cdq:Set Feature - Controller Data Queue (FID 21h)'
-					'get-cdq:Get Feature - Controller Data Queue (FID 21h)'
-				)
-				_describe -t commands "nvme lm commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(create-cdq)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _lm_create_cdq
-					_lm_create_cdq=(
-						--size=':CDQ Size (in dwords)'
-						-s':alias for --size'
-						--cntlid=':Controller ID'
-						-c':alias for --cntlid'
-						--queue-type=':Queue Type (default: 0 = User Data Migration Queue)'
-						-q':alias for --queue-type'
-						--consent':I consent this will not work and understand a CDQ cannot be mapped to user space. If I proceed with the creation of a CDQ, the device will write to invalid memory, inevitably leading to MMU faults or worse.'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme lm create-cdq options" _lm_create_cdq
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(delete-cdq)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _lm_delete_cdq
-					_lm_delete_cdq=(
-						--cdqid=':Controller Data Queue ID'
-						-C':alias for --cdqid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme lm delete-cdq options" _lm_delete_cdq
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(track-send)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _lm_track_send
-					_lm_track_send=(
-						--sel=':Type of management operation to perform 0h = Log User Data Changes 1h = Track Memory Changes'
-						-s':alias for --sel'
-						--mos=':Management operation specific'
-						-m':alias for --mos'
-						--cdqid=':Controller Data Queue ID'
-						-C':alias for --cdqid'
-						--start':Equivalent to start tracking with defaults'
-						--stop':Equivalent to stop tracking with defaults'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme lm track-send options" _lm_track_send
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(migration-send)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--input-file -f" && return
-					local _lm_migration_send
-					_lm_migration_send=(
-						--sel=':Select (SEL) the type of management operation to perform (CDW10[07:00]) 0h = Suspend 1h = Resume 2h = Set Controller State'
-						-s':alias for --sel'
-						--cntlid=':Controller Identifier (CDW11[15:00])'
-						-c':alias for --cntlid'
-						--stype=':Type of suspend (STYPE) (CDW11[23:16] 0h = Suspend Notification 1h = Suspend'
-						-t':alias for --stype'
-						--dudmq':Delete user data migration queue (DUDMQ) as part of suspend operation (CDW11[31])'
-						-d':alias for --dudmq'
-						--seq-ind=':Sequence Indicator (CDW10[17:16]) 0h = Not first not last 1h = First in two or more 2h = Last in two or more 3h = Entire state info'
-						-S':alias for --seq-ind'
-						--csuuidi=':Controller State UUID Index (CSUUIDI) (CDW11[31:24])'
-						-U':alias for --csuuidi'
-						--csvi=':Controller State Version Index (CSVI) (CDW11[23:16])'
-						-V':alias for --csvi'
-						--uidx=':UUID Index (UIDX) (CDW14[16:00])'
-						-u':alias for --uidx'
-						--offset=':Controller State Offset'
-						-O':alias for --offset'
-						--numd=':Number of Dwords (NUMD)'
-						-n':alias for --numd'
-						--input-file=':Controller State Data input file'
-						-f':alias for --input-file'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme lm migration-send options" _lm_migration_send
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(migration-recv)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--output-file -f" && return
-					local _lm_migration_recv
-					_lm_migration_recv=(
-						--sel=':Select (SEL) the type of management operation to perform (CDW10[07:00]) 0h = Get Controller State'
-						-s':alias for --sel'
-						--cntlid=':Controller Identifier (CDW10[31:16])'
-						-c':alias for --cntlid'
-						--csuuidi=':Controller State UUID Index (CSUUIDI) (CDW11[23:16])'
-						-U':alias for --csuuidi'
-						--csvi=':Controller State Version Index (CSVI) (CDW11[7:0])'
-						-V':alias for --csvi'
-						--uidx=':UUID Index (UIDX) (CDW14[16:00])'
-						-u':alias for --uidx'
-						--offset=':Controller State Offset'
-						-O':alias for --offset'
-						--numd=':Number of Dwords (NUMD)'
-						-n':alias for --numd'
-						--output-file=':Controller State Data output file'
-						-f':alias for --output-file'
-						--human-readable':show info in readable format'
-						-H':alias for --human-readable'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme lm migration-recv options" _lm_migration_recv
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-cdq)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _lm_set_cdq
-					_lm_set_cdq=(
-						--cdqid=':Controller Data Queue ID'
-						-C':alias for --cdqid'
-						--hp=':The slot of the head pointer for the specified CDQ'
-						-H':alias for --hp'
-						--tpt=':If specified, the slot that causes the controller to issue a CDQ Tail Pointer event'
-						-T':alias for --tpt'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme lm set-cdq options" _lm_set_cdq
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-cdq)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _lm_get_cdq
-					_lm_get_cdq=(
-						--cdqid=':Controller Data Queue ID'
-						-C':alias for --cdqid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme lm get-cdq options" _lm_get_cdq
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(ocp)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'smart-add-log:Retrieve Extended SMART Information'
-					'latency-monitor-log:Retrieve Latency Monitor Log Page'
-					'set-latency-monitor-feature:Set Latency Monitor Feature'
-					'internal-log:Retrieve and Save Internal Device Telemetry Log'
-					'clear-fw-activate-history:Clear Firmware Update History'
-					'eol-plp-failure-mode:Define EOL or PLP Circuitry Failure Mode'
-					'clear-pcie-correctable-errors:Clear PCIe Correctable Error Counters'
-					'fw-activate-history:Retrieve Firmware Activation History Log Page'
-					'unsupported-reqs-log:Retrieve Unsupported Requirements Log Page'
-					'error-recovery-log:Retrieve Error Recovery Log Page'
-					'device-capability-log:Retrieve Device Capabilities Log Page'
-					'set-dssd-power-state-feature:Set DSSD Power State Feature'
-					'get-dssd-power-state-feature:Get DSSD Power State Feature'
-					'set-plp-health-check-interval:Set PLP Health Check Interval'
-					'get-plp-health-check-interval:Get PLP Health Check Interval'
-					'telemetry-string-log:Retrieve Telemetry String Log Page'
-					'set-telemetry-profile:Set Telemetry Profile Feature'
-					'set-dssd-async-event-config:Set DSSD Asynchronous Event Configuration'
-					'get-dssd-async-event-config:Get DSSD Asynchronous Event Configuration'
-					'tcg-configuration-log:Retrieve TCG Configuration Log Page'
-					'get-error-injection:Get Error Injection Feature'
-					'set-error-injection:Set Error Injection Feature'
-					'get-enable-ieee1667-silo:Get Enable IEEE1667 Silo Feature'
-					'set-enable-ieee1667-silo:Set Enable IEEE1667 Silo Feature'
-					'hardware-component-log:Retrieve Hardware Component Log Page'
-					'get-latency-monitor:Get Latency Monitor Feature'
-					'get-clear-pcie-correctable-errors:Get Clear PCIe Correctable Error Counters Feature'
-					'get-telemetry-profile:Get Telemetry Profile Feature'
-					'persistent-event-log:Retrieve Persistent Event Log with OCP Events'
-					'get-idle-wakeup-time:Get Idle Wake Up Time Configuration'
-				)
-				_describe -t commands "nvme ocp commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(smart-add-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_smart_add_log
-					_ocp_smart_add_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp smart-add-log options" _ocp_smart_add_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(latency-monitor-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_latency_monitor_log
-					_ocp_latency_monitor_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp latency-monitor-log options" _ocp_latency_monitor_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-latency-monitor-feature)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_set_latency_monitor_feature
-					_ocp_set_latency_monitor_feature=(
-						--active_bucket_timer_threshold=':This is the value that loads the Active Bucket Timer Threshold.'
-						-t':alias for --active_bucket_timer_threshold'
-						--active_threshold_a=':This is the value that loads into the Active Threshold A.'
-						-a':alias for --active_threshold_a'
-						--active_threshold_b=':This is the value that loads into the Active Threshold B.'
-						-b':alias for --active_threshold_b'
-						--active_threshold_c=':This is the value that loads into the Active Threshold C.'
-						-c':alias for --active_threshold_c'
-						--active_threshold_d=':This is the value that loads into the Active Threshold D.'
-						-d':alias for --active_threshold_d'
-						--active_latency_config=':This is the value that loads into the Active Latency Configuration.'
-						-f':alias for --active_latency_config'
-						--active_latency_minimum_window=':This is the value that loads into the Active Latency Minimum Window.'
-						-w':alias for --active_latency_minimum_window'
-						--debug_log_trigger_enable=':This is the value that loads into the Debug Log Trigger Enable.'
-						-r':alias for --debug_log_trigger_enable'
-						--discard_debug_log=':Discard Debug Log.'
-						-l':alias for --discard_debug_log'
-						--latency_monitor_feature_enable=':Latency Monitor Feature Enable.'
-						-e':alias for --latency_monitor_feature_enable'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp set-latency-monitor-feature options" _ocp_set_latency_monitor_feature
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(internal-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--output-file -f" && return
-					local _ocp_internal_log
-					_ocp_internal_log=(
-						--telemetry-log=':Telemetry log binary; '\''host.bin'\'' or '\''controller.bin'\'''
-						-l':alias for --telemetry-log'
-						--string-log=':String log binary; '\''C9.bin'\'''
-						-s':alias for --string-log'
-						--output-file=':Output file name with path; e.g. '\''-f ./path/name'\'' '\''-f ./path1/path2/'\''; If requested path does not exist, the directory will be newly created.'
-						-f':alias for --output-file'
-						--data-area=':Telemetry Data Area; 1, 2, 3, or 4; e.g. '\''-a 1 for Data Area 1.'\'' e.g. '\''-a 2 for Data Areas 1 and 2.'\'' e.g. '\''-a 3 for Data Areas 1, 2, and 3.'\'' e.g. '\''-a 4 for Data Areas 1, 2, 3, and 4.'\'';'
-						-a':alias for --data-area'
-						--telemetry-type=':Telemetry Type; '\''host'\'', '\''host0'\'', '\''host1'\'' or '\''controller'\'''
-						-t':alias for --telemetry-type'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp internal-log options" _ocp_internal_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(clear-fw-activate-history)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_clear_fw_activate_history
-					_ocp_clear_fw_activate_history=(
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp clear-fw-activate-history options" _ocp_clear_fw_activate_history
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(eol-plp-failure-mode)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_eol_plp_failure_mode
-					_ocp_eol_plp_failure_mode=(
-						--mode=':[0-3]: default/rom/wtm/normal'
-						-m':alias for --mode'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp eol-plp-failure-mode options" _ocp_eol_plp_failure_mode
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(clear-pcie-correctable-errors)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_clear_pcie_correctable_errors
-					_ocp_clear_pcie_correctable_errors=(
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp clear-pcie-correctable-errors options" _ocp_clear_pcie_correctable_errors
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(fw-activate-history)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_fw_activate_history
-					_ocp_fw_activate_history=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp fw-activate-history options" _ocp_fw_activate_history
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(unsupported-reqs-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_unsupported_reqs_log
-					_ocp_unsupported_reqs_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp unsupported-reqs-log options" _ocp_unsupported_reqs_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(error-recovery-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_error_recovery_log
-					_ocp_error_recovery_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp error-recovery-log options" _ocp_error_recovery_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(device-capability-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_device_capability_log
-					_ocp_device_capability_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp device-capability-log options" _ocp_device_capability_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-dssd-power-state-feature)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_set_dssd_power_state_feature
-					_ocp_set_dssd_power_state_feature=(
-						--power-state=':DSSD Power State to set in watts'
-						-p':alias for --power-state'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp set-dssd-power-state-feature options" _ocp_set_dssd_power_state_feature
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-dssd-power-state-feature)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_dssd_power_state_feature
-					_ocp_get_dssd_power_state_feature=(
-						--sel=':[0-3]: current/default/saved/supported/'
-						-S':alias for --sel'
-						--all':Print out all 3 values at once - Current, Default, and Saved'
-						-a':alias for --all'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-dssd-power-state-feature options" _ocp_get_dssd_power_state_feature
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-plp-health-check-interval)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_set_plp_health_check_interval
-					_ocp_set_plp_health_check_interval=(
-						--plp_health_interval=':[31:16]:PLP Health Check Interval'
-						-p':alias for --plp_health_interval'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp set-plp-health-check-interval options" _ocp_set_plp_health_check_interval
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-plp-health-check-interval)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_plp_health_check_interval
-					_ocp_get_plp_health_check_interval=(
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-plp-health-check-interval options" _ocp_get_plp_health_check_interval
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(telemetry-string-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--output-file -f" && return
-					local _ocp_telemetry_string_log
-					_ocp_telemetry_string_log=(
-						--output-file=':Output file name with path; e.g. '\''-f ./path/name'\'' '\''-f ./path1/path2/'\''; If requested path does not exist, the directory will be newly created.'
-						-f':alias for --output-file'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp telemetry-string-log options" _ocp_telemetry_string_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-telemetry-profile)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_set_telemetry_profile
-					_ocp_set_telemetry_profile=(
-						--telemetry-profile-select=':Telemetry Profile Select for device debug data collection'
-						-t':alias for --telemetry-profile-select'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp set-telemetry-profile options" _ocp_set_telemetry_profile
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-dssd-async-event-config)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_set_dssd_async_event_config
-					_ocp_set_dssd_async_event_config=(
-						--enable-panic-notices':[0]:Enable Panic Notices'
-						-e':alias for --enable-panic-notices'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp set-dssd-async-event-config options" _ocp_set_dssd_async_event_config
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-dssd-async-event-config)
-					_nvme_opt_vals "--sel -S" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_dssd_async_event_config
-					_ocp_get_dssd_async_event_config=(
-						--sel=':[0-3]: current/default/saved/supported'
-						-S':alias for --sel'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-dssd-async-event-config options" _ocp_get_dssd_async_event_config
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(tcg-configuration-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_tcg_configuration_log
-					_ocp_tcg_configuration_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp tcg-configuration-log options" _ocp_tcg_configuration_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-error-injection)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_error_injection
-					_ocp_get_error_injection=(
-						--sel=':[0-3]: current/default/saved/supported'
-						-s':alias for --sel'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--all-ns':Apply to all namespaces'
-						-a':alias for --all-ns'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-error-injection options" _ocp_get_error_injection
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-error-injection)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--data -d" && return
-					local _ocp_set_error_injection
-					_ocp_set_error_injection=(
-						--data=':Error injection data structure entries'
-						-d':alias for --data'
-						--number=':Number of valid error injection data entries'
-						-n':alias for --number'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-N':alias for --no-uuid'
-						--all-ns':Apply to all namespaces'
-						-a':alias for --all-ns'
-						--type=':Error injection type'
-						-t':alias for --type'
-						--nrtdp=':Number of reads to trigger device panic'
-						-r':alias for --nrtdp'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp set-error-injection options" _ocp_set_error_injection
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-enable-ieee1667-silo)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_enable_ieee1667_silo
-					_ocp_get_enable_ieee1667_silo=(
-						--sel=':[0-3]: current/default/saved/supported'
-						-s':alias for --sel'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-enable-ieee1667-silo options" _ocp_get_enable_ieee1667_silo
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(set-enable-ieee1667-silo)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_set_enable_ieee1667_silo
-					_ocp_set_enable_ieee1667_silo=(
-						--enable':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-e':alias for --enable'
-						--save':Specifies that the controller shall save the attribute'
-						-s':alias for --save'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp set-enable-ieee1667-silo options" _ocp_set_enable_ieee1667_silo
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(hardware-component-log)
-					_nvme_opt_vals "--comp-id -i" "asic nand dram pmic pcb cap reg case sn country hw-rev born-on-date vendor" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_hardware_component_log
-					_ocp_hardware_component_log=(
-						--comp-id=':component identifier'
-						-i':alias for --comp-id'
-						--list':list component descriptions'
-						-l':alias for --list'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp hardware-component-log options" _ocp_hardware_component_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-latency-monitor)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_latency_monitor
-					_ocp_get_latency_monitor=(
-						--sel=':[0-3]: current/default/saved/supported/'
-						-s':alias for --sel'
-						--namespace-id=':Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive'
-						-n':alias for --namespace-id'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-u':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-latency-monitor options" _ocp_get_latency_monitor
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-clear-pcie-correctable-errors)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_clear_pcie_correctable_errors
-					_ocp_get_clear_pcie_correctable_errors=(
-						--sel=':[0-3]: current/default/saved/supported/'
-						-s':alias for --sel'
-						--namespace-id=':Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive'
-						-n':alias for --namespace-id'
-						--no-uuid':Do not try to automatically detect UUID index'
-						-u':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-clear-pcie-correctable-errors options" _ocp_get_clear_pcie_correctable_errors
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-telemetry-profile)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_telemetry_profile
-					_ocp_get_telemetry_profile=(
-						--sel=':[0-3]: current/default/saved/supported/'
-						-s':alias for --sel'
-						--namespace-id=':Byte[04-07]: Namespace Identifier Valid/Invalid/Inactive'
-						-n':alias for --namespace-id'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-u':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-telemetry-profile options" _ocp_get_telemetry_profile
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(persistent-event-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_persistent_event_log
-					_ocp_persistent_event_log=(
-						--action=':action the controller shall take during processing this persistent log page command.'
-						-a':alias for --action'
-						--log_len=':number of bytes to retrieve'
-						-l':alias for --log_len'
-						--raw-binary':use binary output'
-						-b':alias for --raw-binary'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp persistent-event-log options" _ocp_persistent_event_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(get-idle-wakeup-time)
-					_nvme_opt_vals "--sel -s" "0 1 2 3" \
-					               "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _ocp_get_idle_wakeup_time
-					_ocp_get_idle_wakeup_time=(
-						--sel=':[0-3]: current/default/saved/supported/'
-						-s':alias for --sel'
-						--namespace-id=':Byte[04-07]: NSID Valid/Invalid/Inactive'
-						-n':alias for --namespace-id'
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-u':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme ocp get-idle-wakeup-time options" _ocp_get_idle_wakeup_time
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(sed)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'discover:Discover SED Opal Locking Features'
-					'1:Discover SED Opal Locking Features'
-					'initialize:Initialize a SED Opal Device for locking'
-					'revert:Revert a SED Opal Device from locking'
-					'lock:Lock a SED Opal Device'
-					'unlock:Unlock a SED Opal Device'
-					'password:Change the SED Opal Device password'
-				)
-				_describe -t commands "nvme sed commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(discover|1)
-					local _sed_discover
-					_sed_discover=(
-						--verbose':Print extended discovery information'
-						-V':alias for --verbose'
-						--udev':Print locking information in form suitable for udev rules'
-						-u':alias for --udev'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme sed discover options" _sed_discover
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(initialize)
-					local _sed_initialize
-					_sed_initialize=(
-						--read-only':Set locking range to read-only'
-						-r':alias for --read-only'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme sed initialize options" _sed_initialize
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(revert)
-					local _sed_revert
-					_sed_revert=(
-						--destructive':destructive revert'
-						-e':alias for --destructive'
-						--psid':PSID revert'
-						-p':alias for --psid'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme sed revert options" _sed_revert
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(lock)
-					local _sed_lock
-					_sed_lock=(
-						--read-only':Set locking range to read-only'
-						-r':alias for --read-only'
-						--ask-key':prompt for SED authentication key'
-						-k':alias for --ask-key'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme sed lock options" _sed_lock
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(unlock)
-					local _sed_unlock
-					_sed_unlock=(
-						--read-only':Set locking range to read-only'
-						-r':alias for --read-only'
-						--ask-key':prompt for SED authentication key'
-						-k':alias for --ask-key'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme sed unlock options" _sed_unlock
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(password)
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
-		(solidigm)
-			if (( CURRENT == 2 )); then
-				local -a _sub
-				_sub=(
-					'id-ctrl:Send NVMe Identify Controller'
-					'smart-log-add:Retrieve Solidigm SMART Log'
-					'vs-smart-add-log:Get SMART / health extended log (redirects to ocp plug-in)'
-					'vs-internal-log:Retrieve Debug log binaries'
-					'garbage-collect-log:Retrieve Garbage Collection Log'
-					'market-log:Retrieve Market Log'
-					'latency-tracking-log:Enable/Retrieve Latency tracking Log'
-					'parse-telemetry-log:Parse Telemetry Log binary'
-					'clear-pcie-correctable-errors:Clear PCIe Correctable Error Counters (redirects to ocp plug-in)'
-					'clear-fw-activate-history:Clear firmware update history log (redirects to ocp plug-in)'
-					'vs-fw-activate-history:Get firmware activation history log (redirects to ocp plug-in)'
-					'log-page-directory:Retrieve log page directory'
-					'temp-stats:Retrieve Temperature Statistics log'
-					'vs-drive-info:Retrieve drive information'
-					'cloud-SSDplugin-version:Prints plug-in OCP version'
-					'workload-tracker:Real Time capture Workload Tracker samples'
-				)
-				_describe -t commands "nvme solidigm commands" _sub
-				return
-			fi
-
-			case ${words[2]} in
-				(id-ctrl)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_id_ctrl
-					_solidigm_id_ctrl=(
-						--vendor-specific':dump binary vendor field'
-						-V':alias for --vendor-specific'
-						--raw-binary':show identify in binary format'
-						-b':alias for --raw-binary'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm id-ctrl options" _solidigm_id_ctrl
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(smart-log-add)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_smart_log_add
-					_solidigm_smart_log_add=(
-						--namespace-id=':(optional) desired namespace'
-						-n':alias for --namespace-id'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm smart-log-add options" _solidigm_smart_log_add
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(vs-smart-add-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_vs_smart_add_log
-					_solidigm_vs_smart_add_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm vs-smart-add-log options" _solidigm_vs_smart_add_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(vs-internal-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--dir-name -d" && return
-					local _solidigm_vs_internal_log
-					_solidigm_vs_internal_log=(
-						--type=':Log type; Defaults to ALL.'
-						-t':alias for --type'
-						--dir-name=':Output directory; defaults to current working directory.'
-						-d':alias for --dir-name'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm vs-internal-log options" _solidigm_vs_internal_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(garbage-collect-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_garbage_collect_log
-					_solidigm_garbage_collect_log=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm garbage-collect-log options" _solidigm_garbage_collect_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(market-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_market_log
-					_solidigm_market_log=(
-						--raw-binary':dump output in binary format'
-						-b':alias for --raw-binary'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm market-log options" _solidigm_market_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(latency-tracking-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_latency_tracking_log
-					_solidigm_latency_tracking_log=(
-						--enable':Enable Latency Tracking'
-						-e':alias for --enable'
-						--disable':Disable Latency Tracking'
-						-d':alias for --disable'
-						--read':Get read statistics'
-						-r':alias for --read'
-						--write':Get write statistics'
-						-w':alias for --write'
-						--type=':Log type to get'
-						-t':alias for --type'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm latency-tracking-log options" _solidigm_latency_tracking_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(parse-telemetry-log)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					_nvme_opt_files "--config-file -j" \
-					                "--source-file -s" && return
-					local _solidigm_parse_telemetry_log
-					_solidigm_parse_telemetry_log=(
-						--host-generate=':Controls when to generate new host initiated report. Default value '\''1'\'' generates new host initiated report, value '\''0'\'' causes retrieval of existing log.'
-						-g':alias for --host-generate'
-						--controller-init':Gather report generated by the controller.'
-						-c':alias for --controller-init'
-						--data-area=':Pick which telemetry data area to report. Default is 3 to fetch areas 1-3. Valid options are 1, 2, 3, 4.'
-						-d':alias for --data-area'
-						--config-file=':JSON configuration file'
-						-j':alias for --config-file'
-						--source-file=':binary file containing log dump'
-						-s':alias for --source-file'
-						--jq-filter=':JSON config entry name containing jq filter'
-						-q':alias for --jq-filter'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm parse-telemetry-log options" _solidigm_parse_telemetry_log
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(clear-pcie-correctable-errors)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_clear_pcie_correctable_errors
-					_solidigm_clear_pcie_correctable_errors=(
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm clear-pcie-correctable-errors options" _solidigm_clear_pcie_correctable_errors
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(clear-fw-activate-history)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_clear_fw_activate_history
-					_solidigm_clear_fw_activate_history=(
-						--no-uuid':Skip UUID index search (UUID index not required for OCP 1.0)'
-						-n':alias for --no-uuid'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm clear-fw-activate-history options" _solidigm_clear_fw_activate_history
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(vs-fw-activate-history)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_vs_fw_activate_history
-					_solidigm_vs_fw_activate_history=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm vs-fw-activate-history options" _solidigm_vs_fw_activate_history
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(log-page-directory)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_log_page_directory
-					_solidigm_log_page_directory=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm log-page-directory options" _solidigm_log_page_directory
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(temp-stats)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_temp_stats
-					_solidigm_temp_stats=(
-						--raw-binary':dump output in binary format'
-						-b':alias for --raw-binary'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm temp-stats options" _solidigm_temp_stats
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(vs-drive-info)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_vs_drive_info
-					_solidigm_vs_drive_info=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm vs-drive-info options" _solidigm_vs_drive_info
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(cloud-SSDplugin-version)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_cloud_SSDplugin_version
-					_solidigm_cloud_SSDplugin_version=(
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm cloud-SSDplugin-version options" _solidigm_cloud_SSDplugin_version
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(workload-tracker)
-					_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-					               "--output-format-version" "1 2" && return
-					local _solidigm_workload_tracker
-					_solidigm_workload_tracker=(
-						--uuid-index=':specify uuid index'
-						-U':alias for --uuid-index'
-						--enable':tracker enable'
-						-e':alias for --enable'
-						--disable':tracker disable'
-						-d':alias for --disable'
-						--sample-time=':Sample interval'
-						-s':alias for --sample-time'
-						--type=':Tracker type'
-						-t':alias for --type'
-						--run-time=':Limit runtime capture time in seconds'
-						-r':alias for --run-time'
-						--flush-freq=':Samples (1 to 126) to wait for extracting data. Default 100 samples'
-						-f':alias for --flush-freq'
-						--wall-clock':Logs current wall timestamp when entry was retrieved'
-						-w':alias for --wall-clock'
-						--trigger-field=':Field name to stop trigger on'
-						-T':alias for --trigger-field'
-						--trigger-threshold=':Field value to trigger stop sampling'
-						-V':alias for --trigger-threshold'
-						--trigger-on-delta':Trigger on delta to stop sampling'
-						-D':alias for --trigger-on-delta'
-						--trigger-on-latency':Use latency tracker to trigger stop sampling'
-						-L':alias for --trigger-on-latency'
-						--verbose':Increase output verbosity'
-						-v':alias for --verbose'
-						--quiet':suppress output messages, overwrites verbose mode'
-						--output-format=':Output format: normal|json|binary'
-						-o':alias for --output-format'
-						--timeout=':timeout value, in milliseconds'
-						--dry-run':show command instead of executing'
-						--no-retries':disable retry logic on errors'
-						--no-ioctl-probing':disable 64-bit IOCTL support probing'
-						--output-format-version=':output format version: 1|2'
-						--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-						--help':show help'
-						-h':alias for --help'
-					)
-					_arguments '*:: :->subcmds'
-					_nvme_describe "nvme solidigm workload-tracker options" _solidigm_workload_tracker
-					_nvme_has_device || compadd -- /dev/nvme*(N)
-					;;
-
-				(*)
-					_files
-					;;
-			esac
-			;;
-
 		(list)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
@@ -11391,6 +11416,162 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_nvme_describe "nvme list-subsys options" _list_subsys
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(show-topology)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _show_topology
+			_show_topology=(
+				--ranking=':Ranking order: namespace|ctrl|multipath'
+				-r':alias for --ranking'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|tabular'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme show-topology options" _show_topology
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(top)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _top
+			_top=(
+				--delay=':refresh interval in seconds'
+				-d':alias for --delay'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme top options" _top
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(reset)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _reset
+			_reset=(
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme reset options" _reset
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(subsystem-reset)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _subsystem_reset
+			_subsystem_reset=(
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme subsystem-reset options" _subsystem_reset
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(ns-rescan)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _ns_rescan
+			_ns_rescan=(
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme ns-rescan options" _ns_rescan
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(virt-mgmt)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _virt_mgmt
+			_virt_mgmt=(
+				--cntlid=':Controller Identifier(CNTLID)'
+				-c':alias for --cntlid'
+				--rt=':Resource Type(RT): [0,1] 0h: VQ Resources 1h: VI Resources'
+				-r':alias for --rt'
+				--act=':Action(ACT): [1,7,8,9] 1h: Primary Flexible 7h: Secondary Offline 8h: Secondary Assign 9h: Secondary Online'
+				-a':alias for --act'
+				--nr=':Number of Controller Resources(NR)'
+				-n':alias for --nr'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme virt-mgmt options" _virt_mgmt
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -12059,40 +12240,11 @@ _nvme () {
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(get-log)
-			_nvme_opt_vals "--log-id -i" "supported-log-pages error smart fw-slot changed-ns cmd-effects device-self-test telemetry-host telemetry-ctrl endurance-group predictable-lat-nvmset predictable-lat-agg ana persistent-event lba-status endurance-grp-evt media-unit-status supported-cap-config-list fid-supported-effects mi-cmd-supported-effects cmd-and-feat-lockdown boot-partition rotational-media-info dispersed-ns-participating-ns mgmt-addr-list phy-rx-eom reachability-groups reachability-associations changed-alloc-ns-list fdp-configs fdp-ruh-usage fdp-stats fdp-events discover host-discover ave-discover pull-model-ddc-req reservation sanitize zns-changed-zones" \
-			               "--output-format -o" "normal json binary tabular" \
+		(supported-log-pages)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			local _get_log
-			_get_log=(
-				--ish':Ignore Shutdown (for NVMe-MI command)'
-				-I':alias for --ish'
-				--namespace-id=':desired namespace'
-				-n':alias for --namespace-id'
-				--log-id=':identifier of log to retrieve'
-				-i':alias for --log-id'
-				--log-len=':how many bytes to retrieve'
-				-l':alias for --log-len'
-				--aen=':result of the aen, use to override log id'
-				-a':alias for --aen'
-				--lpo=':log page offset specifies the location within a log page from where to start returning data'
-				-L':alias for --lpo'
-				--lsp=':log specific field'
-				-s':alias for --lsp'
-				--lsi=':log specific identifier specifies an identifier that is required for a particular log page'
-				-S':alias for --lsi'
-				--rae':Retain an Asynchronous Event'
-				-r':alias for --rae'
-				--uuid-index=':UUID index'
-				-U':alias for --uuid-index'
-				--raw-binary':output in raw format'
-				-b':alias for --raw-binary'
-				--csi=':command set identifier'
-				-y':alias for --csi'
-				--ot':offset type'
-				-O':alias for --ot'
-				--xfer-len=':read chunk size (default 4k)'
-				-x':alias for --xfer-len'
+			local _supported_log_pages
+			_supported_log_pages=(
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -12108,7 +12260,7 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme get-log options" _get_log
+			_nvme_describe "nvme supported-log-pages options" _supported_log_pages
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -12578,80 +12730,6 @@ _nvme () {
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(get-feature)
-			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
-			               "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _get_feature
-			_get_feature=(
-				--feature-id=':feature identifier'
-				-f':alias for --feature-id'
-				--namespace-id=':identifier of desired namespace'
-				-n':alias for --namespace-id'
-				--sel=':[0-3]: current/default/saved/supported'
-				-s':alias for --sel'
-				--data-len=':buffer len (if) data is sent or received'
-				-l':alias for --data-len'
-				--raw-binary':show feature in binary format'
-				-b':alias for --raw-binary'
-				--cdw11=':feature specific dword 11'
-				-c':alias for --cdw11'
-				--uuid-index=':specify uuid index'
-				-U':alias for --uuid-index'
-				--changed':show feature changed'
-				-C':alias for --changed'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme get-feature options" _get_feature
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(device-self-test)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _device_self_test
-			_device_self_test=(
-				--ish':Ignore Shutdown (for NVMe-MI command)'
-				-I':alias for --ish'
-				--namespace-id=':Indicate the namespace in which the device self-test has to be carried out'
-				-n':alias for --namespace-id'
-				--self-test-code=':This field specifies the action taken by the device self-test command : 0h Show current state of device self-test operation 1h Start a short device self-test operation 2h Start a extended device self-test operation 3h Start a Host-Initiated Refresh operation eh Start a vendor specific device self-test operation fh Abort the device self-test operation'
-				-s':alias for --self-test-code'
-				--wait':Wait for the test to finish'
-				-w':alias for --wait'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme device-self-test options" _device_self_test
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
 		(self-test-log)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
@@ -12675,30 +12753,6 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_nvme_describe "nvme self-test-log options" _self_test_log
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(supported-log-pages)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _supported_log_pages
-			_supported_log_pages=(
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme supported-log-pages options" _supported_log_pages
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -13070,145 +13124,6 @@ _nvme () {
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(set-feature)
-			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--data -d" && return
-			local _set_feature
-			_set_feature=(
-				--namespace-id=':desired namespace'
-				-n':alias for --namespace-id'
-				--feature-id=':feature identifier (required)'
-				-f':alias for --feature-id'
-				--value=':new value of feature (required)'
-				-V':alias for --value'
-				--cdw12=':feature cdw12, if used'
-				-c':alias for --cdw12'
-				--uuid-index=':specify uuid index'
-				-U':alias for --uuid-index'
-				--data-len=':buffer len (if) data is sent or received'
-				-l':alias for --data-len'
-				--data=':optional file for feature data (default stdin)'
-				-d':alias for --data'
-				--save':specifies that the controller shall save the attribute'
-				-s':alias for --save'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme set-feature options" _set_feature
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(set-property)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _set_property
-			_set_property=(
-				--offset=':the offset of the property'
-				-O':alias for --offset'
-				--value=':the value of the property to be set'
-				-V':alias for --value'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme set-property options" _set_property
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(get-property)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _get_property
-			_get_property=(
-				--offset=':offset of the requested property'
-				-O':alias for --offset'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme get-property options" _get_property
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(format)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _format
-			_format=(
-				--ish':Ignore Shutdown (for NVMe-MI command)'
-				-I':alias for --ish'
-				--namespace-id=':identifier of desired namespace'
-				-n':alias for --namespace-id'
-				--lbaf=':LBA format to apply (required)'
-				-l':alias for --lbaf'
-				--ses=':[0-2]: secure erase'
-				-s':alias for --ses'
-				--pi=':[0-3]: protection info off/Type 1/Type 2/Type 3'
-				-i':alias for --pi'
-				--pil=':[0-1]: protection info location last/first bytes of metadata'
-				-p':alias for --pil'
-				--ms=':[0-1]: extended format off/on'
-				-m':alias for --ms'
-				--reset':Automatically reset the controller after successful format'
-				-r':alias for --reset'
-				--force':The "I know what I'\''m doing" flag, skip confirmation before sending command'
-				--block-size=':target block size'
-				-b':alias for --block-size'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme format options" _format
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
 		(fw-commit|fw-activate)
 			_nvme_opt_vals "--action -a" "replace replace-and-activate set-active replace-and-activate-immediate replace-boot-partition activate-boot-partition" \
 			               "--output-format -o" "normal json binary tabular" \
@@ -13277,146 +13192,6 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_nvme_describe "nvme fw-download options" _fw_download
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(admin-passthru)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--input-file -i" \
-			                "--metadata -M" && return
-			local _admin_passthru
-			_admin_passthru=(
-				--opcode=':opcode (required)'
-				-O':alias for --opcode'
-				--flags=':command flags'
-				-f':alias for --flags'
-				--prefill=':prefill buffers with known byte-value, default 0'
-				-p':alias for --prefill'
-				--rsvd=':value for reserved field'
-				-R':alias for --rsvd'
-				--namespace-id=':desired namespace'
-				-n':alias for --namespace-id'
-				--data-len=':data I/O length (bytes)'
-				-l':alias for --data-len'
-				--metadata-len=':metadata seg. length (bytes)'
-				-m':alias for --metadata-len'
-				--cdw2=':command dword 2 value'
-				-2':alias for --cdw2'
-				--cdw3=':command dword 3 value'
-				-3':alias for --cdw3'
-				--cdw10=':command dword 10 value'
-				-4':alias for --cdw10'
-				--cdw11=':command dword 11 value'
-				-5':alias for --cdw11'
-				--cdw12=':command dword 12 value'
-				-6':alias for --cdw12'
-				--cdw13=':command dword 13 value'
-				-7':alias for --cdw13'
-				--cdw14=':command dword 14 value'
-				-8':alias for --cdw14'
-				--cdw15=':command dword 15 value'
-				-9':alias for --cdw15'
-				--input-file=':data input or output file'
-				-i':alias for --input-file'
-				--metadata=':metadata input or output file'
-				-M':alias for --metadata'
-				--raw-binary':dump output in binary format'
-				-b':alias for --raw-binary'
-				--show-command':print command before sending'
-				-s':alias for --show-command'
-				--read':set dataflow direction to receive'
-				-r':alias for --read'
-				--write':set dataflow direction to send'
-				-w':alias for --write'
-				--latency':output latency statistics'
-				-T':alias for --latency'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme admin-passthru options" _admin_passthru
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(io-passthru)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--input-file -i" \
-			                "--metadata -M" && return
-			local _io_passthru
-			_io_passthru=(
-				--opcode=':opcode (required)'
-				-O':alias for --opcode'
-				--flags=':command flags'
-				-f':alias for --flags'
-				--prefill=':prefill buffers with known byte-value, default 0'
-				-p':alias for --prefill'
-				--rsvd=':value for reserved field'
-				-R':alias for --rsvd'
-				--namespace-id=':desired namespace'
-				-n':alias for --namespace-id'
-				--data-len=':data I/O length (bytes)'
-				-l':alias for --data-len'
-				--metadata-len=':metadata seg. length (bytes)'
-				-m':alias for --metadata-len'
-				--cdw2=':command dword 2 value'
-				-2':alias for --cdw2'
-				--cdw3=':command dword 3 value'
-				-3':alias for --cdw3'
-				--cdw10=':command dword 10 value'
-				-4':alias for --cdw10'
-				--cdw11=':command dword 11 value'
-				-5':alias for --cdw11'
-				--cdw12=':command dword 12 value'
-				-6':alias for --cdw12'
-				--cdw13=':command dword 13 value'
-				-7':alias for --cdw13'
-				--cdw14=':command dword 14 value'
-				-8':alias for --cdw14'
-				--cdw15=':command dword 15 value'
-				-9':alias for --cdw15'
-				--input-file=':data input or output file'
-				-i':alias for --input-file'
-				--metadata=':metadata input or output file'
-				-M':alias for --metadata'
-				--raw-binary':dump output in binary format'
-				-b':alias for --raw-binary'
-				--show-command':print command before sending'
-				-s':alias for --show-command'
-				--read':set dataflow direction to receive'
-				-r':alias for --read'
-				--write':set dataflow direction to send'
-				-w':alias for --write'
-				--latency':output latency statistics'
-				-T':alias for --latency'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme io-passthru options" _io_passthru
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -13496,76 +13271,6 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_nvme_describe "nvme security-recv options" _security_recv
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(get-lba-status)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _get_lba_status
-			_get_lba_status=(
-				--ish':Ignore Shutdown (for NVMe-MI command)'
-				-I':alias for --ish'
-				--namespace-id=':desired namespace'
-				-n':alias for --namespace-id'
-				--start-lba=':Starting LBA(SLBA) in 64-bit address of the first logical block addressed by this command'
-				-s':alias for --start-lba'
-				--max-dw=':Maximum Number of Dwords(MNDW) specifies maximum number of dwords to return'
-				-m':alias for --max-dw'
-				--action=':Action Type(ATYPE) specifies the mechanism the controller uses in determining the LBA Status Descriptors to return.'
-				-a':alias for --action'
-				--range-len=':Range Length(RL) specifies the length of the range of contiguous LBAs beginning at SLBA'
-				-l':alias for --range-len'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme get-lba-status options" _get_lba_status
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(capacity-mgmt)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _capacity_mgmt
-			_capacity_mgmt=(
-				--ish':Ignore Shutdown (for NVMe-MI command)'
-				-I':alias for --ish'
-				--operation=':Operation to be performed by the controller'
-				-O':alias for --operation'
-				--element-id=':Value specific to the value of the Operation field.'
-				-i':alias for --element-id'
-				--cap-lower=':Least significant 32 bits of the capacity in bytes of the Endurance Group or NVM Set to be created'
-				-l':alias for --cap-lower'
-				--cap-upper=':Most significant 32 bits of the capacity in bytes of the Endurance Group or NVM Set to be created'
-				-u':alias for --cap-upper'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme capacity-mgmt options" _capacity_mgmt
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -13704,6 +13409,993 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_nvme_describe "nvme resv-report options" _resv_report
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(sanitize-log)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _sanitize_log
+			_sanitize_log=(
+				--rae':Retain an Asynchronous Event'
+				-r':alias for --rae'
+				--raw-binary':show log in binary format'
+				-b':alias for --raw-binary'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme sanitize-log options" _sanitize_log
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(gen-dhchap-key)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _gen_dhchap_key
+			_gen_dhchap_key=(
+				--secret=':Optional secret (in hexadecimal characters) to be placed in the representation.'
+				-s':alias for --secret'
+				--key-length=':Length of the secret (32, 48, or 64 bytes).'
+				-l':alias for --key-length'
+				--nqn=':Accepted and ignored; nvme-cli 2.x keyed the transform with it.'
+				-n':alias for --nqn'
+				--hmac=':Hash function the consumer is to apply to the secret (0 = none, 1 = SHA-256, 2 = SHA-384, 3 = SHA-512).'
+				-m':alias for --hmac'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme gen-dhchap-key options" _gen_dhchap_key
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(check-dhchap-key)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _check_dhchap_key
+			_check_dhchap_key=(
+				--key=':KX-HMAC-CHAP secret (in DHHC-1 interchange format) to be validated. Reads from stdin if not given.'
+				-k':alias for --key'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme check-dhchap-key options" _check_dhchap_key
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(gen-tls-key)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _gen_tls_key
+			_gen_tls_key=(
+				--keyring=':Keyring for the retained key.'
+				-k':alias for --keyring'
+				--keytype=':Key type of the retained key.'
+				-t':alias for --keytype'
+				--hostnqn=':Host NQN for the retained key.'
+				-n':alias for --hostnqn'
+				--subsysnqn=':Subsystem NQN for the retained key.'
+				-c':alias for --subsysnqn'
+				--secret=':Optional secret (in hexadecimal characters) to be used for the TLS key.'
+				-s':alias for --secret'
+				--keyfile=':Update key file with the derived TLS PSK.'
+				-f':alias for --keyfile'
+				--hmac=':HMAC function to use for the retained key (1 = SHA-256, 2 = SHA-384).'
+				-m':alias for --hmac'
+				--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
+				-I':alias for --identity'
+				--insert':Insert retained key into the keyring.'
+				-i':alias for --insert'
+				--compat':Use non-RFC 8446 compliant algorithm for deriving TLS PSK for older implementations.'
+				-C':alias for --compat'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme gen-tls-key options" _gen_tls_key
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(check-tls-key)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _check_tls_key
+			_check_tls_key=(
+				--keyring=':Keyring to check for an already loaded key.'
+				-k':alias for --keyring'
+				--keytype=':Key type of the key to look up.'
+				-t':alias for --keytype'
+				--hostnqn=':Host NQN to use when checking whether the key is already loaded.'
+				-n':alias for --hostnqn'
+				--subsysnqn=':Subsystem NQN to use when checking whether the key is already loaded.'
+				-c':alias for --subsysnqn'
+				--keydata=':TLS key (in PSK Interchange format) to be validated. Reads from stdin if not given.'
+				-d':alias for --keydata'
+				--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
+				-I':alias for --identity'
+				--compat':Use non-RFC 8446 compliant algorithm for checking TLS PSK for older implementations.'
+				-C':alias for --compat'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme check-tls-key options" _check_tls_key
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(tls-key)
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(dir-receive)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _dir_receive
+			_dir_receive=(
+				--namespace-id=':identifier of desired namespace'
+				-n':alias for --namespace-id'
+				--data-len=':buffer len (if) data is sent or received'
+				-l':alias for --data-len'
+				--raw-binary':show directive in binary format'
+				-b':alias for --raw-binary'
+				--dir-type=':directive type'
+				-D':alias for --dir-type'
+				--dir-spec=':directive specification associated with directive type'
+				-S':alias for --dir-spec'
+				--dir-oper=':directive operation'
+				-O':alias for --dir-oper'
+				--req-resource=':namespace stream requested'
+				-r':alias for --req-resource'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme dir-receive options" _dir_receive
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(dir-send)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--input-file -i" && return
+			local _dir_send
+			_dir_send=(
+				--namespace-id=':identifier of desired namespace'
+				-n':alias for --namespace-id'
+				--data-len=':buffer len (if) data is sent or received'
+				-l':alias for --data-len'
+				--dir-type=':directive type'
+				-D':alias for --dir-type'
+				--target-dir=':target directive type to be enabled/disabled'
+				-T':alias for --target-dir'
+				--dir-spec=':directive specification associated with directive type'
+				-S':alias for --dir-spec'
+				--dir-oper=':directive operation'
+				-O':alias for --dir-oper'
+				--endir=':directive enable'
+				-e':alias for --endir'
+				--raw-binary':show directive in binary format'
+				-b':alias for --raw-binary'
+				--input-file=':write/send file (default stdin)'
+				-i':alias for --input-file'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme dir-send options" _dir_send
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(io-mgmt-recv)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--data -d" && return
+			local _io_mgmt_recv
+			_io_mgmt_recv=(
+				--namespace-id=':identifier of desired namespace'
+				-n':alias for --namespace-id'
+				--mos=':management operation specific'
+				-s':alias for --mos'
+				--mo=':management operation'
+				-m':alias for --mo'
+				--data=':optional file for data (default stdout)'
+				-d':alias for --data'
+				--data-len=':buffer len (if) data is sent or received'
+				-l':alias for --data-len'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme io-mgmt-recv options" _io_mgmt_recv
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(io-mgmt-send)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--data -d" && return
+			local _io_mgmt_send
+			_io_mgmt_send=(
+				--namespace-id=':identifier of desired namespace'
+				-n':alias for --namespace-id'
+				--mos=':management operation specific'
+				-s':alias for --mos'
+				--mo=':management operation'
+				-m':alias for --mo'
+				--data=':optional file for data (default stdin)'
+				-d':alias for --data'
+				--data-len=':buffer len (if) data is sent or received'
+				-l':alias for --data-len'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme io-mgmt-send options" _io_mgmt_send
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(nvme-mi-recv)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--input-file -i" && return
+			local _nvme_mi_recv
+			_nvme_mi_recv=(
+				--opcode=':opcode (required)'
+				-O':alias for --opcode'
+				--namespace-id=':desired namespace'
+				-n':alias for --namespace-id'
+				--data-len=':data I/O length (bytes)'
+				-l':alias for --data-len'
+				--nmimt=':nvme-mi message type'
+				-m':alias for --nmimt'
+				--nmd0=':nvme management dword 0 value'
+				-0':alias for --nmd0'
+				--nmd1=':nvme management dword 1 value'
+				-1':alias for --nmd1'
+				--input-file=':data input or output file'
+				-i':alias for --input-file'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme nvme-mi-recv options" _nvme_mi_recv
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(nvme-mi-send)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--input-file -i" && return
+			local _nvme_mi_send
+			_nvme_mi_send=(
+				--opcode=':opcode (required)'
+				-O':alias for --opcode'
+				--namespace-id=':desired namespace'
+				-n':alias for --namespace-id'
+				--data-len=':data I/O length (bytes)'
+				-l':alias for --data-len'
+				--nmimt=':nvme-mi message type'
+				-m':alias for --nmimt'
+				--nmd0=':nvme management dword 0 value'
+				-0':alias for --nmd0'
+				--nmd1=':nvme management dword 1 value'
+				-1':alias for --nmd1'
+				--input-file=':data input or output file'
+				-i':alias for --input-file'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme nvme-mi-send options" _nvme_mi_send
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(get-log)
+			_nvme_opt_vals "--log-id -i" "supported-log-pages error smart fw-slot changed-attached-ns changed-ns cmd-effects device-self-test telemetry-host telemetry-ctrl endurance-group predictable-lat-nvmset predictable-lat-agg ana persistent-event lba-status endurance-grp-evt media-unit-status supported-cap-config-list fid-supported-effects mi-cmd-supported-effects cmd-and-feat-lockdown boot-partition rotational-media-info dispersed-ns-participating-ns mgmt-addr-list phy-rx-eom reachability-groups reachability-associations changed-alloc-ns-list fdp-configs fdp-ruh-usage fdp-stats fdp-events discover host-discover ave-discover pull-model-ddc-req reservation sanitize zns-changed-zones" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _get_log
+			_get_log=(
+				--ish':Ignore Shutdown (for NVMe-MI command)'
+				-I':alias for --ish'
+				--namespace-id=':desired namespace'
+				-n':alias for --namespace-id'
+				--log-id=':identifier of log to retrieve'
+				-i':alias for --log-id'
+				--log-len=':how many bytes to retrieve'
+				-l':alias for --log-len'
+				--aen=':result of the aen, use to override log id'
+				-a':alias for --aen'
+				--lpo=':log page offset specifies the location within a log page from where to start returning data'
+				-L':alias for --lpo'
+				--lsp=':log specific field'
+				-s':alias for --lsp'
+				--lsi=':log specific identifier specifies an identifier that is required for a particular log page'
+				-S':alias for --lsi'
+				--rae':Retain an Asynchronous Event'
+				-r':alias for --rae'
+				--uuid-index=':UUID index'
+				-U':alias for --uuid-index'
+				--raw-binary':output in raw format'
+				-b':alias for --raw-binary'
+				--csi=':command set identifier'
+				-y':alias for --csi'
+				--ot':offset type'
+				-O':alias for --ot'
+				--xfer-len=':read chunk size (default 4k)'
+				-x':alias for --xfer-len'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme get-log options" _get_log
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(discover)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--raw -r" \
+			                "--config -J" && return
+			local _discover
+			_discover=(
+				--transport=':transport type'
+				-t':alias for --transport'
+				--nqn=':subsystem nqn'
+				-n':alias for --nqn'
+				--traddr=':transport address'
+				-a':alias for --traddr'
+				--trsvcid=':transport service id (e.g. IP port)'
+				-s':alias for --trsvcid'
+				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
+				-w':alias for --host-traddr'
+				--host-iface=':host interface (for tcp transport)'
+				-f':alias for --host-iface'
+				--hostnqn=':user-defined hostnqn'
+				-q':alias for --hostnqn'
+				--hostid=':user-defined hostid (if default not used)'
+				-I':alias for --hostid'
+				--kxchap-secret=':user-defined kxchap secret (if default not used)'
+				-S':alias for --kxchap-secret'
+				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
+				-C':alias for --kxchap-ctrl-secret'
+				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
+				--tls-key=':TLS key to use (key id or key in interchange format)'
+				--tls-key-identity=':TLS key identity'
+				--nr-io-queues=':number of io queues to use (default is core count)'
+				-i':alias for --nr-io-queues'
+				--nr-write-queues=':number of write queues to use (default 0)'
+				-W':alias for --nr-write-queues'
+				--nr-poll-queues=':number of poll queues to use (default 0)'
+				-P':alias for --nr-poll-queues'
+				--queue-size=':number of io queue elements to use (default 128)'
+				-Q':alias for --queue-size'
+				--keep-alive-tmo=':keep alive timeout period in seconds'
+				-k':alias for --keep-alive-tmo'
+				--reconnect-delay=':reconnect timeout period in seconds'
+				-c':alias for --reconnect-delay'
+				--ctrl-loss-tmo=':controller loss timeout period in seconds'
+				-l':alias for --ctrl-loss-tmo'
+				--fast-io-fail-tmo=':fast I/O fail timeout (default off)'
+				-F':alias for --fast-io-fail-tmo'
+				--tos=':type of service'
+				-T':alias for --tos'
+				--tls_key=':TLS key to use (key id)'
+				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
+				-D':alias for --duplicate-connect'
+				--disable-sqflow':disable controller sq flow control (default false)'
+				--hdr-digest':enable transport protocol header digest (TCP transport)'
+				-g':alias for --hdr-digest'
+				--data-digest':enable transport protocol data digest (TCP transport)'
+				-G':alias for --data-digest'
+				--tls':enable TLS'
+				--concat':enable secure concatenation'
+				--device=':use existing discovery controller device'
+				-d':alias for --device'
+				--raw=':save raw output to file'
+				-r':alias for --raw'
+				--persistent=':persistent discovery connection mode (default: no; auto if given bare)'
+				-p':alias for --persistent'
+				--config=':Use specified INI configuration file (auto-converts a legacy .json) or '\''none'\'' to disable'
+				-J':alias for --config'
+				--no-reuse':always create a new connection, never reuse an existing one'
+				--force':deprecated, see --no-reuse'
+				--nbft':Only look at NBFT tables'
+				--no-nbft':Do not look at NBFT tables'
+				--owner=':record this owner in the registry'
+				--nbft-path=':user-defined path for NBFT tables'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme discover options" _discover
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(connect-all)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--raw -r" \
+			                "--config -J" && return
+			local _connect_all
+			_connect_all=(
+				--transport=':transport type'
+				-t':alias for --transport'
+				--nqn=':subsystem nqn'
+				-n':alias for --nqn'
+				--traddr=':transport address'
+				-a':alias for --traddr'
+				--trsvcid=':transport service id (e.g. IP port)'
+				-s':alias for --trsvcid'
+				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
+				-w':alias for --host-traddr'
+				--host-iface=':host interface (for tcp transport)'
+				-f':alias for --host-iface'
+				--hostnqn=':user-defined hostnqn'
+				-q':alias for --hostnqn'
+				--hostid=':user-defined hostid (if default not used)'
+				-I':alias for --hostid'
+				--kxchap-secret=':user-defined kxchap secret (if default not used)'
+				-S':alias for --kxchap-secret'
+				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
+				-C':alias for --kxchap-ctrl-secret'
+				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
+				--tls-key=':TLS key to use (key id or key in interchange format)'
+				--tls-key-identity=':TLS key identity'
+				--nr-io-queues=':number of io queues to use (default is core count)'
+				-i':alias for --nr-io-queues'
+				--nr-write-queues=':number of write queues to use (default 0)'
+				-W':alias for --nr-write-queues'
+				--nr-poll-queues=':number of poll queues to use (default 0)'
+				-P':alias for --nr-poll-queues'
+				--queue-size=':number of io queue elements to use (default 128)'
+				-Q':alias for --queue-size'
+				--keep-alive-tmo=':keep alive timeout period in seconds'
+				-k':alias for --keep-alive-tmo'
+				--reconnect-delay=':reconnect timeout period in seconds'
+				-c':alias for --reconnect-delay'
+				--ctrl-loss-tmo=':controller loss timeout period in seconds'
+				-l':alias for --ctrl-loss-tmo'
+				--fast-io-fail-tmo=':fast I/O fail timeout (default off)'
+				-F':alias for --fast-io-fail-tmo'
+				--tos=':type of service'
+				-T':alias for --tos'
+				--tls_key=':TLS key to use (key id)'
+				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
+				-D':alias for --duplicate-connect'
+				--disable-sqflow':disable controller sq flow control (default false)'
+				--hdr-digest':enable transport protocol header digest (TCP transport)'
+				-g':alias for --hdr-digest'
+				--data-digest':enable transport protocol data digest (TCP transport)'
+				-G':alias for --data-digest'
+				--tls':enable TLS'
+				--concat':enable secure concatenation'
+				--device=':use existing discovery controller device'
+				-d':alias for --device'
+				--raw=':save raw output to file'
+				-r':alias for --raw'
+				--persistent=':persistent discovery connection mode (default: no; auto if given bare)'
+				-p':alias for --persistent'
+				--config=':Use specified INI configuration file (auto-converts a legacy .json) or '\''none'\'' to disable'
+				-J':alias for --config'
+				--no-reuse':always create a new connection, never reuse an existing one'
+				--force':deprecated, see --no-reuse'
+				--nbft':Only look at NBFT tables'
+				--no-nbft':Do not look at NBFT tables'
+				--owner=':record this owner in the registry'
+				--nbft-path=':user-defined path for NBFT tables'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme connect-all options" _connect_all
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(connect)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--config -J" \
+			                "--devid-file" && return
+			local _connect
+			_connect=(
+				--transport=':transport type'
+				-t':alias for --transport'
+				--nqn=':subsystem nqn'
+				-n':alias for --nqn'
+				--traddr=':transport address'
+				-a':alias for --traddr'
+				--trsvcid=':transport service id (e.g. IP port)'
+				-s':alias for --trsvcid'
+				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
+				-w':alias for --host-traddr'
+				--host-iface=':host interface (for tcp transport)'
+				-f':alias for --host-iface'
+				--hostnqn=':user-defined hostnqn'
+				-q':alias for --hostnqn'
+				--hostid=':user-defined hostid (if default not used)'
+				-I':alias for --hostid'
+				--kxchap-secret=':user-defined kxchap secret (if default not used)'
+				-S':alias for --kxchap-secret'
+				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
+				-C':alias for --kxchap-ctrl-secret'
+				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
+				--tls-key=':TLS key to use (key id or key in interchange format)'
+				--tls-key-identity=':TLS key identity'
+				--nr-io-queues=':number of io queues to use (default is core count)'
+				-i':alias for --nr-io-queues'
+				--nr-write-queues=':number of write queues to use (default 0)'
+				-W':alias for --nr-write-queues'
+				--nr-poll-queues=':number of poll queues to use (default 0)'
+				-P':alias for --nr-poll-queues'
+				--queue-size=':number of io queue elements to use (default 128)'
+				-Q':alias for --queue-size'
+				--keep-alive-tmo=':keep alive timeout period in seconds'
+				-k':alias for --keep-alive-tmo'
+				--reconnect-delay=':reconnect timeout period in seconds'
+				-c':alias for --reconnect-delay'
+				--ctrl-loss-tmo=':controller loss timeout period in seconds'
+				-l':alias for --ctrl-loss-tmo'
+				--fast-io-fail-tmo=':fast I/O fail timeout (default off)'
+				-F':alias for --fast-io-fail-tmo'
+				--tos=':type of service'
+				-T':alias for --tos'
+				--tls_key=':TLS key to use (key id)'
+				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
+				-D':alias for --duplicate-connect'
+				--disable-sqflow':disable controller sq flow control (default false)'
+				--hdr-digest':enable transport protocol header digest (TCP transport)'
+				-g':alias for --hdr-digest'
+				--data-digest':enable transport protocol data digest (TCP transport)'
+				-G':alias for --data-digest'
+				--tls':enable TLS'
+				--concat':enable secure concatenation'
+				--config=':Use specified INI configuration file (auto-converts a legacy .json) or '\''none'\'' to disable'
+				-J':alias for --config'
+				--owner=':record this owner in the registry'
+				--devid-file=':write connected device name to FILE'
+				--idempotent':exit 0 if already connected'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme connect options" _connect
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(disconnect)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _disconnect
+			_disconnect=(
+				--transport=':transport type'
+				-t':alias for --transport'
+				--nqn=':subsystem nqn'
+				-n':alias for --nqn'
+				--traddr=':transport address'
+				-a':alias for --traddr'
+				--trsvcid=':transport service id (e.g. IP port)'
+				-s':alias for --trsvcid'
+				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
+				-w':alias for --host-traddr'
+				--host-iface=':host interface (for tcp transport)'
+				-f':alias for --host-iface'
+				--hostnqn=':user-defined hostnqn'
+				-q':alias for --hostnqn'
+				--hostid=':user-defined hostid (if default not used)'
+				-I':alias for --hostid'
+				--kxchap-secret=':user-defined kxchap secret (if default not used)'
+				-S':alias for --kxchap-secret'
+				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
+				-C':alias for --kxchap-ctrl-secret'
+				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
+				--tls-key=':TLS key to use (key id or key in interchange format)'
+				--tls-key-identity=':TLS key identity'
+				--nr-io-queues=':number of io queues to use (default is core count)'
+				-i':alias for --nr-io-queues'
+				--nr-write-queues=':number of write queues to use (default 0)'
+				-W':alias for --nr-write-queues'
+				--nr-poll-queues=':number of poll queues to use (default 0)'
+				-P':alias for --nr-poll-queues'
+				--queue-size=':number of io queue elements to use (default 128)'
+				-Q':alias for --queue-size'
+				--keep-alive-tmo=':keep alive timeout period in seconds'
+				-k':alias for --keep-alive-tmo'
+				--reconnect-delay=':reconnect timeout period in seconds'
+				-c':alias for --reconnect-delay'
+				--ctrl-loss-tmo=':controller loss timeout period in seconds'
+				-l':alias for --ctrl-loss-tmo'
+				--fast-io-fail-tmo=':fast I/O fail timeout (default off)'
+				-F':alias for --fast-io-fail-tmo'
+				--tos=':type of service'
+				-T':alias for --tos'
+				--tls_key=':TLS key to use (key id)'
+				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
+				-D':alias for --duplicate-connect'
+				--disable-sqflow':disable controller sq flow control (default false)'
+				--hdr-digest':enable transport protocol header digest (TCP transport)'
+				-g':alias for --hdr-digest'
+				--data-digest':enable transport protocol data digest (TCP transport)'
+				-G':alias for --data-digest'
+				--tls':enable TLS'
+				--concat':enable secure concatenation'
+				--device=':nvme device handle'
+				-d':alias for --device'
+				--exclude':write exclusion entry before disconnecting'
+				-x':alias for --exclude'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme disconnect options" _disconnect
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(disconnect-all)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _disconnect_all
+			_disconnect_all=(
+				--transport=':transport type'
+				-t':alias for --transport'
+				--owner=':disconnect only controllers owned by NAME'
+				--force':disconnect all controllers regardless of ownership'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme disconnect-all options" _disconnect_all
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(dim)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _dim
+			_dim=(
+				--nqn=':Comma-separated list of DC nqn'
+				-n':alias for --nqn'
+				--device=':Comma-separated list of DC nvme device handle.'
+				-d':alias for --device'
+				--task=':[register|deregister]'
+				-t':alias for --task'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme dim options" _dim
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(gen-hostnqn)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _gen_hostnqn
+			_gen_hostnqn=(
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme gen-hostnqn options" _gen_hostnqn
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(show-hostnqn)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _show_hostnqn
+			_show_hostnqn=(
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme show-hostnqn options" _show_hostnqn
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(get-feature)
+			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
+			               "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			local _get_feature
+			_get_feature=(
+				--feature-id=':feature identifier'
+				-f':alias for --feature-id'
+				--namespace-id=':identifier of desired namespace'
+				-n':alias for --namespace-id'
+				--sel=':[0-3]: current/default/saved/supported'
+				-s':alias for --sel'
+				--data-len=':buffer len (if) data is sent or received'
+				-l':alias for --data-len'
+				--raw-binary':show feature in binary format'
+				-b':alias for --raw-binary'
+				--cdw11=':feature specific dword 11'
+				-c':alias for --cdw11'
+				--uuid-index=':specify uuid index'
+				-U':alias for --uuid-index'
+				--changed':show feature changed'
+				-C':alias for --changed'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme get-feature options" _get_feature
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(set-feature)
+			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--data -d" && return
+			local _set_feature
+			_set_feature=(
+				--namespace-id=':desired namespace'
+				-n':alias for --namespace-id'
+				--feature-id=':feature identifier (required)'
+				-f':alias for --feature-id'
+				--value=':new value of feature (required)'
+				-V':alias for --value'
+				--cdw12=':feature cdw12, if used'
+				-c':alias for --cdw12'
+				--uuid-index=':specify uuid index'
+				-U':alias for --uuid-index'
+				--data-len=':buffer len (if) data is sent or received'
+				-l':alias for --data-len'
+				--data=':optional file for feature data (default stdin)'
+				-d':alias for --data'
+				--save':specifies that the controller shall save the attribute'
+				-s':alias for --save'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme set-feature options" _set_feature
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -14180,32 +14872,23 @@ _nvme () {
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(sanitize)
-			_nvme_opt_vals "--sanact -a" "exit-failure start-block-erase start-overwrite start-crypto-erase exit-media-verification" \
-			               "--output-format -o" "normal json binary tabular" \
+		(get-lba-status)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			local _sanitize
-			_sanitize=(
+			local _get_lba_status
+			_get_lba_status=(
 				--ish':Ignore Shutdown (for NVMe-MI command)'
 				-I':alias for --ish'
-				--no-dealloc':No deallocate after sanitize.'
-				-d':alias for --no-dealloc'
-				--oipbp':Overwrite invert pattern between passes.'
-				-i':alias for --oipbp'
-				--owpass=':Overwrite pass count.'
-				-n':alias for --owpass'
-				--ause':Allow unrestricted sanitize exit.'
-				-u':alias for --ause'
-				--sanact=':Sanitize action: 1 = Exit failure mode, 2 = Start block erase,3 = Start overwrite, 4 = Start crypto erase, 5 = Exit media verification'
-				-a':alias for --sanact'
-				--ovrpat=':Overwrite pattern.'
-				-p':alias for --ovrpat'
-				--emvs':Enter media verification state.'
-				-e':alias for --emvs'
-				--wait':Wait for the sanitize to finish'
-				-w':alias for --wait'
-				--repeat=':Repeat for the multi cycle sanitization'
-				-r':alias for --repeat'
+				--namespace-id=':desired namespace'
+				-n':alias for --namespace-id'
+				--start-lba=':Starting LBA(SLBA) in 64-bit address of the first logical block addressed by this command'
+				-s':alias for --start-lba'
+				--max-dw=':Maximum Number of Dwords(MNDW) specifies maximum number of dwords to return'
+				-m':alias for --max-dw'
+				--action=':Action Type(ATYPE) specifies the mechanism the controller uses in determining the LBA Status Descriptors to return.'
+				-a':alias for --action'
+				--range-len=':Range Length(RL) specifies the length of the range of contiguous LBAs beginning at SLBA'
+				-l':alias for --range-len'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14221,19 +14904,95 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme sanitize options" _sanitize
+			_nvme_describe "nvme get-lba-status options" _get_lba_status
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(sanitize-log)
+		(capacity-mgmt)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			local _sanitize_log
-			_sanitize_log=(
-				--rae':Retain an Asynchronous Event'
-				-r':alias for --rae'
-				--raw-binary':show log in binary format'
+			local _capacity_mgmt
+			_capacity_mgmt=(
+				--ish':Ignore Shutdown (for NVMe-MI command)'
+				-I':alias for --ish'
+				--operation=':Operation to be performed by the controller'
+				-O':alias for --operation'
+				--element-id=':Value specific to the value of the Operation field.'
+				-i':alias for --element-id'
+				--cap-lower=':Least significant 32 bits of the capacity in bytes of the Endurance Group or NVM Set to be created'
+				-l':alias for --cap-lower'
+				--cap-upper=':Most significant 32 bits of the capacity in bytes of the Endurance Group or NVM Set to be created'
+				-u':alias for --cap-upper'
+				--verbose':Increase output verbosity'
+				-v':alias for --verbose'
+				--quiet':suppress output messages, overwrites verbose mode'
+				--output-format=':Output format: normal|json|binary'
+				-o':alias for --output-format'
+				--timeout=':timeout value, in milliseconds'
+				--dry-run':show command instead of executing'
+				--no-retries':disable retry logic on errors'
+				--no-ioctl-probing':disable 64-bit IOCTL support probing'
+				--output-format-version=':output format version: 1|2'
+				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
+				--help':show help'
+				-h':alias for --help'
+			)
+			_arguments '*:: :->subcmds'
+			_nvme_describe "nvme capacity-mgmt options" _capacity_mgmt
+			_nvme_has_device || compadd -- /dev/nvme*(N)
+			;;
+
+		(admin-passthru)
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2" && return
+			_nvme_opt_files "--input-file -i" \
+			                "--metadata -M" && return
+			local _admin_passthru
+			_admin_passthru=(
+				--opcode=':opcode (required)'
+				-O':alias for --opcode'
+				--flags=':command flags'
+				-f':alias for --flags'
+				--prefill=':prefill buffers with known byte-value, default 0'
+				-p':alias for --prefill'
+				--rsvd=':value for reserved field'
+				-R':alias for --rsvd'
+				--namespace-id=':desired namespace'
+				-n':alias for --namespace-id'
+				--data-len=':data I/O length (bytes)'
+				-l':alias for --data-len'
+				--metadata-len=':metadata seg. length (bytes)'
+				-m':alias for --metadata-len'
+				--cdw2=':command dword 2 value'
+				-2':alias for --cdw2'
+				--cdw3=':command dword 3 value'
+				-3':alias for --cdw3'
+				--cdw10=':command dword 10 value'
+				-4':alias for --cdw10'
+				--cdw11=':command dword 11 value'
+				-5':alias for --cdw11'
+				--cdw12=':command dword 12 value'
+				-6':alias for --cdw12'
+				--cdw13=':command dword 13 value'
+				-7':alias for --cdw13'
+				--cdw14=':command dword 14 value'
+				-8':alias for --cdw14'
+				--cdw15=':command dword 15 value'
+				-9':alias for --cdw15'
+				--input-file=':data input or output file'
+				-i':alias for --input-file'
+				--metadata=':metadata input or output file'
+				-M':alias for --metadata'
+				--raw-binary':dump output in binary format'
 				-b':alias for --raw-binary'
+				--show-command':print command before sending'
+				-s':alias for --show-command'
+				--read':set dataflow direction to receive'
+				-r':alias for --read'
+				--write':set dataflow direction to send'
+				-w':alias for --write'
+				--latency':output latency statistics'
+				-T':alias for --latency'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14249,48 +15008,61 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme sanitize-log options" _sanitize_log
+			_nvme_describe "nvme admin-passthru options" _admin_passthru
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(sanitize-ns)
-			_nvme_opt_vals "--sanact -a" "exit-failure start-crypto-erase exit-media-verification" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _sanitize_ns
-			_sanitize_ns=(
-				--ish':Ignore Shutdown (for NVMe-MI command)'
-				-I':alias for --ish'
-				--ause':Allow unrestricted sanitize exit.'
-				-u':alias for --ause'
-				--sanact=':Sanitize action: 1 = Exit failure mode, 4 = Start a crypto erase namespace sanitize operation, 5 = Exit media verification state'
-				-a':alias for --sanact'
-				--emvs':Enter media verification state.'
-				-e':alias for --emvs'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme sanitize-ns options" _sanitize_ns
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(reset)
+		(io-passthru)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			local _reset
-			_reset=(
+			_nvme_opt_files "--input-file -i" \
+			                "--metadata -M" && return
+			local _io_passthru
+			_io_passthru=(
+				--opcode=':opcode (required)'
+				-O':alias for --opcode'
+				--flags=':command flags'
+				-f':alias for --flags'
+				--prefill=':prefill buffers with known byte-value, default 0'
+				-p':alias for --prefill'
+				--rsvd=':value for reserved field'
+				-R':alias for --rsvd'
+				--namespace-id=':desired namespace'
+				-n':alias for --namespace-id'
+				--data-len=':data I/O length (bytes)'
+				-l':alias for --data-len'
+				--metadata-len=':metadata seg. length (bytes)'
+				-m':alias for --metadata-len'
+				--cdw2=':command dword 2 value'
+				-2':alias for --cdw2'
+				--cdw3=':command dword 3 value'
+				-3':alias for --cdw3'
+				--cdw10=':command dword 10 value'
+				-4':alias for --cdw10'
+				--cdw11=':command dword 11 value'
+				-5':alias for --cdw11'
+				--cdw12=':command dword 12 value'
+				-6':alias for --cdw12'
+				--cdw13=':command dword 13 value'
+				-7':alias for --cdw13'
+				--cdw14=':command dword 14 value'
+				-8':alias for --cdw14'
+				--cdw15=':command dword 15 value'
+				-9':alias for --cdw15'
+				--input-file=':data input or output file'
+				-i':alias for --input-file'
+				--metadata=':metadata input or output file'
+				-M':alias for --metadata'
+				--raw-binary':dump output in binary format'
+				-b':alias for --raw-binary'
+				--show-command':print command before sending'
+				-s':alias for --show-command'
+				--read':set dataflow direction to receive'
+				-r':alias for --read'
+				--write':set dataflow direction to send'
+				-w':alias for --write'
+				--latency':output latency statistics'
+				-T':alias for --latency'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14306,55 +15078,7 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme reset options" _reset
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(subsystem-reset)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _subsystem_reset
-			_subsystem_reset=(
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme subsystem-reset options" _subsystem_reset
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(ns-rescan)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _ns_rescan
-			_ns_rescan=(
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme ns-rescan options" _ns_rescan
+			_nvme_describe "nvme io-passthru options" _io_passthru
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -14481,13 +15205,15 @@ _nvme () {
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(top)
+		(set-property)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			local _top
-			_top=(
-				--delay=':refresh interval in seconds'
-				-d':alias for --delay'
+			local _set_property
+			_set_property=(
+				--offset=':the offset of the property'
+				-O':alias for --offset'
+				--value=':the value of the property to be set'
+				-V':alias for --value'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14503,82 +15229,17 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme top options" _top
+			_nvme_describe "nvme set-property options" _set_property
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(discover)
+		(get-property)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--raw -r" \
-			                "--config -J" && return
-			local _discover
-			_discover=(
-				--transport=':transport type'
-				-t':alias for --transport'
-				--nqn=':subsystem nqn'
-				-n':alias for --nqn'
-				--traddr=':transport address'
-				-a':alias for --traddr'
-				--trsvcid=':transport service id (e.g. IP port)'
-				-s':alias for --trsvcid'
-				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
-				-w':alias for --host-traddr'
-				--host-iface=':host interface (for tcp transport)'
-				-f':alias for --host-iface'
-				--hostnqn=':user-defined hostnqn'
-				-q':alias for --hostnqn'
-				--hostid=':user-defined hostid (if default not used)'
-				-I':alias for --hostid'
-				--kxchap-secret=':user-defined kxchap secret (if default not used)'
-				-S':alias for --kxchap-secret'
-				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
-				-C':alias for --kxchap-ctrl-secret'
-				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
-				--tls-key=':TLS key to use (key id or key in interchange format)'
-				--tls-key-identity=':TLS key identity'
-				--nr-io-queues=':number of io queues to use (default is core count)'
-				-i':alias for --nr-io-queues'
-				--nr-write-queues=':number of write queues to use (default 0)'
-				-W':alias for --nr-write-queues'
-				--nr-poll-queues=':number of poll queues to use (default 0)'
-				-P':alias for --nr-poll-queues'
-				--queue-size=':number of io queue elements to use (default 128)'
-				-Q':alias for --queue-size'
-				--keep-alive-tmo=':keep alive timeout period in seconds'
-				-k':alias for --keep-alive-tmo'
-				--reconnect-delay=':reconnect timeout period in seconds'
-				-c':alias for --reconnect-delay'
-				--ctrl-loss-tmo=':controller loss timeout period in seconds'
-				-l':alias for --ctrl-loss-tmo'
-				--fast_io_fail_tmo=':fast I/O fail timeout (default off)'
-				-F':alias for --fast_io_fail_tmo'
-				--tos=':type of service'
-				-T':alias for --tos'
-				--tls_key=':TLS key to use (key id)'
-				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
-				-D':alias for --duplicate-connect'
-				--disable-sqflow':disable controller sq flow control (default false)'
-				--hdr-digest':enable transport protocol header digest (TCP transport)'
-				-g':alias for --hdr-digest'
-				--data-digest':enable transport protocol data digest (TCP transport)'
-				-G':alias for --data-digest'
-				--tls':enable TLS'
-				--concat':enable secure concatenation'
-				--device=':use existing discovery controller device'
-				-d':alias for --device'
-				--raw=':save raw output to file'
-				-r':alias for --raw'
-				--persistent=':persistent discovery connection mode (default: no; auto if given bare)'
-				-p':alias for --persistent'
-				--config=':Use specified INI configuration file (auto-converts a legacy .json) or '\''none'\'' to disable'
-				-J':alias for --config'
-				--no-reuse':always create a new connection, never reuse an existing one'
-				--force':deprecated, see --no-reuse'
-				--nbft':Only look at NBFT tables'
-				--no-nbft':Do not look at NBFT tables'
-				--owner=':record this owner in the registry'
-				--nbft-path=':user-defined path for NBFT tables'
+			local _get_property
+			_get_property=(
+				--offset=':offset of the requested property'
+				-O':alias for --offset'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14594,82 +15255,23 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme discover options" _discover
+			_nvme_describe "nvme get-property options" _get_property
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(connect-all)
+		(device-self-test)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--raw -r" \
-			                "--config -J" && return
-			local _connect_all
-			_connect_all=(
-				--transport=':transport type'
-				-t':alias for --transport'
-				--nqn=':subsystem nqn'
-				-n':alias for --nqn'
-				--traddr=':transport address'
-				-a':alias for --traddr'
-				--trsvcid=':transport service id (e.g. IP port)'
-				-s':alias for --trsvcid'
-				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
-				-w':alias for --host-traddr'
-				--host-iface=':host interface (for tcp transport)'
-				-f':alias for --host-iface'
-				--hostnqn=':user-defined hostnqn'
-				-q':alias for --hostnqn'
-				--hostid=':user-defined hostid (if default not used)'
-				-I':alias for --hostid'
-				--kxchap-secret=':user-defined kxchap secret (if default not used)'
-				-S':alias for --kxchap-secret'
-				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
-				-C':alias for --kxchap-ctrl-secret'
-				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
-				--tls-key=':TLS key to use (key id or key in interchange format)'
-				--tls-key-identity=':TLS key identity'
-				--nr-io-queues=':number of io queues to use (default is core count)'
-				-i':alias for --nr-io-queues'
-				--nr-write-queues=':number of write queues to use (default 0)'
-				-W':alias for --nr-write-queues'
-				--nr-poll-queues=':number of poll queues to use (default 0)'
-				-P':alias for --nr-poll-queues'
-				--queue-size=':number of io queue elements to use (default 128)'
-				-Q':alias for --queue-size'
-				--keep-alive-tmo=':keep alive timeout period in seconds'
-				-k':alias for --keep-alive-tmo'
-				--reconnect-delay=':reconnect timeout period in seconds'
-				-c':alias for --reconnect-delay'
-				--ctrl-loss-tmo=':controller loss timeout period in seconds'
-				-l':alias for --ctrl-loss-tmo'
-				--fast_io_fail_tmo=':fast I/O fail timeout (default off)'
-				-F':alias for --fast_io_fail_tmo'
-				--tos=':type of service'
-				-T':alias for --tos'
-				--tls_key=':TLS key to use (key id)'
-				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
-				-D':alias for --duplicate-connect'
-				--disable-sqflow':disable controller sq flow control (default false)'
-				--hdr-digest':enable transport protocol header digest (TCP transport)'
-				-g':alias for --hdr-digest'
-				--data-digest':enable transport protocol data digest (TCP transport)'
-				-G':alias for --data-digest'
-				--tls':enable TLS'
-				--concat':enable secure concatenation'
-				--device=':use existing discovery controller device'
-				-d':alias for --device'
-				--raw=':save raw output to file'
-				-r':alias for --raw'
-				--persistent=':persistent discovery connection mode (default: no; auto if given bare)'
-				-p':alias for --persistent'
-				--config=':Use specified INI configuration file (auto-converts a legacy .json) or '\''none'\'' to disable'
-				-J':alias for --config'
-				--no-reuse':always create a new connection, never reuse an existing one'
-				--force':deprecated, see --no-reuse'
-				--nbft':Only look at NBFT tables'
-				--no-nbft':Do not look at NBFT tables'
-				--owner=':record this owner in the registry'
-				--nbft-path=':user-defined path for NBFT tables'
+			local _device_self_test
+			_device_self_test=(
+				--ish':Ignore Shutdown (for NVMe-MI command)'
+				-I':alias for --ish'
+				--namespace-id=':Indicate the namespace in which the device self-test has to be carried out'
+				-n':alias for --namespace-id'
+				--self-test-code=':This field specifies the action taken by the device self-test command : 0h Show current state of device self-test operation 1h Start a short device self-test operation 2h Start a extended device self-test operation 3h Start a Host-Initiated Refresh operation eh Start a vendor specific device self-test operation fh Abort the device self-test operation'
+				-s':alias for --self-test-code'
+				--wait':Wait for the test to finish'
+				-w':alias for --wait'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14685,73 +15287,36 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme connect-all options" _connect_all
+			_nvme_describe "nvme device-self-test options" _device_self_test
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(connect)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+		(sanitize)
+			_nvme_opt_vals "--sanact -a" "exit-failure start-block-erase start-overwrite start-crypto-erase exit-media-verification" \
+			               "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--config -J" \
-			                "--devid-file" && return
-			local _connect
-			_connect=(
-				--transport=':transport type'
-				-t':alias for --transport'
-				--nqn=':subsystem nqn'
-				-n':alias for --nqn'
-				--traddr=':transport address'
-				-a':alias for --traddr'
-				--trsvcid=':transport service id (e.g. IP port)'
-				-s':alias for --trsvcid'
-				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
-				-w':alias for --host-traddr'
-				--host-iface=':host interface (for tcp transport)'
-				-f':alias for --host-iface'
-				--hostnqn=':user-defined hostnqn'
-				-q':alias for --hostnqn'
-				--hostid=':user-defined hostid (if default not used)'
-				-I':alias for --hostid'
-				--kxchap-secret=':user-defined kxchap secret (if default not used)'
-				-S':alias for --kxchap-secret'
-				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
-				-C':alias for --kxchap-ctrl-secret'
-				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
-				--tls-key=':TLS key to use (key id or key in interchange format)'
-				--tls-key-identity=':TLS key identity'
-				--nr-io-queues=':number of io queues to use (default is core count)'
-				-i':alias for --nr-io-queues'
-				--nr-write-queues=':number of write queues to use (default 0)'
-				-W':alias for --nr-write-queues'
-				--nr-poll-queues=':number of poll queues to use (default 0)'
-				-P':alias for --nr-poll-queues'
-				--queue-size=':number of io queue elements to use (default 128)'
-				-Q':alias for --queue-size'
-				--keep-alive-tmo=':keep alive timeout period in seconds'
-				-k':alias for --keep-alive-tmo'
-				--reconnect-delay=':reconnect timeout period in seconds'
-				-c':alias for --reconnect-delay'
-				--ctrl-loss-tmo=':controller loss timeout period in seconds'
-				-l':alias for --ctrl-loss-tmo'
-				--fast_io_fail_tmo=':fast I/O fail timeout (default off)'
-				-F':alias for --fast_io_fail_tmo'
-				--tos=':type of service'
-				-T':alias for --tos'
-				--tls_key=':TLS key to use (key id)'
-				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
-				-D':alias for --duplicate-connect'
-				--disable-sqflow':disable controller sq flow control (default false)'
-				--hdr-digest':enable transport protocol header digest (TCP transport)'
-				-g':alias for --hdr-digest'
-				--data-digest':enable transport protocol data digest (TCP transport)'
-				-G':alias for --data-digest'
-				--tls':enable TLS'
-				--concat':enable secure concatenation'
-				--config=':Use specified INI configuration file (auto-converts a legacy .json) or '\''none'\'' to disable'
-				-J':alias for --config'
-				--owner=':record this owner in the registry'
-				--devid-file=':write connected device name to FILE'
-				--idempotent':exit 0 if already connected'
+			local _sanitize
+			_sanitize=(
+				--ish':Ignore Shutdown (for NVMe-MI command)'
+				-I':alias for --ish'
+				--no-dealloc':No deallocate after sanitize.'
+				-d':alias for --no-dealloc'
+				--oipbp':Overwrite invert pattern between passes.'
+				-i':alias for --oipbp'
+				--owpass=':Overwrite pass count.'
+				-n':alias for --owpass'
+				--ause':Allow unrestricted sanitize exit.'
+				-u':alias for --ause'
+				--sanact=':Sanitize action: 1 = Exit failure mode, 2 = Start block erase,3 = Start overwrite, 4 = Start crypto erase, 5 = Exit media verification'
+				-a':alias for --sanact'
+				--ovrpat=':Overwrite pattern.'
+				-p':alias for --ovrpat'
+				--emvs':Enter media verification state.'
+				-e':alias for --emvs'
+				--wait':Wait for the sanitize to finish'
+				-w':alias for --wait'
+				--repeat=':Repeat for the multi cycle sanitization'
+				-r':alias for --repeat'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14767,70 +15332,24 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme connect options" _connect
+			_nvme_describe "nvme sanitize options" _sanitize
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(disconnect)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+		(sanitize-ns)
+			_nvme_opt_vals "--sanact -a" "exit-failure start-crypto-erase exit-media-verification" \
+			               "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			local _disconnect
-			_disconnect=(
-				--transport=':transport type'
-				-t':alias for --transport'
-				--nqn=':subsystem nqn'
-				-n':alias for --nqn'
-				--traddr=':transport address'
-				-a':alias for --traddr'
-				--trsvcid=':transport service id (e.g. IP port)'
-				-s':alias for --trsvcid'
-				--host-traddr=':host traddr (e.g. FC WWN'\''s)'
-				-w':alias for --host-traddr'
-				--host-iface=':host interface (for tcp transport)'
-				-f':alias for --host-iface'
-				--hostnqn=':user-defined hostnqn'
-				-q':alias for --hostnqn'
-				--hostid=':user-defined hostid (if default not used)'
-				-I':alias for --hostid'
-				--kxchap-secret=':user-defined kxchap secret (if default not used)'
-				-S':alias for --kxchap-secret'
-				--kxchap-ctrl-secret=':user-defined kxchap controller secret (for bi-directional authentication)'
-				-C':alias for --kxchap-ctrl-secret'
-				--keyring=':Keyring for TLS key lookup (key id or keyring name)'
-				--tls-key=':TLS key to use (key id or key in interchange format)'
-				--tls-key-identity=':TLS key identity'
-				--nr-io-queues=':number of io queues to use (default is core count)'
-				-i':alias for --nr-io-queues'
-				--nr-write-queues=':number of write queues to use (default 0)'
-				-W':alias for --nr-write-queues'
-				--nr-poll-queues=':number of poll queues to use (default 0)'
-				-P':alias for --nr-poll-queues'
-				--queue-size=':number of io queue elements to use (default 128)'
-				-Q':alias for --queue-size'
-				--keep-alive-tmo=':keep alive timeout period in seconds'
-				-k':alias for --keep-alive-tmo'
-				--reconnect-delay=':reconnect timeout period in seconds'
-				-c':alias for --reconnect-delay'
-				--ctrl-loss-tmo=':controller loss timeout period in seconds'
-				-l':alias for --ctrl-loss-tmo'
-				--fast_io_fail_tmo=':fast I/O fail timeout (default off)'
-				-F':alias for --fast_io_fail_tmo'
-				--tos=':type of service'
-				-T':alias for --tos'
-				--tls_key=':TLS key to use (key id)'
-				--duplicate-connect':allow duplicate connections between same transport host and subsystem port'
-				-D':alias for --duplicate-connect'
-				--disable-sqflow':disable controller sq flow control (default false)'
-				--hdr-digest':enable transport protocol header digest (TCP transport)'
-				-g':alias for --hdr-digest'
-				--data-digest':enable transport protocol data digest (TCP transport)'
-				-G':alias for --data-digest'
-				--tls':enable TLS'
-				--concat':enable secure concatenation'
-				--device=':nvme device handle'
-				-d':alias for --device'
-				--exclude':write exclusion entry before disconnecting'
-				-x':alias for --exclude'
+			local _sanitize_ns
+			_sanitize_ns=(
+				--ish':Ignore Shutdown (for NVMe-MI command)'
+				-I':alias for --ish'
+				--ause':Allow unrestricted sanitize exit.'
+				-u':alias for --ause'
+				--sanact=':Sanitize action: 1 = Exit failure mode, 4 = Start a crypto erase namespace sanitize operation, 5 = Exit media verification state'
+				-a':alias for --sanact'
+				--emvs':Enter media verification state.'
+				-e':alias for --emvs'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -14846,279 +15365,34 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme disconnect options" _disconnect
+			_nvme_describe "nvme sanitize-ns options" _sanitize_ns
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
-		(disconnect-all)
+		(format)
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2" && return
-			local _disconnect_all
-			_disconnect_all=(
-				--transport=':transport type'
-				-t':alias for --transport'
-				--owner=':disconnect only controllers owned by NAME'
-				--force':disconnect all controllers regardless of ownership'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme disconnect-all options" _disconnect_all
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(dim)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _dim
-			_dim=(
-				--nqn=':Comma-separated list of DC nqn'
-				-n':alias for --nqn'
-				--device=':Comma-separated list of DC nvme device handle.'
-				-d':alias for --device'
-				--task=':[register|deregister]'
-				-t':alias for --task'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme dim options" _dim
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(gen-hostnqn)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _gen_hostnqn
-			_gen_hostnqn=(
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme gen-hostnqn options" _gen_hostnqn
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(show-hostnqn)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _show_hostnqn
-			_show_hostnqn=(
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme show-hostnqn options" _show_hostnqn
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(gen-dhchap-key)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _gen_dhchap_key
-			_gen_dhchap_key=(
-				--secret=':Optional secret (in hexadecimal characters) to be placed in the representation.'
-				-s':alias for --secret'
-				--key-length=':Length of the secret (32, 48, or 64 bytes).'
-				-l':alias for --key-length'
-				--nqn=':Accepted and ignored; nvme-cli 2.x keyed the transform with it.'
-				-n':alias for --nqn'
-				--hmac=':Hash function the consumer is to apply to the secret (0 = none, 1 = SHA-256, 2 = SHA-384, 3 = SHA-512).'
-				-m':alias for --hmac'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme gen-dhchap-key options" _gen_dhchap_key
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(check-dhchap-key)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _check_dhchap_key
-			_check_dhchap_key=(
-				--key=':KX-HMAC-CHAP secret (in DHHC-1 interchange format) to be validated. Reads from stdin if not given.'
-				-k':alias for --key'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme check-dhchap-key options" _check_dhchap_key
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(gen-tls-key)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _gen_tls_key
-			_gen_tls_key=(
-				--keyring=':Keyring for the retained key.'
-				-k':alias for --keyring'
-				--keytype=':Key type of the retained key.'
-				-t':alias for --keytype'
-				--hostnqn=':Host NQN for the retained key.'
-				-n':alias for --hostnqn'
-				--subsysnqn=':Subsystem NQN for the retained key.'
-				-c':alias for --subsysnqn'
-				--secret=':Optional secret (in hexadecimal characters) to be used for the TLS key.'
-				-s':alias for --secret'
-				--keyfile=':Update key file with the derived TLS PSK.'
-				-f':alias for --keyfile'
-				--hmac=':HMAC function to use for the retained key (1 = SHA-256, 2 = SHA-384).'
-				-m':alias for --hmac'
-				--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
-				-I':alias for --identity'
-				--insert':Insert retained key into the keyring.'
-				-i':alias for --insert'
-				--compat':Use non-RFC 8446 compliant algorithm for deriving TLS PSK for older implementations.'
-				-C':alias for --compat'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme gen-tls-key options" _gen_tls_key
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(check-tls-key)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _check_tls_key
-			_check_tls_key=(
-				--keyring=':Keyring to check for an already loaded key.'
-				-k':alias for --keyring'
-				--keytype=':Key type of the key to look up.'
-				-t':alias for --keytype'
-				--hostnqn=':Host NQN to use when checking whether the key is already loaded.'
-				-n':alias for --hostnqn'
-				--subsysnqn=':Subsystem NQN to use when checking whether the key is already loaded.'
-				-c':alias for --subsysnqn'
-				--keydata=':TLS key (in PSK Interchange format) to be validated. Reads from stdin if not given.'
-				-d':alias for --keydata'
-				--identity=':TLS identity version to use (0 = NVMe TCP 1.0c, 1 = NVMe TCP 2.0)'
-				-I':alias for --identity'
-				--compat':Use non-RFC 8446 compliant algorithm for checking TLS PSK for older implementations.'
-				-C':alias for --compat'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme check-tls-key options" _check_tls_key
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(tls-key)
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(dir-receive)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _dir_receive
-			_dir_receive=(
+			local _format
+			_format=(
+				--ish':Ignore Shutdown (for NVMe-MI command)'
+				-I':alias for --ish'
 				--namespace-id=':identifier of desired namespace'
 				-n':alias for --namespace-id'
-				--data-len=':buffer len (if) data is sent or received'
-				-l':alias for --data-len'
-				--raw-binary':show directive in binary format'
-				-b':alias for --raw-binary'
-				--dir-type=':directive type'
-				-D':alias for --dir-type'
-				--dir-spec=':directive specification associated with directive type'
-				-S':alias for --dir-spec'
-				--dir-oper=':directive operation'
-				-O':alias for --dir-oper'
-				--req-resource=':namespace stream requested'
-				-r':alias for --req-resource'
+				--lbaf=':LBA format to apply (required)'
+				-l':alias for --lbaf'
+				--ses=':[0-2]: secure erase'
+				-s':alias for --ses'
+				--pi=':[0-3]: protection info off/Type 1/Type 2/Type 3'
+				-i':alias for --pi'
+				--pil=':[0-1]: protection info location last/first bytes of metadata'
+				-p':alias for --pil'
+				--ms=':[0-1]: extended format off/on'
+				-m':alias for --ms'
+				--reset':Automatically reset the controller after successful format'
+				-r':alias for --reset'
+				--force':The "I know what I'\''m doing" flag, skip confirmation before sending command'
+				--block-size=':target block size'
+				-b':alias for --block-size'
 				--verbose':Increase output verbosity'
 				-v':alias for --verbose'
 				--quiet':suppress output messages, overwrites verbose mode'
@@ -15134,82 +15408,7 @@ _nvme () {
 				-h':alias for --help'
 			)
 			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme dir-receive options" _dir_receive
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(dir-send)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--input-file -i" && return
-			local _dir_send
-			_dir_send=(
-				--namespace-id=':identifier of desired namespace'
-				-n':alias for --namespace-id'
-				--data-len=':buffer len (if) data is sent or received'
-				-l':alias for --data-len'
-				--dir-type=':directive type'
-				-D':alias for --dir-type'
-				--target-dir=':target directive type to be enabled/disabled'
-				-T':alias for --target-dir'
-				--dir-spec=':directive specification associated with directive type'
-				-S':alias for --dir-spec'
-				--dir-oper=':directive operation'
-				-O':alias for --dir-oper'
-				--endir=':directive enable'
-				-e':alias for --endir'
-				--raw-binary':show directive in binary format'
-				-b':alias for --raw-binary'
-				--input-file=':write/send file (default stdin)'
-				-i':alias for --input-file'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme dir-send options" _dir_send
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(virt-mgmt)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _virt_mgmt
-			_virt_mgmt=(
-				--cntlid=':Controller Identifier(CNTLID)'
-				-c':alias for --cntlid'
-				--rt=':Resource Type(RT): [0,1] 0h: VQ Resources 1h: VI Resources'
-				-r':alias for --rt'
-				--act=':Action(ACT): [1,7,8,9] 1h: Primary Flexible 7h: Secondary Offline 8h: Secondary Assign 9h: Secondary Online'
-				-a':alias for --act'
-				--nr=':Number of Controller Resources(NR)'
-				-n':alias for --nr'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme virt-mgmt options" _virt_mgmt
+			_nvme_describe "nvme format options" _format
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 
@@ -15286,180 +15485,6 @@ _nvme () {
 			)
 			_arguments '*:: :->subcmds'
 			_nvme_describe "nvme lockdown options" _lockdown
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(show-topology)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			local _show_topology
-			_show_topology=(
-				--ranking=':Ranking order: namespace|ctrl|multipath'
-				-r':alias for --ranking'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|tabular'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme show-topology options" _show_topology
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(io-mgmt-recv)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--data -d" && return
-			local _io_mgmt_recv
-			_io_mgmt_recv=(
-				--namespace-id=':identifier of desired namespace'
-				-n':alias for --namespace-id'
-				--mos=':management operation specific'
-				-s':alias for --mos'
-				--mo=':management operation'
-				-m':alias for --mo'
-				--data=':optional file for data (default stdout)'
-				-d':alias for --data'
-				--data-len=':buffer len (if) data is sent or received'
-				-l':alias for --data-len'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme io-mgmt-recv options" _io_mgmt_recv
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(io-mgmt-send)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--data -d" && return
-			local _io_mgmt_send
-			_io_mgmt_send=(
-				--namespace-id=':identifier of desired namespace'
-				-n':alias for --namespace-id'
-				--mos=':management operation specific'
-				-s':alias for --mos'
-				--mo=':management operation'
-				-m':alias for --mo'
-				--data=':optional file for data (default stdin)'
-				-d':alias for --data'
-				--data-len=':buffer len (if) data is sent or received'
-				-l':alias for --data-len'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme io-mgmt-send options" _io_mgmt_send
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(nvme-mi-recv)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--input-file -i" && return
-			local _nvme_mi_recv
-			_nvme_mi_recv=(
-				--opcode=':opcode (required)'
-				-O':alias for --opcode'
-				--namespace-id=':desired namespace'
-				-n':alias for --namespace-id'
-				--data-len=':data I/O length (bytes)'
-				-l':alias for --data-len'
-				--nmimt=':nvme-mi message type'
-				-m':alias for --nmimt'
-				--nmd0=':nvme management dword 0 value'
-				-0':alias for --nmd0'
-				--nmd1=':nvme management dword 1 value'
-				-1':alias for --nmd1'
-				--input-file=':data input or output file'
-				-i':alias for --input-file'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme nvme-mi-recv options" _nvme_mi_recv
-			_nvme_has_device || compadd -- /dev/nvme*(N)
-			;;
-
-		(nvme-mi-send)
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2" && return
-			_nvme_opt_files "--input-file -i" && return
-			local _nvme_mi_send
-			_nvme_mi_send=(
-				--opcode=':opcode (required)'
-				-O':alias for --opcode'
-				--namespace-id=':desired namespace'
-				-n':alias for --namespace-id'
-				--data-len=':data I/O length (bytes)'
-				-l':alias for --data-len'
-				--nmimt=':nvme-mi message type'
-				-m':alias for --nmimt'
-				--nmd0=':nvme management dword 0 value'
-				-0':alias for --nmd0'
-				--nmd1=':nvme management dword 1 value'
-				-1':alias for --nmd1'
-				--input-file=':data input or output file'
-				-i':alias for --input-file'
-				--verbose':Increase output verbosity'
-				-v':alias for --verbose'
-				--quiet':suppress output messages, overwrites verbose mode'
-				--output-format=':Output format: normal|json|binary'
-				-o':alias for --output-format'
-				--timeout=':timeout value, in milliseconds'
-				--dry-run':show command instead of executing'
-				--no-retries':disable retry logic on errors'
-				--no-ioctl-probing':disable 64-bit IOCTL support probing'
-				--output-format-version=':output format version: 1|2'
-				--set-options=':set a libnvme library option (key=value[,key=value,...]);'
-				--help':show help'
-				-h':alias for --help'
-			)
-			_arguments '*:: :->subcmds'
-			_nvme_describe "nvme nvme-mi-send options" _nvme_mi_send
 			_nvme_has_device || compadd -- /dev/nvme*(N)
 			;;
 

--- a/completions/bash-nvme-completion.sh
+++ b/completions/bash-nvme-completion.sh
@@ -166,6 +166,54 @@ nvme_list_opts () {
 			               "--output-format-version" "1 2"
 			;;
 
+		"show-topology")
+			opts+=" --ranking= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --ranking -r --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"top")
+			opts+=" --delay= -d --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --delay -d --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"reset")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"subsystem-reset")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"ns-rescan")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"virt-mgmt")
+			opts+=" --cntlid= -c --rt= -r --act= -a --nr= -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --cntlid -c --rt -r --act -a --nr -n --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
 		"id-ctrl")
 			opts+=" --vendor-specific -V --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
 			valopts+=" --output-format -o --timeout --output-format-version --set-options"
@@ -350,12 +398,11 @@ nvme_list_opts () {
 			               "--output-format-version" "1 2"
 			;;
 
-		"get-log")
-			opts+=" --ish -I --namespace-id= -n --log-id= -i --log-len= -l --aen= -a --lpo= -L --lsp= -s --lsi= -S --rae -r --uuid-index= -U --raw-binary -b --csi= -y --ot -O --xfer-len= -x --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --log-id -i --log-len -l --aen -a --lpo -L --lsp -s --lsi -S --uuid-index -U --csi -y --xfer-len -x --output-format -o --timeout --output-format-version --set-options"
+		"supported-log-pages")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
 
-			_nvme_opt_vals "--log-id -i" "supported-log-pages error smart fw-slot changed-ns cmd-effects device-self-test telemetry-host telemetry-ctrl endurance-group predictable-lat-nvmset predictable-lat-agg ana persistent-event lba-status endurance-grp-evt media-unit-status supported-cap-config-list fid-supported-effects mi-cmd-supported-effects cmd-and-feat-lockdown boot-partition rotational-media-info dispersed-ns-participating-ns mgmt-addr-list phy-rx-eom reachability-groups reachability-associations changed-alloc-ns-list fdp-configs fdp-ruh-usage fdp-stats fdp-events discover host-discover ave-discover pull-model-ddc-req reservation sanitize zns-changed-zones" \
-			               "--output-format -o" "normal json binary tabular" \
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
@@ -489,35 +536,9 @@ nvme_list_opts () {
 			               "--output-format-version" "1 2"
 			;;
 
-		"get-feature")
-			opts+=" --feature-id= -f --namespace-id= -n --sel= -s --data-len= -l --raw-binary -b --cdw11= -c --uuid-index= -U --changed -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --feature-id -f --namespace-id -n --sel -s --data-len -l --cdw11 -c --uuid-index -U --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
-			               "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"device-self-test")
-			opts+=" --ish -I --namespace-id= -n --self-test-code= -s --wait -w --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --self-test-code -s --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
 		"self-test-log")
 			opts+=" --dst-entries= -e --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
 			valopts+=" --dst-entries -e --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"supported-log-pages")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
@@ -635,40 +656,6 @@ nvme_list_opts () {
 			               "--output-format-version" "1 2"
 			;;
 
-		"set-feature")
-			opts+=" --namespace-id= -n --feature-id= -f --value= -V --cdw12= -c --uuid-index= -U --data-len= -l --data= -d --save -s --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --feature-id -f --value -V --cdw12 -c --uuid-index -U --data-len -l --data -d --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--data -d"
-			;;
-
-		"set-property")
-			opts+=" --offset= -O --value= -V --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --offset -O --value -V --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-property")
-			opts+=" --offset= -O --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --offset -O --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"format")
-			opts+=" --ish -I --namespace-id= -n --lbaf= -l --ses= -s --pi= -i --pil= -p --ms= -m --reset -r --force --block-size= -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --lbaf -l --ses -s --pi -i --pil -p --ms -m --block-size -b --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
 		"fw-commit"|"fw-activate")
 			opts+=" --ish -I --slot= -s --action= -a --bpid= -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
 			valopts+=" --slot -s --action -a --bpid -b --output-format -o --timeout --output-format-version --set-options"
@@ -687,24 +674,6 @@ nvme_list_opts () {
 			_nvme_opt_files "--fw -f"
 			;;
 
-		"admin-passthru")
-			opts+=" --opcode= -O --flags= -f --prefill= -p --rsvd= -R --namespace-id= -n --data-len= -l --metadata-len= -m --cdw2= -2 --cdw3= -3 --cdw10= -4 --cdw11= -5 --cdw12= -6 --cdw13= -7 --cdw14= -8 --cdw15= -9 --input-file= -i --metadata= -M --raw-binary -b --show-command -s --read -r --write -w --latency -T --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --opcode -O --flags -f --prefill -p --rsvd -R --namespace-id -n --data-len -l --metadata-len -m --cdw2 -2 --cdw3 -3 --cdw10 -4 --cdw11 -5 --cdw12 -6 --cdw13 -7 --cdw14 -8 --cdw15 -9 --input-file -i --metadata -M --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--input-file -i" "--metadata -M"
-			;;
-
-		"io-passthru")
-			opts+=" --opcode= -O --flags= -f --prefill= -p --rsvd= -R --namespace-id= -n --data-len= -l --metadata-len= -m --cdw2= -2 --cdw3= -3 --cdw10= -4 --cdw11= -5 --cdw12= -6 --cdw13= -7 --cdw14= -8 --cdw15= -9 --input-file= -i --metadata= -M --raw-binary -b --show-command -s --read -r --write -w --latency -T --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --opcode -O --flags -f --prefill -p --rsvd -R --namespace-id -n --data-len -l --metadata-len -m --cdw2 -2 --cdw3 -3 --cdw10 -4 --cdw11 -5 --cdw12 -6 --cdw13 -7 --cdw14 -8 --cdw15 -9 --input-file -i --metadata -M --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--input-file -i" "--metadata -M"
-			;;
-
 		"security-send")
 			opts+=" --ish -I --namespace-id= -n --file= -f --nssf= -N --secp= -p --spsp= -s --tl= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
 			valopts+=" --namespace-id -n --file -f --nssf -N --secp -p --spsp -s --tl -t --output-format -o --timeout --output-format-version --set-options"
@@ -717,22 +686,6 @@ nvme_list_opts () {
 		"security-recv")
 			opts+=" --ish -I --namespace-id= -n --size= -x --nssf= -N --secp= -p --spsp= -s --al= -t --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
 			valopts+=" --namespace-id -n --size -x --nssf -N --secp -p --spsp -s --al -t --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-lba-status")
-			opts+=" --ish -I --namespace-id= -n --start-lba= -s --max-dw= -m --action= -a --range-len= -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --start-lba -s --max-dw -m --action -a --range-len -l --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"capacity-mgmt")
-			opts+=" --ish -I --operation= -O --element-id= -i --cap-lower= -l --cap-upper= -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --operation -O --element-id -i --cap-lower -l --cap-upper -u --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
@@ -768,6 +721,195 @@ nvme_list_opts () {
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
+			;;
+
+		"sanitize-log")
+			opts+=" --rae -r --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"gen-dhchap-key")
+			opts+=" --secret= -s --key-length= -l --nqn= -n --hmac= -m --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --secret -s --key-length -l --nqn -n --hmac -m --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"check-dhchap-key")
+			opts+=" --key= -k --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --key -k --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"gen-tls-key")
+			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --secret= -s --keyfile= -f --hmac= -m --identity= -I --insert -i --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --secret -s --keyfile -f --hmac -m --identity -I --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"check-tls-key")
+			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --keydata= -d --identity= -I --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --keydata -d --identity -I --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"dir-receive")
+			opts+=" --namespace-id= -n --data-len= -l --raw-binary -b --dir-type= -D --dir-spec= -S --dir-oper= -O --req-resource= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --data-len -l --dir-type -D --dir-spec -S --dir-oper -O --req-resource -r --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"dir-send")
+			opts+=" --namespace-id= -n --data-len= -l --dir-type= -D --target-dir= -T --dir-spec= -S --dir-oper= -O --endir= -e --raw-binary -b --input-file= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --data-len -l --dir-type -D --target-dir -T --dir-spec -S --dir-oper -O --endir -e --input-file -i --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--input-file -i"
+			;;
+
+		"io-mgmt-recv")
+			opts+=" --namespace-id= -n --mos= -s --mo= -m --data= -d --data-len= -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --mos -s --mo -m --data -d --data-len -l --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--data -d"
+			;;
+
+		"io-mgmt-send")
+			opts+=" --namespace-id= -n --mos= -s --mo= -m --data= -d --data-len= -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --mos -s --mo -m --data -d --data-len -l --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--data -d"
+			;;
+
+		"nvme-mi-recv")
+			opts+=" --opcode= -O --namespace-id= -n --data-len= -l --nmimt= -m --nmd0= -0 --nmd1= -1 --input-file= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --opcode -O --namespace-id -n --data-len -l --nmimt -m --nmd0 -0 --nmd1 -1 --input-file -i --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--input-file -i"
+			;;
+
+		"nvme-mi-send")
+			opts+=" --opcode= -O --namespace-id= -n --data-len= -l --nmimt= -m --nmd0= -0 --nmd1= -1 --input-file= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --opcode -O --namespace-id -n --data-len -l --nmimt -m --nmd0 -0 --nmd1 -1 --input-file -i --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--input-file -i"
+			;;
+
+		"get-log")
+			opts+=" --ish -I --namespace-id= -n --log-id= -i --log-len= -l --aen= -a --lpo= -L --lsp= -s --lsi= -S --rae -r --uuid-index= -U --raw-binary -b --csi= -y --ot -O --xfer-len= -x --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --log-id -i --log-len -l --aen -a --lpo -L --lsp -s --lsi -S --uuid-index -U --csi -y --xfer-len -x --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--log-id -i" "supported-log-pages error smart fw-slot changed-attached-ns changed-ns cmd-effects device-self-test telemetry-host telemetry-ctrl endurance-group predictable-lat-nvmset predictable-lat-agg ana persistent-event lba-status endurance-grp-evt media-unit-status supported-cap-config-list fid-supported-effects mi-cmd-supported-effects cmd-and-feat-lockdown boot-partition rotational-media-info dispersed-ns-participating-ns mgmt-addr-list phy-rx-eom reachability-groups reachability-associations changed-alloc-ns-list fdp-configs fdp-ruh-usage fdp-stats fdp-events discover host-discover ave-discover pull-model-ddc-req reservation sanitize zns-changed-zones" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"discover")
+			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast-io-fail-tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --device= -d --raw= -r --persistent= -p --config= -J --no-reuse --force --nbft --no-nbft --owner= --nbft-path= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast-io-fail-tmo -F --tos -T --tls_key --device -d --raw -r --persistent -p --config -J --owner --nbft-path --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--raw -r" "--config -J"
+			;;
+
+		"connect-all")
+			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast-io-fail-tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --device= -d --raw= -r --persistent= -p --config= -J --no-reuse --force --nbft --no-nbft --owner= --nbft-path= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast-io-fail-tmo -F --tos -T --tls_key --device -d --raw -r --persistent -p --config -J --owner --nbft-path --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--raw -r" "--config -J"
+			;;
+
+		"connect")
+			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast-io-fail-tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --config= -J --owner= --devid-file= --idempotent --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast-io-fail-tmo -F --tos -T --tls_key --config -J --owner --devid-file --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--config -J" "--devid-file"
+			;;
+
+		"disconnect")
+			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast-io-fail-tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --device= -d --exclude -x --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast-io-fail-tmo -F --tos -T --tls_key --device -d --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"disconnect-all")
+			opts+=" --transport= -t --owner= --force --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --transport -t --owner --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"dim")
+			opts+=" --nqn= -n --device= -d --task= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --nqn -n --device -d --task -t --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"gen-hostnqn")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"show-hostnqn")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-feature")
+			opts+=" --feature-id= -f --namespace-id= -n --sel= -s --data-len= -l --raw-binary -b --cdw11= -c --uuid-index= -U --changed -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --feature-id -f --namespace-id -n --sel -s --data-len -l --cdw11 -c --uuid-index -U --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
+			               "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"set-feature")
+			opts+=" --namespace-id= -n --feature-id= -f --value= -V --cdw12= -c --uuid-index= -U --data-len= -l --data= -d --save -s --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --feature-id -f --value -V --cdw12 -c --uuid-index -U --data-len -l --data -d --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--feature-id -f" "arbitration power-mgmt lba-range temp-thresh err-recovery volatile-wc num-queues irq-coalesce irq-config write-atomic async-event auto-pst host-mem-buf timestamp kato hctm nopsc rrl plm-config plm-window lba-sts-interval host-behavior sanitize endurance-evt-cfg iocs-profile spinup-control power-loss-signal perf-characteristics fdp fdp-events ns-admin-label key-value ctrl-data-queue emb-mgmt-ctrl-addr host-mgmt-agent-addr enh-ctrl-metadata ctrl-metadata ns-metadata sw-progress host-id resv-nf-mask resv-persist write-protect bp-write-protect" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--data -d"
 			;;
 
 		"dsm")
@@ -845,54 +987,38 @@ nvme_list_opts () {
 			               "--output-format-version" "1 2"
 			;;
 
-		"sanitize")
-			opts+=" --ish -I --no-dealloc -d --oipbp -i --owpass= -n --ause -u --sanact= -a --ovrpat= -p --emvs -e --wait -w --repeat= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --owpass -n --sanact -a --ovrpat -p --repeat -r --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sanact -a" "exit-failure start-block-erase start-overwrite start-crypto-erase exit-media-verification" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"sanitize-log")
-			opts+=" --rae -r --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+		"get-lba-status")
+			opts+=" --ish -I --namespace-id= -n --start-lba= -s --max-dw= -m --action= -a --range-len= -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --start-lba -s --max-dw -m --action -a --range-len -l --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
-		"sanitize-ns")
-			opts+=" --ish -I --ause -u --sanact= -a --emvs -e --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sanact -a --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sanact -a" "exit-failure start-crypto-erase exit-media-verification" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"reset")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+		"capacity-mgmt")
+			opts+=" --ish -I --operation= -O --element-id= -i --cap-lower= -l --cap-upper= -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --operation -O --element-id -i --cap-lower -l --cap-upper -u --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
-		"subsystem-reset")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+		"admin-passthru")
+			opts+=" --opcode= -O --flags= -f --prefill= -p --rsvd= -R --namespace-id= -n --data-len= -l --metadata-len= -m --cdw2= -2 --cdw3= -3 --cdw10= -4 --cdw11= -5 --cdw12= -6 --cdw13= -7 --cdw14= -8 --cdw15= -9 --input-file= -i --metadata= -M --raw-binary -b --show-command -s --read -r --write -w --latency -T --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --opcode -O --flags -f --prefill -p --rsvd -R --namespace-id -n --data-len -l --metadata-len -m --cdw2 -2 --cdw3 -3 --cdw10 -4 --cdw11 -5 --cdw12 -6 --cdw13 -7 --cdw14 -8 --cdw15 -9 --input-file -i --metadata -M --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
+			_nvme_opt_files "--input-file -i" "--metadata -M"
 			;;
 
-		"ns-rescan")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+		"io-passthru")
+			opts+=" --opcode= -O --flags= -f --prefill= -p --rsvd= -R --namespace-id= -n --data-len= -l --metadata-len= -m --cdw2= -2 --cdw3= -3 --cdw10= -4 --cdw11= -5 --cdw12= -6 --cdw13= -7 --cdw14= -8 --cdw15= -9 --input-file= -i --metadata= -M --raw-binary -b --show-command -s --read -r --write -w --latency -T --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --opcode -O --flags -f --prefill -p --rsvd -R --namespace-id -n --data-len -l --metadata-len -m --cdw2 -2 --cdw3 -3 --cdw10 -4 --cdw11 -5 --cdw12 -6 --cdw13 -7 --cdw14 -8 --cdw15 -9 --input-file -i --metadata -M --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
+			_nvme_opt_files "--input-file -i" "--metadata -M"
 			;;
 
 		"show-regs")
@@ -919,133 +1045,51 @@ nvme_list_opts () {
 			               "--output-format-version" "1 2"
 			;;
 
-		"top")
-			opts+=" --delay= -d --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --delay -d --output-format -o --timeout --output-format-version --set-options"
+		"set-property")
+			opts+=" --offset= -O --value= -V --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --offset -O --value -V --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
-		"discover")
-			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast_io_fail_tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --device= -d --raw= -r --persistent= -p --config= -J --no-reuse --force --nbft --no-nbft --owner= --nbft-path= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast_io_fail_tmo -F --tos -T --tls_key --device -d --raw -r --persistent -p --config -J --owner --nbft-path --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--raw -r" "--config -J"
-			;;
-
-		"connect-all")
-			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast_io_fail_tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --device= -d --raw= -r --persistent= -p --config= -J --no-reuse --force --nbft --no-nbft --owner= --nbft-path= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast_io_fail_tmo -F --tos -T --tls_key --device -d --raw -r --persistent -p --config -J --owner --nbft-path --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--raw -r" "--config -J"
-			;;
-
-		"connect")
-			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast_io_fail_tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --config= -J --owner= --devid-file= --idempotent --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast_io_fail_tmo -F --tos -T --tls_key --config -J --owner --devid-file --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--config -J" "--devid-file"
-			;;
-
-		"disconnect")
-			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast_io_fail_tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --device= -d --exclude -x --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast_io_fail_tmo -F --tos -T --tls_key --device -d --output-format -o --timeout --output-format-version --set-options"
+		"get-property")
+			opts+=" --offset= -O --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --offset -O --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
-		"disconnect-all")
-			opts+=" --transport= -t --owner= --force --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --transport -t --owner --output-format -o --timeout --output-format-version --set-options"
+		"device-self-test")
+			opts+=" --ish -I --namespace-id= -n --self-test-code= -s --wait -w --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --self-test-code -s --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
-		"dim")
-			opts+=" --nqn= -n --device= -d --task= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --nqn -n --device -d --task -t --output-format -o --timeout --output-format-version --set-options"
+		"sanitize")
+			opts+=" --ish -I --no-dealloc -d --oipbp -i --owpass= -n --ause -u --sanact= -a --ovrpat= -p --emvs -e --wait -w --repeat= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --owpass -n --sanact -a --ovrpat -p --repeat -r --output-format -o --timeout --output-format-version --set-options"
 
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			_nvme_opt_vals "--sanact -a" "exit-failure start-block-erase start-overwrite start-crypto-erase exit-media-verification" \
+			               "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
-		"gen-hostnqn")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+		"sanitize-ns")
+			opts+=" --ish -I --ause -u --sanact= -a --emvs -e --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sanact -a --output-format -o --timeout --output-format-version --set-options"
 
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			_nvme_opt_vals "--sanact -a" "exit-failure start-crypto-erase exit-media-verification" \
+			               "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 
-		"show-hostnqn")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"gen-dhchap-key")
-			opts+=" --secret= -s --key-length= -l --nqn= -n --hmac= -m --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --secret -s --key-length -l --nqn -n --hmac -m --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"check-dhchap-key")
-			opts+=" --key= -k --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --key -k --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"gen-tls-key")
-			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --secret= -s --keyfile= -f --hmac= -m --identity= -I --insert -i --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --secret -s --keyfile -f --hmac -m --identity -I --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"check-tls-key")
-			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --keydata= -d --identity= -I --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --keydata -d --identity -I --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"dir-receive")
-			opts+=" --namespace-id= -n --data-len= -l --raw-binary -b --dir-type= -D --dir-spec= -S --dir-oper= -O --req-resource= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --data-len -l --dir-type -D --dir-spec -S --dir-oper -O --req-resource -r --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"dir-send")
-			opts+=" --namespace-id= -n --data-len= -l --dir-type= -D --target-dir= -T --dir-spec= -S --dir-oper= -O --endir= -e --raw-binary -b --input-file= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --data-len -l --dir-type -D --target-dir -T --dir-spec -S --dir-oper -O --endir -e --input-file -i --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--input-file -i"
-			;;
-
-		"virt-mgmt")
-			opts+=" --cntlid= -c --rt= -r --act= -a --nr= -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --cntlid -c --rt -r --act -a --nr -n --output-format -o --timeout --output-format-version --set-options"
+		"format")
+			opts+=" --ish -I --namespace-id= -n --lbaf= -l --ses= -s --pi= -i --pil= -p --ms= -m --reset -r --force --block-size= -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --lbaf -l --ses -s --pi -i --pil -p --ms -m --block-size -b --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
@@ -1066,50 +1110,6 @@ nvme_list_opts () {
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
-			;;
-
-		"show-topology")
-			opts+=" --ranking= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --ranking -r --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"io-mgmt-recv")
-			opts+=" --namespace-id= -n --mos= -s --mo= -m --data= -d --data-len= -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --mos -s --mo -m --data -d --data-len -l --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--data -d"
-			;;
-
-		"io-mgmt-send")
-			opts+=" --namespace-id= -n --mos= -s --mo= -m --data= -d --data-len= -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --mos -s --mo -m --data -d --data-len -l --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--data -d"
-			;;
-
-		"nvme-mi-recv")
-			opts+=" --opcode= -O --namespace-id= -n --data-len= -l --nmimt= -m --nmd0= -0 --nmd1= -1 --input-file= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --opcode -O --namespace-id -n --data-len -l --nmimt -m --nmd0 -0 --nmd1 -1 --input-file -i --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--input-file -i"
-			;;
-
-		"nvme-mi-send")
-			opts+=" --opcode= -O --namespace-id= -n --data-len= -l --nmimt= -m --nmd0= -0 --nmd1= -1 --input-file= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --opcode -O --namespace-id -n --data-len -l --nmimt -m --nmd0 -0 --nmd1 -1 --input-file -i --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--input-file -i"
 			;;
 	esac
 	_nvme_finish_completion "$1" 2
@@ -1143,6 +1143,55 @@ plugin_amzn_opts () {
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
+plugin_config_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"validate")
+			opts+=" --config= -J"
+			valopts+=" --config -J"
+
+			_nvme_opt_files "--config -J"
+			;;
+
+		"show")
+			opts+=" --config= -J --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --config -J --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--config -J"
+			;;
+
+		"convert")
+			opts+=" --config= -J --output= -o --force"
+			valopts+=" --config -J --output -o"
+
+			_nvme_opt_files "--config -J" "--output -o"
+			;;
+
+		"create")
+			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast-io-fail-tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --discovery --persistent= --host-symname= --output= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast-io-fail-tmo -F --tos -T --tls_key --persistent --host-symname --output --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--output"
 			;;
 	esac
 	_nvme_finish_completion "$1" 3
@@ -1257,6 +1306,71 @@ plugin_dir_opts () {
 	_nvme_finish_completion "$1" 3
 }
 
+plugin_exclusion_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"create")
+			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"delete")
+			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"edit")
+			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"list")
+			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"add")
+			opts+=" --name= -N --entry= -e --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --name -N --entry -e --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"remove")
+			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
 plugin_fdp_opts () {
 	local opts=""
 	local valopts=""
@@ -1332,6 +1446,141 @@ plugin_fdp_opts () {
 			valopts+=" --endgrp-id -e --enable-conf-idx -c --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
+plugin_feat_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"arbitration")
+			opts+=" --ab= -a --lpw= -l --mpw= -m --hpw= -H --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --ab -a --lpw -l --mpw -m --hpw -H --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"power-mgmt")
+			opts+=" --ps= -p --wh= -w --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --ps -p --wh -w --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"temp-thresh")
+			opts+=" --tmpth= -T --tmpsel= -m --thsel= -H --tmpthh= -M --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --tmpth -T --tmpsel -m --thsel -H --tmpthh -M --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"volatile-wc")
+			opts+=" --wce -w --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"num-queues")
+			opts+=" --nsqr= -n --ncqr= -c --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --nsqr -n --ncqr -c --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"timestamp")
+			opts+=" --tstmp= -t --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --tstmp -t --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"hctm")
+			opts+=" --tmt1= -t --tmt2= -T --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --tmt1 -t --tmt2 -T --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"host-behavior-support")
+			opts+=" --acre= -a --etdas= -e --lbafee= -l --hdisns= -H --cdfe= -c --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --acre -a --etdas -e --lbafee -l --hdisns -H --cdfe -c --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"perf-characteristics")
+			opts+=" --namespace-id= -n --attri= -a --rvspa -r --r4karl= -R --paid= -p --attrl= -A --vs-data= -V --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --attri -a --r4karl -R --paid -p --attrl -A --vs-data -V --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--vs-data -V"
+			;;
+
+		"power-limit")
+			opts+=" --plv= -p --pls= -l --uuid-index= -u --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --plv -p --pls -l --uuid-index -u --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"power-thresh")
+			opts+=" --ptv= -p --pts= -t --pmts= -m --ept= -e --uuid-index= -u --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --ptv -p --pts -t --pmts -m --ept -e --uuid-index -u --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"power-meas")
+			opts+=" --act= --pmts= --smt= --uuid-index= -u --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --act --pmts --smt --uuid-index -u --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"err-recovery")
+			opts+=" --nsid= -n --tler= -t --dulbe -d --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --nsid -n --tler -t --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			;;
 	esac
@@ -1779,6 +2028,165 @@ plugin_io_mgmt_opts () {
 	_nvme_finish_completion "$1" 3
 }
 
+plugin_keys_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"gen-kxchap-secret")
+			opts+=" --secret= -s --secret-length= -l --hmac= -m --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --secret -s --secret-length -l --hmac -m --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"check-kxchap-secret")
+			opts+=" --keydata= -d --keyring= -k --keytype= -t --identity= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keydata -d --keyring -k --keytype -t --identity -i --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"gen-tls")
+			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --secret= -s --keyfile= -f --hmac= -m --identity= -I --insert -i --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --secret -s --keyfile -f --hmac -m --identity -I --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"check-tls")
+			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --keydata= -d --identity= -I --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --keydata -d --identity -I --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"insert-tls")
+			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --keydata= -d --keyfile= -f --identity= -I --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --keydata -d --keyfile -f --identity -I --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"import")
+			opts+=" --keyring= -k --keyfile= -f --keydata= -d --identity= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keyfile -f --keydata -d --identity -i --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"export")
+			opts+=" --keyring= -k --keyfile= -f --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keyfile -f --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"revoke")
+			opts+=" --keyring= -k --keytype= -t --identity= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --keyring -k --keytype -t --identity -i --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
+plugin_lm_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"create-cdq")
+			opts+=" --size= -s --cntlid= -c --queue-type= -q --consent --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --size -s --cntlid -c --queue-type -q --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"delete-cdq")
+			opts+=" --cdqid= -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --cdqid -C --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"track-send")
+			opts+=" --sel= -s --mos= -m --cdqid= -C --start --stop --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --mos -m --cdqid -C --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"migration-send")
+			opts+=" --sel= -s --cntlid= -c --stype= -t --dudmq -d --seq-ind= -S --csuuidi= -U --csvi= -V --uidx= -u --offset= -O --numd= -n --input-file= -f --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --cntlid -c --stype -t --seq-ind -S --csuuidi -U --csvi -V --uidx -u --offset -O --numd -n --input-file -f --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--input-file -f"
+			;;
+
+		"migration-recv")
+			opts+=" --sel= -s --cntlid= -c --csuuidi= -U --csvi= -V --uidx= -u --offset= -O --numd= -n --output-file= -f --human-readable -H --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --cntlid -c --csuuidi -U --csvi -V --uidx -u --offset -O --numd -n --output-file -f --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--output-file -f"
+			;;
+
+		"set-cdq")
+			opts+=" --cdqid= -C --hp= -H --tpt= -T --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --cdqid -C --hp -H --tpt -T --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-cdq")
+			opts+=" --cdqid= -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --cdqid -C --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
 plugin_log_opts () {
 	local opts=""
 	local valopts=""
@@ -1793,6 +2201,14 @@ plugin_log_opts () {
 	local wantfiles=0
 	_nvme_detect_value_completion
 	case "$1" in
+		"supported-pages")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
 		"smart")
 			opts+=" --namespace-id= -n --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
 			valopts+=" --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
@@ -2436,6 +2852,31 @@ plugin_micron_opts () {
 	_nvme_finish_completion "$1" 3
 }
 
+plugin_nbft_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"show")
+			opts+=" --subsystem -s --hfi -H --discovery -d --nbft-path= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --nbft-path --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
 plugin_netapp_opts () {
 	local opts=""
 	local valopts=""
@@ -2581,6 +3022,326 @@ plugin_nvme_mi_opts () {
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
 			_nvme_opt_files "--input-file -i"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
+plugin_ocp_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"smart-add-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"latency-monitor-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"set-latency-monitor-feature")
+			opts+=" --active_bucket_timer_threshold= -t --active_threshold_a= -a --active_threshold_b= -b --active_threshold_c= -c --active_threshold_d= -d --active_latency_config= -f --active_latency_minimum_window= -w --debug_log_trigger_enable= -r --discard_debug_log= -l --latency_monitor_feature_enable= -e --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --active_bucket_timer_threshold -t --active_threshold_a -a --active_threshold_b -b --active_threshold_c -c --active_threshold_d -d --active_latency_config -f --active_latency_minimum_window -w --debug_log_trigger_enable -r --discard_debug_log -l --latency_monitor_feature_enable -e --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"internal-log")
+			opts+=" --telemetry-log= -l --string-log= -s --output-file= -f --data-area= -a --telemetry-type= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --telemetry-log -l --string-log -s --output-file -f --data-area -a --telemetry-type -t --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--output-file -f"
+			;;
+
+		"clear-fw-activate-history")
+			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"eol-plp-failure-mode")
+			opts+=" --mode= -m --save -s --sel= -S --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --mode -m --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"clear-pcie-correctable-errors")
+			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"fw-activate-history")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"unsupported-reqs-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"error-recovery-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"device-capability-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"set-dssd-power-state-feature")
+			opts+=" --power-state= -p --save -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --power-state -p --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-dssd-power-state-feature")
+			opts+=" --sel= -S --all -a --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"set-plp-health-check-interval")
+			opts+=" --plp_health_interval= -p --save -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --plp_health_interval -p --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-plp-health-check-interval")
+			opts+=" --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"telemetry-string-log")
+			opts+=" --output-file= -f --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-file -f --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--output-file -f"
+			;;
+
+		"set-telemetry-profile")
+			opts+=" --telemetry-profile-select= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --telemetry-profile-select -t --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"set-dssd-async-event-config")
+			opts+=" --enable-panic-notices -e --save -s --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-dssd-async-event-config")
+			opts+=" --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -S" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"tcg-configuration-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-error-injection")
+			opts+=" --sel= -s --no-uuid -n --all-ns -a --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"set-error-injection")
+			opts+=" --data= -d --number= -n --no-uuid -N --all-ns -a --type= -t --nrtdp= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --data -d --number -n --type -t --nrtdp -r --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--data -d"
+			;;
+
+		"get-enable-ieee1667-silo")
+			opts+=" --sel= -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"set-enable-ieee1667-silo")
+			opts+=" --enable -e --save -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"hardware-component-log")
+			opts+=" --comp-id= -i --list -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --comp-id -i --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--comp-id -i" "asic nand dram pmic pcb cap reg case sn country hw-rev born-on-date vendor" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-latency-monitor")
+			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-clear-pcie-correctable-errors")
+			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-telemetry-profile")
+			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"persistent-event-log")
+			opts+=" --action= -a --log_len= -l --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --action -a --log_len -l --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"get-idle-wakeup-time")
+			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--sel -s" "0 1 2 3" \
+			               "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
+plugin_registry_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"list")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"retrieve")
+			opts+=" --attr= -a --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --attr -a --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"update")
+			opts+=" --attr= -a --value= -V --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --attr -a --value -V --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"delete")
+			opts+=" --attr= -a --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --attr -a --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
 			;;
 	esac
 	_nvme_finish_completion "$1" 3
@@ -3122,6 +3883,43 @@ plugin_security_opts () {
 	_nvme_finish_completion "$1" 3
 }
 
+plugin_sed_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"discover"|"1")
+			opts+=" --verbose -V --udev -u"
+			;;
+
+		"initialize")
+			opts+=" --read-only -r"
+			;;
+
+		"revert")
+			opts+=" --destructive -e --psid -p"
+			;;
+
+		"lock")
+			opts+=" --read-only -r --ask-key -k"
+			;;
+
+		"unlock")
+			opts+=" --read-only -r --ask-key -k"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
 plugin_shannon_opts () {
 	local opts=""
 	local valopts=""
@@ -3165,6 +3963,153 @@ plugin_shannon_opts () {
 		"id-ctrl")
 			opts+=" --vendor-specific -V --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
 			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+	esac
+	_nvme_finish_completion "$1" 3
+}
+
+plugin_solidigm_opts () {
+	local opts=""
+	local valopts=""
+	local vals=""
+	local opt=""
+	local val=""
+
+	opts+=" "
+	vals+=" "
+
+	local completing_value=0
+	local wantfiles=0
+	_nvme_detect_value_completion
+	case "$1" in
+		"id-ctrl")
+			opts+=" --vendor-specific -V --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"smart-log-add")
+			opts+=" --namespace-id= -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"vs-smart-add-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"vs-internal-log")
+			opts+=" --type= -t --dir-name= -d --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --type -t --dir-name -d --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--dir-name -d"
+			;;
+
+		"garbage-collect-log")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"market-log")
+			opts+=" --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"latency-tracking-log")
+			opts+=" --enable -e --disable -d --read -r --write -w --type= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --type -t --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"parse-telemetry-log")
+			opts+=" --host-generate= -g --controller-init -c --data-area= -d --config-file= -j --source-file= -s --jq-filter= -q --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --host-generate -g --data-area -d --config-file -j --source-file -s --jq-filter -q --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			_nvme_opt_files "--config-file -j" "--source-file -s"
+			;;
+
+		"clear-pcie-correctable-errors")
+			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"clear-fw-activate-history")
+			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"vs-fw-activate-history")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"log-page-directory")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"temp-stats")
+			opts+=" --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"vs-drive-info")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"cloud-SSDplugin-version")
+			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --output-format -o --timeout --output-format-version --set-options"
+
+			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
+			               "--output-format-version" "1 2"
+			;;
+
+		"workload-tracker")
+			opts+=" --uuid-index= -U --enable -e --disable -d --sample-time= -s --type= -t --run-time= -r --flush-freq= -f --wall-clock -w --trigger-field= -T --trigger-threshold= -V --trigger-on-delta -D --trigger-on-latency -L --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
+			valopts+=" --uuid-index -U --sample-time -s --type -t --run-time -r --flush-freq -f --trigger-field -T --trigger-threshold -V --output-format -o --timeout --output-format-version --set-options"
 
 			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
 			               "--output-format-version" "1 2"
@@ -3808,954 +4753,20 @@ plugin_zns_opts () {
 	_nvme_finish_completion "$1" 3
 }
 
-plugin_nbft_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"show")
-			opts+=" --subsystem -s --hfi -H --discovery -d --nbft-path= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --nbft-path --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_keys_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"gen-kxchap-secret")
-			opts+=" --secret= -s --secret-length= -l --hmac= -m --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --secret -s --secret-length -l --hmac -m --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"check-kxchap-secret")
-			opts+=" --keydata= -d --keyring= -k --keytype= -t --identity= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keydata -d --keyring -k --keytype -t --identity -i --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"gen-tls")
-			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --secret= -s --keyfile= -f --hmac= -m --identity= -I --insert -i --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --secret -s --keyfile -f --hmac -m --identity -I --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"check-tls")
-			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --keydata= -d --identity= -I --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --keydata -d --identity -I --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"insert-tls")
-			opts+=" --keyring= -k --keytype= -t --hostnqn= -n --subsysnqn= -c --keydata= -d --keyfile= -f --identity= -I --compat -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keytype -t --hostnqn -n --subsysnqn -c --keydata -d --keyfile -f --identity -I --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"import")
-			opts+=" --keyring= -k --keyfile= -f --keydata= -d --identity= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keyfile -f --keydata -d --identity -i --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"export")
-			opts+=" --keyring= -k --keyfile= -f --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keyfile -f --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"revoke")
-			opts+=" --keyring= -k --keytype= -t --identity= -i --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --keyring -k --keytype -t --identity -i --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_exclusion_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"create")
-			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"delete")
-			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"edit")
-			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"list")
-			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"add")
-			opts+=" --name= -N --entry= -e --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --name -N --entry -e --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"remove")
-			opts+=" --name= -N --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --name -N --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_registry_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"list")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"retrieve")
-			opts+=" --attr= -a --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --attr -a --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"update")
-			opts+=" --attr= -a --value= -V --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --attr -a --value -V --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"delete")
-			opts+=" --attr= -a --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --attr -a --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_config_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"validate")
-			opts+=" --config= -J"
-			valopts+=" --config -J"
-
-			_nvme_opt_files "--config -J"
-			;;
-
-		"show")
-			opts+=" --config= -J --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --config -J --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--config -J"
-			;;
-
-		"convert")
-			opts+=" --config= -J --output= -o --force"
-			valopts+=" --config -J --output -o"
-
-			_nvme_opt_files "--config -J" "--output -o"
-			;;
-
-		"create")
-			opts+=" --transport= -t --nqn= -n --traddr= -a --trsvcid= -s --host-traddr= -w --host-iface= -f --hostnqn= -q --hostid= -I --kxchap-secret= -S --kxchap-ctrl-secret= -C --keyring= --tls-key= --tls-key-identity= --nr-io-queues= -i --nr-write-queues= -W --nr-poll-queues= -P --queue-size= -Q --keep-alive-tmo= -k --reconnect-delay= -c --ctrl-loss-tmo= -l --fast_io_fail_tmo= -F --tos= -T --tls_key= --duplicate-connect -D --disable-sqflow --hdr-digest -g --data-digest -G --tls --concat --discovery --persistent= --host-symname= --output= --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --transport -t --nqn -n --traddr -a --trsvcid -s --host-traddr -w --host-iface -f --hostnqn -q --hostid -I --kxchap-secret -S --kxchap-ctrl-secret -C --keyring --tls-key --tls-key-identity --nr-io-queues -i --nr-write-queues -W --nr-poll-queues -P --queue-size -Q --keep-alive-tmo -k --reconnect-delay -c --ctrl-loss-tmo -l --fast_io_fail_tmo -F --tos -T --tls_key --persistent --host-symname --output --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--output"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_feat_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"arbitration")
-			opts+=" --ab= -a --lpw= -l --mpw= -m --hpw= -H --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --ab -a --lpw -l --mpw -m --hpw -H --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"power-mgmt")
-			opts+=" --ps= -p --wh= -w --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --ps -p --wh -w --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"temp-thresh")
-			opts+=" --tmpth= -T --tmpsel= -m --thsel= -H --tmpthh= -M --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --tmpth -T --tmpsel -m --thsel -H --tmpthh -M --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"volatile-wc")
-			opts+=" --wce -w --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"num-queues")
-			opts+=" --nsqr= -n --ncqr= -c --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --nsqr -n --ncqr -c --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"timestamp")
-			opts+=" --tstmp= -t --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --tstmp -t --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"hctm")
-			opts+=" --tmt1= -t --tmt2= -T --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --tmt1 -t --tmt2 -T --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"host-behavior-support")
-			opts+=" --acre= -a --etdas= -e --lbafee= -l --hdisns= -H --cdfe= -c --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --acre -a --etdas -e --lbafee -l --hdisns -H --cdfe -c --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"perf-characteristics")
-			opts+=" --namespace-id= -n --attri= -a --rvspa -r --r4karl= -R --paid= -p --attrl= -A --vs-data= -V --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --attri -a --r4karl -R --paid -p --attrl -A --vs-data -V --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--vs-data -V"
-			;;
-
-		"power-limit")
-			opts+=" --plv= -p --pls= -l --uuid-index= -u --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --plv -p --pls -l --uuid-index -u --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"power-thresh")
-			opts+=" --ptv= -p --pts= -t --pmts= -m --ept= -e --uuid-index= -u --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --ptv -p --pts -t --pmts -m --ept -e --uuid-index -u --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"power-meas")
-			opts+=" --act= --pmts= --smt= --uuid-index= -u --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --act --pmts --smt --uuid-index -u --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"err-recovery")
-			opts+=" --nsid= -n --tler= -t --dulbe -d --save -s --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --nsid -n --tler -t --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_lm_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"create-cdq")
-			opts+=" --size= -s --cntlid= -c --queue-type= -q --consent --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --size -s --cntlid -c --queue-type -q --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"delete-cdq")
-			opts+=" --cdqid= -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --cdqid -C --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"track-send")
-			opts+=" --sel= -s --mos= -m --cdqid= -C --start --stop --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --mos -m --cdqid -C --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"migration-send")
-			opts+=" --sel= -s --cntlid= -c --stype= -t --dudmq -d --seq-ind= -S --csuuidi= -U --csvi= -V --uidx= -u --offset= -O --numd= -n --input-file= -f --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --cntlid -c --stype -t --seq-ind -S --csuuidi -U --csvi -V --uidx -u --offset -O --numd -n --input-file -f --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--input-file -f"
-			;;
-
-		"migration-recv")
-			opts+=" --sel= -s --cntlid= -c --csuuidi= -U --csvi= -V --uidx= -u --offset= -O --numd= -n --output-file= -f --human-readable -H --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --cntlid -c --csuuidi -U --csvi -V --uidx -u --offset -O --numd -n --output-file -f --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--output-file -f"
-			;;
-
-		"set-cdq")
-			opts+=" --cdqid= -C --hp= -H --tpt= -T --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --cdqid -C --hp -H --tpt -T --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-cdq")
-			opts+=" --cdqid= -C --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --cdqid -C --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_ocp_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"smart-add-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"latency-monitor-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"set-latency-monitor-feature")
-			opts+=" --active_bucket_timer_threshold= -t --active_threshold_a= -a --active_threshold_b= -b --active_threshold_c= -c --active_threshold_d= -d --active_latency_config= -f --active_latency_minimum_window= -w --debug_log_trigger_enable= -r --discard_debug_log= -l --latency_monitor_feature_enable= -e --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --active_bucket_timer_threshold -t --active_threshold_a -a --active_threshold_b -b --active_threshold_c -c --active_threshold_d -d --active_latency_config -f --active_latency_minimum_window -w --debug_log_trigger_enable -r --discard_debug_log -l --latency_monitor_feature_enable -e --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"internal-log")
-			opts+=" --telemetry-log= -l --string-log= -s --output-file= -f --data-area= -a --telemetry-type= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --telemetry-log -l --string-log -s --output-file -f --data-area -a --telemetry-type -t --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--output-file -f"
-			;;
-
-		"clear-fw-activate-history")
-			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"eol-plp-failure-mode")
-			opts+=" --mode= -m --save -s --sel= -S --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --mode -m --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"clear-pcie-correctable-errors")
-			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"fw-activate-history")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"unsupported-reqs-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"error-recovery-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"device-capability-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"set-dssd-power-state-feature")
-			opts+=" --power-state= -p --save -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --power-state -p --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-dssd-power-state-feature")
-			opts+=" --sel= -S --all -a --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"set-plp-health-check-interval")
-			opts+=" --plp_health_interval= -p --save -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --plp_health_interval -p --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-plp-health-check-interval")
-			opts+=" --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"telemetry-string-log")
-			opts+=" --output-file= -f --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-file -f --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--output-file -f"
-			;;
-
-		"set-telemetry-profile")
-			opts+=" --telemetry-profile-select= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --telemetry-profile-select -t --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"set-dssd-async-event-config")
-			opts+=" --enable-panic-notices -e --save -s --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-dssd-async-event-config")
-			opts+=" --sel= -S --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -S --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -S" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"tcg-configuration-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-error-injection")
-			opts+=" --sel= -s --no-uuid -n --all-ns -a --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"set-error-injection")
-			opts+=" --data= -d --number= -n --no-uuid -N --all-ns -a --type= -t --nrtdp= -r --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --data -d --number -n --type -t --nrtdp -r --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--data -d"
-			;;
-
-		"get-enable-ieee1667-silo")
-			opts+=" --sel= -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"set-enable-ieee1667-silo")
-			opts+=" --enable -e --save -s --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"hardware-component-log")
-			opts+=" --comp-id= -i --list -l --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --comp-id -i --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--comp-id -i" "asic nand dram pmic pcb cap reg case sn country hw-rev born-on-date vendor" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-latency-monitor")
-			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-clear-pcie-correctable-errors")
-			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-telemetry-profile")
-			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"persistent-event-log")
-			opts+=" --action= -a --log_len= -l --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --action -a --log_len -l --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"get-idle-wakeup-time")
-			opts+=" --sel= -s --namespace-id= -n --no-uuid -u --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --sel -s --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--sel -s" "0 1 2 3" \
-			               "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_sed_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"discover"|"1")
-			opts+=" --verbose -V --udev -u"
-			;;
-
-		"initialize")
-			opts+=" --read-only -r"
-			;;
-
-		"revert")
-			opts+=" --destructive -e --psid -p"
-			;;
-
-		"lock")
-			opts+=" --read-only -r --ask-key -k"
-			;;
-
-		"unlock")
-			opts+=" --read-only -r --ask-key -k"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
-plugin_solidigm_opts () {
-	local opts=""
-	local valopts=""
-	local vals=""
-	local opt=""
-	local val=""
-
-	opts+=" "
-	vals+=" "
-
-	local completing_value=0
-	local wantfiles=0
-	_nvme_detect_value_completion
-	case "$1" in
-		"id-ctrl")
-			opts+=" --vendor-specific -V --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"smart-log-add")
-			opts+=" --namespace-id= -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --namespace-id -n --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"vs-smart-add-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"vs-internal-log")
-			opts+=" --type= -t --dir-name= -d --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --type -t --dir-name -d --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--dir-name -d"
-			;;
-
-		"garbage-collect-log")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"market-log")
-			opts+=" --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"latency-tracking-log")
-			opts+=" --enable -e --disable -d --read -r --write -w --type= -t --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --type -t --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"parse-telemetry-log")
-			opts+=" --host-generate= -g --controller-init -c --data-area= -d --config-file= -j --source-file= -s --jq-filter= -q --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --host-generate -g --data-area -d --config-file -j --source-file -s --jq-filter -q --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			_nvme_opt_files "--config-file -j" "--source-file -s"
-			;;
-
-		"clear-pcie-correctable-errors")
-			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"clear-fw-activate-history")
-			opts+=" --no-uuid -n --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"vs-fw-activate-history")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"log-page-directory")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"temp-stats")
-			opts+=" --raw-binary -b --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"vs-drive-info")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"cloud-SSDplugin-version")
-			opts+=" --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-
-		"workload-tracker")
-			opts+=" --uuid-index= -U --enable -e --disable -d --sample-time= -s --type= -t --run-time= -r --flush-freq= -f --wall-clock -w --trigger-field= -T --trigger-threshold= -V --trigger-on-delta -D --trigger-on-latency -L --verbose -v --quiet --output-format= -o --timeout= --dry-run --no-retries --no-ioctl-probing --output-format-version= --set-options="
-			valopts+=" --uuid-index -U --sample-time -s --type -t --run-time -r --flush-freq -f --trigger-field -T --trigger-threshold -V --output-format -o --timeout --output-format-version --set-options"
-
-			_nvme_opt_vals "--output-format -o" "normal json binary tabular" \
-			               "--output-format-version" "1 2"
-			;;
-	esac
-	_nvme_finish_completion "$1" 3
-}
-
 _nvme_subcmds () {
 	local cur prev words cword
 	_init_completion || return
 
 	typeset -Ar _plugin_subcmds=(
 		[amzn]="id-ctrl stats"
+		[config]="validate show status convert create"
 		[dapustor]="smart-log-add"
 		[dell]="id-ctrl"
 		[dera]="smart-log-add stat"
 		[dir]="receive send"
+		[exclusion]="create delete edit list add remove"
 		[fdp]="configs usage stats events status update set-events feature"
+		[feat]="arbitration power-mgmt temp-thresh volatile-wc num-queues timestamp hctm host-behavior-support perf-characteristics power-limit power-thresh power-meas err-recovery"
 		[fw]="download commit activate"
 		[huawei]="list id-ctrl"
 		[ibm]="crit-log vpd persist-event-log"
@@ -4764,20 +4775,27 @@ _nvme_subcmds () {
 		[inspur]="nvme-vendor-log"
 		[intel]="id-ctrl internal-log lat-stats set-bucket-thresholds lat-stats-tracking market-name smart-log-add temp-stats"
 		[io-mgmt]="recv send"
-		[log]="smart ana telemetry fw endurance effects error changed-ns-list changed-alloc-ns-list predictable-lat pred-lat-event-agg persistent-event endurance-event-agg lba-status resv-notif boot-part phy-rx-eom self-test fid-support-effects mi-cmd-support-effects media-unit-stat supported-cap-config mgmt-addr-list rotational-media-info dispersed-ns-participating-nss reachability-groups reachability-associations host-discovery ave-discovery pull-model-ddc-req power-measurement sanitize"
+		[keys]="gen-kxchap-secret check-kxchap-secret gen-tls check-tls insert-tls import export revoke"
+		[lm]="create-cdq delete-cdq track-send migration-send migration-recv set-cdq get-cdq"
+		[log]="supported-pages smart ana telemetry fw endurance effects error changed-ns-list changed-alloc-ns-list predictable-lat pred-lat-event-agg persistent-event endurance-event-agg lba-status resv-notif boot-part phy-rx-eom self-test fid-support-effects mi-cmd-support-effects media-unit-stat supported-cap-config mgmt-addr-list rotational-media-info dispersed-ns-participating-nss reachability-groups reachability-associations host-discovery ave-discovery pull-model-ddc-req power-measurement sanitize"
 		[mangoboost]="id-ctrl"
 		[memblaze]="smart-log-add get-pm-status set-pm-status select-download lat-stats lat-stats-print lat-log lat-log-print clear-error-log smart-log-add-x lat-set-feature-x lat-get-feature-x lat-stats-print-x lat-log-print-x perf-stats-print-x"
 		[micron]="select-download vs-temperature-stats vs-pcie-stats clear-pcie-correctable-errors vs-internal-log vs-telemetry-controller-option vs-nand-stats vs-smart-ext-log vs-drive-info plugin-version cloud-SSD-plugin-version log-page-directory vs-fw-activate-history latency-tracking latency-stats latency-logs vs-smart-add-log clear-fw-activate-history vs-smbus-option cloud-boot-SSD-version vs-device-waf vs-cloud-log vs-work-load-log vs-vendor-telemetry-log smart-log id-ctrl"
+		[nbft]="show"
 		[netapp]="smdevices ontapdevices"
 		[ns]="create delete attach detach get-id"
 		[nvidia]="id-ctrl"
 		[nvme-mi]="recv send"
+		[ocp]="smart-add-log latency-monitor-log set-latency-monitor-feature internal-log clear-fw-activate-history eol-plp-failure-mode clear-pcie-correctable-errors fw-activate-history unsupported-reqs-log error-recovery-log device-capability-log set-dssd-power-state-feature get-dssd-power-state-feature set-plp-health-check-interval get-plp-health-check-interval telemetry-string-log set-telemetry-profile set-dssd-async-event-config get-dssd-async-event-config tcg-configuration-log get-error-injection set-error-injection get-enable-ieee1667-silo set-enable-ieee1667-silo hardware-component-log get-latency-monitor get-clear-pcie-correctable-errors get-telemetry-profile persistent-event-log get-idle-wakeup-time"
+		[registry]="list retrieve update delete"
 		[resv]="acquire register release report"
 		[sndk]="vs-internal-log vs-nand-stats vs-smart-add-log clear-pcie-correctable-errors get-drive-status clear-assert-dump drive-resize vs-fw-activate-history clear-fw-activate-history vs-telemetry-controller-option vs-error-reason-identifier log-page-directory namespace-resize vs-drive-info vs-temperature-stats capabilities cloud-SSD-plugin-version vs-pcie-stats get-latency-monitor-log get-error-recovery-log get-dev-capabilities-log get-unsupported-reqs-log cloud-boot-SSD-version vs-cloud-log vs-hw-rev-log vs-device-waf set-latency-monitor-feature cu-smart-log"
 		[sfx]="smart-log-add lat-stats get-bad-block query-cap change-cap set-feature get-feature dump-evtlog expand-cap status"
 		[seagate]="vs-temperature-stats vs-log-page-sup vs-smart-add-log vs-pcie-stats clear-pcie-correctable-errors get-host-tele get-ctrl-tele vs-internal-log vs-fw-activate-history clear-fw-activate-history plugin-version cloud-SSD-plugin-version"
 		[security]="send recv"
+		[sed]="discover 1 initialize revert lock unlock password"
 		[shannon]="smart-log-add set-additioal-feature get-additional-feature id-ctrl"
+		[solidigm]="id-ctrl smart-log-add vs-smart-add-log vs-internal-log garbage-collect-log market-log latency-tracking-log parse-telemetry-log clear-pcie-correctable-errors clear-fw-activate-history vs-fw-activate-history log-page-directory temp-stats vs-drive-info cloud-SSDplugin-version workload-tracker"
 		[ssstc]="smart-log-add"
 		[toshiba]="vs-smart-add-log vs-internal-log clear-pcie-correctable-errors"
 		[transcend]="healthvalue badblock"
@@ -4786,25 +4804,18 @@ _nvme_subcmds () {
 		[wdc]="cap-diag drive-log get-crash-dump get-pfail-dump id-ctrl purge purge-monitor vs-internal-log vs-nand-stats vs-smart-add-log clear-pcie-correctable-errors drive-essentials get-drive-status clear-assert-dump drive-resize vs-fw-activate-history clear-fw-activate-history enc-get-log vs-telemetry-controller-option vs-error-reason-identifier log-page-directory namespace-resize vs-drive-info vs-temperature-stats capabilities cloud-SSD-plugin-version vs-pcie-stats get-latency-monitor-log get-error-recovery-log get-dev-capabilities-log get-unsupported-reqs-log cloud-boot-SSD-version vs-cloud-log vs-hw-rev-log vs-device-waf set-latency-monitor-feature cu-smart-log"
 		[ymtc]="smart-log-add"
 		[zns]="list id-ctrl id-ns report-zones reset-zone close-zone finish-zone open-zone offline-zone set-zone-desc zrwa-flush-zone changed-zone-list zone-mgmt-recv zone-mgmt-send zone-append"
-		[nbft]="show"
-		[keys]="gen-kxchap-secret check-kxchap-secret gen-tls check-tls insert-tls import export revoke"
-		[exclusion]="create delete edit list add remove"
-		[registry]="list retrieve update delete"
-		[config]="validate show status convert create"
-		[feat]="arbitration power-mgmt temp-thresh volatile-wc num-queues timestamp hctm host-behavior-support perf-characteristics power-limit power-thresh power-meas err-recovery"
-		[lm]="create-cdq delete-cdq track-send migration-send migration-recv set-cdq get-cdq"
-		[ocp]="smart-add-log latency-monitor-log set-latency-monitor-feature internal-log clear-fw-activate-history eol-plp-failure-mode clear-pcie-correctable-errors fw-activate-history unsupported-reqs-log error-recovery-log device-capability-log set-dssd-power-state-feature get-dssd-power-state-feature set-plp-health-check-interval get-plp-health-check-interval telemetry-string-log set-telemetry-profile set-dssd-async-event-config get-dssd-async-event-config tcg-configuration-log get-error-injection set-error-injection get-enable-ieee1667-silo set-enable-ieee1667-silo hardware-component-log get-latency-monitor get-clear-pcie-correctable-errors get-telemetry-profile persistent-event-log get-idle-wakeup-time"
-		[sed]="discover 1 initialize revert lock unlock password"
-		[solidigm]="id-ctrl smart-log-add vs-smart-add-log vs-internal-log garbage-collect-log market-log latency-tracking-log parse-telemetry-log clear-pcie-correctable-errors clear-fw-activate-history vs-fw-activate-history log-page-directory temp-stats vs-drive-info cloud-SSDplugin-version workload-tracker"
 	)
 
 	typeset -Ar _plugin_funcs=(
 		[amzn]="plugin_amzn_opts"
+		[config]="plugin_config_opts"
 		[dapustor]="plugin_dapustor_opts"
 		[dell]="plugin_dell_opts"
 		[dera]="plugin_dera_opts"
 		[dir]="plugin_dir_opts"
+		[exclusion]="plugin_exclusion_opts"
 		[fdp]="plugin_fdp_opts"
+		[feat]="plugin_feat_opts"
 		[fw]="plugin_fw_opts"
 		[huawei]="plugin_huawei_opts"
 		[ibm]="plugin_ibm_opts"
@@ -4813,20 +4824,27 @@ _nvme_subcmds () {
 		[inspur]="plugin_inspur_opts"
 		[intel]="plugin_intel_opts"
 		[io-mgmt]="plugin_io_mgmt_opts"
+		[keys]="plugin_keys_opts"
+		[lm]="plugin_lm_opts"
 		[log]="plugin_log_opts"
 		[mangoboost]="plugin_mangoboost_opts"
 		[memblaze]="plugin_memblaze_opts"
 		[micron]="plugin_micron_opts"
+		[nbft]="plugin_nbft_opts"
 		[netapp]="plugin_netapp_opts"
 		[ns]="plugin_ns_opts"
 		[nvidia]="plugin_nvidia_opts"
 		[nvme-mi]="plugin_nvme_mi_opts"
+		[ocp]="plugin_ocp_opts"
+		[registry]="plugin_registry_opts"
 		[resv]="plugin_resv_opts"
 		[sndk]="plugin_sndk_opts"
 		[sfx]="plugin_sfx_opts"
 		[seagate]="plugin_seagate_opts"
 		[security]="plugin_security_opts"
+		[sed]="plugin_sed_opts"
 		[shannon]="plugin_shannon_opts"
+		[solidigm]="plugin_solidigm_opts"
 		[ssstc]="plugin_ssstc_opts"
 		[toshiba]="plugin_toshiba_opts"
 		[transcend]="plugin_transcend_opts"
@@ -4835,48 +4853,38 @@ _nvme_subcmds () {
 		[wdc]="plugin_wdc_opts"
 		[ymtc]="plugin_ymtc_opts"
 		[zns]="plugin_zns_opts"
-		[nbft]="plugin_nbft_opts"
-		[keys]="plugin_keys_opts"
-		[exclusion]="plugin_exclusion_opts"
-		[registry]="plugin_registry_opts"
-		[config]="plugin_config_opts"
-		[feat]="plugin_feat_opts"
-		[lm]="plugin_lm_opts"
-		[ocp]="plugin_ocp_opts"
-		[sed]="plugin_sed_opts"
-		[solidigm]="plugin_solidigm_opts"
 	)
 
 	local -a _cmds=(
-		list list-subsys id-ctrl id-ns id-ns-granularity id-ns-lba-format
-		list-ns list-ctrl nvm-id-ctrl nvm-id-ns nvm-id-ns-lba-format
-		primary-ctrl-caps list-secondary cmdset-ind-id-ns ns-descs id-nvmset
-		id-uuid id-iocs id-domain list-endgrp create-ns delete-ns attach-ns
-		detach-ns get-ns-id get-log telemetry-log fw-log changed-ns-list-log
+		list list-subsys show-topology top reset subsystem-reset ns-rescan
+		virt-mgmt id-ctrl id-ns id-ns-granularity id-ns-lba-format list-ns
+		list-ctrl nvm-id-ctrl nvm-id-ns nvm-id-ns-lba-format primary-ctrl-caps
+		list-secondary cmdset-ind-id-ns ns-descs id-nvmset id-uuid id-iocs
+		id-domain list-endgrp create-ns delete-ns attach-ns detach-ns
+		get-ns-id supported-log-pages telemetry-log fw-log changed-ns-list-log
 		smart-log ana-log error-log effects-log endurance-log
 		predictable-lat-log pred-lat-event-agg-log persistent-event-log
 		endurance-event-agg-log lba-status-log resv-notif-log boot-part-log
-		phy-rx-eom-log get-feature device-self-test self-test-log
-		supported-log-pages fid-support-effects-log mi-cmd-support-effects-log
-		media-unit-stat-log supported-cap-config-log mgmt-addr-list-log
-		rotational-media-info-log changed-alloc-ns-list-log
-		dispersed-ns-participating-nss-log reachability-groups-log
-		reachability-associations-log host-discovery-log ave-discovery-log
-		pull-model-ddc-req-log power-measurement-log set-feature set-property
-		get-property format fw-commit fw-activate fw-download admin-passthru
-		io-passthru security-send security-recv get-lba-status capacity-mgmt
-		resv-acquire resv-register resv-release resv-report dsm copy flush
-		compare read write write-zeroes write-uncor verify sanitize
-		sanitize-log sanitize-ns reset subsystem-reset ns-rescan show-regs
-		set-reg get-reg top discover connect-all connect disconnect
-		disconnect-all dim gen-hostnqn show-hostnqn gen-dhchap-key
-		check-dhchap-key gen-tls-key check-tls-key tls-key dir-receive
-		dir-send virt-mgmt rpmb lockdown show-topology io-mgmt-recv
-		io-mgmt-send nvme-mi-recv nvme-mi-send amzn dapustor dell dera dir fdp
-		fw huawei ibm id innogrit inspur intel io-mgmt log mangoboost memblaze
-		micron netapp ns nvidia nvme-mi resv sndk sfx seagate security shannon
-		ssstc toshiba transcend utils virtium wdc ymtc zns nbft keys exclusion
-		registry config feat lm ocp sed solidigm help version
+		phy-rx-eom-log self-test-log fid-support-effects-log
+		mi-cmd-support-effects-log media-unit-stat-log
+		supported-cap-config-log mgmt-addr-list-log rotational-media-info-log
+		changed-alloc-ns-list-log dispersed-ns-participating-nss-log
+		reachability-groups-log reachability-associations-log
+		host-discovery-log ave-discovery-log pull-model-ddc-req-log
+		power-measurement-log fw-commit fw-activate fw-download security-send
+		security-recv resv-acquire resv-register resv-release resv-report
+		sanitize-log gen-dhchap-key check-dhchap-key gen-tls-key check-tls-key
+		tls-key dir-receive dir-send io-mgmt-recv io-mgmt-send nvme-mi-recv
+		nvme-mi-send get-log discover connect-all connect disconnect
+		disconnect-all dim gen-hostnqn show-hostnqn get-feature set-feature
+		dsm copy flush compare read write write-zeroes write-uncor verify
+		get-lba-status capacity-mgmt admin-passthru io-passthru show-regs
+		set-reg get-reg set-property get-property device-self-test sanitize
+		sanitize-ns format rpmb lockdown amzn config dapustor dell dera dir
+		exclusion fdp feat fw huawei ibm id innogrit inspur intel io-mgmt keys
+		lm log mangoboost memblaze micron nbft netapp ns nvidia nvme-mi ocp
+		registry resv sndk sfx seagate security sed shannon solidigm ssstc
+		toshiba transcend utils virtium wdc ymtc zns help version
 	)
 
 	local func subcmd

--- a/completions/nvme-completion.ps1
+++ b/completions/nvme-completion.ps1
@@ -15,8 +15,13 @@ $script:NvmeCommands = @(
     'capacity-mgmt'
     'changed-alloc-ns-list-log'
     'changed-ns-list-log'
+    'check-dhchap-key'
+    'check-tls-key'
     'cmdset-ind-id-ns'
     'compare'
+    'config'
+    'connect'
+    'connect-all'
     'copy'
     'create-ns'
     'dapustor'
@@ -25,15 +30,20 @@ $script:NvmeCommands = @(
     'dera'
     'detach-ns'
     'device-self-test'
+    'dim'
     'dir'
     'dir-receive'
     'dir-send'
+    'disconnect'
+    'disconnect-all'
+    'discover'
     'dispersed-ns-participating-nss-log'
     'dsm'
     'effects-log'
     'endurance-event-agg-log'
     'endurance-log'
     'error-log'
+    'exclusion'
     'fdp'
     'feat'
     'fid-support-effects-log'
@@ -44,6 +54,9 @@ $script:NvmeCommands = @(
     'fw-commit'
     'fw-download'
     'fw-log'
+    'gen-dhchap-key'
+    'gen-hostnqn'
+    'gen-tls-key'
     'get-feature'
     'get-lba-status'
     'get-log'
@@ -52,6 +65,7 @@ $script:NvmeCommands = @(
     'get-reg'
     'help'
     'host-discovery-log'
+    'huawei'
     'ibm'
     'id'
     'id-ctrl'
@@ -69,6 +83,7 @@ $script:NvmeCommands = @(
     'io-mgmt-recv'
     'io-mgmt-send'
     'io-passthru'
+    'keys'
     'lba-status-log'
     'list'
     'list-ctrl'
@@ -76,6 +91,7 @@ $script:NvmeCommands = @(
     'list-ns'
     'list-secondary'
     'list-subsys'
+    'lm'
     'lockdown'
     'log'
     'mangoboost'
@@ -84,6 +100,8 @@ $script:NvmeCommands = @(
     'mgmt-addr-list-log'
     'mi-cmd-support-effects-log'
     'micron'
+    'nbft'
+    'netapp'
     'ns'
     'ns-descs'
     'ns-rescan'
@@ -105,6 +123,7 @@ $script:NvmeCommands = @(
     'reachability-associations-log'
     'reachability-groups-log'
     'read'
+    'registry'
     'reset'
     'resv'
     'resv-acquire'
@@ -121,20 +140,26 @@ $script:NvmeCommands = @(
     'security'
     'security-recv'
     'security-send'
+    'sed'
     'self-test-log'
     'set-feature'
     'set-property'
     'set-reg'
+    'sfx'
     'shannon'
+    'show-hostnqn'
     'show-regs'
     'show-topology'
     'smart-log'
+    'sndk'
     'solidigm'
     'ssstc'
     'subsystem-reset'
     'supported-cap-config-log'
     'supported-log-pages'
     'telemetry-log'
+    'tls-key'
+    'top'
     'toshiba'
     'transcend'
     'utils'
@@ -142,46 +167,61 @@ $script:NvmeCommands = @(
     'version'
     'virt-mgmt'
     'virtium'
+    'wdc'
     'write'
     'write-uncor'
     'write-zeroes'
     'ymtc'
+    'zns'
 )
 
 $script:NvmePluginCommands = @{
     'amzn' = @('id-ctrl', 'stats')
+    'config' = @('convert', 'create', 'show', 'status', 'validate')
     'dapustor' = @('smart-log-add')
     'dell' = @('id-ctrl')
     'dera' = @('smart-log-add', 'stat')
     'dir' = @('receive', 'send')
+    'exclusion' = @('add', 'create', 'delete', 'edit', 'list', 'remove')
     'fdp' = @('configs', 'events', 'feature', 'set-events', 'stats', 'status', 'update', 'usage')
     'feat' = @('arbitration', 'err-recovery', 'hctm', 'host-behavior-support', 'num-queues', 'perf-characteristics', 'power-limit', 'power-meas', 'power-mgmt', 'power-thresh', 'temp-thresh', 'timestamp', 'volatile-wc')
     'fw' = @('activate', 'commit', 'download')
+    'huawei' = @('id-ctrl', 'list')
     'ibm' = @('crit-log', 'persist-event-log', 'vpd')
     'id' = @('ctrl', 'ctrl-list', 'domain', 'endgrp-list', 'iocs', 'ns', 'ns-descs', 'ns-granularity', 'ns-ind', 'ns-lba-format', 'ns-list', 'nvm-ctrl', 'nvm-ns', 'nvm-ns-lba-format', 'nvmset', 'primary-ctrl-caps', 'secondary-ctrl-list', 'uuid')
     'innogrit' = @('get-cdump', 'get-eventlog')
     'inspur' = @('nvme-vendor-log')
     'intel' = @('id-ctrl', 'internal-log', 'lat-stats', 'lat-stats-tracking', 'market-name', 'set-bucket-thresholds', 'smart-log-add', 'temp-stats')
     'io-mgmt' = @('recv', 'send')
-    'log' = @('ana', 'ave-discovery', 'boot-part', 'changed-alloc-ns-list', 'changed-ns-list', 'dispersed-ns-participating-nss', 'effects', 'endurance', 'endurance-event-agg', 'error', 'fid-support-effects', 'fw', 'host-discovery', 'lba-status', 'media-unit-stat', 'mgmt-addr-list', 'mi-cmd-support-effects', 'persistent-event', 'phy-rx-eom', 'power-measurement', 'pred-lat-event-agg', 'predictable-lat', 'pull-model-ddc-req', 'reachability-associations', 'reachability-groups', 'resv-notif', 'rotational-media-info', 'sanitize', 'self-test', 'smart', 'supported-cap-config', 'telemetry')
+    'keys' = @('check-kxchap-secret', 'check-tls', 'export', 'gen-kxchap-secret', 'gen-tls', 'import', 'insert-tls', 'revoke')
+    'lm' = @('create-cdq', 'delete-cdq', 'get-cdq', 'migration-recv', 'migration-send', 'set-cdq', 'track-send')
+    'log' = @('ana', 'ave-discovery', 'boot-part', 'changed-alloc-ns-list', 'changed-ns-list', 'dispersed-ns-participating-nss', 'effects', 'endurance', 'endurance-event-agg', 'error', 'fid-support-effects', 'fw', 'host-discovery', 'lba-status', 'media-unit-stat', 'mgmt-addr-list', 'mi-cmd-support-effects', 'persistent-event', 'phy-rx-eom', 'power-measurement', 'pred-lat-event-agg', 'predictable-lat', 'pull-model-ddc-req', 'reachability-associations', 'reachability-groups', 'resv-notif', 'rotational-media-info', 'sanitize', 'self-test', 'smart', 'supported-cap-config', 'supported-pages', 'telemetry')
     'mangoboost' = @('id-ctrl')
     'memblaze' = @('clear-error-log', 'get-pm-status', 'lat-get-feature-x', 'lat-log', 'lat-log-print', 'lat-log-print-x', 'lat-set-feature-x', 'lat-stats', 'lat-stats-print', 'lat-stats-print-x', 'perf-stats-print-x', 'select-download', 'set-pm-status', 'smart-log-add', 'smart-log-add-x')
     'micron' = @('clear-fw-activate-history', 'clear-pcie-correctable-errors', 'cloud-SSD-plugin-version', 'cloud-boot-SSD-version', 'id-ctrl', 'latency-logs', 'latency-stats', 'latency-tracking', 'log-page-directory', 'plugin-version', 'select-download', 'smart-log', 'vs-cloud-log', 'vs-device-waf', 'vs-drive-info', 'vs-fw-activate-history', 'vs-internal-log', 'vs-nand-stats', 'vs-pcie-stats', 'vs-smart-add-log', 'vs-smart-ext-log', 'vs-smbus-option', 'vs-telemetry-controller-option', 'vs-temperature-stats', 'vs-vendor-telemetry-log', 'vs-work-load-log')
+    'nbft' = @('show')
+    'netapp' = @('ontapdevices', 'smdevices')
     'ns' = @('attach', 'create', 'delete', 'detach', 'get-id')
     'nvidia' = @('id-ctrl')
     'nvme-mi' = @('recv', 'send')
     'ocp' = @('clear-fw-activate-history', 'clear-pcie-correctable-errors', 'device-capability-log', 'eol-plp-failure-mode', 'error-recovery-log', 'fw-activate-history', 'get-clear-pcie-correctable-errors', 'get-dssd-async-event-config', 'get-dssd-power-state-feature', 'get-enable-ieee1667-silo', 'get-error-injection', 'get-idle-wakeup-time', 'get-latency-monitor', 'get-plp-health-check-interval', 'get-telemetry-profile', 'hardware-component-log', 'internal-log', 'latency-monitor-log', 'persistent-event-log', 'set-dssd-async-event-config', 'set-dssd-power-state-feature', 'set-enable-ieee1667-silo', 'set-error-injection', 'set-latency-monitor-feature', 'set-plp-health-check-interval', 'set-telemetry-profile', 'smart-add-log', 'tcg-configuration-log', 'telemetry-string-log', 'unsupported-reqs-log')
+    'registry' = @('delete', 'list', 'retrieve', 'update')
     'resv' = @('acquire', 'register', 'release', 'report')
     'seagate' = @('clear-fw-activate-history', 'clear-pcie-correctable-errors', 'cloud-SSD-plugin-version', 'get-ctrl-tele', 'get-host-tele', 'plugin-version', 'vs-fw-activate-history', 'vs-internal-log', 'vs-log-page-sup', 'vs-pcie-stats', 'vs-smart-add-log', 'vs-temperature-stats')
     'security' = @('recv', 'send')
+    'sed' = @('1', 'discover', 'initialize', 'lock', 'password', 'revert', 'unlock')
+    'sfx' = @('change-cap', 'dump-evtlog', 'expand-cap', 'get-bad-block', 'get-feature', 'lat-stats', 'query-cap', 'set-feature', 'smart-log-add', 'status')
     'shannon' = @('get-additional-feature', 'id-ctrl', 'set-additioal-feature', 'smart-log-add')
+    'sndk' = @('capabilities', 'clear-assert-dump', 'clear-fw-activate-history', 'clear-pcie-correctable-errors', 'cloud-SSD-plugin-version', 'cloud-boot-SSD-version', 'cu-smart-log', 'drive-resize', 'get-dev-capabilities-log', 'get-drive-status', 'get-error-recovery-log', 'get-latency-monitor-log', 'get-unsupported-reqs-log', 'log-page-directory', 'namespace-resize', 'set-latency-monitor-feature', 'vs-cloud-log', 'vs-device-waf', 'vs-drive-info', 'vs-error-reason-identifier', 'vs-fw-activate-history', 'vs-hw-rev-log', 'vs-internal-log', 'vs-nand-stats', 'vs-pcie-stats', 'vs-smart-add-log', 'vs-telemetry-controller-option', 'vs-temperature-stats')
     'solidigm' = @('clear-fw-activate-history', 'clear-pcie-correctable-errors', 'cloud-SSDplugin-version', 'garbage-collect-log', 'id-ctrl', 'latency-tracking-log', 'log-page-directory', 'market-log', 'parse-telemetry-log', 'smart-log-add', 'temp-stats', 'vs-drive-info', 'vs-fw-activate-history', 'vs-internal-log', 'vs-smart-add-log', 'workload-tracker')
     'ssstc' = @('smart-log-add')
     'toshiba' = @('clear-pcie-correctable-errors', 'vs-internal-log', 'vs-smart-add-log')
     'transcend' = @('badblock', 'healthvalue')
     'utils' = @('dump-command-metadata')
     'virtium' = @('save-smart-to-vtview-log', 'show-identify')
+    'wdc' = @('cap-diag', 'capabilities', 'clear-assert-dump', 'clear-fw-activate-history', 'clear-pcie-correctable-errors', 'cloud-SSD-plugin-version', 'cloud-boot-SSD-version', 'cu-smart-log', 'drive-essentials', 'drive-log', 'drive-resize', 'enc-get-log', 'get-crash-dump', 'get-dev-capabilities-log', 'get-drive-status', 'get-error-recovery-log', 'get-latency-monitor-log', 'get-pfail-dump', 'get-unsupported-reqs-log', 'id-ctrl', 'log-page-directory', 'namespace-resize', 'purge', 'purge-monitor', 'set-latency-monitor-feature', 'vs-cloud-log', 'vs-device-waf', 'vs-drive-info', 'vs-error-reason-identifier', 'vs-fw-activate-history', 'vs-hw-rev-log', 'vs-internal-log', 'vs-nand-stats', 'vs-pcie-stats', 'vs-smart-add-log', 'vs-telemetry-controller-option', 'vs-temperature-stats')
     'ymtc' = @('smart-log-add')
+    'zns' = @('changed-zone-list', 'close-zone', 'finish-zone', 'id-ctrl', 'id-ns', 'list', 'offline-zone', 'open-zone', 'report-zones', 'reset-zone', 'set-zone-desc', 'zone-append', 'zone-mgmt-recv', 'zone-mgmt-send', 'zrwa-flush-zone')
 }
 
 $script:NvmeOptions = @{
@@ -195,8 +235,17 @@ $script:NvmeOptions = @{
     'capacity-mgmt' = @('--cap-lower', '-l', '--cap-upper', '-u', '--dry-run', '--element-id', '-i', '--ish', '-I', '--no-ioctl-probing', '--no-retries', '--operation', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'changed-alloc-ns-list-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'changed-ns-list-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'check-dhchap-key' = @('--dry-run', '--key', '-k', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'check-tls-key' = @('--compat', '-C', '--dry-run', '--hostnqn', '-n', '--identity', '-I', '--keydata', '-d', '--keyring', '-k', '--keytype', '-t', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--subsysnqn', '-c', '--timeout', '--verbose', '-v', '--help', '-h')
     'cmdset-ind-id-ns' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'compare' = @('--app-tag', '-a', '--app-tag-mask', '-m', '--block-count', '-c', '--block-size', '-b', '--data', '-d', '--data-size', '-z', '--dir-spec', '-S', '--dir-type', '-T', '--dry-run', '--dsm', '-D', '--force', '--force-unit-access', '-f', '--latency', '-t', '--limited-retry', '-l', '--metadata', '-M', '--metadata-size', '-y', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--prinfo', '-p', '--quiet', '--ref-tag', '-r', '--set-options', '--show-command', '-V', '--start-block', '-s', '--storage-tag', '-g', '--storage-tag-check', '-C', '--timeout', '--verbose', '-v', '--help', '-h')
+    'config convert' = @('--config', '-J', '--force', '--output', '-o', '--help', '-h')
+    'config create' = @('--concat', '--ctrl-loss-tmo', '-l', '--data-digest', '-G', '--disable-sqflow', '--discovery', '--dry-run', '--duplicate-connect', '-D', '--fast-io-fail-tmo', '-F', '--hdr-digest', '-g', '--host-iface', '-f', '--host-symname', '--host-traddr', '-w', '--hostid', '-I', '--hostnqn', '-q', '--keep-alive-tmo', '-k', '--keyring', '--kxchap-ctrl-secret', '-C', '--kxchap-secret', '-S', '--no-ioctl-probing', '--no-retries', '--nqn', '-n', '--nr-io-queues', '-i', '--nr-poll-queues', '-P', '--nr-write-queues', '-W', '--output', '--output-format', '-o', '--output-format-version', '--persistent', '--queue-size', '-Q', '--quiet', '--reconnect-delay', '-c', '--set-options', '--timeout', '--tls', '--tls-key', '--tls-key-identity', '--tls_key', '--tos', '-T', '--traddr', '-a', '--transport', '-t', '--trsvcid', '-s', '--verbose', '-v', '--help', '-h')
+    'config show' = @('--config', '-J', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'config status' = @('--help', '-h')
+    'config validate' = @('--config', '-J', '--help', '-h')
+    'connect' = @('--concat', '--config', '-J', '--ctrl-loss-tmo', '-l', '--data-digest', '-G', '--devid-file', '--disable-sqflow', '--dry-run', '--duplicate-connect', '-D', '--fast-io-fail-tmo', '-F', '--hdr-digest', '-g', '--host-iface', '-f', '--host-traddr', '-w', '--hostid', '-I', '--hostnqn', '-q', '--idempotent', '--keep-alive-tmo', '-k', '--keyring', '--kxchap-ctrl-secret', '-C', '--kxchap-secret', '-S', '--no-ioctl-probing', '--no-retries', '--nqn', '-n', '--nr-io-queues', '-i', '--nr-poll-queues', '-P', '--nr-write-queues', '-W', '--output-format', '-o', '--output-format-version', '--owner', '--queue-size', '-Q', '--quiet', '--reconnect-delay', '-c', '--set-options', '--timeout', '--tls', '--tls-key', '--tls-key-identity', '--tls_key', '--tos', '-T', '--traddr', '-a', '--transport', '-t', '--trsvcid', '-s', '--verbose', '-v', '--help', '-h')
+    'connect-all' = @('--concat', '--config', '-J', '--ctrl-loss-tmo', '-l', '--data-digest', '-G', '--device', '-d', '--disable-sqflow', '--dry-run', '--duplicate-connect', '-D', '--fast-io-fail-tmo', '-F', '--force', '--hdr-digest', '-g', '--host-iface', '-f', '--host-traddr', '-w', '--hostid', '-I', '--hostnqn', '-q', '--keep-alive-tmo', '-k', '--keyring', '--kxchap-ctrl-secret', '-C', '--kxchap-secret', '-S', '--nbft', '--nbft-path', '--no-ioctl-probing', '--no-nbft', '--no-retries', '--no-reuse', '--nqn', '-n', '--nr-io-queues', '-i', '--nr-poll-queues', '-P', '--nr-write-queues', '-W', '--output-format', '-o', '--output-format-version', '--owner', '--persistent', '-p', '--queue-size', '-Q', '--quiet', '--raw', '-r', '--reconnect-delay', '-c', '--set-options', '--timeout', '--tls', '--tls-key', '--tls-key-identity', '--tls_key', '--tos', '-T', '--traddr', '-a', '--transport', '-t', '--trsvcid', '-s', '--verbose', '-v', '--help', '-h')
     'copy' = @('--app-tag', '-a', '--app-tag-mask', '-m', '--blocks', '-b', '--dir-spec', '-S', '--dir-type', '-T', '--dry-run', '--expected-app-tag-masks', '-M', '--expected-app-tags', '-A', '--expected-ref-tags', '-R', '--force-unit-access', '-f', '--format', '-F', '--limited-retry', '-l', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--prinfor', '-P', '--prinfow', '-p', '--quiet', '--ref-tag', '-r', '--sdlba', '-d', '--set-options', '--slbs', '-s', '--snsids', '-N', '--sopts', '-O', '--storage-tag', '-t', '--storage-tag-check', '-c', '--timeout', '--verbose', '-v', '--help', '-h')
     'create-ns' = @('--anagrp-id', '-a', '--azr', '-z', '--block-size', '-b', '--csi', '-y', '--dps', '-d', '--dry-run', '--endg-id', '-e', '--flbas', '-f', '--ish', '-I', '--lbstm', '-l', '--ncap', '-c', '--ncap-si', '-C', '--nmic', '-m', '--no-ioctl-probing', '--no-retries', '--nphndls', '-n', '--nsze', '-s', '--nsze-si', '-S', '--nvmset-id', '-i', '--output-format', '-o', '--output-format-version', '--phndls', '-p', '--quiet', '--rar', '-r', '--rnumzrwa', '-u', '--ror', '-O', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'dapustor smart-log-add' = @('--dry-run', '--json', '-j', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -206,16 +255,26 @@ $script:NvmeOptions = @{
     'dera stat' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'detach-ns' = @('--controllers', '-c', '--dry-run', '--ish', '-I', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'device-self-test' = @('--dry-run', '--ish', '-I', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--self-test-code', '-s', '--set-options', '--timeout', '--verbose', '-v', '--wait', '-w', '--help', '-h')
+    'dim' = @('--device', '-d', '--dry-run', '--no-ioctl-probing', '--no-retries', '--nqn', '-n', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--task', '-t', '--timeout', '--verbose', '-v', '--help', '-h')
     'dir receive' = @('--data-len', '-l', '--dir-oper', '-O', '--dir-spec', '-S', '--dir-type', '-D', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--req-resource', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'dir send' = @('--data-len', '-l', '--dir-oper', '-O', '--dir-spec', '-S', '--dir-type', '-D', '--dry-run', '--endir', '-e', '--input-file', '-i', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--target-dir', '-T', '--timeout', '--verbose', '-v', '--help', '-h')
     'dir-receive' = @('--data-len', '-l', '--dir-oper', '-O', '--dir-spec', '-S', '--dir-type', '-D', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--req-resource', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'dir-send' = @('--data-len', '-l', '--dir-oper', '-O', '--dir-spec', '-S', '--dir-type', '-D', '--dry-run', '--endir', '-e', '--input-file', '-i', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--target-dir', '-T', '--timeout', '--verbose', '-v', '--help', '-h')
+    'disconnect' = @('--concat', '--ctrl-loss-tmo', '-l', '--data-digest', '-G', '--device', '-d', '--disable-sqflow', '--dry-run', '--duplicate-connect', '-D', '--exclude', '-x', '--fast-io-fail-tmo', '-F', '--hdr-digest', '-g', '--host-iface', '-f', '--host-traddr', '-w', '--hostid', '-I', '--hostnqn', '-q', '--keep-alive-tmo', '-k', '--keyring', '--kxchap-ctrl-secret', '-C', '--kxchap-secret', '-S', '--no-ioctl-probing', '--no-retries', '--nqn', '-n', '--nr-io-queues', '-i', '--nr-poll-queues', '-P', '--nr-write-queues', '-W', '--output-format', '-o', '--output-format-version', '--queue-size', '-Q', '--quiet', '--reconnect-delay', '-c', '--set-options', '--timeout', '--tls', '--tls-key', '--tls-key-identity', '--tls_key', '--tos', '-T', '--traddr', '-a', '--transport', '-t', '--trsvcid', '-s', '--verbose', '-v', '--help', '-h')
+    'disconnect-all' = @('--dry-run', '--force', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--owner', '--quiet', '--set-options', '--timeout', '--transport', '-t', '--verbose', '-v', '--help', '-h')
+    'discover' = @('--concat', '--config', '-J', '--ctrl-loss-tmo', '-l', '--data-digest', '-G', '--device', '-d', '--disable-sqflow', '--dry-run', '--duplicate-connect', '-D', '--fast-io-fail-tmo', '-F', '--force', '--hdr-digest', '-g', '--host-iface', '-f', '--host-traddr', '-w', '--hostid', '-I', '--hostnqn', '-q', '--keep-alive-tmo', '-k', '--keyring', '--kxchap-ctrl-secret', '-C', '--kxchap-secret', '-S', '--nbft', '--nbft-path', '--no-ioctl-probing', '--no-nbft', '--no-retries', '--no-reuse', '--nqn', '-n', '--nr-io-queues', '-i', '--nr-poll-queues', '-P', '--nr-write-queues', '-W', '--output-format', '-o', '--output-format-version', '--owner', '--persistent', '-p', '--queue-size', '-Q', '--quiet', '--raw', '-r', '--reconnect-delay', '-c', '--set-options', '--timeout', '--tls', '--tls-key', '--tls-key-identity', '--tls_key', '--tos', '-T', '--traddr', '-a', '--transport', '-t', '--trsvcid', '-s', '--verbose', '-v', '--help', '-h')
     'dispersed-ns-participating-nss-log' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'dsm' = @('--ad', '-d', '--blocks', '-b', '--cdw11', '-c', '--ctx-attrs', '-a', '--dry-run', '--idr', '-r', '--idw', '-w', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--slbs', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
     'effects-log' = @('--csi', '-c', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'endurance-event-agg-log' = @('--dry-run', '--log-entries', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'endurance-log' = @('--dry-run', '--group-id', '-g', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'error-log' = @('--csi', '-c', '--dry-run', '--lba', '-l', '--log-entries', '-e', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--opcode', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--sqid', '-S', '--status', '-s', '--timeout', '--trtype', '-t', '--valid-entry', '-V', '--verbose', '-v', '--help', '-h')
+    'exclusion add' = @('--dry-run', '--entry', '-e', '--name', '-N', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'exclusion create' = @('--dry-run', '--name', '-N', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'exclusion delete' = @('--dry-run', '--name', '-N', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'exclusion edit' = @('--dry-run', '--name', '-N', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'exclusion list' = @('--dry-run', '--name', '-N', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'exclusion remove' = @('--dry-run', '--name', '-N', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'fdp configs' = @('--dry-run', '--endgrp-id', '-e', '--human-readable', '-H', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'fdp events' = @('--dry-run', '--endgrp-id', '-e', '--host-events', '-E', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'fdp feature' = @('--disable', '-d', '--dry-run', '--enable-conf-idx', '-c', '--endgrp-id', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -247,6 +306,9 @@ $script:NvmeOptions = @{
     'fw-commit' = @('--action', '-a', '--bpid', '-b', '--dry-run', '--ish', '-I', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--slot', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
     'fw-download' = @('--dry-run', '--fw', '-f', '--ignore-ovr', '-i', '--ish', '-I', '--no-ioctl-probing', '--no-retries', '--offset', '-O', '--output-format', '-o', '--output-format-version', '--progress', '-p', '--quiet', '--set-options', '--stream', '--timeout', '--verbose', '-v', '--xfer', '-x', '--help', '-h')
     'fw-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'gen-dhchap-key' = @('--dry-run', '--hmac', '-m', '--key-length', '-l', '--no-ioctl-probing', '--no-retries', '--nqn', '-n', '--output-format', '-o', '--output-format-version', '--quiet', '--secret', '-s', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'gen-hostnqn' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'gen-tls-key' = @('--compat', '-C', '--dry-run', '--hmac', '-m', '--hostnqn', '-n', '--identity', '-I', '--insert', '-i', '--keyfile', '-f', '--keyring', '-k', '--keytype', '-t', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--secret', '-s', '--set-options', '--subsysnqn', '-c', '--timeout', '--verbose', '-v', '--help', '-h')
     'get-feature' = @('--cdw11', '-c', '--changed', '-C', '--data-len', '-l', '--dry-run', '--feature-id', '-f', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--sel', '-s', '--set-options', '--timeout', '--uuid-index', '-U', '--verbose', '-v', '--help', '-h')
     'get-lba-status' = @('--action', '-a', '--dry-run', '--ish', '-I', '--max-dw', '-m', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--range-len', '-l', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
     'get-log' = @('--aen', '-a', '--csi', '-y', '--dry-run', '--ish', '-I', '--log-id', '-i', '--log-len', '-l', '--lpo', '-L', '--lsi', '-S', '--lsp', '-s', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--ot', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--raw-binary', '-b', '--set-options', '--timeout', '--uuid-index', '-U', '--verbose', '-v', '--xfer-len', '-x', '--help', '-h')
@@ -254,6 +316,8 @@ $script:NvmeOptions = @{
     'get-property' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--offset', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'get-reg' = @('--acq', '--aqa', '--asq', '--bpinfo', '--bpmbl', '--bprsel', '--cap', '--cc', '--cmbebs', '--cmbloc', '--cmbmsc', '--cmbsts', '--cmbswtp', '--cmbsz', '--crto', '--csts', '--dry-run', '--intmc', '--intms', '--no-ioctl-probing', '--no-retries', '--nssd', '--nssr', '--offset', '-O', '--output-format', '-o', '--output-format-version', '--pmrcap', '--pmrctl', '--pmrebs', '--pmrmscl', '--pmrmscu', '--pmrsts', '--pmrswtp', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--vs', '--help', '-h')
     'host-discovery-log' = @('--all-host-entries', '-a', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'huawei id-ctrl' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--vendor-specific', '-V', '--verbose', '-v', '--help', '-h')
+    'huawei list' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'ibm crit-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'ibm persist-event-log' = @('--action', '-a', '--dry-run', '--log_len', '-l', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'ibm vpd' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -299,6 +363,14 @@ $script:NvmeOptions = @{
     'io-mgmt-recv' = @('--data', '-d', '--data-len', '-l', '--dry-run', '--mo', '-m', '--mos', '-s', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'io-mgmt-send' = @('--data', '-d', '--data-len', '-l', '--dry-run', '--mo', '-m', '--mos', '-s', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'io-passthru' = @('--cdw10', '-4', '--cdw11', '-5', '--cdw12', '-6', '--cdw13', '-7', '--cdw14', '-8', '--cdw15', '-9', '--cdw2', '-2', '--cdw3', '-3', '--data-len', '-l', '--dry-run', '--flags', '-f', '--input-file', '-i', '--latency', '-T', '--metadata', '-M', '--metadata-len', '-m', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--opcode', '-O', '--output-format', '-o', '--output-format-version', '--prefill', '-p', '--quiet', '--raw-binary', '-b', '--read', '-r', '--rsvd', '-R', '--set-options', '--show-command', '-s', '--timeout', '--verbose', '-v', '--write', '-w', '--help', '-h')
+    'keys check-kxchap-secret' = @('--dry-run', '--identity', '-i', '--keydata', '-d', '--keyring', '-k', '--keytype', '-t', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'keys check-tls' = @('--compat', '-C', '--dry-run', '--hostnqn', '-n', '--identity', '-I', '--keydata', '-d', '--keyring', '-k', '--keytype', '-t', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--subsysnqn', '-c', '--timeout', '--verbose', '-v', '--help', '-h')
+    'keys export' = @('--dry-run', '--keyfile', '-f', '--keyring', '-k', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'keys gen-kxchap-secret' = @('--dry-run', '--hmac', '-m', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--secret', '-s', '--secret-length', '-l', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'keys gen-tls' = @('--compat', '-C', '--dry-run', '--hmac', '-m', '--hostnqn', '-n', '--identity', '-I', '--insert', '-i', '--keyfile', '-f', '--keyring', '-k', '--keytype', '-t', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--secret', '-s', '--set-options', '--subsysnqn', '-c', '--timeout', '--verbose', '-v', '--help', '-h')
+    'keys import' = @('--dry-run', '--identity', '-i', '--keydata', '-d', '--keyfile', '-f', '--keyring', '-k', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'keys insert-tls' = @('--compat', '-C', '--dry-run', '--hostnqn', '-n', '--identity', '-I', '--keydata', '-d', '--keyfile', '-f', '--keyring', '-k', '--keytype', '-t', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--subsysnqn', '-c', '--timeout', '--verbose', '-v', '--help', '-h')
+    'keys revoke' = @('--dry-run', '--identity', '-i', '--keyring', '-k', '--keytype', '-t', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'lba-status-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'list' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'list-ctrl' = @('--cntid', '-c', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -306,6 +378,13 @@ $script:NvmeOptions = @{
     'list-ns' = @('--all', '-a', '--csi', '-y', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'list-secondary' = @('--cntid', '-c', '--dry-run', '--no-ioctl-probing', '--no-retries', '--num-entries', '-e', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'list-subsys' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'lm create-cdq' = @('--cntlid', '-c', '--consent', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--queue-type', '-q', '--quiet', '--set-options', '--size', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'lm delete-cdq' = @('--cdqid', '-C', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'lm get-cdq' = @('--cdqid', '-C', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'lm migration-recv' = @('--cntlid', '-c', '--csuuidi', '-U', '--csvi', '-V', '--dry-run', '--human-readable', '-H', '--no-ioctl-probing', '--no-retries', '--numd', '-n', '--offset', '-O', '--output-file', '-f', '--output-format', '-o', '--output-format-version', '--quiet', '--sel', '-s', '--set-options', '--timeout', '--uidx', '-u', '--verbose', '-v', '--help', '-h')
+    'lm migration-send' = @('--cntlid', '-c', '--csuuidi', '-U', '--csvi', '-V', '--dry-run', '--dudmq', '-d', '--input-file', '-f', '--no-ioctl-probing', '--no-retries', '--numd', '-n', '--offset', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--sel', '-s', '--seq-ind', '-S', '--set-options', '--stype', '-t', '--timeout', '--uidx', '-u', '--verbose', '-v', '--help', '-h')
+    'lm set-cdq' = @('--cdqid', '-C', '--dry-run', '--hp', '-H', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--tpt', '-T', '--verbose', '-v', '--help', '-h')
+    'lm track-send' = @('--cdqid', '-C', '--dry-run', '--mos', '-m', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--sel', '-s', '--set-options', '--start', '--stop', '--timeout', '--verbose', '-v', '--help', '-h')
     'lockdown' = @('--dry-run', '--ifc', '-f', '--no-ioctl-probing', '--no-retries', '--ofi', '-O', '--output-format', '-o', '--output-format-version', '--prhbt', '-p', '--quiet', '--scp', '-s', '--set-options', '--timeout', '--uuid', '-U', '--verbose', '-v', '--help', '-h')
     'log ana' = @('--dry-run', '--groups', '-g', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'log ave-discovery' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -338,6 +417,7 @@ $script:NvmeOptions = @{
     'log self-test' = @('--dry-run', '--dst-entries', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'log smart' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'log supported-cap-config' = @('--domain-id', '-d', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'log supported-pages' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'log telemetry' = @('--controller-init', '-c', '--data-area', '-d', '--dry-run', '--host-generate', '-g', '--mcda', '-m', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'mangoboost id-ctrl' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--vendor-specific', '-V', '--verbose', '-v', '--help', '-h')
     'media-unit-stat-log' = @('--domain-id', '-d', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -384,6 +464,9 @@ $script:NvmeOptions = @{
     'micron vs-temperature-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'micron vs-vendor-telemetry-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'micron vs-work-load-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'nbft show' = @('--discovery', '-d', '--dry-run', '--hfi', '-H', '--nbft-path', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--subsystem', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'netapp ontapdevices' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'netapp smdevices' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'ns attach' = @('--controllers', '-c', '--dry-run', '--ish', '-I', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'ns create' = @('--anagrp-id', '-a', '--azr', '-z', '--block-size', '-b', '--csi', '-y', '--dps', '-d', '--dry-run', '--endg-id', '-e', '--flbas', '-f', '--ish', '-I', '--lbstm', '-l', '--ncap', '-c', '--ncap-si', '-C', '--nmic', '-m', '--no-ioctl-probing', '--no-retries', '--nphndls', '-n', '--nsze', '-s', '--nsze-si', '-S', '--nvmset-id', '-i', '--output-format', '-o', '--output-format-version', '--phndls', '-p', '--quiet', '--rar', '-r', '--rnumzrwa', '-u', '--ror', '-O', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'ns delete' = @('--dry-run', '--ish', '-I', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -439,6 +522,10 @@ $script:NvmeOptions = @{
     'reachability-associations-log' = @('--associations-only', '-a', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'reachability-groups-log' = @('--dry-run', '--groups-only', '-g', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'read' = @('--app-tag', '-a', '--app-tag-mask', '-m', '--block-count', '-c', '--block-size', '-b', '--data', '-d', '--data-size', '-z', '--dir-spec', '-S', '--dir-type', '-T', '--dry-run', '--dsm', '-D', '--force', '--force-unit-access', '-f', '--latency', '-t', '--limited-retry', '-l', '--metadata', '-M', '--metadata-size', '-y', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--prinfo', '-p', '--quiet', '--ref-tag', '-r', '--set-options', '--show-command', '-V', '--start-block', '-s', '--storage-tag', '-g', '--storage-tag-check', '-C', '--timeout', '--verbose', '-v', '--help', '-h')
+    'registry delete' = @('--attr', '-a', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'registry list' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'registry retrieve' = @('--attr', '-a', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'registry update' = @('--attr', '-a', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--value', '-V', '--verbose', '-v', '--help', '-h')
     'reset' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'resv acquire' = @('--crkey', '-c', '--dry-run', '--iekey', '-i', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--prkey', '-p', '--quiet', '--racqa', '-a', '--rtype', '-t', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'resv register' = @('--cptpl', '-p', '--crkey', '-c', '--dry-run', '--iekey', '-i', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--nrkey', '-k', '--output-format', '-o', '--output-format-version', '--quiet', '--rrega', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -470,17 +557,63 @@ $script:NvmeOptions = @{
     'security send' = @('--dry-run', '--file', '-f', '--ish', '-I', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--nssf', '-N', '--output-format', '-o', '--output-format-version', '--quiet', '--secp', '-p', '--set-options', '--spsp', '-s', '--timeout', '--tl', '-t', '--verbose', '-v', '--help', '-h')
     'security-recv' = @('--al', '-t', '--dry-run', '--ish', '-I', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--nssf', '-N', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--secp', '-p', '--set-options', '--size', '-x', '--spsp', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
     'security-send' = @('--dry-run', '--file', '-f', '--ish', '-I', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--nssf', '-N', '--output-format', '-o', '--output-format-version', '--quiet', '--secp', '-p', '--set-options', '--spsp', '-s', '--timeout', '--tl', '-t', '--verbose', '-v', '--help', '-h')
+    'sed 1' = @('--udev', '-u', '--verbose', '-V', '--help', '-h')
+    'sed discover' = @('--udev', '-u', '--verbose', '-V', '--help', '-h')
+    'sed initialize' = @('--read-only', '-r', '--help', '-h')
+    'sed lock' = @('--ask-key', '-k', '--read-only', '-r', '--help', '-h')
+    'sed password' = @('--help', '-h')
+    'sed revert' = @('--destructive', '-e', '--psid', '-p', '--help', '-h')
+    'sed unlock' = @('--ask-key', '-k', '--read-only', '-r', '--help', '-h')
     'self-test-log' = @('--dry-run', '--dst-entries', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'set-feature' = @('--cdw12', '-c', '--data', '-d', '--data-len', '-l', '--dry-run', '--feature-id', '-f', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--save', '-s', '--set-options', '--timeout', '--uuid-index', '-U', '--value', '-V', '--verbose', '-v', '--help', '-h')
     'set-property' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--offset', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--value', '-V', '--verbose', '-v', '--help', '-h')
     'set-reg' = @('--acq', '--aqa', '--asq', '--bpmbl', '--bprsel', '--cc', '--cmbmsc', '--csts', '--dry-run', '--intmc', '--intms', '--mmio32', '-m', '--no-ioctl-probing', '--no-retries', '--nssd', '--nssr', '--offset', '-O', '--output-format', '-o', '--output-format-version', '--pmrctl', '--pmrmscl', '--pmrmscu', '--quiet', '--set-options', '--timeout', '--value', '-V', '--verbose', '-v', '--help', '-h')
+    'sfx change-cap' = @('--cap', '-c', '--cap-byte', '-z', '--dry-run', '--force', '-f', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sfx dump-evtlog' = @('--dry-run', '--file', '-f', '--namespace_id', '-n', '--no-ioctl-probing', '--no-retries', '--output', '-O', '--output-format', '-o', '--output-format-version', '--parse', '-p', '--quiet', '--set-options', '--storage_medium', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sfx expand-cap' = @('--dry-run', '--lbaf', '-l', '--namespace_cap', '-c', '--namespace_id', '-n', '--namespace_size', '-s', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--units', '-u', '--verbose', '-v', '--help', '-h')
+    'sfx get-bad-block' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sfx get-feature' = @('--dry-run', '--feature-id', '-f', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sfx lat-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--write', '-w', '--help', '-h')
+    'sfx query-cap' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sfx set-feature' = @('--dry-run', '--feature-id', '-f', '--force', '-s', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--value', '-V', '--verbose', '-v', '--help', '-h')
+    'sfx smart-log-add' = @('--dry-run', '--json', '-j', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sfx status' = @('--dry-run', '--json-print', '-j', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'shannon get-additional-feature' = @('--cdw11', '-c', '--data-len', '-l', '--dry-run', '--feature-id', '-f', '--human-readable', '-H', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--sel', '-s', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'shannon id-ctrl' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--vendor-specific', '-V', '--verbose', '-v', '--help', '-h')
     'shannon set-additioal-feature' = @('--data', '-d', '--data-len', '-l', '--dry-run', '--feature-id', '-f', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--save', '-s', '--set-options', '--timeout', '--value', '-V', '--verbose', '-v', '--help', '-h')
     'shannon smart-log-add' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'show-hostnqn' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'show-regs' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'show-topology' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--ranking', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'smart-log' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk capabilities' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk clear-assert-dump' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk clear-fw-activate-history' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk clear-pcie-correctable-errors' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk cloud-SSD-plugin-version' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk cloud-boot-SSD-version' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk cu-smart-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--uuid-index', '-u', '--verbose', '-v', '--help', '-h')
+    'sndk drive-resize' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--size', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk get-dev-capabilities-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk get-drive-status' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk get-error-recovery-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk get-latency-monitor-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk get-unsupported-reqs-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk log-page-directory' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk namespace-resize' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--op-option', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk set-latency-monitor-feature' = @('--active_bucket_timer_threshold', '-t', '--active_latency_config', '-f', '--active_latency_minimum_window', '-w', '--active_threshold_a', '-a', '--active_threshold_b', '-b', '--active_threshold_c', '-c', '--active_threshold_d', '-d', '--debug_log_trigger_enable', '-r', '--discard_debug_log', '-l', '--dry-run', '--latency_monitor_feature_enable', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-cloud-log' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-device-waf' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-drive-info' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-error-reason-identifier' = @('--dry-run', '--file', '-O', '--log-id', '-i', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-fw-activate-history' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-hw-rev-log' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-internal-log' = @('--data-area', '-d', '--file-size', '-f', '--offset', '-e', '--output-file', '-O', '--transfer-size', '-s', '--type', '-t', '--verbose', '-V', '--help', '-h')
+    'sndk vs-nand-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-pcie-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-smart-add-log' = @('--dry-run', '--interval', '-i', '--log-page-mask', '-p', '--log-page-version', '-l', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-telemetry-controller-option' = @('--disable', '-d', '--dry-run', '--enable', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--status', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'sndk vs-temperature-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'solidigm clear-fw-activate-history' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--no-uuid', '-n', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'solidigm clear-pcie-correctable-errors' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--no-uuid', '-n', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'solidigm cloud-SSDplugin-version' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -502,6 +635,8 @@ $script:NvmeOptions = @{
     'supported-cap-config-log' = @('--domain-id', '-d', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'supported-log-pages' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'telemetry-log' = @('--controller-init', '-c', '--data-area', '-d', '--dry-run', '--host-generate', '-g', '--mcda', '-m', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'tls-key' = @('--help', '-h')
+    'top' = @('--delay', '-d', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'toshiba clear-pcie-correctable-errors' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'toshiba vs-internal-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--prev-log', '-p', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'toshiba vs-smart-add-log' = @('--dry-run', '--log', '-l', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
@@ -512,10 +647,62 @@ $script:NvmeOptions = @{
     'virt-mgmt' = @('--act', '-a', '--cntlid', '-c', '--dry-run', '--no-ioctl-probing', '--no-retries', '--nr', '-n', '--output-format', '-o', '--output-format-version', '--quiet', '--rt', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'virtium save-smart-to-vtview-log' = @('--dry-run', '--freq', '-f', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--run-time', '-r', '--set-options', '--test-name', '-n', '--timeout', '--verbose', '-v', '--help', '-h')
     'virtium show-identify' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc cap-diag' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--transfer-size', '-s', '--verbose', '-v', '--help', '-h')
+    'wdc capabilities' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc clear-assert-dump' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc clear-fw-activate-history' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc clear-pcie-correctable-errors' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc cloud-SSD-plugin-version' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc cloud-boot-SSD-version' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc cu-smart-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--uuid-index', '-u', '--verbose', '-v', '--help', '-h')
+    'wdc drive-essentials' = @('--dir-name', '-d', '--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc drive-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc drive-resize' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--size', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc enc-get-log' = @('--dry-run', '--log-id', '-l', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--transfer-size', '-s', '--verbose', '-v', '--help', '-h')
+    'wdc get-crash-dump' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc get-dev-capabilities-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc get-drive-status' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc get-error-recovery-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc get-latency-monitor-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc get-pfail-dump' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-file', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc get-unsupported-reqs-log' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc id-ctrl' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--vendor-specific', '-V', '--verbose', '-v', '--help', '-h')
+    'wdc log-page-directory' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc namespace-resize' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--op-option', '-O', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc purge' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc purge-monitor' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc set-latency-monitor-feature' = @('--active_bucket_timer_threshold', '-t', '--active_latency_config', '-f', '--active_latency_minimum_window', '-w', '--active_threshold_a', '-a', '--active_threshold_b', '-b', '--active_threshold_c', '-c', '--active_threshold_d', '-d', '--debug_log_trigger_enable', '-r', '--discard_debug_log', '-l', '--dry-run', '--latency_monitor_feature_enable', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-cloud-log' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-device-waf' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-drive-info' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-error-reason-identifier' = @('--dry-run', '--file', '-O', '--log-id', '-i', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-fw-activate-history' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-hw-rev-log' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-internal-log' = @('--data-area', '-d', '--file-size', '-f', '--offset', '-e', '--output-file', '-O', '--transfer-size', '-s', '--type', '-t', '--verbose', '-V', '--help', '-h')
+    'wdc vs-nand-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-pcie-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-smart-add-log' = @('--dry-run', '--interval', '-i', '--log-page-mask', '-p', '--log-page-version', '-l', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-telemetry-controller-option' = @('--disable', '-d', '--dry-run', '--enable', '-e', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--status', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'wdc vs-temperature-stats' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
     'write' = @('--app-tag', '-a', '--app-tag-mask', '-m', '--block-count', '-c', '--block-size', '-b', '--data', '-d', '--data-size', '-z', '--dir-spec', '-S', '--dir-type', '-T', '--dry-run', '--dsm', '-D', '--force', '--force-unit-access', '-f', '--latency', '-t', '--limited-retry', '-l', '--metadata', '-M', '--metadata-size', '-y', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--prinfo', '-p', '--quiet', '--ref-tag', '-r', '--set-options', '--show-command', '-V', '--start-block', '-s', '--storage-tag', '-g', '--storage-tag-check', '-C', '--timeout', '--verbose', '-v', '--help', '-h')
     'write-uncor' = @('--block-count', '-c', '--dir-spec', '-S', '--dir-type', '-T', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--start-block', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
     'write-zeroes' = @('--app-tag', '-a', '--app-tag-mask', '-m', '--block-count', '-c', '--deac', '-d', '--dir-spec', '-D', '--dir-type', '-T', '--dry-run', '--force-unit-access', '-f', '--limited-retry', '-l', '--namespace-id', '-n', '--namespace-zeroes', '-Z', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--prinfo', '-p', '--quiet', '--ref-tag', '-r', '--set-options', '--start-block', '-s', '--storage-tag', '-S', '--storage-tag-check', '-C', '--timeout', '--verbose', '-v', '--help', '-h')
     'ymtc smart-log-add' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--raw-binary', '-b', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns changed-zone-list' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--rae', '-r', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns close-zone' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--select-all', '-a', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns finish-zone' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--select-all', '-a', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns id-ctrl' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns id-ns' = @('--dry-run', '--human-readable', '-H', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--vendor-specific', '-V', '--verbose', '-v', '--help', '-h')
+    'zns list' = @('--dry-run', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns offline-zone' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--select-all', '-a', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns open-zone' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--select-all', '-a', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--zrwaa', '-r', '--help', '-h')
+    'zns report-zones' = @('--descs', '-d', '--dry-run', '--extended', '-e', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--partial', '-p', '--quiet', '--set-options', '--start-lba', '-s', '--state', '-S', '--timeout', '--verbose', '-V', '--verbose', '-v', '--help', '-h')
+    'zns reset-zone' = @('--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--select-all', '-a', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--help', '-h')
+    'zns set-zone-desc' = @('--data', '-d', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--zrwaa', '-r', '--help', '-h')
+    'zns zone-append' = @('--data', '-d', '--data-size', '-z', '--dry-run', '--force-unit-access', '-f', '--latency', '-t', '--limited-retry', '-l', '--metadata', '-M', '--metadata-size', '-y', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--piremap', '-P', '--prinfo', '-p', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--zslba', '-s', '--help', '-h')
+    'zns zone-mgmt-recv' = @('--data-len', '-l', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--partial', '-p', '--quiet', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--zra', '-z', '--zrasf', '-S', '--help', '-h')
+    'zns zone-mgmt-send' = @('--data', '-d', '--data-len', '-l', '--dry-run', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--select-all', '-a', '--set-options', '--start-lba', '-s', '--timeout', '--verbose', '-v', '--zsa', '-z', '--zsaso', '-O', '--help', '-h')
+    'zns zrwa-flush-zone' = @('--dry-run', '--lba', '-l', '--namespace-id', '-n', '--no-ioctl-probing', '--no-retries', '--output-format', '-o', '--output-format-version', '--quiet', '--set-options', '--timeout', '--verbose', '-v', '--help', '-h')
 }
 
 $script:NvmeFileOptions = @{
@@ -529,10 +716,30 @@ $script:NvmeFileOptions = @{
     'compare --metadata' = $true
     'compare -M' = $true
     'compare -d' = $true
+    'config convert --config' = $true
+    'config convert --output' = $true
+    'config convert -J' = $true
+    'config convert -o' = $true
+    'config create --output' = $true
+    'config show --config' = $true
+    'config show -J' = $true
+    'config validate --config' = $true
+    'config validate -J' = $true
+    'connect --config' = $true
+    'connect --devid-file' = $true
+    'connect -J' = $true
+    'connect-all --config' = $true
+    'connect-all --raw' = $true
+    'connect-all -J' = $true
+    'connect-all -r' = $true
     'dir send --input-file' = $true
     'dir send -i' = $true
     'dir-send --input-file' = $true
     'dir-send -i' = $true
+    'discover --config' = $true
+    'discover --raw' = $true
+    'discover -J' = $true
+    'discover -r' = $true
     'feat perf-characteristics --vs-data' = $true
     'feat perf-characteristics -V' = $true
     'fw download --fw' = $true
@@ -553,6 +760,10 @@ $script:NvmeFileOptions = @{
     'io-passthru --metadata' = $true
     'io-passthru -M' = $true
     'io-passthru -i' = $true
+    'lm migration-recv --output-file' = $true
+    'lm migration-recv -f' = $true
+    'lm migration-send --input-file' = $true
+    'lm migration-send -f' = $true
     'log boot-part --output-file' = $true
     'log boot-part -f' = $true
     'log telemetry --output-file' = $true
@@ -593,8 +804,18 @@ $script:NvmeFileOptions = @{
     'security-send -f' = $true
     'set-feature --data' = $true
     'set-feature -d' = $true
+    'sfx dump-evtlog --file' = $true
+    'sfx dump-evtlog --output' = $true
+    'sfx dump-evtlog -O' = $true
+    'sfx dump-evtlog -f' = $true
     'shannon set-additioal-feature --data' = $true
     'shannon set-additioal-feature -d' = $true
+    'sndk vs-error-reason-identifier --file' = $true
+    'sndk vs-error-reason-identifier -O' = $true
+    'sndk vs-internal-log --output-file' = $true
+    'sndk vs-internal-log --type' = $true
+    'sndk vs-internal-log -O' = $true
+    'sndk vs-internal-log -t' = $true
     'solidigm parse-telemetry-log --config-file' = $true
     'solidigm parse-telemetry-log --source-file' = $true
     'solidigm parse-telemetry-log -j' = $true
@@ -609,10 +830,36 @@ $script:NvmeFileOptions = @{
     'toshiba vs-smart-add-log -O' = $true
     'virtium save-smart-to-vtview-log --output-file' = $true
     'virtium save-smart-to-vtview-log -O' = $true
+    'wdc cap-diag --output-file' = $true
+    'wdc cap-diag -O' = $true
+    'wdc drive-essentials --dir-name' = $true
+    'wdc drive-essentials -d' = $true
+    'wdc drive-log --output-file' = $true
+    'wdc drive-log -O' = $true
+    'wdc enc-get-log --output-file' = $true
+    'wdc enc-get-log -O' = $true
+    'wdc get-crash-dump --output-file' = $true
+    'wdc get-crash-dump -O' = $true
+    'wdc get-pfail-dump --output-file' = $true
+    'wdc get-pfail-dump -O' = $true
+    'wdc vs-error-reason-identifier --file' = $true
+    'wdc vs-error-reason-identifier -O' = $true
+    'wdc vs-internal-log --output-file' = $true
+    'wdc vs-internal-log --type' = $true
+    'wdc vs-internal-log -O' = $true
+    'wdc vs-internal-log -t' = $true
     'write --data' = $true
     'write --metadata' = $true
     'write -M' = $true
     'write -d' = $true
+    'zns set-zone-desc --data' = $true
+    'zns set-zone-desc -d' = $true
+    'zns zone-append --data' = $true
+    'zns zone-append --metadata' = $true
+    'zns zone-append -M' = $true
+    'zns zone-append -d' = $true
+    'zns zone-mgmt-send --data' = $true
+    'zns zone-mgmt-send -d' = $true
 }
 
 $script:NvmeOptionValues = @{
@@ -646,12 +893,30 @@ $script:NvmeOptionValues = @{
     'changed-ns-list-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'changed-ns-list-log --output-format-version' = @('1', '2')
     'changed-ns-list-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'check-dhchap-key --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'check-dhchap-key --output-format-version' = @('1', '2')
+    'check-dhchap-key -o' = @('normal', 'json', 'binary', 'tabular')
+    'check-tls-key --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'check-tls-key --output-format-version' = @('1', '2')
+    'check-tls-key -o' = @('normal', 'json', 'binary', 'tabular')
     'cmdset-ind-id-ns --output-format' = @('normal', 'json', 'binary', 'tabular')
     'cmdset-ind-id-ns --output-format-version' = @('1', '2')
     'cmdset-ind-id-ns -o' = @('normal', 'json', 'binary', 'tabular')
     'compare --output-format' = @('normal', 'json', 'binary', 'tabular')
     'compare --output-format-version' = @('1', '2')
     'compare -o' = @('normal', 'json', 'binary', 'tabular')
+    'config create --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'config create --output-format-version' = @('1', '2')
+    'config create -o' = @('normal', 'json', 'binary', 'tabular')
+    'config show --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'config show --output-format-version' = @('1', '2')
+    'config show -o' = @('normal', 'json', 'binary', 'tabular')
+    'connect --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'connect --output-format-version' = @('1', '2')
+    'connect -o' = @('normal', 'json', 'binary', 'tabular')
+    'connect-all --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'connect-all --output-format-version' = @('1', '2')
+    'connect-all -o' = @('normal', 'json', 'binary', 'tabular')
     'copy --output-format' = @('normal', 'json', 'binary', 'tabular')
     'copy --output-format-version' = @('1', '2')
     'copy -o' = @('normal', 'json', 'binary', 'tabular')
@@ -679,6 +944,9 @@ $script:NvmeOptionValues = @{
     'device-self-test --output-format' = @('normal', 'json', 'binary', 'tabular')
     'device-self-test --output-format-version' = @('1', '2')
     'device-self-test -o' = @('normal', 'json', 'binary', 'tabular')
+    'dim --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'dim --output-format-version' = @('1', '2')
+    'dim -o' = @('normal', 'json', 'binary', 'tabular')
     'dir receive --output-format' = @('normal', 'json', 'binary', 'tabular')
     'dir receive --output-format-version' = @('1', '2')
     'dir receive -o' = @('normal', 'json', 'binary', 'tabular')
@@ -691,6 +959,15 @@ $script:NvmeOptionValues = @{
     'dir-send --output-format' = @('normal', 'json', 'binary', 'tabular')
     'dir-send --output-format-version' = @('1', '2')
     'dir-send -o' = @('normal', 'json', 'binary', 'tabular')
+    'disconnect --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'disconnect --output-format-version' = @('1', '2')
+    'disconnect -o' = @('normal', 'json', 'binary', 'tabular')
+    'disconnect-all --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'disconnect-all --output-format-version' = @('1', '2')
+    'disconnect-all -o' = @('normal', 'json', 'binary', 'tabular')
+    'discover --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'discover --output-format-version' = @('1', '2')
+    'discover -o' = @('normal', 'json', 'binary', 'tabular')
     'dispersed-ns-participating-nss-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'dispersed-ns-participating-nss-log --output-format-version' = @('1', '2')
     'dispersed-ns-participating-nss-log -o' = @('normal', 'json', 'binary', 'tabular')
@@ -709,6 +986,24 @@ $script:NvmeOptionValues = @{
     'error-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'error-log --output-format-version' = @('1', '2')
     'error-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion add --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion add --output-format-version' = @('1', '2')
+    'exclusion add -o' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion create --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion create --output-format-version' = @('1', '2')
+    'exclusion create -o' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion delete --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion delete --output-format-version' = @('1', '2')
+    'exclusion delete -o' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion edit --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion edit --output-format-version' = @('1', '2')
+    'exclusion edit -o' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion list --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion list --output-format-version' = @('1', '2')
+    'exclusion list -o' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion remove --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'exclusion remove --output-format-version' = @('1', '2')
+    'exclusion remove -o' = @('normal', 'json', 'binary', 'tabular')
     'fdp configs --output-format' = @('normal', 'json', 'binary', 'tabular')
     'fdp configs --output-format-version' = @('1', '2')
     'fdp configs -o' = @('normal', 'json', 'binary', 'tabular')
@@ -836,6 +1131,15 @@ $script:NvmeOptionValues = @{
     'fw-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'fw-log --output-format-version' = @('1', '2')
     'fw-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'gen-dhchap-key --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'gen-dhchap-key --output-format-version' = @('1', '2')
+    'gen-dhchap-key -o' = @('normal', 'json', 'binary', 'tabular')
+    'gen-hostnqn --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'gen-hostnqn --output-format-version' = @('1', '2')
+    'gen-hostnqn -o' = @('normal', 'json', 'binary', 'tabular')
+    'gen-tls-key --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'gen-tls-key --output-format-version' = @('1', '2')
+    'gen-tls-key -o' = @('normal', 'json', 'binary', 'tabular')
     'get-feature --feature-id' = @('arbitration', 'power-mgmt', 'lba-range', 'temp-thresh', 'err-recovery', 'volatile-wc', 'num-queues', 'irq-coalesce', 'irq-config', 'write-atomic', 'async-event', 'auto-pst', 'host-mem-buf', 'timestamp', 'kato', 'hctm', 'nopsc', 'rrl', 'plm-config', 'plm-window', 'lba-sts-interval', 'host-behavior', 'sanitize', 'endurance-evt-cfg', 'iocs-profile', 'spinup-control', 'power-loss-signal', 'perf-characteristics', 'fdp', 'fdp-events', 'ns-admin-label', 'key-value', 'ctrl-data-queue', 'emb-mgmt-ctrl-addr', 'host-mgmt-agent-addr', 'enh-ctrl-metadata', 'ctrl-metadata', 'ns-metadata', 'sw-progress', 'host-id', 'resv-nf-mask', 'resv-persist', 'write-protect', 'bp-write-protect')
     'get-feature --output-format' = @('normal', 'json', 'binary', 'tabular')
     'get-feature --output-format-version' = @('1', '2')
@@ -846,10 +1150,10 @@ $script:NvmeOptionValues = @{
     'get-lba-status --output-format' = @('normal', 'json', 'binary', 'tabular')
     'get-lba-status --output-format-version' = @('1', '2')
     'get-lba-status -o' = @('normal', 'json', 'binary', 'tabular')
-    'get-log --log-id' = @('supported-log-pages', 'error', 'smart', 'fw-slot', 'changed-ns', 'cmd-effects', 'device-self-test', 'telemetry-host', 'telemetry-ctrl', 'endurance-group', 'predictable-lat-nvmset', 'predictable-lat-agg', 'ana', 'persistent-event', 'lba-status', 'endurance-grp-evt', 'media-unit-status', 'supported-cap-config-list', 'fid-supported-effects', 'mi-cmd-supported-effects', 'cmd-and-feat-lockdown', 'boot-partition', 'rotational-media-info', 'dispersed-ns-participating-ns', 'mgmt-addr-list', 'phy-rx-eom', 'reachability-groups', 'reachability-associations', 'changed-alloc-ns-list', 'fdp-configs', 'fdp-ruh-usage', 'fdp-stats', 'fdp-events', 'discover', 'host-discover', 'ave-discover', 'pull-model-ddc-req', 'reservation', 'sanitize', 'zns-changed-zones')
+    'get-log --log-id' = @('supported-log-pages', 'error', 'smart', 'fw-slot', 'changed-attached-ns', 'changed-ns', 'cmd-effects', 'device-self-test', 'telemetry-host', 'telemetry-ctrl', 'endurance-group', 'predictable-lat-nvmset', 'predictable-lat-agg', 'ana', 'persistent-event', 'lba-status', 'endurance-grp-evt', 'media-unit-status', 'supported-cap-config-list', 'fid-supported-effects', 'mi-cmd-supported-effects', 'cmd-and-feat-lockdown', 'boot-partition', 'rotational-media-info', 'dispersed-ns-participating-ns', 'mgmt-addr-list', 'phy-rx-eom', 'reachability-groups', 'reachability-associations', 'changed-alloc-ns-list', 'fdp-configs', 'fdp-ruh-usage', 'fdp-stats', 'fdp-events', 'discover', 'host-discover', 'ave-discover', 'pull-model-ddc-req', 'reservation', 'sanitize', 'zns-changed-zones')
     'get-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'get-log --output-format-version' = @('1', '2')
-    'get-log -i' = @('supported-log-pages', 'error', 'smart', 'fw-slot', 'changed-ns', 'cmd-effects', 'device-self-test', 'telemetry-host', 'telemetry-ctrl', 'endurance-group', 'predictable-lat-nvmset', 'predictable-lat-agg', 'ana', 'persistent-event', 'lba-status', 'endurance-grp-evt', 'media-unit-status', 'supported-cap-config-list', 'fid-supported-effects', 'mi-cmd-supported-effects', 'cmd-and-feat-lockdown', 'boot-partition', 'rotational-media-info', 'dispersed-ns-participating-ns', 'mgmt-addr-list', 'phy-rx-eom', 'reachability-groups', 'reachability-associations', 'changed-alloc-ns-list', 'fdp-configs', 'fdp-ruh-usage', 'fdp-stats', 'fdp-events', 'discover', 'host-discover', 'ave-discover', 'pull-model-ddc-req', 'reservation', 'sanitize', 'zns-changed-zones')
+    'get-log -i' = @('supported-log-pages', 'error', 'smart', 'fw-slot', 'changed-attached-ns', 'changed-ns', 'cmd-effects', 'device-self-test', 'telemetry-host', 'telemetry-ctrl', 'endurance-group', 'predictable-lat-nvmset', 'predictable-lat-agg', 'ana', 'persistent-event', 'lba-status', 'endurance-grp-evt', 'media-unit-status', 'supported-cap-config-list', 'fid-supported-effects', 'mi-cmd-supported-effects', 'cmd-and-feat-lockdown', 'boot-partition', 'rotational-media-info', 'dispersed-ns-participating-ns', 'mgmt-addr-list', 'phy-rx-eom', 'reachability-groups', 'reachability-associations', 'changed-alloc-ns-list', 'fdp-configs', 'fdp-ruh-usage', 'fdp-stats', 'fdp-events', 'discover', 'host-discover', 'ave-discover', 'pull-model-ddc-req', 'reservation', 'sanitize', 'zns-changed-zones')
     'get-log -o' = @('normal', 'json', 'binary', 'tabular')
     'get-ns-id --output-format' = @('normal', 'json', 'binary', 'tabular')
     'get-ns-id --output-format-version' = @('1', '2')
@@ -863,6 +1167,12 @@ $script:NvmeOptionValues = @{
     'host-discovery-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'host-discovery-log --output-format-version' = @('1', '2')
     'host-discovery-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'huawei id-ctrl --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'huawei id-ctrl --output-format-version' = @('1', '2')
+    'huawei id-ctrl -o' = @('normal', 'json', 'binary', 'tabular')
+    'huawei list --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'huawei list --output-format-version' = @('1', '2')
+    'huawei list -o' = @('normal', 'json', 'binary', 'tabular')
     'ibm crit-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'ibm crit-log --output-format-version' = @('1', '2')
     'ibm crit-log -o' = @('normal', 'json', 'binary', 'tabular')
@@ -995,6 +1305,30 @@ $script:NvmeOptionValues = @{
     'io-passthru --output-format' = @('normal', 'json', 'binary', 'tabular')
     'io-passthru --output-format-version' = @('1', '2')
     'io-passthru -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys check-kxchap-secret --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys check-kxchap-secret --output-format-version' = @('1', '2')
+    'keys check-kxchap-secret -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys check-tls --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys check-tls --output-format-version' = @('1', '2')
+    'keys check-tls -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys export --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys export --output-format-version' = @('1', '2')
+    'keys export -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys gen-kxchap-secret --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys gen-kxchap-secret --output-format-version' = @('1', '2')
+    'keys gen-kxchap-secret -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys gen-tls --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys gen-tls --output-format-version' = @('1', '2')
+    'keys gen-tls -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys import --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys import --output-format-version' = @('1', '2')
+    'keys import -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys insert-tls --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys insert-tls --output-format-version' = @('1', '2')
+    'keys insert-tls -o' = @('normal', 'json', 'binary', 'tabular')
+    'keys revoke --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'keys revoke --output-format-version' = @('1', '2')
+    'keys revoke -o' = @('normal', 'json', 'binary', 'tabular')
     'lba-status-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'lba-status-log --output-format-version' = @('1', '2')
     'lba-status-log -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1016,6 +1350,33 @@ $script:NvmeOptionValues = @{
     'list-subsys --output-format' = @('normal', 'json', 'binary', 'tabular')
     'list-subsys --output-format-version' = @('1', '2')
     'list-subsys -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm create-cdq --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'lm create-cdq --output-format-version' = @('1', '2')
+    'lm create-cdq -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm delete-cdq --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'lm delete-cdq --output-format-version' = @('1', '2')
+    'lm delete-cdq -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm get-cdq --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'lm get-cdq --output-format-version' = @('1', '2')
+    'lm get-cdq -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm migration-recv --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'lm migration-recv --output-format-version' = @('1', '2')
+    'lm migration-recv --sel' = @('0', '1', '2', '3')
+    'lm migration-recv -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm migration-recv -s' = @('0', '1', '2', '3')
+    'lm migration-send --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'lm migration-send --output-format-version' = @('1', '2')
+    'lm migration-send --sel' = @('0', '1', '2', '3')
+    'lm migration-send -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm migration-send -s' = @('0', '1', '2', '3')
+    'lm set-cdq --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'lm set-cdq --output-format-version' = @('1', '2')
+    'lm set-cdq -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm track-send --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'lm track-send --output-format-version' = @('1', '2')
+    'lm track-send --sel' = @('0', '1', '2', '3')
+    'lm track-send -o' = @('normal', 'json', 'binary', 'tabular')
+    'lm track-send -s' = @('0', '1', '2', '3')
     'lockdown --output-format' = @('normal', 'json', 'binary', 'tabular')
     'lockdown --output-format-version' = @('1', '2')
     'lockdown -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1112,6 +1473,9 @@ $script:NvmeOptionValues = @{
     'log supported-cap-config --output-format' = @('normal', 'json', 'binary', 'tabular')
     'log supported-cap-config --output-format-version' = @('1', '2')
     'log supported-cap-config -o' = @('normal', 'json', 'binary', 'tabular')
+    'log supported-pages --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'log supported-pages --output-format-version' = @('1', '2')
+    'log supported-pages -o' = @('normal', 'json', 'binary', 'tabular')
     'log telemetry --output-format' = @('normal', 'json', 'binary', 'tabular')
     'log telemetry --output-format-version' = @('1', '2')
     'log telemetry -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1244,6 +1608,15 @@ $script:NvmeOptionValues = @{
     'micron vs-work-load-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'micron vs-work-load-log --output-format-version' = @('1', '2')
     'micron vs-work-load-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'nbft show --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'nbft show --output-format-version' = @('1', '2')
+    'nbft show -o' = @('normal', 'json', 'binary', 'tabular')
+    'netapp ontapdevices --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'netapp ontapdevices --output-format-version' = @('1', '2')
+    'netapp ontapdevices -o' = @('normal', 'json', 'binary', 'tabular')
+    'netapp smdevices --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'netapp smdevices --output-format-version' = @('1', '2')
+    'netapp smdevices -o' = @('normal', 'json', 'binary', 'tabular')
     'ns attach --output-format' = @('normal', 'json', 'binary', 'tabular')
     'ns attach --output-format-version' = @('1', '2')
     'ns attach -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1431,6 +1804,18 @@ $script:NvmeOptionValues = @{
     'read --output-format' = @('normal', 'json', 'binary', 'tabular')
     'read --output-format-version' = @('1', '2')
     'read -o' = @('normal', 'json', 'binary', 'tabular')
+    'registry delete --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'registry delete --output-format-version' = @('1', '2')
+    'registry delete -o' = @('normal', 'json', 'binary', 'tabular')
+    'registry list --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'registry list --output-format-version' = @('1', '2')
+    'registry list -o' = @('normal', 'json', 'binary', 'tabular')
+    'registry retrieve --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'registry retrieve --output-format-version' = @('1', '2')
+    'registry retrieve -o' = @('normal', 'json', 'binary', 'tabular')
+    'registry update --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'registry update --output-format-version' = @('1', '2')
+    'registry update -o' = @('normal', 'json', 'binary', 'tabular')
     'reset --output-format' = @('normal', 'json', 'binary', 'tabular')
     'reset --output-format-version' = @('1', '2')
     'reset -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1542,6 +1927,36 @@ $script:NvmeOptionValues = @{
     'set-reg --output-format' = @('normal', 'json', 'binary', 'tabular')
     'set-reg --output-format-version' = @('1', '2')
     'set-reg -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx change-cap --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx change-cap --output-format-version' = @('1', '2')
+    'sfx change-cap -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx dump-evtlog --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx dump-evtlog --output-format-version' = @('1', '2')
+    'sfx dump-evtlog -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx expand-cap --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx expand-cap --output-format-version' = @('1', '2')
+    'sfx expand-cap -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx get-bad-block --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx get-bad-block --output-format-version' = @('1', '2')
+    'sfx get-bad-block -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx get-feature --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx get-feature --output-format-version' = @('1', '2')
+    'sfx get-feature -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx lat-stats --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx lat-stats --output-format-version' = @('1', '2')
+    'sfx lat-stats -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx query-cap --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx query-cap --output-format-version' = @('1', '2')
+    'sfx query-cap -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx set-feature --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx set-feature --output-format-version' = @('1', '2')
+    'sfx set-feature -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx smart-log-add --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx smart-log-add --output-format-version' = @('1', '2')
+    'sfx smart-log-add -o' = @('normal', 'json', 'binary', 'tabular')
+    'sfx status --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sfx status --output-format-version' = @('1', '2')
+    'sfx status -o' = @('normal', 'json', 'binary', 'tabular')
     'shannon get-additional-feature --output-format' = @('normal', 'json', 'binary', 'tabular')
     'shannon get-additional-feature --output-format-version' = @('1', '2')
     'shannon get-additional-feature --sel' = @('0', '1', '2', '3')
@@ -1556,6 +1971,9 @@ $script:NvmeOptionValues = @{
     'shannon smart-log-add --output-format' = @('normal', 'json', 'binary', 'tabular')
     'shannon smart-log-add --output-format-version' = @('1', '2')
     'shannon smart-log-add -o' = @('normal', 'json', 'binary', 'tabular')
+    'show-hostnqn --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'show-hostnqn --output-format-version' = @('1', '2')
+    'show-hostnqn -o' = @('normal', 'json', 'binary', 'tabular')
     'show-regs --output-format' = @('normal', 'json', 'binary', 'tabular')
     'show-regs --output-format-version' = @('1', '2')
     'show-regs -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1565,6 +1983,87 @@ $script:NvmeOptionValues = @{
     'smart-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'smart-log --output-format-version' = @('1', '2')
     'smart-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk capabilities --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk capabilities --output-format-version' = @('1', '2')
+    'sndk capabilities -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk clear-assert-dump --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk clear-assert-dump --output-format-version' = @('1', '2')
+    'sndk clear-assert-dump -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk clear-fw-activate-history --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk clear-fw-activate-history --output-format-version' = @('1', '2')
+    'sndk clear-fw-activate-history -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk clear-pcie-correctable-errors --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk clear-pcie-correctable-errors --output-format-version' = @('1', '2')
+    'sndk clear-pcie-correctable-errors -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk cloud-SSD-plugin-version --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk cloud-SSD-plugin-version --output-format-version' = @('1', '2')
+    'sndk cloud-SSD-plugin-version -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk cloud-boot-SSD-version --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk cloud-boot-SSD-version --output-format-version' = @('1', '2')
+    'sndk cloud-boot-SSD-version -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk cu-smart-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk cu-smart-log --output-format-version' = @('1', '2')
+    'sndk cu-smart-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk drive-resize --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk drive-resize --output-format-version' = @('1', '2')
+    'sndk drive-resize -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-dev-capabilities-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-dev-capabilities-log --output-format-version' = @('1', '2')
+    'sndk get-dev-capabilities-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-drive-status --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-drive-status --output-format-version' = @('1', '2')
+    'sndk get-drive-status -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-error-recovery-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-error-recovery-log --output-format-version' = @('1', '2')
+    'sndk get-error-recovery-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-latency-monitor-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-latency-monitor-log --output-format-version' = @('1', '2')
+    'sndk get-latency-monitor-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-unsupported-reqs-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk get-unsupported-reqs-log --output-format-version' = @('1', '2')
+    'sndk get-unsupported-reqs-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk log-page-directory --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk log-page-directory --output-format-version' = @('1', '2')
+    'sndk log-page-directory -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk namespace-resize --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk namespace-resize --output-format-version' = @('1', '2')
+    'sndk namespace-resize -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk set-latency-monitor-feature --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk set-latency-monitor-feature --output-format-version' = @('1', '2')
+    'sndk set-latency-monitor-feature -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-cloud-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-cloud-log --output-format-version' = @('1', '2')
+    'sndk vs-cloud-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-device-waf --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-device-waf --output-format-version' = @('1', '2')
+    'sndk vs-device-waf -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-drive-info --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-drive-info --output-format-version' = @('1', '2')
+    'sndk vs-drive-info -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-error-reason-identifier --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-error-reason-identifier --output-format-version' = @('1', '2')
+    'sndk vs-error-reason-identifier -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-fw-activate-history --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-fw-activate-history --output-format-version' = @('1', '2')
+    'sndk vs-fw-activate-history -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-hw-rev-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-hw-rev-log --output-format-version' = @('1', '2')
+    'sndk vs-hw-rev-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-nand-stats --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-nand-stats --output-format-version' = @('1', '2')
+    'sndk vs-nand-stats -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-pcie-stats --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-pcie-stats --output-format-version' = @('1', '2')
+    'sndk vs-pcie-stats -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-smart-add-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-smart-add-log --output-format-version' = @('1', '2')
+    'sndk vs-smart-add-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-telemetry-controller-option --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-telemetry-controller-option --output-format-version' = @('1', '2')
+    'sndk vs-telemetry-controller-option -o' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-temperature-stats --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'sndk vs-temperature-stats --output-format-version' = @('1', '2')
+    'sndk vs-temperature-stats -o' = @('normal', 'json', 'binary', 'tabular')
     'solidigm clear-fw-activate-history --output-format' = @('normal', 'json', 'binary', 'tabular')
     'solidigm clear-fw-activate-history --output-format-version' = @('1', '2')
     'solidigm clear-fw-activate-history -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1628,6 +2127,9 @@ $script:NvmeOptionValues = @{
     'telemetry-log --output-format' = @('normal', 'json', 'binary', 'tabular')
     'telemetry-log --output-format-version' = @('1', '2')
     'telemetry-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'top --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'top --output-format-version' = @('1', '2')
+    'top -o' = @('normal', 'json', 'binary', 'tabular')
     'toshiba clear-pcie-correctable-errors --output-format' = @('normal', 'json', 'binary', 'tabular')
     'toshiba clear-pcie-correctable-errors --output-format-version' = @('1', '2')
     'toshiba clear-pcie-correctable-errors -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1655,6 +2157,114 @@ $script:NvmeOptionValues = @{
     'virtium show-identify --output-format' = @('normal', 'json', 'binary', 'tabular')
     'virtium show-identify --output-format-version' = @('1', '2')
     'virtium show-identify -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cap-diag --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cap-diag --output-format-version' = @('1', '2')
+    'wdc cap-diag -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc capabilities --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc capabilities --output-format-version' = @('1', '2')
+    'wdc capabilities -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc clear-assert-dump --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc clear-assert-dump --output-format-version' = @('1', '2')
+    'wdc clear-assert-dump -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc clear-fw-activate-history --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc clear-fw-activate-history --output-format-version' = @('1', '2')
+    'wdc clear-fw-activate-history -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc clear-pcie-correctable-errors --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc clear-pcie-correctable-errors --output-format-version' = @('1', '2')
+    'wdc clear-pcie-correctable-errors -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cloud-SSD-plugin-version --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cloud-SSD-plugin-version --output-format-version' = @('1', '2')
+    'wdc cloud-SSD-plugin-version -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cloud-boot-SSD-version --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cloud-boot-SSD-version --output-format-version' = @('1', '2')
+    'wdc cloud-boot-SSD-version -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cu-smart-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc cu-smart-log --output-format-version' = @('1', '2')
+    'wdc cu-smart-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc drive-essentials --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc drive-essentials --output-format-version' = @('1', '2')
+    'wdc drive-essentials -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc drive-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc drive-log --output-format-version' = @('1', '2')
+    'wdc drive-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc drive-resize --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc drive-resize --output-format-version' = @('1', '2')
+    'wdc drive-resize -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc enc-get-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc enc-get-log --output-format-version' = @('1', '2')
+    'wdc enc-get-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-crash-dump --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-crash-dump --output-format-version' = @('1', '2')
+    'wdc get-crash-dump -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-dev-capabilities-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-dev-capabilities-log --output-format-version' = @('1', '2')
+    'wdc get-dev-capabilities-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-drive-status --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-drive-status --output-format-version' = @('1', '2')
+    'wdc get-drive-status -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-error-recovery-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-error-recovery-log --output-format-version' = @('1', '2')
+    'wdc get-error-recovery-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-latency-monitor-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-latency-monitor-log --output-format-version' = @('1', '2')
+    'wdc get-latency-monitor-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-pfail-dump --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-pfail-dump --output-format-version' = @('1', '2')
+    'wdc get-pfail-dump -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-unsupported-reqs-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc get-unsupported-reqs-log --output-format-version' = @('1', '2')
+    'wdc get-unsupported-reqs-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc id-ctrl --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc id-ctrl --output-format-version' = @('1', '2')
+    'wdc id-ctrl -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc log-page-directory --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc log-page-directory --output-format-version' = @('1', '2')
+    'wdc log-page-directory -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc namespace-resize --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc namespace-resize --output-format-version' = @('1', '2')
+    'wdc namespace-resize -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc purge --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc purge --output-format-version' = @('1', '2')
+    'wdc purge -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc purge-monitor --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc purge-monitor --output-format-version' = @('1', '2')
+    'wdc purge-monitor -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc set-latency-monitor-feature --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc set-latency-monitor-feature --output-format-version' = @('1', '2')
+    'wdc set-latency-monitor-feature -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-cloud-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-cloud-log --output-format-version' = @('1', '2')
+    'wdc vs-cloud-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-device-waf --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-device-waf --output-format-version' = @('1', '2')
+    'wdc vs-device-waf -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-drive-info --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-drive-info --output-format-version' = @('1', '2')
+    'wdc vs-drive-info -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-error-reason-identifier --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-error-reason-identifier --output-format-version' = @('1', '2')
+    'wdc vs-error-reason-identifier -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-fw-activate-history --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-fw-activate-history --output-format-version' = @('1', '2')
+    'wdc vs-fw-activate-history -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-hw-rev-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-hw-rev-log --output-format-version' = @('1', '2')
+    'wdc vs-hw-rev-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-nand-stats --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-nand-stats --output-format-version' = @('1', '2')
+    'wdc vs-nand-stats -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-pcie-stats --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-pcie-stats --output-format-version' = @('1', '2')
+    'wdc vs-pcie-stats -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-smart-add-log --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-smart-add-log --output-format-version' = @('1', '2')
+    'wdc vs-smart-add-log -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-telemetry-controller-option --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-telemetry-controller-option --output-format-version' = @('1', '2')
+    'wdc vs-telemetry-controller-option -o' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-temperature-stats --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'wdc vs-temperature-stats --output-format-version' = @('1', '2')
+    'wdc vs-temperature-stats -o' = @('normal', 'json', 'binary', 'tabular')
     'write --output-format' = @('normal', 'json', 'binary', 'tabular')
     'write --output-format-version' = @('1', '2')
     'write -o' = @('normal', 'json', 'binary', 'tabular')
@@ -1667,6 +2277,51 @@ $script:NvmeOptionValues = @{
     'ymtc smart-log-add --output-format' = @('normal', 'json', 'binary', 'tabular')
     'ymtc smart-log-add --output-format-version' = @('1', '2')
     'ymtc smart-log-add -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns changed-zone-list --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns changed-zone-list --output-format-version' = @('1', '2')
+    'zns changed-zone-list -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns close-zone --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns close-zone --output-format-version' = @('1', '2')
+    'zns close-zone -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns finish-zone --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns finish-zone --output-format-version' = @('1', '2')
+    'zns finish-zone -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns id-ctrl --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns id-ctrl --output-format-version' = @('1', '2')
+    'zns id-ctrl -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns id-ns --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns id-ns --output-format-version' = @('1', '2')
+    'zns id-ns -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns list --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns list --output-format-version' = @('1', '2')
+    'zns list -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns offline-zone --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns offline-zone --output-format-version' = @('1', '2')
+    'zns offline-zone -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns open-zone --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns open-zone --output-format-version' = @('1', '2')
+    'zns open-zone -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns report-zones --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns report-zones --output-format-version' = @('1', '2')
+    'zns report-zones -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns reset-zone --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns reset-zone --output-format-version' = @('1', '2')
+    'zns reset-zone -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns set-zone-desc --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns set-zone-desc --output-format-version' = @('1', '2')
+    'zns set-zone-desc -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns zone-append --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns zone-append --output-format-version' = @('1', '2')
+    'zns zone-append -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns zone-mgmt-recv --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns zone-mgmt-recv --output-format-version' = @('1', '2')
+    'zns zone-mgmt-recv -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns zone-mgmt-send --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns zone-mgmt-send --output-format-version' = @('1', '2')
+    'zns zone-mgmt-send -o' = @('normal', 'json', 'binary', 'tabular')
+    'zns zrwa-flush-zone --output-format' = @('normal', 'json', 'binary', 'tabular')
+    'zns zrwa-flush-zone --output-format-version' = @('1', '2')
+    'zns zrwa-flush-zone -o' = @('normal', 'json', 'binary', 'tabular')
 }
 
 Register-ArgumentCompleter -Native -CommandName nvme -ScriptBlock {


### PR DESCRIPTION
Picks up the --fast_io_fail_tmo -> --fast-io-fail-tmo rename and the new supported-pages command. The PowerShell completion was generated on Windows, which omits the Linux-only fabrics and plugin commands; regenerating on Linux restores them. Most of the bash/zsh diff is reordering to match the binary's command registration order.