### PR TITLE
libnvme: add the global context to the host ID generators

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -90,12 +90,13 @@ const char *arg_str(const char * const *strings,
 #define NVMF_HOSTNQN_FILE	SYSCONFDIR "/nvme/hostnqn"
 #define NVMF_HOSTID_FILE	SYSCONFDIR "/nvme/hostid"
 
-static int uuid_from_device_tree(char *system_uuid)
+static int uuid_from_device_tree(struct libnvme_global_ctx *ctx,
+				 char *system_uuid)
 {
 	__cleanup_fd int f = -1;
 	ssize_t len;
 
-	f = open(libnvme_uuid_ibm_filename(), O_RDONLY);
+	f = open(libnvme_uuid_ibm_filename(ctx), O_RDONLY);
 	if (f < 0)
 		return -ENXIO;
 
@@ -148,10 +149,11 @@ static int read_file(char *filename, char *buf, size_t size)
 	return len;
 }
 
-static int uuid_from_dmi_entries(char *system_uuid)
+static int uuid_from_dmi_entries(struct libnvme_global_ctx *ctx,
+				 char *system_uuid)
 {
 	__cleanup_dir DIR *d = NULL;
-	const char *entries_dir = libnvme_dmi_entries_dir();
+	const char *entries_dir = libnvme_dmi_entries_dir(ctx);
 	char filename[PATH_MAX];
 	struct dirent *de;
 	char buf[513] = {0};
@@ -200,19 +202,19 @@ static int uuid_from_dmi_entries(char *system_uuid)
 	return strlen(system_uuid) ? 0 : -ENXIO;
 }
 
-#define PATH_DMI_PROD_UUID  "/sys/class/dmi/id/product_uuid"
-
 /**
  * uuid_from_product_uuid() - Get system UUID from product_uuid
+ * @ctx: Global context, for the sysfs path.
  * @system_uuid: Where to save the system UUID.
  *
  * Return: 0 on success, -ENXIO otherwise.
  */
-static int uuid_from_product_uuid(char *system_uuid)
+static int uuid_from_product_uuid(struct libnvme_global_ctx *ctx,
+				  char *system_uuid)
 {
 	__cleanup_file FILE *stream = NULL;
 
-	stream = fopen(PATH_DMI_PROD_UUID, "re");
+	stream = fopen(libnvme_dmi_product_uuid_filename(ctx), "re");
 	if (!stream)
 		return -ENXIO;
 
@@ -242,6 +244,7 @@ static int uuid_from_product_uuid(char *system_uuid)
 
 /**
  * uuid_from_dmi() - read system UUID
+ * @ctx: Global context, for the sysfs paths.
  * @system_uuid: buffer for the UUID
  *
  * The system UUID can be read from two different locations:
@@ -253,23 +256,26 @@ static int uuid_from_product_uuid(char *system_uuid)
  *
  * Return: 0 on success, negative errno otherwise.
  */
-static int uuid_from_dmi(char *system_uuid)
+static int uuid_from_dmi(struct libnvme_global_ctx *ctx, char *system_uuid)
 {
-	int ret = uuid_from_product_uuid(system_uuid);
+	int ret = uuid_from_product_uuid(ctx, system_uuid);
 	if (ret != 0)
-		ret = uuid_from_dmi_entries(system_uuid);
+		ret = uuid_from_dmi_entries(ctx, system_uuid);
 	return ret;
 }
 
-__shr_public char *libnvmf_generate_hostid(void)
+__shr_public char *libnvmf_generate_hostid(struct libnvme_global_ctx *ctx)
 {
 	int ret;
 	char uuid_str[NVME_UUID_LEN_STRING];
 	unsigned char uuid[NVME_UUID_LEN];
 
-	ret = uuid_from_dmi(uuid_str);
+	if (!ctx)
+		return NULL;
+
+	ret = uuid_from_dmi(ctx, uuid_str);
 	if (ret < 0)
-		ret = uuid_from_device_tree(uuid_str);
+		ret = uuid_from_device_tree(ctx, uuid_str);
 	if (ret < 0) {
 		if (libnvme_random_uuid(uuid) < 0)
 			memset(uuid, 0, NVME_UUID_LEN);
@@ -279,14 +285,21 @@ __shr_public char *libnvmf_generate_hostid(void)
 	return strdup(uuid_str);
 }
 
-__shr_public char *libnvmf_generate_hostnqn_from_hostid(char *hostid)
+__shr_public char *libnvmf_generate_hostnqn_from_hostid(
+				struct libnvme_global_ctx *ctx, char *hostid)
 {
 	char *hid = NULL;
 	char *hostnqn;
 	int ret;
 
-	if (!hostid)
-		hostid = hid = libnvmf_generate_hostid();
+	if (!ctx)
+		return NULL;
+
+	if (!hostid) {
+		hostid = hid = libnvmf_generate_hostid(ctx);
+		if (!hostid)
+			return NULL;
+	}
 
 	ret = asprintf(&hostnqn, "nqn.2014-08.org.nvmexpress:uuid:%s", hostid);
 	free(hid);
@@ -294,9 +307,9 @@ __shr_public char *libnvmf_generate_hostnqn_from_hostid(char *hostid)
 	return (ret < 0) ? NULL : hostnqn;
 }
 
-__shr_public char *libnvmf_generate_hostnqn(void)
+__shr_public char *libnvmf_generate_hostnqn(struct libnvme_global_ctx *ctx)
 {
-	return libnvmf_generate_hostnqn_from_hostid(NULL);
+	return libnvmf_generate_hostnqn_from_hostid(ctx, NULL);
 }
 
 static char *nvmf_read_file(const char *f, int len)
@@ -387,7 +400,7 @@ __shr_public int libnvmf_host_get_ids(struct libnvme_global_ctx *ctx,
 	 * fails generate one
 	 */
 	if (!hid) {
-		hid = libnvmf_generate_hostid();
+		hid = libnvmf_generate_hostid(ctx);
 		if (!hid)
 			return -ENOMEM;
 
@@ -397,7 +410,7 @@ __shr_public int libnvmf_host_get_ids(struct libnvme_global_ctx *ctx,
 
 	/* incomplete configuration, thus derive hostnqn from hostid */
 	if (!hnqn) {
-		hnqn = libnvmf_generate_hostnqn_from_hostid(hid);
+		hnqn = libnvmf_generate_hostnqn_from_hostid(ctx, hid);
 		if (!hnqn)
 			return -ENOMEM;
 	}

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -33,14 +33,17 @@ struct libnvmf_tid;
 
 /**
  * libnvmf_generate_hostnqn() - Generate a machine specific host nqn
+ * @ctx:		struct libnvme_global_ctx object
+ *
  * Return: An nvm namespace qualified name string based on the machine
  * identifier, or NULL if not successful.
  */
-char *libnvmf_generate_hostnqn(void);
+char *libnvmf_generate_hostnqn(struct libnvme_global_ctx *ctx);
 
 /**
  * libnvmf_generate_hostnqn_from_hostid() - Generate a host nqn from
  * host identifier
+ * @ctx:		struct libnvme_global_ctx object
  * @hostid:		Host identifier
  *
  * If @hostid is NULL, the function generates it based on the machine
@@ -49,15 +52,17 @@ char *libnvmf_generate_hostnqn(void);
  * Return: On success, an NVMe Qualified Name for host identification. This
  * name is based on the given host identifier. On failure, NULL.
  */
-char *libnvmf_generate_hostnqn_from_hostid(char *hostid);
+char *libnvmf_generate_hostnqn_from_hostid(struct libnvme_global_ctx *ctx,
+					   char *hostid);
 
 /**
  * libnvmf_generate_hostid() - Generate a machine specific host identifier
+ * @ctx:		struct libnvme_global_ctx object
  *
  * Return: On success, an identifier string based on the machine identifier to
  * be used as NVMe Host Identifier, or NULL on failure.
  */
-char *libnvmf_generate_hostid(void);
+char *libnvmf_generate_hostid(struct libnvme_global_ctx *ctx);
 
 /**
  * libnvmf_read_hostnqn() - Reads the host nvm qualified name from the config

--- a/libnvme/src/nvme/no-fabrics.c
+++ b/libnvme/src/nvme/no-fabrics.c
@@ -13,17 +13,18 @@
 
 #include "private.h"
 
-__shr_public char *libnvmf_generate_hostid(void)
+__shr_public char *libnvmf_generate_hostid(struct libnvme_global_ctx *ctx)
 {
 	return NULL;
 }
 
-__shr_public char *libnvmf_generate_hostnqn_from_hostid(char *hostid)
+__shr_public char *libnvmf_generate_hostnqn_from_hostid(
+				struct libnvme_global_ctx *ctx, char *hostid)
 {
 	return NULL;
 }
 
-__shr_public char *libnvmf_generate_hostnqn(void)
+__shr_public char *libnvmf_generate_hostnqn(struct libnvme_global_ctx *ctx)
 {
 	return NULL;
 }

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -40,8 +40,9 @@ const char *libnvme_subsys_sysfs_dir(struct libnvme_global_ctx *ctx);
 const char *libnvme_ctrl_sysfs_dir(struct libnvme_global_ctx *ctx);
 const char *libnvme_ns_sysfs_dir(struct libnvme_global_ctx *ctx);
 const char *libnvme_slots_sysfs_dir(struct libnvme_global_ctx *ctx);
-const char *libnvme_uuid_ibm_filename(void);
-const char *libnvme_dmi_entries_dir(void);
+const char *libnvme_uuid_ibm_filename(struct libnvme_global_ctx *ctx);
+const char *libnvme_dmi_entries_dir(struct libnvme_global_ctx *ctx);
+const char *libnvme_dmi_product_uuid_filename(struct libnvme_global_ctx *ctx);
 
 struct linux_passthru_cmd32 {
 	__u8    opcode;

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -39,6 +39,7 @@
 #define PATH_SYSFS_NVME_SUBSYSTEM	"/sys/class/nvme-subsystem"
 #define PATH_SYSFS_NVME			"/sys/class/nvme"
 #define PATH_DMI_ENTRIES		"/sys/firmware/dmi/entries"
+#define PATH_DMI_PROD_UUID		"/sys/class/dmi/id/product_uuid"
 
 static const char *make_sysfs_dir(struct libnvme_global_ctx *ctx,
 		const char *path)
@@ -94,24 +95,34 @@ const char *libnvme_slots_sysfs_dir(struct libnvme_global_ctx *ctx)
 	return str = make_sysfs_dir(ctx, PATH_SYSFS_SLOTS);
 }
 
-const char *libnvme_uuid_ibm_filename(void)
+const char *libnvme_uuid_ibm_filename(struct libnvme_global_ctx *ctx)
 {
 	static const char *str;
 
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(NULL, PATH_UUID_IBM);
+	return str = make_sysfs_dir(ctx, PATH_UUID_IBM);
 }
 
-const char *libnvme_dmi_entries_dir(void)
+const char *libnvme_dmi_entries_dir(struct libnvme_global_ctx *ctx)
 {
 	static const char *str;
 
 	if (str)
 		return str;
 
-	return str = make_sysfs_dir(NULL, PATH_DMI_ENTRIES);
+	return str = make_sysfs_dir(ctx, PATH_DMI_ENTRIES);
+}
+
+const char *libnvme_dmi_product_uuid_filename(struct libnvme_global_ctx *ctx)
+{
+	static const char *str;
+
+	if (str)
+		return str;
+
+	return str = make_sysfs_dir(ctx, PATH_DMI_PROD_UUID);
 }
 
 static int __nvme_set_attr(const char *path, const char *value)

--- a/libnvme/tests/test-fabrics.c
+++ b/libnvme/tests/test-fabrics.c
@@ -715,6 +715,76 @@ static bool test_dc_decide(struct libnvme_global_ctx *ctx)
 }
 
 /* -------------------------------------------------------------------------
+ * libnvmf_generate_hostid — the machine identifier comes from sysfs, so a
+ * test sandbox must be able to redirect it.  Regression: the generators took
+ * no context and always read the real machine.
+ * -------------------------------------------------------------------------
+ */
+static bool test_generate_hostid(struct libnvme_global_ctx *ctx)
+{
+	static const char uuid[] = "12345678-1234-1234-1234-123456789abc";
+	char dir[] = "/tmp/nvme-hostid-test-XXXXXX";
+	char *hostid = NULL, *hostnqn = NULL;
+	char path[PATH_MAX], want[256];
+	bool pass = true;
+	FILE *f;
+
+	printf("test_generate_hostid:\n");
+
+	if (!mkdtemp(dir)) {
+		CHECK(false, "mkdtemp");
+		return false;
+	}
+
+	snprintf(path, sizeof(path), "%s/sys/class/dmi/id", dir);
+	if (shr_mkdir_p(path, 0755)) {
+		CHECK(false, "create fixture");
+		rmdir(dir);
+		return false;
+	}
+
+	snprintf(path, sizeof(path), "%s/sys/class/dmi/id/product_uuid", dir);
+	f = fopen(path, "w");
+	if (!f) {
+		CHECK(false, "write fixture");
+		return false;
+	}
+	fprintf(f, "%s\n", uuid);
+	fclose(f);
+
+	libnvme_set_test_sysfs_dir(ctx, dir);
+
+	hostid = libnvmf_generate_hostid(ctx);
+	CHECK(hostid && !strcmp(hostid, uuid), "hostid read from the sandbox");
+	pass &= hostid && !strcmp(hostid, uuid);
+
+	hostnqn = libnvmf_generate_hostnqn(ctx);
+	snprintf(want, sizeof(want),
+		 "nqn.2014-08.org.nvmexpress:uuid:%s", uuid);
+	CHECK(hostnqn && !strcmp(hostnqn, want), "hostnqn from that hostid");
+	pass &= hostnqn && !strcmp(hostnqn, want);
+
+	CHECK(!libnvmf_generate_hostid(NULL), "NULL context rejected");
+	pass &= !libnvmf_generate_hostid(NULL);
+
+	free(hostid);
+	free(hostnqn);
+	libnvme_set_test_sysfs_dir(ctx, NULL);
+	unlink(path);
+	snprintf(path, sizeof(path), "%s/sys/class/dmi/id", dir);
+	rmdir(path);
+	snprintf(path, sizeof(path), "%s/sys/class/dmi", dir);
+	rmdir(path);
+	snprintf(path, sizeof(path), "%s/sys/class", dir);
+	rmdir(path);
+	snprintf(path, sizeof(path), "%s/sys", dir);
+	rmdir(path);
+	rmdir(dir);
+
+	return pass;
+}
+
+/* -------------------------------------------------------------------------
  * main
  * -------------------------------------------------------------------------
  */
@@ -749,6 +819,7 @@ int main(int argc, char *argv[])
 	test_nvmf_sanitize_addrs(ctx);
 	test_unescape_uri();
 	test_dc_decide(ctx);
+	test_generate_hostid(ctx);
 
 	libnvme_free_global_ctx(ctx);
 

--- a/src/nvme-cmds-fabrics.c
+++ b/src/nvme-cmds-fabrics.c
@@ -57,6 +57,7 @@ static int gen_hostnqn_cmd(int argc, char **argv, struct command *acmd, struct p
 {
 	const char *desc = "Generate a hostnqn";
 
+	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
 	__cleanup_free char *hostnqn = NULL;
 	int err;
 
@@ -66,7 +67,11 @@ static int gen_hostnqn_cmd(int argc, char **argv, struct command *acmd, struct p
 	if (err)
 		return err;
 
-	hostnqn = libnvmf_generate_hostnqn();
+	ctx = libnvme_create_global_ctx();
+	if (!ctx)
+		return -ENOMEM;
+
+	hostnqn = libnvmf_generate_hostnqn(ctx);
 	if (!hostnqn) {
 		nvme_show_error("\"%s\" not supported. Install lib uuid and rebuild.",
 				acmd->name);
@@ -98,7 +103,7 @@ static int show_hostnqn_cmd(int argc, char **argv, struct command *acmd, struct 
 
 	hostnqn = libnvmf_read_hostnqn(ctx);
 	if (!hostnqn)
-		hostnqn =  libnvmf_generate_hostnqn();
+		hostnqn =  libnvmf_generate_hostnqn(ctx);
 
 	if (!hostnqn) {
 		nvme_show_error("hostnqn is not available -- use nvme gen-hostnqn");


### PR DESCRIPTION
Three public APIs took no global context:

```c
char *libnvmf_generate_hostid(void);
char *libnvmf_generate_hostnqn_from_hostid(char *hostid);
char *libnvmf_generate_hostnqn(void);
```

Every public API takes a context, whether or not it uses one. These were the only exported functions left without one — I checked the whole library, not just this call path.

Threading the context down has a concrete benefit beyond the rule. The host identifier is read from sysfs, and the chain below these three had no context to pass to `make_sysfs_dir()`, so it called `make_sysfs_dir(NULL, ...)` and got the production path back. `libnvme_set_test_sysfs_dir()` did not apply to `/proc/device-tree/ibm,partition-uuid` or `/sys/firmware/dmi/entries`. The `product_uuid` read did not go through `make_sysfs_dir()` at all — it opened a literal in `fabrics.c`. Since `product_uuid` is the first source tried, that one alone was enough to defeat the sandbox on a typical x86 machine.

With the context in place, a unit test can point host-ID generation at a fixture instead of the machine it runs on. `test-fabrics` now does exactly that: it writes a known UUID into a temporary `test-sysfs-dir` and asserts that `libnvmf_generate_hostid()` returns it, and that `libnvmf_generate_hostnqn()` builds the matching NQN. That test was not expressible before.

The three symbols change signature, so this is an ABI break. Their names are unchanged, so the version scripts need no edit.

Callers updated: `libnvmf_host_get_ids()`, `nvme gen-hostnqn`, `nvme show-hostnqn`, and the `no-fabrics.c` stubs. Verified with the default build, `-Dfabrics=disabled`, the full test suite, valgrind and checkpatch.

Two related items left out of this PR, both smaller and neither an ABI change:

- `libnvmf_read_hostnqn()` and `libnvmf_read_hostid()` take a context but still read the compile-time `SYSCONFDIR "/nvme/hostnqn"` and `.../hostid` literals, so a sandbox does not reach them either. Same call path as this fix.
- `libnvmf_config_load*()` falls back to `SYSCONFDIR "/nvme/nvme-fabrics.conf"` the same way.
