### PR TITLE
libnvme: leave registry ownership alone on a reused connection

### DIFF
--- a/Documentation/nvme-connect-all.txt
+++ b/Documentation/nvme-connect-all.txt
@@ -104,6 +104,10 @@ OPTIONS
 	ownership registry, so other orchestrators (and nvme-disconnect-all)
 	leave them alone.  See nvme-disconnect-all(1).  When --nbft is also
 	given, --owner takes precedence over its default owner of 'nbft'.
+	An empty NAME (--owner=) removes the registry entries instead,
+	leaving the controllers unowned.
+	Without --owner, a controller that was already connected keeps
+	the entry it has.
 
 include::fabrics-options.txt[]
 

--- a/Documentation/nvme-connect.txt
+++ b/Documentation/nvme-connect.txt
@@ -49,6 +49,10 @@ OPTIONS
 	Record NAME as the owner of the connected controller in the NVMe
 	ownership registry, so other orchestrators (and nvme-disconnect-all)
 	leave it alone.  See nvme-disconnect-all(1).
+	An empty NAME (--owner=) removes the registry entry instead,
+	leaving the controller unowned.
+	Without --owner, a controller that was already connected keeps
+	the entry it has.
 
 include::fabrics-options.txt[]
 

--- a/libnvme/design/REGISTRY.md
+++ b/libnvme/design/REGISTRY.md
@@ -57,7 +57,17 @@ struct libnvme_global_ctx *ctx = libnvme_create_global_ctx(...);
 libnvme_set_owner(ctx, "stas");   /* registers owner=stas on every connect */
 ```
 
-A process that does not call `libnvme_set_owner()` produces **unowned** connections. On connect, libnvme writes the entry when an owner is set — stamping it with the current `/sys/kernel/uevent_seqnum` (used by the cleanup rule below) — and clears any stale entry for a recycled instance number when it is not.
+A process that does not call `libnvme_set_owner()` produces **unowned** connections.
+
+What a connect does to the entry depends on the owner and on whether the kernel just created the controller:
+
+| owner | new controller | already connected |
+|---|---|---|
+| a name | write the entry, overwriting any existing one | write the entry (an explicit claim) |
+| never set | clear the entry | leave the entry alone |
+| set to `""` | clear the entry | clear the entry (an explicit disown) |
+
+A new controller is cleared because it cannot legitimately be owned by anybody: the entry can only be what a recycled instance number left behind. An already-connected controller may belong to another orchestrator, so an unstated intent must not touch it. Written entries are stamped with the current `/sys/kernel/uevent_seqnum` (used by the cleanup rule below).
 
 From the CLI, pass `--owner NAME` to register ownership at connect time:
 
@@ -67,9 +77,12 @@ nvme discover    --owner discoverd ...
 nvme connect-all --owner discoverd ...
 nvme connect-all --nbft                 # NBFT controllers, owner=nbft
 nvme connect-all --owner boot --nbft    # NBFT controllers, owner=boot (overrides nbft)
+nvme connect     --owner= ...           # explicitly disown
 ```
 
-`nvme connect-all --nbft` records `owner=nbft` automatically to protect firmware boot volumes. That `nbft` is only a default, though: an explicit `--owner NAME` given alongside `--nbft` overrides it, so `nvme connect-all --owner NAME --nbft` records the controllers as `NAME`. A plain `--nbft` (no `--owner`) keeps `owner=nbft`, which is what lets existing boot scripts get ownership for free without being changed. Without `--owner` and without `--nbft`, connections are unowned.
+`nvme connect-all --nbft` records `owner=nbft` automatically to protect firmware boot volumes. That `nbft` is only a default, though: an explicit `--owner NAME` given alongside `--nbft` overrides it, so `nvme connect-all --owner NAME --nbft` records the controllers as `NAME`. A plain `--nbft` (no `--owner`) keeps `owner=nbft`, which is what lets existing boot scripts get ownership for free without being changed. Without `--owner` and without `--nbft`, new connections are unowned and an already-connected controller keeps whatever entry it has.
+
+An empty `--owner=` is the explicit disown, and it beats the `--nbft` default: `nvme connect-all --owner= --nbft` leaves the controllers unowned.
 
 ## Automatic cleanup
 

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1546,21 +1546,59 @@ static int ctrl_instance(struct libnvme_ctrl *c)
 	return instance;
 }
 
