### PR TITLE
nvme-print: trim padding in the stdout discovery log output

### DIFF
--- a/shared/string-util.h
+++ b/shared/string-util.h
@@ -9,6 +9,7 @@
 
 #include <ctype.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
 #include <strings.h>
 
@@ -75,6 +76,22 @@ static inline char *shr_rtrim(char *s)
 		end--;
 	*end = '\0';
 	return s;
+}
+
+/*
+ * Copy a fixed-size, not-necessarily-NUL-terminated wire field @s of
+ * size @sz into a newly allocated, NUL-terminated, right-trimmed C
+ * string. "%.*s" bounds the read to @sz regardless of whether s
+ * contains a NUL. Returns NULL on allocation failure.
+ */
+static inline char *shr_buf2str(const char s[], size_t sz)
+{
+	char *p;
+
+	if (asprintf(&p, "%.*s", (int)sz, s) < 0)
+		return NULL;
+
+	return shr_rtrim(p);
 }
 
 /*

--- a/src/nvme-print-json.c
+++ b/src/nvme-print-json.c
@@ -5331,22 +5331,6 @@ static void json_directive_show(__u8 type, __u8 oper, __u16 spec, __u32 nsid, __
 }
 
 #ifdef CONFIG_FABRICS
-/*
- * Copy a fixed-size, not-necessarily-NUL-terminated wire field @s of
- * size @sz into a newly allocated, NUL-terminated, right-trimmed C
- * string. "%.*s" bounds the read to @sz regardless of whether s
- * contains a NUL. Returns NULL on allocation failure.
- */
-static char *buf2str(const char s[], size_t sz)
-{
-	char *p;
-
-	if (asprintf(&p, "%.*s", (int)sz, s) < 0)
-		return NULL;
-
-	return shr_rtrim(p);
-}
-
 static void json_discovery_log(const struct nvmf_discovery_log *log, int numrec)
 {
 	struct json_object *r = json_r;
@@ -5370,9 +5354,9 @@ static void json_discovery_log(const struct nvmf_discovery_log *log, int numrec)
 		__cleanup_free char *traddr = NULL;
 		__cleanup_free char *subnqn = NULL;
 
-		trsvcid = buf2str(e->trsvcid, sizeof(e->trsvcid));
-		traddr = buf2str(e->traddr, sizeof(e->traddr));
-		subnqn = buf2str(e->subnqn, sizeof(e->subnqn));
+		trsvcid = shr_buf2str(e->trsvcid, sizeof(e->trsvcid));
+		traddr = shr_buf2str(e->traddr, sizeof(e->traddr));
+		subnqn = shr_buf2str(e->subnqn, sizeof(e->subnqn));
 
 		obj_add_str(entry, "trtype", libnvmf_trtype_str(e->trtype));
 		obj_add_str(entry, "adrfam", libnvmf_adrfam_str(e->adrfam));

--- a/src/nvme-print-stdout.c
+++ b/src/nvme-print-stdout.c
@@ -30,6 +30,7 @@
 #include <shared/table-util.h>
 #include <shared/uint128-util.h>
 #include <shared/uuid-util.h>
+#include <shared/string-util.h>
 
 #include "cleanup.h"
 #include "logging.h"
@@ -6824,9 +6825,18 @@ static void stdout_discovery_log(const struct nvmf_discovery_log *log,
 
 		/*
 		 * e->trsvcid/subnqn/traddr are fixed-width fields off the
-		 * wire, not guaranteed NUL-terminated by a non-compliant DC.
-		 * %-.*s bounds the read to the field's own size regardless.
+		 * wire, space-padded per the spec, and not guaranteed
+		 * NUL-terminated by a non-compliant DC. shr_buf2str() bounds
+		 * the read to the field's own size and strips the padding.
 		 */
+		__cleanup_free char *trsvcid = NULL;
+		__cleanup_free char *subnqn = NULL;
+		__cleanup_free char *traddr = NULL;
+
+		trsvcid = shr_buf2str(e->trsvcid, sizeof(e->trsvcid));
+		subnqn = shr_buf2str(e->subnqn, sizeof(e->subnqn));
+		traddr = shr_buf2str(e->traddr, sizeof(e->traddr));
+
 		printf("=====Discovery Log Entry %d======\n", i);
 		printf("trtype:  %s\n", libnvmf_trtype_str(e->trtype));
 		printf("adrfam:  %s\n",
@@ -6835,9 +6845,9 @@ static void stdout_discovery_log(const struct nvmf_discovery_log *log,
 		printf("subtype: %s\n", libnvmf_subtype_str(e->subtype));
 		printf("treq:    %s\n", libnvmf_treq_str(e->treq));
 		printf("portid:  %d\n", le16_to_cpu(e->portid));
-		printf("trsvcid: %-.*s\n", (int)sizeof(e->trsvcid), e->trsvcid);
-		printf("subnqn:  %-.*s\n", (int)sizeof(e->subnqn), e->subnqn);
-		printf("traddr:  %-.*s\n", (int)sizeof(e->traddr), e->traddr);
+		printf("trsvcid: %s\n", trsvcid);
+		printf("subnqn:  %s\n", subnqn);
+		printf("traddr:  %s\n", traddr);
 		printf("eflags:  %s\n",
 		       libnvmf_eflags_str(le16_to_cpu(e->eflags)));
 


### PR DESCRIPTION
traddr in a discovery log entry is a 256-byte fixed-width field, and per the base spec ASCII strings are padded with spaces rather than NUL-terminated. "%-.*s" bounds the read to the field size but does not trim, so all 256 bytes are printed: the address followed by ~245 spaces. The result is a 265-column line that the terminal wraps, which looks like blank lines between traddr and eflags.

json_discovery_log() already handles this with buf2str(), which copies the field out bounded by its own size and right-trims it. Use the same helper for the stdout renderer so both are in sync.

buf2str() was static in nvme-print-json.c, which is only compiled when json-c is found, so move it to nvme-print.c and declare it in nvme-print.h. No functional change to the JSON output.