### PR TITLE
libnvme: examples: validate AE numbers in mi-mctp-ae

### DIFF
--- a/libnvme/examples/mi-mctp-ae.c
+++ b/libnvme/examples/mi-mctp-ae.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 	const uint8_t AEM_FD_INDEX = 0;
 	const uint8_t STD_IN_FD_INDEX = 1;
 
-	if (argc == 4) {
+	if (argc >= 4) {
 		net = atoi(argv[1]);
 		eid = atoi(argv[2]) & 0xff;
 		argv += 2;
@@ -101,6 +101,12 @@ int main(int argc, char **argv)
 		for (int i = 0; i < event_count; i++) {
 			int event = atoi(argv[1+i]);
 
+			if (event < 0 || event > 255) {
+				fprintf(stderr,
+					"invalid AE number %d (must be 0-255)\n",
+					event);
+				return EXIT_FAILURE;
+			}
 			aem_config.enabled_map.enabled[event] = true;
 		}
 	} else {


### PR DESCRIPTION
## Problem

Port of linux-nvme/libnvme#1127 to libnvme3: the example in this tree has the identical argv-parsing bug as the 1.x version: `atoi()` values index the 256-entry `aem_config.enabled_map.enabled[]` stack array unchecked (OOB stack write for out-of-range / negative inputs), and `argc == 4` accepts exactly one AE number although the usage text (`[AE #s separated by spaces]`) and the loop are written for a variable count.

## Fix

- Reject AE numbers outside 0-255 before indexing.
- Lift `argc == 4` to `argc >= 4`, matching the documented usage.

## Testing

- Full meson suite green; argv handling verified decay-free in the 1.x PR (the sandbox has no MCTP interfaces, so endpoint-level runtime checks are not possible here).
