### PR TITLE
libnvme: mi: add libnvme_mi_mi_controller_health_status_poll

### DIFF
--- a/libnvme/examples/mi-mctp.c
+++ b/libnvme/examples/mi-mctp.c
@@ -120,7 +120,56 @@ int do_info(struct libnvme_mi_ep *ep)
 	return 0;
 }
 
-static int show_ctrl(struct libnvme_mi_ep *ep, uint16_t ctrl_id)
+static void show_chsc_flags(uint16_t chsc)
+{
+	static const struct {
+		uint16_t mask;
+		const char *name;
+	} chsc_bits[] = {
+		{ NVME_MI_CHSC_RDY,   "RDY (Ready)" },
+		{ NVME_MI_CHSC_CFS,   "CFS (Controller Fatal Status)" },
+		{ NVME_MI_CHSC_SHST,  "SHST (Shutdown Status)" },
+		{ NVME_MI_CHSC_NSSRO,
+		  "NSSRO (NVM Subsystem Reset Occurred)" },
+		{ NVME_MI_CHSC_CECO,
+		  "CECO (Controller Enable Change Occurred)" },
+		{ NVME_MI_CHSC_NAC,   "NAC (Namespace Attribute Changed)" },
+		{ NVME_MI_CHSC_FA,    "FA (Firmware Activated)" },
+		{ NVME_MI_CHSC_CSTS,  "CSTS (Controller Status Change)" },
+		{ NVME_MI_CHSC_CTEMP,
+		  "CTEMP (Composite Temperature Change)" },
+		{ NVME_MI_CHSC_PDLU,  "PDLU (Percentage Used Change)" },
+		{ NVME_MI_CHSC_SPARE, "SPARE (Available Spare Change)" },
+		{ NVME_MI_CHSC_CWARN, "CWARN (Critical Warning Change)" },
+		{ NVME_MI_CHSC_TCIDA,
+		  "TCIDA (Telemetry Controller-Initiated Data Available)" },
+	};
+	unsigned int i;
+
+	for (i = 0; i < ARRAY_SIZE(chsc_bits); i++) {
+		if (chsc & chsc_bits[i].mask)
+			printf("        flag: %s\n", chsc_bits[i].name);
+	}
+}
+
+static void show_ctrl_health(const struct nvme_mi_ctrl_health_status *chs)
+{
+	uint16_t chsc = (uint16_t)chs->chscf[0] |
+			((uint16_t)chs->chscf[1] << 8);
+
+	printf("    health:\n");
+	printf("      controller status:  0x%04x\n", le16_to_cpu(chs->csts));
+	printf("      composite temp:     %d\n", le16_to_cpu(chs->ctemp));
+	printf("      drive life used:    %d%%\n", chs->pdlu);
+	printf("      available spare:    %d%%\n", chs->spare);
+	printf("      critical warnings:  0x%02x\n", chs->cwarn);
+	printf("      status changed:     0x%04x\n", chsc);
+	if (chsc)
+		show_chsc_flags(chsc);
+}
+
+static int show_ctrl(struct libnvme_mi_ep *ep, uint16_t ctrl_id,
+		     const struct nvme_mi_ctrl_health_status *chs)
 {
 	struct nvme_mi_read_ctrl_info ctrl;
 	int rc;
@@ -145,11 +194,16 @@ static int show_ctrl(struct libnvme_mi_ep *ep, uint16_t ctrl_id)
 	printf("    PCI subsys vendor: %04x\n", le16_to_cpu(ctrl.ssvid));
 	printf("    PCI subsys device: %04x\n", le16_to_cpu(ctrl.ssvid));
 
+	if (chs)
+		show_ctrl_health(chs);
+
 	return 0;
 }
 
 static int do_controllers(struct libnvme_mi_ep *ep)
 {
+	struct nvme_mi_ctrl_health_status *chs = NULL;
+	unsigned int num_health = NVME_ID_CTRL_LIST_MAX;
 	struct nvme_ctrl_list ctrl_list;
 	int rc, i;
 
@@ -159,11 +213,38 @@ static int do_controllers(struct libnvme_mi_ep *ep)
 		return rc;
 	}
 
