### PR TITLE
build: show all leak kinds in the valgrind test setup

### DIFF
--- a/Documentation/TESTING.md
+++ b/Documentation/TESTING.md
@@ -139,6 +139,13 @@ The exact supported targets depend on the toolchains installed in the container.
 A named Valgrind test setup is registered in `meson.build`. It runs all unit
 tests under `valgrind --leak-check=full` and treats any leak as a test failure.
 
+`--show-leak-kinds=all` is set, so the log lists every leak kind with a full
+stack, including blocks that are still reachable from a global at exit. Only
+"definite" and "possible" leaks fail the run, which is Valgrind's default: a
+still-reachable block is usually third-party global state a process holds
+until it exits, so it is reported for inspection rather than gating CI. If
+one of them turns out to be ours and unbounded, fix it or suppress it.
+
 Prerequisites: Valgrind must be installed (`apt install valgrind` or equivalent).
 
 Build and run:

--- a/meson.build
+++ b/meson.build
@@ -793,6 +793,7 @@ if host_system == 'linux'
     valgrind_cmd = [
         'valgrind',
         '--leak-check=full',
+        '--show-leak-kinds=all',
         '--error-exitcode=1',
         '--suppressions=' + meson.current_source_dir() / 'valgrind.supp',
     ]


### PR DESCRIPTION
By default valgrind only prints "definite" and "possible" leaks. A block still reachable from a global at exit is therefore invisible in the test log, with no stack to work from. Pass --show-leak-kinds=all so every leak kind is listed with a full stack. What fails the run remains at valgrind's default itself: reachable blocks are mostly third-party state we do not control, so they are reported for inspection rather than gating CI.