### PR TITLE
shared: check return value of remove() in dir_is_writable()

### DIFF
--- a/shared/tests/test-fs-util.c
+++ b/shared/tests/test-fs-util.c
@@ -130,7 +130,8 @@ static bool dir_is_writable(const char *dir)
 	if (!f)
 		return false;
 	fclose(f);
-	remove(path);
+	if (remove(path))
+		return false;
 
 	return true;
 }


### PR DESCRIPTION
The dir_is_writable() helper writes a temporary marker file to confirm that a directory is accessible, then calls remove() to clean it up. The return value of remove() was not checked.

If remove() fails the function still returns true, leaving a stale marker file behind. Subsequent test runs may encounter the leftover file and produce incorrect results.

Check the return value of remove() and return false if cleanup fails, so the test framework surfaces any filesystem error.