### PR TITLE
nvme: use __u64 for verify ilbrt to match OPT_SUFFIX

### DIFF
--- a/src/nvme-cmds-io.c
+++ b/src/nvme-cmds-io.c
@@ -1290,7 +1290,7 @@ static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		bool	limited_retry;
 		bool	force_unit_access;
 		__u8	prinfo;
-		__u32	ilbrt;
+		__u64	ilbrt;
 		__u16	lbat;
 		__u16	lbatm;
 		__u64	lbst;


### PR DESCRIPTION
`OPT_SUFFIX` (`CFG_LONG_SUFFIX`) parses `--ref-tag` with `shr_suffix_binary_parse()`, which stores 8 bytes via a `uint64_t *` cast. The verify command's config struct declared `ilbrt` as `__u32`, so parsing `--ref-tag` writes 8 bytes into a 4-byte field, overwriting the adjacent `lbat` and `lbatm` config values (stack layout: `ilbrt` u32 followed by `lbat` u16 and `lbatm` u16). It also mismatches `init_pi_tags()` which expects a `__u64` ilbrt.

Make the field `__u64`, consistent with the other I/O commands (`read`/`write`/`compare`/`write-zeroes` all use `__u64`).