### PR TITLE
plugins/solidigm: Improve Telemetry debug info parsing

### DIFF
--- a/plugins/solidigm/solidigm-nvme.c
+++ b/plugins/solidigm/solidigm-nvme.c
@@ -9,7 +9,7 @@
 
 #include "plugin.h"
 
-#define SOLIDIGM_PLUGIN_VERSION "1.23"
+#define SOLIDIGM_PLUGIN_VERSION "1.24"
 
 #include "plugins/ocp/ocp-clear-features.h"
 #include "plugins/ocp/ocp-fw-activation-history.h"

--- a/plugins/solidigm/solidigm-telemetry/data-area.c
+++ b/plugins/solidigm/solidigm-telemetry/data-area.c
@@ -124,19 +124,32 @@ int sldm_telemetry_structure_parse(const struct telemetry_log *tl,
 	}
 
 	name = json_object_get_string(obj);
+	if (!name) {
+		SOLIDIGM_LOG_WARNING(
+			"Warning: Structure definition property 'name' is NULL: %s",
+				     json_object_to_json_string(struct_def));
+		return  -1;
+	}
 
 	if (metadata) {
 		json_object_get(obj);
 		json_object_object_add(metadata, "objName", obj);
 	}
 
-	if (json_object_object_get_ex(struct_def, "type", &obj))
+	if (json_object_object_get_ex(struct_def, "type", &obj)) {
 		type = json_object_get_string(obj);
+		if (!type) {
+			SOLIDIGM_LOG_WARNING(
+				"Warning: Structure '%s' property 'type' is not a string.",
+				name);
+			return -1;
+		}
+	}
 
 	if (!json_object_object_get_ex(struct_def, "offsetBit", &obj)) {
 		SOLIDIGM_LOG_WARNING(
-		    "Warning: Structure definition missing property 'offsetBit': %s",
-		    json_object_to_json_string(struct_def));
+			    "Warning: Structure '%s' missing property 'offsetBit'.",
+			    name);
 		return  -1;
 	}
 
@@ -144,8 +157,8 @@ int sldm_telemetry_structure_parse(const struct telemetry_log *tl,
 
 	if (!json_object_object_get_ex(struct_def, "sizeBit", &obj)) {
 		SOLIDIGM_LOG_WARNING(
-		    "Warning: Structure definition missing property 'sizeBit': %s",
-		    json_object_to_json_string(struct_def));
+			    "Warning: Structure '%s' missing property 'sizeBit'.",
+			    name);
 		return  -1;
 	}
 
@@ -156,27 +169,28 @@ int sldm_telemetry_structure_parse(const struct telemetry_log *tl,
 
 	has_member_list = json_object_object_get_ex(struct_def,
 						    "memberList",
-						    &obj_memberList);
+						    &obj_memberList) &&
+			  json_object_array_length(obj_memberList) > 0;
 
 	if (!json_object_object_get_ex(struct_def, "arraySize",
 				       &obj_arraySizeArray)) {
 		SOLIDIGM_LOG_WARNING(
-		    "Warning: Structure definition missing property 'arraySize': %s",
-		    json_object_to_json_string(struct_def));
+			    "Warning: Structure '%s' missing property 'arraySize'.",
+			    name);
 		return  -1;
 	}
 
 	array_rank = json_object_array_length(obj_arraySizeArray);
 	if (!array_rank) {
 		SOLIDIGM_LOG_WARNING(
-		    "Warning: Structure property 'arraySize' don't support flexible array: %s",
-		    json_object_to_json_string(struct_def));
+			    "Warning: '%s' arraySize does not support flexible arrays.",
+			    name);
 		return -1;
 	}
 	if (array_rank > MAX_ARRAY_RANK) {
 		SOLIDIGM_LOG_WARNING(
-		    "Warning: Structure property 'arraySize' don't support more than %d dimensions: %s",
-		    MAX_ARRAY_RANK, json_object_to_json_string(struct_def));
+		    "Warning: Structure '%s' 'arraySize' exceeds maximum %d dimensions.",
+		    name, MAX_ARRAY_RANK);
 		return -1;
 	}
 
