### PR TITLE
registry: fix unchecked return value from libnvmf_registry_attr_for_each

### DIFF
--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -794,7 +794,7 @@ PyObject *registry_retrieve(struct libnvme_global_ctx *ctx,
 	return str;
 }
 
-static void _registry_collect_device(const char *device, void *user_data)
+static int _registry_collect_device(const char *device, void *user_data)
 {
 	PyObject *str = PyUnicode_FromString(device);
 
@@ -802,6 +802,7 @@ static void _registry_collect_device(const char *device, void *user_data)
 		PyList_Append((PyObject *)user_data, str);
 		Py_DECREF(str);
 	}
+	return 0;
 }
 
 PyObject *registry_devices(struct libnvme_global_ctx *ctx)

--- a/libnvme/src/nvme/registry.c
+++ b/libnvme/src/nvme/registry.c
@@ -553,12 +553,13 @@ __shr_public int libnvmf_registry_delete(struct libnvme_global_ctx *ctx,
 
 __shr_public int libnvmf_registry_device_for_each(
 		struct libnvme_global_ctx *ctx,
-		void (*callback)(const char *device, void *user_data),
+		int (*callback)(const char *device, void *user_data),
 		void *user_data)
 {
 	char dev_path[NAME_MAX + 6]; /* "/dev/" + name + NUL */
 	struct dirent *de;
 	DIR *d;
+	int ret = 0;
 
 	if (!ctx)
 		return -EINVAL;
@@ -600,10 +601,12 @@ __shr_public int libnvmf_registry_device_for_each(
 		if (access(dev_path, F_OK) != 0)
 			continue;
 
-		callback(de->d_name, user_data);
+		ret = callback(de->d_name, user_data);
+		if (ret)
+			break;
 	}
 	closedir(d);
-	return 0;
+	return ret;
 }
 
 __shr_public int libnvmf_registry_attr_for_each(

--- a/libnvme/src/nvme/registry.h
+++ b/libnvme/src/nvme/registry.h
@@ -105,7 +105,7 @@ int libnvmf_registry_delete(struct libnvme_global_ctx *ctx, const char *device);
  */
 int libnvmf_registry_device_for_each(
 		struct libnvme_global_ctx *ctx,
-		void (*callback)(const char *device, void *user_data),
+		int (*callback)(const char *device, void *user_data),
 		void *user_data);
 
 /**

--- a/libnvme/tests/registry.c
+++ b/libnvme/tests/registry.c
@@ -291,13 +291,14 @@ struct for_each_result {
 	int count;
 };
 
-static void collect_device(const char *device, void *user_data)
+static int collect_device(const char *device, void *user_data)
 {
 	struct for_each_result *r = user_data;
 
 	if (r->count < 8)
 		snprintf(r->devices[r->count++], sizeof(r->devices[0]),
 			 "%s", device);
+	return 0;
 }
 
 static bool test_device_for_each(struct libnvme_global_ctx *ctx)

--- a/plugins/registry/registry-nvme.c
+++ b/plugins/registry/registry-nvme.c
@@ -73,11 +73,11 @@ static void print_attr(const char *attr, const char *value, void *user_data)
 	printf("  %-12s %s\n", attr, value);
 }
 
-static void print_device(const char *device, void *user_data)
+static int print_device(const char *device, void *user_data)
 {
 	struct libnvme_global_ctx *ctx = user_data;
 	printf("%s\n", device);
-	libnvmf_registry_attr_for_each(ctx, device, print_attr, NULL);
+	return libnvmf_registry_attr_for_each(ctx, device, print_attr, NULL);
 }
 
 static int registry_list(int argc, char **argv, struct command *acmd,


### PR DESCRIPTION
The print_device() callback calls libnvmf_registry_attr_for_each() to iterate over per-controller registry attributes, but discards the return value. The function returns a negative errno if the device directory cannot be opened at the time of the call.

Silently ignoring the error means registry_list() always returns 0 even when attribute enumeration fails for one or more devices, hiding real I/O errors from the caller.

Change the callback signature of libnvmf_registry_device_for_each() from void to int so that each callback can propagate errors directly. print_device() now returns the result of libnvmf_registry_attr_for_each() and the loop in libnvmf_registry_device_for_each() breaks on the first non-zero return, propagating it to the caller. Update the test callback collect_device() to match the new int-returning signature.