### PR TITLE
tests: use pathlib in the e2e test suite

### DIFF
--- a/tests/e2e/nvme_compare_test.py
+++ b/tests/e2e/nvme_compare_test.py
@@ -64,15 +64,15 @@ class TestNVMeCompareCmd(TestNVMeIO):
             self.skipTest("because: Optional NVM Command 'Compare' (NVMCMPS) not supported")
         self.start_block = 1023
         self.setup_log_dir(self.__class__.__name__)
-        self.compare_file = self.test_log_dir + "/" + "compare_file.txt"
-        self.write_file = self.test_log_dir + "/" + self.write_file
+        self.compare_file = self.test_log_dir / "compare_file.txt"
+        self.write_file = self.test_log_dir / self.write_file
         self.create_data_file(self.write_file, self.data_size, "15")
         self.create_data_file(self.compare_file, self.data_size, "25")
         self.compare_meta_file = None
         if self.ms > 0 and not self.ns_meta_ext:
-            self.write_meta_file = self.test_log_dir + "/" + self.write_meta_file
+            self.write_meta_file = self.test_log_dir / self.write_meta_file
             self.compare_meta_file = \
-                self.test_log_dir + "/" + "compare_meta_file.bin"
+                self.test_log_dir / "compare_meta_file.bin"
             self.create_meta_file(self.write_meta_file, self.ms)
             self.create_meta_file(self.compare_meta_file, self.ms)
 

--- a/tests/e2e/nvme_format_test.py
+++ b/tests/e2e/nvme_format_test.py
@@ -77,7 +77,7 @@ class TestNVMeFormatCmd(TestNVMe):
         self.nsze = ncap
         self.ctrl_id = self.get_ctrl_id()
         self.lba_format_list = []
-        self.test_log_dir = self.log_dir + "/" + self.__class__.__name__
+        self.test_log_dir = self.log_dir / self.__class__.__name__
         self.setup_log_dir(self.__class__.__name__)
         self.delete_all_ns()
 

--- a/tests/e2e/nvme_qpif_test.py
+++ b/tests/e2e/nvme_qpif_test.py
@@ -58,15 +58,15 @@ class TestNVMeQPIFTest(TestNVMeIO):
 
         self.start_block = 1023
         self.storage_tag = 0x1
-        self.test_log_dir = self.log_dir + "/" + self.__class__.__name__
+        self.test_log_dir = self.log_dir / self.__class__.__name__
         self.setup_log_dir(self.__class__.__name__)
-        self.write_file = self.test_log_dir + "/" + self.write_file
-        self.read_file = self.test_log_dir + "/" + self.read_file
+        self.write_file = self.test_log_dir / self.write_file
+        self.read_file = self.test_log_dir / self.read_file
         self.create_data_file(self.write_file, self.data_size, "15")
-        open(self.read_file, 'a').close()
+        self.read_file.touch()
         if self.ms > 0 and not self.ns_meta_ext:
-            self.write_meta_file = self.test_log_dir + "/" + self.write_meta_file
-            self.read_meta_file = self.test_log_dir + "/" + self.read_meta_file
+            self.write_meta_file = self.test_log_dir / self.write_meta_file
+            self.read_meta_file = self.test_log_dir / self.read_meta_file
             self.create_meta_file(self.write_meta_file, self.ms)
 
     def tearDown(self):

--- a/tests/e2e/nvme_read_write_test.py
+++ b/tests/e2e/nvme_read_write_test.py
@@ -48,15 +48,15 @@ class TestNVMeReadWriteTest(TestNVMeIO):
         """ Pre Section for TestNVMeReadWriteTest """
         super().setUp()
         self.start_block = 1023
-        self.test_log_dir = self.log_dir + "/" + self.__class__.__name__
+        self.test_log_dir = self.log_dir / self.__class__.__name__
         self.setup_log_dir(self.__class__.__name__)
