### PR TITLE
libnvme: validate the host NQN and host identifier

### DIFF
--- a/libnvme/libnvme3/tests/test-config.py
+++ b/libnvme/libnvme3/tests/test-config.py
@@ -97,7 +97,7 @@ controller = transport=tcp;traddr=192.168.1.20;trsvcid=4420
 """)
         _write(os.path.join(self.conf + '.d', 'prod.conf'), """
 [Host]
-hostnqn     = nqn.2014-08.org.nvmexpress:uuid:1111
+hostnqn     = nqn.2014-08.org.nvmexpress:1111
 hostid      = 46ba5037-7ce5-41fa-9452-48477bf00080
 hostsymname = prod-persona
 
@@ -110,7 +110,7 @@ controller = transport=tcp;traddr=10.0.0.9;trsvcid=4420
         self.assertEqual(conns[0]['hostsymname'], 'default-persona')
         self.assertEqual(conns[1]['hostsymname'], 'prod-persona')
         self.assertEqual(conns[1]['hostnqn'],
-                         'nqn.2014-08.org.nvmexpress:uuid:1111')
+                         'nqn.2014-08.org.nvmexpress:1111')
         self.assertTrue(conns[1]['source'].endswith('prod.conf'))
 
     def test_multipath_yields_one_connection_per_controller_line(self):

