### PR TITLE
libnvme: reject oversized discovery log record counts

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1965,6 +1965,14 @@ static int nvme_discovery_log(libnvme_ctrl_t ctrl,
 		if (numrec == 0)
 			break;
 
+		if (numrec > (SIZE_MAX - sizeof(*log)) / sizeof(*log->entries)) {
+			libnvme_msg(ctx, LIBNVME_LOG_INFO,
+				 "%s: don't trust record count %" PRIu64 "\n",
+				 name, numrec);
+			err = -EINVAL;
+			goto out_free_log;
+		}
+
 		libnvme_free(log);
 		entries_size = sizeof(*log->entries) * numrec;
 		log = libnvme_alloc(sizeof(*log) + entries_size);


### PR DESCRIPTION
## Problem

libnvme3 keeps the local libnvme 1.x issue (fixed upstream in linux-nvme/libnvme#1121): `nvme_discovery_log()` trusts the device-supplied `numrec`:

```c
entries_size = sizeof(*log->entries) * numrec;
log = libnvme_alloc(sizeof(*log) + entries_size);
```

A controller returning large `numrec` makes `entries_size` (or the `sizeof(*log) +` addition) wrap, producing a small allocation while `log->entries` gets filled with attacker-controlled length — heap overflow.

## Fix

Reject `numrec` values that can't fit in `size_t` before allocating (same shape as the 1.x fix).

## Testing

- Full meson suite green (the one `crypto-util` skip is env-related: OpenSSL absent on this host, also on pristine master).
- Arithmetic verified against the 1.x regression test (linux-nvme/libnvme#1121 includes a unit test on the shared logic semantics; the 3.x structure differs in that there is no standalone mock-IOCTL harness wired for fabrics, so the check here is review-verified against the same boundary condition).
