### PR TITLE
libnvme, python: expose a configuration's top-level defaults and host identity

### DIFF
--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -777,6 +777,47 @@ PyObject *config_defaults(struct libnvme_global_ctx *ctx, const char *file)
 	return dict;
 }
 
+PyObject *config_host(struct libnvme_global_ctx *ctx, const char *file)
+{
+	__cleanup_config struct libnvmf_config *config = NULL;
+	PyObject *dict;
+	const char *val;
+	int ret;
+
+	ret = libnvmf_config_read(ctx, file, &config);
+	if (ret < 0) {
+		PyErr_Format(PyExc_OSError, "config_host failed: %s",
+			     strerror(-ret));
+		return NULL;
+	}
+
+	dict = PyDict_New();
+	if (!dict)
+		return NULL;
+
+	/*
+	 * Only what the file actually names. An absent key is omitted rather
+	 * than reported as empty, so the caller can tell "not configured"
+	 * from "configured to nothing" and fall back accordingly.
+	 */
+	val = libnvmf_config_get_hostnqn(config);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "hostnqn",
+					   PyUnicode_FromString(val));
+
+	val = libnvmf_config_get_hostid(config);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "hostid",
+					   PyUnicode_FromString(val));
+
+	val = libnvmf_config_get_hostsymname(config);
+	if (val)
+		PyDict_SetItemStringDecRef(dict, "hostsymname",
+					   PyUnicode_FromString(val));
+
+	return dict;
+}
+
 void config_validate(struct libnvme_global_ctx *ctx, const char *file)
 {
 	int ret;
@@ -1413,6 +1454,33 @@ PyObject *config_read(struct libnvme_global_ctx *ctx, const char *file = NULL);
 		config_defaults;
 PyObject *config_defaults(struct libnvme_global_ctx *ctx,
 			  const char *file = NULL);
+
+%exception config_host {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%feature("autodoc", "Read the top-level host identity from a "
+		"configuration.\n"
+		"\n"
+		"The default persona, as written in the top-level file's\n"
+		"[Host] section. A drop-in's persona belongs to that\n"
+		"drop-in's own connections and is not reported here.\n"
+		"\n"
+		"Each connection carries the identity it is made under, but a\n"
+		"configuration may name a persona and configure no\n"
+		"connections at all -- a host that connects only what it\n"
+		"discovers. This is how that identity is read.\n"
+		"\n"
+		"Args:\n"
+		"    file: Path to the main configuration file, or None for\n"
+		"          the default.\n"
+		"\n"
+		"Returns:\n"
+		"    A dict with 'hostnqn', 'hostid' and 'hostsymname', each\n"
+		"    present only when the file names it.")
+		config_host;
+PyObject *config_host(struct libnvme_global_ctx *ctx,
+		      const char *file = NULL);
 
 %exception config_validate {
 	$action

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -729,6 +729,54 @@ PyObject *config_read(struct libnvme_global_ctx *ctx, const char *file)
 	return list;
 }
 
+static PyObject *_config_params_to_dict(const struct libnvmf_params *params)
+{
+	PyObject *dict = PyDict_New();
+
+	/* No such *Defaults section is not an error: nothing is defaulted. */
+	if (dict && params)
+		libnvmf_params_for_each(params, _config_collect_param, dict);
+
+	return dict;
+}
+
+PyObject *config_defaults(struct libnvme_global_ctx *ctx, const char *file)
+{
+	__cleanup_config struct libnvmf_config *config = NULL;
+	PyObject *dict, *dc, *ioc;
+	int ret;
+
+	ret = libnvmf_config_read(ctx, file, &config);
+	if (ret < 0) {
+		PyErr_Format(PyExc_OSError, "config_defaults failed: %s",
+			     strerror(-ret));
+		return NULL;
+	}
+
+	/*
+	 * A NULL @via_dc asks for the top-level scope: the defaults that apply
+	 * to a controller with no configured origin. A drop-in's own overlay
+	 * is deliberately not reachable here -- an orchestrator that finds a
+	 * controller over mDNS has no way to know which drop-in it belongs to.
+	 */
+	dc = _config_params_to_dict(
+		libnvmf_config_resolve_discovered(config, NULL, true));
+	ioc = _config_params_to_dict(
+		libnvmf_config_resolve_discovered(config, NULL, false));
+
+	dict = (dc && ioc) ? PyDict_New() : NULL;
+	if (!dict) {
+		Py_XDECREF(dc);
+		Py_XDECREF(ioc);
+		return NULL;
+	}
+
+	PyDict_SetItemStringDecRef(dict, "dc", dc);
+	PyDict_SetItemStringDecRef(dict, "ioc", ioc);
+
+	return dict;
+}
+
 void config_validate(struct libnvme_global_ctx *ctx, const char *file)
 {
 	int ret;
@@ -1340,6 +1388,31 @@ PyObject *nbft_get(struct libnvme_global_ctx *ctx, const char *filename);
 	if (PyErr_Occurred()) SWIG_fail;
 }
 PyObject *config_read(struct libnvme_global_ctx *ctx, const char *file = NULL);
+
+%exception config_defaults {
+	$action
+	if (PyErr_Occurred()) SWIG_fail;
+}
+%feature("autodoc", "Read the default connection parameters from a "
+		"configuration.\n"
+		"\n"
+		"These are the defaults for a controller with no configured\n"
+		"origin -- one found over mDNS, or learned from a discovery\n"
+		"log page -- taken from the top-level file. A drop-in's own\n"
+		"overlay is not included: a controller discovered at runtime\n"
+		"cannot be attributed to a drop-in.\n"
+		"\n"
+		"Args:\n"
+		"    file: Path to the main configuration file, or None for\n"
+		"          the default.\n"
+		"\n"
+		"Returns:\n"
+		"    {'dc': {...}, 'ioc': {...}} -- the [Discovery Controller\n"
+		"    Defaults] and [I/O Controller Defaults] parameters, each\n"
+		"    an empty dict when the section is absent.")
+		config_defaults;
+PyObject *config_defaults(struct libnvme_global_ctx *ctx,
+			  const char *file = NULL);
 
 %exception config_validate {
 	$action

--- a/libnvme/libnvme3/tests/test-config.py
+++ b/libnvme/libnvme3/tests/test-config.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Unit tests for the connection configuration read-side Python bindings
-(nvme.config_read() / nvme.config_defaults() / nvme.config_validate()).
+(nvme.config_read() / nvme.config_defaults() / nvme.config_host() /
+nvme.config_validate()).
 
 Each test points at a throwaway file under /tmp -- the config file is reached
 by an explicit path, so no sandbox rerouting (set_test_base_dir()) is needed,
@@ -255,6 +256,83 @@ controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
         conn, = nvme.config_read(self.ctx, self.conf)
         self.assertEqual(conn['params']['ctrl-loss-tmo'], '1800')
         self.assertEqual(conn['params']['reconnect-delay'], '20')
+
+
+class TestConfigHost(unittest.TestCase):
+    """The top-level [Host] identity."""
+
+    def setUp(self):
+        self.ctx = nvme.GlobalCtx()
+        self.tmpdir = tempfile.TemporaryDirectory(prefix='nvme-config-test-',
+                                                    dir='/tmp')
+        self.conf = os.path.join(self.tmpdir.name, 'nvme-fabrics.conf')
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        self.ctx = None
+
+    def test_absent_config_returns_empty_dict(self):
+        missing = os.path.join(self.tmpdir.name, 'does-not-exist.conf')
+        self.assertEqual(nvme.config_host(self.ctx, missing), {})
+
+    def test_no_host_section_returns_empty_dict(self):
+        _write(self.conf, """
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        self.assertEqual(nvme.config_host(self.ctx, self.conf), {})
+
+    def test_identity_without_any_connection(self):
+        """A [Host] and nothing else: no connections, but an identity. This is
+        the host that connects only what it discovers."""
+        _write(self.conf, """
+[Host]
+hostnqn     = nqn.2014-08.org.nvmexpress:uuid:aaaaaaaa-0000-0000-0000-000000000001
+hostid      = aaaaaaaa-0000-0000-0000-000000000001
+hostsymname = solo
+""")
+        self.assertEqual(nvme.config_read(self.ctx, self.conf), [])
+        self.assertEqual(nvme.config_host(self.ctx, self.conf), {
+            'hostnqn': 'nqn.2014-08.org.nvmexpress:uuid:aaaaaaaa-0000-0000-0000-000000000001',
+            'hostid': 'aaaaaaaa-0000-0000-0000-000000000001',
+            'hostsymname': 'solo',
+        })
+
+    def test_unset_keys_are_omitted(self):
+        """An absent key is omitted rather than reported empty, so the caller
+        can tell "not configured" from "configured to nothing"."""
+        _write(self.conf, """
+[Host]
+hostsymname = symname-only
+""")
+        self.assertEqual(nvme.config_host(self.ctx, self.conf),
+                         {'hostsymname': 'symname-only'})
+
+    def test_drop_in_persona_is_not_reported(self):
+        """A drop-in's persona belongs to that drop-in's own connections."""
+        _write(self.conf, """
+[I/O Controller Defaults]
+ctrl-loss-tmo = 600
+""")
+        dropin_dir = self.conf + '.d'
+        os.mkdir(dropin_dir)
+        _write(os.path.join(dropin_dir, 'persona.conf'), """
+[Host]
+hostnqn = nqn.2014-08.org.nvmexpress:uuid:aaaaaaaa-0000-0000-0000-000000000002
+hostid  = aaaaaaaa-0000-0000-0000-000000000002
+
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        self.assertEqual(nvme.config_host(self.ctx, self.conf), {})
+
+        # ...but the drop-in's own connection is made under it.
+        conn, = nvme.config_read(self.ctx, self.conf)
+        self.assertEqual(
+            conn['hostnqn'],
+            'nqn.2014-08.org.nvmexpress:uuid:aaaaaaaa-0000-0000-0000-000000000002')
 
 
 if __name__ == '__main__':

--- a/libnvme/libnvme3/tests/test-config.py
+++ b/libnvme/libnvme3/tests/test-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: LGPL-2.1-or-later
 """Unit tests for the connection configuration read-side Python bindings
-(nvme.config_read() / nvme.config_validate()).
+(nvme.config_read() / nvme.config_defaults() / nvme.config_validate()).
 
 Each test points at a throwaway file under /tmp -- the config file is reached
 by an explicit path, so no sandbox rerouting (set_test_base_dir()) is needed,
@@ -163,6 +163,98 @@ controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
 """)
         with self.assertRaises(OSError):
             nvme.config_validate(self.ctx, self.conf)
+
+
+class TestConfigDefaults(unittest.TestCase):
+    """The defaults that apply to a controller with no configured origin."""
+
+    def setUp(self):
+        self.ctx = nvme.GlobalCtx()
+        self.tmpdir = tempfile.TemporaryDirectory(prefix='nvme-config-test-',
+                                                    dir='/tmp')
+        self.conf = os.path.join(self.tmpdir.name, 'nvme-fabrics.conf')
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+        self.ctx = None
+
+    def test_absent_config_returns_empty_sets(self):
+        missing = os.path.join(self.tmpdir.name, 'does-not-exist.conf')
+        self.assertEqual(nvme.config_defaults(self.ctx, missing),
+                         {'dc': {}, 'ioc': {}})
+
+    def test_absent_sections_return_empty_sets(self):
+        _write(self.conf, """
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        self.assertEqual(nvme.config_defaults(self.ctx, self.conf),
+                         {'dc': {}, 'ioc': {}})
+
+    def test_each_class_gets_its_own_defaults(self):
+        _write(self.conf, """
+[Discovery Controller Defaults]
+keep-alive-tmo = 30
+ctrl-loss-tmo  = 600
+
+[I/O Controller Defaults]
+ctrl-loss-tmo = 900
+nr-io-queues  = 4
+""")
+        defaults = nvme.config_defaults(self.ctx, self.conf)
+        self.assertEqual(defaults['dc'],
+                         {'keep-alive-tmo': '30', 'ctrl-loss-tmo': '600'})
+        self.assertEqual(defaults['ioc'],
+                         {'ctrl-loss-tmo': '900', 'nr-io-queues': '4'})
+
+    def test_endpoint_overrides_are_not_defaults(self):
+        """A value set on a section belongs to that endpoint, not to the
+        class it happens to be in."""
+        _write(self.conf, """
+[I/O Controller Defaults]
+ctrl-loss-tmo = 900
+
+[Subsystem]
+nqn           = nqn.2024-01.com.example:data.vol1
+ctrl-loss-tmo = 1800
+controller    = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        self.assertEqual(nvme.config_defaults(self.ctx, self.conf)['ioc'],
+                         {'ctrl-loss-tmo': '900'})
+
+    def test_drop_in_overlays_are_excluded(self):
+        """A drop-in's *Defaults section is scoped to that drop-in's own
+        connections. A controller discovered at runtime cannot be attributed
+        to a drop-in, so only the top-level scope is reported."""
+        _write(self.conf, """
+[I/O Controller Defaults]
+ctrl-loss-tmo = 600
+""")
+        dropin_dir = self.conf + '.d'
+        os.mkdir(dropin_dir)
+        _write(os.path.join(dropin_dir, 'persona.conf'), """
+[Host]
+hostnqn = nqn.2014-08.org.nvmexpress:uuid:aaaaaaaa-0000-0000-0000-000000000001
+hostid  = aaaaaaaa-0000-0000-0000-000000000001
+
+[I/O Controller Defaults]
+ctrl-loss-tmo   = 1800
+reconnect-delay = 20
+
+[Subsystem]
+nqn        = nqn.2024-01.com.example:data.vol1
+controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
+""")
+        # The top-level value, not the drop-in's, and nothing the drop-in
+        # alone introduces.
+        self.assertEqual(nvme.config_defaults(self.ctx, self.conf)['ioc'],
+                         {'ctrl-loss-tmo': '600'})
+
+        # The drop-in's own connection still gets its file-scoped overlay.
+        conn, = nvme.config_read(self.ctx, self.conf)
+        self.assertEqual(conn['params']['ctrl-loss-tmo'], '1800')
+        self.assertEqual(conn['params']['reconnect-delay'], '20')
 
 
 if __name__ == '__main__':

--- a/libnvme/src/libnvmf.ld
+++ b/libnvme/src/libnvmf.ld
@@ -23,6 +23,9 @@ LIBNVMF_3 {
 		libnvmf_config_emit_install;
 		libnvmf_config_emit_new;
 		libnvmf_config_free;
+		libnvmf_config_get_hostid;
+		libnvmf_config_get_hostnqn;
+		libnvmf_config_get_hostsymname;
 		libnvmf_config_read;
 		libnvmf_config_resolve_discovered;
 		libnvmf_config_validate;

--- a/libnvme/src/nvme/config-ini.h
+++ b/libnvme/src/nvme/config-ini.h
@@ -201,6 +201,14 @@ struct libnvmf_config {
 	 */
 	struct libnvmf_params *top_dc_params;
 	struct libnvmf_params *top_ioc_params;
+	/*
+	 * Top-level [Host] identity.  Retained because a consumer that
+	 * configures no connections still has a host identity: the
+	 * connections carry a copy each, but there may not be any.
+	 */
+	char *top_hostnqn;
+	char *top_hostid;
+	char *top_hostsymname;
 };
 
 /*

--- a/libnvme/src/nvme/config-resolve.c
+++ b/libnvme/src/nvme/config-resolve.c
@@ -140,6 +140,9 @@ __shr_public void libnvmf_config_free(struct libnvmf_config *conf)
 	free_conns(&conf->conns);
 	libnvmf_params_free(conf->top_dc_params);
 	libnvmf_params_free(conf->top_ioc_params);
+	free(conf->top_hostnqn);
+	free(conf->top_hostid);
+	free(conf->top_hostsymname);
 	free(conf);
 }
 
@@ -399,6 +402,23 @@ int libnvmf_config_load(struct libnvme_global_ctx *ctx, const char *path,
 	conf->top_dc_params = build_base(files[0], files[0], true);
 	conf->top_ioc_params = build_base(files[0], files[0], false);
 	if (!conf->top_dc_params || !conf->top_ioc_params) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	/*
+	 * The top-level persona.  Only a real value is kept: an unset or
+	 * reset field means "no such identity", not an empty one.
+	 */
+	if (real_value(files[0]->hostnqn))
+		conf->top_hostnqn = shr_xstrdup(files[0]->hostnqn);
+	if (real_value(files[0]->hostid))
+		conf->top_hostid = shr_xstrdup(files[0]->hostid);
+	if (real_value(files[0]->hostsymname))
+		conf->top_hostsymname = shr_xstrdup(files[0]->hostsymname);
+	if ((real_value(files[0]->hostnqn) && !conf->top_hostnqn) ||
+	    (real_value(files[0]->hostid) && !conf->top_hostid) ||
+	    (real_value(files[0]->hostsymname) && !conf->top_hostsymname)) {
 		ret = -ENOMEM;
 		goto out;
 	}

--- a/libnvme/src/nvme/config.c
+++ b/libnvme/src/nvme/config.c
@@ -159,6 +159,24 @@ __shr_public const struct libnvmf_params *libnvmf_config_resolve_discovered(
 	return is_dc ? config->top_dc_params : config->top_ioc_params;
 }
 
+__shr_public const char *libnvmf_config_get_hostnqn(
+		const struct libnvmf_config *config)
+{
+	return config ? config->top_hostnqn : NULL;
+}
+
+__shr_public const char *libnvmf_config_get_hostid(
+		const struct libnvmf_config *config)
+{
+	return config ? config->top_hostid : NULL;
+}
+
+__shr_public const char *libnvmf_config_get_hostsymname(
+		const struct libnvmf_config *config)
+{
+	return config ? config->top_hostsymname : NULL;
+}
+
 struct emit_state {
 	void (*callback)(const char *arg, void *user_data);
 	void *user_data;

--- a/libnvme/src/nvme/config.h
+++ b/libnvme/src/nvme/config.h
@@ -276,6 +276,51 @@ const struct libnvmf_params *libnvmf_config_resolve_discovered(
 		bool is_dc);
 
 /**
+ * libnvmf_config_get_hostnqn() - the top-level [Host] host NQN.
+ * @config: the resolved configuration
+ *
+ * The identity of the configuration's default persona, as written in the
+ * top-level file's [Host] section.  A drop-in's persona is deliberately not
+ * reachable here: it belongs to that drop-in's own connections.
+ *
+ * Each connection already carries the identity it is made under, but a
+ * configuration may name a persona and configure no connections at all -- a
+ * host that only connects what it discovers.  This is how that identity is
+ * read.
+ *
+ * Return: borrowed string, valid while @config is alive, or NULL when the
+ * top-level file names no host NQN (the caller falls back to the system
+ * identity in /etc/nvme/hostnqn).
+ */
+const char *libnvmf_config_get_hostnqn(const struct libnvmf_config *config);
+
+/**
+ * libnvmf_config_get_hostid() - the top-level [Host] host ID.
+ * @config: the resolved configuration
+ *
+ * See libnvmf_config_get_hostnqn().
+ *
+ * Return: borrowed string, valid while @config is alive, or NULL when the
+ * top-level file names no host ID (the caller falls back to the system
+ * identity in /etc/nvme/hostid).
+ */
+const char *libnvmf_config_get_hostid(const struct libnvmf_config *config);
+
+/**
+ * libnvmf_config_get_hostsymname() - the top-level [Host] symbolic name.
+ * @config: the resolved configuration
+ *
+ * The symbolic name a Discovery Information Management (DIM) command reports
+ * to a Centralized Discovery Controller (TP8010).  Unlike the host NQN and
+ * host ID it has no system-wide file to fall back on, so this is the only
+ * place it can be configured for a host that connects only what it discovers.
+ *
+ * Return: borrowed string, valid while @config is alive, or NULL when the
+ * top-level file names no symbolic name.
+ */
+const char *libnvmf_config_get_hostsymname(const struct libnvmf_config *config);
+
+/**
  * libnvmf_connect_args_emit() - render a connection as "nvme connect"
  * options.
  * @tid:       addressing + identity, or NULL to emit the parameters only

--- a/libnvme/tests/config-api.c
+++ b/libnvme/tests/config-api.c
@@ -283,6 +283,71 @@ static bool test_resolve_discovered(struct libnvme_global_ctx *ctx,
 	return pass;
 }
 
+static const char host_only_text[] =
+	"[Host]\n"
+	"hostnqn = nqn.2014-08.org.nvmexpress:solo-host\n"
+	"hostid = 8b6b8b6b-0000-4000-8000-00000000dead\n"
+	"hostsymname = solo\n";
+
+static bool test_top_level_host(struct libnvme_global_ctx *ctx,
+				const struct fixture *fx)
+{
+	struct conn_list list = { 0 };
+	struct libnvmf_config *config;
+	char path[352];
+	bool pass = true;
+
+	printf("test_top_level_host:\n");
+
+	/*
+	 * The fixture's main file carries no [Host]; only the drop-in does.
+	 * A drop-in's persona belongs to that drop-in's own connections and
+	 * must not be reported as the configuration's identity.
+	 */
+	shr_assert(!libnvmf_config_read(ctx, fx->main_path, &config));
+	if (libnvmf_config_get_hostnqn(config) ||
+	    libnvmf_config_get_hostid(config) ||
+	    libnvmf_config_get_hostsymname(config)) {
+		printf(" - a drop-in persona must not be reported [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - drop-in persona is not the top-level one [PASS]\n");
+	}
+	libnvmf_config_free(config);
+
+	/*
+	 * A [Host] and nothing else: no connections, but an identity. This is
+	 * the host that connects only what it discovers.
+	 */
+	write_file(fx->dir, "host-only.conf", host_only_text);
+	snprintf(path, sizeof(path), "%s/host-only.conf", fx->dir);
+	shr_assert(!libnvmf_config_read(ctx, path, &config));
+
+	libnvmf_config_conn_for_each(config, collect, &list);
+	if (list.n) {
+		printf(" - expected no connections, got %zu [FAIL]\n", list.n);
+		pass = false;
+	}
+
+	if (!libnvmf_config_get_hostnqn(config) ||
+	    strcmp(libnvmf_config_get_hostnqn(config),
+		   "nqn.2014-08.org.nvmexpress:solo-host") ||
+	    !libnvmf_config_get_hostid(config) ||
+	    strcmp(libnvmf_config_get_hostid(config),
+		   "8b6b8b6b-0000-4000-8000-00000000dead") ||
+	    !libnvmf_config_get_hostsymname(config) ||
+	    strcmp(libnvmf_config_get_hostsymname(config), "solo")) {
+		printf(" - identity of a connection-less config [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - identity without connections [PASS]\n");
+	}
+	libnvmf_config_free(config);
+	rm_file(fx->dir, "host-only.conf");
+
+	return pass;
+}
+
 static bool test_validate(struct libnvme_global_ctx *ctx,
 			  const struct fixture *fx)
 {
@@ -809,6 +874,9 @@ static bool test_edge_cases(struct libnvme_global_ctx *ctx,
 	    libnvmf_config_conn_get_hostsymname(NULL) ||
 	    libnvmf_config_conn_get_source(NULL) ||
 	    libnvmf_config_resolve_discovered(NULL, NULL, true) ||
+	    libnvmf_config_get_hostnqn(NULL) ||
+	    libnvmf_config_get_hostid(NULL) ||
+	    libnvmf_config_get_hostsymname(NULL) ||
 	    libnvmf_params_get(NULL, "tos")) {
 		printf(" - NULL tolerance [FAIL]\n");
 		pass = false;
@@ -835,6 +903,7 @@ int main(void)
 
 	pass &= test_read(ctx, &fx);
 	pass &= test_resolve_discovered(ctx, &fx);
+	pass &= test_top_level_host(ctx, &fx);
 	pass &= test_validate(ctx, &fx);
 	pass &= test_emit(ctx, &fx);
 	pass &= test_hostnqn_precedence(ctx, &fx);


### PR DESCRIPTION
@igaw: My nvme-stas work to incorporate all the goodies of libnvme made me realize that something was missing from the public API (sorry :man_facepalming:). 

Two read-side additions to the Python bindings. 

### `config_defaults()` — the defaults for a discovered controller

Returns `{'dc': {...}, 'ioc': {...}}`, kept apart because the caller picks by the class of controller it is about to connect. No new C API.

### `config_host()` — the top-level `[Host]`

Returns the default persona's `hostnqn`, `hostid` and `hostsymname`.

**This one adds public C API**, which I would rather flag than slip past an RC. `libnvmf_config_get_hostnqn()`, `libnvmf_config_get_hostid()` and `libnvmf_config_get_hostsymname()`. Three getters, three exported symbols, no existing signature or behaviour changed.