### PR TITLE
libnvme: python: stop freeing tree-owned objects in destructors

### DIFF
--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -1550,7 +1550,7 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 		return h;
 	}
 	~libnvme_host() {
-		libnvme_free_host($self);
+		/* tree-owned, do not free */
 	}
 	struct libnvme_host* __enter__() {
 		return $self;
@@ -1599,7 +1599,7 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 		return s;
 	}
 	~libnvme_subsystem() {
-		libnvme_free_subsystem($self);
+		/* tree-owned, do not free */
 	}
 	struct libnvme_subsystem* __enter__() {
 		return $self;
@@ -1962,7 +1962,7 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 		return libnvme_subsystem_lookup_namespace(s, nsid);
 	}
 	~libnvme_ns() {
-		libnvme_free_ns($self);
+		/* tree-owned, do not free */
 	}
 	struct libnvme_ns* __enter__() {
 		return $self;


### PR DESCRIPTION
The Host, Subsystem and Ns constructors are lookup-or-create. They can return an object the tree already owns, so a Python handle going out of scope frees an object the tree still references. A later tree walk or a second handle to the same object then hits freed memory, which crashes the interpreter (SIGSEGV).

Keep the destructor declarations with an empty body. This may occasionally leave a few orphaned objects that will live until the tree is freed, but it's better than getting a SIGSEGV on a double free.