### PR TITLE
libnvme, nvme-discoverd: Fix DUPRETINFO handling

### DIFF
--- a/discoverd/meson.build
+++ b/discoverd/meson.build
@@ -41,6 +41,10 @@ executable(
     install_dir: sbindir,
 )
 
+if get_option('tests')
+    subdir('tests')
+endif
+
 configure_file(
     input: 'systemd/nvme-discoverd.service.in',
     output: 'nvme-discoverd.service',

--- a/discoverd/src/dlp.c
+++ b/discoverd/src/dlp.c
@@ -43,36 +43,17 @@ static struct libnvmf_tid *tid_from_dlpe(const struct nvmf_disc_log_entry *e,
 		       e->subtype == NVME_NQN_DISC);
 }
 
-int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
-	      const struct libnvmf_tid *dc_tid,
-	      void (*ioc_callback)(const struct libnvmf_tid *t,
-				   void *user_data),
-	      void (*dc_callback)(const struct libnvmf_tid *t, bool epcsd,
-				 void *user_data),
-	      void (*self_callback)(bool epcsd, void *user_data),
-	      void *user_data)
+void dlp_process_log(const struct nvmf_discovery_log *log,
+		     const struct libnvmf_tid *dc_tid,
+		     void (*ioc_callback)(const struct libnvmf_tid *t,
+					  void *user_data),
+		     void (*dc_callback)(const struct libnvmf_tid *t,
+					 bool epcsd, void *user_data),
+		     void (*self_callback)(bool epcsd, void *user_data),
+		     void *user_data)
 {
-	struct libnvme_ctrl *ctrl = NULL;
-	struct nvmf_discovery_log *log = NULL;
-	uint64_t numrec;
+	uint64_t numrec = le64toh((__u64)log->numrec);
 	uint64_t i;
-	int ret;
-
-	ret = libnvme_scan_ctrl(ctx->nvme_ctx, devname, &ctrl);
-	if (ret < 0) {
-		disc_warn("%s | %s - scan_ctrl failed: %s",
-			  libnvmf_tid_str(dc_tid), devname, strerror(-ret));
-		goto out;
-	}
-
-	ret = libnvmf_get_discovery_log(ctrl, NULL, &log);
-	if (ret < 0) {
-		disc_warn("%s | %s - get_discovery_log failed: %s",
-			  libnvmf_tid_str(dc_tid), devname, strerror(-ret));
-		goto out;
-	}
-
-	numrec = le64toh((__u64)log->numrec);
 
 	for (i = 0; i < numrec; i++) {
 		const struct nvmf_disc_log_entry *e = &log->entries[i];
@@ -104,6 +85,37 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 
 		tid_free(t);
 	}
+}
+
+int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
+	      const struct libnvmf_tid *dc_tid,
+	      void (*ioc_callback)(const struct libnvmf_tid *t,
+				   void *user_data),
+	      void (*dc_callback)(const struct libnvmf_tid *t, bool epcsd,
+				 void *user_data),
+	      void (*self_callback)(bool epcsd, void *user_data),
+	      void *user_data)
+{
+	struct libnvme_ctrl *ctrl = NULL;
+	struct nvmf_discovery_log *log = NULL;
+	int ret;
+
+	ret = libnvme_scan_ctrl(ctx->nvme_ctx, devname, &ctrl);
+	if (ret < 0) {
+		disc_warn("%s | %s - scan_ctrl failed: %s",
+			  libnvmf_tid_str(dc_tid), devname, strerror(-ret));
+		goto out;
+	}
+
+	ret = libnvmf_get_discovery_log(ctrl, NULL, &log);
+	if (ret < 0) {
+		disc_warn("%s | %s - get_discovery_log failed: %s",
+			  libnvmf_tid_str(dc_tid), devname, strerror(-ret));
+		goto out;
+	}
+
+	dlp_process_log(log, dc_tid, ioc_callback, dc_callback, self_callback,
+			user_data);
 
 	ret = 0;
 out:

--- a/discoverd/src/dlp.c
+++ b/discoverd/src/dlp.c
@@ -79,9 +79,6 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 		uint16_t eflags = le16toh((__u16)e->eflags);
 		struct libnvmf_tid *t;
 
-		if (eflags & NVMF_DISC_EFLAGS_DUPRETINFO)
-			continue;
-
 		t = tid_from_dlpe(e, dc_tid);
 		if (!t)
 			continue;

--- a/discoverd/src/dlp.h
+++ b/discoverd/src/dlp.h
@@ -17,11 +17,11 @@
  *   subtype == NVME_NQN_NVME (I/O controller):       ioc_callback is called.
  *   subtype == NVME_NQN_DISC (referral DC):          dc_callback is called.
  *   subtype == NVME_NQN_CURR (this DC's self entry): self_callback is called.
- *   DUPRETINFO flag set: entry is skipped.
  *
- * self_callback is called at most once, with the self entry's EPCSD bit
- * (EFLAGS bit 1). It is not called at all if the log page carries no self
- * entry; the caller must supply its own fallback for that case.
+ * self_callback is called once per self entry, with that entry's EPCSD bit
+ * (EFLAGS bit 1); a multi-port DC may publish several. It is not called at
+ * all if the log page carries no self entry; the caller must supply its own
+ * fallback for that case.
  *
  * dc_callback is passed the referral entry's own EPCSD bit, i.e. this DC's
  * report of whether the referred-to DC supports persistent connections.

--- a/discoverd/src/dlp.h
+++ b/discoverd/src/dlp.h
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <nvme/nvme-types-fabrics.h>
+
 #include "ctx.h"
 #include "tid.h"
 
@@ -41,3 +43,19 @@ int dlp_fetch(struct discoverd_ctx *ctx, const char *devname,
 				 void *user_data),
 	      void (*self_callback)(bool epcsd, void *user_data),
 	      void *user_data);
+
+/*
+ * Dispatch an already-fetched Discovery Log Page, the second half of
+ * dlp_fetch(). Split out so the entry dispatch can be unit tested against a
+ * synthetic log page, without a device or a fabrics connection.
+ *
+ * log: a Discovery Log Page; numrec is read from its own header.
+ */
+void dlp_process_log(const struct nvmf_discovery_log *log,
+		     const struct libnvmf_tid *dc_tid,
+		     void (*ioc_callback)(const struct libnvmf_tid *t,
+					  void *user_data),
+		     void (*dc_callback)(const struct libnvmf_tid *t,
+					 bool epcsd, void *user_data),
+		     void (*self_callback)(bool epcsd, void *user_data),
+		     void *user_data);

--- a/discoverd/tests/meson.build
+++ b/discoverd/tests/meson.build
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+test_dlp = executable(
+    'test-dlp',
+    ['test-dlp.c', '../src/dlp.c', '../src/log.c', '../src/tid.c'],
+    include_directories: discoverd_inc,
+    dependencies: [
+        ccan_dep,
+        libnvme_dep,
+        libsystemd_dep,
+        shared_dep,
+    ],
+)
+
+test('nvme-discoverd - dlp', test_dlp)

--- a/discoverd/tests/test-dlp.c
+++ b/discoverd/tests/test-dlp.c
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * This file is part of nvme-cli.
+ * Copyright (c) 2026 Dell Technologies Inc. or its subsidiaries.
+ *
+ * Authors: Martin Belanger <martin.belanger@dell.com>
+ */
+
+#include <endian.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <nvme/nvme-types-fabrics.h>
+
+#include "dlp.h"
+
+#define DC_NQN		"nqn.2014-08.org.nvmexpress.discovery"
+#define IOC_NQN		"nqn.1992-08.com.example:sn.xxxx:subsystem.vol1"
+#define REFERRAL_NQN	"nqn.2014-08.org.example:cdc.other"
+
+struct counters {
+	unsigned int ioc;
+	unsigned int dc;
+	unsigned int self;
+	bool dc_epcsd;
+	bool self_epcsd;
+	char last_ioc_subnqn[NVME_NQN_LENGTH];
+};
+
+static void ioc_cb(const struct libnvmf_tid *t, void *user_data)
+{
+	struct counters *c = user_data;
+	const char *nqn = libnvmf_tid_get_subsysnqn(t);
+
+	c->ioc++;
+	snprintf(c->last_ioc_subnqn, sizeof(c->last_ioc_subnqn), "%s",
+		 nqn ? nqn : "");
+}
+
+static void dc_cb(const struct libnvmf_tid *t, bool epcsd, void *user_data)
+{
+	struct counters *c = user_data;
+
+	c->dc++;
+	c->dc_epcsd = epcsd;
+}
+
+static void self_cb(bool epcsd, void *user_data)
+{
+	struct counters *c = user_data;
+
+	c->self++;
+	c->self_epcsd = epcsd;
+}
+
+/*
+ * A Discovery Log Page holding @numrec entries. The entries[] flexible array
+ * member is sized here so the whole page is one allocation, as it is on the
+ * wire.
+ */
+static struct nvmf_discovery_log *make_log(unsigned int numrec)
+{
+	struct nvmf_discovery_log *log;
+	size_t size;
+
+	size = sizeof(*log) + numrec * sizeof(struct nvmf_disc_log_entry);
+	log = calloc(1, size);
+	if (!log) {
+		fprintf(stderr, "out of memory\n");
+		exit(EXIT_FAILURE);
+	}
+
+	log->numrec = htole64(numrec);
+
+	return log;
+}
+
+static void set_entry(struct nvmf_discovery_log *log, unsigned int i,
+		      __u8 subtype, __u16 eflags, const char *traddr,
+		      const char *trsvcid, const char *subnqn)
+{
+	struct nvmf_disc_log_entry *e = &log->entries[i];
+
+	e->trtype = NVMF_TRTYPE_TCP;
+	e->adrfam = NVMF_ADDR_FAMILY_IP4;
+	e->subtype = subtype;
+	e->eflags = htole16(eflags);
+	snprintf(e->traddr, sizeof(e->traddr), "%s", traddr);
+	snprintf(e->trsvcid, sizeof(e->trsvcid), "%s", trsvcid);
+	snprintf(e->subnqn, sizeof(e->subnqn), "%s", subnqn);
+}
+
+static bool check(bool cond, const char *what)
+{
+	printf(" - %s [%s]\n", what, cond ? "PASS" : "FAIL");
+	return cond;
+}
+
+/*
+ * DUPRETINFO must not gate dispatch.
+ *
+ * The bit is defined for Current Discovery Subsystem entries only. NVMe Base
+ * Specification 2.4, Figure 320: "For entries with the SUBTYPE field set to a
+ * value other than 3h, this bit shall be cleared to '0'." On such an entry it
+ * means a set of this Discovery subsystem's ports return the same log page,
+ * so a host need not read the log page from all of them. It does not mean the
+ * entry is uninteresting.
+ *
+ * Reading it as "skip this entry" hid a Discovery controller's own EPCSD
+ * report from the caller, which then parked a controller that does support
+ * persistent connections.
+ */
+static bool test_dupretinfo_does_not_drop_entries(void)
+{
+	__u16 both = NVMF_DISC_EFLAGS_EPCSD | NVMF_DISC_EFLAGS_DUPRETINFO;
+	struct nvmf_discovery_log *log;
+	struct counters c = { 0 };
+	bool pass = true;
+
+	printf("test_dupretinfo_does_not_drop_entries:\n");
+
+	log = make_log(3);
+	set_entry(log, 0, NVME_NQN_CURR, both, "192.168.1.116", "8009",
+		  DC_NQN);
+	set_entry(log, 1, NVME_NQN_NVME, NVMF_DISC_EFLAGS_DUPRETINFO,
+		  "192.168.1.116", "4420", IOC_NQN);
+	set_entry(log, 2, NVME_NQN_DISC, both, "192.168.1.117", "8009",
+		  REFERRAL_NQN);
+
+	dlp_process_log(log, NULL, ioc_cb, dc_cb, self_cb, &c);
+
+	pass &= check(c.self == 1,
+		      "self entry with EPCSD|DUPRETINFO dispatched");
+	pass &= check(c.self_epcsd, "self entry reports EPCSD=1");
+	pass &= check(c.ioc == 1, "I/O entry with DUPRETINFO dispatched");
+	pass &= check(c.dc == 1, "referral with EPCSD|DUPRETINFO dispatched");
+	pass &= check(c.dc_epcsd, "referral reports EPCSD=1");
+
+	free(log);
+
+	return pass;
+}
+
+/* Each subtype reaches its own callback, and EPCSD is passed through. */
+static bool test_subtype_dispatch(void)
+{
+	struct nvmf_discovery_log *log;
+	struct counters c = { 0 };
+	bool pass = true;
+
+	printf("test_subtype_dispatch:\n");
+
+	log = make_log(4);
+	set_entry(log, 0, NVME_NQN_CURR, 0, "192.168.1.116", "8009", DC_NQN);
+	set_entry(log, 1, NVME_NQN_NVME, 0, "192.168.1.116", "4420", IOC_NQN);
+	set_entry(log, 2, NVME_NQN_DISC, 0, "192.168.1.117", "8009",
+		  REFERRAL_NQN);
+	/* A reserved subtype is ignored rather than dispatched anywhere. */
+	set_entry(log, 3, 0, 0, "192.168.1.118", "8009", IOC_NQN);
+
+	dlp_process_log(log, NULL, ioc_cb, dc_cb, self_cb, &c);
+
+	pass &= check(c.self == 1, "one self callback");
+	pass &= check(c.ioc == 1, "one I/O callback");
+	pass &= check(c.dc == 1, "one referral callback");
+	pass &= check(!c.self_epcsd, "self entry reports EPCSD=0");
+	pass &= check(!c.dc_epcsd, "referral reports EPCSD=0");
+	pass &= check(!strcmp(c.last_ioc_subnqn, IOC_NQN),
+		      "I/O callback carries the entry's subnqn");
+
+	free(log);
+
+	return pass;
+}
+
+/*
+ * A multi-port Discovery controller may publish several self entries. Base
+ * Specification 2.4, Figure 320, subtype 03: "Multiple Current Discovery
+ * Subsystem entries may be reported for this Discovery subsystem if the
+ * current Discovery subsystem has multiple NVM subsystem ports."
+ */
+static bool test_multiple_self_entries(void)
+{
+	struct nvmf_discovery_log *log;
+	struct counters c = { 0 };
+	bool pass = true;
+
+	printf("test_multiple_self_entries:\n");
+
+	log = make_log(2);
+	set_entry(log, 0, NVME_NQN_CURR, NVMF_DISC_EFLAGS_EPCSD,
+		  "192.168.1.116", "8009", DC_NQN);
+	set_entry(log, 1, NVME_NQN_CURR, NVMF_DISC_EFLAGS_EPCSD,
+		  "192.168.2.116", "8009", DC_NQN);
+
+	dlp_process_log(log, NULL, ioc_cb, dc_cb, self_cb, &c);
+
+	pass &= check(c.self == 2, "both self entries dispatched");
+
+	free(log);
+
+	return pass;
+}
+
+/* An empty log page dispatches nothing. */
+static bool test_no_entries(void)
+{
+	struct nvmf_discovery_log *log;
+	struct counters c = { 0 };
+	bool pass = true;
+
+	printf("test_no_entries:\n");
+
+	log = make_log(0);
+	dlp_process_log(log, NULL, ioc_cb, dc_cb, self_cb, &c);
+
+	pass &= check(c.self == 0 && c.ioc == 0 && c.dc == 0,
+		      "no callbacks for an empty log page");
+
+	free(log);
+
+	return pass;
+}
+
+/* Every callback is optional. */
+static bool test_null_callbacks(void)
+{
+	struct nvmf_discovery_log *log;
+	bool pass = true;
+
+	printf("test_null_callbacks:\n");
+
+	log = make_log(3);
+	set_entry(log, 0, NVME_NQN_CURR, 0, "192.168.1.116", "8009", DC_NQN);
+	set_entry(log, 1, NVME_NQN_NVME, 0, "192.168.1.116", "4420", IOC_NQN);
+	set_entry(log, 2, NVME_NQN_DISC, 0, "192.168.1.117", "8009",
+		  REFERRAL_NQN);
+
+	dlp_process_log(log, NULL, NULL, NULL, NULL, NULL);
+
+	pass &= check(true, "no callbacks installed: no crash");
+
+	free(log);
+
+	return pass;
+}
+
+int main(void)
+{
+	bool pass = true;
+
+	pass &= test_dupretinfo_does_not_drop_entries();
+	pass &= test_subtype_dispatch();
+	pass &= test_multiple_self_entries();
+	pass &= test_no_entries();
+	pass &= test_null_callbacks();
+
+	fflush(stdout);
+	exit(pass ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/libnvme/src/nvme/fabrics.c
+++ b/libnvme/src/nvme/fabrics.c
@@ -3118,11 +3118,6 @@ static void dc_walk_referral(struct libnvme_global_ctx *ctx,
 	struct libnvme_ctrl *cl;
 	int err;
 
-	if (eflags & NVMF_DISC_EFLAGS_DUPRETINFO) {
-		dc_log_decision(fctx, e, &d, "duplicate information");
-		return;
-	}
-
 	if (depth >= NVMF_MAX_REFERRAL_DEPTH) {
 		dc_log_decision(fctx, e, &d,
 			"referral depth limit reached, not descending");
@@ -3310,6 +3305,14 @@ static int _nvmf_discover(struct libnvme_global_ctx *ctx,
 		const char *transport;
 		__u16 eflags;
 
+		/*
+		 * A self entry describes this same Discovery subsystem.
+		 * Real DCs publish one for the port already connected;
+		 * a multi-port DC may also list its other ports. Base spec
+		 * 2.4 makes acting on either a "may", and a log page entry
+		 * carries no source address or interface, so the only local
+		 * path available is the one this connection already uses.
+		 */
 		if (e->subtype == NVME_NQN_CURR)
 			continue;
 

--- a/libnvme/tests/test-fabrics.c
+++ b/libnvme/tests/test-fabrics.c
@@ -650,6 +650,8 @@ static bool test_dc_decide(struct libnvme_global_ctx *ctx)
 	struct libnvmf_context fctx = { .ctx = ctx };
 	__u16 epcsd_set = NVMF_DISC_EFLAGS_EPCSD;
 	__u16 epcsd_clear = 0;
+	__u16 both_set = NVMF_DISC_EFLAGS_EPCSD | NVMF_DISC_EFLAGS_DUPRETINFO;
+	__u16 dup_only = NVMF_DISC_EFLAGS_DUPRETINFO;
 	bool pass = true, p, d;
 
 	printf("\ntest_dc_decide:\n");
@@ -709,6 +711,34 @@ static bool test_dc_decide(struct libnvme_global_ctx *ctx)
 	d = dc_decide(&fctx, "nqn", DC_OWNED, true, epcsd_set, NULL);
 	p = d;
 	CHECK(p, "DC_OWNED, NO, self EPCSD=1: disconnect=%d", d);
+	pass &= p;
+
+	/*
+	 * DUPRETINFO plays no part in the persistence decision. It says a set
+	 * of this Discovery subsystem's ports return the same log page, so a
+	 * host need not read the log page from all of them. Only EPCSD decides
+	 * whether the connection is kept. Setting DUPRETINFO alongside EPCSD,
+	 * or on its own, must not change the outcome.
+	 */
+	fctx.persistent = LIBNVMF_PERSISTENT_AUTO;
+	d = dc_decide(&fctx, "nqn", DC_OWNED, true, both_set, NULL);
+	p = !d;
+	CHECK(p, "DC_OWNED, AUTO, self EPCSD=1|DUPRETINFO: disconnect=%d", d);
+	pass &= p;
+
+	d = dc_decide(&fctx, "nqn", DC_OWNED, true, dup_only, NULL);
+	p = d;
+	CHECK(p, "DC_OWNED, AUTO, self DUPRETINFO only: disconnect=%d", d);
+	pass &= p;
+
+	d = dc_decide(&fctx, "nqn", DC_OWNED, false, 0, &both_set);
+	p = !d;
+	CHECK(p, "DC_OWNED, AUTO, parent EPCSD=1|DUPRETINFO: disconnect=%d", d);
+	pass &= p;
+
+	d = dc_decide(&fctx, "nqn", DC_OWNED, false, 0, &dup_only);
+	p = d;
+	CHECK(p, "DC_OWNED, AUTO, parent DUPRETINFO only: disconnect=%d", d);
 	pass &= p;
 
 	return pass;


### PR DESCRIPTION
DUPRETINFO is acted on in two places where it changes behavior it should not.

The bit is defined for Current Discovery Subsystem entries only. Base Specification 2.4 Figure 320: for entries with a SUBTYPE other than 3h it shall be cleared to 0.

- `dc_walk_referral()` tested it on a subtype 1h entry (referral). 
- nvme-discoverd dropped every entry carrying the bit before looking at its subtype. A Discovery controller advertising EPCSD and DUPRETINFO together on its self entry never reached `self_callback`, so `dc_effective_epcsd()` returned false and the controller was parked and polled every `epcsd-poll-interval-minutes` despite supporting persistent connections. This one is user-visible.

Both checks are removed rather than moved to subtype 3h. Nothing connects to a self entry, so there is no duplicate connection for the bit to suppress.

That stays true deliberately, and the reason is now a comment in `_nvmf_discover()`. Everything the spec says about acting on a self entry is permissive: a host *need not* read the log page from every port, *may* read several for redundancy, *may* enable the Discovery Log Page Change AEN on one of them. Against real Discovery controllers the self entry describes the port already connected, so acting on it is a re-connect to the endpoint already in hand. A multi-port controller may also list its other ports, but a log page entry is destination-only and carries no source address or interface, so the only local path available is the one already in use. Choosing another would mean a routing lookup, and where interfaces are not separated by subnet that resolves to the default route.

Tested: each commit builds and passes the test suite on its own, with `-Dnvme-discoverd=enabled -Dwerror=true`.
