### PR TITLE
shared: add shr_xstrcmp function

### DIFF
--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -37,6 +37,7 @@
 
 #include <shared/array-util.h>
 #include <shared/compiler-attributes-util.h>
+#include <shared/string-util.h>
 
 #include <libnvme.h>
 
@@ -2475,7 +2476,7 @@ __shr_public bool libnvmf_is_registration_supported(struct libnvme_ctrl *c)
 			return false;
 
 	libnvme_ctrl_get_dctype(c, &dctype, NULL);
-	return !strcmp(dctype, "ddc") || !strcmp(dctype, "cdc");
+	return shr_streq0(dctype, "ddc") || shr_streq0(dctype, "cdc");
 }
 
 __shr_public int libnvmf_register_ctrl(


### PR DESCRIPTION
Allocation-checking strcmp() that returns -1 or 1 for a NULL input.