### PR TITLE
build: compile mdadm from the 4.6 release tag

### DIFF
--- a/.github/workflows/run-nightly-tests.yml
+++ b/.github/workflows/run-nightly-tests.yml
@@ -52,13 +52,16 @@ jobs:
 
             # mdadm has a buffer overflow in v4.3 and was fixed with this commit:
             # https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/?id=7f960c3bd050e76f8bf0a8a0c8fbdcbaa565fc78
-            # The Fedora packages ship v4.3.
-            # We are now compiling and installing mdadm from source with the most
-            # recent known good commit. The v4.4 release does not compile.
+            # The Fedora 44 packages ship v4.3.
+            # We are now compiling and installing mdadm from source using the
+            # mdadm-4.6 release, which includes the fix above.
+            # TODO: once the CI VM base image moves to Fedora 45+ (which ships
+            # mdadm-4.6), drop this block and add mdadm to the dnf install list
+            # above instead.
 
             git clone https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git
             cd mdadm
-            git checkout d764c4829947923142a83251296d04edaee7d2f7
+            git checkout mdadm-4.6
             make -j$(nproc)
             sudo make install
             cd -


### PR DESCRIPTION
The 'Run blktests' job was pinning a post-4.4 development commit of mdadm to get the buffer-overflow fix ahead of a release. That commit predates GCC 16 and fails to build on the current Fedora 44 CI VM with -Werror=unused-but-set-variable.

mdadm-4.6 is now released, includes the buffer-overflow fix, and fixes the GCC 16 warnings. Switch the source build to that tag instead of the dev commit.

Fedora 44 (which the CI VM still runs) ships mdadm-4.3, so installing from the distro repos isn't an option yet; leave a TODO to drop this workaround once the VM base image moves to Fedora 45+.