### PR TITLE
libnvme: account for the appended spaces in libnvmf_get_entity_version()

### DIFF
--- a/libnvme/src/nvme/util-fabrics.c
+++ b/libnvme/src/nvme/util-fabrics.c
@@ -115,7 +115,10 @@ size_t libnvmf_get_entity_version(char *buffer, size_t bufsz)
 	/* /proc/sys/kernel/osrelease contains the Linux
 	 * version (e.g. 5.8.0-63-generic)
 	 */
-	buffer[num_bytes++] = ' '; /* Append a space */
+	if (bufsz) {
+		buffer[num_bytes++] = ' '; /* Append a space */
+		bufsz--;
+	}
 	num_bytes += read_file("/proc/sys/kernel/osrelease",
 			       &buffer[num_bytes], &bufsz);
 
@@ -158,7 +161,10 @@ size_t libnvmf_get_entity_version(char *buffer, size_t bufsz)
 
 		if (name_len) {
 			/* Append a space */
-			buffer[num_bytes++] = ' ';
+			if (bufsz) {
+				buffer[num_bytes++] = ' ';
+				bufsz--;
+			}
 			name_len = min(name_len, bufsz);
 			memcpy(&buffer[num_bytes], name, name_len);
 			bufsz -= name_len;
@@ -167,7 +173,10 @@ size_t libnvmf_get_entity_version(char *buffer, size_t bufsz)
 
 		if (ver_id_len) {
 			/* Append a space */
-			buffer[num_bytes++] = ' ';
+			if (bufsz) {
+				buffer[num_bytes++] = ' ';
+				bufsz--;
+			}
 			ver_id_len = min(ver_id_len, bufsz);
 			memcpy(&buffer[num_bytes], ver_id, ver_id_len);
 			bufsz -= ver_id_len;


### PR DESCRIPTION
## Problem

Port of linux-nvme/libnvme#1136. `libnvmf_get_entity_version()` rests on the invariant `num_bytes + bufsz == capacity` maintained by `read_file()`, but each of the three `' '` separators is appended to `buffer` without checking or decrementing `bufsz`. After such an append the invariant is off by one, so with proc content long enough to fill the buffer the next separator lands one byte past the allocation, and the following `min(len, bufsz)` + `memcpy()` still trusts the inflated `bufsz` (one more byte of overrun then).

## Fix

Guard the separator appends with `if (bufsz)` and decrement `bufsz` in step so the invariant holds, keeping the trailing `memset(&buffer[num_bytes], 0, bufsz)` in bounds.

## Testing

- Full meson suite green (99 pass; crypto-util skips here for missing OpenSSL, also on pristine master).
- Arithmetic/invariant verified by review against the 1.x PR; the overrun requires unusually long `/proc/sys/kernel/osrelease` content so it is rare in practice, but the function's contract becomes provable.