--- a/libnvme/libnvme3/tests/test-ctrl-crypto.py
+++ b/libnvme/libnvme3/tests/test-ctrl-crypto.py
@@ -20,7 +20,7 @@ class TestCtrlCrypto(unittest.TestCase):
         self.ctx.hostnqn = hostnqn
         self.ctx.hostid = hostid
         self.ctrl = nvme.Ctrl(self.ctx, {
-            'subsysnqn': 'nqn.2014-08.org.nvmexpress:uuid:subsys',
+            'subsysnqn': 'nqn.2014-08.org.nvmexpress:subsys',
             'transport': 'tcp',
             'traddr': '192.168.1.100',
             'trsvcid': '4420',
@@ -52,7 +52,7 @@ class TestCtrlCrypto(unittest.TestCase):
     def test_unset_keys_stay_unset(self):
         """A controller built without keys must not grow any."""
         ctrl = nvme.Ctrl(self.ctx, {
-            'subsysnqn': 'nqn.2014-08.org.nvmexpress:uuid:subsys',
+            'subsysnqn': 'nqn.2014-08.org.nvmexpress:subsys',
             'transport': 'tcp',
             'traddr': '192.168.1.100',
             'trsvcid': '4420',

--- a/libnvme/src/nvme/config-ini.c
+++ b/libnvme/src/nvme/config-ini.c
@@ -21,6 +21,7 @@
 
 #include <shared/compiler-attributes-util.h>
 #include <shared/ini-util.h>
+#include <shared/nqn-util.h>
 #include <shared/parse-util.h>
 #include <shared/string-util.h>
 
@@ -604,70 +605,6 @@ fail:
 	return ret;
 }
 
-/*
- * Validate the basic NQN syntax defined by the NVMe Base specification,
- * section 4.7.
- *
- * The expected format starts with "nqn.", followed by a four-digit year,
- * a two-digit month (01-12), and a non-empty suffix after the domain
- * separator.
- *
- * Examples of valid NQNs:
- *
- *   nqn.2014-08.org.nvmexpress
- *   nqn.2014-08.org.example:subsystem1
- *
- * This function checks only the structural format. It does not validate the
- * reverse domain name, domain ownership, or uniqueness requirements.
- */
-static bool nqn_valid(const char *nqn)
-{
-	size_t len = strlen(nqn);
-	const char *p = nqn + 4;
-	int month;
-
-	if (!len || len > NVMF_NQN_SIZE || strncmp(nqn, "nqn.", 4))
-		return false;
-	if (!isdigit((unsigned char)p[0]) || !isdigit((unsigned char)p[1]) ||
-	    !isdigit((unsigned char)p[2]) || !isdigit((unsigned char)p[3]) ||
-	    p[4] != '-' || !isdigit((unsigned char)p[5]) ||
-	    !isdigit((unsigned char)p[6]) || p[7] != '.' || !p[8])
-		return false;
-
-	month = (p[5] - '0') * 10 + (p[6] - '0');
-	if (month < 1 || month > 12)
-		return false;
-
-	for (p = nqn; *p; p++) {
-		if ((unsigned char)*p < 0x21 || (unsigned char)*p > 0x7e)
-			return false;
-	}
-
-	return true;
-}
-
-/*
- * Validate the HostID syntax defined by the NVMe Base specification,
- * section 5.2.26.1.32.2.
- *
- * A HostID is a 128-bit value represented as a UUID string. The all-zero UUID
- * is not a valid HostID because it does not identify a host.
- */
-static bool hostid_valid(const char *hostid)
-{
-	unsigned char uuid[NVME_UUID_LEN];
-	int i;
-
-	if (libnvme_uuid_from_string(hostid, uuid))
-		return false;
-	for (i = 0; i < NVME_UUID_LEN; i++) {
-		if (uuid[i])
-			return true;
-	}
-
-	return false;
-}
-
 static int set_identity(struct conf_parse *pc, char **field, const char *value)
 {
 	free(*field);
@@ -708,7 +645,7 @@ static int conf_kv(struct conf_parse *pc, const char *key, char *value,
 			conf_err(pc, line, "empty nqn");
 			return -EINVAL;
 		}
-		if (!nqn_valid(value)) {
+		if (!shr_nqn_valid(value)) {
 			conf_err(pc, line, "\"%s\" is not a valid NQN", value);
 			return -EINVAL;
 		}
@@ -717,7 +654,7 @@ static int conf_kv(struct conf_parse *pc, const char *key, char *value,
 		if (pc->sect != SECT_HOST)
 			break;
 		if (!strcmp(key, "hostnqn")) {
-			if (*value && !nqn_valid(value)) {
+			if (*value && !shr_nqn_valid(value)) {
 				conf_err(pc, line,
 					 "hostnqn \"%s\" is not a valid NQN",
 					 value);
@@ -726,7 +663,7 @@ static int conf_kv(struct conf_parse *pc, const char *key, char *value,
 			return set_identity(pc, &pc->f->hostnqn, value);
 		}
 		if (!strcmp(key, "hostid")) {
-			if (*value && !hostid_valid(value)) {
+			if (*value && !shr_hostid_valid(value)) {
 				conf_err(pc, line,
 					 "hostid \"%s\" is not a valid, non-zero 128-bit UUID",
 					 value);

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -364,11 +364,11 @@ __shr_public char *libnvmf_read_hostid(struct libnvme_global_ctx *ctx)
 	if (!ctx)
 		return NULL;
 
-	if (shr_uuid_str_valid(ctx->hostid))
+	if (shr_hostid_valid(ctx->hostid))
 		return strdup(ctx->hostid);
 
 	val = nvmf_read_file(NVMF_HOSTID_FILE, NVMF_HOSTID_SIZE);
-	if (shr_uuid_str_valid(val))
+	if (shr_hostid_valid(val))
 		return val;
 
 	if (val) {

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -37,7 +37,9 @@
 
 #include <shared/array-util.h>
 #include <shared/compiler-attributes-util.h>
+#include <shared/nqn-util.h>
 #include <shared/string-util.h>
+#include <shared/uuid-util.h>
 
 #include <libnvme.h>
 
@@ -333,30 +335,50 @@ static char *nvmf_read_file(const char *f, int len)
 
 __shr_public char *libnvmf_read_hostnqn(struct libnvme_global_ctx *ctx)
 {
+	char *val;
+
 	if (!ctx)
 		return NULL;
 
-	if (ctx->hostnqn) {
-		if (!strcmp(ctx->hostnqn, ""))
-			return NULL;
+	if (shr_nqn_valid(ctx->hostnqn))
 		return strdup(ctx->hostnqn);
+
+	val = nvmf_read_file(NVMF_HOSTNQN_FILE, NVMF_NQN_SIZE);
+	if (shr_nqn_valid(val))
+		return val;
+
+	if (val) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR,
+			    "%s does not contain a valid host NQN\n",
+			    NVMF_HOSTNQN_FILE);
+		free(val);
 	}
 
-	return nvmf_read_file(NVMF_HOSTNQN_FILE, NVMF_NQN_SIZE);
+	return NULL;
 }
 
 __shr_public char *libnvmf_read_hostid(struct libnvme_global_ctx *ctx)
 {
+	char *val;
+
 	if (!ctx)
 		return NULL;
 
-	if (ctx->hostid) {
-		if (!strcmp(ctx->hostid, ""))
-			return NULL;
+	if (shr_uuid_str_valid(ctx->hostid))
 		return strdup(ctx->hostid);
+
+	val = nvmf_read_file(NVMF_HOSTID_FILE, NVMF_HOSTID_SIZE);
+	if (shr_uuid_str_valid(val))
+		return val;
+
+	if (val) {
+		libnvme_msg(ctx, LIBNVME_LOG_ERR,
+			    "%s does not contain a valid host identifier\n",
+			    NVMF_HOSTID_FILE);
+		free(val);
 	}
 
-	return nvmf_read_file(NVMF_HOSTID_FILE, NVMF_HOSTID_SIZE);
+	return NULL;
 }
 
 __shr_public int libnvmf_host_get_ids(struct libnvme_global_ctx *ctx,

--- a/libnvme/tests/test-fabrics.c
+++ b/libnvme/tests/test-fabrics.c
@@ -779,7 +779,7 @@ static bool test_create_ctrl_credentials(struct libnvme_global_ctx *ctx)
 
 	printf("\ntest_create_ctrl_credentials:\n");
 
-	fctx.ctrl_params.subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:subsys";
+	fctx.ctrl_params.subsysnqn = "nqn.2014-08.org.nvmexpress:subsys";
 	fctx.ctrl_params.transport = "tcp";
 	fctx.ctrl_params.traddr = "192.168.1.100";
 	fctx.ctrl_params.cfg.tls = true;

--- a/shared/meson.build
+++ b/shared/meson.build
@@ -19,6 +19,7 @@ sources = [
     'hex-util.c',
     'ini-util.c',
     'int-util.c',
+    'nqn-util.c',
     'parse-util.c',
     'progress-util.c',
     'suffix-util.c',

--- a/shared/nqn-util.c
+++ b/shared/nqn-util.c
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <ctype.h>
+#include <string.h>
+
+#include "nqn-util.h"
+#include "uuid-util.h"
+
+#define NQN_PREFIX	"nqn."
+#define NQN_UUID_PREFIX	"nqn.2014-08.org.nvmexpress:uuid:"
+
+/* Length of a "yyyy-mm" date code. */
+#define NQN_DATE_LEN	7
+
+/* A "yyyy-mm" date code, as in "2014-08". */
+static bool date_code_valid(const char *p)
+{
+	int i;
+
+	for (i = 0; i < 4; i++) {
+		if (!isdigit((unsigned char)p[i]))
+			return false;
+	}
+
+	if (p[4] != '-')
+		return false;
+
+	return isdigit((unsigned char)p[5]) && isdigit((unsigned char)p[6]);
+}
+
+bool shr_nqn_valid(const char *nqn)
+{
+	const char *p;
+	size_t len;
+
+	if (!nqn)
+		return false;
+
+	len = strlen(nqn);
+	if (len > SHR_NQN_MAX_LEN)
+		return false;
+
+	if (strncmp(nqn, NQN_PREFIX, strlen(NQN_PREFIX)))
+		return false;
+
+	if (!strncmp(nqn, NQN_UUID_PREFIX, strlen(NQN_UUID_PREFIX)))
+		return shr_uuid_str_valid(nqn + strlen(NQN_UUID_PREFIX));
+
+	/* "nqn." + "yyyy-mm" + "." + at least one more character */
+	if (len < strlen(NQN_PREFIX) + NQN_DATE_LEN + 2)
+		return false;
+
+	p = nqn + strlen(NQN_PREFIX);
+
+	return date_code_valid(p) && p[NQN_DATE_LEN] == '.';
+}

--- a/shared/nqn-util.c
+++ b/shared/nqn-util.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "nqn-util.h"
+#include "string-util.h"
 #include "uuid-util.h"
 
 #define NQN_PREFIX	"nqn."
@@ -21,17 +22,33 @@
 /* A "yyyy-mm" date code, as in "2014-08". */
 static bool date_code_valid(const char *p)
 {
-	int i;
+	int month, i;
 
 	for (i = 0; i < 4; i++) {
 		if (!isdigit((unsigned char)p[i]))
 			return false;
 	}
 
-	if (p[4] != '-')
+	if (p[4] != '-' || !isdigit((unsigned char)p[5]) ||
+	    !isdigit((unsigned char)p[6]))
 		return false;
 
-	return isdigit((unsigned char)p[5]) && isdigit((unsigned char)p[6]);
+	month = (p[5] - '0') * 10 + (p[6] - '0');
+
+	return month >= 1 && month <= 12;
+}
+
+/* Printable ASCII, excluding the space. */
+static bool charset_valid(const char *nqn)
+{
+	const char *p;
+
+	for (p = nqn; *p; p++) {
+		if ((unsigned char)*p < 0x21 || (unsigned char)*p > 0x7e)
+			return false;
+	}
+
+	return true;
 }
 
 bool shr_nqn_valid(const char *nqn)
@@ -49,6 +66,9 @@ bool shr_nqn_valid(const char *nqn)
 	if (strncmp(nqn, NQN_PREFIX, strlen(NQN_PREFIX)))
 		return false;
 
+	if (!charset_valid(nqn))
+		return false;
+
 	if (!strncmp(nqn, NQN_UUID_PREFIX, strlen(NQN_UUID_PREFIX)))
 		return shr_uuid_str_valid(nqn + strlen(NQN_UUID_PREFIX));
 
@@ -59,4 +79,10 @@ bool shr_nqn_valid(const char *nqn)
 	p = nqn + strlen(NQN_PREFIX);
 
 	return date_code_valid(p) && p[NQN_DATE_LEN] == '.';
+}
+
+bool shr_hostid_valid(const char *hostid)
+{
+	return shr_uuid_str_valid(hostid) &&
+	       !shr_streq0(hostid, "00000000-0000-0000-0000-000000000000");
 }

--- a/shared/nqn-util.h
+++ b/shared/nqn-util.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include <stdbool.h>
+
+/* Maximum length of an NQN, excluding the terminating '\0'. */
+#define SHR_NQN_MAX_LEN 223
+
+/*
+ * Check @nqn against the NVMe Qualified Name rules of the NVMe Base
+ * Specification, section 4.7: at most SHR_NQN_MAX_LEN bytes, an "nqn."
+ * prefix, a "yyyy-mm" date code and a non-empty remainder. A name using
+ * the UUID format must carry a canonical UUID.
+ *
+ * The prohibition on "org.nvmexpress" as a format 1 reverse domain is not
+ * enforced, because names of that shape are widely deployed as host NQNs.
+ *
+ * Return: true if @nqn is usable as an NQN.
+ */
+bool shr_nqn_valid(const char *nqn);

--- a/shared/nqn-util.h
+++ b/shared/nqn-util.h
@@ -15,12 +15,28 @@
 /*
  * Check @nqn against the NVMe Qualified Name rules of the NVMe Base
  * Specification, section 4.7: at most SHR_NQN_MAX_LEN bytes, an "nqn."
- * prefix, a "yyyy-mm" date code and a non-empty remainder. A name using
- * the UUID format must carry a canonical UUID.
+ * prefix, a "yyyy-mm" date code whose month is 01 to 12, and a non-empty
+ * remainder. A name using the UUID format must carry a canonical UUID.
+ *
+ * Two deliberate departures from section 4.7:
  *
  * The prohibition on "org.nvmexpress" as a format 1 reverse domain is not
  * enforced, because names of that shape are widely deployed as host NQNs.
  *
+ * Section 4.7 permits any UTF-8 string, but this check accepts printable
+ * ASCII only, excluding the space. Every NQN in practice is built from a
+ * reverse domain name and a vendor string, both ASCII, so the restriction
+ * costs nothing and catches a truncated read or trailing whitespace.
+ *
  * Return: true if @nqn is usable as an NQN.
  */
 bool shr_nqn_valid(const char *nqn);
+
+/*
+ * Check @hostid as an NVMe Host Identifier: a canonical UUID string that is
+ * not all zeros. The Base Specification, section 5.2.26.1.32.2, gives the
+ * all-zero value no meaning, so it cannot identify a host.
+ *
+ * Return: true if @hostid is usable as a host identifier.
+ */
+bool shr_hostid_valid(const char *hostid);

--- a/shared/tests/meson.build
+++ b/shared/tests/meson.build
@@ -35,6 +35,17 @@ test_crc32_util = executable(
 
 test('shared - crc32-util', test_crc32_util)
 
+test_nqn_util = executable(
+    'test-nqn-util',
+    ['test-nqn-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
+
+test('shared - nqn-util', test_nqn_util)
+
 test_ini_util = executable(
     'test-ini-util',
     ['test-ini-util.c'],

--- a/shared/tests/test-nqn-util.c
+++ b/shared/tests/test-nqn-util.c
@@ -50,12 +50,23 @@ static bool test_nqn_valid(void)
 	pass &= check("nqn.2014-08.org.nvmexpress.discovery", true);
 	pass &= check("nqn.2014-08.org.nvmexpress:host-a", true);
 
+	/* Real-world names that must keep working */
+	pass &= check("nqn.1988-11.com.dell:PowerSANxxx:01:"
+		      "20210225100113-454f73093ceb4847a7bdfc6e34ae8e28", true);
+	pass &= check("nqn.1988-11.com.dell:starfleet", true);
+	pass &= check("nqn.1988-11.com.dell:klingons", true);
+
 	/* Malformed */
 	pass &= check("qn.2014-08.com.example:host", false);
 	pass &= check("nqn.201408.com.example:host", false);
 	pass &= check("nqn.2014-0x.com.example:host", false);
 	pass &= check("nqn.2014-08com.example:host", false);
 	pass &= check("nqn.2014-08.", false);
+	pass &= check("nqn.2014-00.com.example:host", false);
+	pass &= check("nqn.2014-13.com.example:host", false);
+	pass &= check("nqn.2014-08.com.example:host name", false);
+	pass &= check("nqn.2014-08.com.example:host\n", false);
+	pass &= check("nqn.2014-08.com.example:h\x7fst", false);
 
 	memset(too_long, 'a', sizeof(too_long) - 1);
 	too_long[sizeof(too_long) - 1] = '\0';
@@ -65,11 +76,43 @@ static bool test_nqn_valid(void)
 	return pass;
 }
 
+static bool check_hostid(const char *hostid, bool want)
+{
+	bool got = shr_hostid_valid(hostid);
+
+	if (got == want) {
+		printf(" - \"%s\" [PASS]\n", hostid ? hostid : "(null)");
+		return true;
+	}
+
+	printf(" - \"%s\": got %s, want %s [FAIL]\n", hostid ? hostid : "(null)",
+	       got ? "valid" : "invalid", want ? "valid" : "invalid");
+	return false;
+}
+
+static bool test_hostid_valid(void)
+{
+	bool pass = true;
+
+	printf("test_hostid_valid:\n");
+
+	pass &= check_hostid(NULL, false);
+	pass &= check_hostid("", false);
+	pass &= check_hostid("1b4e28ba-2fa1-11d2-883f-0016d3cca427", true);
+	pass &= check_hostid("00000000-0000-0000-0000-000000000000", false);
+	pass &= check_hostid("00000000-0000-0000-0000-000000000001", true);
+	pass &= check_hostid("ffffffff-ffff-ffff-ffff-ffffffffffff", true);
+	pass &= check_hostid("abc-123", false);
+
+	return pass;
+}
+
 int main(void)
 {
 	bool pass = true;
 
 	pass &= test_nqn_valid();
+	pass &= test_hostid_valid();
 
 	fflush(stdout);
 	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);

--- a/shared/tests/test-nqn-util.c
+++ b/shared/tests/test-nqn-util.c
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <shared/nqn-util.h>
+
+#define UUID_NQN "nqn.2014-08.org.nvmexpress:uuid:"
+
+static bool check(const char *nqn, bool want)
+{
+	bool got = shr_nqn_valid(nqn);
+
+	if (got == want) {
+		printf(" - \"%s\" [PASS]\n", nqn ? nqn : "(null)");
+		return true;
+	}
+
+	printf(" - \"%s\": got %s, want %s [FAIL]\n", nqn ? nqn : "(null)",
+	       got ? "valid" : "invalid", want ? "valid" : "invalid");
+	return false;
+}
+
+static bool test_nqn_valid(void)
+{
+	char too_long[SHR_NQN_MAX_LEN + 8];
+	bool pass = true;
+
+	printf("test_nqn_valid:\n");
+
+	pass &= check(NULL, false);
+	pass &= check("", false);
+	pass &= check("nqn.", false);
+
+	/* UUID format */
+	pass &= check(UUID_NQN "f81d4fae-7dec-11d0-a765-00a0c91e6bf6", true);
+	pass &= check(UUID_NQN "F81D4FAE-7DEC-11D0-A765-00A0C91E6BF6", true);
+	pass &= check(UUID_NQN "abc-123", false);
+	pass &= check(UUID_NQN "f81d4fae7dec11d0a76500a0c91e6bf6", false);
+	pass &= check(UUID_NQN "f81d4fae-7dec-11d0-a765-00a0c91e6bfg", false);
+	pass &= check(UUID_NQN, false);
+
+	/* Domain format */
+	pass &= check("nqn.2014-08.com.example:nvme:nvm-subsystem-sn-d78432", true);
+	pass &= check("nqn.2014-08.org.nvmexpress.discovery", true);
+	pass &= check("nqn.2014-08.org.nvmexpress:host-a", true);
+
+	/* Malformed */
+	pass &= check("qn.2014-08.com.example:host", false);
+	pass &= check("nqn.201408.com.example:host", false);
+	pass &= check("nqn.2014-0x.com.example:host", false);
+	pass &= check("nqn.2014-08com.example:host", false);
+	pass &= check("nqn.2014-08.", false);
+
+	memset(too_long, 'a', sizeof(too_long) - 1);
+	too_long[sizeof(too_long) - 1] = '\0';
+	memcpy(too_long, "nqn.2014-08.", strlen("nqn.2014-08."));
+	pass &= check(too_long, false);
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_nqn_valid();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/shared/tests/test-uuid-util.c
+++ b/shared/tests/test-uuid-util.c
@@ -39,6 +39,39 @@ static bool test_uuid_to_string(void)
 	return pass;
 }
 
+static bool check_valid(const char *str, bool want)
+{
+	bool got = shr_uuid_str_valid(str);
+
+	if (got == want) {
+		printf(" - \"%s\" [PASS]\n", str ? str : "(null)");
+		return true;
+	}
+
+	printf(" - \"%s\": got %s, want %s [FAIL]\n", str ? str : "(null)",
+	       got ? "valid" : "invalid", want ? "valid" : "invalid");
+	return false;
+}
+
+static bool test_uuid_str_valid(void)
+{
+	bool pass = true;
+
+	printf("test_uuid_str_valid:\n");
+
+	pass &= check_valid(NULL, false);
+	pass &= check_valid("", false);
+	pass &= check_valid("1b4e28ba-2fa1-11d2-883f-0016d3cca427", true);
+	pass &= check_valid("1B4E28BA-2FA1-11D2-883F-0016D3CCA427", true);
+	pass &= check_valid("1b4e28ba2fa111d2883f0016d3cca427", false);
+	pass &= check_valid("1b4e28ba-2fa1-11d2-883f-0016d3cca42", false);
+	pass &= check_valid("1b4e28ba-2fa1-11d2-883f-0016d3cca4277", false);
+	pass &= check_valid("1b4e28ba-2fa1-11d2-883f-0016d3cca42g", false);
+	pass &= check_valid("1b4e28ba:2fa1-11d2-883f-0016d3cca427", false);
+
+	return pass;
+}
+
 static bool test_fw_to_string(void)
 {
 	bool pass = true;
@@ -59,6 +92,7 @@ int main(void)
 	bool pass = true;
 
 	pass &= test_uuid_to_string();
+	pass &= test_uuid_str_valid();
 	pass &= test_fw_to_string();
 
 	fflush(stdout);

--- a/shared/uuid-util.c
+++ b/shared/uuid-util.c
@@ -3,9 +3,34 @@
  * This file is part of nvme-cli.
  */
 
+#include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "uuid-util.h"
+
+bool shr_uuid_str_valid(const char *str)
+{
+	static const int group[] = { 8, 4, 4, 4, 12 };
+	size_t i;
+	int g, n;
+
+	if (!str || strlen(str) != SHR_UUID_LEN_STRING - 1)
+		return false;
+
+	i = 0;
+	for (g = 0; g < 5; g++) {
+		if (g && str[i++] != '-')
+			return false;
+
+		for (n = 0; n < group[g]; n++) {
+			if (!isxdigit((unsigned char)str[i++]))
+				return false;
+		}
+	}
+
+	return true;
+}
 
 const char *shr_uuid_to_string(unsigned char uuid[SHR_UUID_LEN])
 {

--- a/shared/uuid-util.h
+++ b/shared/uuid-util.h
@@ -4,11 +4,22 @@
  */
 #pragma once
 
+#include <stdbool.h>
+
 /* Byte length of a binary UUID. */
 #define SHR_UUID_LEN 16
 
 /* Length of a canonical UUID string, including the trailing '\0'. */
 #define SHR_UUID_LEN_STRING 37
+
+/*
+ * Check that @str is a canonical UUID string, as in
+ * "11111111-2222-3333-4444-555555555555": 32 hexadecimal digits in
+ * 8-4-4-4-12 groups separated by dashes. Case is not significant.
+ *
+ * Return: true if @str is a canonical UUID string.
+ */
+bool shr_uuid_str_valid(const char *str);
 
 const char *shr_uuid_to_string(unsigned char uuid[SHR_UUID_LEN]);
 const char *shr_fw_to_string(char *c);

--- a/tests/cli/nvme_config_convert_test.py
+++ b/tests/cli/nvme_config_convert_test.py
@@ -101,7 +101,7 @@ class ConfigConvertCLITest(TestNVMeBase):
     def test_convert_dc_and_subsystem(self):
         self._write_json({
             'hosts': [{
-                'hostnqn': 'nqn.2014-08.org.nvmexpress:uuid:1111',
+                'hostnqn': 'nqn.2014-08.org.nvmexpress:1111',
                 'hostid': '46ba5037-7ce5-41fa-9452-48477bf00080',
                 'hostsymname': 'lab-host-01',
                 'subsystems': [
@@ -129,7 +129,7 @@ class ConfigConvertCLITest(TestNVMeBase):
         self._convert()
         content = self._read_output()
         self.assertIn('[Host]', content)
-        self.assertIn('hostnqn = nqn.2014-08.org.nvmexpress:uuid:1111',
+        self.assertIn('hostnqn = nqn.2014-08.org.nvmexpress:1111',
                       content)
         self.assertIn('hostid = 46ba5037-7ce5-41fa-9452-48477bf00080',
                       content)
@@ -150,7 +150,7 @@ class ConfigConvertCLITest(TestNVMeBase):
 
     def test_convert_legacy_bare_array_format(self):
         self._write_json([{
-            'hostnqn': 'nqn.2014-08.org.nvmexpress:uuid:2222',
+            'hostnqn': 'nqn.2014-08.org.nvmexpress:2222',
             'subsystems': [{
                 'nqn': 'nqn.2024-01.com.example:data.vol2',
                 'ports': [{
@@ -161,14 +161,14 @@ class ConfigConvertCLITest(TestNVMeBase):
         }])
         self._convert()
         content = self._read_output()
-        self.assertIn('hostnqn = nqn.2014-08.org.nvmexpress:uuid:2222',
+        self.assertIn('hostnqn = nqn.2014-08.org.nvmexpress:2222',
                       content)
         self.assertIn('nqn = nqn.2024-01.com.example:data.vol2', content)
 
     def test_dhchap_default_inherited_by_port(self):
         self._write_json({
             'hosts': [{
-                'hostnqn': 'nqn.2014-08.org.nvmexpress:uuid:3333',
+                'hostnqn': 'nqn.2014-08.org.nvmexpress:3333',
                 'dhchap_key': 'DHHC-1:00:host-default-key:',
                 'subsystems': [{
                     'nqn': 'nqn.2024-01.com.example:data.vol3',
@@ -186,7 +186,7 @@ class ConfigConvertCLITest(TestNVMeBase):
     def test_dhchap_port_value_overrides_default(self):
         self._write_json({
             'hosts': [{
-                'hostnqn': 'nqn.2014-08.org.nvmexpress:uuid:4444',
+                'hostnqn': 'nqn.2014-08.org.nvmexpress:4444',
                 'dhchap_key': 'DHHC-1:00:host-default-key:',
                 'subsystems': [{
                     'nqn': 'nqn.2024-01.com.example:data.vol4',

--- a/tests/cli/nvme_config_create_test.py
+++ b/tests/cli/nvme_config_create_test.py
@@ -80,7 +80,7 @@ class ConfigCreateCLITest(TestNVMeBase):
         self._create('--transport', 'fc',
                      '--traddr=nn-0x58ccf090c92006da:pn-0x58ccf091492806da',
                      '--host-traddr=nn-0x20000024ff7fa448:pn-0x21000024ff7fa448',
-                     '--hostnqn=nqn.2014-08.org.nvmexpress:uuid:62a4ab74',
+                     '--hostnqn=nqn.2014-08.org.nvmexpress:62a4ab74',
                      '--hostid=62a4ab74-1e18-11f1-8bb7-6c1ff71ba506',
                      '--discovery')
         content = self._read_output()
@@ -90,7 +90,7 @@ class ConfigCreateCLITest(TestNVMeBase):
             'traddr=nn-0x58ccf090c92006da:pn-0x58ccf091492806da;'
             'host-traddr=nn-0x20000024ff7fa448:pn-0x21000024ff7fa448',
             content)
-        self.assertIn('hostnqn = nqn.2014-08.org.nvmexpress:uuid:62a4ab74',
+        self.assertIn('hostnqn = nqn.2014-08.org.nvmexpress:62a4ab74',
                       content)
         self.assertIn('hostid = 62a4ab74-1e18-11f1-8bb7-6c1ff71ba506',
                       content)
@@ -111,7 +111,7 @@ class ConfigCreateCLITest(TestNVMeBase):
     def test_host_symname_gets_own_dropin(self):
         self._create('--transport', 'tcp', '--traddr=192.168.1.21',
                      '--nqn=nqn.2024-01.com.example:data.vol2',
-                     '--hostnqn=nqn.2014-08.org.nvmexpress:uuid:aaaa',
+                     '--hostnqn=nqn.2014-08.org.nvmexpress:aaaa',
                      '--host-symname=lab-host-01')
         content = self._read_output()
         self.assertIn('hostsymname = lab-host-01', content)
@@ -192,7 +192,7 @@ class ConfigCreateCLITest(TestNVMeBase):
 
     def test_repeated_identical_create_is_idempotent(self):
         args = ('--transport', 'fc', '--traddr=nn-0x1:pn-0x1', '--discovery',
-               '--hostnqn=nqn.2014-08.org.nvmexpress:uuid:aaaa',
+               '--hostnqn=nqn.2014-08.org.nvmexpress:aaaa',
                '--hostid=46ba5037-7ce5-41fa-9452-48477bf00080')
         self._create(*args)
         self._create(*args)

--- a/tests/cli/nvme_fabrics_mock_test.py
+++ b/tests/cli/nvme_fabrics_mock_test.py
@@ -291,7 +291,7 @@ class FabricsMockCLITest(unittest.TestCase):
                 'transport': 'tcp',
                 'traddr': '192.168.1.200',
                 'trsvcid': '4420',
-                'subsysnqn': 'nqn.2014-08.org.nvmexpress:uuid:mock-target-nvm-subsystem',
+                'subsysnqn': 'nqn.2014-08.org.nvmexpress:mock-target-nvm-subsystem',
             },
         ]
         res = self._run('discover', '-t', 'tcp', '-a', '192.168.1.1')
@@ -303,7 +303,7 @@ class FabricsMockCLITest(unittest.TestCase):
 
     def test_connect_simple(self):
         """Test connecting to a single target."""
-        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        subsysnqn = "nqn.2014-08.org.nvmexpress:my-io-subsys-1"
         self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn)
 
         # The command should succeed, and our mock should have created the sysfs entries.
@@ -317,8 +317,8 @@ class FabricsMockCLITest(unittest.TestCase):
     def test_connect_all_recursive(self):
         """Test connect-all recursive discovery cascade."""
         # Setup pre-configured mock discovery log entries pointing to two standard I/O controllers.
-        subsys1 = "nqn.2014-08.org.nvmexpress:uuid:io-subsys-A"
-        subsys2 = "nqn.2014-08.org.nvmexpress:uuid:io-subsys-B"
+        subsys1 = "nqn.2014-08.org.nvmexpress:io-subsys-A"
+        subsys2 = "nqn.2014-08.org.nvmexpress:io-subsys-B"
         self.server.discovery_entries = [
             {'transport': 'tcp', 'traddr': '192.168.5.1', 'trsvcid': '4420', 'subsysnqn': subsys1},
             {'transport': 'tcp', 'traddr': '192.168.5.2', 'trsvcid': '4420', 'subsysnqn': subsys2},
@@ -339,7 +339,7 @@ class FabricsMockCLITest(unittest.TestCase):
     def test_connect_already_connected(self):
         """Test how connect handles EALREADY (already connected) error gracefully."""
         self.server.connect_errno = 114  # EALREADY
-        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        subsysnqn = "nqn.2014-08.org.nvmexpress:my-io-subsys-1"
 
         # Without --verbose, EALREADY is reported through the exit code alone --
         # no "already connected" text on either stream, so scripts don't have to
@@ -361,7 +361,7 @@ class FabricsMockCLITest(unittest.TestCase):
         """--idempotent turns EALREADY into success (exit 0) instead of a
         failure, still silent unless --verbose is given."""
         self.server.connect_errno = 114  # EALREADY
-        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        subsysnqn = "nqn.2014-08.org.nvmexpress:my-io-subsys-1"
 
         res = self._run('connect', '-t', 'tcp', '-a', '192.168.1.10', '-s', '4420', '-n', subsysnqn,
                         '--idempotent')
@@ -378,7 +378,7 @@ class FabricsMockCLITest(unittest.TestCase):
         ioctl is attempted. The CLI relies on for --idempotent and for
         knowing not to print its own generic "failed to connect" message
         on top of hook_already_connected()'s on the correct error code."""
-        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        subsysnqn = "nqn.2014-08.org.nvmexpress:my-io-subsys-1"
         # Each nvme invocation auto-generates its own random hostnqn/hostid
         # unless one is pinned, landing in a different in-memory host object.
         # lookup_live_ctrl() only searches the *current* host's own
@@ -427,7 +427,7 @@ class FabricsMockCLITest(unittest.TestCase):
     def test_connect_registry_ownership(self):
         """A fresh connect claims the registry entry; a reuse only touches
         it when --owner says so."""
-        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:owned-io-subsys"
+        subsysnqn = "nqn.2014-08.org.nvmexpress:owned-io-subsys"
         args = self._owner_connect_args(subsysnqn)
 
         self._run(*args, '--owner=stas')
@@ -448,7 +448,7 @@ class FabricsMockCLITest(unittest.TestCase):
     def test_connect_fresh_clears_stale_registry_entry(self):
         """A controller the kernel just created cannot legitimately be
         owned, so a recycled instance number's stale entry is dropped."""
-        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:recycled-io-subsys"
+        subsysnqn = "nqn.2014-08.org.nvmexpress:recycled-io-subsys"
         stale = Path(f"{self.base_dir}/registry/nvme0")
         stale.mkdir(parents=True)
         (stale / "owner").write_text("stas\n")
@@ -461,7 +461,7 @@ class FabricsMockCLITest(unittest.TestCase):
         controller through the kernel's EALREADY, before any registry
         update, so connect-all never claims one it did not create."""
         self.server.reject_duplicate_connect = True
-        io_subsys = "nqn.2014-08.org.nvmexpress:uuid:walked-io-subsys"
+        io_subsys = "nqn.2014-08.org.nvmexpress:walked-io-subsys"
         io_addr = '192.168.20.10'
         dc_addr = '192.168.20.1'
 
@@ -481,7 +481,7 @@ class FabricsMockCLITest(unittest.TestCase):
     def test_custom_identify(self):
         """Test getting custom Identify Controller fields steered by environment."""
         # Create a mock controller nvme0 in sysfs first, so nvme list has something to read.
-        subsysnqn = "nqn.2014-08.org.nvmexpress:uuid:my-io-subsys-1"
+        subsysnqn = "nqn.2014-08.org.nvmexpress:my-io-subsys-1"
         inst_dir = self._ctrl_path(0)
         inst_dir.mkdir(parents=True, exist_ok=True)
         (inst_dir / "transport").write_text("tcp\n")
@@ -512,10 +512,10 @@ class FabricsMockCLITest(unittest.TestCase):
 
     def test_connect_all_three_hop_referral_cascade(self):
         """Test connect-all with three Discovery Controllers in a referral chain: DC a -> DC b -> DC c -> IO subsys C."""
-        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-A"
-        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-B"
-        dc_c = "nqn.2014-08.org.nvmexpress:uuid:dc-C"
-        io_c = "nqn.2014-08.org.nvmexpress:uuid:io-subsys-C"
+        dc_a = "nqn.2014-08.org.nvmexpress:dc-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:dc-B"
+        dc_c = "nqn.2014-08.org.nvmexpress:dc-C"
+        io_c = "nqn.2014-08.org.nvmexpress:io-subsys-C"
 
         # Configure our Python mock server to map each subsystem NQN to its specific log entries.
         self.server.discovery_map = {
@@ -633,9 +633,9 @@ class FabricsMockCLITest(unittest.TestCase):
     def test_connect_all_persistent_auto_epcsd_referral_hop(self):
         """Referral (non-self) Discovery Controller entries decide persistence
         from their own EFLAGS directly, without needing a self-entry."""
-        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-epcsd-A"
-        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-epcsd-B"  # EPCSD set: should persist
-        dc_c = "nqn.2014-08.org.nvmexpress:uuid:dc-epcsd-C"  # EPCSD unset: should disconnect
+        dc_a = "nqn.2014-08.org.nvmexpress:dc-epcsd-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:dc-epcsd-B"  # EPCSD set: should persist
+        dc_c = "nqn.2014-08.org.nvmexpress:dc-epcsd-C"  # EPCSD unset: should disconnect
 
         self.server.discovery_map = {
             dc_a: [
@@ -664,8 +664,8 @@ class FabricsMockCLITest(unittest.TestCase):
         """A referred DC's own self entry (SUBTYPE=03h) decides its own
         persistence -- not the EPCSD its parent's referral entry reported
         for it."""
-        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-self-override-A"
-        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-self-override-B"
+        dc_a = "nqn.2014-08.org.nvmexpress:dc-self-override-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:dc-self-override-B"
         dc_b_addr = '192.168.130.2'
         dc_b_trsvcid = '4420'
 
@@ -695,9 +695,9 @@ class FabricsMockCLITest(unittest.TestCase):
         """A referral DC that's already connected before connect-all runs
         must still have its own Discovery Log Page walked, not just
         skipped -- the bug that motivated the discovery-walk rewrite."""
-        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-resume-A"
-        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-resume-B"
-        io_c = "nqn.2014-08.org.nvmexpress:uuid:io-resume-C"
+        dc_a = "nqn.2014-08.org.nvmexpress:dc-resume-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:dc-resume-B"
+        io_c = "nqn.2014-08.org.nvmexpress:io-resume-C"
         dc_b_addr = '192.168.140.2'
         dc_b_trsvcid = '4420'
         # Each invocation of the nvme binary auto-generates its own random
@@ -745,7 +745,7 @@ class FabricsMockCLITest(unittest.TestCase):
         the primary is depth 0, dc_1..dc_8 (depths 1-8) connect, dc_9
         (depth 9) does not."""
         n = 10  # dc_0 (primary) .. dc_9
-        dcs = [f"nqn.2014-08.org.nvmexpress:uuid:dc-depth-{i}" for i in range(n)]
+        dcs = [f"nqn.2014-08.org.nvmexpress:dc-depth-{i}" for i in range(n)]
         self.server.discovery_map = {
             dcs[i]: [{'transport': 'tcp', 'traddr': f'192.168.120.{i + 2}',
                      'trsvcid': '4420', 'subsysnqn': dcs[i + 1]}]
@@ -768,9 +768,9 @@ class FabricsMockCLITest(unittest.TestCase):
         dc_a's Discovery Log Page is fetched exactly once despite the
         cycle, and a sibling entry alongside the back-reference is still
         discovered."""
-        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-cycle-A"
-        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-cycle-B"
-        io_c = "nqn.2014-08.org.nvmexpress:uuid:io-cycle-C"
+        dc_a = "nqn.2014-08.org.nvmexpress:dc-cycle-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:dc-cycle-B"
+        io_c = "nqn.2014-08.org.nvmexpress:io-cycle-C"
 
         self.server.discovery_map = {
             dc_a: [
@@ -799,9 +799,9 @@ class FabricsMockCLITest(unittest.TestCase):
         <-> dc_a, every node referring to both its ring-neighbors) must not
         re-walk any of them: each DC's Discovery Log Page is fetched exactly
         once despite every node having a path back to every other node."""
-        dc_a = "nqn.2014-08.org.nvmexpress:uuid:dc-ring-A"
-        dc_b = "nqn.2014-08.org.nvmexpress:uuid:dc-ring-B"
-        dc_c = "nqn.2014-08.org.nvmexpress:uuid:dc-ring-C"
+        dc_a = "nqn.2014-08.org.nvmexpress:dc-ring-A"
+        dc_b = "nqn.2014-08.org.nvmexpress:dc-ring-B"
+        dc_c = "nqn.2014-08.org.nvmexpress:dc-ring-C"
 
         self.server.discovery_map = {
             dc_a: [

--- a/tests/cli/nvme_keys_test.py
+++ b/tests/cli/nvme_keys_test.py
@@ -58,7 +58,7 @@ _DEPRECATED_CMDS = _has_deprecated_cmds()
 
 _PIN_KXCHAP_KEY = 'DHHC-1:00:9wCYVQqDvADjGIZo6q/v2SfmXZqqkNa9TcvYu97Ly3Q/gajh:'
 _PIN_TLS_KEY = 'NVMeTLSkey-1:01:9wCYVQqDvADjGIZo6q/v2SfmXZqqkNa9TcvYu97Ly3Q/gajh:'
-_HOST_NQN = 'nqn.2014-08.org.nvmexpress:uuid:abc'
+_HOST_NQN = 'nqn.2014-08.org.nvmexpress:abc'
 # The alias prints this when it drops '--nqn'. Matching the option
 # name alone would also hit the getopt error listing it as a
 # candidate, and the help text naming it.
@@ -165,7 +165,7 @@ class KeysCLITest(unittest.TestCase):
         # The payload is the secret, which no NQN takes part in deriving,
         # so '--nqn' is gone rather than accepted and ignored.
         self._run('gen-kxchap-secret', '--secret=pin:1234', '--hmac=1',
-                  '--nqn=nqn.2014-08.org.nvmexpress:uuid:abc',
+                  '--nqn=nqn.2014-08.org.nvmexpress:abc',
                   expect_fail=True)
 
     @unittest.skipUnless(_DEPRECATED_CMDS, 'built without deprecated commands')


### PR DESCRIPTION
`libnvmf_read_hostnqn()` and `libnvmf_read_hostid()` accepted any non-empty string, and `config-ini.c` carried its own private copies of an NQN check and a host identifier check. This adds one definition of each in `shared/` and points everything at it.

**Two validators in `shared/`.** `shr_nqn_valid()` applies the rules from the NVMe Base Specification, section 4.7: at most 223 bytes, an `nqn.` prefix, a `yyyy-mm` date code whose month is 01 to 12, a non-empty remainder, and a canonical UUID when the `nqn.2014-08.org.nvmexpress:uuid:` form is used. `shr_hostid_valid()` requires a canonical UUID that is not all zeros, a value the specification gives no meaning as a host identifier. 

Two deliberate departures from section 4.7, both noted in the header. The prohibition on `org.nvmexpress` as a format 1 reverse domain is not enforced: names of that shape are widely deployed as host NQNs, and 18 distinct ones appear in this tree. And where the specification permits any UTF-8 string, the check accepts printable ASCII only, excluding the space. That is a judgement call rather than a spec rule: a reverse domain name is ASCII, since an internationalized domain reaches the wire as punycode, and a UUID is hex, so no NQN anyone issues is affected. What it buys is catching a truncated read of `/etc/nvme/hostnqn` or a trailing newline, which are the realistic ways a bad value gets there.

**Both read functions now validate.** An invalid value held by the context, including the empty string, falls through to `$SYSCONFDIR/nvme` instead of being used. A file that exists but holds a malformed value is reported at `LIBNVME_LOG_ERR` and treated as absent. A missing file stays silent, as before. This changes what an empty context value means: it used to suppress the file lookup, and is now simply an invalid value like any other.

**The config parser uses the same code.** Its two static checks are gone, and no configuration that parses today stops parsing. One behaviour change follows: a `uuid:`-form NQN whose UUID is malformed is now rejected, where it was previously accepted. Several test fixtures relied on that, spelling a readable label as `nqn.2014-08.org.nvmexpress:uuid:dc-A`. Those labels were never UUIDs, so the fixtures drop the `uuid:` component and stay domain-format names.

Not covered here: `--hostnqn` and `--hostid` reach `libnvmf_host_get_ids()` as arguments ranked above both of these sources, and TIDs accept a `hostnqn=`/`hostid=` pair unchecked. Both are worth doing separately. 

Built with `-Dpython=enabled`. Every commit builds and passes the full suite on its own; checkpatch is clean of errors per commit.
