### PR TITLE
libnvme: examples: fix select() usage in telemetry-listen

### DIFF
--- a/libnvme/examples/telemetry-listen.c
+++ b/libnvme/examples/telemetry-listen.c
@@ -110,7 +110,7 @@ static void check_telemetry(libnvme_ctrl_t c, int ufd)
 	}
 }
 
-static void wait_events(fd_set *fds, struct events *e, int nr)
+static void wait_events(fd_set *fds, struct events *e, int nr, int maxfd)
 {
 	int ret, i;
 
@@ -118,12 +118,15 @@ static void wait_events(fd_set *fds, struct events *e, int nr)
 		check_telemetry(e[i].c, e[i].uevent_fd);
 
 	while (1) {
-		ret = select(nr, fds, NULL, NULL, NULL);
+		/* select() clears the bits of inactive fds, restore them */
+		fd_set read_fds = *fds;
+
+		ret = select(maxfd + 1, &read_fds, NULL, NULL, NULL);
 		if (ret < 0)
 			return;
 
 		for (i = 0; i < nr; i++) {
-			if (!FD_ISSET(e[i].uevent_fd, fds))
+			if (!FD_ISSET(e[i].uevent_fd, &read_fds))
 				continue;
 			check_telemetry(e[i].c, e[i].uevent_fd);
 		}
@@ -134,6 +137,7 @@ int main()
 {
 	struct events *e;
 	fd_set fds;
+	int maxfd = -1;
 	int i = 0;
 
 	struct libnvme_global_ctx *ctx;
@@ -157,6 +161,10 @@ int main()
 				i++;
 
 	e = calloc(i, sizeof(struct events));
+	if (i > 0 && !e) {
+		libnvme_free_global_ctx(ctx);
+		return EXIT_FAILURE;
+	}
 	FD_ZERO(&fds);
 	i = 0;
 
@@ -168,6 +176,8 @@ int main()
 				if (fd < 0)
 					continue;
 				FD_SET(fd, &fds);
+				if (fd > maxfd)
+					maxfd = fd;
 				e[i].uevent_fd = fd;
 				e[i].c = c;
 				i++;
@@ -175,7 +185,8 @@ int main()
 		}
 	}
 
-	wait_events(&fds, e, i);
+	if (i > 0)
+		wait_events(&fds, e, i, maxfd);
 	libnvme_free_global_ctx(ctx);
 	free(e);
 


### PR DESCRIPTION
## Problem

Port of linux-nvme/libnvme#1126 to libnvme3 (the example has the same misuse vector).

`wait_events()` passes the *count* of uevent fds to `select()` as `nfds`; the argument is max-fd+1, and with stdio occupying 0-2 the uevent fds always start at 3, so for the common 1-3 controller case the watcher never wakes on any telemetry AEN. Additionally, `select()` clears inactive fds in the passed set, and the same set is reused — after the first event the loop only monitors fds that happened to be active. With no controller it spins at 100% CPU, and `calloc()` isn't checked.

## Fix

Track maxfd while `FD_SET`ing; pass `maxfd + 1` to `select()` on a re-armed local copy of the set; skip the wait loop when no controller was found; check `calloc()`.

## Testing

- Full meson suite green. The select-nfds semantics were verified with a standalone snippet in the 1.x PR (same mechanism applies verbatim).
