### PR TITLE
libnvme: fix crash on a malformed exclusion entry

### DIFF
--- a/Documentation/nvme-exclusion-list.txt
+++ b/Documentation/nvme-exclusion-list.txt
@@ -12,9 +12,15 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Without --name, print the name of every named exclusion list under
-/etc/nvme/exclusions.conf.d/.  With --name, print the entries contained
-in that one list.
+Without --name, print every exclusion list and its entries: the main
+hand-edited /etc/nvme/exclusions.conf first, shown as '(default)', then
+each named list under /etc/nvme/exclusions.conf.d/.  With --name, print
+the entries of that one list.
+
+An entry that can never match is marked '# invalid: never matches'.  An
+entry is invalid when it uses an unknown key, a token without '=', an
+empty value, or a hostname where the transport requires a numeric
+address.  Add --verbose to log the reason for each one.
 
 This command is read-only and does not require root.
 
@@ -29,7 +35,7 @@ include::global-options.txt[]
 
 EXAMPLES
 --------
-* Show every exclusion list:
+* Show every exclusion list and its entries:
 +
 ------------
 # nvme exclusion list

--- a/libnvme/design/EXCLUSIONS.md
+++ b/libnvme/design/EXCLUSIONS.md
@@ -78,6 +78,9 @@ A controller is **excluded** if it matches **any** entry in **any** list. Matchi
 - **Field absent from the entry** → not checked; the entry can still match on its other fields.
 - **Unknown key in an entry** → that entry **never matches** (fail-safe): a typo weakens nothing.
 - **Empty or field-less entry** → never matches; it cannot be used to exclude everything by accident.
+- **Hostname where the transport requires a numeric address** → never matches; a TID is a canonical post-resolution identity.
+
+Matching runs on every connect attempt, so an invalid entry is reported at DEBUG level only: one typo in a static file must not produce a log line per connect. `nvme exclusion list` marks such entries, which is where an administrator looks for them.
 
 This makes an entry as broad or as narrow as the administrator writes it. `nqn=nqn.…:retired` excludes that subsystem on every transport and address; adding `traddr=` and `trsvcid=` narrows it to one path.
 

