### PR TITLE
libnvme: carry the fabrics context credentials into the controller

### DIFF
--- a/libnvme/libnvme3/meson.build
+++ b/libnvme/libnvme3/meson.build
@@ -99,6 +99,7 @@ if want_python
         [ 'registry', [ files('tests/test-registry.py'), ] ],
         [ 'config', [ files('tests/test-config.py'), ] ],
         [ 'setattr-guards', [ files('tests/test-setattr.py'), ] ],
+        [ 'ctrl-crypto', [ files('tests/test-ctrl-crypto.py'), ] ],
     ]
     foreach test: py_tests
         description = test[0]

--- a/libnvme/libnvme3/tests/test-ctrl-crypto.py
+++ b/libnvme/libnvme3/tests/test-ctrl-crypto.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# This file is part of libnvme.
+"""Tests that the crypto keys given to Ctrl() land on the controller.
+
+Regression: libnvmf_create_ctrl() forwarded only ctrl_params, so 'keyring',
+'tls_key', 'tls_key_identity', 'hostkey' and 'ctrlkey' were accepted by the
+constructor, stored on the fabrics context, and then silently dropped -- the
+connect went out without a key and failed with ENOKEY.
+"""
+
+import unittest
+from libnvme3 import nvme
+
+
+class TestCtrlCrypto(unittest.TestCase):
+
+    def setUp(self):
+        self.ctx = nvme.GlobalCtx()
+        (hostnqn, hostid) = nvme.host_get_ids(self.ctx)
+        self.ctx.hostnqn = hostnqn
+        self.ctx.hostid = hostid
+        self.ctrl = nvme.Ctrl(self.ctx, {
+            'subsysnqn': 'nqn.2014-08.org.nvmexpress:uuid:subsys',
+            'transport': 'tcp',
+            'traddr': '192.168.1.100',
+            'trsvcid': '4420',
+            'tls': True,
+            'hostkey': 'hostkey',
+            'ctrlkey': 'ctrlkey',
+            'keyring': '.nvme',
+            'tls_key': 'tlskey',
+            'tls_key_identity': 'identity',
+        })
+
+    def test_tls_key(self):
+        """'tls_key' must reach the controller."""
+        self.assertEqual(self.ctrl.tls_key, 'tlskey')
+
+    def test_tls_key_identity(self):
+        """'tls_key_identity' must reach the controller."""
+        self.assertEqual(self.ctrl.tls_key_identity, 'identity')
+
+    def test_keyring(self):
+        """'keyring' must reach the controller."""
+        self.assertEqual(self.ctrl.keyring, '.nvme')
+
+    def test_kxchap_keys(self):
+        """'hostkey' and 'ctrlkey' must reach the controller."""
+        self.assertEqual(self.ctrl.kxchap_host_key, 'hostkey')
+        self.assertEqual(self.ctrl.kxchap_ctrl_key, 'ctrlkey')
+
+    def test_unset_keys_stay_unset(self):
+        """A controller built without keys must not grow any."""
+        ctrl = nvme.Ctrl(self.ctx, {
+            'subsysnqn': 'nqn.2014-08.org.nvmexpress:uuid:subsys',
+            'transport': 'tcp',
+            'traddr': '192.168.1.100',
+            'trsvcid': '4420',
+        })
+        self.assertIsNone(ctrl.tls_key)
+        self.assertIsNone(ctrl.tls_key_identity)
+        self.assertIsNone(ctrl.keyring)
+        self.assertIsNone(ctrl.kxchap_host_key)
+        self.assertIsNone(ctrl.kxchap_ctrl_key)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1634,10 +1634,63 @@ static int __nvmf_add_ctrl(struct libnvme_global_ctx *ctx, const char *argstr)
 }
 
 
