### PR TITLE
keys: print check command results only with --verbose

### DIFF
--- a/plugins/keys/keys-plugin.c
+++ b/plugins/keys/keys-plugin.c
@@ -271,7 +271,7 @@ static int check_kxchap(int argc, char **argv, struct command *acmd, struct plug
 	if (err)
 		return err;
 
-	nvme_show_result("Secret is valid (HMAC %d, length %d, CRC %08x)", hmac, decoded_len, crc);
+	nvme_show_verbose_result("Secret is valid (HMAC %d, length %d, CRC %08x)", hmac, decoded_len, crc);
 
 	if (!cfg.identity)
 		return 0;
@@ -299,7 +299,7 @@ static int check_kxchap(int argc, char **argv, struct command *acmd, struct plug
 
 	err = libnvmf_lookup_key(ctx, cfg.keytype, cfg.identity, &key_id);
 	if (err) {
-		nvme_show_result("Secret is not loaded for identity '%s'", cfg.identity);
+		nvme_show_verbose_result("Secret is not loaded for identity '%s'", cfg.identity);
 		return 0;
 	}
 
@@ -311,9 +311,9 @@ static int check_kxchap(int argc, char **argv, struct command *acmd, struct plug
 	}
 
 	if ((size_t)stored_len == strlen(key) && !memcmp(stored, key, stored_len))
-		nvme_show_result("Secret is loaded (serial %08x) and matches", (unsigned int)key_id);
+		nvme_show_verbose_result("Secret is loaded (serial %08x) and matches", (unsigned int)key_id);
 	else
-		nvme_show_result("Secret is loaded (serial %08x) but differs", (unsigned int)key_id);
+		nvme_show_verbose_result("Secret is loaded (serial %08x) but differs", (unsigned int)key_id);
 
 	return 0;
 }
@@ -614,7 +614,7 @@ static int check_tls(int argc, char **argv, struct command *acmd, struct plugin 
 		nvme_show_error("Key decoding failed, %s", libnvme_strerror(-err));
 		return err;
 	}
-	nvme_show_result("Configured PSK is valid (HMAC %u, length %d)", hmac, decoded_len);
+	nvme_show_verbose_result("Configured PSK is valid (HMAC %u, length %d)", hmac, decoded_len);
 
 	if (!cfg.subsysnqn)
 		return 0;
@@ -657,11 +657,11 @@ static int check_tls(int argc, char **argv, struct command *acmd, struct plugin 
 
 	err = libnvmf_lookup_key(ctx, cfg.keytype, tls_id, &key_id);
 	if (err) {
-		nvme_show_result("TLS PSK is not loaded");
+		nvme_show_verbose_result("TLS PSK is not loaded");
 		return 0;
 	}
 
-	nvme_show_result("TLS PSK is loaded (serial %08x)", (unsigned int)key_id);
+	nvme_show_verbose_result("TLS PSK is loaded (serial %08x)", (unsigned int)key_id);
 	return 0;
 }
 

--- a/tests/cli/nvme_keys_test.py
+++ b/tests/cli/nvme_keys_test.py
@@ -214,7 +214,7 @@ class KeysCLITest(unittest.TestCase):
         for form in (('-k', _PIN_KXCHAP_KEY), ('--key', _PIN_KXCHAP_KEY),
                      (f'--key={_PIN_KXCHAP_KEY}',)):
             with self.subTest(form=form):
-                result = self._run_alias('check-dhchap-key', *form,
+                result = self._run_alias('check-dhchap-key', '-v', *form,
                                          stdin_data='')
                 self.assertIn('Secret is valid', result.stdout)
 
@@ -289,11 +289,24 @@ class KeysCLITest(unittest.TestCase):
     # ------------------------------------------------------------------ #
 
     def test_check_kxchap_accepts_generated_key(self):
-        result = self._run('check-kxchap-secret',
+        result = self._run('check-kxchap-secret', '-v',
                            f'--keydata={_PIN_KXCHAP_KEY}')
         self.assertIn('Secret is valid', result.stdout)
         self.assertIn('HMAC 0', result.stdout)
         self.assertIn('length 32', result.stdout)
+
+    def test_check_kxchap_is_silent_without_verbose(self):
+        # POSIX-style check commands encode the verdict in the exit
+        # status; the human-readable line appears only with -v.
+        result = self._run('check-kxchap-secret',
+                           f'--keydata={_PIN_KXCHAP_KEY}')
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, '')
+
+    def test_check_tls_is_silent_without_verbose(self):
+        result = self._run('check-tls-psk', f'--keydata={_PIN_TLS_KEY}')
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, '')
 
     def test_check_kxchap_accepts_every_generated_length(self):
         # gen and check apply the same length rule, so every pair gen
@@ -306,13 +319,13 @@ class KeysCLITest(unittest.TestCase):
                     gen = self._run('gen-kxchap-secret', f'--hmac={hmac}',
                                     f'--secret-length={secret_len}')
                     key = gen.stdout.strip()
-                    result = self._run('check-kxchap-secret',
+                    result = self._run('check-kxchap-secret', '-v',
                                        f'--keydata={key}')
                     self.assertIn(f'HMAC {hmac}', result.stdout)
                     self.assertIn(f'length {secret_len}', result.stdout)
 
     def test_check_kxchap_reads_from_stdin(self):
-        result = self._run('check-kxchap-secret',
+        result = self._run('check-kxchap-secret', '-v',
                            stdin_data=_PIN_KXCHAP_KEY + '\n')
         self.assertIn('Secret is valid', result.stdout)
 
@@ -334,13 +347,13 @@ class KeysCLITest(unittest.TestCase):
     # ------------------------------------------------------------------ #
 
     def test_check_tls_accepts_generated_key(self):
-        result = self._run('check-tls-psk', f'--keydata={_PIN_TLS_KEY}')
+        result = self._run('check-tls-psk', '-v', f'--keydata={_PIN_TLS_KEY}')
         self.assertIn('Configured PSK is valid', result.stdout)
         self.assertIn('HMAC 1', result.stdout)
         self.assertIn('length 32', result.stdout)
 
     def test_check_tls_reads_from_stdin(self):
-        result = self._run('check-tls-psk', stdin_data=_PIN_TLS_KEY + '\n')
+        result = self._run('check-tls-psk', '-v', stdin_data=_PIN_TLS_KEY + '\n')
         self.assertIn('Configured PSK is valid', result.stdout)
 
     def test_check_tls_rejects_malformed_key(self):


### PR DESCRIPTION
Fixes #3902, per igaw's POSIX-style direction on the `keys check-*` commands (status line only with `-v`; exit status carries the verdict).

Both check commands (`check-kxchap-secret`, `check-tls-psk`) move their verdict prints from `nvme_show_result` to `nvme_show_verbose_result`. Errors still go to stderr unconditionally via `nvme_show_error`, and exit codes are unchanged (including the existing "not loaded for identity" case — exit semantics are intentionally untouched here).

Acceptance, verified locally against the build:

```
$ nvme keys check-kxchap-secret --keydata=<valid>
(exit 0, no output)
$ nvme keys check-kxchap-secret -v --keydata=<valid>
Secret is valid (HMAC 0, length 32, CRC ...)
(exit 0)
$ nvme keys check-kxchap-secret --keydata=garbage
Invalid secret header 'garbage'
(exit 1)
```

`nvme_keys_test.py` updated: runs asserting the verdict text pass `-v`, and two new cases assert stdout stays empty / exit stays 0 without `-v`. `meson test`: 106 pass, 0 fail.
