### PR TITLE
seagate: clamp fw-activate-history entry count, bound JSON string copies

### DIFF
--- a/plugins/seagate/seagate-nvme.c
+++ b/plugins/seagate/seagate-nvme.c
@@ -1337,8 +1337,8 @@ static void json_stx_vs_fw_activate_history(const stx_fw_activ_history_log_page 
 	if (fwActivHis->numValidFwActHisEnt > 0) {
 		for (i = 0; i < fwActivHis->numValidFwActHisEnt; i++) {
 			struct json_object *lbaf = json_create_object();
-			char prev_fw[8] = { 0 };
-			char new_fw[8] = { 0 };
+			char prev_fw[9] = { 0 };
+			char new_fw[9] = { 0 };
 
 			json_object_add_value_int(lbaf, "Counter", fwActivHis->fwActHisEnt[i].fwActivCnt);
 
@@ -1350,10 +1350,14 @@ static void json_stx_vs_fw_activate_history(const stx_fw_activ_history_log_page 
 			json_object_add_value_string(lbaf, "Timestamp", buf);
 
 			json_object_add_value_int(lbaf, "PCC", fwActivHis->fwActHisEnt[i].powCycleCnt);
-			sprintf(prev_fw, "%s", fwActivHis->fwActHisEnt[i].previousFW);
+			/* the device supplies fixed-width, not NUL-terminated,
+			 * strings: copy by size and rely on the zeroed buffer */
+			memcpy(prev_fw, fwActivHis->fwActHisEnt[i].previousFW,
+			       sizeof(fwActivHis->fwActHisEnt[i].previousFW));
 			json_object_add_value_string(lbaf, "Previous_FW", prev_fw);
 
-			sprintf(new_fw, "%s", fwActivHis->fwActHisEnt[i].newFW);
+			memcpy(new_fw, fwActivHis->fwActHisEnt[i].newFW,
+			       sizeof(fwActivHis->fwActHisEnt[i].newFW));
 			json_object_add_value_string(lbaf, "New_FW", new_fw);
 
 			json_object_add_value_int(lbaf, "Slot", fwActivHis->fwActHisEnt[i].slotNum);
@@ -1400,6 +1404,14 @@ static int stx_vs_fw_activate_history(int argc, char **argv, struct command *acm
 
 	err = nvme_get_log_simple(hdl, 0xC2, &fwActivHis, sizeof(fwActivHis));
 	if (!err) {
+		/* the device supplies the entry count: never walk past the
+		 * fixed-size table in the log header */
+		const unsigned int max_ent =
+			sizeof(fwActivHis.fwActHisEnt) / sizeof(fwActivHis.fwActHisEnt[0]);
+
+		if (fwActivHis.numValidFwActHisEnt > max_ent)
+			fwActivHis.numValidFwActHisEnt = max_ent;
+
 		if (!(flags & JSON))
 			print_stx_vs_fw_activate_history(&fwActivHis);
 		else


### PR DESCRIPTION
## Problem

The Seagate 0xC2 vendor log page is device-supplied, and the
`fw-activate-history` display paths trusted two fields in it:

1. `numValidFwActHisEnt` (a device u32) was used directly as the loop
   bound against the compiled-in `fwActHisEnt[20]` table — a count >
   20 walks past the table in both the plain and JSON views.
2. The JSON view copied `previousFW` / `newFW` with
   `sprintf(char[8], "%s", …)` from fixed-width `u8[8]` fields that carry
   no NUL guarantee — a malformed page gives a device-controlled stack
   overflow (the plain view copies by size into 9-byte buffers and is
   safe).

## Fix

- Clamp `numValidFwActHisEnt` to the table size immediately after the
  single log read, so both display paths can only walk real entries.
- Make the JSON view copy the fixed-width strings by size into 9-byte
  zeroed buffers, exactly mirroring the plain-print path construction.

The clamp mutates only the local stack struct and only on the success
path; nothing prints the raw count afterwards, so the display simply
tops out at the table size.

## Validation

- Full meson build clean (nvme.link, all plugins).
- ASan/UBSan harness replicating the exact old and new expressions with
  adversarial fixtures (`numValidFwActHisEnt = 0xffffffff`, 8-byte FW
  fields without NULs): pre-fix path reports `stack-buffer-overflow` in
  `old_json_path`; fixed path passes clamp-max-20, pass-through on
  small counts, and 8-byte NUL-termination checks (4/4).