### PR TITLE
Handle invalid tags errors more robust

### DIFF
--- a/src/nvme-cmds-io.c
+++ b/src/nvme-cmds-io.c
@@ -48,6 +48,7 @@
 #include "argconfig.h"
 #include "cleanup.h"
 #include "global-ctx.h"
+#include "nvme-errno.h"
 #include "nvme-print.h"
 #include "plugin.h"
 
@@ -172,7 +173,7 @@ static int invalid_tags(__u64 storage_tag, __u64 ref_tag, __u8 sts, __u8 pif)
 
 	if (sts < 64 && storage_tag >= (1LL << sts)) {
 		nvme_show_error("Storage tag larger than storage tag size");
-		return 1;
+		return -ECLI_INVALID_TAGS;
 	}
 
 	switch (pif) {
@@ -194,10 +195,12 @@ static int invalid_tags(__u64 storage_tag, __u64 ref_tag, __u8 sts, __u8 pif)
 		break;
 	}
 
-	if (result)
-		nvme_show_error("Reference tag larger than allowed by PIF");
+	if (!result)
+		return 0;
 
-	return result;
+	nvme_show_error("Reference tag larger than allowed by PIF");
+
+	return -ECLI_INVALID_TAGS;
 }
 
 static int check_lbstm_byte_granularity(__u64 lbstm, __u8 sts)
@@ -266,10 +269,12 @@ static int get_pif_sts_via_qpif(struct nvme_nvm_id_ns *nvm_ns, __u32 elbaf,
 		break;
 	}
 
-	if (err)
-		nvme_show_error("Logical Block Storage Tag Mask is inconsistent with the Storage Tag Masking Level Attribute");
+	if (!err)
+		return 0;
 
-	return err;
+	nvme_show_error("Logical Block Storage Tag Mask is inconsistent with the Storage Tag Masking Level Attribute");
+
+	return -ECLI_INVALID_PI_FORMAT;
 }
 
 static int get_pif_sts(struct nvme_id_ns *ns, struct nvme_nvm_id_ns *nvm_ns,
@@ -311,7 +316,7 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
 		nvme_show_err(err, "identify namespace");
-		return err;
+		return -ECLI_IDENTIFY_NS_FAILED;
 	}
 
 	nvme_id_ns_flbas_to_lbaf_inuse(ns->flbas, &lba_index);
@@ -349,8 +354,9 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 			lbs += ms;
 	}
 
-	if (invalid_tags(lbst, ilbrt, sts, pif))
-		return -EINVAL;
+	err = invalid_tags(lbst, ilbrt, sts, pif);
+	if (err)
+		return err;
 
 	*logical_block_size = lbs;
 	*metadata_size = ms;
@@ -399,8 +405,9 @@ static int init_pi_tags(struct libnvme_transport_handle *hdl,
 		return NVME_SC_INVALID_FIELD;
 	}
 
-	if (invalid_tags(lbst, ilbrt, sts, pif))
-		return -EINVAL;
+	err = invalid_tags(lbst, ilbrt, sts, pif);
+	if (err)
+		return err;
 
 	nvme_init_var_size_tags(cmd, pif, sts, ilbrt, lbst);
 	nvme_init_app_tag(cmd, lbat, lbatm);

--- a/src/nvme-cmds-io.c
+++ b/src/nvme-cmds-io.c
@@ -345,12 +345,7 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 			return err;
 	} else if (!nvme_status_equals(err, NVME_STATUS_TYPE_NVME,
 				       NVME_SC_INVALID_FIELD)) {
-		/*
-		 * Ignore the invalid field error and skip get_pif_sts().
-		 * Keep the I/O commands behavior same as before.
-		 * Since the error returned by drives unsupported.
-		 */
-		return NVME_SC_INVALID_FIELD;
+		return err;
 	}
 
 	pi_size = (pif == NVME_NVM_PIF_16B_GUARD) ? 8 : 16;
@@ -407,12 +402,7 @@ static int init_pi_tags(struct libnvme_transport_handle *hdl,
 			return err;
 	} else if (!nvme_status_equals(err, NVME_STATUS_TYPE_NVME,
 				       NVME_SC_INVALID_FIELD)) {
-		/*
-		 * Ignore the invalid field error and skip get_pif_sts().
-		 * Keep the I/O commands behavior same as before.
-		 * Since the error returned by drives unsupported.
-		 */
-		return NVME_SC_INVALID_FIELD;
+		return err;
 	}
 
 	err = invalid_tags(lbst, ilbrt, sts, pif);
@@ -530,7 +520,7 @@ static int write_zeroes(int argc, char **argv,
 
 	err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst, cfg.lbat,
 			   cfg.lbatm);
-	if (err && err != NVME_SC_INVALID_FIELD)
+	if (err)
 		return err;
 
 	err = libnvme_exec_io_passthru(hdl, &cmd);
@@ -869,7 +859,7 @@ static int copy_cmd(int argc, char **argv, struct command *acmd, struct plugin *
 		       cfg.fua, cfg.lr, 0, cfg.dspec, copy->f0);
 	err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst, cfg.lbat,
 		cfg.lbatm);
-	if (err != 0 && err != NVME_SC_INVALID_FIELD)
+	if (err)
 		return err;
 	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {
@@ -1248,7 +1238,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	if (pi_available) {
 		err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst,
 			cfg.lbat, cfg.lbatm);
-		if (err && err != NVME_SC_INVALID_FIELD)
+		if (err)
 			return err;
 	}
 	gettimeofday(&start_time, NULL);
@@ -1390,7 +1380,7 @@ static int verify_cmd(int argc, char **argv, struct command *acmd, struct plugin
 		cfg.block_count, control, 0, NULL, 0, NULL, 0);
 	err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst,
 		cfg.lbat, cfg.lbatm);