+	chs = calloc(num_health, sizeof(*chs));
+	if (chs) {
+		rc = libnvme_mi_mi_controller_health_status_poll_all(
+			ep, true, chs, &num_health);
+		if (rc) {
+			warnx("Can't perform Controller Health Poll operation");
+			free(chs);
+			chs = NULL;
+			num_health = 0;
+		}
+	}
+
 	printf("NVMe controller list:\n");
 	for (i = 0; i < le16_to_cpu(ctrl_list.num); i++) {
 		uint16_t id = le16_to_cpu(ctrl_list.identifier[i]);
-		show_ctrl(ep, id);
+		const struct nvme_mi_ctrl_health_status *ctrl_chs = NULL;
+
+		if (chs) {
+			unsigned int j;
+
+			for (j = 0; j < num_health; j++) {
+				if (le16_to_cpu(chs[j].ctlid) == id) {
+					ctrl_chs = &chs[j];
+					break;
+				}
+			}
+		}
+
+		show_ctrl(ep, id, ctrl_chs);
 	}
+
+	free(chs);
 	return 0;
 }
 

--- a/libnvme/src/libnvme-mi.ld
+++ b/libnvme/src/libnvme-mi.ld
@@ -21,6 +21,7 @@ LIBNVME_MI_3 {
 		libnvme_mi_init_transport_handle;
 		libnvme_mi_mi_config_get;
 		libnvme_mi_mi_config_set;
+		libnvme_mi_mi_controller_health_status_poll;
 		libnvme_mi_mi_pda_read;
 		libnvme_mi_mi_pda_write;
 		libnvme_mi_mi_pda_write_zeroes;

--- a/libnvme/src/nvme/mi-types.h
+++ b/libnvme/src/nvme/mi-types.h
@@ -123,6 +123,7 @@ struct nvme_mi_msg_resp {
  * enum nvme_mi_mi_opcode - Operation code for supported NVMe-MI commands.
  * @nvme_mi_mi_opcode_mi_data_read: Read NVMe-MI Data Structure
  * @nvme_mi_mi_opcode_subsys_health_status_poll: Subsystem Health Status Poll
+ * @nvme_mi_mi_opcode_ctrl_health_status_poll: Controller Health Status Poll
  * @nvme_mi_mi_opcode_configuration_set: MI Configuration Set
  * @nvme_mi_mi_opcode_configuration_get: MI Configuration Get
  * @nvme_mi_mi_opcode_pda_read: NVMe-MI PDA Read
@@ -132,6 +133,7 @@ struct nvme_mi_msg_resp {
 enum nvme_mi_mi_opcode {
 	nvme_mi_mi_opcode_mi_data_read = 0x00,
 	nvme_mi_mi_opcode_subsys_health_status_poll = 0x01,
+	nvme_mi_mi_opcode_ctrl_health_status_poll = 0x02,
 	nvme_mi_mi_opcode_configuration_set = 0x03,
 	nvme_mi_mi_opcode_configuration_get = 0x04,
 	nvme_mi_mi_opcode_pda_read = 0x0d,

--- a/libnvme/src/nvme/mi.c
+++ b/libnvme/src/nvme/mi.c
@@ -1178,6 +1178,119 @@ __shr_public int libnvme_mi_mi_subsystem_health_status_poll(
 	return 0;
 }
 
+__shr_public int libnvme_mi_mi_controller_health_status_poll(
+		struct libnvme_mi_ep *ep,
+		struct libnvme_mi_ctrl_health_poll_args *args)
+{
+	struct nvme_mi_mi_resp_hdr resp_hdr;
+	struct nvme_mi_mi_req_hdr req_hdr;
+	struct libnvme_mi_resp resp;
+	struct libnvme_mi_req req;
+	uint16_t current_sctlid;
+	unsigned int total = 0;
+	unsigned int max_entries;
+	uint32_t cdw0, cdw1;
+	uint8_t ccf, all, incf, incpf, incvf;
+	uint8_t cwarn, spare, pdlu, ctemp, csts;
+	int rc;
+
+	if (!args)
+		return -EINVAL;
+
+	if (args->args_size != sizeof(*args))
+		return -EINVAL;
+
+	if (!args->entries || !args->num_entries)
+		return -EINVAL;
+
+	if (*args->num_entries == 0)
+		return -EINVAL;
+
+	max_entries = *args->num_entries;
+	current_sctlid = args->start_ctrl_id;
+
+	ccf = args->clear ? 1 : 0;
+	all = args->all ? 1 : 0;
+	incf = args->inc_pci ? 1 : 0;
+	incpf = args->inc_sriov_pf ? 1 : 0;
+	incvf = args->inc_sriov_vf ? 1 : 0;
+
+	cwarn = args->filter_cwarn ? 1 : 0;
+	spare = args->filter_spare ? 1 : 0;
+	pdlu = args->filter_pdlu ? 1 : 0;
+	ctemp = args->filter_ctemp ? 1 : 0;
+	csts = args->filter_csts ? 1 : 0;
+
+	cdw1 = (uint32_t)ccf << 31 |
+	       (uint32_t)cwarn << 4 |
+	       (uint32_t)spare << 3 |
+	       (uint32_t)pdlu << 2 |
+	       (uint32_t)ctemp << 1 |
+	       (uint32_t)csts;
+
+	while (total < max_entries) {
+		unsigned int remaining = max_entries - total;
+		unsigned int chunk = remaining > 255 ? 255 : remaining;
+		uint8_t maxrent = chunk - 1;
+		size_t exp_len;
+		uint8_t rent;
+
+		cdw0 = (uint32_t)current_sctlid |
+		       (uint32_t)maxrent << 16 |
+		       (uint32_t)incf << 24 |
+		       (uint32_t)incpf << 25 |
+		       (uint32_t)incvf << 26 |
+		       (uint32_t)all << 31;
+
+		libnvme_mi_mi_init_req(ep, &req, &req_hdr, 0,
+			nvme_mi_mi_opcode_ctrl_health_status_poll);
+		req_hdr.cdw0 = cpu_to_le32(cdw0);
+		req_hdr.cdw1 = cpu_to_le32(cdw1);
+
+		memset(&resp, 0, sizeof(resp));
+		resp.hdr = &resp_hdr.hdr;
+		resp.hdr_len = sizeof(resp_hdr);
+		resp.data = &args->entries[total];
+		resp.data_len = chunk * sizeof(*args->entries);
+
+		rc = libnvme_mi_submit(ep, &req, &resp);
+		if (rc) {
+			*args->num_entries = total;
+			return rc;
+		}
+
+		if (resp_hdr.status) {
+			*args->num_entries = total;
+			return resp_hdr.status;
+		}
+
+		rent = resp_hdr.nmresp[2];
+		exp_len = (size_t)rent * sizeof(*args->entries);
+
+		if (resp.data_len != exp_len) {
+			libnvme_msg(ep->ctx, LIBNVME_LOG_WARN,
+				 "MI Controller Health Status length mismatch: got %zd bytes, expected %zd (rent=%u)\n",
+				 resp.data_len, exp_len, rent);
+			*args->num_entries = total;
+			return -EPROTO;
+		}
+
+		total += rent;
+
+		if (rent < chunk)
+			break;
+
+		if (le16_to_cpu(args->entries[total - 1].ctlid) == 0xffff)
+			break;
+
+		current_sctlid =
+			le16_to_cpu(args->entries[total - 1].ctlid) + 1;
+	}
+
+	*args->num_entries = total;
+	return 0;
+}
+
 __shr_public int libnvme_mi_mi_pda_read(struct libnvme_mi_ep *ep,
 		enum nvme_mi_pda_dformat dformat, __u32 dofst, __u32 dlen,
 		void *data, size_t *data_len)

--- a/libnvme/src/nvme/mi.h
+++ b/libnvme/src/nvme/mi.h
@@ -519,6 +519,101 @@ int libnvme_mi_mi_subsystem_health_status_poll(struct libnvme_mi_ep *ep, bool cl
 					    struct nvme_mi_nvm_ss_health_status *nshds);
 
 /**
+ * struct libnvme_mi_ctrl_health_poll_args - Controller Health Poll arguments
+ * @args_size:     Size of &struct libnvme_mi_ctrl_health_poll_args (for ABI
+ *                 extensibility)
+ * @start_ctrl_id: Starting Controller ID (SCTLID)
+ * @clear:         Clear Changed Flags (CCF): clear CHSCF and NAC/FA/TCIDA on
+ *                 returned controllers
+ * @all:           Report All (ALL): ignore error selection filter bits
+ * @inc_pci:       Include non-SR-IOV PCI Functions (INCF)
+ * @inc_sriov_pf:  Include SR-IOV Physical Functions (INCPF)
+ * @inc_sriov_vf:  Include SR-IOV Virtual Functions (INCVF)
+ * @filter_csts:   Filter by Controller Status Changes (CSTS)
+ * @filter_ctemp:  Filter by Composite Temperature Changes (CTEMP)
+ * @filter_pdlu:   Filter by Percentage Used (PDLU)
+ * @filter_spare:  Filter by Available Spare (SPARE)
+ * @filter_cwarn:  Filter by Critical Warning (CWARN)
+ * @entries:       Caller-allocated buffer to store Controller Health Data
+ *                 Structures
+ * @num_entries:   In/Out: on input, maximum entries to return; on output,
+ *                 actual entries returned
+ */
+struct libnvme_mi_ctrl_health_poll_args {
+	__u32 args_size;
+	__u16 start_ctrl_id;
+	bool clear;
+	bool all;
+	bool inc_pci;
+	bool inc_sriov_pf;
+	bool inc_sriov_vf;
+	bool filter_csts;
+	bool filter_ctemp;
+	bool filter_pdlu;
+	bool filter_spare;
+	bool filter_cwarn;
+	struct nvme_mi_ctrl_health_status *entries;
+	unsigned int *num_entries;
+};
+
+#define nvme_mi_ctrl_health_poll_args libnvme_mi_ctrl_health_poll_args
+
+/**
+ * libnvme_mi_mi_controller_health_status_poll() - Read Controller Health Data
+ * Structure entries from the NVM subsystem
+ * @ep:   Endpoint for MI communication
+ * @args: Arguments structure controlling query parameters and output buffers
+ *
+ * Retrieves one or more Controller Health Data Structures into @args->entries
+ * according to NVMe-MI 2.0 section 5.3. When @args->num_entries specifies
+ * more than 255 entries, multiple requests will be issued sequentially to
+ * fulfill the query.
+ *
+ * See &struct libnvme_mi_ctrl_health_poll_args,
+ * &struct nvme_mi_ctrl_health_status.
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or negative error code otherwise.
+ */
+int libnvme_mi_mi_controller_health_status_poll(struct libnvme_mi_ep *ep,
+		struct libnvme_mi_ctrl_health_poll_args *args);
+
+/**
+ * libnvme_mi_mi_controller_health_status_poll_all() - Read Controller Health
+ * Data Structure for all controllers from the NVM subsystem
+ * @ep:          Endpoint for MI communication
+ * @clear:       Flag to clear changed flags for returned controllers
+ * @entries:     Buffer to receive health data structures
+ * @num_entries: In/Out: on input, maximum entries to return; on output, actual
+ *               entries returned
+ *
+ * Convenience helper to query all controller types starting from ID 0 with
+ * Report All enabled.
+ *
+ * Return: The nvme command status if a response was received (see
+ * &enum nvme_status_field) or negative error code otherwise.
+ */
+static inline int libnvme_mi_mi_controller_health_status_poll_all(
+	struct libnvme_mi_ep *ep, bool clear,
+	struct nvme_mi_ctrl_health_status *entries,
+	unsigned int *num_entries)
+{
+	struct libnvme_mi_ctrl_health_poll_args args = {
+		.args_size = sizeof(args),
+		.start_ctrl_id = 0,
+		.clear = clear,
+		.all = true,
+		.inc_pci = true,
+		.inc_sriov_pf = true,
+		.inc_sriov_vf = true,
+		.entries = entries,
+		.num_entries = num_entries,
+	};
+
+	return libnvme_mi_mi_controller_health_status_poll(ep, &args);
+}
+
+/**
  * libnvme_mi_mi_pda_read() - Read the NVMe-MI Persistent Data Area (PDA)
  * @ep: endpoint for MI communication
  * @dformat: data format to use for @dofst and @dlen, see

--- a/libnvme/src/nvme/nvme-types-mi.h
+++ b/libnvme/src/nvme/nvme-types-mi.h
@@ -399,6 +399,7 @@ enum nvme_mi_chscf {
  * @NVME_MI_CSTS_CECO:	Controller Enable Change Occurred
  * @NVME_MI_CSTS_NAC:	Namespace Attribute Changed
  * @NVME_MI_CSTS_FA:	Firmware Activated
+ * @NVME_MI_CSTS_TCIDA:	Telemetry Controller-Initiated Data Available
  */
 enum nvme_mi_csts {
 	NVME_MI_CSTS_RDY	= 1 << 0,
@@ -408,7 +409,22 @@ enum nvme_mi_csts {
 	NVME_MI_CSTS_CECO	= 1 << 5,
 	NVME_MI_CSTS_NAC	= 1 << 6,
 	NVME_MI_CSTS_FA		= 1 << 7,
+	NVME_MI_CSTS_TCIDA	= 1 << 8,
 };
+
+#define NVME_MI_CHSC_RDY	NVME_MI_CHSCF_RDYF
+#define NVME_MI_CHSC_CFS	NVME_MI_CHSCF_CFSF
+#define NVME_MI_CHSC_SHST	NVME_MI_CHSCF_SHSTF
+#define NVME_MI_CHSC_NSSRO	NVME_MI_CHSCF_NSSROF
+#define NVME_MI_CHSC_CECO	NVME_MI_CHSCF_CECOF
+#define NVME_MI_CHSC_NAC	NVME_MI_CHSCF_NACF
+#define NVME_MI_CHSC_FA		NVME_MI_CHSCF_FAF
+#define NVME_MI_CHSC_CSTS	NVME_MI_CHSCF_CSF
+#define NVME_MI_CHSC_CTEMP	NVME_MI_CHSCF_CTEMPF
+#define NVME_MI_CHSC_PDLU	NVME_MI_CHSCF_PDLUF
+#define NVME_MI_CHSC_SPARE	NVME_MI_CHSCF_SPAREF
+#define NVME_MI_CHSC_CWARN	NVME_MI_CHSCF_CWARNF
+#define NVME_MI_CHSC_TCIDA	NVME_MI_CHSCF_TCIDAF
 
 /**
  * enum nvme_mi_cwarn - Controller Health Data Structure (CHDS) - Critical Warning (CWARN)

--- a/libnvme/tests/mi.c
+++ b/libnvme/tests/mi.c
@@ -2216,6 +2216,272 @@ static void test_admin_dlen_doff_resp(struct libnvme_mi_ep *ep)
 	shr_assert(!rc);
 };
 
+/* Controller Health Status Poll tests */
+struct ctrl_health_paging_data {
+	int call_count;
+};
+
+static int test_mi_ctrl_health_single_cb(struct libnvme_mi_ep *ep,
+					 struct libnvme_mi_req *req,
+					 struct libnvme_mi_resp *resp,
+					 void *data)
+{
+	struct nvme_mi_mi_resp_hdr *mi_resp;
+	struct nvme_mi_ctrl_health_status *chs;
+	uint8_t *buf;
+
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
+	buf = (void *)req->hdr;
+	shr_assert(buf[4] == nvme_mi_mi_opcode_ctrl_health_status_poll);
+
+	/*
+	 * Check cdw0: SCTLID = 0, MAXRENT = 0 (1 entry),
+	 * ALL=1, INCF=1, INCPF=1, INCVF=1
+	 */
+	shr_assert(buf[8] == 0x00);
+	shr_assert(buf[9] == 0x00);
+	shr_assert(buf[10] == 0x00);
+	shr_assert(buf[11] == 0x87);
+
+	/* Check cdw1: CCF=0 */
+	shr_assert(buf[12] == 0x00);
+	shr_assert(buf[13] == 0x00);
+	shr_assert(buf[14] == 0x00);
+	shr_assert(buf[15] == 0x00);
+
+	shr_assert(resp->hdr_len >= sizeof(struct nvme_mi_mi_resp_hdr));
+	shr_assert(resp->data_len >= sizeof(*chs));
+
+	mi_resp = (void *)resp->hdr;
+	mi_resp->status = 0;
+	mi_resp->nmresp[0] = 0;
+	mi_resp->nmresp[1] = 0;
+	mi_resp->nmresp[2] = 1; /* RENT = 1 entry */
+
+	chs = (void *)resp->data;
+	memset(chs, 0, sizeof(*chs));
+	chs->ctlid = cpu_to_le16(0x42);
+	chs->csts = cpu_to_le16(NVME_MI_CSTS_RDY);
+	chs->ctemp = cpu_to_le16(310);
+	chs->pdlu = 12;
+	chs->spare = 88;
+	chs->cwarn = 0;
+	chs->chscf[0] = NVME_MI_CHSC_RDY & 0xff;
+	chs->chscf[1] = 0;
+
+	resp->data_len = sizeof(*chs);
+	test_transport_resp_calc_mic(resp);
+	return 0;
+}
+
+static void test_mi_ctrl_health_single(struct libnvme_mi_ep *ep)
+{
+	struct nvme_mi_ctrl_health_status entry = { 0 };
+	unsigned int count = 1;
+	int rc;
+
+	test_set_transport_callback(ep, test_mi_ctrl_health_single_cb, NULL);
+	rc = libnvme_mi_mi_controller_health_status_poll_all(ep, false,
+							     &entry, &count);
+	shr_assert(rc == 0);
+	shr_assert(count == 1);
+	shr_assert(le16_to_cpu(entry.ctlid) == 0x42);
+	shr_assert(le16_to_cpu(entry.csts) == NVME_MI_CSTS_RDY);
+	shr_assert(le16_to_cpu(entry.ctemp) == 310);
+	shr_assert(entry.pdlu == 12);
+	shr_assert(entry.spare == 88);
+}
+
+static int test_mi_ctrl_health_flags_cb(struct libnvme_mi_ep *ep,
+					struct libnvme_mi_req *req,
+					struct libnvme_mi_resp *resp,
+					void *data)
+{
+	struct nvme_mi_mi_resp_hdr *mi_resp;
+	uint8_t *buf;
+
+	shr_assert(req->hdr_len == sizeof(struct nvme_mi_mi_req_hdr));
+	buf = (void *)req->hdr;
+	shr_assert(buf[4] == nvme_mi_mi_opcode_ctrl_health_status_poll);
+
+	/*
+	 * Check cdw0: start_ctrl_id=0x0102, MAXRENT=4 (for count=5),
+	 * ALL=0, INCF=1, INCPF=0, INCVF=0
+	 */
+	shr_assert(buf[8] == 0x02);
+	shr_assert(buf[9] == 0x01);
+	shr_assert(buf[10] == 0x04);
+	shr_assert(buf[11] == 0x01);
+
+	/*
+	 * Check cdw1: clear=1 (bit 31), filter_cwarn=1 (bit 4),
+	 * filter_csts=1 (bit 0)
+	 */
+	shr_assert(buf[12] == 0x11);
+	shr_assert(buf[13] == 0x00);
+	shr_assert(buf[14] == 0x00);
+	shr_assert(buf[15] == 0x80);
+
+	mi_resp = (void *)resp->hdr;
+	mi_resp->status = 0;
+	mi_resp->nmresp[2] = 0; /* RENT = 0 */
+	resp->data_len = 0;
+
+	test_transport_resp_calc_mic(resp);
+	return 0;
+}
+
+static void test_mi_ctrl_health_flags(struct libnvme_mi_ep *ep)
+{
+	struct nvme_mi_ctrl_health_status entries[5] = { 0 };
+	unsigned int count = 5;
+	struct libnvme_mi_ctrl_health_poll_args args = {
+		.args_size = sizeof(args),
+		.start_ctrl_id = 0x0102,
+		.clear = true,
+		.all = false,
+		.inc_pci = true,
+		.inc_sriov_pf = false,
+		.inc_sriov_vf = false,
+		.filter_cwarn = true,
+		.filter_csts = true,
+		.entries = entries,
+		.num_entries = &count,
+	};
+	int rc;
+
+	test_set_transport_callback(ep, test_mi_ctrl_health_flags_cb, NULL);
+	rc = libnvme_mi_mi_controller_health_status_poll(ep, &args);
+	shr_assert(rc == 0);
+	shr_assert(count == 0);
+}
+
+static int test_mi_ctrl_health_autopaging_cb(struct libnvme_mi_ep *ep,
+					     struct libnvme_mi_req *req,
+					     struct libnvme_mi_resp *resp,
+					     void *data)
+{
+	struct ctrl_health_paging_data *pd = data;
+	struct nvme_mi_mi_resp_hdr *mi_resp;
+	struct nvme_mi_ctrl_health_status *chs;
+	uint8_t *buf = (void *)req->hdr;
+	unsigned int i, num;
+
+	shr_assert(buf[4] == nvme_mi_mi_opcode_ctrl_health_status_poll);
+
+	if (pd->call_count == 0) {
+		/*
+		 * First chunk: start_ctrl_id = 0,
+		 * MAXRENT = 254 (255 entries)
+		 */
+		shr_assert(buf[8] == 0x00 && buf[9] == 0x00);
+		shr_assert(buf[10] == 254);
+		num = 255;
+	} else if (pd->call_count == 1) {
+		/*
+		 * Second chunk: start_ctrl_id = 255,
+		 * MAXRENT = 44 (45 entries)
+		 */
+		shr_assert(buf[8] == 255 && buf[9] == 0x00);
+		shr_assert(buf[10] == 44);
+		num = 45;
+	} else {
+		shr_assert(false);
+	}
+
+	mi_resp = (void *)resp->hdr;
+	mi_resp->status = 0;
+	mi_resp->nmresp[2] = num;
+
+	chs = (void *)resp->data;
+	for (i = 0; i < num; i++)
+		chs[i].ctlid = cpu_to_le16(pd->call_count * 255 + i);
+
+	resp->data_len = num * sizeof(*chs);
+	pd->call_count++;
+
+	test_transport_resp_calc_mic(resp);
+	return 0;
+}
+
+static void test_mi_ctrl_health_autopaging(struct libnvme_mi_ep *ep)
+{
+	struct nvme_mi_ctrl_health_status entries[300] = { 0 };
+	struct ctrl_health_paging_data pd = { 0 };
+	unsigned int count = 300;
+	int rc;
+
+	test_set_transport_callback(ep, test_mi_ctrl_health_autopaging_cb, &pd);
+	rc = libnvme_mi_mi_controller_health_status_poll_all(ep, false,
+							     entries, &count);
+	shr_assert(rc == 0);
+	shr_assert(count == 300);
+	shr_assert(pd.call_count == 2);
+	shr_assert(le16_to_cpu(entries[0].ctlid) == 0);
+	shr_assert(le16_to_cpu(entries[254].ctlid) == 254);
+	shr_assert(le16_to_cpu(entries[255].ctlid) == 255);
+	shr_assert(le16_to_cpu(entries[299].ctlid) == 299);
+}
+
+static int test_mi_ctrl_health_mismatch_cb(struct libnvme_mi_ep *ep,
+					   struct libnvme_mi_req *req,
+					   struct libnvme_mi_resp *resp,
+					   void *data)
+{
+	struct nvme_mi_mi_resp_hdr *mi_resp = (void *)resp->hdr;
+
+	mi_resp->status = 0;
+	mi_resp->nmresp[2] = 1; /* RENT = 1, but return 0 bytes */
+	resp->data_len = 0;
+	test_transport_resp_calc_mic(resp);
+	return 0;
+}
+
+static void test_mi_ctrl_health_errors(struct libnvme_mi_ep *ep)
+{
+	struct nvme_mi_ctrl_health_status entry;
+	unsigned int count = 1;
+	struct libnvme_mi_ctrl_health_poll_args args = {
+		.args_size = sizeof(args),
+		.entries = &entry,
+		.num_entries = &count,
+	};
+	int rc;
+
+	/* NULL args */
+	rc = libnvme_mi_mi_controller_health_status_poll(ep, NULL);
+	shr_assert(rc == -EINVAL);
+
+	/* Bad args_size */
+	args.args_size = 0;
+	rc = libnvme_mi_mi_controller_health_status_poll(ep, &args);
+	shr_assert(rc == -EINVAL);
+	args.args_size = sizeof(args);
+
+	/* NULL entries */
+	args.entries = NULL;
+	rc = libnvme_mi_mi_controller_health_status_poll(ep, &args);
+	shr_assert(rc == -EINVAL);
+	args.entries = &entry;
+
+	/* NULL num_entries */
+	args.num_entries = NULL;
+	rc = libnvme_mi_mi_controller_health_status_poll(ep, &args);
+	shr_assert(rc == -EINVAL);
+
+	/* zero num_entries */
+	count = 0;
+	args.num_entries = &count;
+	rc = libnvme_mi_mi_controller_health_status_poll(ep, &args);
+	shr_assert(rc == -EINVAL);
+
+	/* Length mismatch returns -EPROTO */
+	count = 1;
+	test_set_transport_callback(ep, test_mi_ctrl_health_mismatch_cb, NULL);
+	rc = libnvme_mi_mi_controller_health_status_poll(ep, &args);
+	shr_assert(rc == -EPROTO);
+}
+
 #define DEFINE_TEST(name) { #name, test_ ## name }
 struct test {
 	const char *name;
@@ -2264,6 +2530,10 @@ struct test {
 	DEFINE_TEST(admin_dlen_doff_req),
 	DEFINE_TEST(admin_dlen_doff_resp),
 	DEFINE_TEST(mi_invalid_formats),
+	DEFINE_TEST(mi_ctrl_health_single),
+	DEFINE_TEST(mi_ctrl_health_flags),
+	DEFINE_TEST(mi_ctrl_health_autopaging),
+	DEFINE_TEST(mi_ctrl_health_errors),
 };
 
 static void run_test(struct test *test, FILE *logfd, struct libnvme_mi_ep *ep)


### PR DESCRIPTION
Port Controller Health Status Poll changes from linux-nvme/libnvme#1144 to libnvme3.
Implement Controller Health Status Poll (Opcode 02h) defined in NVMe-MI 2.0 (Section 5.3 & 5.3.1) for libnvme3:
1. **mi: add libnvme_mi_mi_controller_health_status_poll**:
   - Add `nvme_mi_mi_opcode_ctrl_health_status_poll` (0x02) to `enum nvme_mi_mi_opcode`.
   - Add `NVME_MI_CSTS_TCIDA` to `enum nvme_mi_csts` and `NVME_MI_CHSC_*` compatibility aliases.
   - Define `struct libnvme_mi_ctrl_health_poll_args` with `args_size` for ABI safety.
   - Implement `libnvme_mi_mi_controller_health_status_poll()` with automatic multi-request paging when requesting >255 entries.
   - Implement `libnvme_mi_mi_controller_health_status_poll_all()` convenience helper.
   - Export `libnvme_mi_mi_controller_health_status_poll` in `libnvme-mi.ld` (verified by `check-public-symbols` and `check-public-headers`).
   - Add unit tests in `libnvme/tests/mi.c` covering single-entry query, filter flags, multi-page chunk boundaries, and error validation.
2. **examples/mi-mctp: add controller health status support**:
   - Update the `controllers` subcommand in `mi-mctp` to poll and display controller health status alongside topology and PCI configuration.
   - Add `show_chsc_flags()` to decode active changed flags (CHSCF).
Signed-off-by: Hao Jiang <jianghao@google.com>