### PR TITLE
global-ctx: forward library logging to stderr

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -4038,7 +4038,7 @@ __shr_public int libnvmf_connect(
 				libnvme_ctrl_get_traddr(c),
 				libnvme_ctrl_get_trsvcid(c),
 				fctx->hooks.user_data);
-		return -EALREADY;
+		return -ENVME_CONNECT_ALREADY;
 	}
 
 	err = libnvme_create_ctrl(ctx, &fctx->ctrl_params, &c);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -4070,20 +4070,35 @@ __shr_public int libnvmf_connect(
 		/*
 		 * Kernel-level race: something else connected between our
 		 * scan and this ioctl. @c is our own unconnected draft, not
-		 * the winner -- rescan to find it.
+		 * the winner.
 		 */
-		if (err == -ENVME_CONNECT_ALREADY &&
-		    libnvme_scan_topology(ctx, NULL, NULL) == 0) {
-			libnvme_ctrl_t winner = lookup_ctrl(h, &fctx->ctrl_params);
-			int instance = ctrl_instance(winner);
+		if (err == -ENVME_CONNECT_ALREADY) {
+			if (libnvme_scan_topology(ctx, NULL, NULL) == 0) {
+				libnvme_ctrl_t winner;
 
-			write_devid_file(fctx, devid_fd, winner);
-			if (instance >= 0)
-				registry_update_on_connect(ctx, instance);
+				winner = lookup_ctrl(h, &fctx->ctrl_params);
+				if (winner) {
+					int instance = ctrl_instance(winner);
+
+					write_devid_file(fctx, devid_fd, winner);
+					if (instance >= 0)
+						registry_update_on_connect(ctx,
+							instance);
+				}
+			}
+
+			if (fctx->hooks.already_connected)
+				fctx->hooks.already_connected(fctx, h,
+					fctx->ctrl_params.subsysnqn,
+					fctx->ctrl_params.transport,
+					fctx->ctrl_params.traddr,
+					fctx->ctrl_params.trsvcid,
+					fctx->hooks.user_data);
+		} else {
+			libnvme_msg(ctx, LIBNVME_LOG_ERR, "could not add new controller: %s\n",
+				libnvme_strerror(-err));
 		}
 
-		libnvme_msg(ctx, LIBNVME_LOG_ERR, "could not add new controller: %s\n",
-			libnvme_strerror(-err));
 		libnvme_free_ctrl(c);
 		return err;
 	}

--- a/src/fabrics.c
+++ b/src/fabrics.c
@@ -1112,14 +1112,14 @@ do_connect:
 	}
 
 	ret = libnvmf_connect(ctx, fctx);