@@ -313,7 +327,6 @@ int sldm_telemetry_structure_parse(const struct telemetry_log *tl,
 				json_object_array_put_idx(sub_output, j, sub_sub_output);
 			else
 				json_object_add_value_object(sub_output, name, sub_sub_output);
-
 			num_members = json_object_array_length(obj_memberList);
 			for (int k = 0; k < num_members; k++) {
 				struct json_object *member = json_object_array_get_idx(obj_memberList, k);

--- a/plugins/solidigm/solidigm-telemetry/debug-info.c
+++ b/plugins/solidigm/solidigm-telemetry/debug-info.c
@@ -10,17 +10,28 @@
 #include "config.h"
 #include "data-area.h"
 #include "debug-info.h"
-#include "nvme-json.h"
+#include "header.h"
 #include "skht.h"
 #include "tracker.h"
 #include "uart-log.h"
 
-#define DEBUG_INFO_SIGNATURE 0x54321234 /* "ST21" */
+#define DEBUG_INFO_SIGNATURE 0x54321234 /* legacy DebugInfoHeader_t */
+#define DEBUG_INFO_SECTION_SIGNATURE 0x58320234 /* DebugInfoSectionHeader_t */
 #define MAX_DEBUG_INFO_CORES 255
 
+static uint32_t get_size_bit(struct json_object *object)
+{
+	struct json_object *size_obj = NULL;
+
+	if (!json_object_object_get_ex(object, "sizeBit", &size_obj))
+		return 0;
+
+	return (uint32_t)json_object_get_int(size_obj);
+}
+
 enum debug_info_id {
-	DEBUG_INFO_ID_UART_LOG				= 3,
-	DEBUG_INFO_ID_TRACKER_INFO			= 6,
+	DEBUG_INFO_ID_UART_LOG			= 3,
+	DEBUG_INFO_ID_TRACKER_INFO		= 6,
 	DEBUG_INFO_ID_TRACKER_BUFFER		= 7,
 	DEBUG_INFO_ID_TRACKER_CONTEXT		= 8,
 };
@@ -37,6 +48,8 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 	uint32_t current_offset_byte;
 	int counter = 0;
 	int err = 0;
+	bool section_format = false;
+	const char *header_key;
 
 	if (!tl || !tl->configuration || !output) {
 		SOLIDIGM_LOG_WARNING("Invalid parameters for debug info parsing");
@@ -49,18 +62,32 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 	}
 
 	/* Get structure definitions from configuration */
-	if (!sldm_config_get_struct_by_key_version(tl->configuration,
-						    "DebugInfoBlkHeader_t",
-						    SKT_VER_MAJOR, SKT_VER_MINOR,
-						    &debug_info_blk_header_def)) {
+	if (!sldm_config_get_struct_by_key_version(
+			tl->configuration, "DebugInfoBlkHeader_t",
+			SKT_VER_MAJOR, SKT_VER_MINOR,
+			&debug_info_blk_header_def) &&
+	    !sldm_config_get_struct_by_key_version(
+			tl->configuration, "DebugInfoMainHeader_t",
+			SKT_VER_MAJOR, SKT_VER_MINOR,
+			&debug_info_blk_header_def)) {
 		SOLIDIGM_LOG_WARNING("DebugInfoBlkHeader_t structure not found in config");
 		return -1;
 	}
 
-	if (!sldm_config_get_struct_by_key_version(tl->configuration,
-						    "DebugInfoHeader_t",
-						    SKT_VER_MAJOR, SKT_VER_MINOR,
-						    &debug_info_header_def)) {
+	if (sldm_config_get_struct_by_key_version(
+			tl->configuration, "DebugInfoHeader_t",
+			SKT_VER_MAJOR, SKT_VER_MINOR, &debug_info_header_def)) {
+		header_key = "DebugInfoHeader_t";
+	} else if (sldm_config_get_struct_by_key_version(
+			tl->configuration, "DebugInfoSectionHeader_t",
+			SKT_VER_MAJOR, SKT_VER_MINOR,
+			&debug_info_header_def)) {
+		/* Newer configs renamed the per-core header to
+		 * DebugInfoSectionHeader_t.
+		 */
+		header_key = "DebugInfoSectionHeader_t";
+		section_format = true;
+	} else {
 		SOLIDIGM_LOG_WARNING("DebugInfoHeader_t structure not found in config");
 		return -1;
 	}
@@ -73,33 +100,35 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 		return -1;
 	}
 
-	/* Parse Debug Info Block Header */
-	current_offset_bit = offset * 8;
-	err = sldm_telemetry_structure_parse(tl, debug_info_blk_header_def,
-					     current_offset_bit, output, NULL);
-	if (err) {
-		SOLIDIGM_LOG_WARNING("Failed to parse DebugInfoBlkHeader_t");
-		return err;
-	}
-
-	/* Get the size of DebugInfoBlkHeader_t to move to the next structure */
-	struct json_object *blk_header_size_obj = NULL;
-
-	if (json_object_object_get_ex(debug_info_blk_header_def, "sizeBit",
-				      &blk_header_size_obj)) {
-		uint32_t blk_header_size_bits = json_object_get_int(blk_header_size_obj);
-
-		current_offset_bit += blk_header_size_bits;
-	} else {
-		SOLIDIGM_LOG_WARNING("Cannot determine DebugInfoBlkHeader_t size");
-		return -1;
-	}
-
-	/* Create arrays for cores and segments */
+	/* Create arrays for cores and segments up front so callers always get
+	 * them.
+	 */
 	cores_array = json_create_array();
 	segments_array = json_create_array();
 	json_object_add_value_array(output, "Cores", cores_array);
 	json_object_add_value_array(output, "Segments", segments_array);
+
+	/* Parse the block header (DebugInfoBlkHeader_t/
+	 * DebugInfoMainHeader_t).
+	 */
+	current_offset_bit = offset * 8;
+	err = sldm_telemetry_structure_parse(tl, debug_info_blk_header_def,
+					     current_offset_bit, output, NULL);
+	if (err)
+		SOLIDIGM_LOG_WARNING("Failed to parse DebugInfoBlkHeader_t");
+
+	/* Get the size of the block header to move to the next structure */
+	struct json_object *blk_header_size_obj = NULL;
+	uint32_t blk_header_size_bits;
+
+	if (!json_object_object_get_ex(debug_info_blk_header_def, "sizeBit",
+				       &blk_header_size_obj)) {
+		SOLIDIGM_LOG_WARNING("Cannot determine DebugInfoBlkHeader_t size");
+		return -1;
+	}
+	blk_header_size_bits = json_object_get_int(blk_header_size_obj);
+
+	current_offset_bit += blk_header_size_bits;
 
 	/* Parse Debug Info Headers for each core */
 	current_offset_byte = (uint32_t)(current_offset_bit / 8);
@@ -133,26 +162,35 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 		/* Validate signature */
 		struct json_object *debug_info_header_obj = NULL;
 
-		if (json_object_object_get_ex(core_debug_info, "DebugInfoHeader_t",
+		if (json_object_object_get_ex(core_debug_info, header_key,
 					      &debug_info_header_obj) &&
 		    json_object_object_get_ex(debug_info_header_obj, "nSignature",
 					      &signature_obj)) {
 			debug_signature = json_object_get_int(signature_obj);
 		}
 
-		if (debug_signature != DEBUG_INFO_SIGNATURE) {
+		uint32_t expected_signature = section_format ?
+			DEBUG_INFO_SECTION_SIGNATURE : DEBUG_INFO_SIGNATURE;
+
+		if (debug_signature != expected_signature) {
 			json_free_object(core_debug_info);
 			break;
 		}
 
 		/* Get total bytes and number of segments */
 		struct json_object *total_bytes_obj = NULL;
+		struct json_object *content_size_obj = NULL;
 		struct json_object *num_segments_obj = NULL;
 		struct json_object *core_id_obj = NULL;
+		uint32_t content_size = 0;
 
 		if (json_object_object_get_ex(debug_info_header_obj, "nTotalBytes",
 					      &total_bytes_obj))
 			total_bytes = json_object_get_int(total_bytes_obj);
+		else if (json_object_object_get_ex(debug_info_header_obj,
+							  "nSize",
+					      &content_size_obj))
+			content_size = json_object_get_int(content_size_obj);
 
 		if (json_object_object_get_ex(debug_info_header_obj, "nNumSegments",
 					      &num_segments_obj))
@@ -161,26 +199,67 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 		if (json_object_object_get_ex(debug_info_header_obj, "nCoreId",
 					      &core_id_obj))
 			core_id = json_object_get_int(core_id_obj);
+		else if (json_object_object_get_ex(debug_info_header_obj,
+							  "nSectionId",
+					      &core_id_obj))
+			core_id = json_object_get_int(core_id_obj);
 
 		/* Add core info to the cores array */
 		json_object_array_add(cores_array, core_debug_info);
 
-		/* Move to the position after DebugInfoHeader_t */
+		/* Move to the position after the per-core header */
 		struct json_object *header_size_obj = NULL;
+		uint32_t header_size_bits = 0;
 
 		if (json_object_object_get_ex(debug_info_header_def, "sizeBit",
-					      &header_size_obj)) {
-			uint32_t header_size_bits = json_object_get_int(header_size_obj);
+					      &header_size_obj))
+			header_size_bits = json_object_get_int(header_size_obj);
 
-			current_offset_bit += header_size_bits;
-			current_offset_byte = (uint32_t)(current_offset_bit / 8);
-		} else {
-			SOLIDIGM_LOG_WARNING("Cannot determine DebugInfoHeader_t size");
+		if (!header_size_bits) {
+			SOLIDIGM_LOG_WARNING(
+				"Cannot determine per-core header size");
 			break;
 		}
 
+		/* DebugInfoHeaderName_t follows the section header when
+		 * HAS_NAME is
+		 * set.
+		 */
+		if (section_format) {
+			struct json_object *attr_obj = NULL;
+
+			if (json_object_object_get_ex(debug_info_header_obj,
+							      "nAttributes",
+							      &attr_obj) &&
+				    json_object_get_uint64(attr_obj) >= 1) {
+				uint32_t name_offset_byte =
+					(uint32_t)(current_offset_bit / 8);
+				const uint8_t *name_ptr;
+
+				name_offset_byte += header_size_bits / 8;
+				name_ptr = (const uint8_t *)tl->log +
+					name_offset_byte;
+				struct json_object *name_obj = NULL;
+
+				sldm_uint8_array_to_string(name_ptr, 32,
+							   &name_obj);
+				json_object_object_add(debug_info_header_obj,
+						       "DebugInfoHeaderName_t",
+						       name_obj);
+				/* DebugInfoHeaderName_t is 32 bytes. */
+				header_size_bits += 256;
+			}
+
+			/* nSize excludes the header, unlike legacy nTotalBytes.
+			 */
+			total_bytes = header_size_bits / 8 + content_size;
+		}
+
+		current_offset_bit += header_size_bits;
+		current_offset_byte = (uint32_t)(current_offset_bit / 8);
+
 		/* Parse segment headers for this core */
-		for (uint32_t seg = 0; seg < num_segments && seg < 16; seg++) {
+		for (uint32_t seg = 0; seg < num_segments; seg++) {
 			struct json_object *tracker_info = NULL;
 			struct json_object *debug_info_uart_log = NULL;
 			struct json_object *segment_info = json_create_object();
@@ -214,12 +293,12 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 
 			/* Move to next segment header */
 			struct json_object *seg_header_size_obj = NULL;
+			uint32_t seg_header_size_bits = 0;
+			uint64_t seg_header_begin_bit = current_offset_bit;
 
 			if (json_object_object_get_ex(debug_info_seg_header_def,
 						      "sizeBit",
 						      &seg_header_size_obj)) {
-				uint32_t seg_header_size_bits;
-
 				seg_header_size_bits = json_object_get_int(seg_header_size_obj);
 				current_offset_bit += seg_header_size_bits;
 				current_offset_byte = (uint32_t)(current_offset_bit / 8);
@@ -228,20 +307,110 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 				json_free_object(segment_info);
 				break;
 			}
-			// Get DebugInfoSegHeader_t size for logging
+
+			/* Examine the parsed segment header and consume any
+			 * optional
+			 * name/tags.
+			 */
 			struct json_object *debug_info_seg_header_obj = NULL;
 			struct json_object *size_obj = NULL;
+			struct json_object *header_size_dw_obj = NULL;
+			struct json_object *attrs_obj = NULL;
 			uint32_t debug_info_seg_size = 0;
+			uint32_t seg_header_total_bytes = 0;
+			uint32_t seg_attributes = 0;
 
 			if (json_object_object_get_ex(segment_info, "DebugInfoSegHeader_t",
 							&debug_info_seg_header_obj) &&
 				json_object_object_get_ex(debug_info_seg_header_obj, "nSize",
-							&size_obj)) {
+								&size_obj)) {
 				debug_info_seg_size = json_object_get_int(size_obj);
 			} else {
 				SOLIDIGM_LOG_WARNING("Cannot determine DebugInfoSegHeader_t size");
 				json_free_object(segment_info);
 				break;
+			}
+
+			if (json_object_object_get_ex(debug_info_seg_header_obj,
+							      "nHeaderSizeDw",
+							&header_size_dw_obj)) {
+				seg_header_total_bytes =
+					(uint32_t)json_object_get_int(
+						header_size_dw_obj) * 4;
+			}
+			if (json_object_object_get_ex(debug_info_seg_header_obj,
+							      "nAttributes",
+							&attrs_obj))
+				seg_attributes = (uint32_t)
+					json_object_get_int(attrs_obj);
+
+			if (seg_attributes >= 1) {
+				const uint8_t *name_ptr;
+				struct json_object *seg_name_obj = NULL;
+
+				name_ptr = (const uint8_t *)tl->log +
+					current_offset_byte;
+				sldm_uint8_array_to_string(name_ptr, 32,
+							   &seg_name_obj);
+				json_object_object_add(segment_info,
+						       "DebugInfoHeaderName_t",
+						       seg_name_obj);
+				current_offset_bit += 32 * 8;
+				current_offset_byte =
+					(uint32_t)(current_offset_bit / 8);
+			}
+
+			uint32_t segment_tags_size_bit = 16 * 8;
+
+			if (seg_attributes >= 2) {
+				struct json_object *segment_tags_def = NULL;
+				struct json_object *tags =
+					json_create_object();
+				uint32_t tags_size_bit = 0;
+
+				if (sldm_config_get_struct_by_key_version(
+							tl->configuration,
+							"debugInfoSegmentTags",
+							SKT_VER_MAJOR,
+							SKT_VER_MINOR,
+							&segment_tags_def)) {
+					err = sldm_telemetry_structure_parse(
+						tl, segment_tags_def,
+						current_offset_bit,
+						tags, NULL);
+					if (!err) {
+						json_object_object_add(
+							segment_info,
+							"DebugInfoSegmentTags_t",
+							tags);
+						/* Use parsed struct size to
+						 * skip past the tags.
+						 */
+						tags_size_bit =
+							get_size_bit(tags);
+					} else {
+						SOLIDIGM_LOG_WARNING(
+							"Failed to parse DebugInfoSegmentTags_t");
+							json_free_object(tags);
+					}
+				} else {
+					SOLIDIGM_LOG_WARNING(
+						"Failed to get DebugInfoSegmentTags_t definition");
+						json_free_object(tags);
+				}
+				if (tags_size_bit)
+					segment_tags_size_bit = tags_size_bit;
+
+				current_offset_bit += segment_tags_size_bit;
+				current_offset_byte =
+					(uint32_t)(current_offset_bit / 8);
+			}
+
+			if (seg_header_total_bytes > seg_header_size_bits / 8) {
+				current_offset_bit = seg_header_begin_bit +
+					seg_header_total_bytes * 8;
+				current_offset_byte =
+					(uint32_t)(current_offset_bit / 8);
 			}
 
 			struct json_object *id_obj = NULL;
@@ -296,6 +465,8 @@ int sldm_debug_info_parse(struct telemetry_log *tl, uint32_t offset, uint32_t si
 						       tracker_info);
 				break;
 			}
+			if (!debug_info_seg_size && !seg_header_total_bytes)
+				break;
 
 			current_offset_bit += debug_info_seg_size * 8;
 			current_offset_byte = (uint32_t)(current_offset_bit / 8);

--- a/plugins/solidigm/solidigm-telemetry/tracker.c
+++ b/plugins/solidigm/solidigm-telemetry/tracker.c
@@ -51,7 +51,7 @@ static struct json_object *get_tracker_entry_info(struct json_object *config, ui
 	// Convert tracker_id to string for JSON key lookup
 	snprintf(tracker_id_str, sizeof(tracker_id_str), "%u", tracker_id);
 
-	// Navigate through JSON hierarchy
+	// Navigate through JSON hierarchy or skip if any level is missing
 	if (!json_object_object_get_ex(config, "Tracker", &tracker_obj))
 		return NULL;
 
@@ -85,7 +85,7 @@ static uint32_t get_struct_size_from_config(struct json_object *struct_def)
 	uint32_t size_bits = 0;
 
 	if (!struct_def) {
-		SOLIDIGM_LOG_WARNING("Cannot get size from NULL structure definition");
+		SOLIDIGM_LOG_WARNING("Warning: NULL structure definition");
 		return 0;
 	}
 
@@ -96,7 +96,7 @@ static uint32_t get_struct_size_from_config(struct json_object *struct_def)
 		return size_bits / 8;
 	}
 
-	SOLIDIGM_LOG_WARNING("Structure definition missing 'sizeBit' property");
+	SOLIDIGM_LOG_WARNING("Warning: 'sizeBit' property missing");
 	return 0;
 }
 
@@ -114,16 +114,24 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 	struct json_object *metadata_obj = NULL;
 	struct json_object *config = tl->configuration;
 
-	// Get structure definitions from the config - all are required for dynamic parsing
 	if (!sldm_config_get_struct_by_key_version(config,
-		"ablist_context_t", SKT_VER_MAJOR, SKT_VER_MINOR, &ablist_context_def) ||
-		!sldm_config_get_struct_by_key_version(config,
-		"ablist_entry_t", SKT_VER_MAJOR, SKT_VER_MINOR, &ablist_entry_def) ||
-		!sldm_config_get_struct_by_key_version(config,
-		"tracker_entry_t", SKT_VER_MAJOR, SKT_VER_MINOR, &tracker_entry_def)) {
+		"ablist_context_t", SKT_VER_MAJOR, SKT_VER_MINOR,
+		&ablist_context_def)) {
+		SOLIDIGM_LOG_WARNING("Warning: ablist_context_t missing");
+		return;
+	}
 
-		SOLIDIGM_LOG_WARNING(
-			"Required structure definitions missing from config");
+	if (!sldm_config_get_struct_by_key_version(config,
+		"ablist_entry_t", SKT_VER_MAJOR, SKT_VER_MINOR,
+		&ablist_entry_def)) {
+		SOLIDIGM_LOG_WARNING("Warning: ablist_entry_t object missing");
+		return;
+	}
+
+	if (!sldm_config_get_struct_by_key_version(config,
+		"tracker_entry_t", SKT_VER_MAJOR, SKT_VER_MINOR,
+		&tracker_entry_def)) {
+		SOLIDIGM_LOG_WARNING("Warning: tracker_entry_t object missing");
 		return;
 	}
 
@@ -133,7 +141,7 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 
 	if (sldm_telemetry_structure_parse(tl, ablist_context_def, chunk_offset * 8,
 				     ctx_obj, metadata_obj) != 0) {
-		SOLIDIGM_LOG_WARNING("Failed to parse ablist_context_t using dynamic parsing");
+		SOLIDIGM_LOG_WARNING("Warning: ablist_context_t parse failed");
 		json_object_put(ctx_obj);
 		json_object_put(metadata_obj);
 		return;
@@ -152,22 +160,22 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 			signature = (uint32_t) json_object_get_int64(sig_obj);
 		else
 			SOLIDIGM_LOG_WARNING(
-				"Failed to find 'signature' field in ablist_context_t");
+				"Warning: ablist_context_t.signature missing");
 
 		if (json_object_object_get_ex(ablist_context_obj, "data_start_offset",
 					    &start_offset_obj))
 			data_start_offset = json_object_get_int(start_offset_obj);
 		else
 			SOLIDIGM_LOG_WARNING(
-				"Failed to find 'data_start_offset' field in ablist_context_t");
+			"Warning: ablist_context_t.data_start_offset missing");
 
 		if (json_object_object_get_ex(ablist_context_obj, "entry_count", &count_obj))
 			entry_count = json_object_get_int(count_obj);
 		else
 			SOLIDIGM_LOG_WARNING(
-				"Failed to find 'entry_count' field in ablist_context_t");
+				"Warning: ablist_context_t.entry_count missing");
 	} else {
-		SOLIDIGM_LOG_WARNING("Nested 'ablist_context_t' object not found in parsed data");
+		SOLIDIGM_LOG_WARNING("Warning: ablist_context_t not found");
 		json_object_put(ctx_obj);
 		json_object_put(metadata_obj);
 		return;
@@ -210,7 +218,7 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 
 		if (ablist_entry_size == 0) {
 			SOLIDIGM_LOG_WARNING(
-				"Failed to get size of ablist_entry_t from configuration");
+				"Warning: Failed getting ablist_entry_t size");
 			json_object_put(entry_json);
 			json_object_put(entry_metadata);
 			return;
@@ -221,7 +229,7 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 		if (sldm_telemetry_structure_parse(tl, ablist_entry_def,
 			chunk_offset * 8 + offset * 8, header_obj, NULL) != 0) {
 			SOLIDIGM_LOG_WARNING(
-				"Failed to parse ablist_entry_t at offset %u", offset);
+				"Warning: ablist_entry_t failed at %u", offset);
 			json_object_put(header_obj);
 			json_object_put(entry_json);
 			json_object_put(entry_metadata);
@@ -241,7 +249,7 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 			chunk_offset * 8 + (offset + ablist_entry_size) * 8,
 			data_obj, entry_metadata) != 0) {
 			SOLIDIGM_LOG_WARNING(
-				"Failed to parse tracker_entry_t at offset %u",
+				"Warning: tracker_entry_t failed at %u",
 				offset + ablist_entry_size);
 			json_object_put(header_obj);
 			json_object_put(data_obj);
@@ -261,7 +269,7 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 		if (!json_object_object_get_ex(header_obj,
 				"ablist_entry_t", &ablist_entry_obj)) {
 			SOLIDIGM_LOG_WARNING(
-				"Failed to find ablist_entry_t in parsed header data");
+				"Warning: ablist_entry_t not in header");
 			json_object_put(header_obj);
 			json_object_put(data_obj);
 			json_object_put(entry_json);
@@ -280,18 +288,17 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 		if (!json_object_object_get_ex(ablist_entry_obj,
 				"next_entry_index", &next_obj)) {
 			SOLIDIGM_LOG_WARNING(
-				"Failed to find 'next_entry_index' in ablist_entry_t");
+				"Warning: ablist_entry_t.next_idx missing");
 			// Continue with next_entry_index = 0 (will likely break)
 		} else {
 			next_entry_index = json_object_get_int(next_obj);
 		}
