### PR TITLE
nvme: continue without PI when get_pi_info() fails

### DIFF
--- a/src/nvme-cmds-io.c
+++ b/src/nvme-cmds-io.c
@@ -317,6 +317,8 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 	nvme_id_ns_flbas_to_lbaf_inuse(ns->flbas, &lba_index);
 	lbs = 1 << ns->lbaf[lba_index].ds;
 	ms = le16_to_cpu(ns->lbaf[lba_index].ms);
+	*logical_block_size = lbs;
+	*metadata_size = ms;
 
 	nvm_ns = libnvme_alloc(sizeof(*nvm_ns));
 	if (!nvm_ns)
@@ -349,8 +351,15 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 			lbs += ms;
 	}
 
-	if (invalid_tags(lbst, ilbrt, sts, pif))
+	if (invalid_tags(lbst, ilbrt, sts, pif)) {
+		/*
+		 * The requested PI is invalid; clear the block size so
+		 * that the caller fails the command.
+		 */
+		*logical_block_size = 0;
+		*metadata_size = 0;
 		return -EINVAL;
+	}
 
 	*logical_block_size = lbs;
 	*metadata_size = ms;
@@ -1117,6 +1126,9 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	} else {
 		err = get_pi_info(hdl, cfg.nsid, cfg.prinfo,
 			cfg.ilbrt, cfg.lbst, &logical_block_size, &ms);
+		if (err && !logical_block_size)
+			return err;
+		/* PI is not available if get_pi_info() failed */
 		pi_available = err == 0;
 	}
 
@@ -1213,7 +1225,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	if (pi_available) {
 		err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst,
 			cfg.lbat, cfg.lbatm);
-		if (err)
+		if (err && err != NVME_SC_INVALID_FIELD)
 			return err;
 	}
 	gettimeofday(&start_time, NULL);


### PR DESCRIPTION
In `submit_io()` (shared by `nvme read`, `nvme write` and `nvme compare`), a failure of `get_pi_info()` (e.g. the Identify Namespace command for the NVM command set is not supported by the drive) only set `pi_available` to false while `logical_block_size` stayed 0. Execution then continued with `logical_block_size == 0` and hit a divide-by-zero (SIGFPE) when computing the block count, unless `--block-count` was given.

Per review: `get_pi_info()` is allowed to fail, in which case PI is simply not available and the I/O should still be submitted. So the command is only aborted when the logical block size cannot be determined at all:

- `get_pi_info()` now returns the logical block size and metadata size as soon as the base Identify Namespace succeeds, so the block size is known even when PI information is not; when the requested PI tags are invalid it clears them again so the command still fails with `-EINVAL`.
- `submit_io()` no longer aborts on a `get_pi_info()` failure when the block size is known; PI is marked unavailable and the I/O is submitted without PI tags.
- As in `write_zeroes()` and `verify()`, an `NVME_SC_INVALID_FIELD` result from `init_pi_tags()` is tolerated instead of failing the command.