### PR TITLE
libnvme: host identity docs and Python binding cleanupHost ids doc fixes

### DIFF
--- a/libnvme/libnvme3/accessors.i
+++ b/libnvme/libnvme3/accessors.i
@@ -139,8 +139,8 @@ struct libnvme_global_ctx {
 	bool force_4k;
 	bool mi_probe_enabled;
 	bool ioctl_probing;
-	const char * hostnqn;
-	const char * hostid;
+	const char * hostnqn;	// no C getter; SWIG emits one anyway
+	const char * hostid;	// no C getter; SWIG emits one anyway
 };
 
 %pythoncode %{

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -331,16 +331,20 @@ static int set_fctx_from_dict(struct libnvme_global_ctx *ctx,
 PyObject *read_hostnqn(struct libnvme_global_ctx *ctx)
 {
 	char *val = libnvmf_read_hostnqn(ctx);
-	PyObject *obj = val ? PyUnicode_FromString(val) : Py_NewRef(Py_None);
+	PyObject *obj = Py_BuildValue("s", val);
+
 	free(val);
+
 	return obj;
 }
 
 PyObject *read_hostid(struct libnvme_global_ctx *ctx)
 {
 	char *val = libnvmf_read_hostid(ctx);
-	PyObject *obj = val ? PyUnicode_FromString(val) : Py_NewRef(Py_None);
+	PyObject *obj = Py_BuildValue("s", val);
+
 	free(val);
+
 	return obj;
 }
 
@@ -349,7 +353,6 @@ PyObject *host_get_ids(struct libnvme_global_ctx *ctx,
 		       const char *hostid_arg)
 {
 	char *hostnqn = NULL, *hostid = NULL;
-	PyObject *hostnqn_obj = NULL, *hostid_obj = NULL;
 	PyObject *obj;
 	int err;
 
@@ -360,28 +363,11 @@ PyObject *host_get_ids(struct libnvme_global_ctx *ctx,
 		return NULL;
 	}
 
-	hostnqn_obj = hostnqn ? PyUnicode_FromString(hostnqn) : Py_NewRef(Py_None);
-	hostid_obj = hostid ? PyUnicode_FromString(hostid) : Py_NewRef(Py_None);
-	if (!hostnqn_obj || !hostid_obj) {
-		Py_XDECREF(hostnqn_obj);
-		Py_XDECREF(hostid_obj);
-		free(hostnqn);
-		free(hostid);
-		return NULL;
-	}
+	obj = Py_BuildValue("(ss)", hostnqn, hostid);
 
-	obj = PyTuple_New(2);
-	if (!obj) {
-		Py_DECREF(hostnqn_obj);
-		Py_DECREF(hostid_obj);
-		free(hostnqn);
-		free(hostid);
-		return NULL;
-	}
-	PyTuple_SET_ITEM(obj, 0, hostnqn_obj);
-	PyTuple_SET_ITEM(obj, 1, hostid_obj);
 	free(hostnqn);
 	free(hostid);
+
 	return obj;
 }
 

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -41,6 +41,18 @@ static inline PyObject *Py_NewRef(PyObject *obj)
 "Ctrl          An NVMe or NVMe-oF controller; connect, discover, disconnect.\n"
 "Namespace     A namespace within a subsystem or controller.\n"
 "\n"
+"Functions\n"
+"---------\n"
+"read_hostnqn(ctx)   The configured host NQN: the GlobalCtx default if\n"
+"                    one is set, otherwise /etc/nvme/hostnqn.\n"
+"read_hostid(ctx)    The configured host ID, resolved the same way.\n"
+"host_get_ids(ctx, hostnqn_arg=None, hostid_arg=None)\n"
+"                    The identity a connect will use, fully resolved:\n"
+"                    the _arg values (a command-line override, if the\n"
+"                    application has one), then the first host in the\n"
+"                    tree, then the two functions above, then derived\n"
+"                    or generated. Returns a (hostnqn, hostid) tuple.\n"
+"\n"
 "Scan attached NVMe devices::\n"
 "\n"
 "    import nvme\n"
@@ -62,7 +74,6 @@ static inline PyObject *Py_NewRef(PyObject *obj)
 "        log = c.discover()\n"
 "\n"
 "All classes support the context manager protocol (the ``with`` statement).\n"
-"read_hostnqn() and read_hostid() return the system-wide host NQN and ID.\n"
 %enddef
 %module(docstring=MODULE_DOCSTRING) nvme
 %feature("autodoc", "1");

--- a/libnvme/src/nvme/fabrics.h
+++ b/libnvme/src/nvme/fabrics.h
@@ -65,12 +65,15 @@ char *libnvmf_generate_hostnqn_from_hostid(struct libnvme_global_ctx *ctx,
 char *libnvmf_generate_hostid(struct libnvme_global_ctx *ctx);
 
 /**
- * libnvmf_read_hostnqn() - Reads the host nvm qualified name from the config
- *			      default location
+ * libnvmf_read_hostnqn() - Get the configured host nvm qualified name
  * @ctx:		struct libnvme_global_ctx object
  *
- * Retrieve the qualified name from the config file located in $SYSCONFDIR/nvme.
- * $SYSCONFDIR is usually /etc.
+ * Return @ctx's hostnqn default if one is set, otherwise read the name
+ * from $SYSCONFDIR/nvme/hostnqn. $SYSCONFDIR is usually /etc. An empty
+ * @ctx default suppresses the file lookup.
+ *
+ * This is not the identity a connect uses. See libnvmf_host_get_ids()
+ * for the full resolution order.
  *
  * Return: The host nqn, or NULL if unsuccessful. If found, the caller
  * is responsible to free the string.
@@ -78,12 +81,15 @@ char *libnvmf_generate_hostid(struct libnvme_global_ctx *ctx);
 char *libnvmf_read_hostnqn(struct libnvme_global_ctx *ctx);
 
 /**
- * libnvmf_read_hostid() - Reads the host identifier from the config default
- *			     location
+ * libnvmf_read_hostid() - Get the configured host identifier
  * @ctx:		struct libnvme_global_ctx object
  *
- * Retrieve the host idenditifer from the config file located in
- * $SYSCONFDIR/nvme/. $SYSCONFDIR is usually /etc.
+ * Return @ctx's hostid default if one is set, otherwise read the
+ * identifier from $SYSCONFDIR/nvme/hostid. $SYSCONFDIR is usually /etc.
+ * An empty @ctx default suppresses the file lookup.
+ *
+ * This is not the identity a connect uses. See libnvmf_host_get_ids()
+ * for the full resolution order.
  *
  * Return: The host identifier, or NULL if unsuccessful. If found, the caller
  *	   is responsible to free the string.

--- a/libnvme/tools/generator/generate_accessors.py
+++ b/libnvme/tools/generator/generate_accessors.py
@@ -2227,6 +2227,11 @@ def generate_swig_fragment(f, prefix, sname, struct_name, members, errors,
           → ``%immutable name;`` immediately before the field declaration
             makes the attribute read-only.
 
+      read == none (all-generated only)
+          → SWIG has no write-only counterpart to ``%immutable``, so the
+            member keeps its Python getter even though no C getter exists.
+            A trailing comment marks the mismatch in the generated file.
+
       both axes == none  →  member is not Python-visible; already excluded
                              by the ``has_accessor`` filter.
 
@@ -2311,10 +2316,14 @@ def generate_swig_fragment(f, prefix, sname, struct_name, members, errors,
         py_name = m.py_alias or m.name
         if m.write_mode == 'none':
             f.write(f'\t%immutable {py_name};\n')
+        # SWIG has no write-only counterpart to %immutable, so a read=none
+        # member still gets a Python getter.  Flag the mismatch in place.
+        note = '\t// no C getter; SWIG emits one anyway' \
+            if m.read_mode == 'none' else ''
         if m.is_scalar_array:
-            f.write(f'\t{m.type} {py_name}[{m.array_size}];\n')
+            f.write(f'\t{m.type} {py_name}[{m.array_size}];{note}\n')
         else:
-            f.write(f'\t{m.type} {py_name};\n')
+            f.write(f'\t{m.type} {py_name};{note}\n')
 
     # Custom members: inside %extend — SWIG calls the hand-written accessor.
     # Members with read=none are excluded: SWIG always generates a getter for


### PR DESCRIPTION
Three small changes around the host identity code, found while re-reading an old review of #3596. No behaviour change.

**Document the ctx default in the host identity docs.** The kdocs for `libnvmf_read_hostnqn()` and `libnvmf_read_hostid()` named `$SYSCONFDIR/nvme` as the only source. They now say that a context default takes priority over the file, that an empty default suppresses the file lookup, and that neither function returns the identity a connect uses. The Python module docstring gains a `Functions` section covering `read_hostnqn()`, `read_hostid()` and `host_get_ids()`, which it did not mention at all.

**Build the host identity Python objects with `Py_BuildValue()`.** `host_get_ids()` assembled its return tuple by hand. `Py_BuildValue()` converts a NULL `char *` to `None` and sets the exception itself on failure, so the reference bookkeeping is not needed. `read_hostnqn()` and `read_hostid()` use it too. Verified identical for NULL, non-NULL and both-NULL inputs, with no change to `None`'s refcount over 10000 calls.

**Flag `read=none` members in the generated SWIG interface.** SWIG has no write-only counterpart to `%immutable`, so a member annotated `read=none` still gets a Python getter while the C side has none. `ctx.hostnqn` and `ctx.hostid` are the only two today. The generator now marks the mismatch in the generated file instead of leaving it silent.

Built with `-Dpython=enabled`, `meson test` clean, checkpatch clean per commit.
