### PR TITLE
utils: fix resource leak in copy_opt_val on strdup failure

### DIFF
--- a/plugins/utils/command-metadata.c
+++ b/plugins/utils/command-metadata.c
@@ -218,7 +218,7 @@ static char *xstrdup(const char *s)
 static int copy_opt_val(const struct argconfig_opt_val *src, const struct argconfig_opt_val **out)
 {
 	struct argconfig_opt_val *dst;
-	size_t n = 0, i;
+	int n = 0, i;
 
 	*out = NULL;
 	if (!src)
@@ -235,8 +235,12 @@ static int copy_opt_val(const struct argconfig_opt_val *src, const struct argcon
 		dst[i] = src[i];
 		/* src[i].str is non-NULL for i < n, so NULL here means OOM. */
 		dst[i].str = strdup(src[i].str);
-		if (!dst[i].str)
+		if (!dst[i].str) {
+			while (--i >= 0)
+				free((char *)dst[i].str);
+			free(dst);
 			return -ENOMEM;
+		}
 	}
 	dst[n].str = NULL;
 


### PR DESCRIPTION
The copy_opt_val() function deep-copies an opt_val table by iterating over each entry and duplicating its str field with strdup(). The dst array is allocated with calloc() before the loop begins.

When strdup() fails for any entry, the function returned -ENOMEM immediately without freeing the already-allocated dst array or the str copies made in previous iterations, leaking all of that memory.

Free all previously duplicated str entries and dst itself before returning on the OOM path to prevent the resource leak.