### PR TITLE
solidigm: fix unchecked return value in ilog_dump_pel()

### DIFF
--- a/plugins/solidigm/solidigm-internal-logs.c
+++ b/plugins/solidigm/solidigm-internal-logs.c
@@ -808,16 +808,18 @@ static int ilog_dump_pel(struct libnvme_transport_handle *hdl, struct ilog *ilog
 	err = nvme_get_log_persistent_event(hdl, NVME_PEVENT_LOG_READ,
 						pevent_log_full, lp.buffer_size);
 	if (err)
-		return err;
+		goto out;
 
 	ilog->count++;
 
 	err = log_save(&lp, ilog->cfg->out_dir, "log_pages", "lid_0x0d_lsp_0x00_lsi_0x0000.bin",
 		       pevent_log_full, lp.buffer_size);
+	if (err)
+		goto out;
 
-	nvme_get_log_persistent_event(hdl, NVME_PEVENT_LOG_RELEASE_CTX,
-				      pevent, sizeof(*pevent));
-
+	err = nvme_get_log_persistent_event(hdl, NVME_PEVENT_LOG_RELEASE_CTX,
+					    pevent, sizeof(*pevent));
+out:
 	return err;
 }
 


### PR DESCRIPTION
The ilog_dump_pel() function calls nvme_get_log_persistent_event() with NVME_PEVENT_LOG_RELEASE_CTX as the final step to release the persistent event log context on the device. The return value of this call was not checked.

If the release call fails, the device-side context is left open. Any subsequent attempt to establish a new context may fail or behave unexpectedly.

Use a goto to ensure the release call is always reached and its return value is captured and returned to the caller.