### PR TITLE
completions: test the generator against a synthetic fixture

### DIFF
--- a/completions/test-bash-completion.sh
+++ b/completions/test-bash-completion.sh
@@ -13,7 +13,21 @@
 # script's `complete` call needs it on to register without error.
 shopt -s progcomp
 
-source "$(dirname "$0")/bash-nvme-completion.sh"
+# The completion under test is generated fresh from a committed metadata fixture
+# rather than sourced from the checked-in bash-nvme-completion.sh: the generator
+# is the unit under test, so we exercise its current output. The fixture
+# (test-command-metadata.json) is a hand-written, schema-validated model of
+# synthetic commands and options -- deliberately not real nvme output -- built
+# to exercise every generator branch, and needs no nvme binary or build.
+_here="$(cd "$(dirname "$0")" && pwd)"
+_generated="$(mktemp)"
+trap 'rm -f "$_generated"' EXIT
+if ! python3 "$_here/generate-completions.py" --bash "$_generated" \
+        < "$_here/test-command-metadata.json"; then
+    echo "failed to generate bash completion from fixture" >&2
+    exit 1
+fi
+source "$_generated"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -274,29 +288,29 @@ echo "========================================"
 expect_match \
     "top-level list offers builtin commands" \
     "nvme " \
-    "id-ctrl.*smart-log"
+    "alpha-cmd.*zulu-cmd"
 
 expect_match \
     "top-level list is filtered by the typed prefix" \
-    "nvme id-" \
-    "id-ctrl.*id-ns"
+    "nvme alpha-" \
+    "alpha-alias.*alpha-cmd"
 
 expect_match \
     "top-level list includes plugin names" \
     "nvme " \
-    "feat.*zns"
+    "beta-plug.*zeta-plug"
 
-# A command's alias is offered alongside its primary name (fw-commit/fw-activate)
+# A command's alias is offered alongside its primary name (zulu-cmd/alpha-alias)
 # and its options complete when invoked by the alias.
 expect_match \
     "top-level list includes a command alias" \
-    "nvme fw-a" \
-    "fw-activate"
+    "nvme alpha-a" \
+    "alpha-alias"
 
 expect_match \
     "a command invoked by its alias completes options" \
-    "nvme fw-activate --" \
-    "--action"
+    "nvme alpha-alias --" \
+    "--mode"
 
 # help and version are dispatcher built-ins (not in the metadata) but are still
 # completable top-level commands.
@@ -315,39 +329,49 @@ expect_match \
 # ---------------------------------------------------------------------------
 expect_match \
     "a plugin lists its sub-commands" \
-    "nvme feat " \
-    "arbitration.*power-mgmt"
+    "nvme zeta-plug " \
+    "no-opt-sub.*report"
 
 expect_match \
     "plugin sub-commands are filtered by the typed prefix" \
-    "nvme feat power-" \
-    "power-meas.*power-mgmt"
+    "nvme zeta-plug r" \
+    "report.*rpt"
 
 # A different plugin, to prove routing isn't hardcoded to one name.
 expect_match \
     "sub-command routing works for any plugin" \
-    "nvme zns " \
-    "report-zones.*reset-zone"
+    "nvme beta-plug " \
+    "local-sub"
 
-# A plugin sub-command alias is listed alongside its primary name (dera defines
-# alias 'stat' for 'smart-log-add').
+# A plugin sub-command alias is listed alongside its primary name (zeta-plug
+# defines alias 'rpt' for 'report').
 expect_match \
     "a plugin lists a sub-command alias" \
-    "nvme dera " \
-    "smart-log-add.*stat"
+    "nvme zeta-plug " \
+    "report.*rpt"
 
 # ---------------------------------------------------------------------------
 # Device-argument injection
 # ---------------------------------------------------------------------------
 expect_device \
     "a builtin command that takes a device offers /dev/nvme*" \
-    "nvme id-ctrl "
+    "nvme alpha-cmd "
 
 # Plugin sub-commands sit one word later, so their opts functions inject the
 # device at a higher non-option-argument threshold (3 vs 2). Cover that path.
 expect_device \
     "a plugin sub-command that takes a device offers /dev/nvme*" \
-    "nvme feat power-meas "
+    "nvme zeta-plug report "
+
+# A command with no options of its own must still inject the device argument --
+# exercises the generator's empty-options path for a builtin and a plugin sub.
+expect_device \
+    "an option-less command still injects a device" \
+    "nvme no-opt-cmd "
+
+expect_device \
+    "an option-less plugin sub-command still injects a device" \
+    "nvme zeta-plug no-opt-sub "
 
 expect_no_device \
     "help takes no device" \
@@ -362,81 +386,88 @@ expect_no_device \
 # not us, so it isn't exercised here.)
 expect_no_device \
     "a device already on the line is not offered again" \
-    "nvme id-ctrl /dev/nvme0 "
+    "nvme alpha-cmd /dev/nvme0 "
 
-# A non-NVMe /dev/* path as an option value (e.g. --output-file /dev/null) is not
+# A non-NVMe /dev/* path as an option value (e.g. --in-file /dev/null) is not
 # the device argument, so device injection must still happen.
 expect_device \
     "a /dev/* option value is not mistaken for the device argument" \
-    "nvme telemetry-log --output-file /dev/null "
+    "nvme alpha-cmd --in-file /dev/null "
 
 # Even a /dev/nvme* path given as an option value is not the positional device
 # argument, so injection must still happen.
 expect_device \
     "a /dev/nvme* option value is not mistaken for the device argument" \
-    "nvme telemetry-log --output-file /dev/nvme0 "
+    "nvme alpha-cmd --in-file /dev/nvme0 "
 
-# Same, but the '=' value form split by bash into '--output-file = /dev/nvme0'.
+# Same, but the '=' value form split by bash into '--in-file = /dev/nvme0'.
 # The /dev/nvme0 must still be recognised as the option's value, not the device.
 expect_device_words \
     "a /dev/nvme* value after a split '=' is not mistaken for the device" \
-    nvme telemetry-log --output-file = /dev/nvme0 ""
+    nvme alpha-cmd --in-file = /dev/nvme0 ""
 
-# And the unsplit-option form '--output-file=' as its own word: the trailing '='
+# And the unsplit-option form '--in-file=' as its own word: the trailing '='
 # must be stripped so the option still matches $valopts and its value is not
 # counted as the device.
 expect_device_words \
     "a /dev/nvme* value after an unsplit '--opt=' token is not the device" \
-    nvme telemetry-log "--output-file=" /dev/nvme0 ""
+    nvme alpha-cmd "--in-file=" /dev/nvme0 ""
 
 # ---------------------------------------------------------------------------
 # Option-name completion
 # ---------------------------------------------------------------------------
 expect_match \
     "-h/--help is always offered" \
-    "nvme id-ctrl -" \
+    "nvme alpha-cmd -" \
     "(^| )--help( |\$)"
 
 expect_match \
     "a partial option name completes to the full option" \
-    "nvme id-ctrl --output-f" \
-    "--output-format"
+    "nvme alpha-cmd --wait-" \
+    "--wait-time"
 
 # Global options are offered per command, straight from the metadata -- so a
-# command that takes them gets them, and one that does not (e.g. intel
-# lat-stats-tracking) is not wrongly offered them.
+# command that takes them gets them, and one that does not (local-sub carries no
+# global 'format' option) is not wrongly offered them.
 expect_match \
     "a command with global options offers them" \
-    "nvme id-ctrl -" \
-    "--output-format"
+    "nvme alpha-cmd -" \
+    "--format"
 
 expect_no_match \
     "a command without global options is not offered them" \
-    "nvme intel lat-stats-tracking -" \
-    "--output-format"
+    "nvme beta-plug local-sub -" \
+    "--format"
 
 # An option that takes a value completes to 'name=' with no trailing space, so
 # the user can type the value immediately.
 expect_compopt \
     "a value-taking option completes with a trailing '=' and no space" \
