### PR TITLE
shared: fix resource leak in test_add_columns_invalid_width

### DIFF
--- a/shared/tests/test-table-util.c
+++ b/shared/tests/test-table-util.c
@@ -197,6 +197,8 @@ static bool test_add_columns_invalid_width(void)
 	t = shr_table_init_with_columns(columns, 2);
 	pass &= check_bool("fixed width smaller than name length fails",
 			    t == NULL);
+	if (t)
+		shr_table_free(t);
 
 	return pass;
 }


### PR DESCRIPTION
The test_add_columns_invalid_width() function calls shr_table_init_with_columns() and checks that it returns NULL for an invalid column width. If the allocation unexpectedly succeeds and returns a non-NULL t, the pointer goes out of scope at return with no corresponding free call.

This results in a resource leak each time the allocation succeeds on this path.

Free t after the check if it is non-NULL to prevent the leak.