### PR TITLE
shared: fix improper use of negative row id in test_multi_type_and_centered

### DIFF
--- a/shared/tests/test-table-util.c
+++ b/shared/tests/test-table-util.c
@@ -258,6 +258,8 @@ static bool test_multi_type_and_centered(void)
 	/* Row A: every value centered, exercising every value type. */
 	ra = shr_table_get_row_id(t);
 	pass &= check_bool("row A id is non-negative", ra >= 0);
+	if (ra < 0)
+		return pass;
 	shr_table_set_value_str(t, 0, ra, "abc", CENTERED);
 	shr_table_set_value_int(t, 1, ra, -5, CENTERED);
 	shr_table_set_value_unsigned(t, 2, ra, 7, CENTERED);
@@ -270,6 +272,8 @@ static bool test_multi_type_and_centered(void)
 	/* Row B: mix of left/right alignment, same set of types. */
 	rb = shr_table_get_row_id(t);
 	pass &= check_bool("row B id is non-negative", rb >= 0);
+	if (rb < 0)
+		return pass;
 	shr_table_set_value_str(t, 0, rb, "xyz", LEFT);
 	shr_table_set_value_int(t, 1, rb, 42, RIGHT);
 	shr_table_set_value_unsigned(t, 2, rb, 3, LEFT);


### PR DESCRIPTION
shr_table_get_row_id() can return a negative error code on allocation failure. The test records the check result but does not bail out, so ra and rb are passed directly to shr_table_set_value_str() and the other set_value helpers.

Those helpers guard with a signed comparison against num_rows, which a negative ra or rb passes. The negative value is then used as an array index into t->rows[], resulting in an out-of-bounds access and undefined behavior.

Return early when ra or rb is negative so the set_value calls are only reached with a valid row id.