### PR TITLE
samsung: Fix security vulnerabilities in vs-internal-log

### DIFF
--- a/Documentation/nvme-samsung-vs-internal-log.txt
+++ b/Documentation/nvme-samsung-vs-internal-log.txt
@@ -54,8 +54,12 @@ OPTIONS
 
 -z::
 --compress::
-	Collect the dumps into a temporary directory and save them as a
-	single compressed .tar.gz archive.
+	Collect the dumps into a 'temp_samsung_dumps' directory next to the
+	output path and save them as a single compressed .tar.gz archive,
+	removing that directory afterwards. The directory is created for
+	this run alone, so the command fails if anything already sits at
+	that path: one left behind by an interrupted run has to be removed
+	before retrying.
 
 -H::
 --hide-progress::

--- a/plugins/samsung/samsung-nvme.c
+++ b/plugins/samsung/samsung-nvme.c
@@ -254,6 +254,7 @@ static void measure_loop_time(struct timeval *begin, __s64 loop_cnt,
  *   /path1/name   path2     /path1/path2  /path1/path2/name
  *
  * Both output strings are allocated and the caller frees them.
+ * Creating dir_name fails if anything already sits at that path.
  */
 static int insert_dir(const char *base_dir, const char *dir_name,
 		char **dir_path, char **result)
@@ -279,9 +280,21 @@ static int insert_dir(const char *base_dir, const char *dir_name,
 	if (asprintf(&path, "%s/%s", dir, name) < 0)
 		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
 
-	ret = shr_mkdir_p(dir, 0777);
+	/*
+	 * Every dump sits here until it is archived, so keep the staging
+	 * directory to this user. shr_mkdir() rather than shr_mkdir_p():
+	 * a path that is already taken must fail rather than be reused,
+	 * since it may be a symlink or a directory somebody else can
+	 * write to. Its parent is already there either way, created by
+	 * the shr_mkdir_from_fname() the caller runs first.
+	 */
+	ret = shr_mkdir(dir, 0700);
 	if (ret < 0) {
 		fprintf(stderr, "mkdir %s: %s\n", dir, strerror(-ret));
+		if (ret == -EEXIST)
+			fprintf(stderr,
+				"A run that was interrupted leaves it behind. "
+				"Remove %s and run the command again.\n", dir);
 		return SAMSUNG_GENERAL_FILE_OPEN_ERROR;
 	}
 

--- a/plugins/samsung/samsung-nvme.c
+++ b/plugins/samsung/samsung-nvme.c
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <errno.h>
+#include <dirent.h>
 
 #include <libnvme.h>
 
@@ -14,6 +15,7 @@
 #include <shared/compiler-attributes-util.h>
 #include <shared/fs-util.h>
 #include <shared/io-util.h>
+#include <shared/proc-util.h>
 #include <shared/progress-util.h>
 #include <shared/string-util.h>
 
@@ -243,19 +245,21 @@ static void measure_loop_time(struct timeval *begin, __s64 loop_cnt,
 
 /*
  * Insert dir_name as an extra directory level in front of the final
- * component of base_dir, create that directory, and hand back the result:
+ * component of base_dir, create that directory, and hand back both paths:
  *
- *   base_dir      dir_name  *result
- *   (NULL)        path2     ./path2/
- *   name          path2     ./path2/name
- *   /path1/       path2     /path1/path2/
- *   /path1/name   path2     /path1/path2/name
+ *   base_dir      dir_name  *dir_path     *result
+ *   (NULL)        path2     ./path2       ./path2/
+ *   name          path2     ./path2       ./path2/name
+ *   /path1/       path2     /path1/path2  /path1/path2/
+ *   /path1/name   path2     /path1/path2  /path1/path2/name
  *
- * *result is allocated and the caller frees it.
+ * Both output strings are allocated and the caller frees them.
  */
-static int insert_dir(const char *base_dir, const char *dir_name, char **result)
+static int insert_dir(const char *base_dir, const char *dir_name,
+		char **dir_path, char **result)
 {
 	__cleanup_free char *dir = NULL;
+	__cleanup_free char *path = NULL;
 	const char *prefix = "./";
 	const char *name = "";
 	int prefix_len = 2;
@@ -272,67 +276,198 @@ static int insert_dir(const char *base_dir, const char *dir_name, char **result)
 	if (asprintf(&dir, "%.*s%s", prefix_len, prefix, dir_name) < 0)
 		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
 
+	if (asprintf(&path, "%s/%s", dir, name) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
 	ret = shr_mkdir_p(dir, 0777);
 	if (ret < 0) {
 		fprintf(stderr, "mkdir %s: %s\n", dir, strerror(-ret));
 		return SAMSUNG_GENERAL_FILE_OPEN_ERROR;
 	}
 
-	if (asprintf(result, "%s/%s", dir, name) < 0)
-		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+	*dir_path = dir;
+	dir = NULL;
+	*result = path;
+	path = NULL;
 
 	return 0;
 }
 
 /*
- * The archiving below runs through system(), as in the other vendor
- * plugins. Every interpolated argument is single-quoted, so reject the one
- * character that could escape that quoting.
+ * Run argv without a shell. No command string is built, so a serial number
+ * or an output path can never become syntax. shr_spawnp() resolves argv[0]
+ * through PATH, as the micron plugin does: tar and rm sit in different
+ * directories across platforms, so there is no absolute path to prefer.
  */
-static bool shell_arg_is_safe(const char *s)
+static int run_command(const char *const argv[])
 {
-	return !strchr(s, '\'');
-}
+	shr_proc_t proc;
+	bool exited;
+	int code;
+	int ret;
 
-static int compress_dump_files(const char *dump_path_with_name, const char *sn)
-{
-	__cleanup_free char *targz_file = NULL;
-	__cleanup_free char *tar_cmd = NULL;
-	__cleanup_free char *rm_cmd = NULL;
-	const char *dump_name_only = shr_basename(dump_path_with_name);
-	int dump_path_len = (int)shr_dir_prefix_len(dump_path_with_name);
+	/*
+	 * The child writes to this process's stdout, so flush what is still
+	 * buffered here or it lands after the child's output.
+	 */
+	fflush(stdout);
 
-	if (!shell_arg_is_safe(dump_path_with_name) || !shell_arg_is_safe(sn)) {
-		fprintf(stderr, "Output path and serial number must not contain \"'\".\n");
-		return SAMSUNG_GENERAL_INVALID_PARAMETER_ERROR;
-	}
-
-	if (asprintf(&targz_file, "../%sSamsung_Dump_%s.tar.gz",
-			dump_name_only, sn) < 0)
-		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
-
-	if (asprintf(&tar_cmd, "cd '%.*s'; tar cvzf '%s' ./*",
-			dump_path_len, dump_path_with_name, targz_file) < 0)
-		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
-
-	if (asprintf(&rm_cmd, "rm -rf '%.*s'",
-			dump_path_len, dump_path_with_name) < 0)
-		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
-
-	printf("Compressing...\n");
-	if (system(tar_cmd)) {
-		fprintf(stderr, "%s failed!\n", tar_cmd);
+	ret = shr_spawnp(argv, -1, -1, &proc);
+	if (!ret)
+		ret = shr_wait_proc(proc, &exited, &code);
+	if (ret) {
+		fprintf(stderr, "%s: %s\n", argv[0], strerror(-ret));
 		return SAMSUNG_GENERAL_FILE_WRITE_ERROR;
 	}
-	printf("%sSamsung_Dump_%s.tar.gz saved at the designated location.\n",
-			dump_name_only, sn);
 
-	if (system(rm_cmd)) {
-		fprintf(stderr, "%s failed!\n", rm_cmd);
+	if (!exited) {
+		fprintf(stderr, "%s was killed.\n", argv[0]);
+		return SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+	}
+
+	if (code != 0) {
+		fprintf(stderr, "%s exited with status %d.\n", argv[0], code);
 		return SAMSUNG_GENERAL_FILE_WRITE_ERROR;
 	}
 
 	return 0;
+}
+
+/* The names of the dump files staged for archiving. */
+struct dump_names {
+	char **name;
+	size_t count;
+};
+
+static void free_dump_names(struct dump_names *names)
+{
+	size_t i;
+
+	for (i = 0; i < names->count; i++)
+		free(names->name[i]);
+	free(names->name);
+	names->name = NULL;
+	names->count = 0;
+}
+
+/*
+ * Collect the staged file names so that tar can be given them one by one.
+ * A "." operand would be shorter, but it also archives the staging
+ * directory itself as a "./" member carrying that directory's mode, and
+ * extracting the member applies the mode to whatever directory the archive
+ * is unpacked into. Skipping names that start with '.' keeps the
+ * behaviour of the shell glob this replaces.
+ */
+static int list_dump_names(const char *dir, struct dump_names *names)
+{
+	struct dirent *entry;
+	DIR *d;
+	int ret = 0;
+
+	names->name = NULL;
+	names->count = 0;
+
+	d = opendir(dir);
+	if (!d) {
+		fprintf(stderr, "opendir %s: %s\n", dir, strerror(errno));
+		return SAMSUNG_GENERAL_FILE_OPEN_ERROR;
+	}
+
+	while ((entry = readdir(d))) {
+		char **grown;
+
+		if (entry->d_name[0] == '.')
+			continue;
+
+		grown = realloc(names->name,
+				(names->count + 1) * sizeof(*grown));
+		if (!grown) {
+			ret = SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+			break;
+		}
+		names->name = grown;
+
+		names->name[names->count] = strdup(entry->d_name);
+		if (!names->name[names->count]) {
+			ret = SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+			break;
+		}
+		names->count++;
+	}
+
+	closedir(d);
+
+	if (ret != 0)
+		free_dump_names(names);
+	else if (names->count == 0) {
+		fprintf(stderr, "No dump was collected in %s.\n", dir);
+		ret = SAMSUNG_GENERAL_FILE_WRITE_ERROR;
+	}
+
+	return ret;
+}
+
+/* "tar" "cvzf" <archive> "-C" <dir> "--", ahead of the file names */
+#define TAR_ARGC_FIXED 6
+
+static int compress_dump_files(const char *temp_dir, const char *output_prefix,
+		const char *sn)
+{
+	__cleanup_free char *targz_file = NULL;
+	__cleanup_free const char **argv = NULL;
+	const char *prefix = output_prefix ? output_prefix : "./";
+	const char *archive_name = shr_basename(prefix);
+	const char *local_prefix = "";
+	struct dump_names names = { NULL, 0 };
+	size_t argc;
+	size_t i;
+	int ret;
+
+#if !defined(_WIN32)
+	/*
+	 * Keep a colon before the first slash from invoking tar's remote mode.
+	 */
+	if (prefix[strcspn(prefix, "/:")] == ':')
+		local_prefix = "./";
+#endif
+
+	if (asprintf(&targz_file, "%s%sSamsung_Dump_%s.tar.gz",
+			local_prefix, prefix, sn) < 0)
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+
+	ret = list_dump_names(temp_dir, &names);
+	if (ret != 0)
+		return ret;
+
+	argv = calloc(TAR_ARGC_FIXED + names.count + 1, sizeof(*argv));
+	if (!argv) {
+		free_dump_names(&names);
+		return SAMSUNG_GENERAL_MEM_ALLOC_ERROR;
+	}
+
+	argc = 0;
+	argv[argc++] = "tar";
+	argv[argc++] = "cvzf";
+	argv[argc++] = targz_file;
+	argv[argc++] = "-C";
+	argv[argc++] = temp_dir;
+	argv[argc++] = "--";
+	for (i = 0; i < names.count; i++)
+		argv[argc++] = names.name[i];
+	argv[argc] = NULL;
+
+	printf("Compressing...\n");
+	ret = run_command(argv);
+	free_dump_names(&names);
+	if (ret != 0)
+		return ret;
+
+	printf("%sSamsung_Dump_%s.tar.gz saved at the designated location.\n",
+			archive_name, sn);
+
+	return run_command((const char *const []) {
+		"rm", "-rf", "--", temp_dir, NULL
+	});
 }
 
 static void print_border(const char *dump_name, char cmd_type, int arg1, int arg2)
@@ -1245,6 +1380,7 @@ static int vs_internal_log(int argc, char **argv, struct command *acmd,
 	char sn[21] = {0,};
 	struct nvme_id_ctrl ctrl = {0,};
 	struct libnvme_passthru_cmd cmd;
+	__cleanup_free char *dump_temp_dir = NULL;
 	__cleanup_free char *dump_save_dir = NULL;
 
 	__cleanup_nvme_global_ctx struct libnvme_global_ctx *ctx = NULL;
@@ -1353,7 +1489,8 @@ static int vs_internal_log(int argc, char **argv, struct command *acmd,
 	}
 
 	if (cfg.compress) {
-		err = insert_dir(cfg.file, "temp_samsung_dumps", &dump_save_dir);
+		err = insert_dir(cfg.file, "temp_samsung_dumps",
+				&dump_temp_dir, &dump_save_dir);
 		if (err != 0) {
 			samsung_print_error(err);
 			return err;
@@ -1428,7 +1565,7 @@ static int vs_internal_log(int argc, char **argv, struct command *acmd,
 	 */
 	err = 0;
 	if (cfg.compress) {
-		err = compress_dump_files(dump_save_dir, sn);
+		err = compress_dump_files(dump_temp_dir, cfg.file, sn);
 		if (err != 0)
 			samsung_print_error(err);
 	}

--- a/plugins/samsung/samsung-nvme.c
+++ b/plugins/samsung/samsung-nvme.c
@@ -119,12 +119,16 @@ static int samsung_nvme_get_log_page(struct libnvme_transport_handle *hdl,
  * The serial number is space padded rather than NUL terminated, so copy
  * the whole field and trim the padding. sn holds sizeof(ctrl->sn) + 1
  * bytes. Trimming from the end keeps a serial that has a space in it.
+ *
+ * The drive supplies this field and make_file_path() puts it straight
+ * into the dump file names, so sanitize it here: a serial holding "../"
+ * would otherwise write the dumps outside the directory -O asked for.
  */
 static void get_serial_number(struct nvme_id_ctrl *ctrl, char *sn)
 {
 	memcpy(sn, ctrl->sn, sizeof(ctrl->sn));
 	sn[sizeof(ctrl->sn)] = '\0';
-	shr_rtrim(sn);
+	shr_sanitize_name(shr_rtrim(sn));
 }
 
 /*

--- a/shared/string-util.h
+++ b/shared/string-util.h
@@ -121,6 +121,13 @@ static inline char *shr_trim(char *s)
 	return shr_ltrim(shr_rtrim(s));
 }
 
+/* True if c may appear in a name: alphanumeric, '_', or '-'. */
+static inline bool shr_name_char(char c)
+{
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+	       (c >= '0' && c <= '9') || c == '_' || c == '-';
+}
+
 /* True if s is non-empty and every character is alphanumeric, '_', or '-'. */
 static inline bool shr_valid_name(const char *s)
 {
@@ -129,12 +136,30 @@ static inline bool shr_valid_name(const char *s)
 	if (!s || !*s)
 		return false;
 	for (p = s; *p; p++) {
-		if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
-		    (*p >= '0' && *p <= '9') || *p == '_' || *p == '-')
-			continue;
-		return false;
+		if (!shr_name_char(*p))
+			return false;
 	}
 	return true;
+}
+
+/*
+ * Replace every character shr_valid_name() would reject with '_', in place,
+ * and return s. This turns a field a device supplies, such as a serial
+ * number, into something that can go into a file name; pair it with
+ * shr_rtrim() so that trailing padding does not become underscores.
+ * A NULL s is returned unchanged.
+ */
+static inline char *shr_sanitize_name(char *s)
+{
+	char *p;
+
+	if (!s)
+		return s;
+	for (p = s; *p; p++) {
+		if (!shr_name_char(*p))
+			*p = '_';
+	}
+	return s;
 }
 
 /*

--- a/shared/tests/test-string-util.c
+++ b/shared/tests/test-string-util.c
@@ -192,6 +192,28 @@ static bool test_valid_name(void)
 	return pass;
 }
 
+static bool test_sanitize_name(void)
+{
+	char valid[] = "Valid_Name-123";
+	char traversal[] = "../etc";
+	char mixed[] = "a b.c";
+	bool pass = true;
+
+	printf("test_sanitize_name:\n");
+
+	pass &= check_str("NULL in, NULL out", shr_sanitize_name(NULL), NULL);
+	pass &= check_str("an already valid name is left alone",
+			   shr_sanitize_name(valid), "Valid_Name-123");
+	pass &= check_str("only the rejected characters are replaced",
+			   shr_sanitize_name(traversal), "___etc");
+	pass &= check_str("spaces and dots become '_'",
+			   shr_sanitize_name(mixed), "a_b_c");
+	pass &= check_bool("the result always satisfies shr_valid_name()",
+			    shr_valid_name(mixed), true);
+
+	return pass;
+}
+
 static bool test_kv_strip(void)
 {
 	char buf1[] = "  key = value \x20\n";
@@ -246,6 +268,7 @@ int main(void)
 	pass &= test_ltrim();
 	pass &= test_trim();
 	pass &= test_valid_name();
+	pass &= test_sanitize_name();
 	pass &= test_kv_strip();
 	pass &= test_kv_keymatch();
 

--- a/tests/cli/nvme_samsung_test.py
+++ b/tests/cli/nvme_samsung_test.py
@@ -18,6 +18,7 @@ import shutil
 import struct
 import subprocess
 import sys
+import tarfile
 import tempfile
 import unittest
 
@@ -190,6 +191,10 @@ class SamsungCLITest(unittest.TestCase):
         self.server = SamsungMockServer(self.ipc_sock_path)
         self.server.start()
         self.env = make_mock_env(_MOCK_LIB, self.ipc_sock_path)
+        self.tool_dir = os.path.join(self.ipc_dir, 'bin')
+        os.makedirs(self.tool_dir)
+        self.env['PATH'] = (self.tool_dir + os.pathsep
+                            + self.env.get('PATH', os.defpath))
         self.cwd = os.getcwd()
         os.chdir(self.out_dir)
 
@@ -214,6 +219,22 @@ class SamsungCLITest(unittest.TestCase):
         self.assertEqual(result.returncode, 0,
                          f'command failed:\nstdout:\n{result.stdout}\n'
                          f'stderr:\n{result.stderr}')
+
+    def _archive_members(self, relative_path):
+        archive = os.path.join(self.out_dir, relative_path)
+        with tarfile.open(archive, 'r:gz') as tar:
+            return tar.getmembers()
+
+    def _archive_files(self, relative_path):
+        return {os.path.basename(member.name)
+                for member in self._archive_members(relative_path)
+                if member.isfile()}
+
+    def _fail_command(self, name):
+        """Shadow a tool on PATH with one that always fails."""
+        path = os.path.join(self.tool_dir, name)
+        os.symlink(shutil.which('false') or '/bin/false', path)
+        return path
 
     # ---------------------------------------------------------------- #
     # Output path handling: -O is a file name prefix, so directories    #
@@ -358,18 +379,88 @@ class SamsungCLITest(unittest.TestCase):
     def test_compress_produces_an_archive_and_removes_the_temp_dir(self):
         result = self.run_cmd('-t', 'ctlr', '-O', './dumps/', '-z')
         self.assertOk(result)
-        names = self.files('dumps')
-        self.assertTrue(any(f.endswith('.tar.gz') for f in names),
-                        f'no archive produced: {names}')
+        archive = f'dumps/Samsung_Dump_{SERIAL}.tar.gz'
+        self.assertTrue(os.path.isfile(os.path.join(self.out_dir, archive)),
+                        f'no archive produced: {self.files("dumps")}')
+        members = self._archive_files(archive)
+        self.assertTrue(members, 'the archive holds no dump file')
+        self.assertTrue(all(name.startswith(SERIAL) for name in members), members)
         self.assertFalse(os.path.isdir(os.path.join(self.out_dir,
                                                     'dumps/temp_samsung_dumps')),
                          'the temporary directory was left behind')
 
-    def test_compress_rejects_a_quote_in_the_output_path(self):
-        os.makedirs(os.path.join(self.out_dir, "od'd"), exist_ok=True)
-        result = self.run_cmd('-t', 'ctlr', '-O', "./od'd/", '-z')
-        self.assertNotEqual(result.returncode, 0,
-                            "a path containing ' must be refused, not shelled out")
+    def test_compress_archives_the_dump_files_and_nothing_else(self):
+        """A directory member would carry the staging directory's mode, and
+        tar applies that mode to the directory the archive is extracted
+        into."""
+        result = self.run_cmd('-t', 'ctlr', '-O', './dumps/', '-z')
+        self.assertOk(result)
+        members = self._archive_members(f'dumps/Samsung_Dump_{SERIAL}.tar.gz')
+        self.assertTrue(members, 'the archive is empty')
+        self.assertTrue(all(member.isfile() for member in members),
+                        [member.name for member in members])
+
+    def test_compress_treats_shell_metacharacters_as_literal_path_data(self):
+        for component in ("odd'; touch PWNED; #", 'odd& echo PWNED &'):
+            with self.subTest(component=component):
+                result = self.run_cmd('-t', 'ctlr', '-O', f'./{component}/', '-z')
+                self.assertOk(result)
+                archive = os.path.join(component,
+                                       f'Samsung_Dump_{SERIAL}.tar.gz')
+                self.assertTrue(os.path.isfile(os.path.join(self.out_dir,
+                                                            archive)))
+                self.assertNotIn('PWNED', self.files(),
+                                 'the output path was interpreted by a shell')
+                self.assertFalse(os.path.exists(os.path.join(
+                    self.out_dir, component, 'temp_samsung_dumps')))
+
+    def test_compress_keeps_file_name_prefixes_local(self):
+        cases = (
+            ('./dumps/run1', f'dumps/run1Samsung_Dump_{SERIAL}.tar.gz',
+             'run1', 'dumps/temp_samsung_dumps'),
+            ('local:name', f'local:nameSamsung_Dump_{SERIAL}.tar.gz',
+             'local:name', 'temp_samsung_dumps'),
+        )
+        for output, archive, member_prefix, staging in cases:
+            with self.subTest(output=output):
+                result = self.run_cmd('-t', 'ctlr', '-O', output, '-z')
+                self.assertOk(result)
+                self.assertTrue(os.path.isfile(os.path.join(self.out_dir,
+                                                            archive)))
+                members = self._archive_files(archive)
+                self.assertTrue(members, 'the archive holds no dump file')
+                self.assertTrue(all(name.startswith(member_prefix + SERIAL)
+                                    for name in members), members)
+                self.assertFalse(os.path.exists(os.path.join(self.out_dir,
+                                                             staging)))
+
+    def test_compress_reports_tool_failures_and_keeps_staging(self):
+        for command in ('tar', 'rm'):
+            with self.subTest(command=command):
+                parent = f'{command}-failure'
+                archive = os.path.join(parent, f'Samsung_Dump_{SERIAL}.tar.gz')
+                failed_tool = self._fail_command(command)
+                try:
+                    result = self.run_cmd('-t', 'ctlr', '-O', f'./{parent}/',
+                                          '-z')
+                finally:
+                    os.unlink(failed_tool)
+
+                self.assertNotEqual(result.returncode, 0)
+                staging = os.path.join(self.out_dir, parent,
+                                       'temp_samsung_dumps')
+                self.assertTrue(os.path.isdir(staging),
+                                'the staged dumps were discarded')
+                staged = set(os.listdir(staging))
+                self.assertTrue(staged, 'the staged dumps were discarded')
+
+                if command == 'tar':
+                    self.assertFalse(os.path.exists(os.path.join(self.out_dir,
+                                                                 archive)))
+                else:
+                    self.assertTrue(os.path.isfile(os.path.join(self.out_dir,
+                                                                archive)))
+                    self.assertEqual(self._archive_files(archive), staged)
 
     # ---------------------------------------------------------------- #
     # Dump type selection                                               #
@@ -568,8 +659,12 @@ class SamsungCLITest(unittest.TestCase):
     def test_compress_without_output_option(self):
         result = self.run_cmd('-t', 'ctlr', '-z')
         self.assertOk(result)
-        self.assertTrue(any(f.endswith('.tar.gz') for f in self.files()),
+        archive = f'Samsung_Dump_{SERIAL}.tar.gz'
+        self.assertTrue(os.path.isfile(os.path.join(self.out_dir, archive)),
                         f'no archive in the cwd: {self.files()}')
+        members = self._archive_files(archive)
+        self.assertTrue(members, 'the archive holds no dump file')
+        self.assertTrue(all(name.startswith(SERIAL) for name in members), members)
         self.assertFalse(os.path.isdir(os.path.join(self.out_dir,
                                                     'temp_samsung_dumps')),
                          'the temporary directory was left behind')

--- a/tests/cli/nvme_samsung_test.py
+++ b/tests/cli/nvme_samsung_test.py
@@ -323,6 +323,35 @@ class SamsungCLITest(unittest.TestCase):
                       '--hide-progress suppressed the --verbose timing table')
 
     # ---------------------------------------------------------------- #
+    # Serial number handling: the drive supplies it and it lands in     #
+    # the dump file names, so it must not steer the output path.        #
+    # ---------------------------------------------------------------- #
+
+    BAD_SERIAL = "../bad'\x01sn"
+    SAFE_SERIAL = '___bad__sn'
+
+    def test_serial_is_sanitized_before_it_is_used_in_file_names(self):
+        self.server.serial = self.BAD_SERIAL
+        result = self.run_cmd('-t', 'ctlr', '-O', './serial/')
+        self.assertOk(result)
+        names = self.files('serial')
+        self.assertTrue(names, 'no dump was written')
+        self.assertTrue(all(f.startswith(self.SAFE_SERIAL) for f in names),
+                        names)
+        self.assertEqual(self.files(), ['serial'],
+                         'the serial escaped the designated output directory')
+
+    def test_serial_is_sanitized_before_it_is_used_in_the_archive_name(self):
+        self.server.serial = self.BAD_SERIAL
+        result = self.run_cmd('-t', 'ctlr', '-O', './serial/', '-z')
+        self.assertOk(result)
+        archive = f'serial/Samsung_Dump_{self.SAFE_SERIAL}.tar.gz'
+        self.assertTrue(os.path.isfile(os.path.join(self.out_dir, archive)),
+                        f'no archive at {archive}: {self.files("serial")}')
+        self.assertEqual(self.files(), ['serial'],
+                         'the serial escaped the designated output directory')
+
+    # ---------------------------------------------------------------- #
     # -z archiving                                                      #
     # ---------------------------------------------------------------- #
 

--- a/tests/cli/nvme_samsung_test.py
+++ b/tests/cli/nvme_samsung_test.py
@@ -15,6 +15,7 @@ Usage: python3 nvme_samsung_test.py <path-to-nvme-binary> <path-to-mock-lib>
 """
 import os
 import shutil
+import stat
 import struct
 import subprocess
 import sys
@@ -434,6 +435,44 @@ class SamsungCLITest(unittest.TestCase):
                 self.assertFalse(os.path.exists(os.path.join(self.out_dir,
                                                              staging)))
 
+    def test_compress_refuses_preexisting_staging_objects(self):
+        for kind in ('directory', 'file', 'symlink'):
+            with self.subTest(kind=kind):
+                relative_parent = f'existing-{kind}'
+                parent = os.path.join(self.out_dir, relative_parent)
+                staging = os.path.join(parent, 'temp_samsung_dumps')
+                os.makedirs(parent)
+
+                if kind == 'directory':
+                    os.mkdir(staging)
+                    sentinel = os.path.join(staging, 'sentinel')
+                elif kind == 'file':
+                    sentinel = staging
+                else:
+                    target = os.path.join(self.out_dir, 'symlink-target')
+                    os.makedirs(target, exist_ok=True)
+                    sentinel = os.path.join(target, 'sentinel')
+                    os.symlink(target, staging)
+
+                with open(sentinel, 'w', encoding='utf-8') as f:
+                    f.write(kind)
+
+                self.server.seen_opcodes.clear()
+                result = self.run_cmd('-t', 'ctlr',
+                                      '-O', f'./{relative_parent}/', '-z')
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn(_OPC_GET_LOG_PAGE, self.server.seen_opcodes,
+                                 'the dump started despite a taken staging path')
+                self.assertIn(f'Remove ./{relative_parent}/temp_samsung_dumps '
+                              'and run the command again', result.stderr,
+                              'the failure does not say what to remove')
+                with open(sentinel, encoding='utf-8') as f:
+                    self.assertEqual(f.read(), kind, 'the sentinel was written over')
+                if kind == 'symlink':
+                    self.assertTrue(os.path.islink(staging))
+                self.assertFalse(os.path.exists(os.path.join(
+                    parent, f'Samsung_Dump_{SERIAL}.tar.gz')))
+
     def test_compress_reports_tool_failures_and_keeps_staging(self):
         for command in ('tar', 'rm'):
             with self.subTest(command=command):
@@ -451,6 +490,8 @@ class SamsungCLITest(unittest.TestCase):
                                        'temp_samsung_dumps')
                 self.assertTrue(os.path.isdir(staging),
                                 'the staged dumps were discarded')
+                self.assertEqual(stat.S_IMODE(os.stat(staging).st_mode), 0o700,
+                                 'the staging directory is not private')
                 staged = set(os.listdir(staging))
                 self.assertTrue(staged, 'the staged dumps were discarded')
 


### PR DESCRIPTION
`shared: add shr_sanitize_name()` comes first: `shr_valid_name()` only validates, and a caller holding a field the device supplies needs to make a usable name rather than turn the device away. It goes next to the validator instead of becoming a third copy of that character set — the micron plugin already carries a local `sanitize_serial()` that can move over separately.

Then three fixes for `nvme samsung vs-internal-log`, one issue per commit:

- The drive-supplied serial number goes into the dump file names unvalidated, so one holding `../` writes the dumps outside the directory `-O` asked for. The old check refused a `'`, ran only from `compress_dump_files()`, and so never ran without `-z`.
- `tar` and `rm` ran through `system()`. The single-quoting covers `/bin/sh` but not the `cmd.exe` that `system()` runs on Windows, where `'` is not a quoting character and `&`, `|`, `>` and `^` still apply. They now spawn through `shr_spawnp()` with a fixed argv, as the micron plugin does.
- The staging directory was created with `shr_mkdir_p()` and mode 0777, so an existing symlink or somebody else's directory at that predictable name would collect the dumps. It is created with `shr_mkdir()` and mode 0700 instead, and a path that is already taken fails.

`tests/cli/nvme_samsung_test.py` grows from 40 to 51 cases, and `shared/tests/test-string-util.c` covers the new helper.