-        self.write_file = self.test_log_dir + "/" + self.write_file
-        self.read_file = self.test_log_dir + "/" + self.read_file
+        self.write_file = self.test_log_dir / self.write_file
+        self.read_file = self.test_log_dir / self.read_file
         self.create_data_file(self.write_file, self.data_size, "15")
-        open(self.read_file, 'a').close()
+        self.read_file.touch()
         if self.ms > 0 and not self.ns_meta_ext:
-            self.write_meta_file = self.test_log_dir + "/" + self.write_meta_file
-            self.read_meta_file = self.test_log_dir + "/" + self.read_meta_file
+            self.write_meta_file = self.test_log_dir / self.write_meta_file
+            self.read_meta_file = self.test_log_dir / self.read_meta_file
             self.create_meta_file(self.write_meta_file, self.ms)
 
     def tearDown(self):

--- a/tests/e2e/nvme_test_io.py
+++ b/tests/e2e/nvme_test_io.py
@@ -22,6 +22,7 @@
 """ Inherit TestNVMeIO for nvme read/write operations """
 
 import os
+from pathlib import Path
 
 from ..nvme_test import TestNVMe
 
@@ -54,13 +55,13 @@ class TestNVMeIO(TestNVMe):
         self.ms, self.prinfo, self.data_size = self._get_rw_io_params_per_lba()
         self.start_block = 0
         self.block_count = 0
-        self.write_file = "write_file.txt"
-        self.read_file = "read_file.txt"
+        self.write_file = Path("write_file.txt")
+        self.read_file = Path("read_file.txt")
         # Basename only; subclasses must prepend the test_log_dir path before
         # use (same convention as write_file and read_file above).
         if self.ms > 0 and not self.ns_meta_ext:
-            self.write_meta_file = "write_meta_file.bin"
-            self.read_meta_file = "read_meta_file.bin"
+            self.write_meta_file = Path("write_meta_file.bin")
+            self.read_meta_file = Path("read_meta_file.bin")
         else:
             self.write_meta_file = None
             self.read_meta_file = None

--- a/tests/e2e/nvme_writeuncor_test.py
+++ b/tests/e2e/nvme_writeuncor_test.py
@@ -50,10 +50,10 @@ class TestNVMeUncor(TestNVMeIO):
             self.skipTest("Write Uncorrectable command not supported by Windows")
         self.start_block = 1023
         self.setup_log_dir(self.__class__.__name__)
-        self.write_file = self.test_log_dir + "/" + self.write_file
-        self.read_file = self.test_log_dir + "/" + self.read_file
+        self.write_file = self.test_log_dir / self.write_file
+        self.read_file = self.test_log_dir / self.read_file
         self.create_data_file(self.write_file, self.data_size, "15")
-        open(self.read_file, 'a').close()
+        self.read_file.touch()
         oncs = to_decimal(self.get_id_ctrl_field_value("oncs"))
         if not oncs & (1 << 1):
             self.skipTest("write-uncor is not supported by this controller")

--- a/tests/e2e/nvme_writezeros_test.py
+++ b/tests/e2e/nvme_writezeros_test.py
@@ -55,15 +55,15 @@ class TestNVMeWriteZeros(TestNVMeIO):
         self.start_block = 1023
         self.block_count = 0
         self.setup_log_dir(self.__class__.__name__)
-        self.write_file = self.test_log_dir + "/" + self.write_file
-        self.read_file = self.test_log_dir + "/" + self.read_file
-        self.zero_file = self.test_log_dir + "/" + "zero_file.txt"
+        self.write_file = self.test_log_dir / self.write_file
+        self.read_file = self.test_log_dir / self.read_file
+        self.zero_file = self.test_log_dir / "zero_file.txt"
         self.create_data_file(self.write_file, self.data_size, "15")
         self.create_data_file(self.zero_file, self.data_size, '\0')
-        open(self.read_file, 'a').close()
+        self.read_file.touch()
         if self.ms > 0 and not self.ns_meta_ext:
