### PR TITLE
libnvme: correct the key-class comment above keys[]

### DIFF
--- a/libnvme/src/nvme/config-ini.c
+++ b/libnvme/src/nvme/config-ini.c
@@ -33,7 +33,7 @@
 static int check_persistent(const char *value);
 
 static const struct libnvmf_key keys[] = {
-	/* connection tunables; only class overridable per controller= line */
+	/* connection tunables; overridable per controller= line */
 	{ "nr-io-queues",		LIBNVMF_KEY_INT,	LIBNVMF_KEY_TUNABLE },
 	{ "nr-write-queues",		LIBNVMF_KEY_INT,	LIBNVMF_KEY_TUNABLE },
 	{ "nr-poll-queues",		LIBNVMF_KEY_INT,	LIBNVMF_KEY_TUNABLE },


### PR DESCRIPTION
The comment above `keys[]` says `LIBNVMF_KEY_TUNABLE` is the only class a `controller =` line accepts. That stopped being true when `LIBNVMF_KEY_DC_TUNABLE` was added.

`config-ini.h` has always described the class correctly, so the two files contradicted each other.

It has already misled Claude who took the comment at face value instead of digging deeper in the code.

Comment only, no behavior change.
