### PR TITLE
Fix the Windows build outside Latin-1 locales

### DIFF
--- a/completions/generate-completions.py
+++ b/completions/generate-completions.py
@@ -981,7 +981,7 @@ GENERATORS = {"bash": generate_bash, "zsh": generate_zsh,
 
 
 def open_out(path):
-    return sys.stdout if path == "-" else open(path, "w")
+    return sys.stdout if path == "-" else open(path, "w", encoding="utf-8")
 
 
 def main():
@@ -1011,7 +1011,7 @@ def main():
     if args.input == "-":
         model = json.load(sys.stdin)
     else:
-        with open(args.input) as src:
+        with open(args.input, encoding="utf-8") as src:
             model = json.load(src)
 
     version = model.get("schema_version")

--- a/libnvme/tools/check-public-headers.py
+++ b/libnvme/tools/check-public-headers.py
@@ -73,7 +73,7 @@ def main():
     ld_syms = {}   # symbol -> Path of the .ld file that declares it
 
     for ld_path in ld_files:
-        for line in ld_path.read_text().splitlines():
+        for line in ld_path.read_text(encoding='utf-8').splitlines():
             m = re.match(r'^\s+([a-z]\w+);', line)
             if m:
                 ld_syms[m.group(1)] = ld_path
@@ -89,7 +89,8 @@ def main():
     header_syms = set()
 
     for hdr_path in headers:
-        for m in re.finditer(r'\b([a-z_]\w+)\s*\(', hdr_path.read_text()):
+        text = hdr_path.read_text(encoding='utf-8')
+        for m in re.finditer(r'\b([a-z_]\w+)\s*\(', text):
             header_syms.add(m.group(1))
 
     # -----------------------------------------------------------------------

--- a/scripts/win-ucrt64-setup.sh
+++ b/scripts/win-ucrt64-setup.sh
@@ -37,6 +37,7 @@ shift $((OPTIND-1))
 # Install the UCRT64 MinGW build toolchain, meson build system, and nvme-cli
 # dependencies. Use -u to also refresh and upgrade all packages.
 pacman $PACMAN_CMD --noconfirm --needed \
+    git \
     mingw-w64-ucrt-x86_64-toolchain \
     mingw-w64-ucrt-x86_64-meson \
     mingw-w64-ucrt-x86_64-ninja \

--- a/tests/unit/py/test_command_metadata_schema.py
+++ b/tests/unit/py/test_command_metadata_schema.py
@@ -48,7 +48,7 @@ def json_c_available():
     proc = subprocess.run(
         [NVME_BIN, "list", "--help"],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        universal_newlines=True)
+        encoding="utf-8")
     return "json" in proc.stdout + proc.stderr
 
 
@@ -59,7 +59,7 @@ def dump_metadata():
         [NVME_BIN, "utils", "dump-command-metadata"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        universal_newlines=True,
+        encoding="utf-8",
     )
     text = proc.stdout.strip()
     if proc.returncode != 0 or not text:
@@ -78,7 +78,7 @@ class TestCommandMetadataSchema(unittest.TestCase):
             if stderr:
                 msg += "\nstderr: " + stderr.rstrip()
             raise AssertionError(msg)
-        with open(SCHEMA_PATH) as f:
+        with open(SCHEMA_PATH, encoding="utf-8") as f:
             cls.schema = json.load(f)
 
     def test_conforms_to_schema(self):
@@ -122,7 +122,7 @@ class TestCommandMetadataSchema(unittest.TestCase):
         proc = subprocess.run(
             [NVME_BIN, "utils", "dump-command-metadata"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            universal_newlines=True)
+            encoding="utf-8")
         self.assertEqual(proc.returncode, 0)
         self.assertEqual(proc.stderr, "")
         json.loads(proc.stdout)  # raises if stdout is not pure JSON
@@ -132,7 +132,7 @@ class TestCommandMetadataSchema(unittest.TestCase):
         runs = [
             subprocess.run(
                 [NVME_BIN, "utils", "dump-command-metadata"],
-                stdout=subprocess.PIPE, universal_newlines=True).stdout
+                stdout=subprocess.PIPE, encoding="utf-8").stdout
             for _ in range(2)
         ]
         self.assertEqual(runs[0], runs[1])

--- a/tests/unit/py/test_generate_completions_args.py
+++ b/tests/unit/py/test_generate_completions_args.py
@@ -37,7 +37,7 @@ class GenerateCompletionsArgsTest(unittest.TestCase):
             [sys.executable, GENERATOR, *args],
             input=MINIMAL_MODEL,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
         )
 
     def test_no_shell_is_rejected(self):
@@ -102,7 +102,7 @@ class GenerateCompletionsArgsTest(unittest.TestCase):
             [sys.executable, GENERATOR, "--bash", "-"],
             input=json.dumps({"schema_version": 999}),
             capture_output=True,
-            text=True,
+            encoding="utf-8",
         )
         self.assertNotEqual(r.returncode, 0)
         self.assertIn("unsupported schema_version", r.stderr)


### PR DESCRIPTION
Building v3.0 on Windows 11 (MSYS2 UCRT64, ANSI codepage 949) hits two problems.

`scripts/win-ucrt64-setup.sh` does not install git, but `scripts/build.sh` calls
`git rev-parse` on its first line. The CI workflow installs git in its own
pacman list, so only people following `Documentation/BUILDING.md` reach this.

The rest is the Python tooling reading files and subprocess output without an
explicit encoding, so Python falls back to the ANSI codepage.

This is not only a CJK problem: the codepage in effect silently changes a
committed artifact. `completions/_nvme` carries a U+2019 (from the Virtium
help text) and `generate-completions.py` writes it through a locale-encoded
stream, so the same generator and the same input give a different file
depending on who ran it:

```
utf-8    b'\xe2\x80\x99'   3 bytes
cp949    b'\xa1\xaf'       2 bytes
cp1252   b'\x92'           1 byte
```

Where the codepage is a multi-byte one, decoding raises instead of garbling
and two tests abort. Clean release build, `PYTHONUTF8` unset, before:

```
30/69 nvme-cli:libnvme - check-public-headers       FAIL   exit status 1
67/69 nvme-cli:nvme-cli - command-metadata-schema   FAIL   exit status 1
Ok: 67   Fail: 2
```

and after:

```
Ok: 69   Fail: 0
```

`libnvme/tools/check-public-symbols.py` already passes `encoding='utf-8'`;
this does the same in the rest of the tooling that runs on Windows.