-            self.write_meta_file = self.test_log_dir + "/" + self.write_meta_file
-            self.read_meta_file = self.test_log_dir + "/" + self.read_meta_file
+            self.write_meta_file = self.test_log_dir / self.write_meta_file
+            self.read_meta_file = self.test_log_dir / self.read_meta_file
             self.create_meta_file(self.write_meta_file, self.ms)
 
     def tearDown(self):

--- a/tests/e2e/plugins/micron/micron_vs_internal_log_test.py
+++ b/tests/e2e/plugins/micron/micron_vs_internal_log_test.py
@@ -26,8 +26,8 @@ Tests in this module verify:
     mis-use, and out-of-range data_area.
 """
 
-import os
 import struct
+from pathlib import Path
 
 from .micron_test import TestMicron
 
@@ -64,8 +64,7 @@ class TestMicronVsInternalLog(TestMicron):
 
     def tearDown(self):
         for path in self._archive_files:
-            if os.path.exists(path):
-                os.remove(path)
+            path.unlink(missing_ok=True)
         super().tearDown()
 
     # ------------------------------------------------------------------
@@ -78,13 +77,13 @@ class TestMicronVsInternalLog(TestMicron):
         The path is registered for automatic deletion in tearDown so that
         large archive files do not accumulate between test runs.
         """
-        path = os.path.join(self.test_log_dir, filename)
+        path = self.test_log_dir / filename
         self._archive_files.append(path)
         return path
 
     def _subdirs(self, path):
         """Return the set of subdirectory names in path."""
-        return {n for n in os.listdir(path) if os.path.isdir(os.path.join(path, n))}
+        return {p.name for p in path.iterdir() if p.is_dir()}
 
     def _run_log(self, args=""):
         """Run micron vs-internal-log against the default controller.
@@ -118,7 +117,7 @@ class TestMicronVsInternalLog(TestMicron):
             after the command returns.
         """
         output_path = self._archive_path(f"internal_log{extension}")
-        cwd = os.getcwd()
+        cwd = Path.cwd()
         dirs_before = self._subdirs(cwd)
 
         result = self._run_log(args=f"--package={output_path}")
@@ -131,11 +130,11 @@ class TestMicronVsInternalLog(TestMicron):
 
         # Archive must exist and contain data.
         self.assertTrue(
-            os.path.isfile(output_path),
+            output_path.is_file(),
             f"Archive was not created: {output_path}",
         )
         self.assertGreater(
-            os.path.getsize(output_path), 0,
+            output_path.stat().st_size, 0,
             f"Archive is empty: {output_path}",
         )
 
@@ -318,10 +317,10 @@ class TestMicronVsInternalLog(TestMicron):
             f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}",
         )
         self.assertTrue(
-            os.path.isfile(output_path),
+            output_path.is_file(),
             f"Telemetry log file was not created: {output_path}",
         )
-        size = os.path.getsize(output_path)
+        size = output_path.stat().st_size
         self.assertGreater(size, 0, "Telemetry log file is empty")
         self.assertEqual(
             size % 512, 0,
@@ -355,11 +354,11 @@ class TestMicronVsInternalLog(TestMicron):
             f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}",
         )
         self.assertTrue(
-            os.path.isfile(output_path),
+            output_path.is_file(),
             f"Telemetry log file was not created: {output_path}",
         )
 
