### PR TITLE
doc: require xmlto when building man pages

### DIFF
--- a/Documentation/meson.build
+++ b/Documentation/meson.build
@@ -441,7 +441,7 @@ if want_docs != 'false'
 
         # man pages
         if want_docs == 'all' or want_docs == 'man'
-            xmlto = find_program('xmlto', required: false)
+            xmlto = find_program('xmlto', required: true)
             if xmlto.found()
                 foreach man_set : man_sets
                     section = man_set['section']

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,10 @@
   failed to configure. They are regenerated from now on, and a
   release aborts if any page is missing.
 
+* Building the man pages now requires `xmlto`. It was optional, so a
+  build with `-Ddocs=man -Ddocs-build=true` and no `xmlto` installed
+  succeeded and produced no man pages at all.
+
 ## Changes in 3.0 (2026-09-07)
 
 ### Feature removals and incompatible changes


### PR DESCRIPTION
`xmlto` was looked up with `required: false` and the whole man page build sat behind if `xmlto.found()`, so `-Ddocs=man -Ddocs-build=true` without `xmlto` installed configured, built and installed successfully while producing no man pages.