### PR TITLE
exclusion: fix insecure temporary file creation in excl_edit()

### DIFF
--- a/plugins/exclusion/exclusion-nvme.c
+++ b/plugins/exclusion/exclusion-nvme.c
@@ -533,7 +533,8 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 	/*
 	 * Edit a private scratch copy under $TMPDIR -- NOT in the exclusion dir.
 	 * The editor needs a real path, but the result is installed by name via
-	 * libnvmf_exclusion_write().  mkstemp() creates the copy 0600.
+	 * libnvmf_exclusion_write().  mkstemp() creates the copy 0600, and we
+	 * set the umask to 0177 first to guarantee no group/other bits leak in.
 	 */
 	tmpdir = getenv("TMPDIR");
 	if (!tmpdir || !*tmpdir)
@@ -541,7 +542,12 @@ static int excl_edit(int argc, char **argv, struct command *acmd,
 	snprintf(tmp_path, sizeof(tmp_path), "%s/nvme-excl-%s.XXXXXX",
 		 tmpdir, cfg.name);
 
-	fd = mkstemp(tmp_path);
+	{
+		mode_t old_umask = umask(0177);
+
+		fd = mkstemp(tmp_path);
+		umask(old_umask);
+	}
 	if (fd < 0) {
 		ret = -errno;
 		nvme_show_error("cannot create temp file: %s",


### PR DESCRIPTION
The excl_edit() function creates a scratch copy of the exclusion list under $TMPDIR using mkstemp().  The call is made without first setting a restrictive umask, so the file permissions are determined by the process umask at the time of the call.

If the inherited umask is permissive (e.g. 0022 or 0000), mkstemp() can create the file with group- or world-readable bits set, exposing the contents of the exclusion list to other users on the system before the editor session completes.

Set the umask to 0177 immediately before calling mkstemp() and restore the original umask immediately after, ensuring the scratch file is always created with mode 0600 regardless of the inherited umask.