### PR TITLE
libnvme: fix unchecked return value of sscanf in ctrl_instance()

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -1528,7 +1528,8 @@ static int ctrl_instance(libnvme_ctrl_t c)
 
 	name = libnvme_ctrl_get_name(c);
 	if (name)
-		sscanf(name, "nvme%d", &instance);
+		if (sscanf(name, "nvme%d", &instance) != 1)
+			instance = -1;
 
 	return instance;
 }


### PR DESCRIPTION
The ctrl_instance() function parses the kernel instance number from a controller's name (e.g. "nvme3" -> 3) using sscanf(). The return value of sscanf() was not checked, so if the name does not match the expected "nvme%d" pattern, instance retains its initial value of -1 but for a different reason than intended — a silent parse failure.

Ignoring the sscanf() return value means a malformed or unexpected controller name goes undetected and the caller receives -1 without any indication of whether parsing succeeded or failed.

Check the return value of sscanf() and explicitly reset instance to -1 on failure, consistent with how sscanf() is checked elsewhere in the same file.