### PR TITLE
tests: fix resource leak in run_handle_plugin()

### DIFF
--- a/tests/unit/c/test-plugin.c
+++ b/tests/unit/c/test-plugin.c
@@ -151,6 +151,10 @@ static int run_handle_plugin(char *argv[], int argc, struct plugin *plugin,
 	if (saved_stdout < 0 || saved_stderr < 0) {
 		printf("ERROR: dup failed: %s\n", libnvme_strerror(errno));
 		test_rc = 1;
+		if (saved_stdout >= 0)
+			close(saved_stdout);
+		if (saved_stderr >= 0)
+			close(saved_stderr);
 		goto done;
 	}
 


### PR DESCRIPTION
run_handle_plugin() duplicates stdout and stderr with dup() before redirecting them for output capture. When the first dup() call succeeds but the second fails, the condition triggers an error jump to done: without closing the already-opened duplicate fd.

This leaks a file descriptor each time the error path is taken.

Close saved_stdout and saved_stderr individually on the error path, guarded by a >= 0 check, so only successfully opened handles are closed regardless of which dup() call failed.

Fixes: CID 562695, CID 562696