### PR TITLE
libnvme: return an empty string for missing namespace attributes

### DIFF
--- a/libnvme/src/nvme/tree.c
+++ b/libnvme/src/nvme/tree.c
@@ -1563,9 +1563,9 @@ __shr_public const char *libnvme_ns_get_model(struct libnvme_ns *n)
 	const char *val;
 
 	if (!n->c)
-		libnvme_subsystem_get_model(n->s, &val, NULL);
+		libnvme_subsystem_get_model(n->s, &val, "");
 	else
-		libnvme_ctrl_get_model(n->c, &val, NULL);
+		libnvme_ctrl_get_model(n->c, &val, "");
 
 	return val;
 }
@@ -1575,9 +1575,9 @@ __shr_public const char *libnvme_ns_get_serial(struct libnvme_ns *n)
 	const char *val;
 
 	if (!n->c)
-		libnvme_subsystem_get_serial(n->s, &val, NULL);
+		libnvme_subsystem_get_serial(n->s, &val, "");
 	else
-		libnvme_ctrl_get_serial(n->c, &val, NULL);
+		libnvme_ctrl_get_serial(n->c, &val, "");
 
 	return val;
 }
@@ -1587,9 +1587,9 @@ __shr_public const char *libnvme_ns_get_firmware(struct libnvme_ns *n)
 	const char *val;
 
 	if (!n->c)
-		libnvme_subsystem_get_firmware(n->s, &val, NULL);
+		libnvme_subsystem_get_firmware(n->s, &val, "");
 	else
-		libnvme_ctrl_get_firmware(n->c, &val, NULL);
+		libnvme_ctrl_get_firmware(n->c, &val, "");
 
 	return val;
 }

--- a/libnvme/tests/tree.c
+++ b/libnvme/tests/tree.c
@@ -286,6 +286,64 @@ static bool test_subsystem_attrs(void)
 }
 
 /**
+ * test_ns_attr_not_null - the namespace attribute getters must not return
+ * NULL when the device does not report the attribute.
+ */
+static bool test_ns_attr_not_null(void)
+{
+	struct libnvme_global_ctx *ctx;
+	struct libnvme_host *h;
+	struct libnvme_subsystem *s;
+	struct libnvme_ns n = {};
+	const char *firmware, *serial, *model;
+	bool pass = true;
+
+	printf("test_ns_attr_not_null:\n");
+
+	ctx = libnvme_create_global_ctx();
+	shr_assert(ctx);
+
+	libnvme_set_logging_file(ctx, stdout);
+	libnvme_set_logging_level(ctx, LIBNVME_LOG_ERR, false, false);
+
+	shr_assert(!libnvme_get_host(ctx, HOSTNQN_1, HOSTID_1, &h));
+	shr_assert(h);
+
+	shr_assert(!libnvme_get_subsystem(ctx, h, SUBSYSNAME_1, SUBSYSNQN_1, &s));
+	shr_assert(s);
+
+	n.s = s;
+
+	firmware = libnvme_ns_get_firmware(&n);
+	serial = libnvme_ns_get_serial(&n);
+	model = libnvme_ns_get_model(&n);
+
+	if (!firmware) {
+		printf(" - firmware getter returned NULL [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - firmware getter returned a string [PASS]\n");
+	}
+
+	if (!serial) {
+		printf(" - serial getter returned NULL [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - serial getter returned a string [PASS]\n");
+	}
+
+	if (!model) {
+		printf(" - model getter returned NULL [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - model getter returned a string [PASS]\n");
+	}
+
+	libnvme_free_global_ctx(ctx);
+	return pass;
+}
+
+/**
  * test_subsystem_iteration - libnvme_for_each_subsystem() must visit every
  * subsystem exactly once.
  */
@@ -335,6 +393,7 @@ int main(int argc, char *argv[])
 	pass &= test_host_iteration();
 	pass &= test_subsystem_dedup();
 	pass &= test_subsystem_attrs();
+	pass &= test_ns_attr_not_null();
 	pass &= test_subsystem_iteration();
 
 	fflush(stdout);


### PR DESCRIPTION
libnvme_ns_get_firmware(), libnvme_ns_get_serial() and libnvme_ns_get_model() returned NULL when a device does not report the attribute, and "nvme list" died in strdup().
 ```
~# nvme list
Segmentation fault         (core dumped) nvme list

 ~# nvme list -o json | jq '.Devices[] | select(.Firmware == null) | .DevicePath'
 "/dev/nvme32n1"

 ```
 
libnvme drops blank attributes, so a controller reporting an all-spaces firmware revision (GCP persistent disks, model "nvme_card-pd") has no firmware string at all.

Return an empty string instead. "nvme list -o json" now prints "" rather than null for a missing attribute.