+static void nvme_parse_tls_args(const char *keyring, const char *tls_key,
+				const char *tls_key_identity,
+				struct libnvme_fabrics_config *cfg, struct libnvme_ctrl *c)
+{
+	if (keyring) {
+		char *endptr;
+		long id = strtol(keyring, &endptr, 0);
+
+		if (endptr != keyring)
+			cfg->keyring_id = id;
+		else
+			libnvme_ctrl_set_keyring(c, keyring);
+	}
+
+	if (tls_key_identity)
+		libnvme_ctrl_set_tls_key_identity(c, tls_key_identity);
+
+	if (tls_key) {
+		char *endptr;
+		long id = strtol(tls_key, &endptr, 0);
+
+		if (endptr != tls_key)
+			cfg->tls_key_id = id;
+		else
+			libnvme_ctrl_set_tls_key(c, tls_key);
+	}
+}
+
 __shr_public int libnvmf_create_ctrl(struct libnvme_global_ctx *ctx,
 		struct libnvmf_context *fctx, struct libnvme_ctrl **cp)
 {
-	return libnvme_create_ctrl(ctx, &fctx->ctrl_params, cp);
+	struct libnvme_ctrl *c;
+	int ret;
+
+	ret = libnvme_create_ctrl(ctx, &fctx->ctrl_params, &c);
+	if (ret)
+		return ret;
+
+	/*
+	 * The credentials live on @fctx next to, not inside, ctrl_params,
+	 * so libnvme_create_ctrl() cannot carry them over. Apply them here
+	 * or a controller created from a context that has them would
+	 * silently connect without.
+	 */
+	if (fctx->hostkey) {
+		libnvme_ctrl_set_kxchap_host_key(c, fctx->hostkey);
+		if (fctx->ctrlkey)
+			libnvme_ctrl_set_kxchap_ctrl_key(c, fctx->ctrlkey);
+	}
+
+	nvme_parse_tls_args(fctx->keyring, fctx->tls_key,
+		fctx->tls_key_identity, &fctx->ctrl_params.cfg, c);
+	update_config(c, &fctx->ctrl_params.cfg);
+
+	*cp = c;
+
+	return 0;
 }
 
 __shr_public int libnvmf_add_ctrl(struct libnvme_host *h, struct libnvme_ctrl *c)