-    "nvme id-ctrl --timeout" \
+    "nvme alpha-cmd --wait-time" \
     "-o nospace"
 
 # But nospace must NOT fire when a prefix matches several options -- e.g.
-# '--output-format' matches both '--output-format=' and '--output-format-version='.
-# bash appends nothing for an ambiguous completion, and suppressing the space
-# would be wrong. (Regression: the check once looked only at COMPREPLY[0].)
+# '--format' matches both '--format=' and '--format-version='. bash appends
+# nothing for an ambiguous completion, and suppressing the space would be wrong.
+# (Regression: the check once looked only at COMPREPLY[0].)
 expect_no_compopt \
     "no nospace when a prefix matches multiple options" \
-    "nvme id-ctrl --output-format" \
+    "nvme alpha-cmd --format" \
     "-o nospace"
+
+# A hidden option is accepted on the command line but suppressed from --help, so
+# the generator must not offer it as a completion.
+expect_no_match \
+    "a hidden option is not offered" \
+    "nvme zulu-cmd -" \
+    "--secret"
 
 # Regression: the generated opts functions once used their loop counter i
 # without declaring it local, silently clobbering the user's own $i. It must
 # stay local so a completion never leaks into the caller's shell.
 expect_no_var_leak \
     "completion does not leak loop variable i" \
-    "nvme id-ctrl " \
+    "nvme alpha-cmd " \
     i
 
 # A flag option takes no value, so completing after it (empty word, i.e. a
@@ -444,152 +475,163 @@ expect_no_var_leak \
 # (which offers nothing and suppresses files). Covers both long and short flags.
 expect_match \
     "completion resumes after a long flag option" \
-    "nvme id-ctrl --verbose " \
+    "nvme alpha-cmd --dry-run " \
     "--help"
 
 expect_match \
     "completion resumes after a short flag option" \
-    "nvme id-ctrl -v " \
+    "nvme zulu-cmd -x " \
     "--help"
 
 # The complement stays correct: a value-taking flagless option still completes
 # its value (guard against the fix over-reaching and disabling value mode).
 expect_match \
     "a value option still completes its value after the fix" \
-    "nvme id-ctrl --output-format " \
-    "normal.*json"
+    "nvme alpha-cmd --format " \
+    "raw.*pretty"
 
 # ---------------------------------------------------------------------------
 # Option-value completion (enumerated values)
 # ---------------------------------------------------------------------------
-# --output-format is a global option available on every command.
+# --format is a global option carried by several commands, with an enumerated
+# value list in the metadata.
 expect_match \
     "a global option lists its values (--opt= form)" \
-    "nvme id-ctrl --output-format=" \
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd --format=" \
+    "raw.*pretty.*wide"
 
 expect_match \
     "a global option lists its values (--opt <space> form)" \
-    "nvme id-ctrl --output-format " \
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd --format " \
+    "raw.*pretty.*wide"
 
 expect_match \
     "a partial value is filtered against the value list" \
-    "nvme id-ctrl --output-format j" \
-    "json"
+    "nvme alpha-cmd --format p" \
+    "pretty"
 
 expect_match \
     "a partial value is filtered after '=' too" \
-    "nvme id-ctrl --output-format=j" \
-    "json"
+    "nvme alpha-cmd --format=p" \
+    "pretty"
 
 expect_match \
     "the short-option form lists the same values" \
-    "nvme id-ctrl -o " \
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd -o " \
+    "raw.*pretty.*wide"
 
 expect_match \
     "the short-option form filters a partial value" \
-    "nvme id-ctrl -o j" \
-    "json"
+    "nvme alpha-cmd -o p" \
+    "pretty"
 
-# nvme's getopt also accepts the short-option '=' form ('-o=json'). When bash
+# nvme's getopt also accepts the short-option '=' form ('-o=pretty'). When bash
 # splits on '=', that arrives as '-o = [partial]'; the value list must appear
 # just as it does for the long-option '=' form.
 expect_match \
     "the short-option '=' form lists values" \
-    "nvme id-ctrl -o=" \
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd -o=" \
+    "raw.*pretty.*wide"
 
 expect_match \
     "the short-option '=' form filters a partial value" \
-    "nvme id-ctrl -o=j" \
-    "json"
+    "nvme alpha-cmd -o=p" \
+    "pretty"
 
-# Depending on COMP_WORDBREAKS, bash may present 'nvme id-ctrl --output-format='
+# Depending on COMP_WORDBREAKS, bash may present 'nvme alpha-cmd --format='
 # as three tokens ending in a bare '=' (option is the previous word) OR as a
-# single unsplit '--output-format=' token. The string helpers always split on
-# '=', so drive both forms explicitly to prove the value list appears either way.
+# single unsplit '--format=' token. The string helpers always split on '=', so
+# drive both forms explicitly to prove the value list appears either way.
 expect_match_words \
     "value list appears when '=' is the current word (split form)" \
-    "normal.*json.*binary.*tabular" \
-    nvme feat power-meas --output-format =
+    "raw.*pretty.*wide" \
+    nvme zeta-plug report --format =
 
 expect_match_words \
     "value list appears for an unsplit '--opt=' token" \
-    "normal.*json.*binary.*tabular" \
-    nvme id-ctrl "--output-format="
+    "raw.*pretty.*wide" \
+    nvme alpha-cmd "--format="
 
-# Same unsplit form but with a partial value ('--output-format=j'), which occurs
-# when '=' is removed from COMP_WORDBREAKS. The partial must still filter the
-# value list down to the match.
+# Same unsplit form but with a partial value ('--format=p'), which occurs when
+# '=' is removed from COMP_WORDBREAKS. The partial must still filter the value
+# list down to the match.
 expect_match_words \
     "partial value filters for an unsplit '--opt=partial' token" \
-    "json" \
-    nvme id-ctrl "--output-format=j"
+    "pretty" \
+    nvme alpha-cmd "--format=p"
 
 # Trailing space after an unsplit '--opt=' token: the previous word is the whole
-# '--output-format=' (with '='), so the value list must still appear -- the
-# detector has to strip the '=' before matching option names.
+# '--format=' (with '='), so the value list must still appear -- the detector
+# has to strip the '=' before matching option names.
 expect_match_words \
     "value list appears after an unsplit '--opt= ' with trailing space" \
-    "normal.*json.*binary.*tabular" \
-    nvme id-ctrl "--output-format=" ""
+    "raw.*pretty.*wide" \
+    nvme alpha-cmd "--format=" ""
 
-# --sel is an enumerated option carried by feat's sub-commands. Its values come
-# from the generator's VALUE_HINTS table (the arg parser leaves --sel
+# --sel is an enumerated option carried by zeta-plug's report. Its values
+# come from the generator's VALUE_HINTS table (the arg parser leaves --sel
 # unconstrained, so the command metadata carries no values). This also exercises
 # value completion reached through the plugin sub-command routing path.
 expect_match \
     "an enumerated option on a plugin sub-command lists its values (--opt= form)" \
-    "nvme feat power-meas --sel=" \
+    "nvme zeta-plug report --sel=" \
     "0.*1.*2.*3"
 
 expect_match \
     "an enumerated option on a plugin sub-command lists its values (space form)" \
-    "nvme feat power-meas --sel " \
+    "nvme zeta-plug report --sel " \
     "0.*1.*2.*3"
 
 expect_match \
     "an enumerated option on a plugin sub-command lists its values (short opt)" \
-    "nvme feat power-meas -S " \
+    "nvme zeta-plug report -S " \
     "0.*1.*2.*3"
 
 # A command-LOCAL enumerated option whose values DO come from the metadata
-# (fw-commit --action has an OPT_VALS table). Regression guard: the generator
-# once emitted the per-command value clause only for global options, so local
-# option values silently never completed.
+# (local-sub --mode carries a value set). Regression guard: the generator once
+# emitted the per-command value clause only for global options, so local option
+# values silently never completed.
 expect_match \
     "a command-local enumerated option lists its metadata values" \