-        actual_size = os.path.getsize(output_path)
+        actual_size = output_path.stat().st_size
         self.assertGreaterEqual(
             actual_size, _TELEMETRY_BLOCK_SIZE,
             f"Telemetry log file is smaller than one block: {actual_size} bytes",
@@ -367,7 +366,7 @@ class TestMicronVsInternalLog(TestMicron):
 
         # Read the data-area block count straight out of the file's header.
         offset, fmt = _DALB_HEADER[data_area]
-        with open(output_path, "rb") as f:
+        with output_path.open("rb") as f:
             header = f.read(_TELEMETRY_BLOCK_SIZE)
         (dalb,) = struct.unpack_from(fmt, header, offset)
 

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -38,14 +38,15 @@ import sys
 import time
 import traceback
 import unittest
+from pathlib import Path
 
 CONFIG_ENV_VAR = 'NVME_E2E_CONFIG'
 
 # Directory this file lives in (tests/e2e in a checkout, or .../nvme_e2e/e2e
 # once pip-installed) and the directory that must be on sys.path for dotted
 # imports under this package to resolve (the checkout root, or site-packages).
-_HERE = os.path.dirname(os.path.abspath(__file__))
-_TOP_LEVEL_DIR = os.path.dirname(os.path.dirname(_HERE))
+_HERE = Path(__file__).resolve().parent
+_TOP_LEVEL_DIR = _HERE.parent.parent
 
 
 def discover_plugin_names() -> list[str]:
@@ -53,12 +54,11 @@ def discover_plugin_names() -> list[str]:
     'ocp'), regardless of which nvme-cli plugins the target binary was built
     with -- that's checked at test time, not here.
     """
-    plugins_dir = os.path.join(_HERE, 'plugins')
-    if not os.path.isdir(plugins_dir):
+    plugins_dir = _HERE / 'plugins'
+    if not plugins_dir.is_dir():
         return []
-    return sorted(
-        name for name in os.listdir(plugins_dir)
-        if os.path.isfile(os.path.join(plugins_dir, name, '__init__.py')))
+    return sorted(p.name for p in plugins_dir.iterdir()
+                  if (p / '__init__.py').is_file())
 
 
 def _iter_test_cases(suite: unittest.TestSuite):
@@ -242,7 +242,7 @@ def build_config(args: argparse.Namespace) -> dict:
     """
     config = {}
     if args.config:
