### PR TITLE
shared: fix time_t truncation in shr_format_ts() on 32-bit archs

### DIFF
--- a/.github/cross/ubuntu-cross-i386.txt
+++ b/.github/cross/ubuntu-cross-i386.txt
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+[binaries]
+c = 'gcc'
+ar = 'ar'
+strip = 'strip'
+pkgconfig = 'pkg-config'
+ld = 'ld'
+
+c_native = 'gcc'
+cpp_native = 'g++'
+
+[built-in options]
+c_args = ['-m32']
+c_link_args = ['-m32']
+
+[properties]
+# Same CPU family as the amd64 build host (gcc-multilib, not a separate
+# cross-gcc), so the 32-bit binaries run directly, no qemu needed.
+needs_exe_wrapper = false
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86'
+cpu = 'i686'
+endian = 'little'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,7 @@ jobs:
           - arch: armhf
           - arch: s390x
           - arch: ppc64le
+          - arch: i386
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: enable foreign arch

--- a/meson.build
+++ b/meson.build
@@ -880,7 +880,11 @@ if want_nvme
     summary(plugin_dict, section: 'Plugins')
 endif
 
+c_args = get_option('c_args')
+c_link_args = get_option('c_link_args')
 conf_dict = {
     'git version':      conf.get('GIT_VERSION'),
+    'CFLAGS':           c_args.length() > 0 ? ' '.join(c_args) : '(none)',
+    'LDFLAGS':          c_link_args.length() > 0 ? ' '.join(c_link_args) : '(none)',
 }
 summary(conf_dict, section: 'Configuration', bool_yn: true)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,7 +28,7 @@ usage() {
     echo " -m [meson]|muon      use meson or muon"
     echo " -p                   enable coverage report"
     echo " -s                   run tests with ASan+UBSan (asanubsan setup)"
-    echo " -t [arm]|ppc64le|s390x  cross compile target"
+    echo " -t [arm]|ppc64le|s390x|i386  cross compile target"
     echo " -x                   run tests with valgrind (valgrind setup)"
     echo ""
     echo "options for the 'tests' config (mirror the e2e-* meson options):"
@@ -253,6 +253,15 @@ config_meson_fallback() {
 }
 
 config_meson_cross() {
+    # armhf/ppc64le/s390x each get a dedicated <triplet>-pkg-config wrapper
+    # from their cross-gcc package, preconfigured to look in the right
+    # multiarch dir. i386 has no such wrapper (it's gcc-multilib, not a
+    # separate cross-gcc), so point plain pkg-config at the i386 multiarch
+    # dir directly instead.
+    if [ "${CROSS_TARGET}" = "i386" ]; then
+        export PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu/pkgconfig
+    fi
+
     CC="${CC}" "${MESON}" setup                 \
         --werror                                \
         --buildtype="${BUILDTYPE}"              \

--- a/shared/time-util.c
+++ b/shared/time-util.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <ccan/array_size/array_size.h>
 
@@ -17,10 +18,11 @@
 #define WHITESPACE " \t\n\r"
 #define DIGITS "0123456789"
 
-int shr_format_ts(time_t time_ms, char *ts_buf)
+int shr_format_ts(int64_t time_ms, char *ts_buf)
 {
 	struct tm  time_info;
-	time_t     time_s, ms;
+	time_t     time_s;
+	int64_t    ms;
 	char       buf[80];
 
 	time_s = time_ms / 1000;

--- a/shared/time-util.h
+++ b/shared/time-util.h
@@ -6,7 +6,6 @@
 
 #include <stdint.h>
 #include <sys/time.h>
-#include <time.h>
 
 #define SHR_USEC_PER_MSEC	UINT64_C(1000)
 #define SHR_USEC_PER_SEC	UINT64_C(1000000)
@@ -24,7 +23,7 @@
  * Format time_ms (milliseconds since the epoch) as "Y-M-D|H:M:S:MS" into
  * ts_buf, which must be at least 32 bytes. Return: 0.
  */
-int shr_format_ts(time_t time_ms, char *ts_buf);
+int shr_format_ts(int64_t time_ms, char *ts_buf);
 
 unsigned long long shr_elapsed_utime(struct timeval start_time,
 				      struct timeval end_time);


### PR DESCRIPTION
shr_format_ts() takes an epoch-milliseconds value but declared it as
time_t, which is 32-bit on i586. Passing today's epoch-ms (already
past 32-bit range before the /1000 split) silently truncated to a
negative number and produced garbage timestamps.

Widen the parameter (and the ms local) to int64_t so the value only
narrows to time_t after dividing down to seconds.