### PR TITLE
gitignore: ignore __pycache__ anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,9 @@ subprojects/*
 cscope.*
 compile_commands.json
 
-tests/**/__pycache__
+__pycache__/
 tests/nvmetests
 tests/**/*.pyc
-libnvme/src/nvme/__pycache__
 
 .build
 .build-ci


### PR DESCRIPTION
Replace the two path-specific __pycache__ entries with a single top-level pattern so Python bytecode caches are ignored wherever they appear.