-    "nvme fw-commit --action " \
-    "replace.*set-active"
+    "nvme beta-plug local-sub --mode " \
+    "fast.*slow"
 
 expect_match \
     "a command-local enumerated option lists its values (short opt)" \
-    "nvme fw-commit -a " \
-    "replace.*set-active"
+    "nvme beta-plug local-sub -m " \
+    "fast.*slow"
 
 # ---------------------------------------------------------------------------
 # File-vs-no-file fallback for value-taking options
 # ---------------------------------------------------------------------------
-# A NUM value (e.g. --timeout, a freeform millisecond count that will never get
-# an OPT_VALS table) must not fall back to listing files.
+# A NUM value (--wait-time, a freeform millisecond count with no value set) must
+# not fall back to listing files.
 expect_suppresses_files \
     "a numeric value offers nothing and suppresses files (--opt= form)" \
-    "nvme id-ctrl --timeout="
+    "nvme alpha-cmd --wait-time="
 
 expect_suppresses_files \
     "a numeric value offers nothing and suppresses files (space form)" \
-    "nvme id-ctrl --timeout "
+    "nvme alpha-cmd --wait-time "
 
-# A FILE value (e.g. fw-download --fw) must leave readline's file completion on.
+# A FILE value (alpha-cmd --in-file) must leave readline's file completion on.
 expect_allows_files \
     "a FILE value keeps file completion enabled (--opt= form)" \
-    "nvme fw-download --fw="
+    "nvme alpha-cmd --in-file="
 
 expect_allows_files \
     "a FILE value keeps file completion enabled (space form)" \
-    "nvme fw-download --fw "
+    "nvme alpha-cmd --in-file "
+
+# A DIRECTORY value is treated the same as FILE (report --out-dir), and
+# sits alongside --in-file so this also exercises the multi-file-option path.
+expect_allows_files \
+    "a DIRECTORY value keeps file completion enabled (--opt= form)" \
+    "nvme zeta-plug report --out-dir="
+
+expect_allows_files \
+    "a DIRECTORY value keeps file completion enabled (space form)" \
+    "nvme zeta-plug report --out-dir "
 
 echo ""
 echo "========================================"

