### PR TITLE
mem: fix integer overflow in allocation rounding

### DIFF
--- a/libnvme/src/nvme/mem-linux.c
+++ b/libnvme/src/nvme/mem-linux.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <malloc.h>
+#include <stdint.h>
 #include <sys/mman.h>
 
 #include <ccan/minmax/minmax.h>
@@ -20,10 +21,40 @@
 
 #define HUGE_MIN 0x80000
 
+/*
+ * Round @n up to the next multiple of @s, rejecting the wrap-around that the
+ * round_up() macro produces for near-SIZE_MAX inputs. Returns false on
+ * overflow (or @s == 0) so callers fail the allocation instead of silently
+ * under-allocating and later overflowing the buffer.
+ */
+static bool round_up_checked(size_t n, size_t s, size_t *out)
+{
+	size_t rem, add;
+
+	if (!s)
+		return false;
+
+	rem = n % s;
+	if (!rem) {
+		*out = n;
+		return true;
+	}
+
+	add = s - rem;
+	if (n > SIZE_MAX - add)
+		return false;
+
+	*out = n + add;
+	return true;
+}
+
 __shr_public void *libnvme_alloc(size_t len)
 {
-	size_t _len = round_up(len, 0x1000);
+	size_t _len;
 	void *p;
+
+	if (!round_up_checked(len, 0x1000, &_len))
+		return NULL;
 
 	if (posix_memalign((void *)&p, getpagesize(), _len))
 		return NULL;
@@ -34,14 +65,19 @@ __shr_public void *libnvme_alloc(size_t len)
 
 __shr_public void *libnvme_realloc(void *p, size_t len)
 {
-	size_t old_len = malloc_usable_size(p);
+	size_t old_len;
+	void *result;
 
-	void *result = libnvme_alloc(len);
+	if (!p)
+		return libnvme_alloc(len);
 
-	if (p && result) {
-		memcpy(result, p, min_t(size_t, old_len, len));
-		free(p);
-	}
+	old_len = malloc_usable_size(p);
+	result = libnvme_alloc(len);
+	if (!result)
+		return NULL;
+
+	memcpy(result, p, min_t(size_t, old_len, len));
+	free(p);
 
 	return result;
 }
@@ -56,7 +92,8 @@ __shr_public void *libnvme_alloc_huge(size_t len,
 {
 	memset(mh, 0, sizeof(*mh));
 
-	len = round_up(len, 0x1000);
+	if (!round_up_checked(len, 0x1000, &len))
+		return NULL;
 
 	/*
 	 * For smaller allocation we just use posix_memalign and hope the kernel
@@ -91,7 +128,8 @@ __shr_public void *libnvme_alloc_huge(size_t len,
 	 * fullfil the request. This gives the kernel a chance to try to claim
 	 * some huge pages. This might still fail though.
 	 */
-	len = round_up(len, 0x200000);
+	if (!round_up_checked(len, 0x200000, &len))
+		return NULL;
 	if (posix_memalign(&mh->p, 0x200000, len))
 		return NULL;
 	mh->libnvme_alloc = true;

--- a/libnvme/src/nvme/mem-linux.c
+++ b/libnvme/src/nvme/mem-linux.c
@@ -56,7 +56,7 @@ __shr_public void *libnvme_alloc(size_t len)
 	if (!round_up_checked(len, 0x1000, &_len))
 		return NULL;
 
-	if (posix_memalign((void *)&p, getpagesize(), _len))
+	if (posix_memalign(&p, getpagesize(), _len))
 		return NULL;
 
 	memset(p, 0, _len);


### PR DESCRIPTION
libnvme_alloc() rounds the requested length up to a page multiple with the round_up() macro:

    size_t _len = round_up(len, 0x1000);

For a length close to SIZE_MAX this arithmetic wraps around and round_up() returns a much smaller value (0 for some inputs on a 64-bit build). posix_memalign() then hands back a tiny (or empty) buffer while libnvme_realloc() copies min(old_len, len) bytes into it, producing a heap buffer overflow driven by device-provided data.

A reachable path exists in nvme-cli's get_dispersed_ns_psub(), where a device-supplied numpsub field feeds the reallocation size:

    psub_list_len = le64_to_cpu(log->numpsub) * NVME_NQN_LENGTH;
    log = libnvme_realloc(log, header_len + psub_list_len);

Add a checked round_up_checked() helper that rejects the wrap-around and returns false on overflow, and make libnvme_alloc()/libnvme_alloc_huge() fail cleanly (return NULL) in that case. Also harden libnvme_realloc() so it does not dereference a NULL result when the allocation fails.

Validation:

Verified with AddressSanitizer using a standalone harness that compiles this file directly and exercises the reported PoC -- an initial libnvme_alloc(0x2000) followed by libnvme_realloc(p, SIZE_MAX - 0x7FF):

  - Before: ASan reports a heap-buffer-overflow, "WRITE of size 8192" 0 bytes after a 1-byte region, in memcpy() at libnvme_realloc(). round_up(SIZE_MAX - 0x7FF, 0x1000) had wrapped to 0, so libnvme_alloc() returned a 1-byte buffer.
  - After: libnvme_alloc() and libnvme_realloc() return NULL for the near-SIZE_MAX size instead of under-allocating, a normal allocate-then-grow path (100 -> 8192 bytes) still preserves its contents, and ASan reports no error.

Found by AISLE in partnership with Red Hat.