### PR TITLE
libnvme: fix out-of-bounds read in do_security_info()

### DIFF
--- a/libnvme/examples/mi-mctp.c
+++ b/libnvme/examples/mi-mctp.c
@@ -538,9 +538,9 @@ int do_security_info(libnvme_mi_ep_t ep, int argc, char **argv)
 	unsigned long tmp;
 	uint16_t ctrl_id;
 	struct {
-		uint8_t		rsvd[6];
-		uint16_t	len;
-		uint8_t		protocols[256];
+		__u8		rsvd[6];
+		__be16		len;
+		__u8		protocols[256];
 	} proto_info;
 	/* protocol 0x00, spsp 0x0000: retrieve supported protocols */
 	void *data = &proto_info;
@@ -573,7 +573,7 @@ int do_security_info(libnvme_mi_ep_t ep, int argc, char **argv)
 	}
 
 	n_proto = be16_to_cpu(proto_info.len);
-	if (data_len < 6 + n_proto) {
+	if (data_len < offsetof(typeof(proto_info), protocols) + n_proto) {
 		warnx("Short response in security receive command (%d bytes), "
 		      "for %d protocols", data_len, n_proto);
 		return -1;


### PR DESCRIPTION
The do_security_info() function issues a Security Receive command and reads the protocol count n_proto from the device response via a big-endian 16-bit field. The existing guard checks whether the response buffer is large enough using offset 6, but the protocols array begins at offset 8 (after the 6-byte reserved field and the 2-byte length field). This allows n_proto to reach 258 before the check triggers, while the protocols array it indexes into is only 256 bytes.

A device-controlled n_proto value of 257 or 258 causes the loop to read one or two bytes past the end of the protocols array, resulting in an out-of-bounds read.

Use offsetof(typeof(proto_info), protocols) in the guard to correctly express the offset at which protocol data begins, ensuring n_proto is bounded by the actual array capacity.