### PR TITLE
shared: check the new row's val pointer in shr_table_get_row_id()

### DIFF
--- a/shared/table-util.c
+++ b/shared/table-util.c
@@ -232,7 +232,7 @@ int shr_table_get_row_id(struct shr_table *t)
 
 	t->rows = new_rows;
 	t->rows[row].val = calloc(t->num_columns, sizeof(struct shr_table_value));
-	if (!t->rows->val)
+	if (!t->rows[row].val)
 		return -ENOMEM;
 
 	t->num_rows++;


### PR DESCRIPTION
The failure test allocates `t->rows[row].val` but checks `t->rows->val`, i.e. row 0. For every row after the first, row 0's `val` is already allocated and non-NULL, so a failed calloc for a later row goes undetected: the row id is returned as valid and `shr_table_set_value_*()` then writes through NULL.

Test against the row that was just allocated.