### PR TITLE
build: bump minimum Meson version to 1.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
 
 ### Feature removals and incompatible changes
 
+* The minimum required Meson version is now 1.0.0, up from 0.62.0.
+  Meson 1.0.0 was released in December 2022, so any reasonably
+  current build environment should already meet it.
+
 * `nvme gen-hostnqn` must now be run as root. The DMI and device tree
   files it reads are readable by root only. An unprivileged run
   returned a random identifier instead. See `nvme-gen-hostnqn(1)`.

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@
 
 project(
     'nvme-cli', ['c'],
-    meson_version: '>= 0.62.0',
+    meson_version: '>= 1.0.0',
     license: [
         'GPL-2.0-only',         # nvme-cli
         'LGPL-2.1-or-later',    # libnvme


### PR DESCRIPTION
Meson 1.0.0 was released in December 2022, so any reasonably current build environment should already meet it. The 0.62.0 floor was never updated after it was originally set and missed the opportunity for the initial 3.0 release.

Fixes https://github.com/linux-nvme/nvme-cli/issues/3994