### PR TITLE
docs: fix typo configuraiton -> configuration

### DIFF
--- a/libnvme/doc/rst/mi.rst
+++ b/libnvme/doc/rst/mi.rst
@@ -1356,7 +1356,7 @@ The fd value or -1 if error
   Endpoint to enable AEs
 
 ``struct libnvme_mi_aem_config *config``
-  AE configuraiton including which events are enabled and the callback function
+  AE configuration including which events are enabled and the callback function
 
 ``void *userdata``
   Application provided context pointer for callback function


### PR DESCRIPTION
Corrects the misspelling `configuraiton` -> `configuration` in `libnvme/doc/rst/mi.rst`.

Documentation only, no behaviour change.