### PR TITLE
Fix issues found during WinPE testing

### DIFF
--- a/libnvme/src/nvme/ctrl-map.c
+++ b/libnvme/src/nvme/ctrl-map.c
@@ -661,12 +661,12 @@ int libnvme_ctrl_map_entry_get_pci_address(const struct ctrl_map_entry *entry,
 		char **address)
 {
 	WCHAR instance_id[MAX_DEVICE_ID_LEN];
-	WCHAR location_info[256];
 	DEVPROPTYPE prop_type = 0;
-	ULONG size;
+	DWORD bus_number = 0, pci_address = 0;
+	unsigned int segment, bus, device, function;
+	ULONG reg_type, size;
 	CONFIGRET cr;
 	DEVINST devinst;
-	unsigned int bus = 0, device = 0, function = 0;
 	char *addr;
 
 	if (!entry || !address || !entry->ctrl_path)
@@ -692,28 +692,39 @@ int libnvme_ctrl_map_entry_get_pci_address(const struct ctrl_map_entry *entry,
 		return -ENODEV;
 
 	/*
-	 * Query DEVPKEY_Device_LocationInfo which returns a string like
-	 * "PCI bus 2, device 0, function 0"
+	 * CM_DRP_BUSNUMBER packs the PCI segment above the low 8 bits, which
+	 * hold the bus. CM_DRP_ADDRESS packs the device number in the high 16
+	 * bits and the function in the low 16, and reads 0xffffffff when the
+	 * bus driver does not supply it.
 	 */
-	size = sizeof(location_info);
-	prop_type = 0;
-	cr = CM_Get_DevNode_PropertyW(
-		devinst,
-		&DEVPKEY_Device_LocationInfo,
-		&prop_type,
-		(PBYTE)location_info,
-		&size,
-		0);
-	if (cr != CR_SUCCESS || prop_type != DEVPROP_TYPE_STRING)
+	reg_type = 0;
+	size = sizeof(bus_number);
+	cr = CM_Get_DevNode_Registry_PropertyW(devinst, CM_DRP_BUSNUMBER,
+					       &reg_type, &bus_number,
+					       &size, 0);
+	if (cr != CR_SUCCESS || reg_type != REG_DWORD)
 		return -ENODEV;
 
-	if (swscanf(location_info, L"PCI bus %u, device %u, function %u",
-		    &bus, &device, &function) != 3)
-		return -EINVAL;
+	reg_type = 0;
+	size = sizeof(pci_address);
+	cr = CM_Get_DevNode_Registry_PropertyW(devinst, CM_DRP_ADDRESS,
+					       &reg_type, &pci_address,
+					       &size, 0);
+	if (cr != CR_SUCCESS || reg_type != REG_DWORD ||
+	    pci_address == 0xffffffff)
+		return -ENODEV;
 
-	/* Format as Linux-compatible BDF: DOMAIN:BUS:DEVICE.FUNCTION */
-	if (asprintf(&addr, "0000:%02x:%02x.%x",
-		     bus, device, function) < 0)
+	segment = (bus_number >> 8) & 0xffff;
+	bus = bus_number & 0xff;
+	device = (pci_address >> 16) & 0xffff;
+	function = pci_address & 0xffff;
+
+	/*
+	 * Format as Linux-compatible BDF: DOMAIN:BUS:DEVICE.FUNCTION, with
+	 * the PCI segment as the domain.
+	 */
+	if (asprintf(&addr, "%04x:%02x:%02x.%x",
+		     segment, bus, device, function) < 0)
 		return -ENOMEM;
 
 	*address = addr;
@@ -1010,8 +1021,14 @@ HDEVINFO libnvme_ctrl_map_entry_get_devinfo(
 		return INVALID_HANDLE_VALUE;
 
 	for (index = 0;; index++) {
-		get_device_interface_path(hdev, index, &ctrl_path,
-			dev_info_data);
+		int ret;
+
+		ret = get_device_interface_path(hdev, index, &ctrl_path,
+						dev_info_data);
+		if (ret == -ENOENT)
+			break;
+		if (ret)
+			continue;
 
 		if (_wcsicmp(ctrl_path, entry->ctrl_path) == 0) {
 			free(ctrl_path);

--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -272,7 +272,7 @@ __shr_public int libnvme_update_block_size(struct libnvme_transport_handle *hdl,
 static int submit_storage_protocol_command(
 		struct libnvme_transport_handle *hdl,
 		struct libnvme_passthru_cmd *cmd,
-		bool entry_called, void *user_data)
+		bool is_admin, bool entry_called, void *user_data)
 {
 	PSTORAGE_PROTOCOL_COMMAND protocol_command = NULL;
 	ULONG buffer_len = 0;
@@ -331,7 +331,7 @@ static int submit_storage_protocol_command(
 	 * to the controller.  Pad these requests with a zeroed Host Software
 	 * Specified Fields buffer.
 	 */
-	if (cmd->opcode == nvme_admin_ns_mgmt && !cmd->data_len)
+	if (is_admin && cmd->opcode == nvme_admin_ns_mgmt && !cmd->data_len)
 		pad_len = sizeof(struct nvme_ns_mgmt_host_sw_specified);
 
 	/* Allocate buffer for STORAGE_PROTOCOL_COMMAND + NVME command + data */
@@ -357,8 +357,9 @@ static int submit_storage_protocol_command(
 	protocol_command->TimeOutValue = (cmd->timeout_ms > 0) ?
 		((cmd->timeout_ms + 999) / 1000) : 10; /* Round up to seconds */
 
-	protocol_command->CommandSpecific =
-		STORAGE_PROTOCOL_SPECIFIC_NVME_ADMIN_COMMAND;
+	protocol_command->CommandSpecific = is_admin ?
+		STORAGE_PROTOCOL_SPECIFIC_NVME_ADMIN_COMMAND :
+		STORAGE_PROTOCOL_SPECIFIC_NVME_NVM_COMMAND;
 	memcpy(protocol_command->Command, cmd,
 		STORAGE_PROTOCOL_COMMAND_LENGTH_NVME);
 
@@ -977,7 +978,7 @@ static int submit_admin_get_log_page(struct libnvme_transport_handle *hdl,
 		 * parameter and only supports NVME_CSI_NVM. For other CSI
 		 * values, fall back to IOCTL_STORAGE_PROTOCOL_COMMAND.
 		 */
-		return submit_storage_protocol_command(hdl, cmd, true, user_data);
+		return submit_storage_protocol_command(hdl, cmd, true, true, user_data);
 	}
 
 	buffer_len = FIELD_OFFSET(STORAGE_PROPERTY_QUERY, AdditionalParameters) +
@@ -1053,7 +1054,7 @@ static int submit_admin_get_log_page(struct libnvme_transport_handle *hdl,
 			 * allows the controller to respond if not supported.
 			 */
 			free(buffer);
-			return submit_storage_protocol_command(hdl, cmd, true, user_data);
+			return submit_storage_protocol_command(hdl, cmd, true, true, user_data);
 		}
 		err = -get_errno_from_error(last_error);
 	} while (hdl->decide_retry(hdl, cmd, err));
@@ -1841,7 +1842,7 @@ static int submit_admin_sanitize(
 		 * Default namespace handle not available,
 		 * fall back to IOCTL_STORAGE_PROTOCOL_COMMAND.
 		 */
-		err = submit_storage_protocol_command(hdl, cmd, false, NULL);
+		err = submit_storage_protocol_command(hdl, cmd, true, false, NULL);
 	}
 
 	return err;
@@ -2006,7 +2007,7 @@ static int submit_admin_format_nvm(struct libnvme_transport_handle *hdl,
 
 	/* For WinPE, use storage protocol command. */
 	if (get_is_win_pe())
-		return submit_storage_protocol_command(hdl, cmd, false, NULL);
+		return submit_storage_protocol_command(hdl, cmd, true, false, NULL);
 
 	if (!libnvme_transport_handle_is_ns(hdl)) {
 		libnvme_msg(hdl->ctx, LIBNVME_LOG_ERR, "Windows only supports "
@@ -2216,11 +2217,11 @@ __shr_public int libnvme_exec_io_passthru(
 	case nvme_cmd_compare:
 		/* Only supported on WinPE */
 		if (get_is_win_pe())
-			return submit_storage_protocol_command(hdl, cmd, false, NULL);
+			return submit_storage_protocol_command(hdl, cmd, false, false, NULL);
 		else
 			return -ENOTSUP;
 	case 0x80 ... 0xFF: /* vendor-specific commands */
-		return submit_storage_protocol_command(hdl, cmd, false, NULL);
+		return submit_storage_protocol_command(hdl, cmd, false, false, NULL);
 	default:
 		libnvme_msg(hdl->ctx, LIBNVME_LOG_DEBUG, "%s: opcode=0x%02x\n",
 			__func__, cmd->opcode);
@@ -2268,7 +2269,7 @@ __shr_public int libnvme_exec_admin_passthru(
 	case nvme_admin_nvme_mi_recv:
 		/* Only supported on WinPE */
 		if (get_is_win_pe())
-			return submit_storage_protocol_command(hdl, cmd, false, NULL);
+			return submit_storage_protocol_command(hdl, cmd, true, false, NULL);
 		else
 			return -ENOTSUP;
 	case nvme_admin_fw_commit:
@@ -2276,7 +2277,7 @@ __shr_public int libnvme_exec_admin_passthru(
 	case nvme_admin_fw_download:
 		return submit_admin_fw_download(hdl, cmd);
 	case nvme_admin_dev_self_test:
-		return submit_storage_protocol_command(hdl, cmd, false, NULL);
+		return submit_storage_protocol_command(hdl, cmd, true, false, NULL);
 	case nvme_admin_format_nvm:
 		return submit_admin_format_nvm(hdl, cmd);
 	case nvme_admin_security_send:
@@ -2285,7 +2286,7 @@ __shr_public int libnvme_exec_admin_passthru(
 	case nvme_admin_sanitize_nvm:
 		return submit_admin_sanitize(hdl, cmd);
 	case 0xC0 ... 0xFF: /* vendor-specific commands */
-		return submit_storage_protocol_command(hdl, cmd, false, NULL);
+		return submit_storage_protocol_command(hdl, cmd, true, false, NULL);
 	default:
 		libnvme_msg(hdl->ctx, LIBNVME_LOG_DEBUG, "%s: opcode=0x%02x\n",
 			__func__, cmd->opcode);

--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -262,6 +262,13 @@ __shr_public int libnvme_update_block_size(struct libnvme_transport_handle *hdl,
 #define PROTOCOL_COMMAND_MAX_PAGES 512
 
 /*
+ * Smallest data-out length the driver accepts for a command that declares a
+ * host to controller transfer but carries no data.  NVMe transfers are dword
+ * granular, so one dword is the minimum.
+ */
+#define PROTOCOL_COMMAND_MIN_DATA_OUT_LEN 4
+
+/*
  * IOCTL_STORAGE_PROTOCOL_COMMAND pass-through implementation used for
  * VU commands and a small subset of other admin and IO commands.
  * 
@@ -323,16 +330,15 @@ static int submit_storage_protocol_command(
 	}
 
 	/*
-	 * The Namespace Management opcode declares a host to controller
-	 * transfer (DTD 01b), so the driver requires a data-out buffer even
-	 * for operations that transfer no data (i.e. Delete).  Namespace
-	 * management requests that carry no host to controller transfer
-	 * fail STORAGE_PROTOCOL_STATUS_INVALID_REQUEST without being submitted
-	 * to the controller.  Pad these requests with a zeroed Host Software
-	 * Specified Fields buffer.
+	 * For commands that declare a host to controller transfer (DTD 01b),
+	 * the driver requires a data-out buffer even for operations that
+	 * transfer no data.  Requests without a data buffer fail with
+	 * STORAGE_PROTOCOL_STATUS_INVALID_REQUEST without being submitted to
+	 * the controller.  Pad these requests with a zeroed buffer to satisfy
+	 * the driver requirement.
 	 */
-	if (is_admin && cmd->opcode == nvme_admin_ns_mgmt && !cmd->data_len)
-		pad_len = sizeof(struct nvme_ns_mgmt_host_sw_specified);
+	if (is_write && !cmd->data_len)
+		pad_len = PROTOCOL_COMMAND_MIN_DATA_OUT_LEN;
 
 	/* Allocate buffer for STORAGE_PROTOCOL_COMMAND + NVME command + data */
 	buffer_len = FIELD_OFFSET(STORAGE_PROTOCOL_COMMAND, Command) +

--- a/libnvme/src/nvme/ioctl-win.c
+++ b/libnvme/src/nvme/ioctl-win.c
@@ -277,6 +277,7 @@ static int submit_storage_protocol_command(
 	PSTORAGE_PROTOCOL_COMMAND protocol_command = NULL;
 	ULONG buffer_len = 0;
 	ULONG returned_len = 0;
+	ULONG pad_len = 0;
 	BOOL result = FALSE;
 	PUCHAR buffer = NULL;
 	int err = 0;
@@ -321,10 +322,22 @@ static int submit_storage_protocol_command(
 		goto out;
 	}
 
+	/*
+	 * The Namespace Management opcode declares a host to controller
+	 * transfer (DTD 01b), so the driver requires a data-out buffer even
+	 * for operations that transfer no data (i.e. Delete).  Namespace
+	 * management requests that carry no host to controller transfer
+	 * fail STORAGE_PROTOCOL_STATUS_INVALID_REQUEST without being submitted
+	 * to the controller.  Pad these requests with a zeroed Host Software
+	 * Specified Fields buffer.
+	 */
+	if (cmd->opcode == nvme_admin_ns_mgmt && !cmd->data_len)
+		pad_len = sizeof(struct nvme_ns_mgmt_host_sw_specified);
+
 	/* Allocate buffer for STORAGE_PROTOCOL_COMMAND + NVME command + data */
 	buffer_len = FIELD_OFFSET(STORAGE_PROTOCOL_COMMAND, Command) +
 		STORAGE_PROTOCOL_COMMAND_LENGTH_NVME +
-		(cmd->data_len > 0 ? cmd->data_len : 0);
+		cmd->data_len + pad_len;
 
 	buffer = (PUCHAR)malloc(buffer_len);
 	if (!buffer) {
@@ -361,6 +374,11 @@ static int submit_storage_protocol_command(
 			STORAGE_PROTOCOL_COMMAND_LENGTH_NVME;
 		memcpy((PUCHAR)buffer + protocol_command->DataToDeviceBufferOffset,
 			(void *)(uintptr_t)cmd->addr, cmd->data_len);
+	} else if (pad_len) {
+		protocol_command->DataToDeviceTransferLength = pad_len;
+		protocol_command->DataToDeviceBufferOffset =
+			FIELD_OFFSET(STORAGE_PROTOCOL_COMMAND, Command) +
+			STORAGE_PROTOCOL_COMMAND_LENGTH_NVME;
 	}
 
 	do {

--- a/libnvme/src/nvme/private-ctrl-map.h
+++ b/libnvme/src/nvme/private-ctrl-map.h
@@ -110,10 +110,11 @@ int libnvme_ctrl_map_entry_get_ctrl_path(const struct ctrl_map_entry *entry,
  * libnvme_ctrl_map_entry_get_pci_address() - Get PCI BDF address for a
  * controller
  * @entry: controller map entry
- * @address: Output BDF string in "DDDD:BB:DD.F" format, allocated on success
+ * @address: Output BDF string in "DDDD:BB:DD.F" format,
+ * allocated on success (caller frees)
  *
- * Queries the Windows CM API for the PCI bus, device, and function numbers
- * and formats them into a Linux-compatible BDF address string.
+ * Queries the Windows CM API for the PCI segment, bus, device, and function
+ * numbers and formats them into a Linux-compatible BDF address string.
  *
  * Return: 0 on success, or a negative error code
  */


### PR DESCRIPTION
Fixes issues found during WinPE testing:
- Fixes device enumeration by using low-level, numeric bus and address values instead of parsing from a string property that can be composed differently based on platform and locale
- Fixes storage protocol commands with opcodes indicating a data transfer to the device but having zero data length by passing a minimal buffer to the driver.  The driver requires a data buffer configuration even if no data transfer is required by the command options.
- Fixes IO storage protocol commands, which were being sent to the driver as admin commands.

All WinPE-specific command handlers are now tested and working:
- Namespace Management
- NVMe-MI Send/Receive
- Format
- Compare