### PR TITLE
libnvme: mi: reject async events that carry the RSP bit in nmp

### DIFF
--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -517,7 +517,7 @@ int libnvme_mi_async_read(libnvme_mi_ep_t ep, struct libnvme_mi_resp *resp)
 		return -EPROTO;
 	}
 
-	if (!(resp->hdr->nmp & ~(NVME_MI_ROR_REQ << 7))) {
+	if (resp->hdr->nmp & (NVME_MI_ROR_RSP << 7)) {
 		libnvme_msg(ep->ctx, LIBNVME_LOG_DEBUG,
 			 "ROR value in response indicates a response\n");
 		return -EIO;


### PR DESCRIPTION
## Problem

Port of linux-nvme/libnvme#1131. The same inverted ROR check reached this tree:

```c
if (!(resp->hdr->nmp & ~(NVME_MI_ROR_REQ << 7)))   /* ~(0 << 7) == all-ones */
	... reject
```

With `NVME_MI_ROR_REQ == 0` the expression reduces to `!nmp`: a message is rejected only when **all** of `nmp` is clear, while a message with the RSP bit (bit 7) set — precisely the condition the error message describes — passes.

## Fix

Test bit 7 with `NVME_MI_ROR_RSP`, matching the polarity of the command-response verification a few dozen lines down.

## Testing

- Full meson suite green.
- One-line polarity fix; validated by review against the parallel implementation (and by the corresponding 1.x PR).