@@ -2679,34 +2732,6 @@ static int set_discovery_kato(struct libnvmf_context *fctx,
 		params->cfg.keep_alive_tmo = 0;
 
 	return tmo;
-}
-
-static void nvme_parse_tls_args(const char *keyring, const char *tls_key,
-				const char *tls_key_identity,
-				struct libnvme_fabrics_config *cfg, struct libnvme_ctrl *c)
-{
-	if (keyring) {
-		char *endptr;
-		long id = strtol(keyring, &endptr, 0);
-
-		if (endptr != keyring)
-			cfg->keyring_id = id;
-		else
-			libnvme_ctrl_set_keyring(c, keyring);
-	}
-
-	if (tls_key_identity)
-		libnvme_ctrl_set_tls_key_identity(c, tls_key_identity);
-
-	if (tls_key) {
-		char *endptr;
-		long id = strtol(tls_key, &endptr, 0);
-
-		if (endptr != tls_key)
-			cfg->tls_key_id = id;
-		else
-			libnvme_ctrl_set_tls_key(c, tls_key);
-	}
 }
 
 enum dc_ownership {
@@ -4062,19 +4087,9 @@ __shr_public int libnvmf_connect(
 		return -ENVME_CONNECT_ALREADY;
 	}
 
-	err = libnvme_create_ctrl(ctx, &fctx->ctrl_params, &c);
+	err = libnvmf_create_ctrl(ctx, fctx, &c);
 	if (err)
 		return err;
-
-	if (fctx->hostkey) {
-		libnvme_ctrl_set_kxchap_host_key(c, fctx->hostkey);
-		if (fctx->ctrlkey)
-			libnvme_ctrl_set_kxchap_ctrl_key(c, fctx->ctrlkey);
-	}
-
-	nvme_parse_tls_args(fctx->keyring, fctx->tls_key,
-		fctx->tls_key_identity, &fctx->ctrl_params.cfg, c);
-	update_config(c, &fctx->ctrl_params.cfg);
 
 	/*
 	 * We are connecting to a discovery controller, so let's treat

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -646,6 +646,9 @@ int libnvmf_discover_nbft(struct libnvme_global_ctx *ctx,
  * @c:			&struct libnvme_ctrl object to return
  *
  * Creates an unconnected controller to be used for libnvme_add_ctrl().
+ * The controller carries over @fctx's connection parameters together with
+ * its authentication and transport encryption settings (kxchap keys,
+ * keyring, TLS key and TLS key identity).
  *
  * Return: 0 on success, negative error code otherwise.
  */

--- a/libnvme/tests/test-fabrics.c
+++ b/libnvme/tests/test-fabrics.c
@@ -715,6 +715,99 @@ static bool test_dc_decide(struct libnvme_global_ctx *ctx)
 }
 
 /* -------------------------------------------------------------------------
+ * libnvmf_create_ctrl — the credentials on the fabrics context live next to
+ * ctrl_params, not inside it.  Regression: the function forwarded only
+ * ctrl_params, so a controller built from a context carrying a keyring, TLS
+ * key or kxchap secret came out without any of them and the connect failed
+ * with ENOKEY.
+ * -------------------------------------------------------------------------
+ */
+static bool test_create_ctrl_credentials(struct libnvme_global_ctx *ctx)
+{
+	struct libnvmf_context fctx = { .ctx = ctx };
+	struct libnvme_ctrl *c = NULL;
+	const char *val;
+	bool pass = true, p;
+	int ret;
+
+	printf("\ntest_create_ctrl_credentials:\n");
+
+	fctx.ctrl_params.subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:subsys";
+	fctx.ctrl_params.transport = "tcp";
+	fctx.ctrl_params.traddr = "192.168.1.100";
+	fctx.ctrl_params.cfg.tls = true;
+
+	/* Named keyring and key: they end up as strings on the ctrl. */
+	fctx.hostkey = "hostkey";
+	fctx.ctrlkey = "ctrlkey";
+	fctx.keyring = ".nvme";
+	fctx.tls_key = "tlskey";
+	fctx.tls_key_identity = "identity";
+
+	ret = libnvmf_create_ctrl(ctx, &fctx, &c);
+	p = ret == 0 && c;
+	CHECK(p, "create with named keys: ret=%d", ret);
+	pass &= p;
+	if (!p)
+		return pass;
+
+	p = libnvme_ctrl_get_kxchap_host_key(c, &val, NULL) == 0 &&
+		!strcmp(val, "hostkey");
+	CHECK(p, "kxchap host key carried over");
+	pass &= p;
+
+	p = libnvme_ctrl_get_kxchap_ctrl_key(c, &val, NULL) == 0 &&
+		!strcmp(val, "ctrlkey");
+	CHECK(p, "kxchap ctrl key carried over");
+	pass &= p;
+
+	p = libnvme_ctrl_get_keyring(c, &val, NULL) == 0 &&
+		!strcmp(val, ".nvme");
+	CHECK(p, "keyring carried over");
+	pass &= p;
+
+	val = libnvme_ctrl_get_tls_key(c);
+	p = val && !strcmp(val, "tlskey");
+	CHECK(p, "tls key carried over");
+	pass &= p;
+
+	val = libnvme_ctrl_get_tls_key_identity(c);
+	p = val && !strcmp(val, "identity");
+	CHECK(p, "tls key identity carried over");
+	pass &= p;
+
+	p = c->cfg.tls;
+	CHECK(p, "fabrics config still carried over");
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	/* Numeric keyring and key: they end up as serials in the config. */
+	c = NULL;
+	fctx.keyring = "0x2a";
+	fctx.tls_key = "42";
+
+	ret = libnvmf_create_ctrl(ctx, &fctx, &c);
+	p = ret == 0 && c;
+	CHECK(p, "create with numeric keys: ret=%d", ret);
+	pass &= p;
+	if (!p)
+		return pass;
+
+	p = c->cfg.keyring_id == 0x2a;
+	CHECK(p, "keyring serial carried over: %ld", c->cfg.keyring_id);
+	pass &= p;
+
+	p = c->cfg.tls_key_id == 42;
+	CHECK(p, "tls key serial carried over: %ld", c->cfg.tls_key_id);
+	pass &= p;
+
+	libnvme_free_ctrl(c);
+
+	return pass;
+}
+
+/* -------------------------------------------------------------------------
  * libnvmf_generate_hostid — the machine identifier comes from sysfs, so a
  * test sandbox must be able to redirect it.  Regression: the generators took
  * no context and always read the real machine.
@@ -819,6 +912,7 @@ int main(int argc, char *argv[])
 	test_nvmf_sanitize_addrs(ctx);
 	test_unescape_uri();
 	test_dc_decide(ctx);
+	test_create_ctrl_credentials(ctx);
 	test_generate_hostid(ctx);
 
 	libnvme_free_global_ctx(ctx);


### PR DESCRIPTION
## What

`libnvmf_create_ctrl()` forwards only `fctx->ctrl_params` to
`libnvme_create_ctrl()`. The authentication and transport encryption settings
live on `struct libnvmf_context` *next to* `ctrl_params`, not inside it:

```c
	/* NVMe controller parameters */
	struct libnvme_ctrl_params ctrl_params;
	...
	/* authentication and transport encryption configuration */
	const char *hostkey;
	const char *ctrlkey;
	const char *keyring;
	char *tls_key;
	const char *tls_key_identity;