--- a/completions/test-command-metadata.json
+++ b/completions/test-command-metadata.json
@@ -1,0 +1,171 @@
+{
+  "schema_version": 1,
+  "name": "nvme",
+  "version": "0.0-fixture",
+  "description": "Synthetic fixture for the completion generator tests.",
+  "commands": [
+    {
+      "name": "zulu-cmd",
+      "alias": "alpha-alias",
+      "description": "zulu builtin command",
+      "options": [
+        {
+          "long": "mode",
+          "short": "m",
+          "argument": "required",
+          "metavar": "MODE",
+          "description": "operating mode",
+          "values": ["fast", "slow"]
+        },
+        {
+          "long": "force",
+          "short": "x",
+          "argument": "none",
+          "description": "don't    prompt for 'confirmation'"
+        },
+        {
+          "long": "format",
+          "short": "o",
+          "argument": "required",
+          "metavar": "FMT",
+          "description": "output format",
+          "global": true,
+          "values": ["raw", "pretty", "wide"]
+        },
+        {
+          "long": "secret",
+          "argument": "none",
+          "hidden": true,
+          "description": "undocumented, hidden from help"
+        },
+        {
+          "long": "verbose-level",
+          "argument": "optional",
+          "description": "verbosity level"
+        }
+      ]
+    },
+    {
+      "name": "no-opt-cmd",
+      "description": "builtin command with no options",
+      "options": []
+    },
+    {
+      "name": "alpha-cmd",
+      "description": "alpha builtin command",
+      "options": [
+        {
+          "long": "wait-time",
+          "short": "w",
+          "argument": "required",
+          "metavar": "NUM",
+          "description": "milliseconds to wait"
+        },
+        {
+          "long": "format",
+          "short": "o",
+          "argument": "required",
+          "metavar": "FMT",
+          "description": "output format",
+          "global": true,
+          "values": ["raw", "pretty", "wide"]
+        },
+        {
+          "long": "in-file",
+          "short": "f",
+          "argument": "required",
+          "metavar": "FILE",
+          "description": "input file path"
+        },
+        {
+          "long": "format-version",
+          "argument": "required",
+          "metavar": "VER",
+          "description": "metadata format version",
+          "global": true,
+          "values": ["1", "2"]
+        },
+        {
+          "long": "dry-run",
+          "argument": "none",
+          "description": "print actions without running them"
+        }
+      ]
+    }
+  ],
+  "plugins": [
+    {
+      "name": "zeta-plug",
+      "description": "zeta plugin",
+      "commands": [
+        {
+          "name": "report",
+          "alias": "rpt",
+          "description": "report a thing",
+          "options": [
+            {
+              "long": "out-dir",
+              "argument": "required",
+              "metavar": "DIRECTORY",
+              "description": "output directory"
+            },
+            {
+              "long": "format",
+              "short": "o",
+              "argument": "required",
+              "metavar": "FMT",
+              "description": "output format",
+              "global": true,
+              "values": ["raw", "pretty", "wide"]
+            },
+            {
+              "long": "sel",
+              "short": "S",
+              "argument": "required",
+              "metavar": "SEL",
+              "description": "selection source"
+            },
+            {
+              "long": "in-file",
+              "short": "f",
+              "argument": "required",
+              "metavar": "FILE",
+              "description": "input file path"
+            }
+          ]
+        },
+        {
+          "name": "no-opt-sub",
+          "description": "sub-command with no options",
+          "options": []
+        }
+      ]
+    },
+    {
+      "name": "beta-plug",
+      "description": "beta plugin",
+      "commands": [
+        {
+          "name": "local-sub",
+          "description": "sub-command with local options but no globals",
+          "options": [
+            {
+              "long": "mode",
+              "short": "m",
+              "argument": "required",
+              "metavar": "MODE",
+              "description": "operating mode",
+              "values": ["fast", "slow"]
+            },
+            {
+              "long": "secret",
+              "argument": "none",
+              "hidden": true,
+              "description": "undocumented, hidden from help"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/completions/test-powershell-completion.ps1
+++ b/completions/test-powershell-completion.ps1
@@ -4,13 +4,32 @@
 #
 # Unit tests for the generated PowerShell completion (nvme-completion.ps1).
 #
-# PowerShell's Register-ArgumentCompleter drives completion via the framework,
-# so we test by calling TabExpansion2 against the loaded completer and
-# inspecting the CompletionResult list.
+# The completion under test is generated fresh from a committed metadata fixture
+# rather than sourced from the checked-in nvme-completion.ps1: the generator is
+# the unit under test, so we exercise its current output. The fixture
+# (test-command-metadata.json) is a hand-written, schema-validated model of
+# synthetic commands and options -- deliberately not real nvme output -- built to
+# exercise every generator branch, and needs no nvme binary or build.
+#
+# PowerShell's Register-ArgumentCompleter drives completion via the framework, so
+# we test by calling TabExpansion2 against the loaded completer and inspecting the
+# CompletionResult list.
 
 $ErrorActionPreference = 'Stop'
 
-. "$PSScriptRoot/nvme-completion.ps1"
+# PowerShell has no '< file' stdin redirection, so pipe the fixture into the
+# generator (which reads JSON on stdin and writes the completer to its path arg).
+$python = Get-Command python3 -ErrorAction SilentlyContinue
+if (-not $python) { $python = Get-Command python -ErrorAction SilentlyContinue }
+if (-not $python) { Write-Error 'python3 not found'; exit 1 }
+
+$generated = Join-Path ([System.IO.Path]::GetTempPath()) `
+    ("nvme-completion-{0}.ps1" -f [System.IO.Path]::GetRandomFileName())
+Get-Content -Raw "$PSScriptRoot/test-command-metadata.json" |
+    & $python.Source "$PSScriptRoot/generate-completions.py" --powershell $generated
+if ($LASTEXITCODE -ne 0) { Write-Error 'failed to generate PowerShell completion from fixture'; exit 1 }
+. $generated
+Remove-Item $generated -ErrorAction SilentlyContinue
 
 $script:TestsRun = 0
 $script:TestsPassed = 0
@@ -59,21 +78,6 @@ function Assert-NoMatch {
     }
 }
 
-function Assert-Empty {
-    param([string]$Desc, [string]$InputScript)
-    $script:TestsRun++
-    $completions = Get-Completions $InputScript
-    if ($completions.Count -eq 0) {
-        Write-Host "  PASS: $Desc" -ForegroundColor Green
-        $script:TestsPassed++
-    } else {
-        Write-Host "  FAIL: $Desc" -ForegroundColor Red
-        Write-Host "    Input: '$InputScript'" -ForegroundColor Yellow
-        Write-Host "    Expected nothing, got: '$($completions -join ' ')'" -ForegroundColor Yellow
-        $script:TestsFailed++
-    }
-}
-
 Write-Host "========================================"
 Write-Host "PowerShell Completion Tests"
 Write-Host "========================================"
@@ -87,12 +91,19 @@ Write-Host "Top-level command dispatch:"
 Assert-Match `
     "top-level list offers builtin commands" `
     "nvme " `
-    "\blist\b"
+    "\balpha-cmd\b"
 
 Assert-Match `
     "top-level list includes plugin names" `
     "nvme " `
-    "feat"
+    "\bzeta-plug\b"
+
+# A command alias is listed alongside its primary name (alpha-alias is an alias
+# of zulu-cmd).
+Assert-Match `
+    "top-level list includes a command alias" `
+    "nvme " `
+    "\balpha-alias\b"
 
 Assert-Match `
     "top-level list includes help" `
@@ -106,13 +117,13 @@ Assert-Match `
 
 Assert-Match `
     "prefix narrows the top-level list" `
-    "nvme li" `
-    "\blist\b"
+    "nvme alpha-" `
+    "\balpha-cmd\b"
 
 Assert-NoMatch `
     "prefix excludes non-matching commands" `
-    "nvme li" `
-    "\bformat\b"
+    "nvme alpha-" `
+    "\bzulu-cmd\b"
 
 Write-Host ""
 
@@ -123,18 +134,21 @@ Write-Host "Plugin sub-command listing:"
 
 Assert-Match `
     "a plugin lists its sub-commands" `
-    "nvme feat " `
-    "power-mgmt"
+    "nvme zeta-plug " `
+    "\breport\b"
 
+# A different plugin, to prove sub-command routing isn't hardcoded to one name.
 Assert-Match `
     "sub-command routing works for any plugin" `
-    "nvme ocp " `
-    "smart-add-log"
+    "nvme beta-plug " `
+    "\blocal-sub\b"
 
+# A plugin sub-command alias is listed alongside its primary name (zeta-plug
+# defines alias 'rpt' for 'report').
 Assert-Match `
     "a plugin lists a sub-command alias" `
-    "nvme dera " `
-    "stat"
+    "nvme zeta-plug " `
+    "\brpt\b"
 
 Write-Host ""
 
@@ -145,33 +159,42 @@ Write-Host "Option-name completion:"
 
 Assert-Match `
     "a builtin command offers its options" `
-    "nvme list --out" `
-    "--output-format"
+    "nvme alpha-cmd --wait-" `
+    "--wait-time"
 
+# A command invoked by its alias completes the same options (alpha-alias is an
+# alias of zulu-cmd).
 Assert-Match `
     "a command invoked by alias completes options" `
-    "nvme fw activate --a" `
-    "--action"
+    "nvme alpha-alias --m" `
+    "--mode"
 
 Assert-Match `
     "a plugin sub-command offers its options" `
-    "nvme feat power-meas --s" `
+    "nvme zeta-plug report --s" `
     "--sel"
 
 Assert-Match `
     "all options listed for a command (space trigger)" `
-    "nvme list " `
-    "--output-format"
+    "nvme alpha-cmd " `
+    "--format"
 
 Assert-Match `
     "short options are offered" `
-    "nvme list " `
+    "nvme alpha-cmd " `
     "(^| )-o( |$)"
 
 Assert-Match `
     "--help is always offered" `
-    "nvme list --hel" `
+    "nvme alpha-cmd --hel" `
     "--help"
+
+# A hidden option is accepted on the command line but suppressed from --help, so
+# the generator must not offer it as a completion (zulu-cmd has a hidden 'secret').
+Assert-NoMatch `
+    "a hidden option is not offered" `
+    "nvme zulu-cmd -" `
+    "--secret"
 
 Write-Host ""
 
@@ -183,9 +206,9 @@ Write-Host "help / version built-ins:"
 Assert-Match `
     "help completes a command name" `
     "nvme help " `
-    "\blist\b"
+    "\balpha-cmd\b"
 
-# Note: 'nvme help list <TAB>' and 'nvme version <TAB>' -- our completer
+# Note: 'nvme help alpha-cmd <TAB>' and 'nvme version <TAB>' -- our completer
 # returns nothing (correct), but PowerShell's framework falls back to file
 # completion which we cannot suppress from a native-command completer.
 
@@ -198,33 +221,37 @@ Write-Host "Option-value completion:"
 
 Assert-Match `
     "a value option lists its values (long opt)" `
-    "nvme list --output-format " `
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd --format " `
+    "raw.*pretty.*wide"
 
 Assert-Match `
     "a value option lists its values (short opt)" `
-    "nvme list -o " `
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd -o " `
+    "raw.*pretty.*wide"
 
+# --sel values come from the generator's VALUE_HINTS table, reached through the
+# plugin sub-command routing path.
 Assert-Match `
     "a value option on a plugin sub-command (--sel)" `
-    "nvme feat power-meas --sel " `
+    "nvme zeta-plug report --sel " `
     "0.*1.*2.*3"
 
 Assert-Match `
     "a value option on a plugin sub-command (short opt)" `
-    "nvme feat power-meas -S " `
+    "nvme zeta-plug report -S " `
     "0.*1.*2.*3"
 
+# A command-local enumerated option whose values come from the metadata
+# (local-sub --mode carries a value set).
 Assert-Match `
     "a command-local enumerated option lists its values" `
-    "nvme fw commit --action " `
-    "replace.*set-active"
+    "nvme beta-plug local-sub --mode " `
+    "fast.*slow"
 
 Assert-Match `
     "--opt=value attached form lists values" `
-    "nvme list --output-format=" `
-    "output-format=normal.*output-format=json"
+    "nvme alpha-cmd --format=" `
+    "--format=raw.*--format=pretty"
 
 Write-Host ""
 
@@ -233,20 +260,43 @@ Write-Host ""
 # ---------------------------------------------------------------------------
 Write-Host "File-valued options:"
 
-Assert-Match `
-    "a file-valued option completes filenames (long opt)" `
-    "nvme fw download --fw " `
-    "."
+# File completion enumerates the real filesystem (Get-ChildItem), so seed a temp
+# directory with a known file and complete from there: a file-valued option must
+# then offer that file, and an enumerated option must not. Asserting the sentinel
+# name -- rather than "any output" -- is deterministic and independent of cwd.
+$fileDir = Join-Path ([System.IO.Path]::GetTempPath()) `
+    ("nvme-filetest-{0}" -f [System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $fileDir | Out-Null
+$sentinel = 'fixture-sentinel-file'
+New-Item -ItemType File -Path (Join-Path $fileDir $sentinel) | Out-Null
+Push-Location $fileDir
+try {
+    Assert-Match `
+        "a file-valued option completes filenames (long opt)" `
+        "nvme alpha-cmd --in-file " `
+        $sentinel
 
-Assert-Match `
-    "a file-valued option completes filenames (short opt)" `
-    "nvme fw download -f " `
-    "."
+    Assert-Match `
+        "a file-valued option completes filenames (short opt)" `
+        "nvme alpha-cmd -f " `
+        $sentinel
 
-Assert-NoMatch `
-    "an enumerated option does not offer files" `
-    "nvme list --output-format " `
-    "\\\\|/"
+    # A DIRECTORY-valued option is treated the same as FILE (report --out-dir).
+    Assert-Match `
+        "a directory-valued option completes filenames" `
+        "nvme zeta-plug report --out-dir " `
+        $sentinel
+
+    # An enumerated option lists its values, never the filesystem -- so even with
+    # the seeded file present it must not be offered.
+    Assert-NoMatch `
+        "an enumerated option does not offer files" `
+        "nvme alpha-cmd --format " `
+        $sentinel
+} finally {
+    Pop-Location
+    Remove-Item $fileDir -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 Write-Host ""
 
@@ -257,12 +307,12 @@ Write-Host "Device argument hint:"
 
 Assert-Match `
     "a command offers /dev/nvme as a device hint" `
-    "nvme list " `
+    "nvme alpha-cmd " `
     "/dev/nvme"
 
 Assert-Match `
     "typing /dev narrows to the device hint" `
-    "nvme list /dev" `
+    "nvme alpha-cmd /dev" `
     "/dev/nvme"
 
 Write-Host ""
@@ -293,7 +343,7 @@ if (Test-OrdinalSorted $completions) {
 }
 
 $script:TestsRun++
-$completions = Get-Completions "nvme list "
+$completions = Get-Completions "nvme alpha-cmd "
 # Exclude short options and /dev/nvme hint; --help is appended last by design.
 $optOnly = @($completions | Where-Object { $_ -like '--*' -and $_ -ne '--help' })
 if (Test-OrdinalSorted $optOnly) {
@@ -312,15 +362,16 @@ Write-Host ""
 # ---------------------------------------------------------------------------
 Write-Host "Per-command global options:"
 
+# alpha-cmd carries the global 'format' option; local-sub carries no globals.
 Assert-Match `
     "a command with global options offers them" `
-    "nvme list --verb" `
-    "--verbose"
+    "nvme alpha-cmd -" `
+    "--format"
 
 Assert-NoMatch `
     "a command without global options is not offered them" `
-    "nvme intel lat-stats-tracking --output" `
-    "--output-format"
+    "nvme beta-plug local-sub -" `
+    "--format"
 
 Write-Host ""
 

--- a/completions/test-zsh-completion.sh
+++ b/completions/test-zsh-completion.sh
@@ -14,7 +14,21 @@
 autoload -Uz compinit
 compinit -u 2>/dev/null
 
-source "${0:A:h}/_nvme"
+# The completion under test is generated fresh from a committed metadata fixture
+# rather than sourced from the checked-in _nvme: the generator is the unit under
+# test, so we exercise its current output. The fixture
+# (test-command-metadata.json) is a hand-written, schema-validated model of
+# synthetic commands and options -- deliberately not real nvme output -- built
+# to exercise every generator branch, and needs no nvme binary or build.
+_here="${0:A:h}"
+_generated="$(mktemp)"
+trap 'rm -f "$_generated"' EXIT
+if ! python3 "$_here/generate-completions.py" --zsh "$_generated" \
+        < "$_here/test-command-metadata.json"; then
+    print -u2 "failed to generate zsh completion from fixture"
+    exit 1
+fi
+source "$_generated"
 
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
@@ -198,12 +212,12 @@ echo "========================================"
 expect_match \
     "top-level list offers builtin commands" \
     "nvme " \
-    "id-ctrl"
+    "alpha-cmd"
 
 expect_match \
     "top-level list includes plugin names" \
     "nvme " \
-    "feat"
+    "zeta-plug"
 
 expect_match \
     "top-level list includes the help built-in" \
@@ -215,117 +229,125 @@ expect_match \
     "nvme " \
     "version"
 
-# A command alias is listed alongside its primary name (fw-activate is an alias
-# of fw-commit).
+# A command alias is listed alongside its primary name (alpha-alias is an alias
+# of zulu-cmd).
 expect_match \
     "top-level list includes a command alias" \
     "nvme " \
-    "fw-activate"
+    "alpha-alias"
 
 # A plugin lists its sub-commands.
 expect_match \
     "a plugin lists its sub-commands" \
-    "nvme feat " \
-    "power-mgmt"
+    "nvme zeta-plug " \
+    "report"
 
 # A different plugin, to prove sub-command routing isn't hardcoded to one name.
 expect_match \
     "sub-command routing works for any plugin" \
-    "nvme zns " \
-    "report-zones"
+    "nvme beta-plug " \
+    "local-sub"
 
-# A plugin sub-command alias is listed alongside its primary name (dera defines
-# alias 'stat' for 'smart-log-add').
+# A plugin sub-command alias is listed alongside its primary name (zeta-plug
+# defines alias 'rpt' for 'report').
 expect_match \
     "a plugin lists a sub-command alias" \
-    "nvme dera " \
-    "stat"
+    "nvme zeta-plug " \
+    "rpt"
 
 # ---------------------------------------------------------------------------
 # Option-name completion
 # ---------------------------------------------------------------------------
 # Regression: builtin commands complete their options at the first option word.
 # The dispatch once guarded on CURRENT > 2, so a builtin's first option (e.g.
-# 'nvme id-ctrl -<TAB>', CURRENT == 2) fell through to file completion and
+# 'nvme alpha-cmd -<TAB>', CURRENT == 2) fell through to file completion and
 # offered nothing. Only plugin sub-command options (CURRENT >= 3) worked.
 expect_match \
     "a builtin command offers its options at the first option word" \
-    "nvme id-ctrl -" \
-    "--output-format"
+    "nvme alpha-cmd -" \
+    "--format"
 
-# A command invoked by its alias completes the same options (fw-activate is an
-# alias of fw-commit).
+# A command invoked by its alias completes the same options (alpha-alias is an
+# alias of zulu-cmd).
 expect_match \
     "a command invoked by its alias completes options" \
-    "nvme fw-activate -" \
-    "--action"
+    "nvme alpha-alias -" \
+    "--mode"
 
 # -h/--help is offered for every command (added explicitly; it is not in the
 # metadata option list).
 expect_match \
     "--help is always offered" \
-    "nvme id-ctrl -" \
+    "nvme alpha-cmd -" \
     "--help"
 
 # Global options are offered per command, straight from the metadata -- so a
-# command that takes them gets them, and one that does not (intel
-# lat-stats-tracking) is not wrongly offered them.
+# command that takes them gets them, and one that does not (local-sub carries no
+# global 'format' option) is not wrongly offered them.
 expect_match \
     "a command with global options offers them" \
-    "nvme id-ctrl -" \
-    "--output-format"
+    "nvme alpha-cmd -" \
+    "--format"
 
 expect_no_match \
     "a command without global options is not offered them" \
-    "nvme intel lat-stats-tracking -" \
-    "--output-format"
+    "nvme beta-plug local-sub -" \
+    "--format"
+
+# Option descriptions are flattened (runs of whitespace collapsed to one space)
+# and their quotes survive escaping -- zulu-cmd's 'force' carries a description
+# with both. Regression guard on the generator's flatten() and zsh_escape().
+expect_match \
+    "an option description is flattened and quote-escaped" \
+    "nvme zulu-cmd -" \
+    "don't prompt for 'confirmation'"
 
 # ---------------------------------------------------------------------------
 # Option-value completion (enumerated values)
 # ---------------------------------------------------------------------------
 expect_match \
     "a value option lists its values (--opt= form)" \
-    "nvme id-ctrl --output-format=" \
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd --format=" \
+    "raw.*pretty.*wide"
 
 expect_match \
     "a value option lists its values (space form)" \
-    "nvme id-ctrl --output-format " \
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd --format " \
+    "raw.*pretty.*wide"
 
 expect_match \
     "the short-option form lists the same values" \
-    "nvme id-ctrl -o " \
-    "normal.*json.*binary.*tabular"
+    "nvme alpha-cmd -o " \
+    "raw.*pretty.*wide"
 
 # --sel values come from the generator's VALUE_HINTS table, reached through the
 # plugin sub-command routing path.
 expect_match \
     "an enumerated option on a plugin sub-command lists its values (--opt= form)" \
-    "nvme feat power-meas --sel=" \
+    "nvme zeta-plug report --sel=" \
     "0.*1.*2.*3"
 
 expect_match \
     "an enumerated option on a plugin sub-command lists its values (space form)" \
-    "nvme feat power-meas --sel " \
+    "nvme zeta-plug report --sel " \
     "0.*1.*2.*3"
 
 expect_match \
     "an enumerated option on a plugin sub-command lists its values (short opt)" \
-    "nvme feat power-meas -S " \
+    "nvme zeta-plug report -S " \
     "0.*1.*2.*3"
 
 # A command-local enumerated option whose values come from the metadata
-# (fw-commit --action has an OPT_VALS table).
+# (local-sub --mode carries a value set).
 expect_match \
     "a command-local enumerated option lists its metadata values" \
-    "nvme fw-commit --action " \
-    "replace.*set-active"
+    "nvme beta-plug local-sub --mode " \
+    "fast.*slow"
 
 expect_match \
     "a command-local enumerated option lists its values (short opt)" \
-    "nvme fw-commit -a " \
-    "replace.*set-active"
+    "nvme beta-plug local-sub -m " \
+    "fast.*slow"
 
 # ---------------------------------------------------------------------------
 # File-valued options (metavar FILE/DIRECTORY)
@@ -334,31 +356,47 @@ expect_match \
 # forms, and via its short spelling.
 expect_files \
     "a file-valued option completes filenames (space form)" \
-    "nvme fw-download --fw "
+    "nvme alpha-cmd --in-file "
 
 expect_files \
     "a file-valued option completes filenames (--opt= form)" \
-    "nvme fw-download --fw="
+    "nvme alpha-cmd --in-file="
 
 expect_files \
     "a file-valued option completes filenames (short opt)" \
-    "nvme fw-download -f "
+    "nvme alpha-cmd -f "
+
+# A DIRECTORY-valued option is treated the same as FILE, and sits alongside
+# --in-file so this also exercises the multi-file-option path.
+expect_files \
+    "a directory-valued option completes filenames" \
+    "nvme zeta-plug report --out-dir "
 
 # A non-file value option must NOT trigger file completion (it lists values).
 expect_no_files \
     "an enumerated option does not offer files" \
-    "nvme id-ctrl --output-format "
+    "nvme alpha-cmd --format "
 
 # ---------------------------------------------------------------------------
 # Device-argument injection
 # ---------------------------------------------------------------------------
 expect_device \
     "a command that takes a device offers /dev/nvme*" \
-    "nvme id-ctrl "
+    "nvme alpha-cmd "
 
 expect_device \
     "a plugin sub-command that takes a device offers /dev/nvme*" \
-    "nvme feat power-meas "
+    "nvme zeta-plug report "
+
+# A command with no options of its own must still offer the device -- exercises
+# the generator's empty-options path for a builtin and a plugin sub-command.
+expect_device \
+    "an option-less command still offers a device" \
+    "nvme no-opt-cmd "
+
+expect_device \
+    "an option-less plugin sub-command still offers a device" \
+    "nvme zeta-plug no-opt-sub "
 
 # help and version never offer a device.
 expect_no_device \
@@ -378,7 +416,7 @@ expect_no_device \
 expect_match \
     "help completes a command name" \
     "nvme help " \
-    "id-ctrl"
+    "alpha-cmd"
 
 expect_no_files \
     "help does not fall through to file completion" \
@@ -388,7 +426,7 @@ expect_no_files \
 # (and it must not fall through to file completion).
 expect_nothing \
     "help offers nothing past its one command argument" \
-    "nvme help id-ctrl "
+    "nvme help alpha-cmd "
 
 # 'version' takes no argument, so it offers nothing at all -- in particular it
 # does not fall through to file completion.
@@ -399,21 +437,23 @@ expect_nothing \
 # Once a device is on the line the injection is suppressed (_nvme_has_device).
 expect_no_device \
     "a device already on the line is not offered again" \
-    "nvme id-ctrl /dev/nvme0 "
+    "nvme alpha-cmd /dev/nvme0 "
 
 # ---------------------------------------------------------------------------
 # Generated-output assertions
 # ---------------------------------------------------------------------------
-# _nvme is a generated artifact, so its text is a legitimate thing to test: the
-# generator must not tag the option groups with the reserved 'options' tag.
-# Alongside the device candidate, the completion system suppresses that tag's
-# group at an empty prefix, so '--help' etc. rendered only after a '-' was
+# The completion is a generated artifact, so its text is a legitimate thing to
+# test: the generator must not tag the option groups with the reserved 'options'
+# tag. Alongside the device candidate, the completion system suppresses that
+# tag's group at an empty prefix, so '--help' etc. rendered only after a '-' was
 # typed. The live rendering is what breaks, but the stubbed harness above cannot
-# observe it -- the enforceable generator contract is "don't emit that tag".
+# observe it -- the enforceable generator contract is "don't emit that tag". Grep
+# the freshly generated completer, not the committed _nvme, so this tracks the
+# generator under test.
 (( TESTS_RUN++ ))
 print ""
 print "TEST $TESTS_RUN: option groups avoid the reserved 'options' tag"
-if grep -Eq $'_describe -t options|_describe -t eq-options' "${0:A:h}/_nvme"; then
+if grep -Eq $'_describe -t options|_describe -t eq-options' "$_generated"; then
     print "  ${RED}FAIL${NC}: _nvme uses the reserved 'options'/'eq-options' tag"
     (( TESTS_FAILED++ ))
 else

--- a/tests/unit/py/meson.build
+++ b/tests/unit/py/meson.build
@@ -35,4 +35,46 @@ if python3.found()
         ],
         timeout: 60,
     )
+
+    # The generated completion scripts must not depend on the order commands,
+    # plugins, or options arrive in; this shuffles the committed fixture and
+    # checks each shell's output is byte-identical. Committed inputs, no binary.
+    test(
+        'nvme-cli - generate-completions-stable',
+        python3,
+        args: [
+            files('test_generate_completions_stable.py'),
+            meson.project_source_root() / 'completions' / 'generate-completions.py',
+            meson.project_source_root() / 'completions' / 'test-command-metadata.json',
+        ],
+        timeout: 60,
+    )
+
+    # Commands, plugins, sub-commands, and options must be listed
+    # alphabetically; this checks each shell's generated output is sorted.
+    # Complements the stability test above. Committed inputs, no binary.
+    test(
+        'nvme-cli - generate-completions-sorted',
+        python3,
+        args: [
+            files('test_generate_completions_sorted.py'),
+            meson.project_source_root() / 'completions' / 'generate-completions.py',
+            meson.project_source_root() / 'completions' / 'test-command-metadata.json',
+        ],
+        timeout: 60,
+    )
+
+    # The completion test fixture is a hand-written, synthetic metadata model;
+    # validate it against the schema so a schema change the fixture no longer
+    # satisfies is caught. Both inputs are committed, so no binary needed.
+    test(
+        'nvme-cli - completion-fixture-schema',
+        python3,
+        args: [
+            files('test_completion_fixture_schema.py'),
+            meson.project_source_root() / 'completions' / 'test-command-metadata.json',
+            meson.project_source_root() / 'plugins' / 'utils' / 'command-metadata-schema.json',
+        ],
+        timeout: 60,
+    )
 endif

--- a/tests/unit/py/test_completion_fixture_schema.py
+++ b/tests/unit/py/test_completion_fixture_schema.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+# This file is part of nvme-cli.
+"""Validate the completion test fixture against the command-metadata schema.
+
+completions/test-command-metadata.json is a hand-written, synthetic model that
+the bash/zsh completion test suites feed to generate-completions.py. It is not
+real `nvme utils dump-command-metadata` output, so it can drift from the
+metadata format the generator expects. This test is the tripwire: it validates
+the fixture against the same command-metadata-schema.json that
+test_command_metadata_schema.py checks the live command against. A schema change
+the fixture no longer satisfies fails here, forcing the fixture to be updated.
+
+Needs no nvme binary or json-c build -- both inputs are committed files.
+
+Usage: test_completion_fixture_schema.py <fixture.json> <schema.json>
+
+Exits 77 (meson "skip") when the jsonschema module is unavailable.
+"""
+import json
+import sys
+import unittest
+
+try:
+    import jsonschema
+except ImportError:
+    print("jsonschema module not available; skipping")
+    sys.exit(77)
+
+if len(sys.argv) < 3:
+    sys.exit("usage: %s <fixture-path> <schema-path>" % sys.argv[0])
+
+FIXTURE_PATH = sys.argv[1]
+SCHEMA_PATH = sys.argv[2]
+
+
+class TestCompletionFixtureSchema(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(FIXTURE_PATH) as f:
+            cls.data = json.load(f)
+        with open(SCHEMA_PATH) as f:
+            cls.schema = json.load(f)
+
+    def test_conforms_to_schema(self):
+        """The committed fixture validates against command-metadata-schema.json."""
+        jsonschema.validate(self.data, self.schema)
+
+    def test_not_empty(self):
+        """The fixture still carries commands and plugins (guard against an
+        edit that silently emptied it)."""
+        self.assertTrue(self.data["commands"], msg="fixture has no commands")
+        self.assertTrue(self.data["plugins"], msg="fixture has no plugins")
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/tests/unit/py/test_generate_completions_sorted.py
+++ b/tests/unit/py/test_generate_completions_sorted.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+# This file is part of nvme-cli.
+"""Test that generate-completions.py emits commands and options alphabetically.
+
+Complements test_generate_completions_stable.py (order-invariance): this checks
+the canonical order the generator settles on is actually sorted. Works at the
+generated-output level, one extractor per shell, pulling out the top-level
+command list, each plugin's sub-command list, and each command's option list and
+asserting each is ascending (C-locale / ordinal). The generator appends --help
+last rather than sorting it in, so the option check asserts that placement --
+sorted long options with --help (where present) as the sole final entry.
+
+Usage: test_generate_completions_sorted.py <generate-completions.py> <fixture.json>
+"""
+import re
+import subprocess
+import sys
+import unittest
+
+SHELLS = ("bash", "zsh", "powershell")
+
+# A broken extractor that finds nothing would pass every "is sorted" check
+# vacuously. Require at least this many option groups with 2+ long options so a
+# silent extraction regression fails loudly instead.
+MIN_MULTI_OPTION_GROUPS = 3
+
+
+def long_options(tokens):
+    """Reduce a raw option token list to the comparable long-option names in
+    emission order: keep '--foo', strip any '=' suffix, drop shorts. --help is
+    kept so the ordering check can confirm the generator appends it last."""
+    return [tok.rstrip("=") for tok in tokens if tok.startswith("--")]
+
+
+class ExtractedLists:
+    """The ordered lists pulled from one shell's generated output.
+
+    Each member is a Python list. `commands` and `plugin_names` are flat lists
+    of name strings; `subcommands` and `options` are lists of (label, names)
+    tuples, one tuple per plugin / per command:
+
+    commands     -- list of name strings, e.g. ['alpha-cmd', 'beta-plug', ...]
+    plugin_names -- list of plugin-name strings, e.g. ['beta-plug', 'zeta-plug'];
+                    None if the shell does not emit them as an ordered list
+    subcommands  -- list of (label, [sub-command names]), one per plugin,
+                    e.g. [('zeta-plug', ['no-opt-sub', 'report', 'rpt'])]
+    options      -- list of (label, [long option names]), one per command,
+                    e.g. [('alpha-cmd', ['--dry-run', '--format', ...])]
+
+    `label` only identifies the group in an assertion failure message; its form
+    varies by shell (a plugin/command name, or the shell array it came from) and
+    is never used for logic.
+    """
+
+    def __init__(self, commands, plugin_names, subcommands, options):
+        self.commands = commands
+        self.plugin_names = plugin_names
+        self.subcommands = subcommands
+        self.options = options
+
+
+def extract_powershell(text):
+    """PowerShell emits a clean data model: an array of commands and two
+    hashtables (plugin -> sub-commands, command -> options)."""
+    m = re.search(r"NvmeCommands = @\((.*?)\)", text, re.S)
+    commands = re.findall(r"'([^']+)'", m.group(1))
+
+    m = re.search(r"NvmePluginCommands = @\{(.*?)\n\}", text, re.S)
+    plugin_names, subcommands = [], []
+    for line in m.group(1).strip().splitlines():
+        mm = re.match(r"\s*'([^']+)'\s*=\s*@\((.*)\)", line)
+        plugin_names.append(mm.group(1))
+        subcommands.append((mm.group(1), re.findall(r"'([^']+)'", mm.group(2))))
+
+    m = re.search(r"NvmeOptions = @\{(.*?)\n\}", text, re.S)
+    options = []
+    for line in m.group(1).strip().splitlines():
+        mm = re.match(r"\s*'([^']+)'\s*=\s*@\((.*)\)", line)
+        toks = re.findall(r"'([^']+)'", mm.group(2))
+        options.append((mm.group(1), long_options(toks)))
+
+    return ExtractedLists(commands, plugin_names, subcommands, options)
+
+
+def extract_bash(text):
+    """bash lists commands in a `_cmds=(...)` array, plugin sub-commands in a
+    `_plugin_subcmds=([plug]="a b c")` map, and each command's options in an
+    `opts+=" --foo= -f ..."` line under a `case "$1" in` arm."""
+    m = re.search(r"_cmds=\((.*?)\)", text, re.S)
+    commands = m.group(1).split()
+
+    m = re.search(r"_plugin_subcmds=\((.*?)\n\t*\)", text, re.S)
+    plugin_names, subcommands = [], []
+    for line in m.group(1).strip().splitlines():
+        mm = re.match(r'\s*\[([^\]]+)\]="([^"]*)"', line)
+        plugin_names.append(mm.group(1))
+        subcommands.append((mm.group(1), mm.group(2).split()))
+
+    # The command name(s) live on the preceding case arm (e.g. `"report"|"rpt")`);
+    # use it as the group label. The shared `_nvme_finish_completion` helper also
+    # holds an `opts+=" -h --help"`, but it sits before any arm, so a None label
+    # skips it rather than mislabelling it.
+    options = []
+    label = None
+    for line in text.splitlines():
+        s = line.strip()
+        arm = re.match(r'("[^"]+"(?:\|"[^"]+")*)\)$', s)
+        if arm:
+            label = "|".join(re.findall(r'"([^"]+)"', arm.group(1)))
+        elif s.startswith('opts+="') and "--" in s and label is not None:
+            toks = s[len('opts+="'):].rstrip('"').split()
+            options.append((label, long_options(toks)))
+            label = None
+
+    return ExtractedLists(commands, plugin_names, subcommands, options)
+
+
+def _zsh_name(entry):
+    """A zsh command entry is `'name:description'` or `'name'`."""
+    return entry.strip().strip("'").split(":", 1)[0]
+
+
+def extract_zsh(text):
+    """zsh embeds each list in a `NAME=( ... )` array. `_cmds` holds the
+    top-level commands, each `_sub` a plugin's sub-commands, and per-command
+    arrays (e.g. `_alpha_cmd`) the options -- classified by whether the entries
+    are command tokens (`'name:desc'`) or option tokens (`--foo=':desc'`).
+
+    zsh does not emit the plugin names as their own ordered list (they are case
+    arms), so plugin_names is None -- their order is covered by `_cmds`.
+    """
+    commands, subcommands, options = [], [], []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        m = re.match(r"\s*([A-Za-z_][A-Za-z0-9_]*)=\(\s*$", lines[i])
+        if not m:
+            i += 1
+            continue
+        name = m.group(1)
+        entries, j = [], i + 1
+        while j < len(lines) and not re.match(r"\s*\)\s*$", lines[j]):
+            entries.append(lines[j].strip())
+            j += 1
+        i = j
+        if not entries:
+            continue
+        if name == "_cmds":
+            commands = [_zsh_name(e) for e in entries]
+        elif name == "_sub":
+            subcommands.append((name, [_zsh_name(e) for e in entries]))
+        elif entries[0].startswith("-"):
+            toks = [re.match(r"(-{1,2}[A-Za-z0-9-]+=?)", e).group(1) for e in entries]
+            options.append((name, long_options(toks)))
+
+    return ExtractedLists(commands, None, subcommands, options)
+
+
+EXTRACTORS = {
+    "bash": extract_bash,
+    "zsh": extract_zsh,
+    "powershell": extract_powershell,
+}
+
+
+def assert_sorted(testcase, label, names):
+    testcase.assertEqual(
+        names, sorted(names), msg="%s not in alphabetical order: %r" % (label, names)
+    )
+
+
+def assert_options_sorted(testcase, label, opts):
+    """Long options must be alphabetical, except --help, which the generator
+    appends last (after the sorted list) rather than sorting in. Where it
+    appears -- zsh and PowerShell attach it per command; bash adds it in a shared
+    helper, so it is absent from the bash-extracted groups -- it must be the sole
+    final entry, and everything before it must be sorted."""
+    body = opts
+    if "--help" in opts:
+        testcase.assertEqual(
+            opts[-1], "--help", msg="%s: --help must be last, got %r" % (label, opts)
+        )
+        body = opts[:-1]
+        testcase.assertNotIn(
+            "--help", body, msg="%s: --help appears more than once: %r" % (label, opts)
+        )
+    assert_sorted(testcase, label + " (excluding trailing --help)", body)
+
+
+class GenerateCompletionsSortedTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(FIXTURE) as f:
+            model = f.read()
+        cls.by_shell = {}
+        for shell in SHELLS:
+            r = subprocess.run(
+                [sys.executable, GENERATOR, "-", "--%s" % shell, "-"],
+                input=model,
+                capture_output=True,
+                text=True,
+            )
+            assert r.returncode == 0, r.stderr
+            cls.by_shell[shell] = EXTRACTORS[shell](r.stdout)
+
+    def test_command_sets_agree_across_shells(self):
+        """Guard the extractors: every shell must yield the same, non-empty set
+        of top-level commands (a broken parser would diverge here)."""
+        sets = {shell: frozenset(self.by_shell[shell].commands) for shell in SHELLS}
+        self.assertTrue(all(sets.values()), msg="a shell yielded no commands: %r" % sets)
+        self.assertEqual(len(set(sets.values())), 1, msg="command sets differ: %r" % sets)
+
+    def test_extraction_is_substantive(self):
+        """Guard against vacuous passes: each shell must expose several option
+        groups with more than one long option to actually order-check."""
+        for shell in SHELLS:
+            multi = [
+                o
+                for _, o in self.by_shell[shell].options
+                if len([x for x in o if x != "--help"]) >= 2
+            ]
+            self.assertGreaterEqual(
+                len(multi),
+                MIN_MULTI_OPTION_GROUPS,
+                msg="%s exposed too few multi-option groups (%d); extractor broken?"
+                % (shell, len(multi)),
+            )
+
+    def test_commands_are_sorted(self):
+        for shell in SHELLS:
+            assert_sorted(self, "%s commands" % shell, self.by_shell[shell].commands)
+
+    def test_plugin_names_are_sorted(self):
+        for shell in SHELLS:
+            keys = self.by_shell[shell].plugin_names
+            if keys is not None:
+                assert_sorted(self, "%s plugin names" % shell, keys)
+
+    def test_plugin_subcommands_are_sorted(self):
+        for shell in SHELLS:
+            for label, subs in self.by_shell[shell].subcommands:
+                assert_sorted(self, "%s sub-commands of %s" % (shell, label), subs)
+
+    def test_options_are_sorted(self):
+        for shell in SHELLS:
+            for label, opts in self.by_shell[shell].options:
+                assert_options_sorted(self, "%s options of %s" % (shell, label), opts)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        sys.exit("usage: %s <generate-completions.py> <fixture.json>" % sys.argv[0])
+    FIXTURE = sys.argv.pop(2)
+    GENERATOR = sys.argv.pop(1)
+    unittest.main()

--- a/tests/unit/py/test_generate_completions_stable.py
+++ b/tests/unit/py/test_generate_completions_stable.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (c) 2026 Micron Technology, Inc.
+#
+# This file is part of nvme-cli.
+"""Test that generate-completions.py output is invariant to input order.
+
+The generated completion scripts must be a pure function of the command,
+plugin, and option *set* -- not the order in which those appear in
+`nvme utils dump-command-metadata` output. That order tracks C registration
+and declaration order, which shifts as commands and options are added, moved,
+or renamed; if the generator echoed it, every such C change would churn the
+committed completion files. The generator defends against this by sorting
+commands, plugins, and options, so a reordered model produces byte-identical
+scripts.
+
+This feeds the committed completion fixture, shuffles its commands, plugins,
+sub-commands, and each command's options under several fixed seeds, and asserts
+every shell's output matches the unshuffled baseline byte-for-byte.
+
+Usage: test_generate_completions_stable.py <generate-completions.py> <fixture.json>
+"""
+import copy
+import json
+import random
+import subprocess
+import sys
+import unittest
+
+SHELLS = ("bash", "zsh", "powershell")
+SEEDS = (1, 42, 6789, 99999)
+
+
+def shuffle_model(model, seed):
+    """Return a deep copy of `model` with every command, plugin, sub-command,
+    and option list reordered under a seeded RNG."""
+    rng = random.Random(seed)
+    m = copy.deepcopy(model)
+
+    def shuffle_options(command):
+        if "options" in command:
+            rng.shuffle(command["options"])
+
+    rng.shuffle(m.get("commands", []))
+    for command in m.get("commands", []):
+        shuffle_options(command)
+
+    rng.shuffle(m.get("plugins", []))
+    for plugin in m.get("plugins", []):
+        rng.shuffle(plugin.get("commands", []))
+        for command in plugin.get("commands", []):
+            shuffle_options(command)
+
+    return m
+
+
+class GenerateCompletionsStableTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(FIXTURE) as f:
+            cls.model = json.load(f)
+        cls.baseline = {shell: cls.generate(cls.model, shell) for shell in SHELLS}
+
+    @staticmethod
+    def generate(model, shell):
+        """Generate `shell` completions from `model`, returning the script text."""
+        r = subprocess.run(
+            [sys.executable, GENERATOR, "-", "--%s" % shell, "-"],
+            input=json.dumps(model),
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode == 0, r.stderr
+        return r.stdout
+
+    def test_baseline_is_nonempty(self):
+        for shell in SHELLS:
+            self.assertTrue(self.baseline[shell], msg="%s baseline empty" % shell)
+
+    def test_output_is_order_invariant(self):
+        for seed in SEEDS:
+            shuffled = shuffle_model(self.model, seed)
+            for shell in SHELLS:
+                self.assertEqual(
+                    self.generate(shuffled, shell),
+                    self.baseline[shell],
+                    msg="%s output changed under shuffle seed %d" % (shell, seed),
+                )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        sys.exit("usage: %s <generate-completions.py> <fixture.json>" % sys.argv[0])
+    FIXTURE = sys.argv.pop(2)
+    GENERATOR = sys.argv.pop(1)
+    unittest.main()


### PR DESCRIPTION
Drive the bash, zsh, and PowerShell completion test suites from a hand-written synthetic metadata fixture instead of a curated subset of real nvme output, and add Python unit tests asserting the generator's output is schema-valid, order-invariant, and alphabetically sorted.