--- a/libnvme/src/nvme/exclusion.c
+++ b/libnvme/src/nvme/exclusion.c
@@ -214,15 +214,18 @@ static bool tid_subset_match(const struct libnvmf_tid *e,
  * Check one entry against a transport ID (minimal match): the entry is parsed
  * into a partial TID, and only the fields it sets are compared against @tid.  A
  * malformed entry (unknown key, bare token, or empty value) or one that sets no
- * fields matches nothing -- we never guess.  Parsed silently (ctx == NULL):
- * matching runs on every connect, so a bad hand-edited entry must stay quiet.
+ * fields matches nothing -- we never guess.  The parse reports what was wrong
+ * at DEBUG: matching runs on every connect, so a bad hand-edited entry must
+ * stay quiet by default.  "nvme exclusion list" flags it for the admin.
  */
-static bool entry_matches(const char *entry, const struct libnvmf_tid *tid)
+static bool entry_matches(struct libnvme_global_ctx *ctx, const char *entry,
+			  const struct libnvmf_tid *tid)
 {
 	struct libnvmf_tid *e;
 	bool matches;
 
-	if (libnvmf_tid_parse_strict(NULL, entry, &e))
+	if (_libnvmf_tid_parse_strict_at_level(ctx, LIBNVME_LOG_DEBUG,
+					       entry, &e))
 		return false;
 	if (libnvmf_tid_is_empty(e)) {
 		libnvmf_tid_free(e);
@@ -236,8 +239,8 @@ static bool entry_matches(const char *entry, const struct libnvmf_tid *tid)
 
 /*
  * Validate an entry before writing it: it must parse cleanly (every key known,
- * no malformed token) and set at least one field.  @ctx is used only to log
- * what was wrong; it may be NULL to validate silently.
+ * no malformed token) and set at least one field.  @ctx must be non-NULL; it
+ * is used to log what was wrong.
  */
 static bool entry_valid(struct libnvme_global_ctx *ctx, const char *entry)
 {
@@ -312,9 +315,9 @@ static enum excl_line_type classify_line(char *s, bool *in_excl, char **val)
 	return EXCL_LINE_ENTRY;
 }
 
-typedef bool (*scan_fn)(const char *entry, void *ctx);
+typedef bool (*scan_fn)(const char *entry, void *user_data);
 
-static bool scan_conf_file(const char *path, scan_fn fn, void *ctx)
+static bool scan_conf_file(const char *path, scan_fn fn, void *user_data)
 {
 	FILE *f;
 	char line[EXCL_LINE_MAX];
@@ -332,7 +335,7 @@ static bool scan_conf_file(const char *path, scan_fn fn, void *ctx)
 		if (classify_line(s, &in_excl, &val) != EXCL_LINE_ENTRY)
 			continue;
 
-		if (fn(val, ctx)) {
+		if (fn(val, user_data)) {
 			result = true;
 			break;
 		}
@@ -341,15 +344,23 @@ static bool scan_conf_file(const char *path, scan_fn fn, void *ctx)
 	return result;
 }
 
-static bool match_entry(const char *entry, void *ctx)
+struct match_ctx {
+	struct libnvme_global_ctx *ctx;
+	const struct libnvmf_tid *tid;
+};
+
+static bool match_entry(const char *entry, void *user_data)
 {
-	return entry_matches(entry, ctx);
+	const struct match_ctx *mc = user_data;
+
+	return entry_matches(mc->ctx, entry, mc->tid);
 }
 
 __shr_public bool libnvmf_exclusion_match(struct libnvme_global_ctx *ctx,
 					      const struct libnvmf_tid *tid)
 {
 	const char *dir, *mainp;
+	struct match_ctx mc;
 	DIR *d;
 	struct dirent *de;
 	bool found = false;
@@ -357,9 +368,12 @@ __shr_public bool libnvmf_exclusion_match(struct libnvme_global_ctx *ctx,
 	if (!ctx || !tid)
 		return false;
 
+	mc.ctx = ctx;
+	mc.tid = tid;
+
 	/* The hand-edited main list first, then each managed drop-in. */
 	mainp = excl_main_path(ctx);
-	if (mainp && scan_conf_file(mainp, match_entry, (void *)tid))
+	if (mainp && scan_conf_file(mainp, match_entry, &mc))
 		return true;
 
 	dir = excl_dropin_dir(ctx);
@@ -385,7 +399,7 @@ __shr_public bool libnvmf_exclusion_match(struct libnvme_global_ctx *ctx,
 		if (snprintf(path, sizeof(path), "%s/%s", dir,
 			     de->d_name) >= (int)sizeof(path))
 			continue;
-		found = scan_conf_file(path, match_entry, (void *)tid);
+		found = scan_conf_file(path, match_entry, &mc);
 	}
 	closedir(d);
 	return found;

--- a/libnvme/src/nvme/private-fabrics.h
+++ b/libnvme/src/nvme/private-fabrics.h
@@ -107,6 +107,16 @@ struct libnvmf_context { // !generate-accessors:read=generated,write=generated
  */
 int _libnvmf_persistent_from_str(const char *str, enum libnvmf_persistent *val);
 
+/*
+ * Like libnvmf_tid_parse_strict(), but emit the parse diagnostics at @level
+ * instead of WARN.  The exclusion match path runs on every connect attempt, so
+ * it reports a malformed entry at DEBUG: the entry is static, and one typo
+ * would otherwise produce a log line per connect.
+ */
+int _libnvmf_tid_parse_strict_at_level(struct libnvme_global_ctx *ctx,
+				       int level, const char *str,
+				       struct libnvmf_tid **out);
+
 /**
  * NVMe-oF private struct definitions.
  *

--- a/libnvme/src/nvme/tid.c
+++ b/libnvme/src/nvme/tid.c
@@ -327,8 +327,10 @@ __shr_public struct libnvmf_tid *libnvmf_tid_dup(
  * (no '='), an empty value, or an unrecognized key -- fails the whole parse
  * with -EINVAL; in lenient mode such tokens are logged and skipped.  Empty
  * tokens (from ";;" or a trailing ';') are always benign and skipped.
+ * Diagnostics are emitted at @level.  A caller that parses on a hot path asks
+ * for LIBNVME_LOG_DEBUG so that one bad entry cannot flood the log.
  */
-static int tid_parse(struct libnvme_global_ctx *ctx, const char *str,
+static int tid_parse(struct libnvme_global_ctx *ctx, int level, const char *str,
 		     bool strict, struct libnvmf_tid **out)
 {
 	struct libnvmf_tid *t;
@@ -340,7 +342,12 @@ static int tid_parse(struct libnvme_global_ctx *ctx, const char *str,
 		return -EINVAL;
 	*out = NULL;
 
-	if (!str)
+	/*
+	 * A NULL @ctx is rejected here rather than tolerated in the logging
+	 * path: libnvme_msg() dereferences it, so the check belongs at the
+	 * entry point.
+	 */
+	if (!ctx || !str)
 		return -EINVAL;
 
 	rc = libnvmf_tid_new(&t);
@@ -359,7 +366,7 @@ static int tid_parse(struct libnvme_global_ctx *ctx, const char *str,
 
 		if (!eq) {
 			if (*shr_trim(tok)) {
-				libnvme_msg(ctx, LIBNVME_LOG_WARN,
+				libnvme_msg(ctx, level,
 					    "tid_parse: ignoring \"%s\": missing '='\n",
 					    tok);
 				bad = strict;
@@ -372,7 +379,7 @@ static int tid_parse(struct libnvme_global_ctx *ctx, const char *str,
 			val = shr_trim(eq + 1);
 
 			if (!*val) {
-				libnvme_msg(ctx, LIBNVME_LOG_WARN,
+				libnvme_msg(ctx, level,
 					    "tid_parse: ignoring empty value for \"%s\"\n",
 					    key);
 				bad = strict;
@@ -409,7 +416,7 @@ static int tid_parse(struct libnvme_global_ctx *ctx, const char *str,
 				t->hostid = strdup(val);
 				oom = !t->hostid;
 			} else {
-				libnvme_msg(ctx, LIBNVME_LOG_WARN,
+				libnvme_msg(ctx, level,
 					    "tid_parse: ignoring unknown key \"%s\"\n",
 					    key);
 				bad = strict;
@@ -430,6 +437,10 @@ static int tid_parse(struct libnvme_global_ctx *ctx, const char *str,
 	}
 
 	rc = tid_sanitize_addr(t);
+	if (rc == -EINVAL)
+		libnvme_msg(ctx, level,
+			    "tid_parse: bad address for transport \"%s\"\n",
+			    t->transport);
 	if (rc) {
 		libnvmf_tid_free(t);
 		return rc;
@@ -443,14 +454,21 @@ __shr_public int libnvmf_tid_parse(struct libnvme_global_ctx *ctx,
 					const char *str,
 					struct libnvmf_tid **out)
 {
-	return tid_parse(ctx, str, false, out);
+	return tid_parse(ctx, LIBNVME_LOG_WARN, str, false, out);
 }
 
 __shr_public int libnvmf_tid_parse_strict(struct libnvme_global_ctx *ctx,
 					       const char *str,
 					       struct libnvmf_tid **out)
 {
-	return tid_parse(ctx, str, true, out);
+	return tid_parse(ctx, LIBNVME_LOG_WARN, str, true, out);
+}
+
+int _libnvmf_tid_parse_strict_at_level(struct libnvme_global_ctx *ctx,
+				       int level, const char *str,
+				       struct libnvmf_tid **out)
+{
+	return tid_parse(ctx, level, str, true, out);
 }
 
 /*

--- a/libnvme/src/nvme/tid.h
+++ b/libnvme/src/nvme/tid.h
@@ -73,8 +73,7 @@ struct libnvmf_tid *libnvmf_tid_dup(const struct libnvmf_tid *tid);
 /**
  * libnvmf_tid_parse() - Allocate a TID from a semicolon-separated key=value
  * string.
- * @ctx: Global context used only for logging the diagnostics below; may be NULL
- *       to parse silently.
+ * @ctx: Global context used only for logging the diagnostics below.
  * @str: Input string, e.g. "transport=tcp;traddr=1.2.3.4;trsvcid=8009".
  * @out: The allocated TID on success; NULL on error.
  *
@@ -83,13 +82,13 @@ struct libnvmf_tid *libnvmf_tid_dup(const struct libnvmf_tid *tid);
  * "host-traddr", and "host-iface" string keys map onto the struct's
  * subsysnqn, host_traddr, and host_iface fields, whose names follow the
  * C-identifier convention.)  Unknown keys, bare keys (no '='), and empty
- * values are logged at WARN level (when @ctx is non-NULL) and skipped.
+ * values are logged at WARN level and skipped.
  * Whitespace around keys and values is trimmed.
  * Like libnvmf_tid_from_fields(), a traddr/host-traddr that is not numeric on
  * an IP transport fails the whole parse.
  *
- * Return: 0 on success (*@out is the allocated TID); -EINVAL if @out or @str
- * is NULL, or a traddr/host-traddr is not numeric on an IP transport;
+ * Return: 0 on success (*@out is the allocated TID); -EINVAL if @ctx, @out or
+ * @str is NULL, or a traddr/host-traddr is not numeric on an IP transport;
  * -ENOMEM on allocation failure.
  */
 int libnvmf_tid_parse(struct libnvme_global_ctx *ctx, const char *str,
@@ -98,7 +97,7 @@ int libnvmf_tid_parse(struct libnvme_global_ctx *ctx, const char *str,
 /**
  * libnvmf_tid_parse_strict() - Like libnvmf_tid_parse(), but reject malformed
  * input.
- * @ctx: Global context for logging; may be NULL to parse silently.
+ * @ctx: Global context for logging.
  * @str: Input string.
  * @out: The allocated TID on success; NULL on error.
  *
@@ -108,8 +107,8 @@ int libnvmf_tid_parse(struct libnvme_global_ctx *ctx, const char *str,
  * are still benign.  Useful when an unrecognized key should be treated as an
  * error (e.g. a typo in a hand-edited config) rather than silently ignored.
  *
- * Return: 0 on success (*@out is the allocated TID); -EINVAL if @out or @str
- * is NULL, or on a malformed token; -ENOMEM on allocation failure.
+ * Return: 0 on success (*@out is the allocated TID); -EINVAL if @ctx, @out or
+ * @str is NULL, or on a malformed token; -ENOMEM on allocation failure.
  */
 int libnvmf_tid_parse_strict(struct libnvme_global_ctx *ctx, const char *str,
 			     struct libnvmf_tid **out);

--- a/libnvme/tests/exclusion.c
+++ b/libnvme/tests/exclusion.c
@@ -19,6 +19,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <ccan/array_size/array_size.h>
+
 #include <nvme/lib.h>
 #include <nvme/exclusion.h>
 #include <nvme/tid.h>
@@ -39,6 +41,7 @@ static void cleanup_tmpdir(struct libnvme_global_ctx *ctx)
 
 	libnvmf_exclusion_delete(ctx, "list");
 	libnvmf_exclusion_delete(ctx, "fresh");
+	libnvmf_exclusion_delete(ctx, "bad");
 	snprintf(dropin, sizeof(dropin), "%s/exclusions.conf.d", tmpdir);
 	rmdir(dropin);
 	rmdir(tmpdir);
@@ -365,6 +368,82 @@ static bool test_match(struct libnvme_global_ctx *ctx)
 }
 
 /*
+ * A malformed hand-edited entry must never match, and must never take the
+ * caller down.  Regression: the match path parsed entries with a NULL context
+ * while the parser dereferences that context to log a malformed token, so one
+ * typo in exclusions.conf crashed every process that consults the list.
+ */
+static bool test_malformed_entry(struct libnvme_global_ctx *ctx)
+{
+	/*
+	 * Unknown key, no '=', empty value, the code-style spelling of the
+	 * "nqn" key, and a hostname where a numeric address is required.
+	 */
+	static const char *const bad[] = {
+		"bogus=x",
+		"baretoken",
+		"nqn=",
+		"subsysnqn=nqn.example",
+		"transport=tcp;traddr=dc.example.com",
+	};
+	struct libnvmf_tid *tid;
+	char path[512];
+	bool pass = true;
+	FILE *f;
+	size_t i;
+	int ret;
+
+	printf("test_malformed_entry:\n");
+
+	ret = libnvmf_exclusion_create(ctx, "bad");
+	if (ret) {
+		printf(" - create failed: %d [FAIL]\n", ret);
+		return false;
+	}
+
+	snprintf(path, sizeof(path), "%s/exclusions.conf.d/bad.conf", tmpdir);
+	f = fopen(path, "a");
+	shr_assert(f);
+	fputs("[exclusions]\n", f);
+	for (i = 0; i < ARRAY_SIZE(bad); i++)
+		fprintf(f, "exclusion = %s\n", bad[i]);
+	fputs("exclusion = transport=tcp;traddr=7.7.7.7\n", f);
+	fclose(f);
+
+	for (i = 0; i < ARRAY_SIZE(bad); i++) {
+		if (libnvmf_exclusion_entry_valid(ctx, bad[i])) {
+			printf(" - \"%s\" reported valid [FAIL]\n", bad[i]);
+			pass = false;
+		}
+	}
+
+	/* Nothing the malformed entries name is excluded. */
+	libnvmf_tid_from_fields("tcp", "1.2.3.4", "4420", "nqn.example",
+				NULL, NULL, NULL, NULL, &tid);
+	if (libnvmf_exclusion_match(ctx, tid)) {
+		printf(" - malformed entries match nothing [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - malformed entries match nothing [PASS]\n");
+	}
+	libnvmf_tid_free(tid);
+
+	/* The well-formed entry in the same file still works. */
+	libnvmf_tid_from_fields("tcp", "7.7.7.7", "4420", "nqn.example",
+				NULL, NULL, NULL, NULL, &tid);
+	if (libnvmf_exclusion_match(ctx, tid)) {
+		printf(" - valid entry after malformed ones matches [PASS]\n");
+	} else {
+		printf(" - valid entry after malformed ones matches [FAIL]\n");
+		pass = false;
+	}
+	libnvmf_tid_free(tid);
+
+	libnvmf_exclusion_delete(ctx, "bad");
+	return pass;
+}
+
+/*
  * Section semantics: entries count only inside [exclusions].  Writing is
  * strict (a stray entry or malformed header is rejected); reading is
  * fail-safe (anything outside the section is skipped, foreign sections are
@@ -519,6 +598,7 @@ int main(void)
 	setup_tmpdir(ctx);
 
 	pass &= test_match(ctx);
+	pass &= test_malformed_entry(ctx);
 	pass &= test_mode_policy(ctx);
 	pass &= test_read_write_roundtrip(ctx);
 	pass &= test_stale_rejected(ctx);

--- a/libnvme/tests/test-tid.c
+++ b/libnvme/tests/test-tid.c
@@ -64,6 +64,10 @@ static bool test_tid_parse_null(void)
 	pass = (libnvmf_tid_parse(ctx, NULL, &t) == -EINVAL && t == NULL);
 	CHECK(pass, "NULL input → -EINVAL");
 
+	pass &= (libnvmf_tid_parse(NULL, "transport=tcp", &t) == -EINVAL &&
+		 t == NULL);
+	CHECK(pass, "NULL ctx → -EINVAL");
+
 	libnvme_free_global_ctx(ctx);
 
 	return pass;

--- a/plugins/exclusion/exclusion-nvme.c
+++ b/plugins/exclusion/exclusion-nvme.c
@@ -108,22 +108,55 @@ static int excl_delete(int argc, char **argv, struct command *acmd,
 	return ret;
 }
 
-static void print_list_name(const char *name, void *user_data __attribute__((unused)))
+struct entry_print_ctx {
+	struct libnvme_global_ctx *ctx;
+	unsigned int count;
+};
+
+/*
+ * An entry that fails validation can never match anything, so say so: a typo
+ * in a hand-edited list is otherwise invisible.  stdout is flushed first
+ * because at -v the validator logs the reason to stderr.
+ */
+static void print_entry(const char *entry, void *user_data)
 {
-	printf("%s\n", name);
+	struct entry_print_ctx *pc = user_data;
+	bool valid;
+
+	pc->count++;
+	fflush(stdout);
+	valid = libnvmf_exclusion_entry_valid(pc->ctx, entry);
+	printf("  %s%s\n", entry, valid ? "" : "  # invalid: never matches");
 }
 
-static void print_entry(const char *entry, void *user_data __attribute__((unused)))
+/* @name is NULL for the main hand-edited list. */
+static void print_one_list(struct libnvme_global_ctx *ctx, const char *name)
 {
-	printf("  %s\n", entry);
+	struct entry_print_ctx pc = { .ctx = ctx };
+	int ret;
+
+	printf("%s\n", name ? name : "(default)");
+
+	ret = libnvmf_exclusion_entry_for_each(ctx, name, print_entry, &pc);
+	if (ret && ret != -ENOENT)
+		nvme_show_error("list failed: %s", libnvme_strerror(-ret));
+	else if (!pc.count)
+		printf("  (empty)\n");
+}
+
+static void print_named_list(const char *name, void *user_data)
+{
+	printf("\n");
+	print_one_list(user_data, name);
 }
 
 static int excl_list(int argc, char **argv, struct command *acmd,
 		     struct plugin *plugin)
 {
 	const char *desc = "List exclusion lists, or entries within a named list.";
-	const char *name_help = "exclusion list name (omit to list all lists)";
+	const char *name_help = "exclusion list name (omit to list every list)";
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
+	struct entry_print_ctx pc = { 0 };
 	int ret;
 
 	struct config {
@@ -142,17 +175,23 @@ static int excl_list(int argc, char **argv, struct command *acmd,
 		return ret;
 
 	if (!cfg.name) {
-		ret = libnvmf_exclusion_list_for_each(ctx, print_list_name, NULL);
+		print_one_list(ctx, NULL);
+		ret = libnvmf_exclusion_list_for_each(ctx, print_named_list,
+						      ctx);
 		if (ret)
-			nvme_show_error("list failed: %s", libnvme_strerror(-ret));
+			nvme_show_error("list failed: %s",
+					libnvme_strerror(-ret));
 		return ret;
 	}
 
-	ret = libnvmf_exclusion_entry_for_each(ctx, cfg.name, print_entry, NULL);
+	pc.ctx = ctx;
+	ret = libnvmf_exclusion_entry_for_each(ctx, cfg.name, print_entry, &pc);
 	if (ret == -ENOENT)
 		nvme_show_error("exclusion list '%s' not found", cfg.name);
 	else if (ret)
 		nvme_show_error("list failed: %s", libnvme_strerror(-ret));
+	else if (!pc.count)
+		printf("  (empty)\n");
 	return ret;
 }
 


### PR DESCRIPTION
Any exclusion entry with an unknown key, a token without `=`, or an empty value crashes every caller of `libnvmf_exclusion_match()`: `nvme connect-all`, `nvme-discoverd`, and anything else that consults the list.

```
printf '[exclusions]\nexclusion = bogus=x\n' > /etc/nvme/exclusions.conf
nvme connect-all ...     # SIGSEGV
```

`entry_matches()` parsed each entry with a NULL context to keep the match path quiet, but `tid_parse()` logs those three cases and `libnvme_msg()` dereferences the context.

The fix threads the caller's real context down instead, and reports a bad entry at DEBUG. Matching runs on every connect attempt, so one static typo must not produce a log line per connect. `libnvmf_tid_parse()` and `libnvmf_tid_parse_strict()` now return `-EINVAL` for a NULL context rather than documenting it as "parse silently", which was never true.

The second commit makes the typo visible where an admin would look for it. `nvme exclusion list` showed only drop-in names, so the entries of the main hand-edited `/etc/nvme/exclusions.conf` could not be listed at all. It now prints every list with its entries and marks the ones that can never match:

```
$ nvme exclusion list
(default)
  nqn=nqn.2014-08.org.nvmexpress:uuid:abc
  bogus=x  # invalid: never matches

user
  transport=tcp;traddr=10.0.0.1
```

`--verbose` logs the reason for each one.

Regression tests cover the four malformed forms plus a hostname in `traddr`, which was silently rejected with no diagnostic before.