+enum registry_action {
+	REG_NONE,	/* leave the entry alone */
+	REG_CLAIM,	/* record @owner, overwriting any entry */
+	REG_CLEAR,	/* delete the entry */
+};
+
 /*
- * Best-effort registry update after a successful connect: record ownership
- * when an owner is set, otherwise clear any stale entry for a recycled
- * instance.  Failures are logged but never fail the connection.
+ * Decide what a successful connect does to the registry entry. Pure
+ * function, no I/O, so it is directly unit-testable.
+ *
+ * @owner: ctx->owner. NULL means --owner was never given, "" means an
+ *         explicit disown, and a name means a claim.
+ * @fresh: whether the kernel just created this controller for us. A
+ *         controller that already existed may belong to another
+ *         orchestrator, so an unstated intent must not touch its entry.
+ *         A fresh one cannot legitimately be owned by anybody, so its
+ *         entry is cleared to drop what a recycled instance number left
+ *         behind.
+ */
+static enum registry_action registry_action_on_connect(const char *owner,
+						       bool fresh)
+{
+	if (owner && *owner)
+		return REG_CLAIM;
+
+	if (fresh || owner)
+		return REG_CLEAR;
+
+	return REG_NONE;
+}
+
+/*
+ * Best-effort registry update after a successful connect. Failures are
+ * logged but never fail the connection.
  */
 static void registry_update_on_connect(struct libnvme_global_ctx *ctx,
-				       int instance)
+				       int instance, bool fresh)
 {
 	int ret;
 
-	if (ctx->owner)
+	switch (registry_action_on_connect(ctx->owner, fresh)) {
+	case REG_CLAIM:
 		ret = libnvmf_registry_create_instance(ctx, instance,
 						       ctx->owner);
-	else
+		break;
+	case REG_CLEAR:
 		ret = libnvmf_registry_delete_instance(ctx, instance);
+		break;
+	case REG_NONE:
+	default:
+		return;
+	}
+
 	if (ret)
 		libnvme_msg(ctx, LIBNVME_LOG_WARN,
 			    "nvme%d: registry update failed: %s\n",
@@ -1624,7 +1662,7 @@ static int __nvmf_add_ctrl(struct libnvme_global_ctx *ctx, const char *argstr)
 		if (!*p)
 			continue;
 		if (sscanf(p, "instance=%d", &instance) == 1) {
-			registry_update_on_connect(ctx, instance);
+			registry_update_on_connect(ctx, instance, true);
 			return instance;
 		}
 	}
@@ -4076,7 +4114,7 @@ __shr_public int libnvmf_connect(
 
 		write_devid_file(fctx, devid_fd, c);
 		if (instance >= 0)
-			registry_update_on_connect(ctx, instance);
+			registry_update_on_connect(ctx, instance, false);
 		if (fctx->hooks.already_connected)
 			fctx->hooks.already_connected(fctx, h,
 				libnvme_ctrl_get_subsysnqn(c),
@@ -4119,7 +4157,7 @@ __shr_public int libnvmf_connect(
 					write_devid_file(fctx, devid_fd, winner);
 					if (instance >= 0)
 						registry_update_on_connect(ctx,
-							instance);
+							instance, false);
 				}
 			}
 

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -414,7 +414,12 @@ struct libnvme_fabric_options { // !generate-accessors
 };
 
 struct libnvme_global_ctx { // !generate-accessors:read=none,write=none,prefix=libnvme !generate-python:alias=GlobalCtx
-	char *owner; /* orchestrator identity; NULL = unowned */
+	/*
+	 * Orchestrator identity. Tri-state: NULL means --owner was never
+	 * given, "" means an explicit disown, and a name means a claim.
+	 * On a reuse the NULL case leaves the registry entry alone.
+	 */
+	char *owner;
 	struct list_head endpoints; /* MI endpoints */
 	struct list_head hosts;
 	struct libnvme_log log;

--- a/libnvme/tests/test-fabrics.c
+++ b/libnvme/tests/test-fabrics.c
@@ -715,6 +715,53 @@ static bool test_dc_decide(struct libnvme_global_ctx *ctx)
 }
 
 /* -------------------------------------------------------------------------
+ * registry_action_on_connect — what a successful connect does to the
+ * registry entry
+ * -------------------------------------------------------------------------
+ */
+static bool test_registry_action_on_connect(void)
+{
+	bool pass = true, p;
+	enum registry_action a;
+
+	printf("\ntest_registry_action_on_connect:\n");
+
+	a = registry_action_on_connect("stas", true);
+	p = a == REG_CLAIM;
+	CHECK(p, "owner=\"stas\", fresh: action=%d", a);
+	pass &= p;
+
+	/* A fresh instance number may carry a stale entry; drop it. */
+	a = registry_action_on_connect(NULL, true);
+	p = a == REG_CLEAR;
+	CHECK(p, "owner=NULL, fresh: action=%d", a);
+	pass &= p;
+
+	a = registry_action_on_connect("", true);
+	p = a == REG_CLEAR;
+	CHECK(p, "owner=\"\", fresh: action=%d", a);
+	pass &= p;
+
+	a = registry_action_on_connect("stas", false);
+	p = a == REG_CLAIM;
+	CHECK(p, "owner=\"stas\", reuse: action=%d", a);
+	pass &= p;
+
+	a = registry_action_on_connect("", false);
+	p = a == REG_CLEAR;
+	CHECK(p, "owner=\"\", reuse: action=%d", a);
+	pass &= p;
+
+	/* No intent stated on a controller we did not create: don't touch. */
+	a = registry_action_on_connect(NULL, false);
+	p = a == REG_NONE;
+	CHECK(p, "owner=NULL, reuse: action=%d", a);
+	pass &= p;
+
+	return pass;
+}
+
+/* -------------------------------------------------------------------------
  * libnvmf_create_ctrl — the credentials on the fabrics context live next to
  * ctrl_params, not inside it.  Regression: the function forwarded only
  * ctrl_params, so a controller built from a context carrying a keyring, TLS
@@ -912,6 +959,7 @@ int main(int argc, char *argv[])
 	test_nvmf_sanitize_addrs(ctx);
 	test_unescape_uri();
 	test_dc_decide(ctx);
+	test_registry_action_on_connect();
 	test_create_ctrl_credentials(ctx);
 	test_generate_hostid(ctx);
 

--- a/tests/cli/nvme_fabrics_mock_test.py
+++ b/tests/cli/nvme_fabrics_mock_test.py
@@ -87,6 +87,10 @@ class FabricsMockIPCServer(MockIPCServer):
         # Test-specific state overrides, steered from Python tests.
         self.connect_errno = 0
         self.ioctl_errno = 0
+        # Off by default: the mock hands out a fresh instance for every
+        # connect. Turn it on to make a repeat connect fail with EALREADY
+        # the way the kernel does.
+        self.reject_duplicate_connect = False
         self.discovery_entries = []  # fallback list of dicts (see _pack_disc_log_entry)
         self.discovery_map = {}      # maps subsysnqn (str) -> list of dicts
         self.model_number = "Mock NVMe Controller"
@@ -108,14 +112,23 @@ class FabricsMockIPCServer(MockIPCServer):
                 k, v = part.split('=', 1)
                 opts[k.strip()] = v.strip()
 
-        inst = int(opts.get('instance', self.next_instance))
-        if 'instance' not in opts:
-            self.next_instance += 1
-
         subsysnqn = opts.get('nqn', opts.get('subsysnqn', ''))
         transport = opts.get('transport', 'tcp')
         traddr = opts.get('traddr', '')
         trsvcid = opts.get('trsvcid', '4420')
+
+        if self.reject_duplicate_connect:
+            key = (transport, traddr, trsvcid, subsysnqn)
+            for c in self.controllers.values():
+                if (c['transport'], c['traddr'], c['trsvcid'],
+                        c['subsysnqn']) == key:
+                    self.send_response(conn, -1, errno_val=114)  # EALREADY
+                    return
+
+        inst = int(opts.get('instance', self.next_instance))
+        if 'instance' not in opts:
+            self.next_instance += 1
+
         host_traddr = opts.get('host_traddr', 'none')
         host_iface = opts.get('host_iface', 'none')
         hostnqn = opts.get('hostnqn', '')
@@ -246,6 +259,13 @@ class FabricsMockCLITest(unittest.TestCase):
 
     def _ctrl_path(self, instance):
         return Path(f"{self.sysfs_dir}/sys/class/nvme/nvme{instance}")
+
+    def _owner_path(self, instance):
+        return Path(f"{self.base_dir}/registry/nvme{instance}/owner")
+
+    def _owner(self, instance):
+        path = self._owner_path(instance)
+        return path.read_text().strip() if path.exists() else None
 
     def _subsysnqn(self, instance):
         return (self._ctrl_path(instance) / "subsysnqn").read_text().strip()
@@ -387,6 +407,76 @@ class FabricsMockCLITest(unittest.TestCase):
         res = self._run(*connect_args, '--idempotent')
         self.assertNotIn("already connected", res.stdout)
         self.assertNotIn("already connected", res.stderr)
+
+    # ------------------------------------------------------------------ #
+    # Registry ownership across connect                                  #
+    # ------------------------------------------------------------------ #
+    #
+    # A pinned hostnqn is required throughout: every nvme invocation
+    # otherwise generates its own, landing in a different in-memory host
+    # object, and lookup_live_ctrl() only searches the current host's
+    # subsystems. Without it a second connect could never be recognized as
+    # a reuse (see test_connect_already_connected_precheck).
+    _OWNER_HOSTNQN = ("nqn.2014-08.org.nvmexpress:uuid:"
+                      "33333333-3333-3333-3333-333333333333")
+
+    def _owner_connect_args(self, subsysnqn, traddr='192.168.20.10'):
+        return ('connect', '-t', 'tcp', '-a', traddr, '-s', '4420',
+                '-n', subsysnqn, '--hostnqn', self._OWNER_HOSTNQN)
+
+    def test_connect_registry_ownership(self):
+        """A fresh connect claims the registry entry; a reuse only touches
+        it when --owner says so."""
+        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:owned-io-subsys"
+        args = self._owner_connect_args(subsysnqn)
+
+        self._run(*args, '--owner=stas')
+        self.assertEqual(self._owner(0), 'stas')
+
+        # Reuse without --owner: intent unstated, entry left alone.
+        self._run(*args, '--idempotent')
+        self.assertEqual(self._owner(0), 'stas')
+
+        # Reuse with --owner: an explicit steal.
+        self._run(*args, '--idempotent', '--owner=other')
+        self.assertEqual(self._owner(0), 'other')
+
+        # Reuse with an empty --owner: an explicit disown.
+        self._run(*args, '--idempotent', '--owner=')
+        self.assertIsNone(self._owner(0))
+
+    def test_connect_fresh_clears_stale_registry_entry(self):
+        """A controller the kernel just created cannot legitimately be
+        owned, so a recycled instance number's stale entry is dropped."""
+        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:recycled-io-subsys"
+        stale = Path(f"{self.base_dir}/registry/nvme0")
+        stale.mkdir(parents=True)
+        (stale / "owner").write_text("stas\n")
+
+        self._run(*self._owner_connect_args(subsysnqn))
+        self.assertIsNone(self._owner(0))
+
+    def test_connect_all_does_not_steal_io_ctrl_ownership(self):
+        """The Discovery Log Page walk reaches an already-connected I/O
+        controller through the kernel's EALREADY, before any registry
+        update, so connect-all never claims one it did not create."""
+        self.server.reject_duplicate_connect = True
+        io_subsys = "nqn.2014-08.org.nvmexpress:uuid:walked-io-subsys"
+        io_addr = '192.168.20.10'
+        dc_addr = '192.168.20.1'
+
+        self._run(*self._owner_connect_args(io_subsys, io_addr),
+                  '--owner=stas')
+        self.assertEqual(self._owner(0), 'stas')
+
+        self.server.discovery_entries = [
+            {'transport': 'tcp', 'traddr': io_addr, 'trsvcid': '4420',
+             'subsysnqn': io_subsys},
+        ]
+        self._run('connect-all', '-t', 'tcp', '-a', dc_addr,
+                  '--hostnqn', self._OWNER_HOSTNQN, '--owner=other')
+
+        self.assertEqual(self._owner(0), 'stas')
 
     def test_custom_identify(self):
         """Test getting custom Identify Controller fields steered by environment."""


### PR DESCRIPTION
nvme connect wrote the ownership registry even when it did not create the controller. A bare connect against a controller nvme-stas or nvme-discoverd already holds deleted that controller's ownership entry, with no flag, no prompt and no output. The controller keeps running, but it now reads as unowned and loses the protection the registry gives it.

Passing --owner=NAME to claim a controller is a stated intent and keeps working. Without --owner no intent is stated, so an existing entry is left alone.

A controller the kernel just created still gets its entry cleared, since a recycled instance number can leave a stale one behind. An empty --owner= now disowns instead of recording an empty owner.