### PR TITLE
nvme: fix improper value passed to libnvme_strerror in identify_ctrl

### DIFF
--- a/src/nvme-cmds-sanitize.c
+++ b/src/nvme-cmds-sanitize.c
@@ -423,7 +423,7 @@ struct nvme_id_ctrl *identify_ctrl(struct libnvme_transport_handle *hdl)
 	nvme_init_identify_ctrl(&cmd, ctrl);
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
-		nvme_show_error("identify-ctrl: %s", libnvme_strerror(err));
+		nvme_show_err(err, "identify-ctrl");
 		libnvme_free(ctrl);
 		return NULL;
 	}
@@ -833,8 +833,8 @@ static int format_cmd(int argc, char **argv, struct command *acmd, struct plugin
 	nvme_init_identify_ctrl(&cmd, ctrl);
 	err = libnvme_exec_admin_passthru(hdl, &cmd);
 	if (err) {
-		nvme_show_error("identify-ctrl: %s", libnvme_strerror(err));
-		return -errno;
+		nvme_show_err(err, "identify-ctrl");
+		return err;
 	}
 
 	if (ctrl->fna & NVME_CTRL_FNA_FMT_ALL_NAMESPACES) {


### PR DESCRIPTION
The identify_ctrl() function calls libnvme_exec_admin_passthru() and stores the result in err. libnvme_exec_admin_passthru() returns either a positive NVMe status code when the device responds with a command error, or a negative errno when a system or transport error occurs. The raw err value was passed directly to libnvme_strerror().

libnvme_strerror() routes values below ENVME_CONNECT_RESOLVE (1000) to strerror(), which requires a positive errno. A negative err causes strerror() to receive an out-of-range index, producing a wrong or undefined error string. Negating err unconditionally would break the positive NVMe status code path, routing it into strerror() instead of libnvme_errno_to_string().

Pass err < 0 ? -err : err to libnvme_strerror() so that negative errno values are correctly converted to positive before the strerror() call, while positive NVMe status codes are passed through unchanged.