### PR TITLE
libnvme: simplify file existence check in test_creates_missing_directory()

### DIFF
--- a/libnvme/tests/config-emit.c
+++ b/libnvme/tests/config-emit.c
@@ -289,14 +289,12 @@ static bool test_creates_missing_directory(struct libnvme_global_ctx *ctx,
 	}
 	libnvmf_config_emit_free(e);
 
-	if (access(nested_main, F_OK)) {
+	if (unlink(nested_main)) {
 		printf(" - main file missing after install [FAIL]\n");
 		pass = false;
 	} else {
 		printf(" - missing parent directories created [PASS]\n");
 	}
-
-	unlink(nested_main);
 	rmdir(nested_dir);
 	snprintf(nested_dir, sizeof(nested_dir), "%s/a/b", fx->dir);
 	rmdir(nested_dir);


### PR DESCRIPTION
The test called access() on nested_main to verify the file existed, then immediately called unlink() to remove it.

The access() call is redundant: unlink() already returns 0 on success and -1 (ENOENT) on failure, directly indicating whether the file was present. Using the return value of unlink() as the pass/fail indicator removes an unnecessary syscall and makes the intent clearer.

This also resolves a Coverity TOCTOU diagnostic (CID 562382) which flags the access()-then-unlink() pattern as a security best practices violation regardless of context.