### PR TITLE
shared: fix resource leaks in test_read_file

### DIFF
--- a/shared/tests/test-fs-util.c
+++ b/shared/tests/test-fs-util.c
@@ -354,6 +354,7 @@ static bool test_read_file(void)
 
 	buf = shr_read_file(NULL, "shr-test-read-file-does-not-exist", &size, 1);
 	pass &= check_bool("a missing file returns NULL", buf == NULL);
+	free(buf);
 
 	/* A NULL/empty @path means "the whole path is in @dir". */
 	buf = shr_read_file(path, NULL, &size, 1);
@@ -382,6 +383,7 @@ static bool test_read_file(void)
 
 		buf = shr_read_file(NULL, template, &size, 1);
 		pass &= check_bool("an empty file returns NULL", buf == NULL);
+		free(buf);
 
 		shr_unlink(template);
 	}


### PR DESCRIPTION
The test_read_file() function calls shr_read_file() twice expecting NULL: once for a missing file and once for an empty file. The results are recorded with check_bool() but execution always continues. If shr_read_file() unexpectedly returns non-NULL on either path, buf is overwritten or goes out of scope without being freed first.

This results in a memory leak each time the unexpected path is taken.

Add free(buf) after each expected-NULL check to release any allocation before buf is reused or the enclosing block exits, matching the pattern used by all other shr_read_file() calls in the function.