### PR TITLE
 gen-hostnqn: derive a stable host identifier without DMI

### DIFF
--- a/Documentation/nvme-gen-hostnqn.txt
+++ b/Documentation/nvme-gen-hostnqn.txt
@@ -12,9 +12,31 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Generate a random host NQN in the form:
+Generate a host NQN in the form:
 nqn.2014-08.org.nvmexpress:uuid:1b4e28ba-2fa1-11d2-883f-0016d3cca427
-and prints it to stdout.
+and print it to stdout.
+
+The UUID is taken from the first of these sources that provides a usable
+value:
+
+1. The system UUID reported by DMI, from /sys/class/dmi/id/product_uuid or
+   /sys/firmware/dmi/entries.
+2. The firmware device tree, from /proc/device-tree/ibm,partition-uuid.
+3. The local machine ID, /etc/machine-id. The machine ID itself is never
+   published: the UUID is derived from it with HMAC-SHA256 and a fixed
+   application identifier, as systemd's
+   sd_id128_get_machine_app_specific(3) does.
+4. A random UUID, if none of the above is available. This value is not
+   stable across invocations, and a warning is printed.
+
+The first two sources describe the hardware and survive a reinstall. The
+machine ID describes the installation and does not. A UUID that is all zeros
+or all ones is a placeholder reported by some virtual machines and firmware,
+and is skipped.
+
+This command must be run as root. The DMI and device tree files are readable
+by root only, so an unprivileged run cannot reach the stable sources, and its
+output cannot be written to /etc/nvme/hostnqn either.
 
 OPTIONS
 -------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,23 @@
 <!-- SPDX-License-Identifier: GPL-2.0-only -->
 # NEWS
 
+## Changes in 3.1 (unreleased)
+
+### Feature removals and incompatible changes
+
+* `nvme gen-hostnqn` must now be run as root. The DMI and device tree
+  files it reads are readable by root only. An unprivileged run
+  returned a random identifier instead. See `nvme-gen-hostnqn(1)`.
+
+### libnvme
+
+* `libnvmf_generate_hostid()` now falls back to the local machine ID,
+  after DMI and the device tree and before a random UUID. The machine
+  ID itself is never published. The UUID is derived from it with
+  HMAC-SHA256 and a fixed application identifier.
+
+* A system UUID of all zeros or all ones is now discarded as invalid.
+
 ## Changes in 3.0 (2026-09-07)
 
 ### Feature removals and incompatible changes

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -37,6 +37,7 @@
 
 #include <shared/array-util.h>
 #include <shared/compiler-attributes-util.h>
+#include <shared/machine-id-util.h>
 #include <shared/nqn-util.h>
 #include <shared/string-util.h>
 #include <shared/uuid-util.h>
