### PR TITLE
shared/tests: fix improper use of negative row id in test_basic_table

### DIFF
--- a/shared/tests/test-table-util.c
+++ b/shared/tests/test-table-util.c
@@ -44,6 +44,10 @@ static bool test_basic_table(void)
 
 	row = shr_table_get_row_id(t);
 	pass &= check_bool("row id is non-negative", row >= 0);
+	if (row < 0) {
+		shr_table_free(t);
+		return pass;
+	}
 	pass &= check_bool("set string value succeeds",
 			    shr_table_set_value_str(t, 0, row, "widgets", LEFT) == 0);
 	pass &= check_bool("set int value succeeds",


### PR DESCRIPTION
test_basic_table() calls shr_table_get_row_id() and records whether the returned row is non-negative, but does not guard the code that follows. shr_table_get_row_id() can return -ENOMEM when either of its internal allocations fails.

A negative row is then passed as an array index to shr_table_set_value_str(), shr_table_set_value_int(), and shr_table_add_row(), all of which use it to dereference the rows array. This results in undefined behaviour.

Return early after the failed check, freeing the table to avoid a resource leak, so that the negative row is never used as an array index.