### PR TITLE
libnvme: drop the static stat buffer in nvme_verify_chr()

### DIFF
--- a/libnvme/src/nvme/ioctl-linux.c
+++ b/libnvme/src/nvme/ioctl-linux.c
@@ -31,7 +31,7 @@
 
 static int nvme_verify_chr(struct libnvme_transport_handle *hdl)
 {
-	static struct stat nvme_stat;
+	struct stat nvme_stat;
 	int err = fstat(hdl->fd, &nvme_stat);
 
 	if (err < 0)


### PR DESCRIPTION
## Problem

`nvme_verify_chr()` uses a `static struct stat` as the fstat() target, shared across all threads — concurrent resets / rescans on different transport handles race writing into it and can observe a torn `st_mode`. (The companion 1.x issue of returning a positive errno, linux-nvme/libnvme#1130, is already correct in this tree — it returns `-errno`.)

## Fix

Make the buffer automatic; nothing in the function is meant to be shared or retained.

## Testing

- Full meson suite green. Single-keyword change; no behavioral difference for single-threaded consumers.