```

so a controller created from a context that carries any of them comes out with
none of them. `build_options()` then emits an argstr ending in `,tls` with no
key at all and the connect fails with `ENOKEY`:

```
connect ctrl, 'nqn=…,ctrl_loss_tmo=600,tls'
Failed to write to /dev/nvme-fabrics: Required key not available
```

`libnvmf_connect()` never hit this: it called `libnvme_create_ctrl()` itself
and applied the credentials in its own body afterwards. Everything that goes
through the public helper did — including the libnvme3 Python bindings, whose
`nvme.Ctrl()` constructor accepts `hostkey`, `ctrlkey`, `keyring`, `tls_key`
and `tls_key_identity`, stores them on the fabrics context via
`libnvmf_context_set_crypto()`, and then loses them again.

Reported by @martin-belanger while reviewing
[nvme-stas#500](https://github.com/linux-nvme/nvme-stas/pull/500#issuecomment-5443118566),
where nvme-stas had to work around it by setting the keys on the `nvme.Ctrl`
object after construction.

## The change

The credential handling moves into `libnvmf_create_ctrl()`, so the function
returns a controller that reflects the whole context rather than half of it,
and `libnvmf_connect()` calls it instead of repeating the sequence.
`nvme_parse_tls_args()` moves up unchanged to be visible from there. No
behaviour change for `libnvmf_connect()`; `examples/discover-loop.c` and the
Python bindings get the credentials they were already asking for.

## Tests

Two regression tests, both of which fail without the fix:

- `libnvme/tests/test-fabrics.c` — `test_create_ctrl_credentials()`: named keys
  land on the controller as strings, numeric ones land in `cfg.keyring_id` /
  `cfg.tls_key_id`, and the fabrics config still comes across.
- `libnvme/libnvme3/tests/test-ctrl-crypto.py` — the reported symptom at the
  binding level: keys handed to `nvme.Ctrl()` must be readable back off the
  controller, and a controller built without keys must not grow any.

`meson test`: 115 ok, 0 fail (python bindings enabled).

## End-to-end

Patched and unpatched builds side by side against a NetApp ONTAP 9.19.1
subsystem over NVMe/TCP with TLS 1.3 (kernel 7.1.8), connecting the way
nvme-stas does — credentials in the `nvme.Ctrl()` dict — with the `.nvme`
keyring emptied first so the dict is the only source of the PSK:

| | argstr | result |
|---|---|---|
| before | `…,ctrl_loss_tmo=600,tls` | `Required key not available` |
| after | `…,keyring=0x1c398c1a,tls_key=0x0fadb176,tls` | controller `live` |

A 512 KiB write/read round-trip over the TLS path compares identical. Passing
`tls_key_identity` as well also works and reuses the retained key rather than
re-importing it (key serial unchanged).

Note that two things mask the bug on a normal host, in case this looks
untriggerable: `libnvmf_add_ctrl()` copies the keys over from a sibling
controller on the same subsystem, and the kernel resolves a pre-provisioned
PSK by identity on its own. It shows up on the first connection to a subsystem
whose PSK has not been provisioned into the keyring by other means.
