### PR TITLE
plugins/samsung: add Samsung vendor specific extensions plugin

### DIFF
--- a/Documentation/cmd-plugins.txt
+++ b/Documentation/cmd-plugins.txt
@@ -381,3 +381,6 @@ linknvme:nvme-keys-export[1]::
 
 linknvme:nvme-keys-revoke[1]::
 	Revoke an NVMeoF TLS PSK from a keyring
+
+linknvme:nvme-samsung-vs-internal-log[1]::
+	Retrieve Samsung vendor specific internal firmware logs

--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -174,6 +174,7 @@ adoc_sources_man1 = [
     'nvme-rpmb-read-data',
     'nvme-rpmb-write-config',
     'nvme-rpmb-write-data',
+    'nvme-samsung-vs-internal-log',
     'nvme-sanitize',
     'nvme-seagate-clear-fw-activate-history',
     'nvme-seagate-clear-pcie-correctable-errors',

--- a/Documentation/nvme-samsung-vs-internal-log.txt
+++ b/Documentation/nvme-samsung-vs-internal-log.txt
@@ -1,0 +1,103 @@
+nvme-samsung-vs-internal-log(1)
+===============================
+
+NAME
+----
+nvme-samsung-vs-internal-log - Retrieve Samsung vendor specific internal
+firmware logs
+
+SYNOPSIS
+--------
+[verse]
+'nvme' [<global-options>] 'samsung vs-internal-log' <device> [OPTIONS]
+
+DESCRIPTION
+-----------
+Collect the internal firmware logs of a Samsung NVMe SSD and write them to
+disk. Host-initiated telemetry, controller-initiated telemetry and the
+vendor crash, memory and debug dumps are supported. Each dump is saved as
+its own file, so a single run usually produces several files.
+
+Use '--dump-type' to pick which dumps to collect; several types may be
+requested in a single run.
+
+This command will only work on Samsung devices supporting this feature.
+
+The '<device>' parameter is mandatory and may be either an NVMe character
+device (ex: /dev/nvme0) or an nvme block device (ex: /dev/nvme0n1).
+
+OPTIONS
+-------
+-t <TYPE>::
+--dump-type=<TYPE>::
+	Comma-separated list of dump types to extract, given without
+	spaces. The supported types are 'host0' and 'host1' for the
+	host-initiated telemetry dump using Log Specific Parameter 0 and
+	1 respectively, 'ctlr' for the controller-initiated telemetry
+	dump, and 'vendor' for the vendor dumps. When this option is
+	omitted, every dump type except 'host0' is extracted; 'host0'
+	is only collected when it is requested explicitly.
+
+-a <NUM>::
+--telemetry-data-area=<NUM>::
+	Telemetry data area to retrieve, 1 to 4. Defaults to 0, which
+	retrieves every data area. Data area 4 is only extracted when the
+	device reports that it supports it. This option only affects the
+	telemetry dumps.
+
+-O <FILE>::
+--output-file=<FILE>::
+	Output file name, optionally preceded by a path (ex:
+	'./path/name' or './path1/path2/'). Any directory in the path
+	that does not exist yet is created. When this option is omitted,
+	the dumps are written to the current directory.
+
+-z::
+--compress::
+	Collect the dumps into a temporary directory and save them as a
+	single compressed .tar.gz archive.
+
+-H::
+--hide-progress::
+	Do not print the incremental progress of an extraction. Useful
+	where the output is captured line by line and a carriage return
+	does not overwrite, so that every update would be kept. The
+	completion line of each dump is still printed.
+
+include::global-options.txt[]
+
+EXAMPLES
+--------
+Extract the controller-initiated telemetry, the host-initiated telemetry
+using Log Specific Parameter 1 and the vendor dumps of the given device
+into the current directory.
+
+------------
+# nvme samsung vs-internal-log /dev/nvme0
+------------
+
+Extract only the controller-initiated telemetry and the vendor dumps,
+naming both types in a single run.
+
+------------
+# nvme samsung vs-internal-log /dev/nvme0 -t ctlr,vendor
+------------
+
+Extract the host-initiated telemetry using Log Specific Parameter 0, which
+is not collected unless it is named explicitly, into ./dumps/, creating
+that directory if it does not exist.
+
+------------
+# nvme samsung vs-internal-log /dev/nvme0 -t host0 -O ./dumps/
+------------
+
+Extract data area 2 of the host-initiated telemetry using Log Specific
+Parameter 1, store the result compressed and keep the output quiet.
+
+------------
+# nvme samsung vs-internal-log /dev/nvme0 -t host1 -a 2 -z -H
+------------
+
+NVME
+----
+Part of the nvme-user suite

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -239,9 +239,9 @@ option(
   choices: ['amzn', 'config', 'dapustor', 'dell', 'dera', 'dir',
             'exclusion', 'fdp', 'feat', 'fw', 'huawei', 'ibm', 'id', 'innogrit', 'inspur',
             'intel', 'io-mgmt', 'keys', 'lm', 'log', 'mangoboost', 'memblaze', 'micron', 'nbft',
-            'netapp', 'ns', 'nvidia', 'nvme-mi', 'ocp', 'registry', 'resv', 'rpmb', 'sandisk',
-            'scaleflux', 'seagate', 'security', 'sed', 'shannon', 'solidigm', 'ssstc', 'toshiba',
-            'transcend', 'utils', 'virtium', 'wdc', 'ymtc', 'zns'],
+            'netapp', 'ns', 'nvidia', 'nvme-mi', 'ocp', 'registry', 'resv', 'rpmb', 'samsung',
+            'sandisk', 'scaleflux', 'seagate', 'security', 'sed', 'shannon', 'solidigm', 'ssstc',
+            'toshiba', 'transcend', 'utils', 'virtium', 'wdc', 'ymtc', 'zns'],
   description : 'comma-separated list of plugins to build (all plugins are included if unset, [] = no plugins)'
 )
 option(

--- a/plugins/samsung/meson.build
+++ b/plugins/samsung/meson.build
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+plugin_sources += [
+    'plugins/samsung/samsung-nvme.c',
+]

--- a/plugins/samsung/samsung-nvme.c
+++ b/plugins/samsung/samsung-nvme.c
@@ -1,0 +1,1460 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <errno.h>
+
+#include <libnvme.h>
+
+#include <ccan/endian/endian.h>
+#include <shared/compiler-attributes-util.h>
+#include <shared/fs-util.h>
+#include <shared/io-util.h>
+#include <shared/progress-util.h>
+#include <shared/string-util.h>
+
+#include "cleanup.h"
+#include "global-ctx.h"
+#include "nvme-cmds.h"
+#include "nvme-print.h"
+#include "plugin.h"
+
+#define SAMSUNG_PLUGIN_VERSION "3.0.15"
+
+#define SAMSUNG_GENERAL_FILE_WRITE_ERROR                    -1
+#define SAMSUNG_GENERAL_FILE_OPEN_ERROR                     -2
+#define SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR             -3
+#define SAMSUNG_GENERAL_INVALID_VID_ERROR                   -4
+#define SAMSUNG_GENERAL_MEM_ALLOC_ERROR                     -5
+
+static bool g_hide_progress;
+
+static const char *samsung_plugin_status_to_string(__s32 status)
+{
+	const char *str;
+
+	switch (status) {
+	case SAMSUNG_GENERAL_FILE_WRITE_ERROR:
+		str = "File write error.";
+		break;
+	case SAMSUNG_GENERAL_FILE_OPEN_ERROR:
+		str = "File open error.";
+		break;
+	case SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR:
+		str = "Invalid parameter error.";
+		break;
+	case SAMSUNG_GENERAL_INVALID_VID_ERROR:
+		str = "Only Samsung products are supported.";
+		break;
+	case SAMSUNG_GENERAL_MEM_ALLOC_ERROR:
+		str = "Memory allocation error.";
+		break;
+	default:
+		str = "Unknown.";
+	}
+	return str;
+}
+
+static void samsung_print_error(int err)
+{
+	if (err > 0) {
+		if ((err & 0xFF) == NVME_SC_INVALID_FIELD
+				|| (err & 0xFF) == NVME_SC_INVALID_LOG_PAGE) {
+			fprintf(stderr, "This device is not supported.\n");
+		} else {
+			fprintf(stderr, "NVMe Status: %s(0x%X)\n",
+					libnvme_status_to_string(err, false), err);
+		}
+	} else if (err < 0)
+		fprintf(stderr, "%s(%d)\n", samsung_plugin_status_to_string(err), err);
+}
+
+static void samsung_initialize(void)
+{
+	// Set stdout to unbuffered (always fflush immediately)
+	// Must be called before any other printf().
+	setvbuf(stdout, NULL, _IONBF, 0);
+}
+
+static int samsung_nvme_submit_admin_passthru(
+		struct libnvme_transport_handle *hdl, struct libnvme_passthru_cmd *cmd)
+{
+	return libnvme_exec_admin_passthru(hdl, cmd);
+}
+
+static int samsung_nvme_get_log_page(struct libnvme_transport_handle *hdl,
+		__u32 nsid, __u8 log_id, __u32 data_len, void *data, __u64 lpo,
+		__u8 lsp, __u8 rae, __u32 cdw14)
+{
+	struct libnvme_passthru_cmd cmd = {
+		.opcode   = nvme_admin_get_log_page,
+		.nsid     = nsid,
+		.addr     = (__u64)(uintptr_t) data,
+		.data_len = data_len,
+		.cdw10    = ((lsp & 0x7F) << 8) | log_id,
+		.cdw12    = lpo & 0xFFFFFFFF,
+		.cdw13    = lpo >> 32,
+		.cdw14    = cdw14,
+	};
+
+	return libnvme_get_log(hdl, &cmd, rae, data_len);
+}
+
+#define UNIT_DATA_SIZE_1KB   (1024)
+#define UNIT_DATA_SIZE_5KB   (5 * 1024)
+#define UNIT_DATA_SIZE_8KB   (8 * 1024)
+#define UNIT_DATA_SIZE_16KB  (16 * 1024)
+#define UNIT_DATA_SIZE_32KB  (32 * 1024)
+#define UNIT_DATA_SIZE_78KB  (78 * 1024)
+#define UNIT_DATA_SIZE_94KB  (94 * 1024)
+#define UNIT_DATA_SIZE_127KB (127 * 1024)
+#define UNIT_DATA_SIZE_128KB (128 * 1024)
+#define UNIT_DATA_SIZE_512KB (512 * 1024)
+
+/*
+ * The serial number is space padded rather than NUL terminated, so copy
+ * the whole field and trim the padding. sn holds sizeof(ctrl->sn) + 1
+ * bytes. Trimming from the end keeps a serial that has a space in it.
+ */
+static void get_serial_number(struct nvme_id_ctrl *ctrl, char *sn)
+{
+	memcpy(sn, ctrl->sn, sizeof(ctrl->sn));
+	sn[sizeof(ctrl->sn)] = '\0';
+	shr_rtrim(sn);
+}
+
+/*
+ * The name of one dump file: the -O prefix, if any, with the serial number
+ * and the feature name appended.
+ * Return: an allocated path the caller frees, or NULL when out of memory.
+ */
+static char *make_file_path(const char *feature_name, const char *file_name,
+		const char *sn)
+{
+	char *path = NULL;
+
+	if (asprintf(&path, "%s%s_%s.bin", file_name ? file_name : "", sn,
+			feature_name) < 0)
+		return NULL;
+
+	return path;
+}
+
+static void measure_time(struct timeval *begin, bool set_begin)
+{
+	if (set_begin)
+		gettimeofday(begin, NULL);
+	else {
+		struct timeval end;
+
+		gettimeofday(&end, NULL);
+		if (end.tv_usec < begin->tv_usec)
+			printf("Time Taken: %ld.%.6lds\n",
+					(long)(end.tv_sec - begin->tv_sec - 1),
+					(long)(1000000 + end.tv_usec - begin->tv_usec));
+		else
+			printf("Time Taken: %ld.%.6lds\n",
+					(long)(end.tv_sec - begin->tv_sec),
+					(long)(end.tv_usec - begin->tv_usec));
+	}
+}
+
+/*
+ * __s64/__u64 are long on LP64 targets such as ppc64le, so cast in the
+ * macro to keep the %lld conversions below correct everywhere.
+ */
+#define SEC(time) ((long long)((time) / 1000000))
+#define USEC_3(time) ((long long)((time) % 1000000 / 1000))
+
+static void measure_loop_time(struct timeval *begin, __s64 loop_cnt,
+		__s64 total_loop_cnt)
+{
+	static __s64 time_10;
+	static __s64 time_10_per_loop;
+	static __s64 time_100;
+	static __s64 time_100_per_loop;
+	static __s64 time_1000;
+	static __s64 time_1000_per_loop;
+	struct timeval end;
+
+	/*
+	 * Developer timing, on its own axis: this table answers to --verbose
+	 * only, never to --hide-progress.
+	 */
+	if (!nvme_args.verbose)
+		return;
+
+	if (loop_cnt == 9) {
+		gettimeofday(&end, NULL);
+		time_10 = (end.tv_sec * 1000000 + end.tv_usec)
+				- (begin->tv_sec * 1000000 + begin->tv_usec);
+		time_10_per_loop = time_10 / 10;
+	} else if (loop_cnt == 99) {
+		gettimeofday(&end, NULL);
+		time_100 = (end.tv_sec * 1000000 + end.tv_usec)
+				 - (begin->tv_sec * 1000000 + begin->tv_usec);
+		time_100_per_loop = time_100 / 100;
+	} else if (loop_cnt == 999) {
+		gettimeofday(&end, NULL);
+		time_1000 = (end.tv_sec * 1000000 + end.tv_usec)
+				  - (begin->tv_sec * 1000000 + begin->tv_usec);
+		time_1000_per_loop = time_1000 / 1000;
+	}
+
+	if (loop_cnt + 1 == total_loop_cnt) {
+		printf("Total loops: %lld loops\n", (long long)total_loop_cnt);
+		printf("Loops | Elapsed time | Avg time per loop\n");
+
+		if (total_loop_cnt >= 10) {
+			printf("   10 | %7lld.%03lld | %13lld.%03lld\n",
+					SEC(time_10), USEC_3(time_10),
+					SEC(time_10_per_loop), USEC_3(time_10_per_loop));
+		}
+		if (total_loop_cnt >= 100) {
+			printf("  100 | %7lld.%03lld | %13lld.%03lld\n",
+					SEC(time_100), USEC_3(time_100),
+					SEC(time_100_per_loop), USEC_3(time_100_per_loop));
+		}
+		if (total_loop_cnt >= 1000) {
+			printf(" 1000 | %7lld.%03lld | %13lld.%03lld\n",
+					SEC(time_1000), USEC_3(time_1000),
+					SEC(time_1000_per_loop), USEC_3(time_1000_per_loop));
+		}
+
+		gettimeofday(&end, NULL);
+		__s64 total_time = (end.tv_sec * 1000000 + end.tv_usec)
+				- (begin->tv_sec * 1000000 + begin->tv_usec);
+		__s64 time_per_loop = total_time / total_loop_cnt;
+
+		printf("%5lld | %7lld.%03lld | %13lld.%03lld\n",
+				(long long)total_loop_cnt,
+				SEC(total_time), USEC_3(total_time),
+				SEC(time_per_loop), USEC_3(time_per_loop));
+	}
+}
+
+/*
+ * Insert dir_name as an extra directory level in front of the final
+ * component of base_dir, create that directory, and hand back the result:
+ *
+ *   base_dir      dir_name  *result
+ *   (NULL)        path2     ./path2/
+ *   name          path2     ./path2/name
+ *   /path1/       path2     /path1/path2/
+ *   /path1/name   path2     /path1/path2/name
+ *
+ * *result is allocated and the caller frees it.
+ */
+static int insert_dir(const char *base_dir, const char *dir_name, char **result)
+{
+	__cleanup_free char *dir = NULL;
+	const char *prefix = "./";
+	const char *name = "";
+	int prefix_len = 2;
+	int ret;
+
+	if (base_dir) {
+		name = shr_basename(base_dir);
+		if (name != base_dir) {
+			prefix = base_dir;
+			prefix_len = (int)shr_dir_prefix_len(base_dir);
+		}
+	}
+
+	if (asprintf(&dir, "%.*s%s", prefix_len, prefix, dir_name) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	ret = shr_mkdir_p(dir, 0777);
+	if (ret < 0) {
+		fprintf(stderr, "mkdir %s: %s\n", dir, strerror(-ret));
+		return SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+	}
+
+	if (asprintf(result, "%s/%s", dir, name) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	return 0;
+}
+
+/*
+ * The archiving below runs through system(), as in the other vendor
+ * plugins. Every interpolated argument is single-quoted, so reject the one
+ * character that could escape that quoting.
+ */
+static bool shell_arg_is_safe(const char *s)
+{
+	return !strchr(s, '\'');
+}
+
+static int compress_dump_files(const char *dump_path_with_name, const char *sn)
+{
+	__cleanup_free char *targz_file = NULL;
+	__cleanup_free char *tar_cmd = NULL;
+	__cleanup_free char *rm_cmd = NULL;
+	const char *dump_name_only = shr_basename(dump_path_with_name);
+	int dump_path_len = (int)shr_dir_prefix_len(dump_path_with_name);
+
+	if (!shell_arg_is_safe(dump_path_with_name) || !shell_arg_is_safe(sn)) {
+		fprintf(stderr, "Output path and serial number must not contain \"'\".\n");
+		return SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR;
+	}
+
+	if (asprintf(&targz_file, "../%sSamsung_Dump_%s.tar.gz",
+			dump_name_only, sn) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	if (asprintf(&tar_cmd, "cd '%.*s'; tar cvzf '%s' ./*",
+			dump_path_len, dump_path_with_name, targz_file) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	if (asprintf(&rm_cmd, "rm -rf '%.*s'",
+			dump_path_len, dump_path_with_name) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	printf("Compressing...\n");
+	if (system(tar_cmd)) {
+		fprintf(stderr, "%s failed!\n", tar_cmd);
+		return SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+	}
+	printf("%sSamsung_Dump_%s.tar.gz saved at the designated location.\n",
+			dump_name_only, sn);
+
+	if (system(rm_cmd)) {
+		fprintf(stderr, "%s failed!\n", rm_cmd);
+		return SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+	}
+
+	return 0;
+}
+
+static void print_border(const char *dump_name, char cmd_type, int arg1, int arg2)
+{
+	printf("\n-------------------------------------------------------------\n");
+	printf("\nExtracting %s", dump_name);
+	if (cmd_type == 'g')
+		printf("([Get Log] LID %Xh)\n", arg1);
+	else if (cmd_type == 's')
+		printf("([Secu] SPSP %Xh Op %Xh)\n", arg1, arg2);
+	else if (cmd_type == 'v')
+		printf("([Vendor] Op %Xh)\n", arg1);
+}
+
+
+/*
+ * The HOST/CTLR values double as the Get Log Page LID (0x07 / 0x08), so keep
+ * them fixed.  HOST_0 / HOST_1 select the Telemetry Host-Initiated LSP
+ * (0 = retain the existing capture, 1 = generate a new one).
+ */
+enum DUMP_TYPE {
+	DUMP_TYPE_ALL  = 0,
+	DUMP_TYPE_HOST = 7,
+	DUMP_TYPE_CTLR = 8,
+	DUMP_TYPE_HOST_0,
+	DUMP_TYPE_HOST_1,
+	DUMP_TYPE_VENDOR,
+	DUMP_TYPE_MAX,
+};
+
+#define TELEMETRY_HEADER_SIZE    512
+#define TELEMETRY_BYTE_PER_BLOCK 512
+
+#pragma pack(push, 1)
+
+struct reason_identifier {
+	__u8 error_id[64];            //[ 63: 0]
+	__u8 file_id[8];              //[ 71:64]
+	__u8 line_number[2];          //[ 73:72]
+	__u8 valid_flags;             //[ 74:74]
+	__u8 rsvd75[21];              //[ 95:75]
+	__u8 vu_reason_extension[32]; //[127:96]
+};
+
+struct telemetry_initiated_log {
+	__u8   log_identifier;            //[  0:  0]
+	__u8   rsvd1[4];                  //[  4:  1]
+	__u8   IEEE[3];                   //[  7:  5]
+	__le16 data_area1_last_block;     //[  9:  8]
+	__le16 data_area2_last_block;     //[ 11: 10]
+	__le16 data_area3_last_block;     //[ 13: 12]
+	__u8   rsvd14[2];                 //[ 15: 14]
+	__le32 data_area4_last_block;     //[ 19: 16]
+	__u8   rsvd20[360];               //[379: 20]
+	__u8   _380;                      //[380:380]
+	__u8   _381;                      //[381:381]
+	__u8   ctlr_init_data_available;  //[382:382]
+	__u8   ctlr_init_data_gen_number; //[383:383]
+	struct reason_identifier ri;      //[511:384]
+};
+
+#pragma pack(pop)
+
+static void print_telemetry_header(struct telemetry_initiated_log *log_header,
+		int tele_type)
+{
+	if (log_header != NULL) {
+		unsigned int i = 0, j = 0;
+
+		if (tele_type == DUMP_TYPE_HOST)
+			printf("============== Telemetry Host Header ==============\n");
+		else
+			printf("=========== Telemetry Controller Header ===========\n");
+
+		printf("Log Identifier         : 0x%02X\n", log_header->log_identifier);
+		printf("IEEE                   : 0x%02X%02X%02X\n",
+				log_header->IEEE[0], log_header->IEEE[1], log_header->IEEE[2]);
+		printf("Data Area 1 Last Block : 0x%04X\n",
+				le16_to_cpu(log_header->data_area1_last_block));
+		printf("Data Area 2 Last Block : 0x%04X\n",
+				le16_to_cpu(log_header->data_area2_last_block));
+		printf("Data Area 3 Last Block : 0x%04X\n",
+				le16_to_cpu(log_header->data_area3_last_block));
+		printf("Data Area 4 Last Block : 0x%08X\n",
+				le32_to_cpu(log_header->data_area4_last_block));
+
+		if (tele_type == DUMP_TYPE_HOST) {
+			printf("Host-init Scope                  : 0x%02X\n",
+					log_header->_380);
+			printf("Host-init Data Generation Number : 0x%02X\n",
+					log_header->_381);
+		} else
+			printf("Ctlr-init Scope                  : 0x%02X\n",
+					log_header->_381);
+
+		printf("Ctlr-init Data Available         : 0x%02X\n",
+				log_header->ctlr_init_data_available);
+		printf("Ctlr-init Data Generation Number : 0x%02X\n",
+				log_header->ctlr_init_data_gen_number);
+
+		printf("\n<Reason Identifier>\n");
+
+		__u8 *ri = (__u8 *)&log_header->ri;
+
+		for (i = 0; i < 8; i++) {
+			printf("  ");
+			for (j = 0; j < 16; j++)
+				printf(" %02X", ri[127 - ((i * 16) + j)]);
+			printf("\n");
+		}
+
+		printf("===================================================\n");
+	}
+}
+
+// Get DA4S bit (Data Area 4 Support)
+// Admin command - Identify - Identify Controller - Log Page Attributes
+static int get_da4s(struct nvme_id_ctrl *ctrl, bool *da4s)
+{
+	*da4s = ((ctrl->lpa >> 6) & 0x01);
+	return 0;
+}
+
+// Get MCDAS bit (Maximum Created Data Area Support)
+// Admin command - Get Log Page - Supported Log Pages - LID Supported and Effects
+static int get_mcdas(struct libnvme_transport_handle *hdl, __u32 nsid, bool *mcdas)
+{
+	__u8 data[1024] = {0,};
+	int err = 0;
+
+	err = samsung_nvme_get_log_page(hdl, nsid, 0, sizeof(data), data, 0, 0, 0, 0);
+	if (err != 0) {
+		*mcdas = false;
+		return err;
+	}
+
+	// data[30] is "lower 8 bits of LIDSP" for "LID Supported and Effects Data
+	// Structure for LID 7"; data[30] & 1 is MCDAS for LID 7.
+	*mcdas = (data[30] & 1) ? true : false;
+
+	return 0;
+}
+
+static int get_telemetry_header(struct libnvme_transport_handle *hdl, __u32 nsid,
+		__u8 tele_type, __u32 data_len, void *data, __u8 lsp, __u8 rae)
+{
+	return samsung_nvme_get_log_page(hdl, nsid, tele_type, data_len, data, 0,
+			lsp, rae, 0);
+}
+
+/*
+ * dump_size is 64-bit: Data Area 4 carries a 32-bit last block number, so a
+ * telemetry area can be larger than INT_MAX even though each individual
+ * transfer stays within transfer_size.
+ */
+static int extract_telemetry_dump_data(char *feature_name, char *file_name,
+		char *sn, __s64 dump_size, int transfer_size,
+		struct libnvme_transport_handle *hdl, __u32 nsid, __u8 log_id,
+		__u8 lsp, __u64 offset, bool rae)
+{
+	__cleanup_free char *feature_name_header = NULL;
+	__cleanup_free char *file_path_header = NULL;
+	__cleanup_free char *file_path = NULL;
+	__cleanup_free char *data = NULL;
+	__s64 loop = 0;
+	int err = 0;
+
+	struct timeval begin;
+	int output = -1, output_header = -1;
+	__s64 total_loop_cnt = dump_size / transfer_size;
+	int last_xfer_size = dump_size % transfer_size;
+	int retrieve_size;
+
+	data = calloc(transfer_size, sizeof(char));
+	if (!data)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	if (asprintf(&feature_name_header, "%s_header", feature_name) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	file_path = make_file_path(feature_name, file_name, sn);
+	file_path_header = make_file_path(feature_name_header, file_name, sn);
+	if (!file_path || !file_path_header)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	if (last_xfer_size != 0)
+		total_loop_cnt++;
+	else
+		last_xfer_size = transfer_size;
+
+	measure_time(&begin, true);
+
+	err = get_telemetry_header(hdl, nsid, log_id, TELEMETRY_HEADER_SIZE, data,
+			lsp, rae);
+	if (err != 0)
+		goto end;
+
+	output_header = shr_open_rawdata(file_path_header, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (output_header < 0) {
+		err = SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+		goto end;
+	}
+
+	if (shr_write_all(output_header, data, TELEMETRY_HEADER_SIZE)) {
+		err = SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+		goto close_output_header;
+	}
+
+	for (loop = 0; loop < total_loop_cnt; loop++) {
+		retrieve_size = (loop == total_loop_cnt - 1) ? last_xfer_size : transfer_size;
+		memset(data, 0, transfer_size);
+
+		err = samsung_nvme_get_log_page(hdl, nsid, log_id, retrieve_size, data,
+				offset, lsp, rae, 0);
+		if (err != 0) {
+			if (loop > 0)
+				goto close_output;
+			else
+				goto close_output_header;
+		}
+
+		if (loop == 0) {
+			output = shr_open_rawdata(file_path,
+					O_WRONLY | O_CREAT | O_TRUNC, 0666);
+			if (output < 0) {
+				err = SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+				goto close_output_header;
+			}
+		}
+
+		if (shr_write_all(output, data, retrieve_size)
+				|| shr_write_all(output_header, data, retrieve_size)) {
+			err = SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+			goto close_output;
+		}
+
+		measure_loop_time(&begin, loop, total_loop_cnt);
+		offset += retrieve_size;
+		if (!g_hide_progress)
+			shr_spinner(feature_name,
+					(loop + 1) / (float)total_loop_cnt, stdout);
+	}
+
+	/* Completion line: printed even under --hide-progress, see above. */
+	shr_spinner(feature_name, 1.0, stdout);
+	printf("\n");
+	printf("The log file was saved in \"%s\"\n", file_path);
+	printf("The log file was saved in \"%s\"\n", file_path_header);
+	measure_time(&begin, false);
+
+close_output:
+	if (output >= 0)
+		close(output);
+
+close_output_header:
+	if (output_header >= 0)
+		close(output_header);
+
+end:
+	return err;
+}
+
+static int open_write_close(char *file_name, __u8 *buffer, int size)
+{
+	int err = 0;
+	int output = 0;
+
+	output = shr_open_rawdata(file_name, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (output < 0) {
+		err = SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+		return err;
+	}
+
+	if (shr_write_all(output, buffer, size))
+		err = SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+
+	close(output);
+	return err;
+}
+
+static int get_telemetry_dump(struct libnvme_transport_handle *hdl,
+		struct nvme_id_ctrl *ctrl, char *file_name, char *sn,
+		enum DUMP_TYPE tele_type, int data_area, bool header_print,
+		int transfer_size)
+{
+	__u32 nsid = NVME_NSID_ALL;
+	int err = 0;
+	__u8 lsp = 0, rae = 1;
+	char *feature_name = 0;
+
+	bool is_enabled_data_area4 = false;
+	bool da4s = false;
+	bool mcdas = false;
+	bool host_behavior_changed = false;
+
+	if (tele_type == DUMP_TYPE_HOST_0) {
+		feature_name = "Host(0)";
+		lsp = 0;
+		tele_type = DUMP_TYPE_HOST;
+	} else if (tele_type == DUMP_TYPE_HOST_1) {
+		feature_name = "Host(1)";
+		lsp = 1;
+		tele_type = DUMP_TYPE_HOST;
+	} else { // DUMP_TYPE_CTLR
+		feature_name = "Controller";
+		lsp = 0;
+	}
+
+	struct telemetry_initiated_log log_header;
+	__cleanup_free char *dump_name = NULL;
+	__cleanup_free char *file_path = NULL;
+
+	// [Data Area 4] Initialize
+	if ((data_area == 0) || (data_area == 4))
+		is_enabled_data_area4 = true;
+
+	// [Data Area 4] 1. Check DA4S bit (Data Area 4 Support)
+	if (is_enabled_data_area4) {
+		get_da4s(ctrl, &da4s);
+		if (da4s != true) {
+			/* Continue on if this fails, it's not a fatal condition */
+			printf("\nData Area 4 Support(DA4S) bit is 0.\n");
+			is_enabled_data_area4 = false;
+		}
+	}
+
+	// [Data Area 4] 2. Check MCDAS bit and set MCDA only if creating host log
+	if (is_enabled_data_area4 && (lsp == 1)) {
+		err = get_mcdas(hdl, nsid, &mcdas);
+		if (err) {
+			/* Extract Data Area 4 regardless of MCDAS */
+			printf("\nGet Maximum Created Data Area Support(MCDAS) "
+					"bit is not supported. (0x%X)\n", err);
+		} else if (mcdas != true) {
+			/* Extract Data Area 4 regardless of MCDAS */
+			printf("\nMaximum Created Data Area Support(MCDAS) bit is 0.\n");
+		} else {
+			// Set MCDA to 4 (Maximum Created Data Area)
+			lsp |= (4 << 1);
+		}
+	}
+
+	// [Data Area 4] 3. Set ETDAS bit (Extended Telemetry Data Area 4 Supported)
+	if (is_enabled_data_area4) {
+		err = libnvme_set_etdas(hdl, &host_behavior_changed);
+		if (err) {
+			/* Continue on if this fails, it's not a fatal condition */
+			printf("\nSet ETDAS bit is not supported. (0x%X)\n", err);
+			is_enabled_data_area4 = false;
+		}
+	}
+
+	// [Data Area 4] Notify the user whether area 4 can be extracted
+	if ((data_area == 0) || (data_area == 4)) {
+		if (is_enabled_data_area4 != true) {
+			printf("\nData Area 4 will not be extracted. "
+					"(It might be displayed as empty.)\n");
+			printf("To verify detailed information, please check "
+					"the above logs to confirm\n");
+			printf("that DA4S, MCDAS, and other settings are "
+					"configured correctly.\n\n");
+		} else
+			printf("\nSetup for Data Area 4 extraction is done.\n\n");
+	}
+
+	// Get Header
+	err = get_telemetry_header(hdl, nsid, tele_type, TELEMETRY_HEADER_SIZE,
+			(void *)&log_header, lsp, rae);
+	if (err)
+		goto restore_etdas;
+
+	if (header_print)
+		print_telemetry_header(&log_header, tele_type);
+
+	if (asprintf(&dump_name, "Telemetry_%s_header_only", feature_name) < 0) {
+		err = SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+		goto restore_etdas;
+	}
+	file_path = make_file_path(dump_name, file_name, sn);
+	if (!file_path) {
+		err = SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+		goto restore_etdas;
+	}
+	err = open_write_close(file_path, (__u8 *)&log_header, TELEMETRY_HEADER_SIZE);
+	if (err)
+		goto restore_etdas;
+
+	__s64 last_block[5] = {0,};
+	__u64 offset[5] = {0,};
+	__s64 size[5] = {TELEMETRY_HEADER_SIZE, 0, 0, 0, 0};
+
+	last_block[1] = le16_to_cpu(log_header.data_area1_last_block);
+	last_block[2] = le16_to_cpu(log_header.data_area2_last_block);
+	last_block[3] = le16_to_cpu(log_header.data_area3_last_block);
+	last_block[4] = le32_to_cpu(log_header.data_area4_last_block);
+
+	for (int i = 1; i <= 4; i++) {
+		offset[i] = (last_block[i - 1] + 1) * TELEMETRY_HEADER_SIZE;
+		size[i] = (last_block[i] - last_block[i - 1]) * TELEMETRY_BYTE_PER_BLOCK;
+	}
+
+	int area_start, area_end;
+
+	if (data_area == 0) // extract all area if not designated
+		area_start = 1, area_end = 4;
+	else // extract designated area only
+		area_start = area_end = data_area;
+
+	for (int area = area_start; area <= area_end && err == 0; area++) {
+		printf("\n");
+		if (size[area] <= 0) {
+			printf("Telemetry %s Area %d is empty.\n", feature_name, area);
+			continue;
+		}
+
+		__cleanup_free char *area_name = NULL;
+
+		if (asprintf(&area_name, "Telemetry_%s_Area_%d", feature_name, area) < 0) {
+			err = SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+			break;
+		}
+		err = extract_telemetry_dump_data(area_name, file_name, sn, size[area],
+				transfer_size, hdl, nsid, tele_type, 0, offset[area], rae);
+	}
+
+restore_etdas:
+	// [Data Area 4] 4. Restore ETDAS bit (Extended Telemetry Data Area 4 Supported)
+	if (host_behavior_changed) {
+		host_behavior_changed = false;
+
+		int restore_err = libnvme_clear_etdas(hdl, &host_behavior_changed);
+
+		if (restore_err) {
+			/* Continue on if this fails, it's not a fatal condition */
+			printf("\nRestore ETDAS bit is not supported. (0x%X)\n", restore_err);
+		}
+	}
+
+	return err;
+}
+
+static void print_telemetry_info(enum DUMP_TYPE tele_type, int data_area,
+		int lid, int transfer_size)
+{
+	printf("\n-------------------------------------------------------------\n");
+
+	if (tele_type == DUMP_TYPE_HOST_0)
+		printf("\nExtracting Telemetry Host 0 Dump ");
+	else if (tele_type == DUMP_TYPE_HOST_1)
+		printf("\nExtracting Telemetry Host 1 Dump ");
+	else
+		printf("\nExtracting Telemetry Controller Dump ");
+
+	if (data_area == 0)
+		printf("(Data Area 1 to 4)");
+	else
+		printf("(Data Area %d)", data_area);
+
+	printf("([Get Log] LID %Xh)", lid);
+	printf("(Xfer %dK)\n", transfer_size / 1024);
+}
+
+#define MERGE_MAX_AREA 4
+#define MERGE_COPY_CHUNK (64 * 1024)
+
+static bool file_is_readable(const char *path)
+{
+	return !access(path, R_OK);
+}
+
+/*
+ * Append the whole of path to the already open descriptor out.
+ * Return: 0 on success, -errno otherwise.
+ */
+static int append_file(int out, const char *path)
+{
+	char *buf;
+	int in;
+	int ret = 0;
+
+	in = shr_open_rawdata(path, O_RDONLY);
+	if (in < 0)
+		return -errno;
+
+	buf = malloc(MERGE_COPY_CHUNK);
+	if (!buf) {
+		close(in);
+		return -ENOMEM;
+	}
+
+	for (;;) {
+		ssize_t n = read(in, buf, MERGE_COPY_CHUNK);
+
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			ret = -errno;
+			break;
+		}
+		if (n == 0)
+			break;
+
+		ret = shr_write_all(out, buf, (size_t)n);
+		if (ret)
+			break;
+	}
+
+	free(buf);
+	close(in);
+	return ret;
+}
+
+/*
+ * Concatenate the telemetry header and the data area dumps into a single
+ * file.
+ *
+ * get_telemetry_dump() writes no file for an area the controller reports as
+ * empty, so the merge list is built from the areas that are actually on
+ * disk and the output is named after those alone. Doing this in process
+ * rather than through "cat a b c > out" matters: the shell truncates -- and
+ * so creates -- the output before cat runs, which left a 0-byte file when
+ * no area had been retrieved, and otherwise a name promising areas the file
+ * did not contain.
+ */
+static int merge_telemetry_log(const char *dump_save_dir, const char *sn,
+		enum DUMP_TYPE tele_type, int total_area_num)
+{
+	char *area_file[MERGE_MAX_AREA + 1] = {0,};
+	__cleanup_free char *output_file = NULL;
+	__cleanup_free char *area_list = NULL;
+	int found[MERGE_MAX_AREA];
+	int found_cnt = 0;
+	const char *dump_type;
+	int out;
+	int err;
+
+	if (tele_type == DUMP_TYPE_HOST_0)
+		dump_type = "Host(0)";
+	else if (tele_type == DUMP_TYPE_HOST_1)
+		dump_type = "Host(1)";
+	else if (tele_type == DUMP_TYPE_CTLR)
+		dump_type = "Controller";
+	else
+		return 0;
+
+	if (total_area_num < 1 || total_area_num > MERGE_MAX_AREA)
+		return SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR;
+
+	err = SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	if (asprintf(&area_file[0], "%s%s_Telemetry_%s_header_only.bin",
+			dump_save_dir, sn, dump_type) < 0) {
+		area_file[0] = NULL;
+		goto free_names;
+	}
+
+	for (int i = 1; i <= total_area_num; i++) {
+		if (asprintf(&area_file[i], "%s%s_Telemetry_%s_Area_%d.bin",
+				dump_save_dir, sn, dump_type, i) < 0) {
+			area_file[i] = NULL;
+			goto free_names;
+		}
+
+		if (file_is_readable(area_file[i]))
+			found[found_cnt++] = i;
+	}
+
+	/*
+	 * An area the controller reported as empty is never written, so
+	 * finding none means there is simply nothing to merge. A missing
+	 * header is a different matter and is left to fail below: it is
+	 * written before any area is, and a failure there aborts the dump
+	 * before the merge is ever reached.
+	 */
+	if (!found_cnt) {
+		printf("Nothing to merge: no data area was retrieved.\n");
+		err = 0;
+		goto free_names;
+	}
+
+	/* Name the merged dump after the areas it really holds. */
+	for (int i = 0; i < found_cnt; i++) {
+		__cleanup_free char *prev = area_list;
+
+		if (asprintf(&area_list, "%s%s%d", prev ? prev : "",
+				prev ? "+" : "", found[i]) < 0) {
+			area_list = NULL;
+			goto free_names;
+		}
+	}
+
+	if (asprintf(&output_file, "%s%s_Telemetry_%s_Area_%s.bin",
+			dump_save_dir, sn, dump_type, area_list) < 0) {
+		output_file = NULL;
+		goto free_names;
+	}
+
+	out = shr_open_rawdata(output_file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (out < 0) {
+		err = SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+		goto free_names;
+	}
+
+	err = 0;
+	for (int i = 0; i <= found_cnt && !err; i++) {
+		/* Index 0 is the header, which always leads the merge. */
+		const char *src = i ? area_file[found[i - 1]] : area_file[0];
+
+		err = append_file(out, src);
+		if (err)
+			fprintf(stderr, "%s: %s\n", src, strerror(-err));
+	}
+
+	close(out);
+
+	if (err)
+		err = SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+	else
+		printf("The log file was saved in \"%s\"\n", output_file);
+
+free_names:
+	for (int i = 0; i <= MERGE_MAX_AREA; i++)
+		free(area_file[i]);
+
+	return err;
+}
+
+/*
+ * Retrieve one telemetry dump, reporting a failure as it happens.
+ * Collection is best effort, so the status is returned for the sake of
+ * try_get_telemetry_all(), which must not merge over a failed retrieval;
+ * callers that only collect ignore it.
+ */
+static int try_get_telemetry(struct libnvme_transport_handle *hdl,
+		struct nvme_id_ctrl *ctrl, char *dump_save_dir, char *sn,
+		enum DUMP_TYPE tele_type, int data_area, bool header_print)
+{
+	int err = 0;
+	int get_log_lid;
+	int tele_xfer_size = UNIT_DATA_SIZE_127KB;
+
+	if (tele_type == DUMP_TYPE_CTLR)
+		get_log_lid = 0x08;
+	else // Host-init
+		get_log_lid = 0x07;
+
+	print_telemetry_info(tele_type, data_area, get_log_lid, tele_xfer_size);
+
+	err = get_telemetry_dump(hdl, ctrl, dump_save_dir, sn, tele_type,
+			data_area, header_print, tele_xfer_size);
+	if (err != 0)
+		samsung_print_error(err);
+
+	return err;
+}
+
+/*
+ * Retrieve every data area of one telemetry type and merge the results.
+ * A host dump is merged twice, into the 1+2 and the 1+2+3+4 view; the
+ * controller dump only into the full one.
+ */
+static void try_get_telemetry_all(struct libnvme_transport_handle *hdl,
+		struct nvme_id_ctrl *ctrl, char *dump_save_dir, char *sn,
+		enum DUMP_TYPE tele_type)
+{
+	static const int host_merges[] = {2, 4};
+	static const int ctlr_merges[] = {4};
+	bool is_ctlr = tele_type == DUMP_TYPE_CTLR;
+	const int *merges = is_ctlr ? ctlr_merges : host_merges;
+	int nr_merges = is_ctlr ? 1 : 2;
+
+	/*
+	 * Nothing to merge if the retrieval failed, and merging anyway would
+	 * be worse than nothing: the area files of an earlier run may still
+	 * be on disk, and joining those would present stale data as a
+	 * complete dump.
+	 */
+	if (try_get_telemetry(hdl, ctrl, dump_save_dir, sn, tele_type, 0, true))
+		return;
+
+	for (int i = 0; i < nr_merges; i++) {
+		int err;
+
+		printf("\n-------------------------------------------------------------\n\n");
+
+		err = merge_telemetry_log(dump_save_dir, sn, tele_type, merges[i]);
+		if (err != 0)
+			samsung_print_error(err);
+	}
+}
+
+static int samsung_nvme_get_vendor_dump(struct libnvme_transport_handle *hdl,
+		__u8 op_code, void *data, __u32 data_len, __u8 sub_op_code,
+		__u8 op_type, __u32 offset)
+{
+	struct libnvme_passthru_cmd cmd = {
+		.opcode		= op_code,
+		.addr		= (__u64)(uintptr_t) data,
+		.data_len	= data_len,
+		.cdw10		= data_len / 4,
+		.cdw12		= (sub_op_code << 24) | op_type,
+		.cdw14		= offset,
+		.timeout_ms = 15 * 1000,
+	};
+
+	return samsung_nvme_submit_admin_passthru(hdl, &cmd);
+}
+
+static int get_vendor_dump_header(struct libnvme_transport_handle *hdl,
+		__u8 op_code, __u8 op_type, __u8 *data, int *total_dump_size)
+{
+	int err = 0;
+
+	err = samsung_nvme_get_vendor_dump(hdl, op_code, data,
+			UNIT_DATA_SIZE_8KB, 8, op_type, 0);
+	if (err != 0)
+		return err;
+
+	*total_dump_size = (data[15] << 24)	| (data[14] << 16)
+					 | (data[13] <<  8) |  data[12];
+
+	return err;
+}
+
+static int get_vendor_dump_data(struct libnvme_transport_handle *hdl,
+		__u8 op_code, __u8 op_type, __u8 *data, __u32 offset)
+{
+	return samsung_nvme_get_vendor_dump(hdl, op_code, data,
+			UNIT_DATA_SIZE_32KB, 8, op_type, offset);
+}
+
+static int get_vendor_dump(struct libnvme_transport_handle *hdl,
+		char *feature_name, char *file_name, char *sn,
+		__u8 op_code, __u8 op_type)
+{
+	__cleanup_free char *file_path = NULL;
+	int err = 0;
+	int output = 0;
+	int offset = 0, total_dump_size = 0;
+	struct timeval begin;
+	__u8 *data = libnvme_alloc(UNIT_DATA_SIZE_32KB);
+
+	if (!data)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	file_path = make_file_path(feature_name, file_name, sn);
+	if (!file_path) {
+		libnvme_free(data);
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+	}
+
+	measure_time(&begin, true);
+
+	err = get_vendor_dump_header(hdl, op_code, op_type, data, &total_dump_size);
+	if (err != 0)
+		goto end;
+
+	output = shr_open_rawdata(file_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (output < 0) {
+		err = SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+		goto end;
+	}
+
+	if (shr_write_all(output, data, UNIT_DATA_SIZE_8KB)) {
+		err = SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+		goto close_output;
+	}
+
+	for (offset = 1; offset <= total_dump_size; offset += 4) {
+		memset(data, 0, UNIT_DATA_SIZE_32KB);
+		err = get_vendor_dump_data(hdl, op_code, op_type, data, offset);
+		if (err < 0) // last piece returns 2 on some devices.
+			goto close_output;
+
+		if (shr_write_all(output, data, UNIT_DATA_SIZE_32KB)) {
+			err = SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+			goto close_output;
+		}
+
+		measure_loop_time(&begin, offset / 4, total_dump_size / 4);
+		if (!g_hide_progress)
+			shr_spinner(feature_name,
+					offset / (float)total_dump_size, stdout);
+	}
+	/*
+	 * The completion line prints even under --hide-progress: it is what
+	 * marks the dump as complete in a captured terminal log.
+	 */
+	shr_spinner(feature_name, 1.0, stdout);
+	printf("\n");
+	printf("The log file was saved in \"%s\"\n", file_path);
+	measure_time(&begin, false);
+	err = 0;
+
+close_output:
+	close(output);
+
+end:
+	libnvme_free(data);
+	return err;
+}
+
+static int get_vendor_crash_dump_0xf7(struct libnvme_transport_handle *hdl,
+		char *file_name, char *sn)
+{
+	return get_vendor_dump(hdl, "VendorCrashDump_0xF7", file_name, sn, 0xF7, 0);
+}
+
+static int get_vendor_memory_dump_0xf7(struct libnvme_transport_handle *hdl,
+		char *file_name, char *sn)
+{
+	return get_vendor_dump(hdl, "VendorMemoryDump_0xF7", file_name, sn, 0xF7, 1);
+}
+
+static int get_vendor_debug_dump_0xf7(struct libnvme_transport_handle *hdl,
+		char *file_name, char *sn)
+{
+	return get_vendor_dump(hdl, "VendorDebugDump_0xF7", file_name, sn, 0xF7, 2);
+}
+
+static int get_vendor_crash_dump_0xf8(struct libnvme_transport_handle *hdl,
+		char *file_name, char *sn)
+{
+	return get_vendor_dump(hdl, "VendorCrashDump_0xF8", file_name, sn, 0xF8, 0);
+}
+
+static int get_vendor_memory_dump_0xf8(struct libnvme_transport_handle *hdl,
+		char *file_name, char *sn)
+{
+	return get_vendor_dump(hdl, "VendorMemoryDump_0xF8", file_name, sn, 0xF8, 1);
+}
+
+static int get_vendor_debug_dump_0xf8(struct libnvme_transport_handle *hdl,
+		char *file_name, char *sn)
+{
+	return get_vendor_dump(hdl, "VendorDebugDump_0xF8", file_name, sn, 0xF8, 2);
+}
+
+/*
+ * Run one vendor dump. A status of 1 means the device does not implement
+ * that particular dump, which is not a failure of the command.
+ */
+static void run_vendor_dump(int (*get_dump)(struct libnvme_transport_handle *,
+			char *, char *),
+		struct libnvme_transport_handle *hdl, const char *label,
+		int op_code, char *dump_save_dir, char *sn)
+{
+	int err;
+
+	print_border(label, 'v', op_code, 0);
+
+	err = get_dump(hdl, dump_save_dir, sn);
+	if (err == 1)
+		fprintf(stderr, "This device is not supported\n");
+	else if (err != 0)
+		samsung_print_error(err);
+}
+
+/*
+ * Translate one dump-type token (e.g. "host0") into a selection in @sel.
+ * Called once per comma-separated token so -t accepts a list such as
+ * "host0,ctlr,vendor". Returns 0 on success, or a SAMSUNG_GENERAL_* error
+ * code if the token is not a recognized dump type.
+ */
+static int vs_internal_log_select_type(const char *tok, bool *sel)
+{
+	if (!strcmp(tok, "host0"))
+		sel[DUMP_TYPE_HOST_0] = true;
+	else if (!strcmp(tok, "host1"))
+		sel[DUMP_TYPE_HOST_1] = true;
+	else if (!strcmp(tok, "ctlr") || !strcmp(tok, "controller"))
+		sel[DUMP_TYPE_CTLR] = true;
+	else if (!strcmp(tok, "vendor"))
+		sel[DUMP_TYPE_VENDOR] = true;
+	else {
+		printf("Invalid dump type: '%s'.\n", tok);
+		return SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR;
+	}
+
+	return 0;
+}
+
+/*
+ * A dump type is extracted when either no -t was given (select_all, i.e.
+ * extract everything) or it was explicitly named in sel[].
+ */
+#define WANT_DUMP(t) (select_all || sel[(t)])
+
+static int vs_internal_log(int argc, char **argv, struct command *acmd,
+		struct plugin *plugin)
+{
+	const char *desc = "Retrieve and save internal firmware log.";
+	const char *type = "Use this option if you want to extract a specific kind of dump.\n"
+			"Comma-separate to extract several at once (no spaces).\n"
+			"Example) -t host1   or   -t host1,ctlr,vendor\n"
+			"host0---Host_Initiated_Telemetry_Dump(LSP_0)\n"
+			"host1---Host_Initiated_Telemetry_Dump(LSP_1)\n"
+			"ctlr----Controller_Initiated_Telemetry_Dump\n"
+			"vendor--Vendor_Dumps\n";
+	const char *area = "Telemetry Data Area; 1 to 4. Default: 0(all).";
+	const char *file = "Output file name with path;\n"
+			"e.g. '-O ./path/name'\n'-O ./path1/path2/';\n"
+			"If requested path does not exist, "
+			"the directory will be newly created.";
+	const char *compress = "Save dumps in a compressed file.";
+	const char *hide_progress = "Hide the incremental extraction progress.\n"
+			"The completion line of each dump is still printed.";
+
+	int err = 0;
+	char sn[21] = {0,};
+	struct nvme_id_ctrl ctrl = {0,};
+	struct libnvme_passthru_cmd cmd;
+	__cleanup_free char *dump_save_dir = NULL;
+
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
+	__cleanup_nvme_transport_handle struct libnvme_transport_handle *hdl = NULL;
+
+	bool sel[DUMP_TYPE_MAX] = { false };
+	bool select_all = false;
+	int tele_data_area = 0;
+
+	struct config {
+		char *type;
+		int area;
+		char *file;
+		int compress;
+		int hide_progress;
+	};
+
+	struct config cfg = {
+		.type = NULL,
+		.area = 0,
+		.file = NULL,
+		.compress = 0,
+		.hide_progress = 0,
+	};
+
+	NVME_ARGS_OUTPUT_FORMATS(opts, NORMAL, "Output format: normal",
+		OPT_STRING("dump-type", 't', "TYPE", &cfg.type, type),
+		OPT_INT("telemetry-data-area", 'a', &cfg.area, area),
+		OPT_FILE("output-file", 'O', &cfg.file, file),
+		OPT_FLAG("compress", 'z', &cfg.compress, compress),
+		OPT_FLAG("hide-progress", 'H', &cfg.hide_progress, hide_progress));
+
+	samsung_initialize();
+
+	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
+	if (err)
+		return err;
+
+	nvme_init_identify_ctrl(&cmd, &ctrl);
+	err = libnvme_exec_admin_passthru(hdl, &cmd);
+	if (err) {
+		samsung_print_error(err);
+		return err;
+	}
+
+	if (le16_to_cpu(ctrl.vid) != 0x144d) {
+		samsung_print_error(SAMSUNG_GENERAL_INVALID_VID_ERROR);
+		fprintf(stderr, "Current Vendor ID: 0x%X\n", le16_to_cpu(ctrl.vid));
+		return SAMSUNG_GENERAL_INVALID_VID_ERROR;
+	}
+
+	get_serial_number(&ctrl, sn);
+
+	/*
+	 * -a applies to the telemetry dumps whether or not -t was given, so
+	 * validate it before the dump type selection.
+	 */
+	tele_data_area = cfg.area;
+	if (tele_data_area < 0 || tele_data_area > 4) {
+		fprintf(stderr, "\nUnsupported data area entered. "
+				"Valid range: 0 to 4.\n");
+		samsung_print_error(SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR);
+		return SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR;
+	}
+
+	if (!cfg.type)
+		select_all = true;
+	else {
+		__cleanup_free char *type_buf = NULL;
+		char *tok, *saveptr = NULL;
+
+		/*
+		 * -t accepts a comma-separated list, e.g. "host0,ctlr,vendor".
+		 * strtok_r() mutates its input, so parse a copy of cfg.type
+		 * rather than the option string itself.
+		 */
+		type_buf = strdup(cfg.type);
+		if (!type_buf)
+			return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+		for (tok = strtok_r(type_buf, ",", &saveptr); tok != NULL;
+				tok = strtok_r(NULL, ",", &saveptr)) {
+			err = vs_internal_log_select_type(tok, sel);
+			if (err != 0) {
+				samsung_print_error(err);
+				return err;
+			}
+		}
+	}
+
+	/*
+	 * -O is a file name prefix: make_file_path() concatenates it onto the
+	 * generated name without inserting a separator, so "./dumps/" yields
+	 * "./dumps/<sn>_..." and "./dumps/run1" yields "./dumps/run1<sn>_...".
+	 * Either way the directories end at the last '/', which is what
+	 * shr_mkdir_from_fname() creates. A bare "run1" has no directory
+	 * part and reduces to creating ".", a harmless no-op.
+	 */
+	if (cfg.file) {
+		err = shr_mkdir_from_fname(cfg.file, 0777);
+		if (err < 0) {
+			fprintf(stderr, "mkdir for %s: %s\n", cfg.file,
+					strerror(-err));
+			return SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+		}
+	}
+
+	if (cfg.compress) {
+		err = insert_dir(cfg.file, "temp_samsung_dumps", &dump_save_dir);
+		if (err != 0) {
+			samsung_print_error(err);
+			return err;
+		}
+	} else {
+		dump_save_dir = strdup(cfg.file ? cfg.file : "./");
+		if (!dump_save_dir)
+			return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+	}
+
+	g_hide_progress = cfg.hide_progress;
+
+	/*
+	 * Collection is best effort: every dump is attempted and each failure
+	 * is reported where it happens, so one unsupported or failing dump
+	 * does not cost the others.
+	 */
+
+	/*
+	 * Host(0) is intentionally excluded from "all" dumps (only run when
+	 * explicitly selected), so it is gated on sel[] directly rather than
+	 * WANT_DUMP()/select_all.
+	 */
+	if (sel[DUMP_TYPE_HOST_0]) {
+		if (tele_data_area == 0)
+			try_get_telemetry_all(hdl, &ctrl, dump_save_dir, sn,
+					DUMP_TYPE_HOST_0);
+		else
+			try_get_telemetry(hdl, &ctrl, dump_save_dir, sn,
+					DUMP_TYPE_HOST_0, tele_data_area, true);
+	}
+
+	if (WANT_DUMP(DUMP_TYPE_HOST_1)) {
+		if (tele_data_area == 0)
+			try_get_telemetry_all(hdl, &ctrl, dump_save_dir, sn,
+					DUMP_TYPE_HOST_1);
+		else
+			try_get_telemetry(hdl, &ctrl, dump_save_dir, sn,
+					DUMP_TYPE_HOST_1, tele_data_area, true);
+	}
+
+	if (WANT_DUMP(DUMP_TYPE_CTLR)) {
+		if (tele_data_area == 0)
+			try_get_telemetry_all(hdl, &ctrl, dump_save_dir, sn,
+					DUMP_TYPE_CTLR);
+		else
+			try_get_telemetry(hdl, &ctrl, dump_save_dir, sn,
+					DUMP_TYPE_CTLR, tele_data_area, true);
+	}
+
+	if (WANT_DUMP(DUMP_TYPE_VENDOR)) {
+		run_vendor_dump(get_vendor_crash_dump_0xf7, hdl,
+				"Vendor Crash Dump", 0xF7, dump_save_dir, sn);
+		run_vendor_dump(get_vendor_crash_dump_0xf8, hdl,
+				"Vendor Crash Dump", 0xF8, dump_save_dir, sn);
+		run_vendor_dump(get_vendor_memory_dump_0xf7, hdl,
+				"Vendor Memory Dump", 0xF7, dump_save_dir, sn);
+		run_vendor_dump(get_vendor_memory_dump_0xf8, hdl,
+				"Vendor Memory Dump", 0xF8, dump_save_dir, sn);
+		run_vendor_dump(get_vendor_debug_dump_0xf7, hdl,
+				"Vendor Debug Dump", 0xF7, dump_save_dir, sn);
+		run_vendor_dump(get_vendor_debug_dump_0xf8, hdl,
+				"Vendor Debug Dump", 0xF8, dump_save_dir, sn);
+	}
+
+	printf("\n-------------------------------------------------------------\n");
+
+	/*
+	 * Archiving is the one step whose failure is reported through the
+	 * exit status: without it the user does not have the file they asked
+	 * -z for, while the dumps themselves are already on disk.
+	 */
+	err = 0;
+	if (cfg.compress) {
+		err = compress_dump_files(dump_save_dir, sn);
+		if (err != 0)
+			samsung_print_error(err);
+	}
+
+	printf("vs-internal-log done.\n");
+
+	return err;
+}
+
+#undef WANT_DUMP
+
+static struct command vs_internal_log_cmd = {
+	.name = "vs-internal-log",
+	.help = "Retrieve and save internal firmware log",
+	.fn = vs_internal_log,
+};
+
+static struct command *commands[] = {
+	&vs_internal_log_cmd,
+	NULL,
+};
+
+static struct plugin plugin = {
+	.name = "samsung",
+	.desc = "Samsung vendor specific extensions",
+	.version = SAMSUNG_PLUGIN_VERSION,
+};
+
+static void __shr_constructor register_plugin(void)
+{
+	plugin_add_group(&plugin, NULL, commands);
+	register_extension(&plugin);
+}

--- a/shared/fs-util.c
+++ b/shared/fs-util.c
@@ -48,6 +48,16 @@ int shr_mkdir_from_fname(const char *file, mode_t mode)
 {
 	__cleanup_free char *file_copy = NULL;
 	char *parent;
+	size_t len = strlen(file);
+
+	/*
+	 * A trailing '/' means there is no file name to strip and the path is
+	 * a directory in full. dirname() cannot be used for it: it removes
+	 * the trailing '/' before the last component, so "a/b/" would come
+	 * back as "a" and leave "a/b" uncreated.
+	 */
+	if (len && file[len - 1] == '/')
+		return shr_mkdir_p(file, mode);
 
 	file_copy = strdup(file);
 	if (!file_copy)
@@ -62,6 +72,11 @@ char *shr_basename(const char *path)
 	char *p = (char *)strrchr(path, '/');
 
 	return p ? p + 1 : (char *)path;
+}
+
+size_t shr_dir_prefix_len(const char *path)
+{
+	return (size_t)(shr_basename(path) - path);
 }
 
 static char *join_path(const char *dir, const char *path)

--- a/shared/fs-util.h
+++ b/shared/fs-util.h
@@ -26,7 +26,8 @@ int shr_mkdir_p(const char *path, mode_t mode);
 
 /*
  * Create path and every missing parent directory using shr_mkdir_p
- * from a full path including a filename.
+ * from a full path including a filename. A path ending in '/' carries no
+ * filename and is created in full.
  */
 int shr_mkdir_from_fname(const char *file, mode_t mode);
 
@@ -66,6 +67,17 @@ int shr_unlink(const char *path);
  * never returns a pointer to static storage.
  */
 char *shr_basename(const char *path);
+
+/*
+ * The length of the leading directory part of path, including the '/' that
+ * ends it, or 0 when path holds no '/'. The counterpart of shr_basename():
+ *
+ *	path + shr_dir_prefix_len(path) == shr_basename(path)
+ *
+ * Unlike dirname(), a trailing '/' keeps its meaning, so the directory part
+ * of "a/b/" is "a/b/" rather than "a".
+ */
+size_t shr_dir_prefix_len(const char *path);
 
 /*
  * dirname returns the string up to, but not including, the final '/', and

--- a/shared/tests/test-fs-util.c
+++ b/shared/tests/test-fs-util.c
@@ -293,6 +293,14 @@ static bool test_mkdir_from_fname(void)
 	pass &= check_ret("bare filename without directories is a no-op success",
 			   ret, 0);
 
+	snprintf(fname, sizeof(fname), "%s/level1/level3/", base);
+	ret = shr_mkdir_from_fname(fname, 0755);
+	pass &= check_ret("a path ending in '/' has no file name to strip",
+			   ret, 0);
+	snprintf(fname, sizeof(fname), "%s/level1/level3", base);
+	pass &= check_bool("its last component is created, not dropped",
+			    dir_is_writable(fname));
+
 	{
 		char toolong[PATH_MAX + 10];
 
@@ -305,6 +313,7 @@ static bool test_mkdir_from_fname(void)
 	}
 
 	/* Clean up what we created, deepest first. */
+	shr_rmdir("shr-test-mkdir-fname-dir/level1/level3");
 	shr_rmdir("shr-test-mkdir-fname-dir/level1/level2");
 	shr_rmdir("shr-test-mkdir-fname-dir/level1");
 	shr_rmdir("shr-test-mkdir-fname-dir");

--- a/shared/tests/test-fs-util.c
+++ b/shared/tests/test-fs-util.c
@@ -74,6 +74,39 @@ static bool test_basename(void)
 	return pass;
 }
 
+static bool check_len(const char *name, size_t got, size_t want)
+{
+	if (got == want) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got %zu, want %zu [FAIL]\n", name, got, want);
+	return false;
+}
+
+static bool test_dir_prefix_len(void)
+{
+	static const char *path = "/a/b/c";
+	const char *name = shr_basename(path);
+	bool pass = true;
+
+	printf("test_dir_prefix_len:\n");
+
+	pass &= check_len("counts up to and including the '/'",
+			   shr_dir_prefix_len(path), 5);
+	pass &= check_len("no slash at all → 0",
+			   shr_dir_prefix_len("noslash"), 0);
+	pass &= check_len("trailing slash keeps the whole path",
+			   shr_dir_prefix_len("/trailing/"), 10);
+	pass &= check_len("bare \"/\" → 1", shr_dir_prefix_len("/"), 1);
+	pass &= check_len("empty input → 0", shr_dir_prefix_len(""), 0);
+	pass &= check_bool("advancing path by it lands on shr_basename()",
+			    path + shr_dir_prefix_len(path) == name);
+
+	return pass;
+}
+
 static bool test_dirname(void)
 {
 	struct {
@@ -541,6 +574,7 @@ int main(void)
 	bool pass = true;
 
 	pass &= test_basename();
+	pass &= test_dir_prefix_len();
 	pass &= test_dirname();
 	pass &= test_mkdir();
 	pass &= test_mkdir_p();

--- a/tests/cli/meson.build
+++ b/tests/cli/meson.build
@@ -94,5 +94,13 @@ if python3.found()
              args: [files('nvme_init_pi_tags_test.py'), nvme_exe, mock_nvme_lib],
              env: cli_test_env,
              depends: [nvme_exe, mock_nvme_lib])
+
+        if 'samsung' in selected_plugins
+            test('nvme-cli - samsung-cli',
+                 python3,
+                 args: [files('nvme_samsung_test.py'), nvme_exe, mock_nvme_lib],
+                 env: cli_test_env,
+                 depends: [nvme_exe, mock_nvme_lib])
+        endif
     endif
 endif

--- a/tests/cli/nvme_samsung_test.py
+++ b/tests/cli/nvme_samsung_test.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of nvme-cli.
+"""Tests for "nvme samsung vs-internal-log".
+
+Everything that does not touch the device is exercised here: option
+handling, output-path composition and directory creation, dump file
+naming, the data-area merge, -z archiving, progress and timing output,
+and the exit status. The device itself is a mock that returns
+well-formed synthetic dumps, so a failure below is a bug in the plugin
+rather than in a drive.
+
+Usage: python3 nvme_samsung_test.py <path-to-nvme-binary> <path-to-mock-lib>
+"""
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from nvme_mock_ipc import MockIPCServer, make_mock_env, resolve_mock_lib_path, run_nvme
+
+_NVME_BIN = sys.argv[1] if len(sys.argv) > 1 and not sys.argv[1].startswith('-') else 'nvme'
+_MOCK_LIB = resolve_mock_lib_path("./libmock_nvme.so")
+
+# Meson passes these as paths relative to the build directory, and the
+# tests below chdir into a scratch directory to exercise the default
+# output location. Pin them down first.
+if os.path.exists(_NVME_BIN):
+    _NVME_BIN = os.path.abspath(_NVME_BIN)
+if os.path.exists(_MOCK_LIB):
+    _MOCK_LIB = os.path.abspath(_MOCK_LIB)
+
+SAMSUNG_VID = 0x144D
+SERIAL = "MOCKSN0001"
+
+_OPC_GET_LOG_PAGE = 0x02
+_OPC_IDENTIFY = 0x06
+_OPC_SET_FEATURES = 0x09
+_OPC_GET_FEATURES = 0x0A
+
+_FID_HOST_BEHAVIOR = 0x16
+_HOST_BEHAVIOR_SIZE = 512
+_ETDAS_OFFSET = 1  # struct nvme_feat_host_behavior: acre, etdas, ...
+
+# Samsung vendor dump opcodes
+_OPC_VENDOR_F7 = 0xF7
+_OPC_VENDOR_F8 = 0xF8
+
+_ID_CTRL_SIZE = 4096
+_TELEMETRY_HEADER_SIZE = 512
+_BYTES_PER_BLOCK = 512
+
+# The vendor dump header reports its size at bytes 12..15, counted in 8K
+# units; the plugin then reads 32K per step. 4 keeps the mock dump small.
+_VENDOR_DUMP_UNITS = 4
+
+
+def pack_id_ctrl(vid=SAMSUNG_VID, serial=SERIAL, da4s=False):
+    """struct nvme_id_ctrl. Only VID (0), SN (4..23) and LPA (261) matter:
+    LPA bit 6 is Data Area 4 Supported."""
+    buf = bytearray(_ID_CTRL_SIZE)
+    struct.pack_into('<H', buf, 0, vid)
+    sn = serial.encode().ljust(20)[:20]
+    buf[4:24] = sn
+    if da4s:
+        buf[261] |= 1 << 6
+    return bytes(buf)
+
+
+def pack_telemetry_header(last_blocks=(2, 4, 0, 0)):
+    """struct telemetry_initiated_log. last_blocks is the last block of
+    data areas 1..4; area N is empty when its last block does not advance
+    past area N-1."""
+    buf = bytearray(_TELEMETRY_HEADER_SIZE)
+    buf[0] = 0x07
+    struct.pack_into('<H', buf, 8, last_blocks[0])
+    struct.pack_into('<H', buf, 10, last_blocks[1])
+    struct.pack_into('<H', buf, 12, last_blocks[2])
+    struct.pack_into('<I', buf, 16, last_blocks[3])
+    return bytes(buf)
+
+
+def pack_supported_log_pages(mcdas=True):
+    """Log page 0. data[30] bit 0 is MCDAS for LID 7."""
+    buf = bytearray(1024)
+    if mcdas:
+        buf[30] |= 1
+    return bytes(buf)
+
+
+def pack_vendor_dump_header(units=_VENDOR_DUMP_UNITS):
+    buf = bytearray(8 * 1024)
+    struct.pack_into('<I', buf, 12, units)
+    return bytes(buf)
+
+
+class SamsungMockServer(MockIPCServer):
+    """Answers the commands vs-internal-log issues. Anything not listed
+    succeeds with zeroes, which is enough for the feature negotiation the
+    plugin does around Data Area 4."""
+
+    def __init__(self, sock_path):
+        super().__init__(sock_path)
+        self.vid = SAMSUNG_VID
+        self.serial = SERIAL
+        self.da4s = False
+        self.mcdas = True
+        self.last_blocks = (2, 4, 0, 0)
+        self.vendor_supported = True
+        self.telemetry_sc_status = 0
+        self.seen_opcodes = []
+        # ETDAS lives in the device across commands, so the mock has to
+        # keep it: set_etdas() only writes when it reads back as 0, and
+        # clear_etdas() only restores when it reads back as 1.
+        self.etdas = 0
+        self.set_features_calls = 0
+        self.log_lsps = []
+
+    def handle_ioctl(self, conn, fd, request, opcode, nsid,
+                     cdw10, cdw11, cdw12, cdw13, cdw14, cdw15, lpo, req_len):
+        self.seen_opcodes.append(opcode)
+
+        if opcode == _OPC_GET_FEATURES and (cdw10 & 0xFF) == _FID_HOST_BEHAVIOR:
+            buf = bytearray(_HOST_BEHAVIOR_SIZE)
+            buf[_ETDAS_OFFSET] = self.etdas
+            self.send_response(conn, 0, payload=bytes(buf)[:req_len])
+            return
+
+        if opcode == _OPC_SET_FEATURES and (cdw10 & 0xFF) == _FID_HOST_BEHAVIOR:
+            # The outgoing buffer is not forwarded to the mock, but the
+            # caller only ever writes the value it did not read, so
+            # toggling tracks it exactly.
+            self.etdas ^= 1
+            self.set_features_calls += 1
+            self.send_response(conn, 0)
+            return
+
+        if opcode == _OPC_IDENTIFY:
+            payload = pack_id_ctrl(self.vid, self.serial, self.da4s)
+            self.send_response(conn, 0, payload=payload[:req_len])
+            return
+
+        if opcode == _OPC_GET_LOG_PAGE:
+            lid = cdw10 & 0xFF
+            self.log_lsps.append((lid, (cdw10 >> 8) & 0x7F))
+            if lid == 0:
+                payload = pack_supported_log_pages(self.mcdas)
+            elif lid in (0x07, 0x08):
+                if self.telemetry_sc_status:
+                    self.send_response(conn, 0, sc_status=self.telemetry_sc_status)
+                    return
+                if req_len == _TELEMETRY_HEADER_SIZE and lpo == 0:
+                    payload = pack_telemetry_header(self.last_blocks)
+                else:
+                    payload = bytes([lid]) * req_len
+            else:
+                payload = bytes(req_len)
+            self.send_response(conn, 0, payload=payload[:req_len])
+            return
+
+        if opcode in (_OPC_VENDOR_F7, _OPC_VENDOR_F8):
+            if not self.vendor_supported:
+                self.send_response(conn, 0, sc_status=0x02)  # INVALID_FIELD
+                return
+            if req_len == 8 * 1024:
+                payload = pack_vendor_dump_header()
+            else:
+                payload = bytes([0xAB]) * req_len
+            self.send_response(conn, 0, payload=payload[:req_len])
+            return
+
+        self.send_response(conn, 0, payload=bytes(req_len))
+
+
+class SamsungCLITest(unittest.TestCase):
+
+    DEVICE = '/dev/nvme0'
+
+    def setUp(self):
+        self.sysfs_dir = tempfile.mkdtemp(prefix='nvme-samsung-sysfs-', dir='/tmp')
+        self.base_dir = tempfile.mkdtemp(prefix='nvme-samsung-base-', dir='/tmp')
+        self.ipc_dir = tempfile.mkdtemp(prefix='nvme-samsung-ipc-', dir='/tmp')
+        self.out_dir = tempfile.mkdtemp(prefix='nvme-samsung-out-', dir='/tmp')
+        self.ipc_sock_path = os.path.join(self.ipc_dir, "ipc.sock")
+
+        self.server = SamsungMockServer(self.ipc_sock_path)
+        self.server.start()
+        self.env = make_mock_env(_MOCK_LIB, self.ipc_sock_path)
+        self.cwd = os.getcwd()
+        os.chdir(self.out_dir)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        self.server.shutdown()
+        self.server.join()
+        for d in (self.sysfs_dir, self.base_dir, self.ipc_dir, self.out_dir):
+            shutil.rmtree(d, ignore_errors=True)
+
+    def run_cmd(self, *args):
+        return run_nvme(_NVME_BIN, self.env, self.sysfs_dir, self.base_dir,
+                        'samsung', 'vs-internal-log', self.DEVICE, *args)
+
+    def files(self, subdir=''):
+        root = os.path.join(self.out_dir, subdir) if subdir else self.out_dir
+        if not os.path.isdir(root):
+            return []
+        return sorted(os.listdir(root))
+
+    def assertOk(self, result):
+        self.assertEqual(result.returncode, 0,
+                         f'command failed:\nstdout:\n{result.stdout}\n'
+                         f'stderr:\n{result.stderr}')
+
+    # ---------------------------------------------------------------- #
+    # Output path handling: -O is a file name prefix, so directories    #
+    # end at the last '/' whichever form is used.                       #
+    # ---------------------------------------------------------------- #
+
+    def test_output_dir_with_trailing_slash_is_created(self):
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/')
+        self.assertOk(result)
+        self.assertTrue(os.path.isdir(os.path.join(self.out_dir, 'dumps')),
+                        './dumps/ was not created')
+        self.assertTrue(any(f.startswith(SERIAL) for f in self.files('dumps')),
+                        f'no dump written into ./dumps/: {self.files("dumps")}')
+
+    def test_output_nested_dir_is_created(self):
+        result = self.run_cmd('-t', 'ctlr', '-O', './a/b/c/')
+        self.assertOk(result)
+        self.assertTrue(os.path.isdir(os.path.join(self.out_dir, 'a/b/c')),
+                        './a/b/c was not created')
+
+    def test_output_relative_dir_without_dot_is_created(self):
+        """The old mkdirs() rejected any path not starting with '.' or '/'."""
+        result = self.run_cmd('-t', 'ctlr', '-O', 'dumps/')
+        self.assertOk(result)
+        self.assertTrue(os.path.isdir(os.path.join(self.out_dir, 'dumps')),
+                        'dumps/ was not created')
+
+    def test_output_last_component_is_a_file_name_prefix(self):
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/run1')
+        self.assertOk(result)
+        names = self.files('dumps')
+        self.assertFalse(os.path.isdir(os.path.join(self.out_dir, 'dumps/run1')),
+                         'run1 became a directory; it is a file name prefix')
+        self.assertTrue(any(f.startswith('run1' + SERIAL) for f in names),
+                        f'no run1-prefixed dump: {names}')
+
+    # ---------------------------------------------------------------- #
+    # Data area merge                                                   #
+    # ---------------------------------------------------------------- #
+
+    def test_merge_name_lists_only_the_areas_present(self):
+        """Areas 3 and 4 are empty here, so the merged dump must not claim
+        them. Area 4's last block is lower than area 3's, which is the
+        unsigned-wrap case."""
+        self.server.last_blocks = (2, 4, 0, 0)
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/')
+        self.assertOk(result)
+        names = self.files('dumps')
+        self.assertTrue(any('Area_1+2.bin' in f for f in names),
+                        f'no Area_1+2.bin: {names}')
+        self.assertFalse(any('Area_1+2+3+4.bin' in f for f in names),
+                         f'claimed areas that were never retrieved: {names}')
+
+    def test_merge_includes_all_four_areas_when_present(self):
+        self.server.last_blocks = (2, 4, 6, 8)
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/')
+        self.assertOk(result)
+        names = self.files('dumps')
+        self.assertTrue(any('Area_1+2+3+4.bin' in f for f in names),
+                        f'no Area_1+2+3+4.bin: {names}')
+
+    def test_merged_file_is_header_plus_areas(self):
+        self.server.last_blocks = (2, 4, 0, 0)
+        self.assertOk(self.run_cmd('-t', 'ctlr', '-O', './dumps/'))
+        d = os.path.join(self.out_dir, 'dumps')
+        merged = [f for f in os.listdir(d) if f.endswith('Area_1+2.bin')][0]
+        header = [f for f in os.listdir(d) if f.endswith('header_only.bin')][0]
+        a1 = [f for f in os.listdir(d) if f.endswith('Area_1.bin')][0]
+        a2 = [f for f in os.listdir(d) if f.endswith('Area_2.bin')][0]
+        expect = (os.path.getsize(os.path.join(d, header))
+                  + os.path.getsize(os.path.join(d, a1))
+                  + os.path.getsize(os.path.join(d, a2)))
+        self.assertEqual(os.path.getsize(os.path.join(d, merged)), expect,
+                         'merged size is not header + area 1 + area 2')
+
+    # ---------------------------------------------------------------- #
+    # Progress, timing and -H / --verbose                               #
+    # ---------------------------------------------------------------- #
+
+    def test_hide_progress_keeps_the_completion_line(self):
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/', '-H')
+        self.assertOk(result)
+        self.assertIn('100%', result.stdout,
+                      '--hide-progress swallowed the completion line')
+
+    def test_hide_progress_drops_incremental_updates(self):
+        with_progress = self.run_cmd('-t', 'ctlr', '-O', './a/')
+        without = self.run_cmd('-t', 'ctlr', '-O', './b/', '-H')
+        self.assertOk(with_progress)
+        self.assertOk(without)
+        self.assertLess(without.stdout.count('%'), with_progress.stdout.count('%'),
+                        '--hide-progress did not reduce the progress output')
+
+    def test_timing_table_is_verbose_only(self):
+        quiet = self.run_cmd('-t', 'ctlr', '-O', './a/')
+        loud = self.run_cmd('-t', 'ctlr', '-O', './b/', '--verbose')
+        self.assertOk(quiet)
+        self.assertNotIn('Avg time per loop', quiet.stdout,
+                         'timing table printed without --verbose')
+        self.assertIn('Avg time per loop', loud.stdout,
+                      'timing table missing under --verbose')
+
+    def test_timing_table_is_not_tied_to_hide_progress(self):
+        result = self.run_cmd('-t', 'ctlr', '-O', './a/', '-H', '--verbose')
+        self.assertOk(result)
+        self.assertIn('Avg time per loop', result.stdout,
+                      '--hide-progress suppressed the --verbose timing table')
+
+    # ---------------------------------------------------------------- #
+    # -z archiving                                                      #
+    # ---------------------------------------------------------------- #
+
+    def test_compress_produces_an_archive_and_removes_the_temp_dir(self):
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/', '-z')
+        self.assertOk(result)
+        names = self.files('dumps')
+        self.assertTrue(any(f.endswith('.tar.gz') for f in names),
+                        f'no archive produced: {names}')
+        self.assertFalse(os.path.isdir(os.path.join(self.out_dir,
+                                                    'dumps/temp_samsung_dumps')),
+                         'the temporary directory was left behind')
+
+    def test_compress_rejects_a_quote_in_the_output_path(self):
+        os.makedirs(os.path.join(self.out_dir, "od'd"), exist_ok=True)
+        result = self.run_cmd('-t', 'ctlr', '-O', "./od'd/", '-z')
+        self.assertNotEqual(result.returncode, 0,
+                            "a path containing ' must be refused, not shelled out")
+
+    # ---------------------------------------------------------------- #
+    # Dump type selection                                               #
+    # ---------------------------------------------------------------- #
+
+    def test_comma_separated_dump_types(self):
+        result = self.run_cmd('-t', 'ctlr,vendor', '-O', './dumps/')
+        self.assertOk(result)
+        names = self.files('dumps')
+        self.assertTrue(any('Telemetry_Controller' in f for f in names), names)
+        self.assertTrue(any('VendorCrashDump' in f for f in names), names)
+
+    def test_host0_is_excluded_unless_named(self):
+        self.assertOk(self.run_cmd('-O', './all/'))
+        self.assertFalse(any('Host(0)' in f for f in self.files('all')),
+                         'host0 was collected without being named')
+        self.assertOk(self.run_cmd('-t', 'host0', '-O', './h0/'))
+        self.assertTrue(any('Host(0)' in f for f in self.files('h0')),
+                        f'host0 was not collected when named: {self.files("h0")}')
+
+    def test_unknown_dump_type_is_rejected(self):
+        result = self.run_cmd('-t', 'nosuchtype', '-O', './dumps/')
+        self.assertNotEqual(result.returncode, 0,
+                            'an unknown -t token must fail')
+
+    # ---------------------------------------------------------------- #
+    # -a validation, which used to be skipped without -t                #
+    # ---------------------------------------------------------------- #
+
+    def test_data_area_out_of_range_is_rejected_with_dump_type(self):
+        result = self.run_cmd('-t', 'ctlr', '-a', '7', '-O', './dumps/')
+        self.assertNotEqual(result.returncode, 0, '-a 7 must be refused')
+
+    def test_data_area_out_of_range_is_rejected_without_dump_type(self):
+        result = self.run_cmd('-a', '7', '-O', './dumps/')
+        self.assertNotEqual(result.returncode, 0,
+                            '-a 7 must be refused even without -t')
+
+    def test_single_data_area_extracts_only_that_area(self):
+        self.server.last_blocks = (2, 4, 6, 8)
+        result = self.run_cmd('-t', 'ctlr', '-a', '2', '-O', './dumps/')
+        self.assertOk(result)
+        names = self.files('dumps')
+        self.assertTrue(any('Area_2.bin' in f for f in names), names)
+        self.assertFalse(any('Area_3.bin' in f for f in names), names)
+
+    # ---------------------------------------------------------------- #
+    # Exit status                                                       #
+    # ---------------------------------------------------------------- #
+
+    def test_non_samsung_device_fails(self):
+        self.server.vid = 0x1234
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/')
+        self.assertNotEqual(result.returncode, 0,
+                            'a non-Samsung VID must not exit successfully')
+        self.assertIn('0x1234', result.stderr,
+                      f'VID not reported endian-converted: {result.stderr}')
+
+    def test_unsupported_vendor_dump_is_reported_but_not_fatal(self):
+        self.server.vendor_supported = False
+        result = self.run_cmd('-t', 'vendor', '-O', './dumps/')
+        self.assertOk(result)
+        self.assertIn('not supported', result.stdout + result.stderr)
+
+    # ---------------------------------------------------------------- #
+    # Option surface                                                    #
+    # ---------------------------------------------------------------- #
+
+    def test_help_declares_normal_output_format_only(self):
+        result = subprocess.run(
+            [_NVME_BIN, 'samsung', 'vs-internal-log', '--help'],
+            capture_output=True, text=True)
+        self.assertIn('Output format: normal', result.stdout + result.stderr)
+
+    def test_help_keeps_capital_O_for_output_file(self):
+        result = subprocess.run(
+            [_NVME_BIN, 'samsung', 'vs-internal-log', '--help'],
+            capture_output=True, text=True)
+        out = result.stdout + result.stderr
+        self.assertIn('--output-file=<FILE>, -O <FILE>', out)
+        self.assertIn('--output-format=<FMT>, -o <FMT>', out)
+
+    # ---------------------------------------------------------------- #
+    # Data Area 4: DA4S / MCDAS negotiation and the ETDAS round trip    #
+    # ---------------------------------------------------------------- #
+
+    def _enable_da4(self):
+        self.server.da4s = True
+        self.server.mcdas = True
+        self.server.last_blocks = (2, 4, 6, 8)
+
+    def test_da4_setup_completes_when_supported(self):
+        self._enable_da4()
+        result = self.run_cmd('-t', 'host1', '-O', './dumps/')
+        self.assertOk(result)
+        self.assertIn('Setup for Data Area 4 extraction is done', result.stdout)
+        self.assertTrue(any('Area_4.bin' in f for f in self.files('dumps')),
+                        f'area 4 not extracted: {self.files("dumps")}')
+
+    def test_da4_etdas_is_set_and_restored(self):
+        self._enable_da4()
+        self.assertOk(self.run_cmd('-t', 'host1', '-O', './dumps/'))
+        self.assertGreaterEqual(self.server.set_features_calls, 2,
+                                'ETDAS was not both set and restored')
+        self.assertEqual(self.server.etdas, 0,
+                         'ETDAS was left set on the device')
+
+    def test_da4_sets_mcda_in_the_log_specific_parameter(self):
+        """With MCDAS set, the host dump asks for MCDA 4: lsp |= 4 << 1,
+        so LSP 1 becomes 9."""
+        self._enable_da4()
+        self.assertOk(self.run_cmd('-t', 'host1', '-O', './dumps/'))
+        lsps = [lsp for lid, lsp in self.server.log_lsps if lid == 0x07]
+        self.assertIn(9, lsps, f'MCDA 4 never requested; LSPs seen: {lsps}')
+
+    def test_da4_unsupported_is_reported_and_not_fatal(self):
+        self.server.da4s = False
+        self.server.last_blocks = (2, 4, 6, 8)
+        result = self.run_cmd('-t', 'host1', '-O', './dumps/')
+        self.assertOk(result)
+        self.assertIn('Data Area 4 Support(DA4S) bit is 0', result.stdout)
+        self.assertIn('Data Area 4 will not be extracted', result.stdout)
+        self.assertEqual(self.server.set_features_calls, 0,
+                         'ETDAS touched although DA4S is 0')
+
+    def test_mcdas_off_still_extracts_but_says_so(self):
+        self.server.da4s = True
+        self.server.mcdas = False
+        self.server.last_blocks = (2, 4, 6, 8)
+        result = self.run_cmd('-t', 'host1', '-O', './dumps/')
+        self.assertOk(result)
+        self.assertIn('Maximum Created Data Area Support(MCDAS) bit is 0',
+                      result.stdout)
+        self.assertIn('Setup for Data Area 4 extraction is done', result.stdout)
+
+    def test_ctlr_dump_does_not_consult_mcdas(self):
+        """MCDAS is only meaningful for the host-initiated log (lsp == 1)."""
+        self._enable_da4()
+        self.assertOk(self.run_cmd('-t', 'ctlr', '-O', './dumps/'))
+        self.assertNotIn('Maximum Created Data Area Support', self.run_cmd(
+            '-t', 'ctlr', '-O', './b/').stdout)
+
+    # ---------------------------------------------------------------- #
+    # Remaining option combinations                                     #
+    # ---------------------------------------------------------------- #
+
+    def test_host1_dump_type(self):
+        result = self.run_cmd('-t', 'host1', '-O', './dumps/')
+        self.assertOk(result)
+        self.assertTrue(any('Host(1)' in f for f in self.files('dumps')),
+                        f'no host1 dump: {self.files("dumps")}')
+
+    def test_all_dump_types_named_explicitly(self):
+        self._enable_da4()
+        result = self.run_cmd('-t', 'host0,host1,ctlr,vendor', '-O', './dumps/')
+        self.assertOk(result)
+        names = self.files('dumps')
+        for want in ('Host(0)', 'Host(1)', 'Controller', 'VendorCrashDump'):
+            self.assertTrue(any(want in f for f in names),
+                            f'{want} missing from {names}')
+
+    def test_each_single_data_area(self):
+        self._enable_da4()
+        for area in (1, 2, 3, 4):
+            with self.subTest(area=area):
+                out = f'./a{area}/'
+                result = self.run_cmd('-t', 'ctlr', '-a', str(area), '-O', out)
+                self.assertOk(result)
+                names = self.files(f'a{area}')
+                self.assertTrue(any(f'Area_{area}.bin' in f for f in names),
+                                f'-a {area} produced {names}')
+                for other in {1, 2, 3, 4} - {area}:
+                    self.assertFalse(any(f'Area_{other}.bin' in f for f in names),
+                                     f'-a {area} also wrote area {other}: {names}')
+
+    def test_default_output_is_the_current_directory(self):
+        result = self.run_cmd('-t', 'ctlr')
+        self.assertOk(result)
+        self.assertTrue(any(f.startswith(SERIAL) for f in self.files()),
+                        f'nothing written to the cwd: {self.files()}')
+
+    def test_compress_with_single_data_area(self):
+        result = self.run_cmd('-t', 'ctlr', '-a', '2', '-O', './dumps/', '-z')
+        self.assertOk(result)
+        self.assertTrue(any(f.endswith('.tar.gz') for f in self.files('dumps')),
+                        f'no archive: {self.files("dumps")}')
+
+    def test_compress_with_hide_progress(self):
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/', '-z', '-H')
+        self.assertOk(result)
+        self.assertTrue(any(f.endswith('.tar.gz') for f in self.files('dumps')),
+                        f'no archive: {self.files("dumps")}')
+        self.assertIn('100%', result.stdout,
+                      'the completion line went missing under -z -H')
+
+    def test_compress_without_output_option(self):
+        result = self.run_cmd('-t', 'ctlr', '-z')
+        self.assertOk(result)
+        self.assertTrue(any(f.endswith('.tar.gz') for f in self.files()),
+                        f'no archive in the cwd: {self.files()}')
+        self.assertFalse(os.path.isdir(os.path.join(self.out_dir,
+                                                    'temp_samsung_dumps')),
+                         'the temporary directory was left behind')
+
+
+if __name__ == '__main__':
+    unittest.main(argv=[sys.argv[0]], verbosity=2)


### PR DESCRIPTION
Samsung SSDs keep internal firmware logs that are useful when diagnosing
field issues. This adds a Samsung vendor plugin with a single command,
`nvme samsung vs-internal-log`, which collects them and writes each dump
to its own file: host-initiated telemetry (Log Specific Parameter 0 and
1), controller-initiated telemetry, and the vendor crash, memory and
debug dumps.

`-t` takes a comma-separated list, so several dump types can be pulled in
one run:

    nvme samsung vs-internal-log /dev/nvme0 -t ctlr,vendor -O ./dumps/

With no `-t`, everything except `host0` is collected; `host0` is only
retrieved when it is named explicitly. `-a` limits the telemetry dumps to
a single data area (1-4, default all), `-O` sets the output path and
creates any missing directories, `-z` saves the dumps as one compressed
archive, and `-H` suppresses the incremental progress output.

The command writes binary dumps and prints its own progress rather than
going through `nvme_print()`, so it declares NORMAL as its only output
format, and `--output-file` uses `-O` because `-o` is the global
`--output-format`.

A man page is included.

### Two shared/ prerequisites

The review pointed at path helpers being reimplemented in the plugin, so
the series now leads with the two pieces that belong in `shared/`:

1. **`shared: handle a path with no file name in shr_mkdir_from_fname()`** --
   the helper goes through `dirname()`, which strips a trailing `/` before
   dropping the last component, so `-O ./a/b/` created only `./a` and left
   `./a/b` missing. That form is documented for this option.

2. **`shared: add shr_dir_prefix_len()`** -- the counterpart to
   `shr_basename()`, for the directory part of a path that `dirname()`
   cannot express. `path + shr_dir_prefix_len(path) == shr_basename(path)`.

Both come with tests.

### CLI tests

The last commit adds `tests/cli/nvme_samsung_test.py`. Only the dumps
themselves need the device: option handling, output path composition,
dump file naming, the data area merge, `-z` archiving and the exit
status all sit above it. The test drives the whole command through
`libmock_nvme.so`, which also lets it present cases a single drive
cannot -- a device missing data areas 3 and 4, one that reports no Data
Area 4 support, a non-Samsung vendor ID, and a vendor dump the device
does not implement.

Each of the four commits builds and passes the unit tests on its own.
