### PR TITLE
tests: fix improper use of negative return value in test_shr_table_print()

### DIFF
--- a/shared/tests/test-table-util.c
+++ b/shared/tests/test-table-util.c
@@ -382,6 +382,9 @@ static bool test_shr_table_print(void)
 		return pass;
 
 	row = shr_table_get_row_id(t);
+	pass &= check_bool("row id is non-negative", row >= 0);
+	if (row < 0)
+		return pass;
 	shr_table_set_value_str(t, 0, row, "stdout-target", LEFT);
 	shr_table_add_row(t, row);
 


### PR DESCRIPTION
shr_table_get_row_id() allocates a new row in the table and returns its index on success, or a negative error code (-ENOMEM) on failure. In test_shr_table_print() the return value of row was used directly in shr_table_set_value_str() and shr_table_add_row() without first checking whether the allocation succeeded.

Passing a negative row to these functions results in an out-of-bounds array access and undefined behavior.

Add the same non-negative guard already present in the other test functions: record the check via check_bool() and return early if row is negative.