### PR TITLE
nbft: skip TLS/concat update when there is no discovery log entry

### DIFF
--- a/nbft.c
+++ b/nbft.c
@@ -106,6 +106,10 @@ static bool validate_uri(struct nbft_info_discovery *dd,
 static void update_tls_concat(struct nvmf_disc_log_entry *e,
 		struct nvme_fabrics_config *cfg)
 {
+	/* Direct connects (e.g. NBFT io controllers) have no log entry. */
+	if (!e)
+		return;
+
 	if (e->trtype != NVMF_TRTYPE_TCP ||
 	    e->tsas.tcp.sectype == NVMF_TCP_SECTYPE_NONE)
 		return;


### PR DESCRIPTION
Tip-of-branch regression: `4963779e6` ("fabrics: add helper to update tls and concat") moved `--tls`/`--concat` detection into `update_tls_concat()`, which unconditionally reads `e->trtype`. `do_connect()` passes `e = NULL` for direct connects (NBFT io controllers), so `nvme connect-all` segfaults on any machine whose NBFT describes io controllers:

```
Program received signal SIGSEGV
do_connect (r=..., h=..., e=0x0, ss=..., trcfg=..., cfg=...) at nbft.c:170
170     update_tls_concat(e, cfg);
#1  discover_from_nbft  nbft.c:391
#2  nvmf_discover  fabrics.c:808
```

There is nothing to infer without a discovery log entry — skip the update. With this one-line guard, `connect-all` completes on the same hardware and successfully attaches the NBFT-described controllers (verified locally; crash reproduced on pristine tip/nvme-cli-2.x build).

Fixes: 4963779e6
