### PR TITLE
nvme: return -EINVAL for invalid prinfo in submit_io

### DIFF
--- a/src/nvme-cmds-io.c
+++ b/src/nvme-cmds-io.c
@@ -1062,7 +1062,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	}
 
 	if (cfg.prinfo > 0xf)
-		return err;
+		return -EINVAL;
 
 	dsmgmt = cfg.dsmgmt;
 	control |= (cfg.prinfo << 10);


### PR DESCRIPTION
The prinfo range check in `submit_io()` returns `err`, which is always zero at this point (only successful `parse_and_open()` / get-namespace-id results reach this line). Passing `--prinfo=0x10` or higher to `nvme read`/`write`/`compare` therefore exits with status 0 without submitting any I/O, silently faking success.

Return `-EINVAL`, matching the identical check in `write_zeroes()` and `verify_cmd()`.