### PR TITLE
nvme: make --quiet suppress informational output

### DIFF
--- a/src/args.h
+++ b/src/args.h
@@ -59,7 +59,7 @@ enum nvme_print_flags {
 		OPT_INCR("verbose",      'v', &nvme_args.verbose,                      \
                          "Increase output verbosity"),                                 \
 		OPT_FLAG("quiet",        0, &nvme_args.quiet,                          \
-                         "suppress output messages, overwrites verbose mode"),         \
+			 "suppress informational output"),                             \
 		OPT_FMT("output-format", 'o', &nvme_args.output_format, of_desc),      \
 		OPT_UINT("timeout",        0, &nvme_args.timeout,                      \
                          "timeout value, in milliseconds"),                            \

--- a/src/fabrics.c
+++ b/src/fabrics.c
@@ -775,8 +775,9 @@ static int check_ctrl_owner(struct libnvme_global_ctx *ctx,
 	if (owner && streq(reg_owner, owner))
 		return 0;
 
-	nvme_show_error("owned by '%s'; skipping -- owner handles discovery",
-			 reg_owner);
+	nvme_show_message(false,
+			  "owned by '%s'; skipping -- owner handles discovery",
+			  reg_owner);
 	return 1;
 }
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -32,6 +32,7 @@ bool is_printable_at_level(int level)
 
 int map_log_level(int verbose, bool quiet)
 {
+	// quiet cancels -v but never goes below ERR
 	if (quiet)
 		return LIBNVME_LOG_ERR;
 

--- a/src/nvme-print.c
+++ b/src/nvme-print.c
@@ -1767,6 +1767,9 @@ static void show_message(bool error, const char *msg, va_list ap)
 {
 	struct print_ops *ops = nvme_print_ops(NORMAL);
 
+	if (nvme_args.quiet && !error)
+		return;
+
 	if (nvme_is_output_format_json())
 		ops = nvme_print_ops(JSON);
 


### PR DESCRIPTION
--quiet had no effect. map_log_level() returned LIBNVME_LOG_ERR for it, the same level verbose == 0 already returns, and show_message() never consulted nvme_args.quiet.

nvmf-connect@.service passes --quiet on every udev-triggered connect-all. However, connect-all --quiet would log a "skip connect" message for every Discovery Log Page change AEN. That skip is the designed outcome, not an error, so it now uses nvme_show_message().

Errors still print under --quiet.