-	if (err != 0 && err != NVME_SC_INVALID_FIELD)
+	if (err)
 		return err;
 	err = libnvme_exec_io_passthru(hdl, &cmd);
 	if (err) {

--- a/src/nvme-cmds-io.c
+++ b/src/nvme-cmds-io.c
@@ -322,6 +322,16 @@ static int get_pi_info(struct libnvme_transport_handle *hdl,
 	nvme_id_ns_flbas_to_lbaf_inuse(ns->flbas, &lba_index);
 	lbs = 1 << ns->lbaf[lba_index].ds;
 	ms = le16_to_cpu(ns->lbaf[lba_index].ms);
+	/*
+	 * Conservative fallback: if Identify NVM CS NS below fails for any
+	 * reason other than Invalid Field, we return early with PI simply
+	 * unavailable, and this is the size submit_io() will use. For an
+	 * extended-LBA namespace the metadata is always part of the
+	 * transfer, so publish the full size now; the PRACT exception below
+	 * can only shrink it once PI info actually comes back.
+	 */
+	*logical_block_size = lbs + (NVME_FLBAS_META_EXT(ns->flbas) ? ms : 0);
+	*metadata_size = ms;
 
 	nvm_ns = libnvme_alloc(sizeof(*nvm_ns));
 	if (!nvm_ns)
@@ -1124,7 +1134,25 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	} else {
 		err = get_pi_info(hdl, cfg.nsid, cfg.prinfo,
 			cfg.ilbrt, cfg.lbst, &logical_block_size, &ms);
-		pi_available = err == 0;
+		switch (err) {
+		case 0:
+			pi_available = true;
+			break;
+		case -ENOMEM:
+			/* Could not even allocate the Identify buffer. */
+		case -ECLI_IDENTIFY_NS_FAILED:
+			/* Base Identify Namespace failed: no logical block size. */
+		case -ECLI_INVALID_TAGS:
+			/* Reference/storage tag is invalid for this PI format. */
+		case -ECLI_INVALID_PI_FORMAT:
+			/* Namespace's reported PI format is self-inconsistent. */
+			return err;
+		default:
+			/* Identify NVM CS NS failed/unsupported: PI unavailable. */
+			nvme_show_err(err, "identify NVM CS NS: continuing without protection information");
+			pi_available = false;
+			break;
+		}
 	}
 
 	buffer_size = ((long long)cfg.block_count + 1) * logical_block_size;
@@ -1220,7 +1248,7 @@ static int submit_io(int opcode, char *command, const char *desc, int argc, char
 	if (pi_available) {
 		err = init_pi_tags(hdl, &cmd, cfg.nsid, cfg.ilbrt, cfg.lbst,
 			cfg.lbat, cfg.lbatm);
-		if (err)
+		if (err && err != NVME_SC_INVALID_FIELD)
 			return err;
 	}
 	gettimeofday(&start_time, NULL);

--- a/src/nvme-errno.h
+++ b/src/nvme-errno.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 SUSE Software Solutions
+ *
+ * Authors: Daniel Wagner <dwagner@suse.de>
+ */
+#pragma once
+
+/**
+ * enum cli_error_codes - nvme-cli internal error codes
+ * @ECLI_INVALID_TAGS: the requested reference/storage tag is invalid for
+ *		        the namespace's protection information format
+ * @ECLI_INVALID_PI_FORMAT: the namespace's protection information format,
+ *			     as reported by Identify NVM CS NS, is internally
+ *			     inconsistent (e.g. LBSTM disagrees with PIFA's
+ *			     masking level)
+ * @ECLI_IDENTIFY_NS_FAILED: the base Identify Namespace command failed
+ */
+enum cli_error_codes {
+	ECLI_INVALID_TAGS = 2000,
+	ECLI_INVALID_PI_FORMAT = 2001,
+	ECLI_IDENTIFY_NS_FAILED = 2002,
+};

--- a/tests/cli/libmock_nvme.c
+++ b/tests/cli/libmock_nvme.c
@@ -114,8 +114,9 @@ struct __attribute__((packed)) ipc_request {
 };
 
 struct __attribute__((packed)) ipc_response {
-	int32_t  status;	/* 0 for success, -1 for error */
-	int32_t  errno_val;	/* errno to return on error */
+	int32_t  status;	/* 0 for success, -1 for a real syscall/errno failure */
+	int32_t  errno_val;	/* errno to return on error (status == -1 only) */
+	int32_t  sc_status;	/* NVMe completion status */
 	uint32_t result;	/* cmd->result */
 	uint32_t data_len;	/* payload length (follows immediately) */
 };
@@ -563,8 +564,8 @@ static int handle_passthru_ioctl(int instance, unsigned long request,
 	orig_write(ipc_fd, &req, sizeof(req));
 
 	resp_data = read_ipc_response(ipc_fd, &resp);
-	mock_dbg("ioctl received IPC response status %d, result %u, data_len %u\n",
-		 resp.status, resp.result, resp.data_len);
+	mock_dbg("ioctl received IPC response status %d, sc_status %d, result %u, data_len %u\n",
+		 resp.status, resp.sc_status, resp.result, resp.data_len);
 
 	if (resp.status == -1) {
 		free(resp_data);
@@ -594,7 +595,7 @@ static int handle_passthru_ioctl(int instance, unsigned long request,
 	free(resp_data);
 	orig_close(ipc_fd);
 
-	return 0;
+	return resp.sc_status;
 }
 
 int ioctl(int fd, unsigned long request, ...)

--- a/tests/cli/libmock_nvme.c
+++ b/tests/cli/libmock_nvme.c
@@ -8,15 +8,17 @@
  */
 
 /*
- * LD_PRELOAD shim for the fabrics CLI tests (see nvme_fabrics_mock_test.py).
+ * LD_PRELOAD shim for the CLI-driven, hardware-free tests under tests/cli/.
  *
- * It intercepts open()/write()/ioctl()/close() on /dev/nvme-fabrics and
- * /dev/nvme<N> so that "nvme discover"/"connect"/"connect-all" can run
- * against a fake target without a kernel nvme-fabrics module or root
- * privileges. Every intercepted write() (connect args) and ioctl() (admin
- * passthru command) is forwarded over a Unix socket to a Python-side IPC
- * server that supplies the response, so all test scenarios are steered from
- * the Python test file rather than from this shim.
+ * Intercepts open()/write()/ioctl()/close() on /dev/nvme-fabrics,
+ * /dev/nvme<N> (controller char device), and /dev/nvme<N>n<M> (namespace
+ * char device). This lets any nvme-cli command run against a fake target,
+ * with no kernel nvme-fabrics module, no real hardware, and no root.
+ *
+ * Every intercepted write() (fabrics connect args) or ioctl() (admin or
+ * I/O passthru command) goes over a Unix socket to a Python IPC server.
+ * The server sends back the response. This way, the Python test file
+ * controls the whole scenario, not this shim.
  */
 
 #undef _FILE_OFFSET_BITS
@@ -44,11 +46,6 @@
 
 #include <shared/compiler-attributes-util.h>
 
-/*
- * Mirrors struct linux_passthru_cmd32/64 in libnvme/src/nvme/private.h --
- * the layout libnvme's own ioctl() callers use -- so casting the ioctl()
- * argp we're handed back to this type lines up with the real fields.
- */
 struct linux_passthru_cmd32 {
 	__u8	opcode;
 	__u8	flags;
@@ -93,7 +90,9 @@ struct linux_passthru_cmd64 {
 };
 
 #define LIBNVME_IOCTL_ADMIN_CMD		_IOWR('N', 0x41, struct linux_passthru_cmd32)
+#define LIBNVME_IOCTL_IO_CMD		_IOWR('N', 0x43, struct linux_passthru_cmd32)
 #define LIBNVME_IOCTL_ADMIN64_CMD	_IOWR('N', 0x47, struct linux_passthru_cmd64)
+#define LIBNVME_IOCTL_IO64_CMD		_IOWR('N', 0x48, struct linux_passthru_cmd64)
 
 /* Wire format shared with the Python IPC server -- keep both sides in sync. */
 struct __attribute__((packed)) ipc_request {
@@ -129,6 +128,8 @@ typedef ssize_t (*orig_write_t)(int fd, const void *buf, size_t count);
 typedef ssize_t (*orig_read_t)(int fd, void *buf, size_t count);
 typedef int (*orig_ioctl_t)(int fd, unsigned long request, ...);
 typedef int (*orig_close_t)(int fd);
+typedef int (*orig_fstat_t)(int fd, struct stat *buf);
+typedef int (*orig_fstat64_t)(int fd, struct stat64 *buf);
 
 static orig_open_t orig_open;
 static orig_open64_t orig_open64;
@@ -138,6 +139,8 @@ static orig_write_t orig_write;
 static orig_read_t orig_read;
 static orig_ioctl_t orig_ioctl;
 static orig_close_t orig_close;
+static orig_fstat_t orig_fstat;
+static orig_fstat64_t orig_fstat64;
 
 static int mock_fabrics_fd = -1;
 static int mock_fabrics_manager_fd = -1;
@@ -147,6 +150,7 @@ static bool mock_debug;
 static struct {
 	int fd;
 	int instance;
+	bool is_block;
 } mock_ctrl_fds[MAX_MOCK_CTRLS];
 static int num_mock_ctrls;
 
@@ -159,7 +163,7 @@ static int num_mock_ctrls;
 static void __shr_constructor mock_init(void)
 {
 	mock_debug = !!getenv("MOCK_DEBUG");
-	mock_dbg("libmock_fabrics loaded, sizeof(ipc_request)=%zu, sizeof(ipc_response)=%zu\n",
+	mock_dbg("libmock_nvme loaded, sizeof(ipc_request)=%zu, sizeof(ipc_response)=%zu\n",
 		 sizeof(struct ipc_request), sizeof(struct ipc_response));
 }
 
@@ -176,6 +180,8 @@ static void init_orig_functions(void)
 	orig_read = (orig_read_t)dlsym(RTLD_NEXT, "read");
 	orig_ioctl = (orig_ioctl_t)dlsym(RTLD_NEXT, "ioctl");
 	orig_close = (orig_close_t)dlsym(RTLD_NEXT, "close");
+	orig_fstat = (orig_fstat_t)dlsym(RTLD_NEXT, "fstat");
+	orig_fstat64 = (orig_fstat64_t)dlsym(RTLD_NEXT, "fstat64");
 }
 
 static int connect_ipc_socket(void)
@@ -199,7 +205,8 @@ static int connect_ipc_socket(void)
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, sock_path, sizeof(addr.sun_path) - 1);
 	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-		mock_dbg("connect failed to '%s': %s\n", sock_path, strerror(errno));
+		mock_dbg("connect failed to '%s': %s\n",
+			sock_path, strerror(errno));
 		orig_close(fd);
 		return -1;
 	}
@@ -207,10 +214,20 @@ static int connect_ipc_socket(void)
 	return fd;
 }
 
-/* Returns -2 when @pathname is not one we intercept. */
+const char *default_opts =
+	"instance,cntlid,concat,ctrl_loss_tmo,data_digest,"
+	"dhchap_ctrl_secret,dhchap_secret,disable_sqflow,"
+	"discovery,duplicate_connect,fast_io_fail_tmo,"
+	"hdr_digest,host_iface,host_traddr,hostid,hostnqn,"
+	"keep_alive_tmo,keyring,nqn,nr_io_queues,"
+	"nr_poll_queues,nr_write_queues,queue_size,"
+	"reconnect_delay,tls,tls_key,tos,traddr,transport,"
+	"trsvcid\n";
+
 static int handle_open_intercept(const char *pathname, int flags)
 {
 	int instance, real_fd, sv[2];
+	bool is_block;
 	char *endp;
 
 	if (!pathname)
@@ -229,14 +246,7 @@ static int handle_open_intercept(const char *pathname, int flags)
 			const char *opts = getenv("MOCK_SUPPORTED_OPTIONS");
 
 			if (!opts)
-				opts = "instance,cntlid,concat,ctrl_loss_tmo,data_digest,"
-				       "dhchap_ctrl_secret,dhchap_secret,disable_sqflow,"
-				       "discovery,duplicate_connect,fast_io_fail_tmo,"
-				       "hdr_digest,host_iface,host_traddr,hostid,hostnqn,"
-				       "keep_alive_tmo,keyring,nqn,nr_io_queues,"
-				       "nr_poll_queues,nr_write_queues,queue_size,"
-				       "reconnect_delay,tls,tls_key,tos,traddr,transport,"
-				       "trsvcid\n";
+				opts = default_opts;
 			orig_write(mock_fabrics_manager_fd, opts, strlen(opts));
 			orig_close(mock_fabrics_manager_fd);
 			mock_fabrics_manager_fd = -1;
@@ -251,14 +261,23 @@ static int handle_open_intercept(const char *pathname, int flags)
 		return -2;
 
 	instance = strtol(pathname + 9, &endp, 10);
-	if (!endp || *endp != '\0')
+	is_block = (*endp == 'n');
+	if (is_block) {
+		char *nsp;
+
+		strtol(endp + 1, &nsp, 10);
+		if (nsp == endp + 1 || *nsp != '\0')
+			return -2;
+	} else if (*endp != '\0') {
 		return -2;
+	}
 
 	real_fd = orig_open("/dev/null", flags);
 	if (real_fd >= 0) {
 		if (num_mock_ctrls < MAX_MOCK_CTRLS) {
 			mock_ctrl_fds[num_mock_ctrls].fd = real_fd;
 			mock_ctrl_fds[num_mock_ctrls].instance = instance;
+			mock_ctrl_fds[num_mock_ctrls].is_block = is_block;
 			num_mock_ctrls++;
 		}
 		mock_dbg("intercepted /dev/nvme%d open (mapped to fd %d)\n",
@@ -348,15 +367,6 @@ int openat64(int dirfd, const char *pathname, int flags, ...)
 	return orig_openat64(dirfd, pathname, flags, mode);
 }
 
-/*
- * With _FORTIFY_SOURCE >= 1 and optimization enabled, glibc's <fcntl.h>
- * rewrites the 2-argument form of open()/openat() (no O_CREAT, so no mode)
- * at the call site into a call to these symbols instead of open()/openat().
- * Callers built that way (e.g. the Tumbleweed release CI job, which passes
- * -D_FORTIFY_SOURCE=3 -O2) bypass our open()/openat() overrides entirely
- * unless these are intercepted too. No mode argument is needed here since
- * the 2-argument form implies O_CREAT/O_TMPFILE weren't set.
- */
 int __open_2(const char *pathname, int flags)
 {
 	int fd;
@@ -405,11 +415,6 @@ int __openat64_2(int dirfd, const char *pathname, int flags)
 	return orig_openat64(dirfd, pathname, flags, 0);
 }
 
-/* read() on a stream socket may return fewer bytes than requested even
- * when more are on the way; loop until @len bytes are read, an orig_read()
- * error/EOF occurs, or a short read is treated as an error by the caller.
- * Returns true if all @len bytes were read.
- */
 static bool read_full(int fd, void *buf, size_t len)
 {
 	size_t total_read = 0;
@@ -425,10 +430,6 @@ static bool read_full(int fd, void *buf, size_t len)
 	return true;
 }
 
-/* Reads the fixed-size ipc_response header, then its variable-length
- * payload (if any) into a freshly malloc()'d buffer. Returns the payload
- * (NULL if empty or on error) and fills in @resp.
- */
 static void *read_ipc_response(int ipc_fd, struct ipc_response *resp)
 {
 	char *payload;
@@ -515,14 +516,27 @@ static int mock_ctrl_instance(int fd)
 	return -1;
 }
 
-static int handle_admin_ioctl(int instance, unsigned long request,
-			       struct linux_passthru_cmd64 *cmd)
+static bool mock_ctrl_is_block(int fd, bool *is_block)
+{
+	for (int i = 0; i < num_mock_ctrls; i++) {
+		if (mock_ctrl_fds[i].fd == fd) {
+			*is_block = mock_ctrl_fds[i].is_block;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static int handle_passthru_ioctl(int instance, unsigned long request,
+				  struct linux_passthru_cmd64 *cmd)
 {
 	struct ipc_response resp;
 	void *resp_data;
 	int ipc_fd;
 
-	mock_dbg("ioctl intercepted on instance %d\n", instance);
+	mock_dbg("ioctl intercepted on instance %d (request 0x%lx)\n",
+		instance, request);
 
 	ipc_fd = connect_ipc_socket();
 	if (ipc_fd < 0) {
@@ -559,16 +573,10 @@ static int handle_admin_ioctl(int instance, unsigned long request,
 		return -1;
 	}
 
-	/*
-	 * argp is only guaranteed to be a full struct linux_passthru_cmd64
-	 * for the ADMIN64_CMD request; for the legacy ADMIN_CMD request it
-	 * really points at the smaller struct linux_passthru_cmd32, whose
-	 * result field is 4 bytes narrower and sits 4 bytes earlier. Writing
-	 * through the wider cmd64 view in that case scribbles 8 bytes past
-	 * the end of the caller's 32-bit struct.
-	 */
-	if (request == LIBNVME_IOCTL_ADMIN_CMD) {
-		struct linux_passthru_cmd32 *cmd32 = (struct linux_passthru_cmd32 *)cmd;
+	if (request == LIBNVME_IOCTL_ADMIN_CMD ||
+			request == LIBNVME_IOCTL_IO_CMD) {
+		struct linux_passthru_cmd32 *cmd32 =
+			(struct linux_passthru_cmd32 *)cmd;
 
 		cmd32->result = resp.result;
 	} else {
@@ -603,8 +611,11 @@ int ioctl(int fd, unsigned long request, ...)
 	va_end(args);
 
 	if (instance >= 0 &&
-	    (request == LIBNVME_IOCTL_ADMIN_CMD || request == LIBNVME_IOCTL_ADMIN64_CMD)) {
-		ret = handle_admin_ioctl(instance, request, argp);
+			(request == LIBNVME_IOCTL_ADMIN_CMD ||
+			request == LIBNVME_IOCTL_ADMIN64_CMD ||
+			request == LIBNVME_IOCTL_IO_CMD ||
+			request == LIBNVME_IOCTL_IO64_CMD)) {
+		ret = handle_passthru_ioctl(instance, request, argp);
 		if (ret != -2)
 			return ret;
 	}
@@ -612,11 +623,6 @@ int ioctl(int fd, unsigned long request, ...)
 	return orig_ioctl(fd, request, argp);
 }
 
-/*
- * Some libc admin-passthru call sites resolve ioctl() through this alias
- * rather than the public symbol; keep it in sync with ioctl() above so
- * those calls are intercepted too.
- */
 int __ioctl(int fd, unsigned long request, ...)
 {
 	va_list args;
@@ -648,4 +654,34 @@ int close(int fd)
 	}
 
 	return orig_close(fd);
+}
+
+int fstat(int fd, struct stat *buf)
+{
+	bool is_block;
+
+	init_orig_functions();
+
+	if (mock_ctrl_is_block(fd, &is_block)) {
+		memset(buf, 0, sizeof(*buf));
+		buf->st_mode = (is_block ? S_IFBLK : S_IFCHR) | 0600;
+		return 0;
+	}
+
+	return orig_fstat(fd, buf);
+}
+
+int fstat64(int fd, struct stat64 *buf)
+{
+	bool is_block;
+
+	init_orig_functions();
+
+	if (mock_ctrl_is_block(fd, &is_block)) {
+		memset(buf, 0, sizeof(*buf));
+		buf->st_mode = (is_block ? S_IFBLK : S_IFCHR) | 0600;
+		return 0;
+	}
+
+	return orig_fstat64(fd, buf);
 }

--- a/tests/cli/meson.build
+++ b/tests/cli/meson.build
@@ -65,19 +65,22 @@ if python3.found()
              depends: nvme_exe)
     endif
 
-    if want_fabrics and (not is_static) and (not is_cross)
-        mock_fabrics_lib = shared_library(
-            'mock_fabrics',
-            'libmock_fabrics.c',
+    if (not is_static) and (not is_cross) and (host_system == 'linux')
+        mock_nvme_lib = shared_library(
+            'mock_nvme',
+            'libmock_nvme.c',
             include_directories: '../..',
             dependencies: dl_dep,
             install: false
         )
         # cli_test_env.prepend('MOCK_DEBUG', '1')
-        test('nvme-cli - fabrics-mock-cli',
-             python3,
-             args: [files('nvme_fabrics_mock_test.py'), nvme_exe, mock_fabrics_lib],
-             env: cli_test_env,
-             depends: [nvme_exe, mock_fabrics_lib])
+
+        if want_fabrics
+            test('nvme-cli - fabrics-mock-cli',
+                 python3,
+                 args: [files('nvme_fabrics_mock_test.py'), nvme_exe, mock_nvme_lib],
+                 env: cli_test_env,
+                 depends: [nvme_exe, mock_nvme_lib])
+        endif
     endif
 endif

--- a/tests/cli/meson.build
+++ b/tests/cli/meson.build
@@ -82,5 +82,11 @@ if python3.found()
                  env: cli_test_env,
                  depends: [nvme_exe, mock_nvme_lib])
         endif
+
+        test('nvme-cli - pif-sts-cli',
+             python3,
+             args: [files('nvme_pif_sts_test.py'), nvme_exe, mock_nvme_lib],
+             env: cli_test_env,
+             depends: [nvme_exe, mock_nvme_lib])
     endif
 endif

--- a/tests/cli/meson.build
+++ b/tests/cli/meson.build
@@ -88,5 +88,11 @@ if python3.found()
              args: [files('nvme_pif_sts_test.py'), nvme_exe, mock_nvme_lib],
              env: cli_test_env,
              depends: [nvme_exe, mock_nvme_lib])
+
+        test('nvme-cli - init-pi-tags-cli',
+             python3,
+             args: [files('nvme_init_pi_tags_test.py'), nvme_exe, mock_nvme_lib],
+             env: cli_test_env,
+             depends: [nvme_exe, mock_nvme_lib])
     endif
 endif

--- a/tests/cli/nvme_fabrics_mock_test.py
+++ b/tests/cli/nvme_fabrics_mock_test.py
@@ -7,25 +7,23 @@
 # Authors: Daniel Wagner <dwagner@suse.com>
 """Integration tests for 'nvme discover', 'nvme connect', and 'nvme connect-all'.
 
-Uses LD_PRELOAD mocking (see libmock_fabrics.c), so no real NVMe hardware or
+Uses LD_PRELOAD mocking (see libmock_nvme.c), so no real NVMe hardware or
 root privileges are required. The mock shim forwards every connect() write
-and admin passthru ioctl() over a Unix socket to the MockIPCServer below,
-which is steered per-test to fabricate discovery log pages, Identify data,
-and simulated errno failures.
+and admin passthru ioctl() over a Unix socket to the FabricsMockIPCServer
+below, which is steered per-test to fabricate discovery log pages, Identify
+data, and simulated errno failures.
 
 Usage: python3 nvme_fabrics_mock_test.py <path-to-nvme-binary> <path-to-mock-lib>
 """
 import os
-import shlex
 import shutil
-import socket
 import struct
-import subprocess
 import sys
 import tempfile
-import threading
 import unittest
 from pathlib import Path
+
+from nvme_mock_ipc import MockIPCServer, make_mock_env, resolve_mock_lib_path, run_nvme
 
 # Capture the nvme binary path and preload library path from argv before
 # unittest.main() strips them.
@@ -44,32 +42,11 @@ NVME_NQN_CURR = 3   # This Discovery Controller's own port
 # struct nvmf_disc_log_entry EFLAGS bit (enum nvmf_disc_eflags).
 NVMF_DISC_EFLAGS_EPCSD = 1 << 1
 
-# IPC wire format shared with libmock_fabrics.c -- keep both sides in sync.
-_IPC_REQUEST_FMT = "=IIII B3x I IIIIII QI"
-_IPC_REQUEST_LEN = struct.calcsize(_IPC_REQUEST_FMT)
-_IPC_RESPONSE_FMT = "=iiII"
-
 _NVME_OPCODE_GET_LOG_PAGE = 0x02
 _NVME_OPCODE_IDENTIFY = 0x06
 _DISCOVERY_LOG_LID = 0x70
 
-
-def resolve_mock_lib_path():
-    if len(sys.argv) > 2:
-        raw_path = sys.argv[2]
-        candidates = (
-            Path(raw_path),
-            Path(raw_path).resolve(),
-            Path(os.getcwd()) / ".build" / raw_path,
-            Path(__file__).parent.parent.parent / ".build" / raw_path,
-        )
-        for candidate in candidates:
-            if candidate.exists():
-                return str(candidate.resolve())
-    return "./libmock_fabrics.so"
-
-
-_MOCK_LIB = resolve_mock_lib_path()
+_MOCK_LIB = resolve_mock_lib_path("./libmock_nvme.so")
 
 
 def _pack_disc_log_entry(portid, entry):
@@ -103,15 +80,9 @@ def _pack_disc_log_entry(portid, entry):
     return header + rsvd12 + trsvcid_bytes + rsvd64 + subnqn_bytes + traddr_bytes + tsas
 
 
-class MockIPCServer(threading.Thread):
+class FabricsMockIPCServer(MockIPCServer):
     def __init__(self, sock_path):
-        super().__init__()
-        self.sock_path = sock_path
-        self.running = True
-        self.server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.server_sock.bind(self.sock_path)
-        self.server_sock.listen(5)
-        self.server_sock.settimeout(0.5)
+        super().__init__(sock_path)
 
         # Test-specific state overrides, steered from Python tests.
         self.connect_errno = 0
@@ -125,26 +96,10 @@ class MockIPCServer(threading.Thread):
         self.controllers = {}        # maps instance (int) -> dict of connect options
         self.log_page_fetch_count = {}  # maps subsysnqn (str) -> completed-fetch count
 
-    def run(self):
-        while self.running:
-            try:
-                conn, _ = self.server_sock.accept()
-            except socket.timeout:
-                continue
-            except OSError:
-                break
-
-            self.handle_client(conn)
-
-    @staticmethod
-    def _send_response(conn, status, errno_val=0, result=0, payload=b""):
-        conn.sendall(struct.pack(_IPC_RESPONSE_FMT, status, errno_val, result, len(payload)))
-        if payload:
-            conn.sendall(payload)
-
-    def _handle_connect(self, conn, payload):
+    def handle_write(self, conn, payload):
+        """A write() on /dev/nvme-fabrics: fabrics connect args."""
         if self.connect_errno != 0:
-            self._send_response(conn, -1, errno_val=self.connect_errno)
+            self.send_response(conn, -1, errno_val=self.connect_errno)
             return
 
         opts = {}
@@ -178,7 +133,7 @@ class MockIPCServer(threading.Thread):
                                     host_traddr, host_iface, hostnqn, hostid)
 
         resp_payload = f"instance={inst}\n".encode('utf-8')
-        self._send_response(conn, 0, payload=resp_payload)
+        self.send_response(conn, 0, payload=resp_payload)
 
     def _write_sysfs_ctrl(self, inst, subsysnqn, transport, traddr, trsvcid,
                            host_traddr, host_iface, hostnqn, hostid):
@@ -208,15 +163,16 @@ class MockIPCServer(threading.Thread):
         (sub_path / "subsysnqn").write_text(f"{subsysnqn}\n")
         (sub_path / f"nvme{inst}").mkdir(exist_ok=True)
 
-    def _handle_ioctl(self, conn, fd, opcode, cdw10, lpo, req_len):
+    def handle_ioctl(self, conn, fd, request, opcode, nsid,
+                      cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len):
         if self.ioctl_errno != 0:
-            self._send_response(conn, -1, errno_val=self.ioctl_errno)
+            self.send_response(conn, -1, errno_val=self.ioctl_errno)
             return
 
         resp_payload = b""
 
         if opcode == _NVME_OPCODE_GET_LOG_PAGE and (cdw10 & 0xff) == _DISCOVERY_LOG_LID:
-            # fd carries the controller instance for IOCTLs (see libmock_fabrics.c).
+            # fd carries the controller instance for IOCTLs (see libmock_nvme.c).
             ctrl_nqn = self.controllers.get(fd, {}).get('subsysnqn', '')
             entries = self.discovery_map.get(ctrl_nqn, self.discovery_entries)
 
@@ -244,38 +200,7 @@ class MockIPCServer(threading.Thread):
             rsvd = b"\x00" * (4096 - len(vid) - len(sn_bytes) - len(mn_bytes) - len(fr_bytes))
             resp_payload = (vid + sn_bytes + mn_bytes + fr_bytes + rsvd)[:req_len]
 
-        self._send_response(conn, 0, payload=resp_payload)
-
-    def handle_client(self, conn):
-        try:
-            req_header = conn.recv(_IPC_REQUEST_LEN)
-            if len(req_header) < _IPC_REQUEST_LEN:
-                return
-
-            req_type, fd, data_len, _ioctl_request, opcode, _nsid, \
-                cdw10, _cdw11, _cdw12, _cdw13, _cdw14, _cdw15, lpo, req_len = \
-                struct.unpack(_IPC_REQUEST_FMT, req_header)
-
-            payload = conn.recv(data_len) if data_len > 0 else b""
-
-            if req_type == 1:    # WRITE (connect args)
-                self._handle_connect(conn, payload)
-            elif req_type == 2:  # IOCTL (admin passthru)
-                self._handle_ioctl(conn, fd, opcode, cdw10, lpo, req_len)
-        except OSError as e:
-            print(f"Exception handling IPC client: {e}", file=sys.stderr)
-        finally:
-            conn.close()
-
-    def shutdown(self):
-        self.running = False
-        try:
-            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            client.connect(self.sock_path)
-            client.close()
-        except OSError:
-            pass
-        self.server_sock.close()
+        self.send_response(conn, 0, payload=resp_payload)
 
 
 class FabricsMockCLITest(unittest.TestCase):
@@ -294,21 +219,11 @@ class FabricsMockCLITest(unittest.TestCase):
         self.ipc_dir = tempfile.mkdtemp(prefix='nvme-mock-ipc-', dir='/tmp')
         self.ipc_sock_path = os.path.join(self.ipc_dir, "ipc.sock")
 
-        self.server = MockIPCServer(self.ipc_sock_path)
+        self.server = FabricsMockIPCServer(self.ipc_sock_path)
         self.server.sysfs_dir = self.sysfs_dir
         self.server.start()
 
-        self.env = os.environ.copy()
-        # Append (don't clobber) LD_PRELOAD so an existing entry, e.g.
-        # libasan, is kept. If libasan isn't first in the LD_PRELOAD list,
-        # ASan warns/aborts because its interceptors weren't installed
-        # first; verify_asan_link_order=0 silences that check, since we
-        # can't control the order and it isn't a real problem here.
-        existing_preload = self.env.get("LD_PRELOAD", "")
-        self.env["LD_PRELOAD"] = f"{existing_preload} {_MOCK_LIB}".strip()
-        existing_asan_options = self.env.get("ASAN_OPTIONS", "")
-        self.env["ASAN_OPTIONS"] = f"{existing_asan_options}:verify_asan_link_order=0".strip(':')
-        self.env["MOCK_IPC_SOCK"] = self.ipc_sock_path
+        self.env = make_mock_env(_MOCK_LIB, self.ipc_sock_path)
 
     def tearDown(self):
         self.server.shutdown()
@@ -319,44 +234,14 @@ class FabricsMockCLITest(unittest.TestCase):
         shutil.rmtree(self.ipc_dir, ignore_errors=True)
 
     def _run(self, *args, expect_fail=False):
-        cmd = [
-            _NVME_BIN,
-            '--set-options', f'test-sysfs-dir={self.sysfs_dir},test-base-dir={self.base_dir}',
-        ] + list(args)
-
-        # Under 'meson test --setup=valgrind' this script itself runs under
-        # valgrind, but nvme must run natively. Valgrind rewrites LD_PRELOAD
-        # on every execve() it traps (to strip its own vgpreload bookkeeping),
-        # which wipes out our appended mock lib entry too since it's part of
-        # the same string. Route through a shell: the exec() below is what
-        # valgrind sees and mangles, but the shell's own subsequent exec of
-        # nvme happens in a process valgrind no longer traces, so the
-        # LD_PRELOAD it sets there reaches nvme intact.
-        env = dict(self.env)
-        ld_preload = env.pop("LD_PRELOAD", "")
-        wrapped_cmd = [
-            '/bin/sh', '-c', f'export LD_PRELOAD={shlex.quote(ld_preload)}; exec "$@"',
-            'nvme-mock-wrapper',
-        ] + cmd
-
-        result = subprocess.run(wrapped_cmd, env=env,
-                                stdin=subprocess.DEVNULL,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                encoding='utf-8')
-
-        # Print outputs to sys.stderr so they are displayed by unittest on failure.
-        print(f"\n--- RUN: {' '.join(cmd)} ---", file=sys.stderr)
-        print(f"STDOUT:\n{result.stdout}", file=sys.stderr)
-        print(f"STDERR:\n{result.stderr}", file=sys.stderr)
-        print("-----------------------------------", file=sys.stderr)
+        result = run_nvme(_NVME_BIN, self.env, self.sysfs_dir, self.base_dir, *args)
 
         if not expect_fail:
             self.assertEqual(result.returncode, 0,
-                             f'Command {cmd} failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+                             f'Command {args} failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
         else:
             self.assertNotEqual(result.returncode, 0,
-                                f'Command {cmd} was expected to fail but succeeded')
+                                f'Command {args} was expected to fail but succeeded')
         return result
 
     def _ctrl_path(self, instance):

--- a/tests/cli/nvme_init_pi_tags_test.py
+++ b/tests/cli/nvme_init_pi_tags_test.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+# Copyright (c) 2026 SUSE LLC
+#
+# Authors: Daniel Wagner <dwagner@suse.com>
+"""Test for a PI tags initialization
+
+Usage: python3 nvme_init_pi_tags_test.py <path-to-nvme-binary> <path-to-mock-lib>
+"""
+import errno
+import os
+import shutil
+import signal
+import struct
+import sys
+import tempfile
+import unittest
+
+from nvme_mock_ipc import MockIPCServer, make_mock_env, resolve_mock_lib_path, run_nvme
+
+_NVME_BIN = sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith('-') else 'nvme'
+_MOCK_LIB = resolve_mock_lib_path("./libmock_nvme.so")
+
+_NVME_OPCODE_READ = 0x02
+_NVME_OPCODE_IDENTIFY = 0x06
+_NVME_IDENTIFY_CNS_NS = 0x00
+_NVME_IDENTIFY_CNS_CSI_NS = 0x05
+
+NVME_SC_INVALID_FIELD = 0x2
+NVME_SC_INTERNAL = 0x6
+
+PIF_16B_GUARD = 0
+PIF_QTYPE = 3
+
+PIFA_BYTE_GRANULARITY_MASKING = 0x1
+
+_ID_NS_SIZE = 4096
+_NVM_ID_NS_SIZE = 4096
+
+
+_FLBAS_META_EXT = 0x10
+
+
+def _pack_id_ns(lba_index=0, ds=9, ms=0, meta_ext=False):
+    """Pack a struct nvme_id_ns (4096 bytes). FLBAS (offset 26) selects
+    @lba_index as the in-use LBA format, and its META_EXT bit (0x10) says
+    whether @ms bytes of metadata are transferred as part of the extended
+    LBA. LBAF[@lba_index] (offset 128 + 4*index) encodes a 2**@ds byte
+    logical block with @ms bytes of metadata. This is everything
+    get_pi_info() reads out of the base Identify Namespace response."""
+    buf = bytearray(_ID_NS_SIZE)
+    buf[26] = (lba_index & 0xff) | (_FLBAS_META_EXT if meta_ext else 0)
+    struct.pack_into("<HBB", buf, 128 + 4 * lba_index, ms, ds, 0)
+    return bytes(buf)
+
+
+def _expected_buffer_size(data_size, logical_block_size):
+    """Mirrors submit_io()'s sizing math when --block-count is not given:
+    round the block count up to fit @data_size, then re-derive the buffer
+    size from that (zero-based) block count."""
+    nblocks = (data_size + logical_block_size - 1) // logical_block_size - 1
+    return (nblocks + 1) * logical_block_size
+
+
+def _pack_nvm_id_ns(lba_index=0, sts=0, pif=PIF_16B_GUARD, qpif=0, qpifs=False,
+                     pifa=0, lbstm=0):
+    """Pack struct nvme_nvm_id_ns: LBSTM (offset 0), PIC.QPIFS (offset 8,
+    bit 3), PIFA.STMLA (offset 9), and ELBAF[@lba_index] (offset
+    12 + 4*index), encoding (@sts, @pif, @qpif)."""
+    buf = bytearray(_NVM_ID_NS_SIZE)
+    struct.pack_into("<Q", buf, 0, lbstm)
+    buf[8] = 0x8 if qpifs else 0
+    buf[9] = pifa & 0xf
+    elbaf = (sts & 0x7f) | ((pif & 0x3) << 7) | ((qpif & 0xf) << 9)
+    struct.pack_into("<I", buf, 12 + 4 * lba_index, elbaf)
+    return bytes(buf)
+
+
+class PITagsMockIPCServer(MockIPCServer):
+
+    def __init__(self, sock_path):
+        super().__init__(sock_path)
+        self.id_ns = _pack_id_ns()
+        self.id_ns_sc_status = 0
+        self.nvm_id_ns = None
+        self.nvm_id_ns_sc_status = 0
+        self.last_read_req_len = None
+
+    def handle_ioctl(self, conn, fd, request, opcode, nsid,
+                      cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len):
+        if opcode == _NVME_OPCODE_IDENTIFY and (cdw10 & 0xff) == _NVME_IDENTIFY_CNS_NS:
+            if self.id_ns_sc_status:
+                self.send_response(conn, 0, sc_status=self.id_ns_sc_status)
+            else:
+                self.send_response(conn, 0, payload=self.id_ns[:req_len])
+        elif opcode == _NVME_OPCODE_IDENTIFY and (cdw10 & 0xff) == _NVME_IDENTIFY_CNS_CSI_NS:
+            if self.nvm_id_ns_sc_status:
+                self.send_response(conn, 0, sc_status=self.nvm_id_ns_sc_status)
+            elif self.nvm_id_ns is not None:
+                self.send_response(conn, 0, payload=self.nvm_id_ns[:req_len])
+            else:
+                self.send_response(conn, -1, errno_val=errno.ENOTTY)
+        else:
+            if opcode == _NVME_OPCODE_READ:
+                self.last_read_req_len = req_len
+            self.send_response(conn, 0)
+
+
+class PITagsMockTestBase(unittest.TestCase):
+
+    DEVICE = '/dev/nvme0n1'
+    NSID = '1'
+
+    def setUp(self):
+        self.sysfs_dir = tempfile.mkdtemp(prefix='nvme-pi-tags-sysfs-', dir='/tmp')
+        self.base_dir = tempfile.mkdtemp(prefix='nvme-pi-tags-base-', dir='/tmp')
+        self.ipc_dir = tempfile.mkdtemp(prefix='nvme-pi-tags-ipc-', dir='/tmp')
+        self.ipc_sock_path = os.path.join(self.ipc_dir, "ipc.sock")
+
+        self.server = PITagsMockIPCServer(self.ipc_sock_path)
+        self.server.start()
+
+        self.env = make_mock_env(_MOCK_LIB, self.ipc_sock_path)
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.join()
+
+        shutil.rmtree(self.sysfs_dir, ignore_errors=True)
+        shutil.rmtree(self.base_dir, ignore_errors=True)
+        shutil.rmtree(self.ipc_dir, ignore_errors=True)
+
+    def _run(self, *args):
+        return run_nvme(_NVME_BIN, self.env, self.sysfs_dir, self.base_dir, *args)
+
+
+# ==================================================================== #
+# 'nvme read'/'write'/'compare' (submit_io()).                         #
+#                                                                        #
+# No --block-size: get_pi_info() runs. Identify NVM CS NS itself        #
+# failing (unsupported, ioctl error, any completion status) just means  #
+# "no PI", not an error. But a format get_pi_info() *did* evaluate and   #
+# found self-inconsistent -- ECLI_INVALID_TAGS (bad ref/storage tag) or  #
+# ECLI_INVALID_PI_FORMAT (get_pif_sts() masking check) -- must abort,    #
+# same as every init_pi_tags() caller below.                            #
+# --block-size given: get_pi_info() is skipped; PI comes from            #
+# init_pi_tags(), same as write-zeroes/copy below.                      #
+# ==================================================================== #
+
+class SubmitIOMockTestBase(PITagsMockTestBase):
+
+    def _read(self, *args):
+        return self._run('read', self.DEVICE, '-n', self.NSID, '--data-size', '4096', *args)
+
+
+class SubmitIOAutoDiscoveredBlockSizeTest(SubmitIOMockTestBase):
+    """No --block-size."""
+
+    def test_nvm_cs_ns_ioctl_failure_falls_back_without_pi(self):
+        """Must not SIGFPE dividing by a block size get_pi_info() left at
+        0; the read must still succeed."""
+        result = self._read()
+
+        self.assertNotEqual(result.returncode, -signal.SIGFPE,
+                            f'nvme read crashed with SIGFPE (divide by zero in submit_io()):\n'
+                            f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+        self.assertEqual(result.returncode, 0,
+                         f'nvme read failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_nvm_cs_ns_invalid_field_falls_back_and_succeeds(self):
+        """Invalid Field -> not supported -> proceed without PI."""
+        self.server.nvm_id_ns_sc_status = NVME_SC_INVALID_FIELD
+        result = self._read()
+        self.assertEqual(result.returncode, 0,
+                         f'nvme read failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_nvm_cs_ns_other_status_error_falls_back_without_pi(self):
+        """Any other failure (Internal Error here) is tolerated too: only
+        ECLI_INVALID_TAGS aborts. More lenient than write-zeroes/copy and
+        submit_io() with --block-size (see below)."""
+        self.server.nvm_id_ns_sc_status = NVME_SC_INTERNAL
+        result = self._read()
+        self.assertEqual(result.returncode, 0,
+                         f'nvme read failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_extended_lba_cs_ns_failure_still_uses_full_transfer_size(self):
+        """A failing Identify NVM CS NS only means "no PI" -- it must not
+        also shrink the transfer size. For an extended-LBA namespace the
+        metadata rides along in each logical block, so the buffer/transfer
+        size must stay 2**ds + ms, not fall back to the bare 2**ds get_pi_info()
+        reads out of the base Identify Namespace before it even attempts
+        Identify NVM CS NS."""
+        ds, ms = 9, 8
+        self.server.id_ns = _pack_id_ns(ds=ds, ms=ms, meta_ext=True)
+        self.server.nvm_id_ns_sc_status = NVME_SC_INTERNAL
+
+        result = self._read()
+
+        self.assertEqual(result.returncode, 0,
+                         f'nvme read failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+        full_lbs = (1 << ds) + ms
+        expected_len = _expected_buffer_size(4096, full_lbs)
+        bare_len = _expected_buffer_size(4096, 1 << ds)
+        self.assertNotEqual(expected_len, bare_len,
+                            'test bug: full and bare sizes must differ to be a useful check')
+        self.assertEqual(self.server.last_read_req_len, expected_len,
+                         f'expected the full extended-LBA transfer size {expected_len} bytes, '
+                         f'got {self.server.last_read_req_len} (bare-block-size {bare_len} would '
+                         f'undersize the buffer)')
+
+    def test_base_identify_ns_failure_aborts_without_dividing_by_zero(self):
+        """Unlike a failing Identify NVM CS NS, a failing *base* Identify
+        Namespace leaves get_pi_info() unable to report a block size at
+        all -- it returns -ECLI_IDENTIFY_NS_FAILED precisely so submit_io()
+        can tell the two apart and abort here instead of dividing by the
+        block size it never got (the same SIGFPE this whole change set is
+        meant to prevent)."""
+        self.server.id_ns_sc_status = NVME_SC_INTERNAL
+
+        result = self._read()
+
+        self.assertNotEqual(result.returncode, -signal.SIGFPE,
+                            f'nvme read crashed with SIGFPE (divide by zero in submit_io()):\n'
+                            f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+        self.assertNotEqual(result.returncode, 0,
+                            f'nvme read with a failing base Identify Namespace should have failed:\n'
+                            f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_invalid_ref_tag_aborts_the_command(self):
+        """An invalid ref tag must still abort, unlike the failures above."""
+        # 16B Guard, STS=8: ref tag is 32-8=24 bits; 0x1000000 is one past.
+        self.server.nvm_id_ns = _pack_nvm_id_ns(sts=8, pif=PIF_16B_GUARD)
+
+        result = self._read('--ref-tag', '0x1000000')
+
+        self.assertNotEqual(result.returncode, 0,
+                            f'nvme read with an out-of-range ref tag should have failed:\n'
+                            f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_qpif_masking_inconsistent_aborts_the_command(self):
+        """Identify NVM CS NS succeeds, but get_pif_sts()'s masking check
+        on the data it returned fails: unlike an unsupported/failing
+        Identify NVM CS NS above, this is a real error (the drive's own
+        reported PI format is self-inconsistent) and must abort, not
+        silently fall back to "no PI"."""
+        # STS=16 (2 full bytes), byte-granularity masking, but LBSTM only
+        # masks one of those two bytes -> get_pif_sts_via_qpif() fails.
+        self.server.nvm_id_ns = _pack_nvm_id_ns(
+            sts=16, pif=PIF_QTYPE, qpif=PIF_16B_GUARD, qpifs=True,
+            pifa=PIFA_BYTE_GRANULARITY_MASKING, lbstm=0x01ff)
+
+        result = self._read()
+
+        self.assertNotEqual(result.returncode, 0,
+                            f'nvme read with an inconsistent PI format should have failed:\n'
+                            f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+        self.assertIn("Logical Block Storage Tag Mask is inconsistent",
+                      result.stdout + result.stderr)
+
+
+class SubmitIOExplicitBlockSizeTest(SubmitIOMockTestBase):
+    """--block-size given: PI comes from init_pi_tags(), not get_pi_info()."""
+
+    def _read_with_block_size(self, *args):
+        return self._read('--block-size', '512', *args)
+
+    def test_nvm_cs_ns_invalid_field_falls_back_and_succeeds(self):
+        self.server.nvm_id_ns_sc_status = NVME_SC_INVALID_FIELD
+        result = self._read_with_block_size()
+        self.assertEqual(result.returncode, 0,
+                         f'nvme read failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_nvm_cs_ns_other_status_error_aborts(self):
+        """No "tolerate anything" fallback here: a real failure aborts the
+        command, same as write-zeroes/copy."""
+        self.server.nvm_id_ns_sc_status = NVME_SC_INTERNAL
+        result = self._read_with_block_size()
+        self.assertNotEqual(result.returncode, 0,
+                            f'nvme read --block-size with Identify NVM CS NS failing on a real '
+                            f'error should have failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_invalid_ref_tag_aborts_the_command(self):
+        self.server.nvm_id_ns = _pack_nvm_id_ns(sts=8, pif=PIF_16B_GUARD)
+
+        result = self._read_with_block_size('--ref-tag', '0x1000000')
+
+        self.assertNotEqual(result.returncode, 0,
+                            f'nvme read --block-size with an out-of-range ref tag should have '
+                            f'failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+
+# ==================================================================== #
+# 'nvme write-zeroes' (write_zeroes(), an init_pi_tags() caller).       #
+# ==================================================================== #
+
+class WriteZeroesInvalidTagsTest(PITagsMockTestBase):
+
+    def setUp(self):
+        super().setUp()
+        # Fixed 16B Guard/STS=8 by default; individual tests override
+        # nvm_id_ns_sc_status instead.
+        self.server.nvm_id_ns = _pack_nvm_id_ns(sts=8, pif=PIF_16B_GUARD)
+
+    def _write_zeroes(self, ref_tag):
+        return self._run('write-zeroes', self.DEVICE, '-n', self.NSID,
+                         '--ref-tag', hex(ref_tag), '--verbose')
+
+    def test_valid_ref_tag_succeeds(self):
+        """STS=8 -> ref tag is 24 bits; 0xffffff is the largest valid value."""
+        result = self._write_zeroes(ref_tag=0xffffff)
+        self.assertEqual(result.returncode, 0,
+                         f'write-zeroes failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_invalid_ref_tag_aborts_the_command(self):
+        result = self._write_zeroes(ref_tag=0x1000000)
+        self.assertNotEqual(result.returncode, 0,
+                            f'write-zeroes with an out-of-range ref tag should have failed:\n'
+                            f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+        self.assertIn("Reference tag larger than allowed by PIF", result.stdout + result.stderr)
+
+    def test_nvm_cs_ns_invalid_field_falls_back_and_succeeds(self):
+        self.server.nvm_id_ns_sc_status = NVME_SC_INVALID_FIELD
+        result = self._write_zeroes(ref_tag=0)
+        self.assertEqual(result.returncode, 0,
+                         f'write-zeroes failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+
+# ==================================================================== #
+# 'nvme copy' (copy_cmd(), an init_pi_tags() caller).                   #
+# ==================================================================== #
+
+class CopyInvalidTagsTest(PITagsMockTestBase):
+
+    def setUp(self):
+        super().setUp()
+        self.server.nvm_id_ns = _pack_nvm_id_ns(sts=8, pif=PIF_16B_GUARD)
+
+    def _copy(self, ref_tag):
+        # One source block ("0" is 1 block) is enough: init_pi_tags() only
+        # cares about -n/--ref-tag/--storage-tag.
+        return self._run('copy', self.DEVICE, '-n', self.NSID,
+                         '--sdlba', '0', '--slbs', '0', '--blocks', '0',
+                         '--ref-tag', hex(ref_tag), '--verbose')
+
+    def test_valid_ref_tag_succeeds(self):
+        result = self._copy(ref_tag=0xffffff)
+        self.assertEqual(result.returncode, 0,
+                         f'copy failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+    def test_invalid_ref_tag_aborts_the_command(self):
+        result = self._copy(ref_tag=0x1000000)
+        self.assertNotEqual(result.returncode, 0,
+                            f'copy with an out-of-range ref tag should have failed:\n'
+                            f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+        self.assertIn("Reference tag larger than allowed by PIF", result.stdout + result.stderr)
+
+    def test_nvm_cs_ns_invalid_field_falls_back_and_succeeds(self):
+        self.server.nvm_id_ns_sc_status = NVME_SC_INVALID_FIELD
+        result = self._copy(ref_tag=0)
+        self.assertEqual(result.returncode, 0,
+                         f'copy failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+
+
+if __name__ == '__main__':
+    # If called standalone, strip the arguments parsed above and run
+    # standard unittest main.
+    unittest_args = [sys.argv[0]]
+    if len(sys.argv) > 3:
+        unittest_args.extend(sys.argv[3:])
+    unittest.main(argv=unittest_args)

--- a/tests/cli/nvme_mock_ipc.py
+++ b/tests/cli/nvme_mock_ipc.py
@@ -28,7 +28,8 @@ from pathlib import Path
 # IPC wire format shared with libmock_nvme.c -- keep both sides in sync.
 IPC_REQUEST_FMT = "=IIII B3x I IIIIII QI"
 IPC_REQUEST_LEN = struct.calcsize(IPC_REQUEST_FMT)
-IPC_RESPONSE_FMT = "=iiII"
+# status, errno_val, sc_status, result, data_len -- see struct ipc_response.
+IPC_RESPONSE_FMT = "=iiiII"
 
 IPC_TYPE_WRITE = 1  # write() on /dev/nvme-fabrics (connect args)
 IPC_TYPE_IOCTL = 2  # ioctl() admin or I/O passthru command
@@ -81,8 +82,11 @@ class MockIPCServer(threading.Thread):
             self.handle_client(conn)
 
     @staticmethod
-    def send_response(conn, status, errno_val=0, result=0, payload=b""):
-        conn.sendall(struct.pack(IPC_RESPONSE_FMT, status, errno_val, result, len(payload)))
+    def send_response(conn, status, errno_val=0, sc_status=0, result=0, payload=b""):
+        """@status/@errno_val: a real syscall/errno-level failure (status=-1),
+        vs. a normal ioctl() return (status=0). @sc_status: with status=0,
+        the raw NVMe completion status ioctl() itself should return."""
+        conn.sendall(struct.pack(IPC_RESPONSE_FMT, status, errno_val, sc_status, result, len(payload)))
         if payload:
             conn.sendall(payload)
 

--- a/tests/cli/nvme_mock_ipc.py
+++ b/tests/cli/nvme_mock_ipc.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+# Copyright (c) 2026 SUSE LLC
+#
+# Authors: Daniel Wagner <dwagner@suse.com>
+"""libmock_nvme.c intercepts open()/write()/ioctl()/close() on
+/dev/nvme-fabrics, /dev/nvme<N>, and /dev/nvme<N>n<M>. It forwards every
+intercepted write() (fabrics connect args) and ioctl() (admin or I/O
+passthru command) over a Unix socket to a MockIPCServer instance running in
+this process. This lets nvme-cli run against a fake target, with no real
+hardware and no root.
+
+Test files subclass MockIPCServer and override handle_write()/
+handle_ioctl() to steer responses for their own scenario. run_nvme()
+provides the common subprocess-invocation mechanics.
+"""
+import os
+import shlex
+import socket
+import struct
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+# IPC wire format shared with libmock_nvme.c -- keep both sides in sync.
+IPC_REQUEST_FMT = "=IIII B3x I IIIIII QI"
+IPC_REQUEST_LEN = struct.calcsize(IPC_REQUEST_FMT)
+IPC_RESPONSE_FMT = "=iiII"
+
+IPC_TYPE_WRITE = 1  # write() on /dev/nvme-fabrics (connect args)
+IPC_TYPE_IOCTL = 2  # ioctl() admin or I/O passthru command
+
+
+def resolve_mock_lib_path(default="./libmock_nvme.so"):
+    """Locates libmock_nvme.so. Reads argv[2], the built shared_library()
+    path meson.build passes in. Falls back to a few likely build-directory
+    layouts for a standalone/manual run, then to @default."""
+    if len(sys.argv) > 2:
+        raw_path = sys.argv[2]
+        candidates = (
+            Path(raw_path),
+            Path(raw_path).resolve(),
+            Path(os.getcwd()) / ".build" / raw_path,
+            Path(__file__).parent.parent.parent / ".build" / raw_path,
+        )
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate.resolve())
+    return default
+
+
+class MockIPCServer(threading.Thread):
+    """Generic Unix-socket IPC server for libmock_nvme.c.
+
+    Subclasses hold their own test-scenario state and override
+    handle_write()/handle_ioctl() to fabricate responses for it. Socket
+    setup, request framing, and thread lifecycle are shared here.
+    """
+
+    def __init__(self, sock_path):
+        super().__init__()
+        self.sock_path = sock_path
+        self.running = True
+        self.server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.server_sock.bind(self.sock_path)
+        self.server_sock.listen(5)
+        self.server_sock.settimeout(0.5)
+
+    def run(self):
+        while self.running:
+            try:
+                conn, _ = self.server_sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+            self.handle_client(conn)
+
+    @staticmethod
+    def send_response(conn, status, errno_val=0, result=0, payload=b""):
+        conn.sendall(struct.pack(IPC_RESPONSE_FMT, status, errno_val, result, len(payload)))
+        if payload:
+            conn.sendall(payload)
+
+    def handle_write(self, conn, payload):
+        """Override for IPC_TYPE_WRITE. Default: report success."""
+        self.send_response(conn, 0)
+
+    def handle_ioctl(self, conn, fd, request, opcode, nsid,
+                      cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len):
+        """Override for IPC_TYPE_IOCTL. @fd is the controller instance, not
+        a real fd (see libmock_nvme.c). Default: report success, result 0,
+        no payload."""
+        self.send_response(conn, 0)
+
+    def handle_client(self, conn):
+        try:
+            req_header = conn.recv(IPC_REQUEST_LEN, socket.MSG_WAITALL)
+            if len(req_header) < IPC_REQUEST_LEN:
+                return
+
+            req_type, fd, data_len, ioctl_request, opcode, nsid, \
+                cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len = \
+                struct.unpack(IPC_REQUEST_FMT, req_header)
+
+            payload = (conn.recv(data_len, socket.MSG_WAITALL)
+                       if data_len > 0 else b"")
+
+            if req_type == IPC_TYPE_WRITE:
+                self.handle_write(conn, payload)
+            elif req_type == IPC_TYPE_IOCTL:
+                self.handle_ioctl(conn, fd, ioctl_request, opcode, nsid,
+                                   cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len)
+        except OSError as e:
+            print(f"Exception handling IPC client: {e}", file=sys.stderr)
+        finally:
+            conn.close()
+
+    def shutdown(self):
+        self.running = False
+        try:
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.connect(self.sock_path)
+            client.close()
+        except OSError:
+            pass
+        self.server_sock.close()
+
+
+def make_mock_env(mock_lib, ipc_sock_path):
+    """Builds the environment run_nvme() needs. Appends @mock_lib to
+    LD_PRELOAD instead of replacing it, so an existing entry like libasan
+    stays first. Sets MOCK_IPC_SOCK. Also tweaks ASAN_OPTIONS, so ASan does
+    not warn or abort over libmock_nvme.so not being first in LD_PRELOAD:
+    we do not control that order, and it is not a real problem here."""
+    env = os.environ.copy()
+    existing_preload = env.get("LD_PRELOAD", "")
+    env["LD_PRELOAD"] = f"{existing_preload} {mock_lib}".strip()
+    existing_asan_options = env.get("ASAN_OPTIONS", "")
+    env["ASAN_OPTIONS"] = f"{existing_asan_options}:verify_asan_link_order=0".strip(':')
+    env["MOCK_IPC_SOCK"] = ipc_sock_path
+    return env
+
+
+def run_nvme(nvme_bin, env, sysfs_dir, base_dir, *args):
+    """Runs `nvme_bin *args` under libmock_nvme.c. Returns the completed
+    subprocess.Popen result, with stdout/stderr captured as text. Callers
+    check .returncode/.stdout/.stderr themselves."""
+    cmd = [
+        nvme_bin,
+        '--set-options', f'test-sysfs-dir={sysfs_dir},test-base-dir={base_dir}',
+    ] + list(args)
+
+    # Under 'meson test --setup=valgrind' this script runs under valgrind,
+    # but nvme must run natively. Valgrind rewrites LD_PRELOAD on every
+    # execve() it traps, to strip its own vgpreload bookkeeping. That wipes
+    # out our appended mock lib entry too, since it is part of the same
+    # string. So route through a shell: valgrind sees and mangles the
+    # exec() below, but the shell's own exec of nvme runs in a process
+    # valgrind no longer traces. The LD_PRELOAD set there reaches nvme
+    # intact.
+    env = dict(env)
+    ld_preload = env.pop("LD_PRELOAD", "")
+    wrapped_cmd = [
+        '/bin/sh', '-c', f'export LD_PRELOAD={shlex.quote(ld_preload)}; exec "$@"',
+        'nvme-mock-wrapper',
+    ] + cmd
+
+    result = subprocess.run(wrapped_cmd, env=env,
+                            stdin=subprocess.DEVNULL,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            encoding='utf-8')
+
+    # Print outputs to sys.stderr so they are displayed by unittest on failure.
+    print(f"\n--- RUN: {' '.join(cmd)} ---", file=sys.stderr)
+    print(f"STDOUT:\n{result.stdout}", file=sys.stderr)
+    print(f"STDERR:\n{result.stderr}", file=sys.stderr)
+    print("-----------------------------------", file=sys.stderr)
+
+    return result

--- a/tests/cli/nvme_pif_sts_test.py
+++ b/tests/cli/nvme_pif_sts_test.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+# Copyright (c) 2026 SUSE LLC
+#
+# Authors: Daniel Wagner <dwagner@suse.com>
+"""Tests for get_pif_sts()/get_pif_sts_via_qpif() and invalid_tags() in
+src/nvme-cmds-io.c.
+
+Usage: python3 nvme_pif_sts_test.py <path-to-nvme-binary> <path-to-mock-lib>
+"""
+import os
+import shutil
+import struct
+import sys
+import tempfile
+import unittest
+
+from nvme_mock_ipc import MockIPCServer, make_mock_env, resolve_mock_lib_path, run_nvme
+
+_NVME_BIN = sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith('-') else 'nvme'
+_MOCK_LIB = resolve_mock_lib_path("./libmock_nvme.so")
+
+_NVME_OPCODE_IDENTIFY = 0x06
+_NVME_IDENTIFY_CNS_NS = 0x00
+_NVME_IDENTIFY_CNS_CSI_NS = 0x05
+
+PIF_16B_GUARD = 0
+PIF_32B_GUARD = 1
+PIF_64B_GUARD = 2
+PIF_QTYPE = 3
+
+PIFA_BIT_GRANULARITY_MASKING = 0x0
+PIFA_BYTE_GRANULARITY_MASKING = 0x1
+PIFA_MASKING_NOT_SUPPORTED = 0x2
+
+_ID_NS_SIZE = 4096
+_NVM_ID_NS_SIZE = 4096
+
+
+def _pack_id_ns(lba_index=0):
+    """Pack a struct nvme_id_ns (4096 bytes). FLBAS (offset 26) selects
+    @lba_index as the in-use LBA format. Every other field stays 0:
+    get_pif_sts() only reads FLBAS out of this struct."""
+    buf = bytearray(_ID_NS_SIZE)
+    buf[26] = lba_index & 0xff  # lba_index <= 15 here, so HIGHER stays 0
+    return bytes(buf)
+
+
+def _pack_elbaf(sts, pif, qpif=0):
+    return (sts & 0x7f) | ((pif & 0x3) << 7) | ((qpif & 0xf) << 9)
+
+
+def _pack_nvm_id_ns(lba_index=0, sts=0, pif=0, qpif=0, qpifs=False, pifa=0, lbstm=0):
+    """Pack a struct nvme_nvm_id_ns (4096 bytes): LBSTM (offset 0),
+    PIC.QPIFS (offset 8, bit 3), PIFA.STMLA (offset 9), and
+    ELBAF[@lba_index] (offset 12 + 4*index), encoding (@sts, @pif, @qpif)."""
+    buf = bytearray(_NVM_ID_NS_SIZE)
+    struct.pack_into("<Q", buf, 0, lbstm)
+    buf[8] = 0x8 if qpifs else 0
+    buf[9] = pifa & 0xf
+    struct.pack_into("<I", buf, 12 + 4 * lba_index, _pack_elbaf(sts, pif, qpif))
+    return bytes(buf)
+
+
+class PIFMockIPCServer(MockIPCServer):
+
+    def __init__(self, sock_path):
+        super().__init__(sock_path)
+        self.id_ns = _pack_id_ns()
+        self.nvm_id_ns = _pack_nvm_id_ns()
+
+    def handle_ioctl(self, conn, fd, request, opcode, nsid,
+                      cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len):
+        if opcode == _NVME_OPCODE_IDENTIFY:
+            cns = cdw10 & 0xff
+            if cns == _NVME_IDENTIFY_CNS_NS:
+                payload = self.id_ns[:req_len]
+            elif cns == _NVME_IDENTIFY_CNS_CSI_NS:
+                payload = self.nvm_id_ns[:req_len]
+            else:
+                payload = b"\x00" * req_len
+            self.send_response(conn, 0, payload=payload)
+        else:
+            self.send_response(conn, 0)
+
+
+class PIFStsCLITest(unittest.TestCase):
+
+    DEVICE = '/dev/nvme0n1'
+    NSID = '1'
+
+    def setUp(self):
+        self.sysfs_dir = tempfile.mkdtemp(prefix='nvme-pif-sysfs-', dir='/tmp')
+        self.base_dir = tempfile.mkdtemp(prefix='nvme-pif-base-', dir='/tmp')
+        self.ipc_dir = tempfile.mkdtemp(prefix='nvme-pif-ipc-', dir='/tmp')
+        self.ipc_sock_path = os.path.join(self.ipc_dir, "ipc.sock")
+
+        self.server = PIFMockIPCServer(self.ipc_sock_path)
+        self.server.start()
+
+        self.env = make_mock_env(_MOCK_LIB, self.ipc_sock_path)
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.join()
+
+        shutil.rmtree(self.sysfs_dir, ignore_errors=True)
+        shutil.rmtree(self.base_dir, ignore_errors=True)
+        shutil.rmtree(self.ipc_dir, ignore_errors=True)
+
+    def _verify(self, ref_tag=0, storage_tag=0, expect_fail=False, lba_index=0, **ns_kwargs):
+        self.server.id_ns = _pack_id_ns(lba_index=lba_index)
+        self.server.nvm_id_ns = _pack_nvm_id_ns(lba_index=lba_index, **ns_kwargs)
+
+        result = run_nvme(_NVME_BIN, self.env, self.sysfs_dir, self.base_dir,
+                          'verify', self.DEVICE, '-n', self.NSID,
+                          '--ref-tag', hex(ref_tag), '--storage-tag', hex(storage_tag),
+                          '--verbose')
+
+        desc = f"ref_tag={hex(ref_tag)}, storage_tag={hex(storage_tag)}, lba_index={lba_index}, {ns_kwargs}"
+        if expect_fail:
+            self.assertNotEqual(result.returncode, 0,
+                                f'verify ({desc}) was expected to fail but succeeded')
+        else:
+            self.assertEqual(result.returncode, 0,
+                             f'verify ({desc}) failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+            self.assertIn("NVME Verify Success", result.stdout)
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Static PIFs (ELBAF.PIF selects 16B/32B/64B Guard directly): ref-tag #
+    # and storage-tag width bounds from invalid_tags().                  #
+    # ------------------------------------------------------------------ #
+
+    def test_16b_guard_ref_tag_at_boundary_succeeds(self):
+        """16B Guard: ref tag is (32 - STS) bits. STS=8 -> 24 bits.
+        Largest valid ref tag: 2**24-1."""
+        self._verify(sts=8, pif=PIF_16B_GUARD, ref_tag=0xffffff, storage_tag=0xff)
+
+    def test_16b_guard_ref_tag_over_boundary_fails(self):
+        res = self._verify(sts=8, pif=PIF_16B_GUARD,
+                           ref_tag=0x1000000, storage_tag=0, expect_fail=True)
+        self.assertIn("Reference tag larger than allowed by PIF", res.stdout + res.stderr)
+
+    def test_16b_guard_storage_tag_over_boundary_fails(self):
+        res = self._verify(sts=8, pif=PIF_16B_GUARD,
+                           ref_tag=0, storage_tag=0x100, expect_fail=True)
+        self.assertIn("Storage tag larger than storage tag size", res.stdout + res.stderr)
+
+    def test_32b_guard_ref_tag_at_boundary_succeeds(self):
+        """32B Guard: ref tag is (80 - STS) bits, checked only for STS>16.
+        STS=64 -> 16 bits. Largest valid ref tag: 2**16-1."""
+        self._verify(sts=64, pif=PIF_32B_GUARD, ref_tag=0xffff, storage_tag=0)
+
+    def test_32b_guard_ref_tag_over_boundary_fails(self):
+        res = self._verify(sts=64, pif=PIF_32B_GUARD,
+                           ref_tag=0x10000, storage_tag=0, expect_fail=True)
+        self.assertIn("Reference tag larger than allowed by PIF", res.stdout + res.stderr)
+
+    def test_64b_guard_ref_tag_at_boundary_succeeds(self):
+        """64B Guard: ref tag is (48 - STS) bits. STS=40 -> 8 bits.
+        Largest valid ref tag: 2**8-1."""
+        self._verify(sts=40, pif=PIF_64B_GUARD, ref_tag=0xff, storage_tag=0)
+
+    def test_64b_guard_ref_tag_over_boundary_fails(self):
+        res = self._verify(sts=40, pif=PIF_64B_GUARD,
+                           ref_tag=0x100, storage_tag=0, expect_fail=True)
+        self.assertIn("Reference tag larger than allowed by PIF", res.stdout + res.stderr)
+
+    def test_elbaf_uses_the_in_use_lba_format_index(self):
+        """get_pif_sts() must index ELBAF by the FLBAS-selected format, not
+        always slot 0. Slot 0 stays all-zero (STS=0, 16B Guard: ref tags
+        unchecked up to 2**32-1); the boundary-testing format goes in
+        slot 2. A get_pif_sts() that ignores FLBAS would let this
+        over-boundary ref tag through."""
+        self._verify(lba_index=2, sts=8, pif=PIF_16B_GUARD,
+                     ref_tag=0x1000000, storage_tag=0, expect_fail=True)
+
+    # ------------------------------------------------------------------ #
+    # QPIF (ELBAF.PIF == QTYPE, PIC.QPIFS set): PIF comes from ELBAF.QPIF #
+    # instead. LBSTM must agree with PIFA.STMLA's masking level --        #
+    # get_pif_sts_via_qpif()'s job.                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_qpif_bit_granularity_masking_ignores_lbstm(self):
+        """STMLA=Bit Granularity Masking: any LBSTM value is valid."""
+        self._verify(sts=8, pif=PIF_QTYPE, qpif=PIF_16B_GUARD, qpifs=True,
+                     pifa=PIFA_BIT_GRANULARITY_MASKING, lbstm=0x1234,
+                     ref_tag=0xffffff, storage_tag=0xff)
+
+    def test_qpif_byte_granularity_masking_valid_lbstm_succeeds(self):
+        """STMLA=Byte Granularity Masking, STS=16 (2 full bytes): each
+        LBSTM byte covered by STS must be all-0 or all-1."""
+        self._verify(sts=16, pif=PIF_QTYPE, qpif=PIF_16B_GUARD, qpifs=True,
+                     pifa=PIFA_BYTE_GRANULARITY_MASKING, lbstm=0x00ff)
+
+    def test_qpif_byte_granularity_masking_invalid_lbstm_fails(self):
+        res = self._verify(sts=16, pif=PIF_QTYPE, qpif=PIF_16B_GUARD, qpifs=True,
+                           pifa=PIFA_BYTE_GRANULARITY_MASKING, lbstm=0x01ff,
+                           expect_fail=True)
+        self.assertIn("Logical Block Storage Tag Mask is inconsistent", res.stdout + res.stderr)
+
+    def test_qpif_masking_not_supported_fully_masked_succeeds(self):
+        """STMLA=Masking Not Supported: LBSTM must be all-ones across STS.
+        The controller can't mask, so the host must not ask for it."""
+        self._verify(sts=8, pif=PIF_QTYPE, qpif=PIF_16B_GUARD, qpifs=True,
+                     pifa=PIFA_MASKING_NOT_SUPPORTED, lbstm=0xff)
+
+    def test_qpif_masking_not_supported_partially_masked_fails(self):
+        res = self._verify(sts=8, pif=PIF_QTYPE, qpif=PIF_16B_GUARD, qpifs=True,
+                           pifa=PIFA_MASKING_NOT_SUPPORTED, lbstm=0xfe,
+                           expect_fail=True)
+        self.assertIn("Logical Block Storage Tag Mask is inconsistent", res.stdout + res.stderr)
+
+    def test_qpif_reserved_pif_value_rejected(self):
+        """ELBAF.QPIF outside {16B,32B,64B Guard} must be rejected by
+        invalid_tags()'s default case, not silently accepted."""
+        res = self._verify(sts=8, pif=PIF_QTYPE, qpif=5, qpifs=True,
+                           pifa=PIFA_BIT_GRANULARITY_MASKING, lbstm=0,
+                           expect_fail=True)
+        self.assertIn("Invalid PIF", res.stdout + res.stderr)
+
+
+if __name__ == '__main__':
+    # Standalone run: strip the args parsed above, hand the rest to unittest.
+    unittest_args = [sys.argv[0]]
+    if len(sys.argv) > 3:
+        unittest_args.extend(sys.argv[3:])
+    unittest.main(argv=unittest_args)

--- a/tests/cli/nvme_pif_sts_test.py
+++ b/tests/cli/nvme_pif_sts_test.py
@@ -242,15 +242,11 @@ class PIFStsCLITest(unittest.TestCase):
         PIF/STS default to 16B Guard/0, and the command proceeds."""
         self._verify(nvm_id_ns_sc_status=NVME_SC_INVALID_FIELD, ref_tag=0, storage_tag=0)
 
-    def test_nvm_cs_ns_other_status_error_also_falls_back(self):
-        """Surprising: this hits the *same* fallback as Invalid Field
-        above, not a propagated error. init_pi_tags() collapses any
-        Identify NVM CS NS failure into the same NVME_SC_INVALID_FIELD
-        sentinel, so verify_cmd() cannot tell them apart. A genuinely
-        unexpected failure (Internal Error here) is silently treated as
-        "not supported" instead of surfacing as an error. This documents
-        current behavior; it does not claim the behavior is correct."""
-        self._verify(nvm_id_ns_sc_status=NVME_SC_INTERNAL, ref_tag=0, storage_tag=0)
+    def test_nvm_cs_ns_other_status_error_propagates(self):
+        """Any other failure (Internal Error here) is a real error, not
+        "not supported". It must not be swallowed: the command fails."""
+        self._verify(nvm_id_ns_sc_status=NVME_SC_INTERNAL, ref_tag=0, storage_tag=0,
+                     expect_fail=True)
 
 
 if __name__ == '__main__':

--- a/tests/cli/nvme_pif_sts_test.py
+++ b/tests/cli/nvme_pif_sts_test.py
@@ -26,6 +26,9 @@ _NVME_OPCODE_IDENTIFY = 0x06
 _NVME_IDENTIFY_CNS_NS = 0x00
 _NVME_IDENTIFY_CNS_CSI_NS = 0x05
 
+NVME_SC_INVALID_FIELD = 0x2
+NVME_SC_INTERNAL = 0x6
+
 PIF_16B_GUARD = 0
 PIF_32B_GUARD = 1
 PIF_64B_GUARD = 2
@@ -70,18 +73,21 @@ class PIFMockIPCServer(MockIPCServer):
         super().__init__(sock_path)
         self.id_ns = _pack_id_ns()
         self.nvm_id_ns = _pack_nvm_id_ns()
+        self.nvm_id_ns_sc_status = 0
 
     def handle_ioctl(self, conn, fd, request, opcode, nsid,
                       cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len):
         if opcode == _NVME_OPCODE_IDENTIFY:
             cns = cdw10 & 0xff
             if cns == _NVME_IDENTIFY_CNS_NS:
-                payload = self.id_ns[:req_len]
+                self.send_response(conn, 0, payload=self.id_ns[:req_len])
             elif cns == _NVME_IDENTIFY_CNS_CSI_NS:
-                payload = self.nvm_id_ns[:req_len]
+                if self.nvm_id_ns_sc_status:
+                    self.send_response(conn, 0, sc_status=self.nvm_id_ns_sc_status)
+                else:
+                    self.send_response(conn, 0, payload=self.nvm_id_ns[:req_len])
             else:
-                payload = b"\x00" * req_len
-            self.send_response(conn, 0, payload=payload)
+                self.send_response(conn, 0, payload=b"\x00" * req_len)
         else:
             self.send_response(conn, 0)
 
@@ -110,9 +116,11 @@ class PIFStsCLITest(unittest.TestCase):
         shutil.rmtree(self.base_dir, ignore_errors=True)
         shutil.rmtree(self.ipc_dir, ignore_errors=True)
 
-    def _verify(self, ref_tag=0, storage_tag=0, expect_fail=False, lba_index=0, **ns_kwargs):
+    def _verify(self, ref_tag=0, storage_tag=0, expect_fail=False, lba_index=0,
+               nvm_id_ns_sc_status=0, **ns_kwargs):
         self.server.id_ns = _pack_id_ns(lba_index=lba_index)
         self.server.nvm_id_ns = _pack_nvm_id_ns(lba_index=lba_index, **ns_kwargs)
+        self.server.nvm_id_ns_sc_status = nvm_id_ns_sc_status
 
         result = run_nvme(_NVME_BIN, self.env, self.sysfs_dir, self.base_dir,
                           'verify', self.DEVICE, '-n', self.NSID,
@@ -221,6 +229,28 @@ class PIFStsCLITest(unittest.TestCase):
                            pifa=PIFA_BIT_GRANULARITY_MASKING, lbstm=0,
                            expect_fail=True)
         self.assertIn("Invalid PIF", res.stdout + res.stderr)
+
+    # ------------------------------------------------------------------ #
+    # Identify NVM CS NS itself failing: init_pi_tags()'s "skip           #
+    # get_pif_sts() on Invalid Field" fallback -- a controller that does  #
+    # not support the NVM Command Set Identify Namespace data structure   #
+    # at all (e.g. pre-TP4068).                                           #
+    # ------------------------------------------------------------------ #
+
+    def test_nvm_cs_ns_invalid_field_falls_back_and_succeeds(self):
+        """Invalid Field means "not supported": get_pif_sts() is skipped,
+        PIF/STS default to 16B Guard/0, and the command proceeds."""
+        self._verify(nvm_id_ns_sc_status=NVME_SC_INVALID_FIELD, ref_tag=0, storage_tag=0)
+
+    def test_nvm_cs_ns_other_status_error_also_falls_back(self):
+        """Surprising: this hits the *same* fallback as Invalid Field
+        above, not a propagated error. init_pi_tags() collapses any
+        Identify NVM CS NS failure into the same NVME_SC_INVALID_FIELD
+        sentinel, so verify_cmd() cannot tell them apart. A genuinely
+        unexpected failure (Internal Error here) is silently treated as
+        "not supported" instead of surfacing as an error. This documents
+        current behavior; it does not claim the behavior is correct."""
+        self._verify(nvm_id_ns_sc_status=NVME_SC_INTERNAL, ref_tag=0, storage_tag=0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The PIF code is a constant source of errors. Thus make the libmock fabrics test code more generic and add tests cases around ` get_pi_info`. 

Fixes #3897 