### PR TITLE
NEWS: drop the --epcsd entries from the 3.0 release notes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -278,10 +278,6 @@
   writes a matching entry to the exclusion list before disconnecting.
   See `nvme-disconnect(1)`.
 
-* `nvme discover` and `nvme config-create` gained
-  `--epcsd`/`--no-epcsd`, to request or refuse Explicit Persistent
-  Connection Support for Discovery. See `nvme-config-create(1)`.
-
 * `nvme utils dump-command-metadata` prints the full command and
   option tree as JSON. It is meant to  drive shell-completion
   generation.
@@ -314,9 +310,8 @@
   and Python scripts that reference the library, its headers, or the
   Python module by name must update.
 
-* `nvme-fabrics.conf` entries can now record `persistent` and
-  `epcsd` settings per discovery controller, matching the CLI flags
-  above.
+* `nvme-fabrics.conf` entries can now record a `persistent` setting
+  per discovery controller, matching the `--persistent` CLI option.
 
 * New diagnostic accessors report per-path, per-namespace, and
   per-controller command retry/error counts, multipath failover


### PR DESCRIPTION
`745ada20f` removed `--epcsd`/`--no-epcsd` a month before the release, but the shipped 3.0 NEWS.md still announce them, and also announce an `epcsd` setting for the INI config. Neither the options nor the INI key exist in the tree, so a reader following the NEWS gets an unknown-option error.

Two changes: the `--epcsd` bullet is removed, and the `nvme-fabrics.conf` bullet now mentions only `persistent`, which is real.

The 3.0 section of NEWS.md is already tagged (so maybe it's too late for the change). 
