### PR TITLE
ocp: remove logically dead code in parse_event_fifo()

### DIFF
--- a/plugins/ocp/ocp-telemetry-decode.c
+++ b/plugins/ocp/ocp-telemetry-decode.c
@@ -1148,9 +1148,6 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 			(struct nvme_ocp_telemetry_event_descriptor *)
 			(pfifo_start + offset_to_move);
 
-		if (pevent_descriptor == NULL)
-			break;
-
 		/* check if at the end of the list */
 		if (pevent_descriptor->debug_event_class_type == RESERVED_CLASS_TYPE)
 			break;
@@ -1288,9 +1285,7 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 				else
 					printf(STR_LINE2);
 			}
-		} else if ((pevent_descriptor != NULL) &&
-			(pevent_descriptor->debug_event_class_type ==
-				STATISTIC_SNAPSHOT_CLASS_TYPE)) {
+		} else {
 			parse_ocp_telemetry_string_log(0, event_id,
 				pevent_descriptor->debug_event_class_type, EVENT_STRING,
 				description_str);
@@ -1342,15 +1337,7 @@ int parse_event_fifo(unsigned int fifo_num, unsigned char *pfifo_start,
 					pstats_array,
 					fp);
 			}
-		} else {
-			if (fp)
-				fprintf(fp, "Unknown or null event class %p\n", pevent_descriptor);
-			else
-				printf("Unknown or null event class %p\n", pevent_descriptor);
-
-			break;
 		}
-
 		offset_to_move += (data_size + event_des_size);
 	}
 


### PR DESCRIPTION
The parse_event_fifo() function assigns pevent_descriptor by casting the sum of pfifo_start and offset_to_move. Since pfifo_start is validated non-NULL at function entry and offset_to_move is always non-negative, this pointer arithmetic can never produce NULL. The null check immediately following the assignment is therefore always false and the break is unreachable.

The if-branch handles all events where the class type is not STATISTIC_SNAPSHOT_CLASS_TYPE, so the following branch implicitly handles the statistic snapshot case. The explicit class type check in the else-if condition is therefore redundant.

Remove the dead null check and break, simplify the else-if to a plain else, and remove the now-unreachable else block.