### PR TITLE
libnvme: check return value of sscanf in libnvme_ns_generic_to_blkdev()

### DIFF
--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -557,14 +557,14 @@ static inline bool libnvme_ns_is_generic(const char *name)
 
 static char *libnvme_ns_generic_to_blkdev(const char *generic)
 {
-
 	int instance, head_instance;
 	char blkdev[PATH_MAX];
 
 	if (!libnvme_ns_is_generic(generic))
 		return strdup(generic);
 
-	sscanf(generic, "ng%dn%d", &instance, &head_instance);
+	if (sscanf(generic, "ng%dn%d", &instance, &head_instance) != 2)
+		return NULL;
 	sprintf(blkdev, "nvme%dn%d", instance, head_instance);
 
 	return strdup(blkdev);


### PR DESCRIPTION
libnvme_ns_generic_to_blkdev() calls libnvme_ns_is_generic() to validate the format of generic, then calls sscanf() again to parse instance and head_instance without checking the return value.

If sscanf() fails to match both fields, instance and head_instance are left uninitialized when passed to sprintf(), resulting in undefined behavior.

Check the return value of sscanf() and return NULL if it does not match the expected two fields.