### PR TITLE
python-libnvme: stop scanning the topology when a GlobalCtx is created

### DIFF
--- a/libnvme/examples/discover-loop.py
+++ b/libnvme/examples/discover-loop.py
@@ -55,6 +55,13 @@ def discover(ctx, host, ctrl, iteration):
             discover(ctx, host, new_ctrl, iteration + 1)
 
 ctx = nvme.GlobalCtx()
+
+# scan_topology() is optional. It parses sysfs and builds a tree of the
+# Host, Subsystem and Ctrl objects that already exist. With that tree in
+# place, the controller created below inherits configuration from a peer
+# controller on the same subsystem.
+ctx.scan_topology()
+
 host = nvme.Host(ctx)
 subsysnqn = nvme.NVME_DISC_SUBSYS_NAME
 transport = 'tcp'

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -1464,7 +1464,7 @@ struct libnvme_ns *libnvme_ctrl_first_ns(struct libnvme_ctrl *c);
 struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_ns *n);
 
 %extend libnvme_global_ctx {
-	%feature("autodoc", "__init__(self, owner=None)\n"
+	%feature("autodoc", "__init__(self, owner=None, hostnqn=None, hostid=None)\n"
 		"\n"
 		"Create the root context for the libnvme device tree.\n"
 		"\n"
@@ -1474,8 +1474,14 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 		"Args:\n"
 		"    owner: Orchestrator identity (e.g. 'stas', 'nbft').\n"
 		"           Pass None if this process does not participate\n"
-		"           in the ownership registry.") libnvme_global_ctx;
-	libnvme_global_ctx(const char *owner = NULL) {
+		"           in the ownership registry.\n"
+		"    hostnqn: Default host NQN. Pass None to use\n"
+		"           $SYSCONFDIR/nvme/hostnqn.\n"
+		"    hostid: Default host identifier. Pass None to use\n"
+		"           $SYSCONFDIR/nvme/hostid.") libnvme_global_ctx;
+	libnvme_global_ctx(const char *owner = NULL,
+			   const char *hostnqn = NULL,
+			   const char *hostid = NULL) {
 		struct libnvme_global_ctx *ctx;
 
 		ctx = libnvme_create_global_ctx();
@@ -1485,6 +1491,11 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 
 		if (owner)
 			libnvme_set_owner(ctx, owner);
+
+		if (hostnqn)
+			libnvme_set_hostnqn(ctx, hostnqn);
+		if (hostid)
+			libnvme_set_hostid(ctx, hostid);
 
 		libnvme_scan_topology(ctx, NULL, NULL);
 

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -1468,7 +1468,8 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 		"\n"
 		"Create the root context for the libnvme device tree.\n"
 		"\n"
-		"Scans the NVMe topology on creation.\n"
+		"The device tree starts empty. Call scan_topology() to\n"
+		"populate it.\n"
 		"Supports use as a context manager (``with GlobalCtx() as ctx:``).\n"
 		"\n"
 		"Args:\n"
@@ -1496,8 +1497,6 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 			libnvme_set_hostnqn(ctx, hostnqn);
 		if (hostid)
 			libnvme_set_hostid(ctx, hostid);
-
-		libnvme_scan_topology(ctx, NULL, NULL);
 
 		return ctx;
 	}

--- a/libnvme/libnvme3/nvme.i
+++ b/libnvme/libnvme3/nvme.i
@@ -1531,7 +1531,22 @@ struct libnvme_ns *libnvme_ctrl_next_ns(struct libnvme_ctrl *c, struct libnvme_n
 	        yield h
 	        h = _libnvme_next_host(self, h)
 	%}
-	%feature("autodoc", "Rescan the NVMe topology and update the device tree.") refresh_topology;
+	%feature("autodoc", "Scan the NVMe topology and add what is found to "
+		"the device tree.\n"
+		"\n"
+		"Only adds: a device already in the tree is updated in place, "
+		"and nothing is removed. Objects held by the caller stay "
+		"valid.") scan_topology;
+	void scan_topology() {
+		libnvme_scan_topology($self, NULL, NULL);
+	}
+	%feature("autodoc", "Discard the device tree and scan the NVMe "
+		"topology again.\n"
+		"\n"
+		"Destructive: every host, subsystem, controller and namespace "
+		"is freed before the scan, so any object the caller still "
+		"holds becomes invalid. Use it to drop devices that have gone "
+		"away; use scan_topology() to pick up new ones.") refresh_topology;
 	void refresh_topology() {
 		libnvme_refresh_topology($self);
 	}


### PR DESCRIPTION
The Python `GlobalCtx()` constructor scanned the NVMe topology unconditionally. The C API does not: `libnvme_create_global_ctx()` only allocates the context, and every C caller scans when it needs the tree.

That deviation cost more than a wasted sysfs walk. Every public API takes a context, including many that have nothing to do with the device tree, so a context created for configuration, registry or identity work paid for a tree it never used. The scan also created a host the caller never asked for. In nvme-stas, `GlobalCtx(owner=...)` followed by an explicit `Host(...)` left **two** hosts in the tree: the automatically-invented one and the real one the user is asking for. In `discover-loop.py`, the explicit `Host(ctx)` returned the object the scan had already made, so it created nothing at all.

**`GlobalCtx()` no longer scans.** Callers that want the tree call `scan_topology()`. nvme-stas needs no change — it never walks the tree.

**`scan_topology()` is now exposed.** The bindings offered only `refresh_topology()`, which frees every host, subsystem, controller and namespace before scanning, so any object the caller still holds becomes invalid. `scan_topology()` only adds: a device already in the tree is updated in place, nothing is removed. Both docstrings now say which is which. `refresh_topology()` stays, since dropping devices that have gone away may be needed for certain applications.

**`GlobalCtx()` accepts `hostnqn` and `hostid`**, matching the existing `owner` keyword, so a caller can build a fully configured context in one call.

The example keeps its `scan_topology()` call, with a comment explaining that it is optional and what it buys: a controller created afterwards inherits configuration from a peer controller on the same subsystem.

This is an intentional behaviour change to a public interface, taken before 3.0. Built with `-Dpython=enabled`, `meson test` clean, checkpatch clean per commit.
