### PR TITLE
fw: fix improper value passed to libnvme_strerror in fw_commit_support_mud

### DIFF
--- a/plugins/fw/fw-plugin.c
+++ b/plugins/fw/fw-plugin.c
@@ -330,7 +330,8 @@ static bool fw_commit_support_mud(struct libnvme_transport_handle *hdl)
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 
 	if (err)
-		nvme_show_error("identify-ctrl: %s", libnvme_strerror(err));
+		nvme_show_error("identify-ctrl: %s",
+				libnvme_strerror(err < 0 ? -err : err));
 	else if (ctrl->frmw >> 5 & 0x1)
 		return true;
 


### PR DESCRIPTION
The fw_commit_support_mud() function calls libnvme_exec_admin_passthru() and stores the result in err. libnvme_exec_admin_passthru() returns either a positive NVMe status code when the device responds with a command error, or a negative errno when a system or transport error occurs. The raw err value was passed directly to libnvme_strerror().

libnvme_strerror() routes values below ENVME_CONNECT_RESOLVE (1000) to strerror(), which requires a positive errno. A negative err causes strerror() to receive an out-of-range index, producing a wrong or undefined error string. Negating err unconditionally would break the positive NVMe status code path, routing it into strerror() instead of libnvme_errno_to_string().

Pass err < 0 ? -err : err to libnvme_strerror() so that negative errno values are correctly converted to positive before the strerror() call, while positive NVMe status codes are passed through unchanged.