### PR TITLE
log: add force option to report data area 4

### DIFF
--- a/libnvme/src/nvme/util.h
+++ b/libnvme/src/nvme/util.h
@@ -185,6 +185,23 @@ libnvme_opcode_status_to_string(int status, bool admin, __u8 opcode)
 }
 
 /**
+ * libnvme_status_is_invalid_field() - Checks nvme status if invalid field.
+ * @status: Return status from an nvme command
+ *
+ * Return: true if it is an nvme status invalid field or false if not.
+ */
+static inline bool
+libnvme_status_is_invalid_field(int status)
+{
+	if (status < 0 ||
+	    nvme_status_get_type(status) != NVME_STATUS_TYPE_NVME)
+		return false;
+
+	return nvme_status_code_type(status) == NVME_SCT_GENERIC &&
+	       nvme_status_code(status) == NVME_SC_INVALID_FIELD;
+}
+
+/**
  * libnvme_errno_to_string() - Returns string describing nvme connect failures
  * @err: Returned error code from libnvme_add_ctrl()
  *

--- a/plugins/log/log-plugin.c
+++ b/plugins/log/log-plugin.c
@@ -460,6 +460,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 	const char *dgen = "Pick which telemetry data area to report. Default is 3 to fetch areas 1-3. Valid options are 1, 2, 3, 4.";
 	const char *mcda = "Host-init Maximum Created Data Area. Valid options are 0 ~ 4 "
 		"If given, This option will override dgen. 0 : controller determines data area";
+	const char *force = "Report data area 4 without LPA: DA4S and ETDAS";
 
 	__cleanup_libnvme_free struct nvme_telemetry_log *log = NULL;
 	__cleanup_libnvme_free struct nvme_id_ctrl *id_ctrl = NULL;
@@ -482,6 +483,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 		int	data_area;
 		bool	rae;
 		__u8	mcda;
+		bool	force;
 	};
 	struct config cfg = {
 		.file_name	= NULL,
@@ -498,8 +500,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 		  OPT_FLAG("controller-init", 'c', &cfg.ctrl_init, cgen),
 		  OPT_UINT("data-area",       'd', &cfg.data_area, dgen),
 		  OPT_FLAG("rae",             'r', &cfg.rae,       rae),
-		  OPT_BYTE("mcda",            'm', &cfg.mcda,      mcda));
-
+		  OPT_BYTE("mcda",            'm', &cfg.mcda,      mcda),
+		  OPT_FLAG("force",             0, &cfg.force,     force));
 
 	err = parse_and_open(&ctx, &hdl, argc, argv, desc, opts);
 	if (err)
@@ -538,7 +540,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 			return err;
 		}
 
-		da4_support = id_ctrl->lpa & 0x40;
+		da4_support = id_ctrl->lpa & 0x40 || cfg.force;
 
 		if (!da4_support) {
 			nvme_show_error("%s: Telemetry data area 4 not supported by device",
@@ -547,7 +549,7 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 		}
 
 		err = libnvme_set_etdas(hdl, &host_behavior_changed);
-		if (err) {
+		if (err && !cfg.force) {
 			nvme_show_error("%s: Failed to set ETDAS bit", __func__);
 			return err;
 		}

--- a/plugins/log/log-plugin.c
+++ b/plugins/log/log-plugin.c
@@ -549,7 +549,8 @@ static int get_telemetry_log(int argc, char **argv, struct command *acmd,
 		}
 
 		err = libnvme_set_etdas(hdl, &host_behavior_changed);
-		if (err && !cfg.force) {
+		if (err && !libnvme_status_is_invalid_field(err) &&
+		    !cfg.force) {
 			nvme_show_error("%s: Failed to set ETDAS bit", __func__);
 			return err;
 		}


### PR DESCRIPTION
Since the LPA: DA4S and ETDAS settings are not mandatory.