### PR TITLE
tests: probe both stdout and stderr for _probe_command

### DIFF
--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -64,11 +64,13 @@ def _probe_command(nvme_bin, command):
     key = (nvme_bin, command)
     if key not in _command_cache:
         probe = subprocess.run(f"{nvme_bin} {command} --help", shell=True,
-                               stdout=subprocess.DEVNULL,
-                               stderr=subprocess.PIPE)
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT)
         # --help always exits non-zero whether or not the command exists,
-        # so check for the appropriate error message instead.
-        supported = b"Invalid sub-command" not in probe.stderr
+        # so check for the error message instead of returncode. nvme-cli
+        # prints it to stderr on current builds but to stdout on 2.16 and
+        # earlier, so capture both into one stream rather than picking one.
+        supported = b"Invalid sub-command" not in probe.stdout
         _command_cache[key] = command if supported else _LEGACY_COMMANDS[command]
     return _command_cache[key]
 


### PR DESCRIPTION
_probe_command() decides whether the installed nvme binary supports the newer grouped syntax (e.g. 'id ctrl') by running the command with --help and checking whether nvme-cli rejected it with "Invalid sub-command"; if so, it falls back to the legacy hyphenated form (id-ctrl). But the message moved: nvme-cli <= 2.16 prints it via printf() to stdout, while the current v3.0 dev line prints it via fprintf(stderr, ...) to stderr. The probe only checked stderr, so on 2.16 it never saw the rejection, always assumed the grouped form was supported, and never fell back -- every test then failed for real with the same "Invalid sub-command" error 2.16 gives for 'id ctrl'.

Redirect stderr into stdout and check the combined output instead, so detection works regardless of which stream a given nvme-cli version uses.