### PR TITLE
build: regenerate and verify every man page section

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,14 @@
   Specification's requirement for that token. DHCP root-path and NBFT
   data are not consistent about its case.
 
+### Build
+
+* `-Ddocs=man` and `-Ddocs=all` install the man pages shipped in
+  `Documentation/` unless `-Ddocs-build=true` is also given. The
+  section 5 and 8 pages were never written there, so those builds
+  failed to configure. They are regenerated from now on, and a
+  release aborts if any page is missing.
+
 ## Changes in 3.0 (2026-09-07)
 
 ### Feature removals and incompatible changes

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -96,7 +96,10 @@ if [ "$force" = false ] ; then
 fi
 
 if [ "$build_doc" = true ]; then
-    ./scripts/update-docs.sh
+    if ! ./scripts/update-docs.sh; then
+        echo "release.sh: failed to regenerate the documentation" >&2
+        exit 1
+    fi
     git add Documentation libnvme/doc
     git commit -s -m "doc: Regenerate all docs for $VERSION"
 fi

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -4,14 +4,21 @@
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
 BUILDDIR="$(mktemp -d)"
-trap 'rm -rf -- $BUILDDIR' EXIT
+CHECKDIR="$(mktemp -d)"
+trap 'rm -rf -- $BUILDDIR $CHECKDIR' EXIT
 
-meson setup                                 \
-	-Dnvme=enabled                          \
-	-Dlibnvme=enabled                       \
-	-Ddocs=all                              \
-	-Ddocs-build=true                       \
-	"${BUILDDIR}"
+# Some man pages are only listed when their option is enabled. Enable them
+# here so the build and the check below both see every page.
+doc_setup() {
+	meson setup                             \
+		-Dnvme=enabled                      \
+		-Dlibnvme=enabled                   \
+		-Dnvme-discoverd=enabled            \
+		-Ddocs=all                          \
+		"$@"
+}
+
+doc_setup -Ddocs-build=true "${BUILDDIR}"
 # TODO add 'docs' target
 meson compile -C "${BUILDDIR}"
 
@@ -32,5 +39,11 @@ cp "${BUILDDIR}/libnvme/doc/config-schema.json" libnvme/doc
 
 # nvme-cli
 find "${BUILDDIR}/Documentation" -maxdepth 1 \
-     \( -name '*.1' -o -name '*.html' \) \
+     \( -name '*.[0-9]' -o -name '*.html' \) \
      -exec cp {} Documentation/ \;
+
+# Fail if a pre-built doc file is missing.
+if ! doc_setup -Ddocs-build=false "${CHECKDIR}"; then
+	echo "update-docs.sh: a pre-built doc file is missing" >&2
+	exit 1
+fi


### PR DESCRIPTION
update-docs.sh copied only *.1 and *.html out of the build directory, and did not enable nvme-discoverd, so the section 5 and 8 pages were never written to Documentation/. Nothing then checked that the regenerated documentation covers every page meson installs, and release.sh ignored update-docs.sh's exit status.

Reported against v3.0.

Fixes: #4010 