-
 		// Get the inner object from data_obj - only supporting nested
 		// structure format
 		if (!json_object_object_get_ex(data_obj,
 				"tracker_entry_t", &tracker_entry_obj)) {
 			SOLIDIGM_LOG_WARNING(
-				"Failed to find tracker_entry_t in parsed data");
+				"Warning: tracker_entry_t not in data");
 			json_object_put(header_obj);
 			json_object_put(data_obj);
 			json_object_put(entry_json);
@@ -305,12 +312,11 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 			entry_count--;
 			continue;
 		}
-
 		// Get hash value from tracker_entry_obj
 		if (!json_object_object_get_ex(tracker_entry_obj,
 				"hash", &hash_obj)) {
 			SOLIDIGM_LOG_WARNING(
-				"Failed to find 'hash' in tracker_entry_t");
+				"Warning: tracker_entry_t.hash missing");
 			json_object_put(header_obj);
 			json_object_put(data_obj);
 			json_object_put(entry_json);
@@ -329,7 +335,6 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 
 		// Get tracker entry info from config
 		struct json_object *entry_info = get_tracker_entry_info(config, hash);
-
 		// Handle case where no entry info is found
 		if (!entry_info) {
 			// Clean up the entry JSON since we won't be adding it to the array
@@ -375,7 +380,6 @@ static void parse_tracker_chunk_json(const struct telemetry_log *tl, uint32_t ch
 			entry_count--;
 			continue;
 		}
-
 		if (json_object_object_get_ex(tracker_entry_obj, "time",
 					   &time_obj)) {
 			json_object_add_value_uint64(entry_json, "time",


### PR DESCRIPTION
- Add debug info structures.
- Fix optional segment fields.
- Fix debug info segment tag parsing.
- Allow empty MemberList in telemetry configuration files.