### PR TITLE
nvme: free the plugin command groups at exit

### DIFF
--- a/src/nvme.c
+++ b/src/nvme.c
@@ -145,6 +145,26 @@ void register_extension(struct plugin *plugin)
 	nvme.extensions->tail = plugin;
 }
 
+/*
+ * plugin_add_group() runs from constructors, before main(), and its
+ * allocations live for the whole process. Release them at exit.
+ */
+static void free_plugins(void)
+{
+	struct plugin *plugin;
+
+	for (plugin = nvme.extensions; plugin; plugin = plugin->next) {
+		while (plugin->groups) {
+			struct command_group *group = plugin->groups;
+
+			plugin->groups = group->next;
+			free(group);
+		}
+		free(plugin->commands);
+		plugin->commands = NULL;
+	}
+}
+
 int main(int argc, char **argv)
 {
 	int err;
@@ -159,6 +179,7 @@ int main(int argc, char **argv)
 #endif
 
 	nvme.extensions->parent = &nvme;
+	atexit(free_plugins);
 	if (argc < 2) {
 		general_help(&builtin, NULL);
 		return 0;


### PR DESCRIPTION
Valgrind reports a "still reachable" hint for all nvme commands as shown below:

...
944 bytes in 1 blocks are still reachable in loss record 98 of 98
	realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	plugin_add_group (plugin.c:172)
	__libc_start_main@@GLIBC_2.34 (in /lib64/libc.so.6)
	(below main) (start.S:115)

LEAK SUMMARY:
	definitely lost: 0 bytes in 0 blocks
	indirectly lost: 0 bytes in 0 blocks
	possibly lost: 0 bytes in 0 blocks
	still reachable: 5,664 bytes in 108 blocks
	suppressed: 0 bytes in 0 blocks

plugin_add_group() runs from constructors, before main(), and allocates a command_group node plus the merged plugin->commands table for every built-in command group and plugin. Nothing ever frees them, so valgrind reports them as still reachable at exit. Register an atexit() handler that walks the plugin list and releases both allocations to avoid this "still reachable" hint.