### PR TITLE
build: fix static build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,14 @@ debug:
 
 .PHONY: static
 static:
-	meson setup ${BUILD-DIR} ${MESON_ARGS}
+	meson setup ${BUILD-DIR} ${MESON_ARGS} \
 		--buildtype=release \
-		--wrap-mode=forcefallback \
 		--default-library=static \
+		--wrap-mode=forcefallback \
 		--prefix=/usr \
 		-Dc_link_args="-static" \
 		-Dkeyutils=disabled \
+		-Dlibkmod=disabled \
 		-Dliburing=disabled \
 		-Dpython=disabled \
 		-Dopenssl=disabled \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -316,6 +316,7 @@ config_meson_static() {
         --prefix=/usr                           \
         -Dc_link_args="-static"                 \
         -Dkeyutils=disabled                     \
+        -Dlibkmod=disabled                      \
         -Dliburing=disabled                     \
         -Dpython=disabled                       \
         -Dopenssl=disabled                      \
@@ -358,6 +359,7 @@ config_meson_minimal_static() {
         -Dc_args="${cflags_str}"                \
         -Dc_link_args="${ldflags_str}"          \
         -Dfabrics=disabled                      \
+        -Dlibkmod=disabled                      \
         -Dmi=disabled                           \
         -Djson-c=disabled                       \
         -Dopenssl=disabled                      \


### PR DESCRIPTION
libkmod needs to be disable for static build as well.

Fixes: https://github.com/linux-nvme/nvme-cli/issues/4007