### PR TITLE
libnvme: examples: free the context in display-columnar

### DIFF
--- a/libnvme/examples/display-columnar.c
+++ b/libnvme/examples/display-columnar.c
@@ -142,6 +142,8 @@ int main()
 			}
 		}
 	}
+
+	libnvme_free_global_ctx(ctx);
 	return 0;
 }
 


### PR DESCRIPTION
## Problem

Port of linux-nvme/libnvme#1141. `display-columnar` builds the topology into the global context but never releases it on exit (every other scanning example calls `libnvme_free_global_ctx()`). Runtime impact nil, but the example is regularly copied as a starting template and should model complete teardown.

## Fix

Call `libnvme_free_global_ctx(ctx)` before returning from `main()`.

## Testing

- Full meson suite green.
