### PR TITLE
nvme: match `Invalid Field` by status code alone in `init_pi_tags`

### DIFF
--- a/src/nvme-cmds-io.c
+++ b/src/nvme-cmds-io.c
@@ -400,8 +400,8 @@ static int init_pi_tags(struct libnvme_transport_handle *hdl,
 		err = get_pif_sts(ns, nvm_ns, &pif, &sts);
 		if (err)
 			return err;
-	} else if (!nvme_status_equals(err, NVME_STATUS_TYPE_NVME,
-				       NVME_SC_INVALID_FIELD)) {
+	} else if (nvme_status_get_type(err) != NVME_STATUS_TYPE_NVME ||
+		   nvme_status_code(nvme_status_get_value(err)) != NVME_SC_INVALID_FIELD) {
 		return err;
 	}
 

--- a/tests/e2e/plugins/plugin_test.py
+++ b/tests/e2e/plugins/plugin_test.py
@@ -38,7 +38,8 @@ class TestPlugin(TestNVMe):
         super().setUp()
         self.setup_log_dir(self.__class__.__name__)
         # Verify the plugin is available
-        ret = self.exec_cmd(f"{self.nvme_bin} {self.plugin_name} help")
+        ret = self.exec_cmd(f"{self.nvme_bin} {self.plugin_name} help",
+                            quiet=True)
         if ret != 0:
             self.skipTest(f"Plugin '{self.plugin_name}' not available")
 

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -108,7 +108,7 @@ class TestNVMeBase(unittest.TestCase):
         if not logging.getLogger().handlers:
             logging.basicConfig(format='%(message)s', stream=sys.stdout)
 
-    def run_cmd(self, cmd, stdin_data=None, shell=True):
+    def run_cmd(self, cmd, stdin_data=None, shell=True, quiet=False):
         """ Run a command using subprocess.run, log the command and its
             output, and return the CompletedProcess result.
             - Args:
@@ -116,6 +116,8 @@ class TestNVMeBase(unittest.TestCase):
                   (the default); an argv list when shell=False.
                 - stdin_data : optional string to pass as stdin input.
                 - shell : passed straight through to subprocess.run().
+                - quiet : don't echo captured stdout/stderr to the
+                  console/log files.
             - Returns:
                 - CompletedProcess result.
         """
@@ -123,20 +125,21 @@ class TestNVMeBase(unittest.TestCase):
         result = subprocess.run(cmd, shell=shell, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE, encoding='utf-8',
                                 input=stdin_data)
-        if result.stdout:
-            logger.debug(result.stdout)
-            sys.stdout.write(result.stdout)
-            sys.stdout.flush()
-            if getattr(self, 'stdout_log', None):
-                self.stdout_log.write(result.stdout)
-                self.stdout_log.flush()
-        if result.stderr:
-            logger.debug(result.stderr)
-            sys.stderr.write(result.stderr)
-            sys.stderr.flush()
-            if getattr(self, 'stderr_log', None):
-                self.stderr_log.write(result.stderr)
-                self.stderr_log.flush()
+        if not quiet:
+            if result.stdout:
+                logger.debug(result.stdout)
+                sys.stdout.write(result.stdout)
+                sys.stdout.flush()
+                if getattr(self, 'stdout_log', None):
+                    self.stdout_log.write(result.stdout)
+                    self.stdout_log.flush()
+            if result.stderr:
+                logger.debug(result.stderr)
+                sys.stderr.write(result.stderr)
+                sys.stderr.flush()
+                if getattr(self, 'stderr_log', None):
+                    self.stderr_log.write(result.stderr)
+                    self.stderr_log.flush()
         self._record_device_data(cmd, result)
         return result
 
@@ -396,9 +399,9 @@ class TestNVMe(TestNVMeBase):
             self.fail(f"ERROR : missing key '{key}' in {context}: {data!r}")
         return data.get(key, default)
 
-    def exec_cmd(self, cmd):
+    def exec_cmd(self, cmd, quiet=False):
         """ Wrapper for executing a shell command and return the result. """
-        return self.run_cmd(cmd).returncode
+        return self.run_cmd(cmd, quiet=quiet).returncode
 
     def nvme_reset_ctrl(self):
         """ Wrapper for nvme reset command.


### PR DESCRIPTION
init_pi_tags treats a failing Identify NVM CS NS as tolerable only when
it matches `NVME_SC_INVALID_FIELD` exactly via nvme_status_equals. Real
controllers commonly set MORE and/or DNR alongside the status code (e.g.
raw status 0x6002, not the bare 0x2), so the exact-value match misses
them and the command aborts instead of falling back to "no PI
available".

Fixes https://github.com/linux-nvme/nvme-cli/issues/3992
