### PR TITLE
libnvme: examples: bound device-supplied lengths in mi-mctp, fix ssid print

### DIFF
--- a/libnvme/examples/mi-mctp.c
+++ b/libnvme/examples/mi-mctp.c
@@ -143,7 +143,7 @@ static int show_ctrl(libnvme_mi_ep_t ep, uint16_t ctrl_id)
 	printf("    PCI vendor: %04x\n", le16_to_cpu(ctrl.vid));
 	printf("    PCI device: %04x\n", le16_to_cpu(ctrl.did));
 	printf("    PCI subsys vendor: %04x\n", le16_to_cpu(ctrl.ssvid));
-	printf("    PCI subsys device: %04x\n", le16_to_cpu(ctrl.ssvid));
+	printf("    PCI subsys device: %04x\n", le16_to_cpu(ctrl.ssid));
 
 	return 0;
 }
@@ -151,7 +151,7 @@ static int show_ctrl(libnvme_mi_ep_t ep, uint16_t ctrl_id)
 static int do_controllers(libnvme_mi_ep_t ep)
 {
 	struct nvme_ctrl_list ctrl_list;
-	int rc, i;
+	int rc, i, num;
 
 	rc = libnvme_mi_mi_read_mi_data_ctrl_list(ep, 0, &ctrl_list);
 	if (rc) {
@@ -160,7 +160,13 @@ static int do_controllers(libnvme_mi_ep_t ep)
 	}
 
 	printf("NVMe controller list:\n");
-	for (i = 0; i < le16_to_cpu(ctrl_list.num); i++) {
+	num = le16_to_cpu(ctrl_list.num);
+	if (num > NVME_ID_CTRL_LIST_MAX) {
+		warnx("controller list reports %d entries, list only has %d",
+		      num, NVME_ID_CTRL_LIST_MAX);
+		num = NVME_ID_CTRL_LIST_MAX;
+	}
+	for (i = 0; i < num; i++) {
 		uint16_t id = le16_to_cpu(ctrl_list.identifier[i]);
 		show_ctrl(ep, id);
 	}
@@ -578,6 +584,11 @@ int do_security_info(libnvme_mi_ep_t ep, int argc, char **argv)
 	if (data_len < offsetof(typeof(proto_info), protocols) + n_proto) {
 		warnx("Short response in security receive command (%d bytes), "
 		      "for %d protocols", data_len, n_proto);
+		return -1;
+	}
+	if (n_proto > (int)sizeof(proto_info.protocols)) {
+		warnx("Too many protocols in security receive response (%d)",
+		      n_proto);
 		return -1;
 	}
 


### PR DESCRIPTION
## Problem

Port of linux-nvme/libnvme#1140. Same three issues as the 1.x example:

1. `do_controllers()` iterates `le16_to_cpu(ctrl_list.num)` entries of `ctrl_list.identifier[]`; `num` is 16-bit while the array holds `NVME_ID_CTRL_LIST_MAX` (2047) entries. A non-conformant device reporting more than that makes the loop read ~63 KB past the array and issue thousands of spurious MI transactions.
2. `do_security_info()` validates `n_proto` against `data_len` (covering the whole 264-byte buffer) rather than `protocols[256]`, so a full-length response can pass with counts of 257-258 → the print loop reads past the array.
3. `show_ctrl()` prints `ctrl.ssvid` (vendor ID) a second time for "PCI subsys device" instead of `ctrl.ssid`.

## Fix

Clamp the controller count with a warning; reject oversized `n_proto`; print `ctrl.ssid`.

## Testing

- Full meson suite green. Example MI paths need real MCTP hardware; build/review-validated only.
