### PR TITLE
ocp: fix unchecked return value of ocp_get_uuid_index

### DIFF
--- a/plugins/ocp/ocp-fw-activation-history.c
+++ b/plugins/ocp/ocp-fw-activation-history.c
@@ -44,11 +44,12 @@ int ocp_fw_activation_history_log(int argc, char **argv, struct command *acmd,
 	if (err)
 		return err;
 
-	/*
-	 * Best effort attempt at uuid. Otherwise, assume no index (i.e. 0)
-	 * Log GUID check will ensure correctness of returned data
-	 */
-	ocp_get_uuid_index(hdl, &uuid_index);
+	err = ocp_get_uuid_index(hdl, &uuid_index);
+	if (err) {
+		nvme_show_error("ERROR : OCP : Failed to get UUID index: %s",
+				libnvme_strerror(-err));
+		return err;
+	}
 	nvme_init_get_log(&cmd, NVME_NSID_ALL,
 			  (enum nvme_cmd_get_log_lid)OCP_LID_FAHL_OBSOLETE,
 			  NVME_CSI_NVM, &fw_history, sizeof(fw_history));

--- a/plugins/ocp/ocp-smart-extended-log.c
+++ b/plugins/ocp/ocp-smart-extended-log.c
@@ -52,7 +52,12 @@ static int get_c0_log_page(struct libnvme_transport_handle *hdl, char *format,
 	}
 	memset(data, 0, sizeof(*data));
 
-	ocp_get_uuid_index(hdl, &uidx);
+	ret = ocp_get_uuid_index(hdl, &uidx);
+	if (ret < 0) {
+		nvme_show_error("ERROR : OCP : get uuid index : %s",
+				libnvme_strerror(-ret));
+		goto out;
+	}
 	nvme_init_get_log(&cmd, NVME_NSID_ALL,
 			  (enum nvme_cmd_get_log_lid)OCP_LID_SMART,
 			  NVME_CSI_NVM, data, sizeof(*data));

--- a/plugins/ocp/ocp-utils.c
+++ b/plugins/ocp/ocp-utils.c
@@ -11,6 +11,7 @@
 #include <ccan/endian/endian.h>
 
 #include "nvme-cmds.h"
+#include "nvme-print.h"
 #include "ocp-nvme.h"
 #include "ocp-utils.h"
 
@@ -26,7 +27,7 @@ int ocp_find_uuid_index(struct nvme_id_uuid_list *uuid_list, __u8 *index)
 	if (i > 0)
 		*index = i;
 	else
-		return -errno;
+		return i;
 
 	return 0;
 }
@@ -53,8 +54,14 @@ int ocp_get_log_simple(struct libnvme_transport_handle *hdl,
 {
 	struct libnvme_passthru_cmd cmd;
 	__u8 uidx;
+	int err;
 
-	ocp_get_uuid_index(hdl, &uidx);
+	err = ocp_get_uuid_index(hdl, &uidx);
+	if (err) {
+		nvme_show_error("ERROR : OCP : Failed to get UUID index: %s",
+				libnvme_strerror(-err));
+		return err;
+	}
 	nvme_init_get_log(&cmd, NVME_NSID_ALL, (enum nvme_cmd_get_log_lid) lid,
 			   NVME_CSI_NVM, log, len);
 	cmd.cdw14 |= NVME_FIELD_ENCODE(uidx,


### PR DESCRIPTION
The get_c0_log_page(), ocp_get_log_simple() and
ocp_fw_activation_history_log() functions all call ocp_get_uuid_index() but discard the return value. ocp_get_uuid_index() returns a non-zero value on failure, leaving uidx at its default of 0.

Proceeding with uidx set to 0 encodes the wrong UUID index into the CDW14 field, causing log page retrievals to use an invalid UUID index rather than failing cleanly.

Check the return value of ocp_get_uuid_index() in all three callers, log the error using libnvme_strerror(-ret) since ocp_get_uuid_index() returns the error code directly and does not set errno, and return the error to the caller.

Also fix ocp_find_uuid_index() which incorrectly returned -errno on failure instead of propagating the negative error code returned by libnvme_find_uuid(). libnvme_find_uuid() does not set errno; it returns a negative error code directly, so -errno produced a stale unrelated value.