### PR TITLE
libnvme: size the AEM ack recv buffer to what's actually left

### DIFF
--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -1954,7 +1954,8 @@ __shr_public int libnvme_mi_aem_process(libnvme_mi_ep_t ep, void *userdata)
 		reset_list_info(ep->aem_ctx);
 
 		if (action == NVME_MI_AEM_HNA_ACK) {
-			response_len = sizeof(response_buffer);
+			response_len = sizeof(response_buffer) -
+				offsetof(struct nvme_mi_aem_msg, occ_list_hdr);
 
 			rc = libnvme_mi_aem_ack(ep, &response->occ_list_hdr, &response_len);
 			if (rc)


### PR DESCRIPTION
## Problem

Same issue as fixed in libnvme 1.x in linux-nvme/libnvme#1122: `libnvme_mi_aem_process()` receives the async event into `response_buffer` (4096 bytes), then issues the ACK read with the data pointer set to `&response->occ_list_hdr` — `offsetof(occ_list_hdr)` into the buffer — but passes `sizeof(response_buffer)` as the capacity:

```c
response_len = sizeof(response_buffer);
rc = libnvme_mi_aem_ack(ep, &response->occ_list_hdr, &response_len);
```

If the ACK payload approaches the stated capacity, the transport writes up to `~offsetof(struct nvme_mi_aem_msg, occ_list_hdr)` bytes past the end of the 4096-byte stack buffer.

The other two `response_buffer` sites in the file point at the buffer base and are correct.

## Fix

Pass the actual remaining capacity: `sizeof(response_buffer) - offsetof(struct nvme_mi_aem_msg, occ_list_hdr)`.

## Testing

- Full meson suite green (build + 99 passed; `crypto-util` skips on this host due to missing OpenSSL, also on pristine master).
- MI paths are hardware-bound; validated by review against the AEM spec layout and the 1.x correspondence (linux-nvme/libnvme#1122).
