### PR TITLE
shared: fix missing negative-return check in test_invalid_format_type

### DIFF
--- a/shared/tests/test-table-util.c
+++ b/shared/tests/test-table-util.c
@@ -334,6 +334,9 @@ static bool test_invalid_format_type(void)
 		return pass;
 
 	row = shr_table_get_row_id(t);
+	pass &= check_bool("row id is non-negative", row >= 0);
+	if (row < 0)
+		return pass;
 	shr_table_set_value_int(t, 0, row, 0, CENTERED);
 	shr_table_set_value_int(t, 1, row, 0, RIGHT);
 	/* Force an out-of-range format type to exercise the defensive


### PR DESCRIPTION
The test_invalid_format_type() function calls shr_table_get_row_id() to allocate a new table row and stores the result in row. The return value was never checked before row was used as an array index and passed to shr_table_set_value_int().

If shr_table_get_row_id() fails and returns -ENOMEM, the subsequent use of row as a negative array index results in an out-of-bounds memory access and undefined behavior.

Guard the result with a check_bool() assertion and return early if row is negative, matching the pattern already used in every other test function in the file.