-        with open(args.config) as f:
+        with Path(args.config).open() as f:
             config = json.load(f)
 
     overrides = {
@@ -285,8 +285,8 @@ def load_tests(test_module_name: str | None,
         module = importlib.import_module(test_module_name)
         return loader.loadTestsFromModule(module)
 
-    suite = loader.discover(start_dir=_HERE, pattern='*_test.py',
-                            top_level_dir=_TOP_LEVEL_DIR)
+    suite = loader.discover(start_dir=str(_HERE), pattern='*_test.py',
+                            top_level_dir=str(_TOP_LEVEL_DIR))
     return filter_plugins(suite, enabled_plugins)
 
 
@@ -324,7 +324,7 @@ def run_tests(test_module_name: str | None, json_report: str | None,
             'finished_at': finished_at,
             'tests': result.records,
         }
-        with open(json_report, 'w') as f:
+        with Path(json_report).open('w') as f:
             json.dump(report, f, indent=2)
 
     return result.wasSuccessful()

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -29,11 +29,12 @@ import os
 import platform
 import re
 import shutil
-import stat
 import subprocess
 import sys
 import unittest
 import time
+from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -197,7 +198,7 @@ class TestNVMe(TestNVMeBase):
         # common code used in various testcases.
         self.ctrl = "XXX"
         self.ns1 = "XXX"
-        self.test_log_dir = "XXX"
+        self.test_log_dir: Optional[Path] = None
         self.do_validate_pci_device = True
         self.default_nsid = 0x1
         self.flbas = 0
@@ -294,7 +295,7 @@ class TestNVMe(TestNVMeBase):
         config = json.loads(raw_config)
         self.ctrl = config['controller']
         self.ns1 = config['ns1']
-        self.log_dir = config.get('log_dir', 'nvmetests')
+        self.log_dir = Path(config.get('log_dir', 'nvmetests'))
         self.nvme_bin = config.get('nvme_bin', self.nvme_bin)
         self.do_validate_pci_device = config.get(
             'do_validate_pci_device', self.do_validate_pci_device)
@@ -310,8 +311,7 @@ class TestNVMe(TestNVMeBase):
         if self.clear_log_dir is True:
             shutil.rmtree(self.log_dir, ignore_errors=True)
 
-        if not os.path.exists(self.log_dir):
-            os.makedirs(self.log_dir)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
 
     def setup_log_dir(self, test_name):
         """ Set up the log directory for a testcase
@@ -320,11 +320,10 @@ class TestNVMe(TestNVMeBase):
             Returns:
               - None
         """
-        self.test_log_dir = self.log_dir + "/" + test_name
-        if not os.path.exists(self.test_log_dir):
-            os.makedirs(self.test_log_dir)
-        self.stdout_log = open(self.test_log_dir + "/" + "stdout.log", "w")
-        self.stderr_log = open(self.test_log_dir + "/" + "stderr.log", "w")
+        self.test_log_dir = self.log_dir / test_name
+        self.test_log_dir.mkdir(parents=True, exist_ok=True)
+        self.stdout_log = (self.test_log_dir / "stdout.log").open("w")
+        self.stderr_log = (self.test_log_dir / "stderr.log").open("w")
 
     def _capture_device_metadata(self):
         """ Run 'nvme id ctrl' once and cache the fields that identify this
@@ -360,10 +359,10 @@ class TestNVMe(TestNVMeBase):
             - Returns:
                 - None
         """
-        if self.test_log_dir == "XXX" or not self.device_data:
+        if self.test_log_dir is None or not self.device_data:
             return
-        path = os.path.join(self.test_log_dir, "device_data.json")
-        with open(path, "w") as f:
+        path = self.test_log_dir / "device_data.json"
+        with path.open("w") as f:
             json.dump({
                 'metadata': self.device_metadata or {},
                 'commands': self.device_data,
@@ -748,7 +747,7 @@ class TestNVMe(TestNVMeBase):
         device_path = f"{self.ctrl}n{str(nsid)}"
         stop_time = time.time() + 5
         while time.time() < stop_time:
-            if os.path.exists(device_path) and stat.S_ISBLK(os.stat(device_path).st_mode):
+            if Path(device_path).is_block_device():
                 return 0
             time.sleep(0.1)
 
@@ -929,23 +928,22 @@ class TestNVMe(TestNVMeBase):
         data_size = data_size_per_lba * count
         metadata_size = ms * count if ms > 0 and not self.ns_meta_ext else 0
 
-        log_root = self.test_log_dir if self.test_log_dir != "XXX" else self.log_dir
-        if not os.path.exists(log_root):
-            os.makedirs(log_root)
+        log_root = self.test_log_dir if self.test_log_dir is not None else self.log_dir
+        log_root.mkdir(parents=True, exist_ok=True)
 
-        write_file = os.path.join(log_root, f"run_ns_io_write_{nsid}.bin")
-        read_file = os.path.join(log_root, f"run_ns_io_read_{nsid}.bin")
-        write_meta_file = os.path.join(log_root, f"run_ns_io_write_meta_{nsid}.bin")
-        read_meta_file = os.path.join(log_root, f"run_ns_io_read_meta_{nsid}.bin")
+        write_file = log_root / f"run_ns_io_write_{nsid}.bin"
+        read_file = log_root / f"run_ns_io_read_{nsid}.bin"
+        write_meta_file = log_root / f"run_ns_io_write_meta_{nsid}.bin"
+        read_meta_file = log_root / f"run_ns_io_read_meta_{nsid}.bin"
 
-        with open(write_file, "wb") as out_file:
+        with write_file.open("wb") as out_file:
             out_file.write(bytes(data_size))
-        open(read_file, 'a').close()
+        read_file.touch()
 
         if metadata_size > 0:
-            with open(write_meta_file, "wb") as meta_out:
+            with write_meta_file.open("wb") as meta_out:
                 meta_out.write(bytes(metadata_size))
-            open(read_meta_file, 'a').close()
+            read_meta_file.touch()
 
         read_cmd = self._build_nvme_rw_cmd("read", ns_path, 0, block_count,
                                            data_size, read_file, prinfo,


### PR DESCRIPTION
Closes #3876.

Replaces `os.path` and the `os.*` filesystem calls in the e2e test suite with
`pathlib` equivalents.

### The sentinel

Worth flagging as the non-mechanical part of this. `test_log_dir` used the
string sentinel `"XXX"` to mean "not set up yet", checked in two places:

```python
if self.test_log_dir == "XXX" or not self.device_data:
log_root = self.test_log_dir if self.test_log_dir != "XXX" else self.log_dir
```

A `Path` never compares equal to a `str`, so both of these would have silently
inverted once `test_log_dir` became a `Path` — no exception, just the wrong
branch. The sentinel and its comparisons are replaced with `None` / `is None`.

### Idioms used

| before | after |
|---|---|
| `open(f, 'a').close()` | `f.touch()` |
| `os.path.exists()` + `os.remove()` | `Path.unlink(missing_ok=True)` |
| `os.path.exists()` + `os.makedirs()` | `Path.mkdir(parents=True, exist_ok=True)` |
| `os.path.exists()` + `stat.S_ISBLK(os.stat(...).st_mode)` | `Path.is_block_device()` |

The last one removes the only use of the `stat` module, so that import is
dropped. Collapsing the `exists()`/`makedirs()` pairs also closes the TOCTOU
window between the two calls.

### On scope

The issue says "e2e test cases", but most of the `os.path` usage lives in the
shared `tests/nvme_test.py` base class, which `tests/cli/` also imports. I've
included it, because the two can't actually be separated: the e2e test cases
build their data-file paths by concatenating `test_log_dir` with a basename,
which raises `TypeError` the moment it becomes a `Path`. Splitting them would
produce a commit that doesn't run.

Happy to rework this if you'd rather keep the base class untouched — though I
think that would mean leaving the e2e cases on `os.path` too.

### Verification

Done without a device, so this is all host-side:

- Every module under `tests/e2e/` imports cleanly, at each commit in the series
  (checked in throwaway worktrees, so the requirement holds per-commit and not
  just at the tip).
- Unit-tested `setup_log_dir()` and `discover_plugin_names()` directly, bypassing
  `setUp()` (which needs a device), including the sentinel fallback behaviour.
- **Paths interpolate correctly into the nvme command strings.**
  `_build_nvme_rw_cmd()` builds `--data="{data_file}"` via f-string; confirmed a
  `Path` renders as the plain path and not as `PosixPath('...')`.
- **`Path.is_block_device()` matches the old `os.path.exists()` +
  `stat.S_ISBLK(os.stat(...).st_mode)`** across a real block device, a character
  device, a regular file, a directory, and a missing path.
- `filecmp.cmp()` accepts `Path` arguments; `touch()` leaves an existing file's
  contents intact, matching `open(f, 'a').close()`; `create_data_file()` works
  with a `Path` argument.
- `flake8 tests/` goes from 117 to 109 findings on the touched files — 8 fewer,
  none new. The `/` operator produces shorter lines than `+ "/" +`.

One behaviour difference worth naming: `Path.is_block_device()` returns `False`
on `OSError` (e.g. `EACCES`) where `os.stat()` would raise. In that
device-polling loop the new behaviour seems preferable — it keeps polling rather
than propagating — but it is a change, and I did not test the permission-denied
case.

Two things I could not verify, and one I'd like your view on:

- **I don't have NVMe hardware**, so the e2e suite itself has not been run, and
  the micron plugin paths (`is_file()`, `stat().st_size`,
  `unlink(missing_ok=True)`) were never executed. That needs CI or a reviewer
  with a device.
- **`mypy --strict` goes from 1510 to 1521.** All eleven are the same shape:
  subclasses call `setup_log_dir()` (which assigns `test_log_dir`) and then use
  it, and mypy can't see through the setter, so `Optional[Path]` stays
  possibly-`None` at the use sites. These aren't new bugs — mypy is surfacing a
  precondition that was invisible while the sentinel was an untyped string. I
  left them rather than scatter `assert`s through the test cases, but happy to
  take a different approach.
- `tests/pyproject.toml` declares `requires-python = ">=3.10"` while
  `run_py_linters.py` runs mypy with `--python-version 3.8`. Everything here is
  3.8-safe either way (`unlink(missing_ok=True)` is exactly 3.8), but you may
  want to reconcile those separately.