@@ -246,6 +247,43 @@ static int uuid_from_product_uuid(struct libnvme_global_ctx *ctx,
 }
 
 /**
+ * uuid_from_machine_id() - Derive a system UUID from the local machine ID
+ * @ctx: Global context, for the file path.
+ * @system_uuid: Where to save the system UUID.
+ *
+ * The machine ID identifies an installation rather than the hardware, so it
+ * is less stable than DMI or the device tree. It is still deterministic, and
+ * unlike them it is readable without privileges.
+ *
+ * Return: 0 on success, negative errno otherwise.
+ */
+static int uuid_from_machine_id(struct libnvme_global_ctx *ctx,
+				char *system_uuid)
+{
+	/*
+	 * Fixed application ID for nvme-cli's use of the local machine ID.
+	 * Chosen once, at random, and part of the derivation: changing it
+	 * changes the host identifier of every machine that has no DMI or
+	 * device tree UUID.
+	 */
+	static const unsigned char app_id[SHR_UUID_LEN] = {
+		0x85, 0x3c, 0x32, 0x20, 0xca, 0x64, 0x4d, 0xad,
+		0xa0, 0x6f, 0x1d, 0xc7, 0x52, 0xe3, 0x22, 0x63
+	};
+	unsigned char uuid[NVME_UUID_LEN];
+	int ret;
+
+	ret = shr_machine_id_app_specific(libnvme_machine_id_filename(ctx),
+					  app_id, uuid);
+	if (ret)
+		return ret;
+
+	libnvme_uuid_to_string(uuid, system_uuid);
+
+	return 0;
+}
+
+/**
  * uuid_from_dmi() - read system UUID
  * @ctx: Global context, for the sysfs paths.
  * @system_uuid: buffer for the UUID
@@ -267,23 +305,68 @@ static int uuid_from_dmi(struct libnvme_global_ctx *ctx, char *system_uuid)
 	return ret;
 }
 
+/*
+ * Virtual machines and some firmware report a placeholder instead of a real
+ * identifier. Every machine reporting the same placeholder would end up with
+ * the same host identifier.
+ *
+ * shr_hostid_valid() rejects the all-zeros UUID. The all-ones UUID is the
+ * other common placeholder, but it is a legitimate value to configure by
+ * hand, so it is refused here rather than in the shared validator.
+ */
+static bool hostid_source_usable(const char *system_uuid)
+{
+	return shr_hostid_valid(system_uuid) &&
+	       !shr_streqcase0(system_uuid,
+			       "ffffffff-ffff-ffff-ffff-ffffffffffff");
+}
+
 __shr_public char *libnvmf_generate_hostid(struct libnvme_global_ctx *ctx)
 {
-	int ret;
+	/*
+	 * Ordered from most to least stable. The firmware sources describe
+	 * the hardware and survive a reinstall; the machine ID describes the
+	 * installation and does not.
+	 */
+	static const struct {
+		const char *name;
+		int (*get)(struct libnvme_global_ctx *ctx, char *system_uuid);
+	} hostid_sources[] = {
+		{ "DMI",         uuid_from_dmi },
+		{ "device tree", uuid_from_device_tree },
+		{ "machine ID",  uuid_from_machine_id },
+	};
 	char uuid_str[NVME_UUID_LEN_STRING];
 	unsigned char uuid[NVME_UUID_LEN];
+	size_t i;
 
 	if (!ctx)
 		return NULL;
 
-	ret = uuid_from_dmi(ctx, uuid_str);
-	if (ret < 0)
-		ret = uuid_from_device_tree(ctx, uuid_str);
-	if (ret < 0) {
-		if (libnvme_random_uuid(uuid) < 0)
-			memset(uuid, 0, NVME_UUID_LEN);
-		libnvme_uuid_to_string(uuid, uuid_str);
+	for (i = 0; i < ARRAY_SIZE(hostid_sources); i++) {
+		if (hostid_sources[i].get(ctx, uuid_str))
+			continue;
+
+		if (!hostid_source_usable(uuid_str)) {
+			libnvme_msg(ctx, LIBNVME_LOG_DEBUG,
+				    "%s reports an unusable host identifier '%s'\n",
+				    hostid_sources[i].name, uuid_str);
+			continue;
+		}
+
+		libnvme_msg(ctx, LIBNVME_LOG_DEBUG,
+			    "host identifier taken from %s\n",
+			    hostid_sources[i].name);
+
+		return strdup(uuid_str);
 	}
+
+	libnvme_msg(ctx, LIBNVME_LOG_WARN,
+		    "no stable host identifier available, using a random one\n");
+
+	if (libnvme_random_uuid(uuid) < 0)
+		memset(uuid, 0, NVME_UUID_LEN);
+	libnvme_uuid_to_string(uuid, uuid_str);
 
 	return strdup(uuid_str);
 }

--- a/libnvme/src/nvme/private.h
+++ b/libnvme/src/nvme/private.h
@@ -43,6 +43,7 @@ const char *libnvme_slots_sysfs_dir(struct libnvme_global_ctx *ctx);
 const char *libnvme_uuid_ibm_filename(struct libnvme_global_ctx *ctx);
 const char *libnvme_dmi_entries_dir(struct libnvme_global_ctx *ctx);
 const char *libnvme_dmi_product_uuid_filename(struct libnvme_global_ctx *ctx);
+const char *libnvme_machine_id_filename(struct libnvme_global_ctx *ctx);
 
 struct linux_passthru_cmd32 {
 	__u8    opcode;

--- a/libnvme/src/nvme/tree-linux.c
+++ b/libnvme/src/nvme/tree-linux.c
@@ -40,6 +40,7 @@
 #define PATH_SYSFS_NVME			"/sys/class/nvme"
 #define PATH_DMI_ENTRIES		"/sys/firmware/dmi/entries"
 #define PATH_DMI_PROD_UUID		"/sys/class/dmi/id/product_uuid"
+#define PATH_MACHINE_ID			"/etc/machine-id" /* no SYSCONFDIR */
 
 static const char *make_sysfs_dir(struct libnvme_global_ctx *ctx,
 		const char *path)
@@ -123,6 +124,16 @@ const char *libnvme_dmi_product_uuid_filename(struct libnvme_global_ctx *ctx)
 		return str;
 
 	return str = make_sysfs_dir(ctx, PATH_DMI_PROD_UUID);
+}
+
+const char *libnvme_machine_id_filename(struct libnvme_global_ctx *ctx)
+{
+	static const char *str;
+
+	if (str)
+		return str;
+
+	return str = make_sysfs_dir(ctx, PATH_MACHINE_ID);
 }
 
 static int __nvme_set_attr(const char *path, const char *value)

--- a/libnvme/tests/test-fabrics.c
+++ b/libnvme/tests/test-fabrics.c
@@ -863,6 +863,11 @@ static bool test_create_ctrl_credentials(struct libnvme_global_ctx *ctx)
 static bool test_generate_hostid(struct libnvme_global_ctx *ctx)
 {
 	static const char uuid[] = "12345678-1234-1234-1234-123456789abc";
+	static const char placeholder[] =
+		"ffffffff-ffff-ffff-ffff-ffffffffffff";
+	static const char machine_id[] = "3d1b2f4c5e6a7b8c9d0e1f2a3b4c5d6e";
+	static const char from_machine_id[] =
+		"122333a9-35f5-474d-9a82-4507e71c4fb1";
 	char dir[] = "/tmp/nvme-hostid-test-XXXXXX";
 	char *hostid = NULL, *hostnqn = NULL;
 	char path[PATH_MAX], want[256];
@@ -909,7 +914,44 @@ static bool test_generate_hostid(struct libnvme_global_ctx *ctx)
 
 	free(hostid);
 	free(hostnqn);
+
+	/*
+	 * A placeholder from DMI must be skipped, and the machine ID picked up
+	 * instead. The expected value is the one systemd derives from this
+	 * machine ID; see shared/tests/test-machine-id-util.c.
+	 */
+	snprintf(path, sizeof(path), "%s/sys/class/dmi/id/product_uuid", dir);
+	f = fopen(path, "w");
+	if (f) {
+		fprintf(f, "%s\n", placeholder);
+		fclose(f);
+	}
+
+	snprintf(path, sizeof(path), "%s/etc", dir);
+	if (shr_mkdir_p(path, 0755)) {
+		CHECK(false, "create etc fixture");
+		return false;
+	}
+
+	snprintf(path, sizeof(path), "%s/etc/machine-id", dir);
+	f = fopen(path, "w");
+	if (f) {
+		fprintf(f, "%s\n", machine_id);
+		fclose(f);
+	}
+
+	hostid = libnvmf_generate_hostid(ctx);
+	CHECK(hostid && !strcmp(hostid, from_machine_id),
+	      "placeholder skipped, machine ID used");
+	pass &= hostid && !strcmp(hostid, from_machine_id);
+	free(hostid);
+
+	unlink(path);
+	snprintf(path, sizeof(path), "%s/etc", dir);
+	rmdir(path);
+
 	libnvme_set_test_sysfs_dir(ctx, NULL);
+	snprintf(path, sizeof(path), "%s/sys/class/dmi/id/product_uuid", dir);
 	unlink(path);
 	snprintf(path, sizeof(path), "%s/sys/class/dmi/id", dir);
 	rmdir(path);

--- a/shared/machine-id-util-linux.c
+++ b/shared/machine-id-util-linux.c
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "cleanup-util.h"
+#include "machine-id-util.h"
+#include "sha256-util.h"
+
+#define MACHINE_ID_LEN_STRING	32
+
+static int parse_hex_digit(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'a' && c <= 'f')
+		return c - 'a' + 10;
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+
+	return -EINVAL;
+}
+
+static int read_machine_id(const char *path, unsigned char id[SHR_UUID_LEN])
+{
+	char buf[MACHINE_ID_LEN_STRING + 2] = {};
+	__cleanup_file FILE *f = NULL;
+	bool all_zero = true;
+	size_t len, i;
+
+	f = fopen(path, "re");
+	if (!f)
+		return -errno;
+
+	/*
+	 * An empty file, and the "uninitialized" marker systemd writes during
+	 * the first boot of an image, are both too short to parse.
+	 */
+	len = fread(buf, 1, sizeof(buf) - 1, f);
+	if (len < MACHINE_ID_LEN_STRING)
+		return -EINVAL;
+
+	for (i = 0; i < SHR_UUID_LEN; i++) {
+		int hi = parse_hex_digit(buf[i * 2]);
+		int lo = parse_hex_digit(buf[i * 2 + 1]);
+
+		if (hi < 0 || lo < 0)
+			return -EINVAL;
+
+		id[i] = (hi << 4) | lo;
+		if (id[i])
+			all_zero = false;
+	}
+
+	return all_zero ? -EINVAL : 0;
+}
+
+int shr_machine_id_app_specific(const char *path,
+		const unsigned char app_id[SHR_UUID_LEN],
+		unsigned char out[SHR_UUID_LEN])
+{
+	unsigned char hmac[SHR_SHA256_DIGEST_SIZE];
+	unsigned char id[SHR_UUID_LEN];
+	int ret;
+
+	if (!path || !app_id || !out)
+		return -EINVAL;
+
+	ret = read_machine_id(path, id);
+	if (ret)
+		return ret;
+
+	shr_hmac_sha256_raw(id, sizeof(id), app_id, SHR_UUID_LEN, hmac);
+
+	/* Keep the first half only. */
+	memcpy(out, hmac, SHR_UUID_LEN);
+
+	/* RFC 9562: version 4, variant DCE. */
+	out[6] = (out[6] & 0x0f) | 0x40;
+	out[8] = (out[8] & 0x3f) | 0x80;
+
+	return 0;
+}

--- a/shared/machine-id-util.h
+++ b/shared/machine-id-util.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+#pragma once
+
+#include "uuid-util.h"
+
+/*
+ * Derive an application-specific UUID from the local machine ID.
+ *
+ * Linux only. The machine ID is a systemd concept, and the sole caller is
+ * fabrics code, which is not built for other platforms.
+ *
+ * @path:   File holding the machine ID, normally "/etc/machine-id". Passed in
+ *          so tests can redirect it.
+ * @app_id: Fixed 16-byte constant identifying the application. Must not be
+ *          all zeros.
+ * @out:    Where to store the derived UUID.
+ *
+ * The machine ID must not be published, so it is never returned directly.
+ * The result is HMAC-SHA256(key=machine ID, data=@app_id), truncated to 16
+ * bytes and shaped into a version 4 UUID. Two applications using different
+ * @app_id values derive unrelated UUIDs from the same machine.
+ *
+ * This is the derivation systemd's sd_id128_get_machine_app_specific(3)
+ * performs, reimplemented so it needs no libsystemd and no OpenSSL.
+ *
+ * Return: 0 on success, negative errno otherwise. -EINVAL covers every
+ * unusable machine ID: absent, empty, not yet initialized, malformed, or all
+ * zeros.
+ */
+int shr_machine_id_app_specific(const char *path,
+		const unsigned char app_id[SHR_UUID_LEN],
+		unsigned char out[SHR_UUID_LEN]);

--- a/shared/meson.build
+++ b/shared/meson.build
@@ -41,6 +41,7 @@ if host_system == 'windows'
 else
     sources += [
         'fs-util-linux.c',
+        'machine-id-util-linux.c',
         'net-util-linux.c',
         'crypto-util-linux.c',
         'proc-util-linux.c',

--- a/shared/meson.build
+++ b/shared/meson.build
@@ -22,6 +22,7 @@ sources = [
     'nqn-util.c',
     'parse-util.c',
     'progress-util.c',
+    'sha256-util.c',
     'suffix-util.c',
     'table-util.c',
     'time-util.c',

--- a/shared/sha256-util.c
+++ b/shared/sha256-util.c
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ *
+ * SHA-256 (FIPS 180-2) and HMAC-SHA256 (FIPS 198). Taken from systemd
+ * (src/fundamental/sha256.c and src/basic/hmac.c), which took SHA-256 from
+ * the GNU C Library. Both are LGPL-2.1-or-later, matching this file.
+ */
+
+#include <string.h>
+
+#include "assert-util.h"
+#include "sha256-util.h"
+
+/*
+ * total64 is read through the total[2] overlay, so the halves swap with the
+ * byte order.
+ */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define SWAP(n)		__builtin_bswap32(n)
+#define TOTAL64_LOW	0
+#define TOTAL64_HIGH	1
+#else
+#define SWAP(n)		(n)
+#define TOTAL64_LOW	1
+#define TOTAL64_HIGH	0
+#endif
+
+#define IS_ALIGNED32(p)	(((uintptr_t)(p) % sizeof(uint32_t)) == 0)
+
+/* Bytes used to pad the buffer to the next 64-byte boundary (FIPS 180-2:5.1.1) */
+static const uint8_t fillbuf[64] = { 0x80, 0 /* , 0, 0, ... */ };
+
+/* Constants for SHA-256 from FIPS 180-2:4.2.2 */
+static const uint32_t K[64] = {
+	0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+	0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+	0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+	0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+	0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+	0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+	0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+	0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+	0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+	0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+	0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+	0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+	0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+	0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+	0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+	0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+/*
+ * Zero memory in a way the compiler may not remove. The plain memset() of a
+ * buffer that is never read again is dead code and may be optimized away,
+ * which would leave key material on the stack.
+ */
+static void erase(void *p, size_t len)
+{
+	volatile unsigned char *v = p;
+
+	while (len--)
+		*v++ = 0;
+}
+
+/* Process len bytes of buffer into ctx. len must be a multiple of 64. */
+static void sha256_process_block(const void *buffer, size_t len,
+		struct shr_sha256_ctx *ctx)
+{
+	const uint32_t *words = buffer;
+	size_t nwords = len / sizeof(uint32_t);
+	uint32_t a, b, c, d, e, f, g, h;
+
+	shr_assert(buffer);
+	shr_assert(ctx);
+
+	a = ctx->H[0];
+	b = ctx->H[1];
+	c = ctx->H[2];
+	d = ctx->H[3];
+	e = ctx->H[4];
+	f = ctx->H[5];
+	g = ctx->H[6];
+	h = ctx->H[7];
+
+	/*
+	 * FIPS 180-2 allows a length up to 2^64 bits. Only the number of
+	 * bytes is counted here.
+	 */
+	ctx->total64 += len;
+
+	while (nwords > 0) {
+		uint32_t W[64];
+		uint32_t a_save = a;
+		uint32_t b_save = b;
+		uint32_t c_save = c;
+		uint32_t d_save = d;
+		uint32_t e_save = e;
+		uint32_t f_save = f;
+		uint32_t g_save = g;
+		uint32_t h_save = h;
+		size_t t;
+
+		/* Operators defined in FIPS 180-2:4.1.2 */
+#define CYCLIC(w, s) ((w >> s) | (w << (32 - s)))
+#define Ch(x, y, z) ((x & y) ^ (~x & z))
+#define Maj(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
+#define S0(x) (CYCLIC(x, 2) ^ CYCLIC(x, 13) ^ CYCLIC(x, 22))
+#define S1(x) (CYCLIC(x, 6) ^ CYCLIC(x, 11) ^ CYCLIC(x, 25))
+#define R0(x) (CYCLIC(x, 7) ^ CYCLIC(x, 18) ^ (x >> 3))
+#define R1(x) (CYCLIC(x, 17) ^ CYCLIC(x, 19) ^ (x >> 10))
+
+		/* Message schedule, FIPS 180-2:6.2.2 step 2 */
+		for (t = 0; t < 16; ++t) {
+			W[t] = SWAP(*words);
+			++words;
+		}
+		for (t = 16; t < 64; ++t)
+			W[t] = R1(W[t - 2]) + W[t - 7] + R0(W[t - 15]) +
+			       W[t - 16];
+
+		/* FIPS 180-2:6.2.2 step 3 */
+		for (t = 0; t < 64; ++t) {
+			uint32_t T1 = h + S1(e) + Ch(e, f, g) + K[t] + W[t];
+			uint32_t T2 = S0(a) + Maj(a, b, c);
+
+			h = g;
+			g = f;
+			f = e;
+			e = d + T1;
+			d = c;
+			c = b;
+			b = a;
+			a = T1 + T2;
+		}
+
+#undef CYCLIC
+#undef Ch
+#undef Maj
+#undef S0
+#undef S1
+#undef R0
+#undef R1
+
+		/* FIPS 180-2:6.2.2 step 4 */
+		a += a_save;
+		b += b_save;
+		c += c_save;
+		d += d_save;
+		e += e_save;
+		f += f_save;
+		g += g_save;
+		h += h_save;
+
+		nwords -= 16;
+	}
+
+	ctx->H[0] = a;
+	ctx->H[1] = b;
+	ctx->H[2] = c;
+	ctx->H[3] = d;
+	ctx->H[4] = e;
+	ctx->H[5] = f;
+	ctx->H[6] = g;
+	ctx->H[7] = h;
+}
+
+/* FIPS 180-2:5.3.2 */
+void shr_sha256_init(struct shr_sha256_ctx *ctx)
+{
+	shr_assert(ctx);
+
+	ctx->H[0] = 0x6a09e667;
+	ctx->H[1] = 0xbb67ae85;
+	ctx->H[2] = 0x3c6ef372;
+	ctx->H[3] = 0xa54ff53a;
+	ctx->H[4] = 0x510e527f;
+	ctx->H[5] = 0x9b05688c;
+	ctx->H[6] = 0x1f83d9ab;
+	ctx->H[7] = 0x5be0cd19;
+
+	ctx->total64 = 0;
+	ctx->buflen = 0;
+}
+
+void shr_sha256_update(struct shr_sha256_ctx *ctx, const void *data,
+		size_t len)
+{
+	shr_assert(ctx);
+	shr_assert(data);
+
+	/* Concatenate with whatever is already buffered. */
+	if (ctx->buflen != 0) {
+		size_t left_over = ctx->buflen;
+		size_t add = 128 - left_over > len ? len : 128 - left_over;
+
+		memcpy(&ctx->buffer[left_over], data, add);
+		ctx->buflen += add;
+
+		if (ctx->buflen > 64) {
+			sha256_process_block(ctx->buffer, ctx->buflen & ~63,
+					     ctx);
+			ctx->buflen &= 63;
+			/* The copied regions cannot overlap. */
+			memcpy(ctx->buffer,
+			       &ctx->buffer[(left_over + add) & ~63],
+			       ctx->buflen);
+		}
+
+		data = (const char *)data + add;
+		len -= add;
+	}
+
+	/* Process available complete blocks. */
+	if (len >= 64) {
+		if (IS_ALIGNED32(data)) {
+			sha256_process_block(data, len & ~63, ctx);
+			data = (const char *)data + (len & ~63);
+			len &= 63;
+		} else {
+			while (len > 64) {
+				memcpy(ctx->buffer, data, 64);
+				sha256_process_block(ctx->buffer, 64, ctx);
+				data = (const char *)data + 64;
+				len -= 64;
+			}
+		}
+	}
+
+	/* Move the remaining bytes into the internal buffer. */
+	if (len > 0) {
+		size_t left_over = ctx->buflen;
+
+		memcpy(&ctx->buffer[left_over], data, len);
+		left_over += len;
+		if (left_over >= 64) {
+			sha256_process_block(ctx->buffer, 64, ctx);
+			left_over -= 64;
+			memcpy(ctx->buffer, &ctx->buffer[64], left_over);
+		}
+		ctx->buflen = left_over;
+	}
+}
+
+uint8_t *shr_sha256_final(struct shr_sha256_ctx *ctx,
+		uint8_t out[SHR_SHA256_DIGEST_SIZE])
+{
+	uint32_t bytes;
+	size_t pad, i;
+
+	shr_assert(ctx);
+	shr_assert(out);
+
+	bytes = ctx->buflen;
+	ctx->total64 += bytes;
+
+	pad = bytes >= 56 ? 64 + 56 - bytes : 56 - bytes;
+	memcpy(&ctx->buffer[bytes], fillbuf, pad);
+
+	/* Append the length in *bits* as a 64-bit big-endian value. */
+	ctx->buffer32[(bytes + pad + 4) / 4] =
+		SWAP(ctx->total[TOTAL64_LOW] << 3);
+	ctx->buffer32[(bytes + pad) / 4] =
+		SWAP((ctx->total[TOTAL64_HIGH] << 3) |
+		     (ctx->total[TOTAL64_LOW] >> 29));
+
+	sha256_process_block(ctx->buffer, bytes + pad + 8, ctx);
+
+	for (i = 0; i < 8; ++i) {
+		uint32_t w = SWAP(ctx->H[i]);
+
+		memcpy(out + i * sizeof(uint32_t), &w, sizeof(w));
+	}
+
+	return out;
+}
+
+uint8_t *shr_sha256(const void *data, size_t len,
+		uint8_t out[SHR_SHA256_DIGEST_SIZE])
+{
+	struct shr_sha256_ctx ctx;
+
+	shr_sha256_init(&ctx);
+	shr_sha256_update(&ctx, data, len);
+
+	return shr_sha256_final(&ctx, out);
+}
+
+#define HMAC_BLOCK_SIZE		64
+#define INNER_PADDING_BYTE	0x36
+#define OUTER_PADDING_BYTE	0x5c
+
+void shr_hmac_sha256_raw(const void *key, size_t key_len, const void *data,
+		size_t data_len, uint8_t out[SHR_SHA256_DIGEST_SIZE])
+{
+	uint8_t inner_padding[HMAC_BLOCK_SIZE] = {};
+	uint8_t outer_padding[HMAC_BLOCK_SIZE] = {};
+	uint8_t replacement_key[SHR_SHA256_DIGEST_SIZE];
+	struct shr_sha256_ctx hash;
+	size_t i;
+
+	shr_assert(key);
+	shr_assert(key_len > 0);
+	shr_assert(out);
+
+	/* The key must be at most one block long; hash it if it is longer. */
+	if (key_len > HMAC_BLOCK_SIZE) {
+		shr_sha256(key, key_len, replacement_key);
+		key = replacement_key;
+		key_len = SHR_SHA256_DIGEST_SIZE;
+	}
+
+	/*
+	 * Copy the key into both padding arrays. A key shorter than the block
+	 * size leaves the rest zero, as FIPS 198 requires.
+	 */
+	memcpy(inner_padding, key, key_len);
+	memcpy(outer_padding, key, key_len);
+
+	for (i = 0; i < HMAC_BLOCK_SIZE; i++) {
+		inner_padding[i] ^= INNER_PADDING_BYTE;
+		outer_padding[i] ^= OUTER_PADDING_BYTE;
+	}
+
+	shr_sha256_init(&hash);
+	shr_sha256_update(&hash, inner_padding, HMAC_BLOCK_SIZE);
+	shr_sha256_update(&hash, data, data_len);
+	shr_sha256_final(&hash, out);
+
+	shr_sha256_init(&hash);
+	shr_sha256_update(&hash, outer_padding, HMAC_BLOCK_SIZE);
+	shr_sha256_update(&hash, out, SHR_SHA256_DIGEST_SIZE);
+	shr_sha256_final(&hash, out);
+
+	/* All of these are trivially reversible to the key. */
+	erase(inner_padding, sizeof(inner_padding));
+	erase(outer_padding, sizeof(outer_padding));
+	erase(replacement_key, sizeof(replacement_key));
+	erase(&hash, sizeof(hash));
+}

--- a/shared/sha256-util.h
+++ b/shared/sha256-util.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ *
+ * SHA-256 (FIPS 180-2) and HMAC-SHA256 (FIPS 198), with no external
+ * dependency. Taken from systemd (src/fundamental/sha256.h,
+ * src/fundamental/sha256.c, src/basic/hmac.c), which took SHA-256 from
+ * glibc. Reindented to nvme-cli style and reduced to the entry points used
+ * here.
+ *
+ * OpenSSL is faster and is the right choice where it is already linked. Use
+ * this where linking OpenSSL is not acceptable, such as code that must work
+ * in a build configured with -Dopenssl=disabled.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SHR_SHA256_DIGEST_SIZE	32
+
+struct shr_sha256_ctx {
+	uint32_t H[8];
+
+	union {
+		uint64_t total64;
+		uint32_t total[2];
+	};
+
+	uint32_t buflen;
+
+	union {
+		uint8_t buffer[128];	// always aligned for uint32_t
+		uint32_t buffer32[32];
+		uint64_t buffer64[16];
+	};
+};
+
+void shr_sha256_init(struct shr_sha256_ctx *ctx);
+void shr_sha256_update(struct shr_sha256_ctx *ctx, const void *data,
+		size_t len);
+uint8_t *shr_sha256_final(struct shr_sha256_ctx *ctx,
+		uint8_t out[SHR_SHA256_DIGEST_SIZE]);
+
+/*
+ * Compute SHA-256 over data in one call. Returns out.
+ */
+uint8_t *shr_sha256(const void *data, size_t len,
+		uint8_t out[SHR_SHA256_DIGEST_SIZE]);
+
+/*
+ * Compute HMAC-SHA256 into a caller-provided buffer. Unlike
+ * shr_hmac_sha256() in crypto-util.h, this allocates nothing and needs no
+ * OpenSSL.
+ */
+void shr_hmac_sha256_raw(const void *key, size_t key_len, const void *data,
+		size_t data_len, uint8_t out[SHR_SHA256_DIGEST_SIZE]);

--- a/shared/tests/meson.build
+++ b/shared/tests/meson.build
@@ -299,6 +299,19 @@ test_assert_util = executable(
 
 test('shared - assert-util', test_assert_util)
 
+if host_system != 'windows'
+    test_machine_id_util = executable(
+        'test-machine-id-util',
+        ['test-machine-id-util.c'],
+        dependencies: [
+            config_dep,
+            shared_dep,
+        ],
+    )
+
+    test('shared - machine-id-util', test_machine_id_util)
+endif
+
 test_sha256_util = executable(
     'test-sha256-util',
     ['test-sha256-util.c'],

--- a/shared/tests/meson.build
+++ b/shared/tests/meson.build
@@ -298,3 +298,14 @@ test_assert_util = executable(
 )
 
 test('shared - assert-util', test_assert_util)
+
+test_sha256_util = executable(
+    'test-sha256-util',
+    ['test-sha256-util.c'],
+    dependencies: [
+        config_dep,
+        shared_dep,
+    ],
+)
+
+test('shared - sha256-util', test_sha256_util)

--- a/shared/tests/test-machine-id-util.c
+++ b/shared/tests/test-machine-id-util.c
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <shared/fs-util.h>
+#include <shared/machine-id-util.h>
+
+/* Fixed application ID, so the expected value below stays reproducible. */
+static const unsigned char app_id[SHR_UUID_LEN] = {
+	0x85, 0x3c, 0x32, 0x20, 0xca, 0x64, 0x4d, 0xad,
+	0xa0, 0x6f, 0x1d, 0xc7, 0x52, 0xe3, 0x22, 0x63
+};
+
+static bool write_machine_id(const char *path, const char *content)
+{
+	FILE *f = fopen(path, "wb");
+
+	if (!f)
+		return false;
+
+	fputs(content, f);
+	fclose(f);
+
+	return true;
+}
+
+static bool check(const char *path, const char *name, const char *content,
+		  int want_ret, const char *want_uuid)
+{
+	unsigned char out[SHR_UUID_LEN] = {};
+	char got_uuid[2 * SHR_UUID_LEN + 1] = {};
+	size_t i;
+	int ret;
+
+	if (!write_machine_id(path, content)) {
+		printf(" - %s: cannot write %s [FAIL]\n", name, path);
+		return false;
+	}
+
+	ret = shr_machine_id_app_specific(path, app_id, out);
+	if (ret != want_ret) {
+		printf(" - %s: got %d, want %d [FAIL]\n", name, ret, want_ret);
+		return false;
+	}
+
+	if (!want_uuid) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	for (i = 0; i < SHR_UUID_LEN; i++)
+		snprintf(got_uuid + i * 2, 3, "%02x", out[i]);
+
+	if (strcmp(got_uuid, want_uuid)) {
+		printf(" - %s: got %s, want %s [FAIL]\n", name, got_uuid,
+		       want_uuid);
+		return false;
+	}
+
+	printf(" - %s [PASS]\n", name);
+
+	return true;
+}
+
+/*
+ * The derivation was checked against systemd on a live machine:
+ *
+ *   systemd-id128 machine-id --app-specific=853c3220-ca64-4dad-a06f-1dc752e32263
+ *
+ * produced the same value as this code reading the same /etc/machine-id. The
+ * vector below uses a fixed machine ID instead, so the test does not depend
+ * on the machine it runs on.
+ */
+static bool test_known_answer(const char *path)
+{
+	printf("test_known_answer:\n");
+
+	return check(path, "known answer",
+		     "3d1b2f4c5e6a7b8c9d0e1f2a3b4c5d6e\n", 0,
+		     "122333a935f5474d9a824507e71c4fb1");
+}
+
+static bool test_accepted(const char *path)
+{
+	bool pass = true;
+
+	printf("test_accepted:\n");
+
+	/* systemd writes the ID without a trailing newline in some images. */
+	pass &= check(path, "no trailing newline",
+		      "3d1b2f4c5e6a7b8c9d0e1f2a3b4c5d6e", 0,
+		      "122333a935f5474d9a824507e71c4fb1");
+	pass &= check(path, "uppercase digits",
+		      "3D1B2F4C5E6A7B8C9D0E1F2A3B4C5D6E\n", 0,
+		      "122333a935f5474d9a824507e71c4fb1");
+
+	return pass;
+}
+
+static bool test_rejected(const char *path)
+{
+	unsigned char out[SHR_UUID_LEN];
+	bool pass = true;
+
+	printf("test_rejected:\n");
+
+	pass &= check(path, "empty file", "", -EINVAL, NULL);
+	pass &= check(path, "uninitialized", "uninitialized\n", -EINVAL, NULL);
+	pass &= check(path, "too short", "3d1b2f4c\n", -EINVAL, NULL);
+	pass &= check(path, "not hexadecimal",
+		      "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n", -EINVAL, NULL);
+	pass &= check(path, "all zeros",
+		      "00000000000000000000000000000000\n", -EINVAL, NULL);
+
+	unlink(path);
+	if (shr_machine_id_app_specific(path, app_id, out) != -ENOENT) {
+		printf(" - missing file: wrong error [FAIL]\n");
+		pass = false;
+	} else {
+		printf(" - missing file [PASS]\n");
+	}
+
+	return pass;
+}
+
+int main(void)
+{
+	char path[] = "nvme-machine-id-XXXXXX";
+	bool pass = true;
+	int fd;
+
+	fd = shr_mkstemp(path);
+	if (fd < 0) {
+		printf("cannot create a temporary file\n");
+		exit(EXIT_FAILURE);
+	}
+	close(fd);
+
+	pass &= test_known_answer(path);
+	pass &= test_accepted(path);
+	pass &= test_rejected(path);
+
+	unlink(path);
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/shared/tests/test-sha256-util.c
+++ b/shared/tests/test-sha256-util.c
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ *
+ * SHA-256 vectors are from FIPS 180-2. HMAC-SHA256 vectors are from
+ * RFC 4231.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <shared/sha256-util.h>
+
+static bool check(const char *name, const unsigned char *got,
+		  const char *want_hex)
+{
+	char buf[2 * SHR_SHA256_DIGEST_SIZE + 1] = {};
+	size_t i;
+
+	for (i = 0; i < SHR_SHA256_DIGEST_SIZE; i++)
+		snprintf(buf + i * 2, 3, "%02x", got[i]);
+
+	if (!strcmp(buf, want_hex)) {
+		printf(" - %s [PASS]\n", name);
+		return true;
+	}
+
+	printf(" - %s: got %s, want %s [FAIL]\n", name, buf, want_hex);
+
+	return false;
+}
+
+static bool test_sha256(void)
+{
+	unsigned char out[SHR_SHA256_DIGEST_SIZE];
+	char long_input[200];
+	bool pass = true;
+
+	printf("test_sha256:\n");
+
+	shr_sha256("", 0, out);
+	pass &= check("empty", out,
+		      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+	shr_sha256("abc", 3, out);
+	pass &= check("abc", out,
+		      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+
+	/* Spans two blocks. */
+	shr_sha256("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", 56,
+		   out);
+	pass &= check("two blocks", out,
+		      "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+
+	memset(long_input, 'a', sizeof(long_input));
+	shr_sha256(long_input, sizeof(long_input), out);
+	pass &= check("200 bytes", out,
+		      "c2a908d98f5df987ade41b5fce213067efbcc21ef2240212a41e54b5e7c28ae5");
+
+	return pass;
+}
+
+static bool test_sha256_incremental(void)
+{
+	unsigned char out[SHR_SHA256_DIGEST_SIZE];
+	struct shr_sha256_ctx ctx;
+
+	printf("test_sha256_incremental:\n");
+
+	/* Feeding the same input in pieces must give the same digest. */
+	shr_sha256_init(&ctx);
+	shr_sha256_update(&ctx, "a", 1);
+	shr_sha256_update(&ctx, "b", 1);
+	shr_sha256_update(&ctx, "c", 1);
+	shr_sha256_final(&ctx, out);
+
+	return check("abc in three calls", out,
+		     "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+static bool test_hmac_sha256(void)
+{
+	unsigned char out[SHR_SHA256_DIGEST_SIZE];
+	unsigned char key[131];
+	bool pass = true;
+
+	printf("test_hmac_sha256:\n");
+
+	memset(key, 0x0b, 20);
+	shr_hmac_sha256_raw(key, 20, "Hi There", 8, out);
+	pass &= check("RFC 4231 case 1", out,
+		      "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+
+	shr_hmac_sha256_raw("Jefe", 4, "what do ya want for nothing?", 28, out);
+	pass &= check("RFC 4231 case 2", out,
+		      "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
+
+	/* Key longer than the block size, so it is hashed first. */
+	memset(key, 0xaa, sizeof(key));
+	shr_hmac_sha256_raw(key, sizeof(key),
+			    "Test Using Larger Than Block-Size Key - Hash Key First",
+			    54, out);
+	pass &= check("RFC 4231 case 6", out,
+		      "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54");
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_sha256();
+	pass &= test_sha256_incremental();
+	pass &= test_hmac_sha256();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/src/nvme-cmds-fabrics.c
+++ b/src/nvme-cmds-fabrics.c
@@ -67,6 +67,16 @@ static int gen_hostnqn_cmd(int argc, char **argv, struct command *acmd, struct p
 	if (err)
 		return err;
 
+	/*
+	 * The firmware sources are readable by root only. A regular user
+	 * silently produces a random identifier instead of the machine's own,
+	 * which is useless.
+	 */
+	if (geteuid()) {
+		nvme_show_error("\"%s\" must be run as root.", acmd->name);
+		return -EPERM;
+	}
+
 	ctx = libnvme_create_global_ctx();
 	if (!ctx)
 		return -ENOMEM;


### PR DESCRIPTION
`nvme gen-hostnqn` returns a random UUID whenever DMI is unreadable, and a different one on every call. That happens without root, and on machines with no DMI at all, such as containers and some virtual machines. Nothing says it happened.

Fixes #3977.

- Add `/etc/machine-id` to the chain, between the firmware sources and the random fallback. The firmware sources describe the hardware and survive a reinstall; the machine ID describes the installation. The chain is `DMI -> device tree -> machine ID -> random`.
- Skip a system UUID of all zeros or all ones. Some firmware and some virtual machines report one, and every machine reporting it would share a host identifier.
- Report the source that won, and warn when falling through to random. Normal operation is unchanged: `nvme gen-hostnqn` prints the hostnqn on stdout and nothing else. The source line is `LIBNVME_LOG_DEBUG`, below the default level; the fallback warning goes to stderr.
- Require root for `nvme gen-hostnqn`. The firmware files are readable by root only, and the output belongs in a root-owned file, so an unprivileged run cannot produce or install a usable value. **This is a behavior change**: the command used to return a random UUID instead.

The machine ID must not be published, so it is never used directly. The UUID is `HMAC-SHA256` over a fixed application ID, keyed by the machine ID, shaped into a version 4 UUID. This is the derivation `sd_id128_get_machine_app_specific(3)` performs, and it produces the same value, verified against `systemd-id128`.

The HMAC comes from a copy of systemd's own SHA-256 and HMAC code rather than from OpenSSL. `gen-hostnqn` runs from distribution post-install scripts and must also work in a build configured with `-Dopenssl=disabled`, where `shr_hmac_sha256()` returns NULL. systemd carries this code for the same reason, since libsystemd cannot link OpenSSL either. Both files are LGPL-2.1-or-later. No libsystemd dependency is added.

Tested: each commit builds with `-Dwerror=true` and passes the test suite on its own. New unit tests cover the FIPS 180-2 and RFC 4231 vectors, the machine ID parsing including the empty and `uninitialized` states, and the placeholder being skipped in favor of the machine ID.

A natural follow-up, not included: `shr_hmac_sha256()` and `shr_md5()` could move onto this implementation, which would drop OpenSSL from `shared/` entirely.
