### PR TITLE
libnvme: fix resource leak in read_discovery()

### DIFF
--- a/libnvme/src/nvme/nbft.c
+++ b/libnvme/src/nvme/nbft.c
@@ -584,6 +584,7 @@ static int read_discovery(struct libnvme_global_ctx *ctx,
 		libnvme_msg(ctx, LIBNVME_LOG_DEBUG,
 			 "file %s: discovery %d HFI not found\n",
 			 nbft->filename, discovery->index);
+		r = -EINVAL;
 		goto error;
 	}
 
@@ -595,6 +596,7 @@ static int read_discovery(struct libnvme_global_ctx *ctx,
 				 "file %s: discovery %d security descriptor %d not found, skipping entry\n",
 				 nbft->filename, discovery->index,
 				 raw_discovery->sec_index);
+			r = -EINVAL;
 			goto error;
 		}
 	}


### PR DESCRIPTION
The read_discovery() function allocates discovery early in the parse path. Two error branches — HFI not found and security descriptor not found — jump to the shared cleanup label without setting r to a non-zero value first.

When get_heap_obj() for the NQN field succeeds and returns 0, r holds 0 at the point of the jump. The cleanup guard "if (r) free(discovery)" then evaluates false and the allocation is not freed, causing a memory leak.

Set r to -EINVAL before each of the two affected goto statements so the cleanup guard always frees discovery on every error path.