-	if (idempotent && (ret == -EALREADY || ret == -ENVME_CONNECT_ALREADY))
+	if (ret == -ENVME_CONNECT_ALREADY && idempotent)
 		ret = 0;
 	if (ret) {
 		/*
 		 * hook_already_connected() already reported the specific
 		 * reason; the generic message here would just overwrite it.
 		 */
-		if (ret != -EALREADY && ret != -ENVME_CONNECT_ALREADY)
+		if (ret != -ENVME_CONNECT_ALREADY)
 			nvme_show_error("failed to connect: %s",
 				libnvme_strerror(-ret));
 		return ret;

--- a/src/fabrics.c
+++ b/src/fabrics.c
@@ -190,7 +190,6 @@ static int setup_common_context(struct libnvmf_context *fctx,
 struct hook_fabrics_data {
 	nvme_print_flags_t flags;
 	char *raw;
-	bool idempotent;
 };
 
 static bool hook_decide_retry(struct libnvmf_context *fctx, int err,
@@ -235,20 +234,13 @@ static void hook_already_connected(struct libnvmf_context *fctx,
 		const char *transport, const char *traddr,
 		const char *trsvcid, void *user_data)
 {
-	struct hook_fabrics_data *hfd = user_data;
-
-	if (nvme_args.quiet)
-		return;
-
-	if (hfd->idempotent) {
-		nvme_show_verbose_info(
-			"already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
-			libnvme_host_get_hostnqn(host), subsysnqn,
-			transport, traddr, trsvcid);
-		return;
-	}
-
-	nvme_show_error("already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
+	/*
+	 * Already-connected is reported through the exit code alone; this is
+	 * just extra detail for --verbose, not a message a script should
+	 * have to filter out of normal output.
+	 */
+	nvme_show_verbose_info(
+		"already connected to hostnqn=%s,nqn=%s,transport=%s,traddr=%s,trsvcid=%s",
 		libnvme_host_get_hostnqn(host), subsysnqn,
 		transport, traddr, trsvcid);
 }
@@ -1091,7 +1083,6 @@ do_connect:
 	struct hook_fabrics_data hfd = {
 		.flags = flags,
 		.raw = raw,
-		.idempotent = idempotent,
 	};
 	ret = create_common_context(ctx, &fa, &hfd, &fctx);
 	if (ret)

--- a/src/global-ctx.c
+++ b/src/global-ctx.c
@@ -146,7 +146,7 @@ static int __nvme_create_global_ctx(struct libnvme_global_ctx **pctx)
 		return -ENOMEM;
 
 	log_level = map_log_level(nvme_args.verbose, nvme_args.quiet);
-	libnvme_set_logging_file(ctx, stdout);
+	libnvme_set_logging_file(ctx, stderr);
 	libnvme_set_logging_level(ctx, log_level, false, false);
 
 	if (!nvme_args.set_options)

--- a/tests/cli/nvme_fabrics_mock_test.py
+++ b/tests/cli/nvme_fabrics_mock_test.py
@@ -467,6 +467,42 @@ class FabricsMockCLITest(unittest.TestCase):
                         '--idempotent', '-v')
         self.assertIn("already connected", res.stdout)
 
+    def test_connect_already_connected_precheck(self):
+        """A second connect to an already-live target is caught by
+        libnvmf_connect()'s own precheck (lookup_live_ctrl()), before any
+        ioctl is attempted. The CLI relies on for --idempotent and for
+        knowing not to print its own generic "failed to connect" message
+        on top of hook_already_connected()'s on the correct error code."""
+        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        # Each nvme invocation auto-generates its own random hostnqn/hostid
+        # unless one is pinned, landing in a different in-memory host object.
+        # lookup_live_ctrl() only searches the *current* host's own
+        # subsystems, so without a shared identity the second process could
+        # never recognize this as already connected, no matter what the
+        # fake sysfs tree says.
+        hostnqn = "nqn.2014-08.org.nvmexpress:uuid:22222222-2222-2222-2222-222222222222"
+        connect_args = ('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn,
+                        '--hostnqn', hostnqn)
+
+        self._run(*connect_args)
+        self.assertTrue(self._ctrl_path(0).exists(), "Mock controller directory was not created under sysfs")
+
+        # Plain connect: fails, silently unless -v, and without a second,
+        # generic "failed to connect" message alongside it.
+        res = self._run(*connect_args, expect_fail=True)
+        self.assertNotIn("already connected", res.stdout)
+        self.assertNotIn("already connected", res.stderr)
+        self.assertNotIn("failed to connect", res.stderr)
+
+        res = self._run(*connect_args, '-v', expect_fail=True)
+        self.assertIn("already connected", res.stdout)
+        self.assertNotIn("failed to connect", res.stderr)
+
+        # --idempotent: succeeds instead.
+        res = self._run(*connect_args, '--idempotent')
+        self.assertNotIn("already connected", res.stdout)
+        self.assertNotIn("already connected", res.stderr)
+
     def test_custom_identify(self):
         """Test getting custom Identify Controller fields steered by environment."""
         # Create a mock controller nvme0 in sysfs first, so nvme list has something to read.

--- a/tests/cli/nvme_fabrics_mock_test.py
+++ b/tests/cli/nvme_fabrics_mock_test.py
@@ -435,9 +435,36 @@ class FabricsMockCLITest(unittest.TestCase):
         """Test how connect handles EALREADY (already connected) error gracefully."""
         self.server.connect_errno = 114  # EALREADY
         subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+
+        # Without --verbose, EALREADY is reported through the exit code alone --
+        # no "already connected" text on either stream, so scripts don't have to
+        # filter it out of normal output.
         res = self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn,
                         expect_fail=True)
-        # nvme-cli connect handles EALREADY gracefully and prints 'already connected' to stdout.
+        self.assertNotIn("already connected", res.stdout)
+        self.assertNotIn("already connected", res.stderr)
+
+        # -v surfaces the detail. nvme-cli reports it itself (rather than relying
+        # on libnvme's own internal logging), so it lands on stdout as info --
+        # nvme-cli's own --verbose output is not the same thing as libnvme's
+        # internal logging, which is what moved to stderr.
+        res = self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn,
+                        '-v', expect_fail=True)
+        self.assertIn("already connected", res.stdout)
+
+    def test_connect_already_connected_idempotent(self):
+        """--idempotent turns EALREADY into success (exit 0) instead of a
+        failure, still silent unless --verbose is given."""
+        self.server.connect_errno = 114  # EALREADY
+        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+
+        res = self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn,
+                        '--idempotent')
+        self.assertNotIn("already connected", res.stdout)
+        self.assertNotIn("already connected", res.stderr)
+
+        res = self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn,
+                        '--idempotent', '-v')
         self.assertIn("already connected", res.stdout)
 
     def test_custom_identify(self):
@@ -560,9 +587,10 @@ class FabricsMockCLITest(unittest.TestCase):
         self.server.discovery_entries = [self._self_entry(addr, eflags=0)]
 
         # -v raises the log level to WARN so the "not persisting" message shows up.
+        # It's libnvme's own internal diagnostic, so it lands on stderr, not stdout.
         res = self._run('discover', '-t', 'tcp', '-a', addr, '--persistent=auto', '-v')
         self._assert_disconnected(self._DISCOVERY_INSTANCE)
-        self.assertIn("EPCSD", res.stdout)
+        self.assertIn("EPCSD", res.stderr)
 
     def test_discover_persistent_auto_no_self_entry_disconnects(self):
         """No self-entry (SUBTYPE=03h) at all is defined identically to EPCSD=0."""


### PR DESCRIPTION
The logging output should be sent to stderr so scripts are able to operate on the expected command output.