### PR TITLE
ioctl-win: retry skipped log pages with generic passthrough

### DIFF
--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -254,25 +254,39 @@ __shr_public int libnvme_update_block_size(struct libnvme_transport_handle *hdl,
 }
 
 /*
+ * IOCTL_STORAGE_PROTOCOL_COMMAND supports a maximum transfer size of 512 pages.
+ * However, the driver does not correctly enforce this limit and larger
+ * requested transfers may still execute and cause problems.
+ * Enforce a maximum of 512 pages for safety.
+*/
+#define PROTOCOL_COMMAND_MAX_PAGES 512
+
+/*
  * IOCTL_STORAGE_PROTOCOL_COMMAND pass-through implementation used for
  * VU commands and a small subset of other admin and IO commands.
+ * 
+ * If this function is called after the handle's submit_entry() callback has
+ * been called, set entry_called to true and pass the user_data returned by
+ * the previous call to submit_entry().
  */
 static int submit_storage_protocol_command(
 		struct libnvme_transport_handle *hdl,
-		struct libnvme_passthru_cmd *cmd)
+		struct libnvme_passthru_cmd *cmd,
+		bool entry_called, void *user_data)
 {
 	PSTORAGE_PROTOCOL_COMMAND protocol_command = NULL;
 	ULONG buffer_len = 0;
 	ULONG returned_len = 0;
 	BOOL result = FALSE;
 	PUCHAR buffer = NULL;
-	void *user_data = NULL;
 	int err = 0;
 	DWORD last_error = 0;
 	bool is_read = false;
 	bool is_write = false;
 
-	user_data = hdl->submit_entry(hdl, cmd);
+	if (!entry_called)
+		user_data = hdl->submit_entry(hdl, cmd);
+
 	if (hdl->ctx->dry_run)
 		goto out;
 
@@ -282,6 +296,11 @@ static int submit_storage_protocol_command(
 	}
 
 	if (cmd->data_len > 0 && !cmd->addr) {
+		err = -EINVAL;
+		goto out;
+	}
+
+	if (cmd->data_len > PROTOCOL_COMMAND_MAX_PAGES * shr_getpagesize()) {
 		err = -EINVAL;
 		goto out;
 	}
@@ -906,19 +925,6 @@ out:
  * Windows-specific admin command implementations.
  */
 
-static int get_log_page_status(DWORD error)
-{
-	if (!error)
-		return 0;
-
-	/* Translate error codes to NVMe status codes where possible. */
-	if (error == ERROR_INVALID_FUNCTION)
-		return create_nvme_status_code(NVME_SC_INVALID_LOG_PAGE,
-					NVME_SCT_CMD_SPECIFIC, false);
-
-	return -get_errno_from_error(error);
-}
-
 static int submit_admin_get_log_page(struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd)
 {
@@ -1014,7 +1020,20 @@ static int submit_admin_get_log_page(struct libnvme_transport_handle *hdl,
 			break;
 
 		last_error = GetLastError();
-		err = get_log_page_status(last_error);
+		if (last_error == ERROR_INVALID_FUNCTION) {
+			/*
+			 * IOCTL_STORAGE_QUERY_PROPERTY is the preferred path
+			 * for getting log pages, but it blocks logs not listed
+			 * in supported logs, returning ERROR_INVALID_FUNCTION
+			 * without submitting the command to the controller.
+			 * Try IOCTL_STORAGE_PROTOCOL_COMMAND for better parity
+			 * with Linux behavior, which submits the command and
+			 * allows the controller to respond if not supported.
+			 */
+			free(buffer);
+			return submit_storage_protocol_command(hdl, cmd, true, user_data);
+		}
+		err = -get_errno_from_error(last_error);
 	} while (hdl->decide_retry(hdl, cmd, err));
 
 	if (err) {
@@ -1800,7 +1819,7 @@ static int submit_admin_sanitize(
 		 * Default namespace handle not available,
 		 * fall back to IOCTL_STORAGE_PROTOCOL_COMMAND.
 		 */
-		err = submit_storage_protocol_command(hdl, cmd);
+		err = submit_storage_protocol_command(hdl, cmd, false, NULL);
 	}
 
 	return err;
@@ -1965,7 +1984,7 @@ static int submit_admin_format_nvm(struct libnvme_transport_handle *hdl,
 
 	/* For WinPE, use storage protocol command. */
 	if (get_is_win_pe())
-		return submit_storage_protocol_command(hdl, cmd);
+		return submit_storage_protocol_command(hdl, cmd, false, NULL);
 
 	if (!libnvme_transport_handle_is_ns(hdl)) {
 		libnvme_msg(hdl->ctx, LIBNVME_LOG_ERR, "Windows only supports "
@@ -2175,11 +2194,11 @@ __shr_public int libnvme_exec_io_passthru(
 	case nvme_cmd_compare:
 		/* Only supported on WinPE */
 		if (get_is_win_pe())
-			return submit_storage_protocol_command(hdl, cmd);
+			return submit_storage_protocol_command(hdl, cmd, false, NULL);
 		else
 			return -ENOTSUP;
 	case 0x80 ... 0xFF: /* vendor-specific commands */
-		return submit_storage_protocol_command(hdl, cmd);
+		return submit_storage_protocol_command(hdl, cmd, false, NULL);
 	default:
 		libnvme_msg(hdl->ctx, LIBNVME_LOG_DEBUG, "%s: opcode=0x%02x\n",
 			__func__, cmd->opcode);
@@ -2227,7 +2246,7 @@ __shr_public int libnvme_exec_admin_passthru(
 	case nvme_admin_nvme_mi_recv:
 		/* Only supported on WinPE */
 		if (get_is_win_pe())
-			return submit_storage_protocol_command(hdl, cmd);
+			return submit_storage_protocol_command(hdl, cmd, false, NULL);
 		else
 			return -ENOTSUP;
 	case nvme_admin_fw_commit:
@@ -2235,7 +2254,7 @@ __shr_public int libnvme_exec_admin_passthru(
 	case nvme_admin_fw_download:
 		return submit_admin_fw_download(hdl, cmd);
 	case nvme_admin_dev_self_test:
-		return submit_storage_protocol_command(hdl, cmd);
+		return submit_storage_protocol_command(hdl, cmd, false, NULL);
 	case nvme_admin_format_nvm:
 		return submit_admin_format_nvm(hdl, cmd);
 	case nvme_admin_security_send:
@@ -2244,7 +2263,7 @@ __shr_public int libnvme_exec_admin_passthru(
 	case nvme_admin_sanitize_nvm:
 		return submit_admin_sanitize(hdl, cmd);
 	case 0xC0 ... 0xFF: /* vendor-specific commands */
-		return submit_storage_protocol_command(hdl, cmd);
+		return submit_storage_protocol_command(hdl, cmd, false, NULL);
 	default:
 		libnvme_msg(hdl->ctx, LIBNVME_LOG_DEBUG, "%s: opcode=0x%02x\n",
 			__func__, cmd->opcode);

--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -954,8 +954,12 @@ static int submit_admin_get_log_page(struct libnvme_transport_handle *hdl,
 				NVME_LOG_CDW14_CSI_SHIFT,
 				NVME_LOG_CDW14_CSI_MASK);
 	if (csi != NVME_CSI_NVM) {
-		err = -ENOTSUP;
-		goto out;
+		/*
+		 * IOCTL_STORAGE_QUERY_PROPERTY doesn't take a CSI-equivalent
+		 * parameter and only supports NVME_CSI_NVM. For other CSI
+		 * values, fall back to IOCTL_STORAGE_PROTOCOL_COMMAND.
+		 */
+		return submit_storage_protocol_command(hdl, cmd, true, user_data);
 	}
 
 	buffer_len = FIELD_OFFSET(STORAGE_PROPERTY_QUERY, AdditionalParameters) +

--- a/libnvme/src/nvme/nvme-cmds.c
+++ b/libnvme/src/nvme/nvme-cmds.c
@@ -173,7 +173,7 @@ __shr_public int libnvme_get_log_dynamic_chunk(
 		 */
 		if (ret < 0 ||
 		    (ret > 0 &&
-		     (ret >> NVME_SCT_SHIFT) <= NVME_SCT_CMD_SPECIFIC)) {
+		     (nvme_status_code_type(ret) <= NVME_SCT_CMD_SPECIFIC))) {
 			xfer_len = (xfer_len / 2) &
 				   ~(__u32)(NVME_LOG_PAGE_PDU_SIZE - 1);
 			if (xfer_len < NVME_LOG_PAGE_PDU_SIZE)


### PR DESCRIPTION
It was discovered that IOCTL_STORAGE_QUERY_PROPERTY returns ERROR_INVALID_FUNCTION for logs not listed in the supported logs list without ever submitting the command. It was also discovered that IOCTL_STORAGE_PROTOCOL_COMMAND works for getting log pages without this early filtering behavior, although this is not documented.

Microsoft documents IOCTL_STORAGE_QUERY_PROPERTY as the preferred method for getting logs, and it handles large log requests more cleanly. Keep it as the default, but try IOCTL_STORAGE_PROTOCOL_COMMAND if ERROR_INVALID_FUNCTION is returned, allowing the controller to respond. This behavior better matches Linux's passthrough behavior.

* Retries get log page commands that fail with ERROR_INVALID_FUNCTION using generic IOCTL_STORAGE_QUERY_PROPERTY.
* Uses IOCTL_STORAGE_QUERY_PROPERTY for CSI values other than NVM.
* Fixes retry check in libnvme_get_log_dynamic_chunk to better handle NVME statuses.  Error found during testing.