### PR TITLE
nvme-print: fix null pointer dereference in strset_iterate_sorted_

### DIFF
--- a/src/nvme-print-stdout.c
+++ b/src/nvme-print-stdout.c
@@ -167,8 +167,13 @@ static bool name_collect(const char *name, void *arg)
 	struct name_collector *nc = arg;
 
 	if (nc->count == nc->capacity) {
+		const char **tmp;
+
 		nc->capacity = nc->capacity ? nc->capacity * 2 : 16;
-		nc->names = realloc(nc->names, nc->capacity * sizeof(*nc->names));
+		tmp = realloc(nc->names, nc->capacity * sizeof(*nc->names));
+		if (!tmp)
+			return false;
+		nc->names = tmp;
 	}
 
 	nc->names[nc->count++] = name;


### PR DESCRIPTION
The strset_iterate_sorted_() function collects set members into a dynamically grown array via name_collect(). When the array needs to grow, realloc() is called and its return value is stored directly back into nc->names without checking for NULL.

On allocation failure nc->names becomes NULL and is immediately dereferenced on the next line, causing a crash.

Store the realloc() result in a temporary pointer and return false on failure so iteration aborts cleanly.